### PR TITLE
Fixes for Windows compatibility

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -376,12 +376,12 @@ public:
     folly::Future<std::vector<VariantKey>> batch_write(std::vector<std::pair<PartialKey, SegmentInMemory>> &&key_segments,
                 const std::shared_ptr<DeDupMap>& de_dup_map,
                 const BatchWriteArgs &args) override {
-        std::size_t write_count = args.lib_write_count == 0 ? 16ul : args.lib_write_count;
+        std::size_t write_count = args.lib_write_count == 0 ? 16ULL : args.lib_write_count;
 
         std::shared_ptr<std::vector<VariantKey>> res = std::make_shared<std::vector<VariantKey>>(key_segments.size());
 
-        auto count = 0ul;
-        for (std::size_t start = 0ul, nxt; start < key_segments.size(); start = nxt) {
+        auto count = 0ULL;
+        for (std::size_t start = 0ULL, nxt; start < key_segments.size(); start = nxt) {
             nxt = std::min(start + write_count, key_segments.size());
             auto range = folly::Range(key_segments.begin() + start, key_segments.begin() + nxt);
             auto key_segs = std::make_shared<std::vector<storage::KeySegmentPair>>();

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -89,7 +89,7 @@ TEST(Async, DeDupTest) {
     auto keys = store.batch_write(std::move(key_segments), de_dup_map, ast::StreamSink::BatchWriteArgs()).get();
 
     //The first key will be de-duped, second key will be fresh because indexes dont match
-    ASSERT_EQ(2ul, keys.size());
+    ASSERT_EQ(2ULL, keys.size());
     ASSERT_EQ(k, to_atom(keys[0]));
     ASSERT_NE(k, to_atom(keys[1]));
     ASSERT_NE(999, to_atom(keys[1]).creation_ts());

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -309,7 +309,7 @@ void decode(const Segment& segment,
         util::check(fields_size == hdr.fields_size(), "Mismatch between descriptor and header field size: {} != {}", fields_size, hdr.fields_size());
         const auto start_row = res.row_count();
 
-        const auto seg_row_count = fields_size ? ssize_t(hdr.fields(0).ndarray().items_count()) : 0L;
+        const auto seg_row_count = fields_size ? ssize_t(hdr.fields(0).ndarray().items_count()) : 0LL;
         res.init_column_map();
 
         for (std::size_t i = 0; i < static_cast<size_t>(fields_size); ++i) {

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -68,10 +68,6 @@ position_t SegmentInMemoryImpl::add_column(const FieldDescriptor::Proto &field, 
     return columns_.size() - 1;
 }
 
-//position_t SegmentInMemoryImpl::add_column(const FieldDescriptor::Proto &field, const std::shared_ptr<Column>& column) {
-//    return add_column(field.proto(), column);
-//}
-
 void SegmentInMemoryImpl::change_schema(StreamDescriptor descriptor) {
     //util::check(vector_is_unique(descriptor.fields()), "Non-unique fields in descriptor: {}", descriptor.fields());
     init_column_map();

--- a/cpp/arcticdb/entity/atom_key.hpp
+++ b/cpp/arcticdb/entity/atom_key.hpp
@@ -50,8 +50,8 @@ class AtomKeyImpl {
     const auto& gen_id() const { return version_id_; }
     const auto& creation_ts() const { return creation_ts_; }
     TimestampRange time_range() const { return {start_time(), end_time()}; }
-    timestamp start_time() const { if (std::holds_alternative<timestamp>(index_start_)) return std::get<timestamp>(index_start_); else return 0L; }
-    timestamp end_time() const { if (std::holds_alternative<timestamp>(index_end_)) return std::get<timestamp>(index_end_); else return 0L; }
+    timestamp start_time() const { if (std::holds_alternative<timestamp>(index_start_)) return std::get<timestamp>(index_start_); else return 0LL; }
+    timestamp end_time() const { if (std::holds_alternative<timestamp>(index_end_)) return std::get<timestamp>(index_end_); else return 0LL; }
     const auto& content_hash() const { return content_hash_; }
     const auto& type() const { return key_type_; }
     auto& type() { return key_type_; }

--- a/cpp/arcticdb/entity/serialized_key.hpp
+++ b/cpp/arcticdb/entity/serialized_key.hpp
@@ -290,7 +290,7 @@ inline AtomKey from_tokenized_atom_key(const uint8_t *data, size_t size, KeyType
         std::ostringstream strm;
         strm << *it++;
 
-        for(auto j = 0ul; j < extra; ++j) {
+        for(auto j = 0ULL; j < extra; ++j) {
             strm << NewKeyDelimiter << *it;
             it = vec.erase(it);
         }

--- a/cpp/arcticdb/entity/test/test_atom_key.cpp
+++ b/cpp/arcticdb/entity/test/test_atom_key.cpp
@@ -111,9 +111,9 @@ TEST(Key, Formatting) {
         StreamId{999},
         VersionId(123),
         timestamp(123000000LL),
-        0x789456321UL,
-        NumericIndex(122000000UL),
-        NumericIndex(122000999UL),
+        0x789456321ULL,
+        NumericIndex(122000000ULL),
+        NumericIndex(122000999ULL),
         KeyType::TABLE_DATA};
 
     AtomKey k2 = k;

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -205,7 +205,7 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool
             case SinkConf::kRotFile:
                 sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
                     make_parent_dir(sink_conf.rot_file().path(), "./arcticdb.rot.log"),
-                    util::as_opt(sink_conf.rot_file().max_size_bytes()).value_or(64UL * (1UL << 20)),
+                    util::as_opt(sink_conf.rot_file().max_size_bytes()).value_or(64ULL* (1ULL<< 20)),
                     util::as_opt(sink_conf.rot_file().max_file_count()).value_or(8)
                 ));
                 break;

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -201,7 +201,7 @@ size_t get_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys)
 
 std::pair<size_t, size_t> offset_and_row_count(const std::shared_ptr<pipelines::PipelineContext>& context) {
     // count rows
-    std::size_t row_count = 0ul;
+    std::size_t row_count = 0ULL;
     for(auto s = 0u; s < context->slice_and_keys_.size(); ++s) {
         if (context->fetch_index_[s]) {
             row_count += context->slice_and_keys_[s].slice_.row_range.diff();
@@ -211,7 +211,7 @@ std::pair<size_t, size_t> offset_and_row_count(const std::shared_ptr<pipelines::
         }
     }
 
-    std::size_t offset = row_count ? context->slice_and_keys_[0].slice_.row_range.first : 0ul;
+    std::size_t offset = row_count ? context->slice_and_keys_[0].slice_.row_range.first : 0ULL;
     ARCTICDB_DEBUG(log::version(), "Got offset {} and row_count {}", offset, row_count);
     return std::make_pair(offset, row_count);
 }

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -47,7 +47,7 @@ struct InputTensorFrame {
         bucketize_dynamic = bucketize;
     }
 
-    bool has_index() const { return desc.index().field_count() != 0ul; }
+    bool has_index() const { return desc.index().field_count() != 0ULL; }
 
     void set_index_range() {
             // Fill index range

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -144,7 +144,7 @@ inline bool is_column_selected(size_t start_col, size_t end_col, const util::Bit
         auto col = sc.get_first();
         return col < end_col;
     } else {
-        auto col = sc.get_next(start_col - 1ul);
+        auto col = sc.get_next(start_col - 1ULL);
         return col != 0 && col < end_col;
     }
 }

--- a/cpp/arcticdb/pipeline/slicing.cpp
+++ b/cpp/arcticdb/pipeline/slicing.cpp
@@ -62,7 +62,7 @@ std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::Input
     auto index = frame.desc.index();
 
     std::vector<FrameSlice> slices;
-    slices.reserve(field_count / col_per_slice_ + std::size_t((field_count % col_per_slice_) == 0ul));
+    slices.reserve(field_count / col_per_slice_ + std::size_t((field_count % col_per_slice_) == 0ULL));
 
     const auto [first_row, last_row] = get_first_and_last_row(frame);
 

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -299,7 +299,7 @@ std::vector<SliceAndKey> flatten_and_fix_rows(const std::vector<std::vector<Slic
     for(auto group : groups) {
         if(group.empty()) continue;
         auto group_start = group.begin()->slice_.row_range.first;
-        auto group_end = std::accumulate(std::begin(group), std::end(group), 0UL, [](size_t a, const SliceAndKey& sk) { return std::max(a, sk.slice_.row_range.second); });
+        auto group_end = std::accumulate(std::begin(group), std::end(group), 0ULL, [](size_t a, const SliceAndKey& sk) { return std::max(a, sk.slice_.row_range.second); });
         std::transform(std::begin(group), std::end(group), std::back_inserter(output), [&] (auto& sk) {
             auto range_start = global_count + (sk.slice_.row_range.first - group_start);
             auto new_range = RowRange{range_start, range_start + (sk.slice_.row_range.diff())};

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -95,7 +95,7 @@ struct RowNumberLimitClause {
         auto procs = std::move(p);
         procs.broadcast([&store, this](ProcessingSegment &proc) {
             auto row_range = proc.data()[0].slice_.row_range;
-            if (row_range.start() == 0UL && row_range.end() > n) {
+            if (row_range.start() == 0ULL && row_range.end() > n) {
                 util::BitSet bv(static_cast<util::BitSet::size_type>(row_range.diff()));
                 bv.set_range(0, bv_size(n));
                 proc.apply_filter(bv, store);

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -390,7 +390,7 @@ bool operator()(int64_t t, const std::unordered_set<uint64_t>& u) const {
         return u.count(t) > 0;
 }
 // This is the version called when checking string set membership
-bool operator()(long t, const emilib::HashSet<int64_t>& u) const {
+bool operator()(int64_t t, const emilib::HashSet<int64_t>& u) const {
     return u.contains(t);
 }
 };
@@ -413,7 +413,7 @@ bool operator()(int64_t t, const std::unordered_set<uint64_t>& u) const {
         return u.count(t) == 0;
 }
 // This is the version called when checking string set membership
-bool operator()(long t, const emilib::HashSet<int64_t>& u) const {
+bool operator()(int64_t t, const emilib::HashSet<int64_t>& u) const {
     return !u.contains(t);
 }
 };

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -29,7 +29,7 @@ LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const C
     write_mutex_(new std::mutex{}),
     env_(std::make_unique<::lmdb::env>(::lmdb::env::create(conf.flags()))){
     fs::path root_path = conf.path().c_str();
-    auto lib_path_str = library_path.to_delim_path('/');
+    auto lib_path_str = library_path.to_delim_path(fs::path::preferred_separator);
 
     auto lib_dir = root_path / lib_path_str;
     if (!fs::exists(lib_dir)) {
@@ -54,7 +54,7 @@ LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const C
     // Windows needs a sensible size as it allocates disk for the whole file even before any writes. Linux just gets an arbitrarily large size
     // that it probably won't ever reach.
 #ifdef _WIN32
-    constexpr uint64_t default_map_size = 1ULL << 30; /* 1 GiB */
+    constexpr uint64_t default_map_size = 1ULL << 23; /* 8 MiB */
 #else
     constexpr uint64_t default_map_size = 100ULL * (4ULL << 30); /* 400 GiB */
 #endif

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -151,7 +151,7 @@ inline std::optional<Aws::Client::ClientConfiguration> parse_proxy_env_var(Aws::
     }
     // env_var format: hostname[:port]
     auto port_start_idx = env_var.rfind(':');
-    unsigned long port;
+    uint64_t port;
     if (port_start_idx == std::string::npos){
         port = endpoint_scheme == Aws::Http::Scheme::HTTPS ? 443 : 80;
     } else {

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -151,7 +151,7 @@ std::vector<SliceAndKey> get_incomplete(
     const std::shared_ptr<Store> &store,
     const StreamId &stream_id,
     const pipelines::FilterRange &range,
-    unsigned long last_row,
+    uint64_t last_row,
     bool via_iteration,
     bool load_data) {
     using namespace arcticdb::pipelines;

--- a/cpp/arcticdb/stream/append_map.hpp
+++ b/cpp/arcticdb/stream/append_map.hpp
@@ -62,7 +62,7 @@ std::vector<pipelines::SliceAndKey> get_incomplete(
     const std::shared_ptr<Store> &store,
     const StreamId &stream_id,
     const pipelines::FilterRange &range,
-    unsigned long last_row,
+    uint64_t last_row,
     bool via_iteration,
     bool load_data);
 

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -95,8 +95,8 @@ struct StreamSink {
         SegmentInMemory &&segment) = 0;
 
     struct BatchWriteArgs {
-        std::size_t lib_write_count = 0ul;
-        BatchWriteArgs() : lib_write_count(0ul) {}
+        std::size_t lib_write_count = 0ULL;
+        BatchWriteArgs() : lib_write_count(0ULL) {}
     };
 
     [[nodiscard]] virtual folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&& ks) = 0;

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -92,7 +92,7 @@ ChunkedBuffer scan_floating_point_to_sparse(
     util::BitMagic& block_bitset) {
     auto scan_ptr = ptr;
     for (size_t idx = 0; idx < rows_to_write; ++idx, ++scan_ptr) {
-        block_bitset[idx] = isnan(*scan_ptr) <= 0;
+        block_bitset[idx] = !isnan(*scan_ptr);
     }
 
     const auto bytes = block_bitset.count() * sizeof(RawType);

--- a/cpp/arcticdb/util/storage_lock.hpp
+++ b/cpp/arcticdb/util/storage_lock.hpp
@@ -60,7 +60,7 @@ struct StorageLockTimeout : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
-inline unsigned long get_thread_id() {
+inline uint64_t get_thread_id() {
 #ifdef _WIN32
     return pthread_self()->threadID;
 #else

--- a/cpp/arcticdb/util/test/test_hash.cpp
+++ b/cpp/arcticdb/util/test/test_hash.cpp
@@ -64,33 +64,33 @@ TEST(HashComm, Commutative) {
             commutative_hash_combine(g2, g1)
     );
 
-    std::cout<<commutative_hash_combine(9726480045861996436ul, std::string("10442909"))<<std::endl;
-    std::cout<<commutative_hash_combine(17243764687685379754ul, std::string("[N/A]"))<<std::endl;
-    std::cout<<commutative_hash_combine(9457389251931416297ul, std::string("98956PAF9"))<<std::endl;
-    std::cout<<commutative_hash_combine(2648263869243483102ul, std::string("1"))<<std::endl;
-    std::cout<<commutative_hash_combine(10692736793407104629ul, std::string("US98956PAF99"))<<std::endl;
-    std::cout<<commutative_hash_combine(7633205480517386763ul, std::string("4"))<<std::endl;
-    std::cout<<commutative_hash_combine(8481507868260942362ul, std::string("CORP"))<<std::endl;
-    std::cout<<commutative_hash_combine(4419353893253087336ul, std::string("USD_HGD"))<<std::endl;
-    std::cout<<commutative_hash_combine(10212419605264796417ul, std::string("20210824"))<<std::endl;
+    std::cout<<commutative_hash_combine(9726480045861996436ULL, std::string("10442909"))<<std::endl;
+    std::cout<<commutative_hash_combine(17243764687685379754ULL, std::string("[N/A]"))<<std::endl;
+    std::cout<<commutative_hash_combine(9457389251931416297ULL, std::string("98956PAF9"))<<std::endl;
+    std::cout<<commutative_hash_combine(2648263869243483102ULL, std::string("1"))<<std::endl;
+    std::cout<<commutative_hash_combine(10692736793407104629ULL, std::string("US98956PAF99"))<<std::endl;
+    std::cout<<commutative_hash_combine(7633205480517386763ULL, std::string("4"))<<std::endl;
+    std::cout<<commutative_hash_combine(8481507868260942362ULL, std::string("CORP"))<<std::endl;
+    std::cout<<commutative_hash_combine(4419353893253087336ULL, std::string("USD_HGD"))<<std::endl;
+    std::cout<<commutative_hash_combine(10212419605264796417ULL, std::string("20210824"))<<std::endl;
 
-    std::cout<<commutative_hash_combine(9726480045861996436ul, std::string("10442909"), std::string("[N/A]")) <<std::endl;
+    std::cout<<commutative_hash_combine(9726480045861996436ULL, std::string("10442909"), std::string("[N/A]")) <<std::endl;
 
-    auto h1 = commutative_hash_combine_generic(9726480045861996436ul, folly::Hash{}, std::string("10442909"), std::string("[N/A]"));
-    auto h2 = commutative_hash_combine_generic(9726480045861996436ul, folly::Hash{}, std::string("10442909"));
+    auto h1 = commutative_hash_combine_generic(9726480045861996436ULL, folly::Hash{}, std::string("10442909"), std::string("[N/A]"));
+    auto h2 = commutative_hash_combine_generic(9726480045861996436ULL, folly::Hash{}, std::string("10442909"));
     auto h3 = commutative_hash_combine_generic(h2, folly::Hash{}, std::string("[N/A]"));
     
-    auto h4 = commutative_hash_combine_generic(9726480045861996436ul, folly::Hash{}, std::string("[N/A]"));
+    auto h4 = commutative_hash_combine_generic(9726480045861996436ULL, folly::Hash{}, std::string("[N/A]"));
     auto h5 = commutative_hash_combine_generic(h4, folly::Hash{}, std::string("10442909"));
 
     EXPECT_EQ(h1, h3);
     EXPECT_EQ(h1, h5);
 
-    auto j1 = commutative_hash_combine(9726480045861996436ul, std::string("10442909"), std::string("[N/A]"));
-    auto j2 = commutative_hash_combine(9726480045861996436ul, std::string("10442909"));
+    auto j1 = commutative_hash_combine(9726480045861996436ULL, std::string("10442909"), std::string("[N/A]"));
+    auto j2 = commutative_hash_combine(9726480045861996436ULL, std::string("10442909"));
     auto j3 = commutative_hash_combine(j2, std::string("[N/A]"));
 
-    auto j4 = commutative_hash_combine(9726480045861996436ul, std::string("[N/A]"));
+    auto j4 = commutative_hash_combine(9726480045861996436ULL, std::string("[N/A]"));
     auto j5 = commutative_hash_combine(j4, std::string("10442909"));
 
     EXPECT_NE(j1, j3);

--- a/cpp/arcticdb/util/test/test_slab_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_slab_allocator.cpp
@@ -26,7 +26,7 @@ std::size_t const num_blocks_per_thread = 10000;
 std::size_t const num_loops = 10000;
 
 template <typename MemoryChunk>
-pointer_set<MemoryChunk> call_alloc_and_dealloc(MemoryChunk& mc, std::size_t n, long long& execution_time_ms) {
+pointer_set<MemoryChunk> call_alloc_and_dealloc(MemoryChunk& mc, std::size_t n, int64_t& execution_time_ms) {
     
     pointer_set<MemoryChunk> mcps;
     mcps.reserve(n);
@@ -55,8 +55,8 @@ void check_sets(const pointer_set<MemoryChunk>& s1, const pointer_set<MemoryChun
 template <typename MemoryChunk>
 void run_test(MemoryChunk& mc, unsigned int K)
 {
-    std::vector<long long> execution_times(num_threads);
-    long long avg = 0;
+    std::vector<int64_t> execution_times(num_threads);
+    int64_t avg = 0;
     for (size_t k = 0; k < K; ++k ) {
         std::vector<std::future<pointer_set<MemoryChunk>>> v;
         for (size_t i = 0; i < num_threads; ++i ) {

--- a/cpp/arcticdb/util/timer.hpp
+++ b/cpp/arcticdb/util/timer.hpp
@@ -37,14 +37,14 @@ typedef std::map<name_type, double> total_map;
 
 struct interval_results {
     double total;
-    long count;
+    int64_t count;
     double mean;
 };
 
 struct interval {
 private:
     double total_;
-    long count_;
+    int64_t count_;
     timespec timer_;
     bool running_;
 
@@ -100,8 +100,7 @@ private:
         }
     }
 
-#define BILLION  1000000000L
-
+#define BILLION  1000000000LL
     static double time_diff(timespec &start, timespec &stop) {
         double secs = stop.tv_sec - start.tv_sec;
         double nsecs = double(stop.tv_nsec - start.tv_nsec) / BILLION;

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -581,7 +581,7 @@ TEST(VersionMap, StressTestWrite) {
     std::vector<AtomKey> keys;
     const size_t num_tests = 999;
     StreamId id{"test"};
-    for (auto i = 0ul; i < num_tests; ++i) {
+    for (auto i = 0ULL; i < num_tests; ++i) {
         keys.emplace_back(
                 atom_key_builder().version_id(i).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(i).start_index( \
                 4).end_index(5).build(id, KeyType::TABLE_INDEX));
@@ -605,7 +605,7 @@ TEST(VersionMap, StressTestBatchSameSymbol) {
     std::vector<AtomKey> keys;
     const size_t num_tests = 999;
     StreamId id{"test"};
-    for (auto i = 0ul; i < num_tests; ++i) {
+    for (auto i = 0ULL; i < num_tests; ++i) {
         keys.emplace_back(
             atom_key_builder().version_id(i).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(i).start_index( \
             4).end_index(5).build(id, KeyType::TABLE_INDEX));
@@ -623,7 +623,7 @@ TEST(VersionMap, StressTestBatchWrite) {
     std::vector<AtomKey> keys;
     const size_t num_tests = 999;
 
-    for (auto i = 0ul; i < num_tests; ++i) {
+    for (auto i = 0ULL; i < num_tests; ++i) {
         StreamId id{fmt::format("test_{}", i)};
         keys.emplace_back(
             atom_key_builder().version_id(i).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(i).start_index( \


### PR DESCRIPTION
Port Windows changes from internal PR #1003

- Prevent numpy strings for now and only support dynamic strings on Windows
- Find and replace long literals -> long long literals
- Python changes from PR #1003
- Replace long -> int64_t
- Minor C++ tweaks to reduce VS 2022 compiler warnings
- Skip some failing Python tests
- Use smaller LMDB database to save disk and use windows suitable fixture paths