### PR TITLE
Fix rebase error from Numeric IsIn work

### DIFF
--- a/cpp/arcticdb/processing/operation_dispatch_binary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.cpp
@@ -29,7 +29,6 @@ VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, EmptyResul
         case OperationType::AND:
             return EmptyResult{};
         case OperationType::OR:
-            return left;
         case OperationType::XOR:
             return left;
         default:
@@ -56,7 +55,6 @@ VariantData binary_boolean(EmptyResult, FullResult, OperationType operation) {
         case OperationType::AND:
             return EmptyResult{};
         case OperationType::OR:
-            return FullResult{};
         case OperationType::XOR:
             return FullResult{};
         default:
@@ -67,7 +65,6 @@ VariantData binary_boolean(EmptyResult, FullResult, OperationType operation) {
 VariantData binary_boolean(FullResult, FullResult, OperationType operation) {
     switch(operation) {
         case OperationType::AND:
-            return FullResult{};
         case OperationType::OR:
             return FullResult{};
         case OperationType::XOR:

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -90,8 +90,8 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                 } else if constexpr (is_numeric_type(ColumnTagType::data_type) && is_numeric_type(ValueSetBaseTypeTag::data_type)) {
                     using ValueSetBaseType =  typename decltype(value_set_desc_tag)::DataTypeTag::raw_type;
 
-                    using comp = typename arcticdb::Comparable<ColumnType, ValueSetBaseType>;
-                    auto typed_value_set = value_set.get_set<typename comp::right_type>();
+                    using WideType = typename type_arithmetic_promoted_type<ColumnType, ValueSetBaseType, std::remove_reference_t<Func>>::type;
+                    auto typed_value_set = value_set.get_set<WideType>();
                     auto column_data = column_with_strings.column_->data();
 
                     util::BitSet::bulk_insert_iterator inserter(*output);
@@ -100,7 +100,7 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                         auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
                         const auto row_count = block.value().row_count();
                         for (auto i = 0u; i < row_count; ++i, ++pos) {
-                            if(func(static_cast<typename comp::right_type>(*ptr++), *typed_value_set))
+                            if(func(static_cast<WideType>(*ptr++), *typed_value_set))
                                 inserter = pos;
                         }
                     }

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -844,6 +844,18 @@ def test_filter_numeric_isnotin(lmdb_version_store, df, vals):
     generic_filter_test(lmdb_version_store, "test_filter_numeric_isnotin", df, q, pandas_query)
 
 
+def test_filter_numeric_isnotin_hashing_overflow(lmdb_version_store):
+    df = pd.DataFrame({"a": [256]})
+    lmdb_version_store.write("test_filter_numeric_isnotin_hashing_overflow", df)
+
+    q = QueryBuilder()
+    isnotin_vals = np.array([], np.uint8)
+    q = q[q["a"].isnotin(isnotin_vals)]
+    result = lmdb_version_store.read("test_filter_numeric_isnotin_hashing_overflow", query_builder=q).data
+
+    assert_frame_equal(df, result)
+
+
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
 @given(df=dataframes_with_names_and_dtypes(["a"], integral_type_strategies()))


### PR DESCRIPTION
Refactor for PR #128 accidentally removed the fix from PR #148 which addressed issues #149 and #150.

This just puts the main fix back, and adds a little more test coverage. Strangely it also fixes compilation on MSVC.

It also fixes a couple of clang warnings for good measure.