### PR TITLE
Fix correct python linking problem

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,6 +6,13 @@ project(arcticdb VERSION 0.0.1)
 
 enable_testing()
 
+message(ENV_BASE_DIR="${ENV_BASE_DIR}")
+message(Python_ROOT_DIR="${Python_ROOT_DIR}")
+message(PYTHON_LIBRARIES="${PYTHON_LIBRARIES}")
+message(PYTHON_INCLUDE_DIRS="${PYTHON_INCLUDE_DIRS}")
+message(BUILD_PYTHON_VERSION="${BUILD_PYTHON_VERSION}")
+message(PYTHON_LIBRARY_SO="${PYTHON_LIBRARY_SO}")
+
 if(WIN32)
     add_compile_definitions(NOGDI)
     add_compile_definitions(WIN32_LEAN_AND_MEAN)
@@ -37,23 +44,6 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# BUILD_PYTHON_VERSION is set by the Python build hooks regardless of whether building an internal egg or an external
-# wheel. If invoking CMake directly however (which would normally be the case in an IDE) BUILD_PYTHON_VERSION will not
-# be set. In this case. we'll set BUILD_PYTHON_VERSION as well as 4 other required build variables to sane default
-# values.
-if(NOT BUILD_PYTHON_VERSION AND NOT WIN32)
-    message("Resetting Python include locations...")
-    # /default-medusa-venv is symlinked to /default-pegasus-venv
-    set(ENV_BASE_DIR "/default-medusa-venv")
-
-    set(BUILD_PYTHON_VERSION 3.6)
-
-    set(PYTHON_LIBRARIES "${ENV_BASE_DIR}/lib")
-    set(PYTHON_EXECUTABLE "${ENV_BASE_DIR}/bin/python")
-    set(PYTHON_INCLUDE_DIRS "${ENV_BASE_DIR}/include/python${BUILD_PYTHON_VERSION}m")
-    set(PYTHON_LIBRARY_SO "${ENV_BASE_DIR}/lib/libpython${BUILD_PYTHON_VERSION}m.so")
-endif()
 
 add_subdirectory(third_party)
 add_subdirectory(proto)


### PR DESCRIPTION
Setting the correct flag for cmake so that the right python libraries will be selected for linking.
Also, the default flag setup has been moved to setup.py for simplification