### PR TITLE
Do not iterate on failure, rely on version ref keys

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1192,7 +1192,7 @@ class NativeVersionStore:
     def _get_version_query(self, as_of: VersionQueryInput, **kwargs):
         version_query = _PythonVersionStoreVersionQuery()
         version_query.set_skip_compat(_assume_true("skip_compat", kwargs))
-        version_query.set_iterate_on_failure(_assume_true("iterate_on_failure", kwargs))
+        version_query.set_iterate_on_failure(_assume_false("iterate_on_failure", kwargs))
 
         if isinstance(as_of, six.string_types):
             version_query.set_snap_name(as_of)
@@ -1593,7 +1593,7 @@ class NativeVersionStore:
         symbol: Optional[str] = None,
         snapshot: Optional[str] = None,
         latest_only: Optional[bool] = False,
-        iterate_on_failure: Optional[bool] = True,
+        iterate_on_failure: Optional[bool] = False,
         skip_snapshots: Optional[bool] = False,
     ) -> List[Dict]:
         """

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1167,7 +1167,7 @@ class Library:
             symbol=symbol,
             snapshot=snapshot,
             latest_only=latest_only,
-            iterate_on_failure=True,
+            iterate_on_failure=False,
             skip_snapshots=skip_snapshots,
         )
         return {


### PR DESCRIPTION
Prevents expensive and unnecessary IO when eg reading a key that does not exist.

Forward-port of internal commit 487e39e2bad.