### PR TITLE
Fix for incorrect handling of numpy array with negative strides

### DIFF
--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -88,7 +88,7 @@ void aggregator_set_data(
         util::check(type_desc.data_type() == tensor.data_type(), "Type desc {} != {} tensor type", type_desc.data_type(),
                     tensor.data_type());
         util::check(type_desc.data_type() == dt, "Type desc {} != {} static type", type_desc.data_type(), dt);
-        auto c_style = tensor.strides(0) == sizeof(RawType);
+        auto c_style = util::is_cstyle_array<RawType>(tensor);
         if constexpr (is_sequence_type(dt)) {
             ARCTICDB_SUBSAMPLE_AGG(SetDataString)
             if (is_fixed_string_type(dt)) {

--- a/cpp/arcticdb/util/flatten_utils.hpp
+++ b/cpp/arcticdb/util/flatten_utils.hpp
@@ -17,7 +17,7 @@ using namespace arcticdb::entity;
 template<class T, template<class> class Tensor>
 inline bool has_funky_strides(Tensor<T> &a) {
     for (ssize_t i = 0; i < a.ndim(); ++i) {
-        if (a.strides(i) % a.itemsize() != 0)
+        if (a.strides(i) < 0 || a.strides(i) % a.itemsize() != 0)
             return true;
     }
     return false;
@@ -26,10 +26,15 @@ inline bool has_funky_strides(Tensor<T> &a) {
 template<class T>
 inline bool has_funky_strides(py::array_t<T>& a) {
     for (ssize_t i = 0; i < a.ndim(); ++i) {
-        if (a.strides(i) % a.itemsize() != 0)
+        if (a.strides(i) < 0 || a.strides(i) % a.itemsize() != 0)
             return true;
     }
     return false;
+}
+
+template <typename RawType, typename TensorType>
+inline bool is_cstyle_array(const TensorType& tensor){
+    return tensor.size() == 0 || tensor.strides(tensor.ndim() - 1) == sizeof(RawType);
 }
 
 template<typename T>


### PR DESCRIPTION
Improve the detection for non c-style array, e.g. those with negative strides, so they will be flattened correctly