### PR TITLE
Small tweaks to get Python tests running on Windows

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,8 +14,8 @@ if(WIN32)
 
     # Guide to MSVC compilation warnings https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199?view=msvc-170
     set(CMAKE_CXX_FLAGS "/DWIN32 /D_WINDOWS /w /GR /bigobj /EHsc /w /wd4244 /wd4267")
-    set(CMAKE_CXX_FLAGS_RELEASE "/MD /DNDEBUG")
-    set(CMAKE_CXX_FLAGS_DEBUG "/MDd /Zi /RTC1")
+    set(CMAKE_CXX_FLAGS_RELEASE "/MT /DNDEBUG")
+    set(CMAKE_CXX_FLAGS_DEBUG "/MTd /Zi /RTC1")
 else()
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")
     set(CMAKE_CXX_FLAGS_DEBUG "-ggdb")
@@ -59,14 +59,18 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-include(PythonUtils) # Must be called before Pybind (third_party) to override its finding mechanism
+if(NOT WIN32)
+    include(PythonUtils) # Must be called before Pybind (third_party) to override its finding mechanism
+endif()
 
 add_subdirectory(third_party)
 add_subdirectory(proto)
 
-python_utils_dump_vars_if_enabled("After Pybind")
-python_utils_check_include_dirs("accepted by pybind")
-python_utils_check_version_is_as_expected()
+if(NOT WIN32)
+    python_utils_dump_vars_if_enabled("After Pybind")
+    python_utils_check_include_dirs("accepted by pybind")
+    python_utils_check_version_is_as_expected()
+endif()
 
 #proto files are generated there so it's necessary to include them
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -59,18 +59,14 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-if(NOT WIN32)
-    include(PythonUtils) # Must be called before Pybind (third_party) to override its finding mechanism
-endif()
+include(PythonUtils) # Must be called before Pybind (third_party) to override its finding mechanism
 
 add_subdirectory(third_party)
 add_subdirectory(proto)
 
-if(NOT WIN32)
-    python_utils_dump_vars_if_enabled("After Pybind")
-    python_utils_check_include_dirs("accepted by pybind")
-    python_utils_check_version_is_as_expected()
-endif()
+python_utils_dump_vars_if_enabled("After Pybind")
+python_utils_check_include_dirs("accepted by pybind")
+python_utils_check_version_is_as_expected()
 
 #proto files are generated there so it's necessary to include them
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,8 +14,8 @@ if(WIN32)
 
     # Guide to MSVC compilation warnings https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199?view=msvc-170
     set(CMAKE_CXX_FLAGS "/DWIN32 /D_WINDOWS /w /GR /bigobj /EHsc /w /wd4244 /wd4267")
-    set(CMAKE_CXX_FLAGS_RELEASE "/MT /DNDEBUG")
-    set(CMAKE_CXX_FLAGS_DEBUG "/MTd /Zi /RTC1")
+    set(CMAKE_CXX_FLAGS_RELEASE "/MD /DNDEBUG")
+    set(CMAKE_CXX_FLAGS_DEBUG "/MDd /Zi /RTC1")
 else()
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")
     set(CMAKE_CXX_FLAGS_DEBUG "-ggdb")

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -10,8 +10,8 @@
       "installDir": "${sourceDir}/out/install"
     },
     {
-      "name": "windows-cl-debug",
-      "displayName": "Windows x64 Debug Cl",
+      "name": "windows-cl-release",
+      "displayName": "Windows x64 Release Cl",
       "description": "Target Windows with the Visual Studio development environment.",
       "inherits": "common",
       "generator": "Ninja",
@@ -24,7 +24,7 @@
         "strategy": "external"
       },
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "cl",
         "CMAKE_CXX_COMPILER": "cl",
         "VCPKG_TARGET_TRIPLET": "x64-windows-static"
@@ -36,14 +36,30 @@
       }
     },
     {
-      "name": "windows-cl-release",
-      "displayName": "Windows x64 Release Cl",
-      "inherits": "windows-cl-debug",
+      "name": "windows-cl-debug-logging",
+      "displayName": "Windows x64 Release with Debug Logging",
+      "description": "A release build, with debug logging enabled. Can be run in a non-debug Python interpreter.",
+      "inherits": "windows-cl-release",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_CXX_FLAGS_RELEASE": "/MT"
+      },
+      "environment": {
+        "DEBUG_BUILD": "TRUE",
+        "ARCTICDB_DEBUG_FIND_PYTHON": "TRUE"
       }
     },
