### PR TITLE
Add specific error message when range searching on unsorted data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "cpp/third_party/rapidcheck"]
 	path = cpp/third_party/rapidcheck
 	url = https://github.com/emil-e/rapidcheck.git
+[submodule "cpp/vcpkg"]
+	path = cpp/vcpkg
+	url = https://github.com/microsoft/vcpkg.git

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -63,7 +63,7 @@ std::optional<util::BitSet> check_and_mark_slices(
         RowRange current = *pos;
         std::advance(pos, 1);
         for(; pos != row_ranges.end(); ++pos){
-            util::check(pos->start() == current.end(), "Non-contiguous rows, range search on unsorted data? {} {}", current, *pos);
+            sorting::check<ErrorCode::E_UNSORTED_DATA>(pos->start() == current.end(), "Non-contiguous rows, range search on unsorted data? {} {}", current, *pos);
             current = *pos;
         }
     }

--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -28,7 +28,8 @@ enum class ErrorCategory : BaseType {
     NORMALIZATION = 2,
     MISSING_DATA = 3,
     SCHEMA = 4,
-    STORAGE = 5
+    STORAGE = 5,
+    SORTING = 6
 };
 
 // FUTURE(GCC9): use magic_enum
@@ -38,7 +39,8 @@ inline std::unordered_map<ErrorCategory, const char*> get_error_category_names()
         {ErrorCategory::NORMALIZATION, "NORMALIZATION"},
         {ErrorCategory::MISSING_DATA, "MISSING_DATA"},
         {ErrorCategory::SCHEMA, "SCHEMA"},
-        {ErrorCategory::STORAGE, "STORAGE"}
+        {ErrorCategory::STORAGE, "STORAGE"},
+        {ErrorCategory::SORTING, "SORTING"}
     };
 }
 
@@ -57,7 +59,8 @@ inline std::unordered_map<ErrorCategory, const char*> get_error_category_names()
     ERROR_CODE(3000, E_NO_SUCH_VERSION)  \
     ERROR_CODE(4000, E_DESCRIPTOR_MISMATCH)  \
     ERROR_CODE(5000, E_KEY_NOT_FOUND) \
-    ERROR_CODE(5001, E_DUPLICATE_KEY)
+    ERROR_CODE(5001, E_DUPLICATE_KEY) \
+    ERROR_CODE(6000, E_UNSORTED_DATA)
 
 enum class ErrorCode : BaseType {
 #define ERROR_CODE(code, Name, ...) Name = code,
@@ -120,6 +123,7 @@ using NormalizationException = ArcticBaseException<ErrorCategory::NORMALIZATION>
 using NoSuchVersionException = ArcticSpecificException<ErrorCode::E_NO_SUCH_VERSION>;
 using StorageException = ArcticBaseException<ErrorCategory::STORAGE>;
 using MissingDataException = ArcticBaseException<ErrorCategory::MISSING_DATA>;
+using UnsortedDataException = ArcticSpecificException<ErrorCode::E_UNSORTED_DATA>;
 
 template<ErrorCode error_code>
 [[noreturn]] void throw_error(const std::string& msg) {
@@ -129,6 +133,11 @@ template<ErrorCode error_code>
 template<>
 [[noreturn]] inline void throw_error<ErrorCode::E_NO_SUCH_VERSION>(const std::string& msg) {
     throw ArcticSpecificException<ErrorCode::E_NO_SUCH_VERSION>(msg);
+}
+
+template<>
+[[noreturn]] inline void throw_error<ErrorCode::E_UNSORTED_DATA>(const std::string& msg) {
+    throw ArcticSpecificException<ErrorCode::E_UNSORTED_DATA>(msg);
 }
 
 }

--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -58,6 +58,14 @@ template<ErrorCode code>
 constexpr auto raise = check<code>.raise;
 }
 
+namespace sorting {
+    template<ErrorCode code>
+    constexpr auto check = util::detail::Check<code, ErrorCategory::SORTING>{};
+
+    template<ErrorCode code>
+    constexpr auto raise = check<code>.raise;
+}
+
 // TODO Change legacy codes to internal::
 namespace util {
 

--- a/docs/mkdocs/docs/error_messages.md
+++ b/docs/mkdocs/docs/error_messages.md
@@ -49,6 +49,12 @@ Note that for legacy reasons, the terms `symbol`, `stream`, and `stream ID` are 
 | 5000       | A missing key has been requested.                                      | ArcticDB has requested a key that does not exist in storage. Please ensure that you have requested a `symbol`, `snapshot` or `version` that exists. |
 | 5001       | ArcticDB is attempting to write to an already-existing key in storage. | This error is unexpected - please ensure that no other tools are writing data the same storage location that may conflict with ArcticDB.            |
 
+### Sorting Errors
+
+| Error Code | Cause                                                                  | Resolution                                                                                                                                          |
+|------------|------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 6000       | Data should be sorted for this operation.                              | The requested operation requires data to be sorted. If this is a modification operation such as update, sort the input data.                        |
+
 ## Errors without numeric error codes
 
 ### Pickling errors


### PR DESCRIPTION
At the moment if you try to do a range search on unsorted data it throws an InternalException, which is not ideal as those are intended for assertion failures and really should not be used for anything that users might see (even under less-than-ideal circumstances). Throw a specific exception with the correct error code.