### PR TITLE
#184 Apply library options to LMDB too in order to turn on dynamic strings

### DIFF
--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -11,6 +11,26 @@ from arcticdb_ext.storage import Library
 from abc import ABC, abstractmethod
 
 
+def set_library_options(lib_desc: "LibraryConfig", options: LibraryOptions):
+    write_options = lib_desc.version.write_options
+
+    write_options.dynamic_strings = True
+    write_options.recursive_normalizers = True
+    write_options.use_tombstones = True
+    write_options.fast_tombstone_all = True
+    lib_desc.version.symbol_list = True
+
+    write_options.prune_previous_version = False
+    write_options.pickle_on_failure = False
+    write_options.snapshot_dedup = False
+    write_options.delayed_deletes = False
+
+    write_options.dynamic_schema = options.dynamic_schema
+    write_options.de_duplication = options.dedup
+    write_options.segment_row_size = options.rows_per_segment
+    write_options.column_group_size = options.columns_per_segment
+
+
 class ArcticLibraryAdapter(ABC):
     CONFIG_LIBRARY_NAME = "_arctic_cfg"  # TODO: Should come from native module
 

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -13,7 +13,7 @@ from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
 from arcticdb.version_store.helper import add_lmdb_library_to_env
 from arcticdb.config import _DEFAULT_ENV
 from arcticdb.version_store._store import NativeVersionStore
-from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter
+from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter, set_library_options
 from arcticdb_ext.storage import Library
 
 
@@ -56,6 +56,8 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
         env_cfg = EnvironmentConfigsMap()
 
         add_lmdb_library_to_env(env_cfg, lib_name=name, env_name=_DEFAULT_ENV, db_dir=self._path)
+
+        set_library_options(env_cfg.env_by_id[_DEFAULT_ENV].lib_by_path[name], library_options)
 
         lib = NativeVersionStore.create_store_from_config(env_cfg, _DEFAULT_ENV, name)
 

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -14,7 +14,7 @@ from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
 from arcticdb.version_store.helper import add_s3_library_to_env
 from arcticdb.config import _DEFAULT_ENV
 from arcticdb.version_store._store import NativeVersionStore
-from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter
+from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter, set_library_options
 from arcticdb_ext.storage import Library
 from collections import namedtuple
 from dataclasses import dataclass, fields
@@ -22,26 +22,6 @@ from distutils.util import strtobool
 
 PARSED_QUERY = namedtuple("PARSED_QUERY", ["region"])
 USE_AWS_CRED_PROVIDERS_TOKEN = "_RBAC_"
-
-
-def set_library_options(lib_desc: "LibraryConfig", options: LibraryOptions):
-    write_options = lib_desc.version.write_options
-
-    write_options.dynamic_strings = True
-    write_options.recursive_normalizers = True
-    write_options.use_tombstones = True
-    write_options.fast_tombstone_all = True
-    lib_desc.version.symbol_list = True
-
-    write_options.prune_previous_version = False
-    write_options.pickle_on_failure = False
-    write_options.snapshot_dedup = False
-    write_options.delayed_deletes = False
-
-    write_options.dynamic_schema = options.dynamic_schema
-    write_options.de_duplication = options.dedup
-    write_options.segment_row_size = options.rows_per_segment
-    write_options.column_group_size = options.columns_per_segment
 
 
 @dataclass


### PR DESCRIPTION
It turns out that library options were not being applied correctly to LMDB at all, so this applies all of them.

This also takes the opportunity to run many of the `test_arctic.py` tests against the LMDB backend too, whose test coverage was pretty non-existent. The LMDB backed tests execute extremely quickly so build time is not a concern.