-
+    {
+      "name": "windows-cl-debug",
+      "displayName": "Windows x64 Debug",
+      "description": "A debug build. Extension can only run in a debug Python interpreter build.",
+      "inherits": "windows-cl-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "environment": {
+        "ARCTICDB_DEBUG_FIND_PYTHON": "TRUE"
+      }
+    },
     {
       "name": "linux-debug",
       "displayName": "Linux x64 Debug",
@@ -70,6 +86,7 @@
     }
   ],
   "buildPresets": [
+    {"name": "windows-cl-debug-logging", "configurePreset": "windows-cl-debug-logging", "targets": "arcticdb_ext" },
     {"name": "windows-cl-debug",   "configurePreset": "windows-cl-debug",   "targets": "arcticdb_ext" },
     {"name": "windows-cl-release", "configurePreset": "windows-cl-release", "targets": "arcticdb_ext" },
     {"name": "linux-debug",        "configurePreset": "linux-debug",        "targets": "arcticdb_ext" },

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -27,7 +27,7 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_C_COMPILER": "cl",
         "CMAKE_CXX_COMPILER": "cl",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static"
       },
       "condition": {
         "type": "equals",

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -102,11 +102,8 @@ IF($ENV{DEBUG_BUILD})
     ADD_DEFINITIONS(-DUSE_REMOTERY)
     ADD_DEFINITIONS(-DARCTICDB_TRACK_ALLOCS)
     ADD_DEFINITIONS(-DDEBUG_BUILD)
-    #if(WIN32)
-        # See https://github.com/pybind/pybind11/issues/3403#issuecomment-962878324
-        # Pybind pybind11*Tools.cmake try to add the same when PYTHON_IS_DEBUG, but does not seem to work?
-    #    add_compile_definitions(Py_DEBUG)
-    #endif()
+    # Uncomment to build against debug build of Python
+    #add_compile_definitions(Py_DEBUG)
 ELSE()
     message(STATUS "Not setting debug flags")
 ENDIF()

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -96,14 +96,18 @@ IF("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND NOT DEFINED ENV{DEBUG_BUILD})
     set(ENV{DEBUG_BUILD} TRUE)
 ENDIF()
 
+IF(("${CMAKE_BUILD_TYPE}" STREQUAL "Debug") AND WIN32)
+    # See https://github.com/pybind/pybind11/issues/3403#issuecomment-962878324
+    # Pybind pybind11*Tools.cmake try to add the same when PYTHON_IS_DEBUG, but does not seem to work?
+    add_compile_definitions(Py_DEBUG)
+ENDIF()
+
 IF($ENV{DEBUG_BUILD})
     # Add macros definition here
     message("Setting debug flags")
     ADD_DEFINITIONS(-DUSE_REMOTERY)
     ADD_DEFINITIONS(-DARCTICDB_TRACK_ALLOCS)
     ADD_DEFINITIONS(-DDEBUG_BUILD)
-    # Uncomment to build against debug build of Python
-    #add_compile_definitions(Py_DEBUG)
 ELSE()
     message(STATUS "Not setting debug flags")
 ENDIF()

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -102,11 +102,11 @@ IF($ENV{DEBUG_BUILD})
     ADD_DEFINITIONS(-DUSE_REMOTERY)
     ADD_DEFINITIONS(-DARCTICDB_TRACK_ALLOCS)
     ADD_DEFINITIONS(-DDEBUG_BUILD)
-    if(WIN32)
+    #if(WIN32)
         # See https://github.com/pybind/pybind11/issues/3403#issuecomment-962878324
         # Pybind pybind11*Tools.cmake try to add the same when PYTHON_IS_DEBUG, but does not seem to work?
-        add_compile_definitions(Py_DEBUG)
-    endif()
+    #    add_compile_definitions(Py_DEBUG)
+    #endif()
 ELSE()
     message(STATUS "Not setting debug flags")
 ENDIF()
@@ -509,7 +509,7 @@ if (STRIP_BUILDS)
     set_target_properties(arcticdb_ext PROPERTIES LINK_FLAGS_RELEASE -s)
 endif()
 
-if (HIDE_LINKED_SYMBOLS)
+if (HIDE_LINKED_SYMBOLS AND (NOT WIN32))
     list(APPEND additional_link_flags
             "-Wl,--exclude-libs,ALL"
             "-Wl,--gc-sections"
@@ -546,7 +546,6 @@ if(${TEST})
     message("Python for test compilation:")
     unset(Python_USE_STATIC_LIBS)
     find_package(Python 3 COMPONENTS Interpreter Development REQUIRED)
-    python_utils_dump_vars_if_enabled("Python for tests")
 
     set(unit_test_srcs
             async/test/test_async.cpp

--- a/cpp/arcticdb/processing/operation_dispatch.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch.hpp
@@ -269,7 +269,7 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                             if(func(static_cast<typename comp::right_type>(*ptr++), *typed_value_set))
                                 inserter = pos;
                         }
-                   }
+                    }
                     inserter.flush();
                 } else {
                     util::raise_rte("Cannot check membership of {} in set of {} (possible categorical?)",

--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -12,7 +12,7 @@
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
-#undef GetMessage
+#undef GetMessage  // defined as GetMessageA on Windows
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -12,6 +12,7 @@
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
+#undef GetMessage
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -95,8 +95,6 @@ constexpr ErrorCategory get_error_category(ErrorCode code) {
 
 template<ErrorCategory error_category>
 struct ArcticBaseException : public std::runtime_error {
-    ARCTICDB_MOVE_ONLY_DEFAULT(ArcticBaseException)
-
     explicit ArcticBaseException(const std::string& msg_with_error_code):
         std::runtime_error(msg_with_error_code) {
     }
@@ -104,8 +102,6 @@ struct ArcticBaseException : public std::runtime_error {
 
 template<ErrorCode specific_code>
 struct ArcticSpecificException : public ArcticBaseException<get_error_category(specific_code)> {
-    ARCTICDB_MOVE_ONLY_DEFAULT(ArcticSpecificException)
-
     static constexpr ErrorCategory category = get_error_category(specific_code);
 
     explicit ArcticSpecificException(const std::string& msg_with_error_code) :

--- a/cpp/third_party/vcpkg_overlays/folly/no_exception_tracer.patch
+++ b/cpp/third_party/vcpkg_overlays/folly/no_exception_tracer.patch
@@ -5,8 +5,8 @@ index e0e16df12..a7c412658 100644
 @@ -27,7 +27,6 @@ install(
    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
  )
-
+ 
 -add_subdirectory(experimental/exception_tracer)
  add_subdirectory(logging/example)
-
+ 
  if (PYTHON_EXTENSIONS)

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     msgpack
     psutil
     pyyaml
-    pymongo
     decorator
     prometheus_client
     protobuf


### PR DESCRIPTION
There are still a few failures that I'll look at next, but this gets us as far as having most of the tests pass. It also lets us build the extension with a Python of our choice easily, and debug the extension from Python tests.