### PR TITLE
getNamedPrefix

### DIFF
--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -66,7 +66,11 @@ public:
                 ARCTICDB_SAMPLE_THREAD();
               func();
             });
-  }
+    }
+
+    virtual const std::string& getNamePrefix() const override{
+        return named_factory_.getNamePrefix();
+    }
 
 private:
     folly::NamedThreadFactory named_factory_;


### PR DESCRIPTION
new folly versions need the `getNamedPrefix` in  any class deriving from `folly::ThreadFactory`