### PR TITLE
Remove typing and dataclasses deps on modern Pythons

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,8 @@ install_requires =
     # Runtime dependencies
     numpy
     pandas
-    typing ; python_version < '3.8'
     attrs
-    dataclasses ; python_version < '3.8'
+    dataclasses ; python_version < '3.7'
     enum-compat
     grpcio-tools
     xxhash


### PR DESCRIPTION
The typing module is part of the interpreter since python 3.5, the dataclasses since python 3.7. typing features from 3.7 on are _not_ included in the PyPi wheel. 

This prevents issues where installing the typing module was shadows the built-in typing module and prevents use of newer features.

(See also internal PR https://mangit.maninvestments.com/projects/DATA/repos/arcticc/pull-requests/1029)