### PR TITLE
Change msgpack's default object size to maximum

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1177,6 +1177,7 @@ _MAX_USER_DEFINED_META = MsgPackNormalizer.MMAP_DEFAULT_SIZE
 
 def _init_msgpack_metadata():
     cfg = VersionStoreConfig.MsgPack()
+    cfg.max_blob_size = _MAX_USER_DEFINED_META
     return MsgPackNormalizer(cfg)
 
 

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -807,9 +807,8 @@ class MsgPackNormalizer(Normalizer):
     Fall back plan for the time being to store arbitrary data
     """
 
-    MMAP_DEFAULT_SIZE = 1 << 32  # Allow up to 4 gib pickles in memory, most of these compress fairly well.
-    # Allow 4gb extension and bin sizes in msgpack by default.
-    MSG_PACK_MAX_SIZE = 1 << 32
+    MMAP_DEFAULT_SIZE = (1 << 32) - 1  # Maximum object size allowed by msgpack
+    MSG_PACK_MAX_SIZE = (1 << 32) - 1
 
     def __init__(self, cfg=None):
         self._size = MsgPackNormalizer.MMAP_DEFAULT_SIZE if cfg is None else cfg.max_blob_size
@@ -1173,12 +1172,11 @@ _NORMALIZER = CompositeNormalizer()
 normalize = _NORMALIZER.normalize
 denormalize = _NORMALIZER.denormalize
 
-_MAX_USER_DEFINED_META = 16 << 20
+_MAX_USER_DEFINED_META = MsgPackNormalizer.MMAP_DEFAULT_SIZE
 
 
 def _init_msgpack_metadata():
     cfg = VersionStoreConfig.MsgPack()
-    cfg.max_blob_size = _MAX_USER_DEFINED_META
     return MsgPackNormalizer(cfg)
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -50,7 +50,6 @@ configure_test_logger()
 
 BUCKET_ID = 0
 
-
 def run_server(port):
     werkzeug.run_simple(
         "0.0.0.0", port, DomainDispatcherApplication(create_backend_app, service="s3"), threaded=True, ssl_context=None

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -43,12 +43,15 @@ from arcticdb.config import Defaults
 from arcticdb.util.test import configure_test_logger, apply_lib_cfg
 from arcticdb.version_store.helper import ArcticMemoryConfig
 from arcticdb.version_store import NativeVersionStore
+from arcticdb.version_store._normalization import MsgPackNormalizer
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap  # Importing from arcticdb dynamically loads arcticc.pb2
 from arcticc.pb2.lmdb_storage_pb2 import Config as LmdbConfig
 
 configure_test_logger()
 
 BUCKET_ID = 0
+# Use a smaller memory mapped limit for all tests, or will hit the memory size limit in github action
+MsgPackNormalizer.MMAP_DEFAULT_SIZE = 20 * (1 << 20)
 
 def run_server(port):
     werkzeug.run_simple(

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -68,10 +68,11 @@ def test_user_meta_and_msg_pack(d):
 
 def test_fails_humongous_meta():
     with pytest.raises(ArcticNativeNotYetImplemented):
-        from arcticdb.version_store._normalization import _MAX_USER_DEFINED_META as MAX
-
-        meta = {"a": "x" * (MAX)}
-        normalize_metadata(meta)
+        import arcticdb.version_store._normalization as _normalization
+        obj_size = 20 * (1 << 20)
+        _normalization._MAX_USER_DEFINED_META = obj_size
+        meta = {"a": "x" * (obj_size)}
+        _normalization.normalize_metadata(meta)
 
 
 def test_fails_humongous_data():

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -43,7 +43,7 @@ params = {
     "pd_ts": {"a": pd.Timestamp("2018-01-12 09:15"), "b": pd.Timestamp("2017-01-31", tz="America/New_York")},
 }
 
-# Use a smaller memory mapped limit for this test, no point memor mapping 2g
+# Use a smaller memory mapped limit for all tests, or will hit the memory size limit in github action
 MsgPackNormalizer.MMAP_DEFAULT_SIZE = 20 * (1 << 20)
 test_msgpack_normalizer = MsgPackNormalizer()
 
@@ -77,7 +77,7 @@ def test_fails_humongous_meta():
 def test_fails_humongous_data():
     norm = test_msgpack_normalizer
     with pytest.raises(ArcticNativeNotYetImplemented):
-        big = [1] * (norm.MMAP_DEFAULT_SIZE + 1)
+        big = [1] * norm.MMAP_DEFAULT_SIZE
         norm.normalize(big)
 
 


### PR DESCRIPTION
Set msgpack's default object size to 2^32 - 1 bytes (maximum size supported by msgpack)