### PR TITLE
Ensure 4GB - 1byte can be used in msgpack normalization

### DIFF
--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -361,6 +361,8 @@ def apply_lib_cfg(lib_cfg: LibraryDescriptor, cfg_dict: Mapping[str, Any]):
             setattr(write_opts, k, v)
         elif k in VersionStoreConfig.DESCRIPTOR.fields_by_name:
             setattr(lib_cfg.version, k, v)
+        elif k in VersionStoreConfig.MsgPack.DESCRIPTOR.fields_by_name:
+            setattr(lib_cfg.version.msg_pack, k, v)
         elif k in LibraryDescriptor.DESCRIPTOR.fields_by_name:
             setattr(lib_cfg, k, v)
         else:

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -820,9 +820,10 @@ class MsgPackNormalizer(Normalizer):
     Fall back plan for the time being to store arbitrary data
     """
 
-    MMAP_DEFAULT_SIZE = 1 << 32  # Allow up to 4 gib pickles in memory, most of these compress fairly well.
-    # Allow 4gb extension and bin sizes in msgpack by default.
-    MSG_PACK_MAX_SIZE = 1 << 32
+    MMAP_DEFAULT_SIZE = (1 << 32) + 1024  # Allow up to 4 gib pickles in msgpack by default, most of these compress fairly well.
+    # msgpack checks whether the size of pickled data within 1 << 32 - 1 byte only
+    # Extra memory is needed in mmap for msgpack's overhead
+    MSG_PACK_MAX_SIZE = (1 << 32) + 1024
 
     def __init__(self, cfg=None):
         self._size = MsgPackNormalizer.MMAP_DEFAULT_SIZE if cfg is None else cfg.max_blob_size

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -820,10 +820,10 @@ class MsgPackNormalizer(Normalizer):
     Fall back plan for the time being to store arbitrary data
     """
 
-    MMAP_DEFAULT_SIZE = (1 << 32) + 1024  # Allow up to 4 gib pickles in msgpack by default, most of these compress fairly well.
+    MSG_PACK_MAX_SIZE = (1 << 32) + 1024
+    MMAP_DEFAULT_SIZE = MSG_PACK_MAX_SIZE  # Allow up to 4 gib pickles in msgpack by default, most of these compress fairly well.
     # msgpack checks whether the size of pickled data within 1 << 32 - 1 byte only
     # Extra memory is needed in mmap for msgpack's overhead
-    MSG_PACK_MAX_SIZE = (1 << 32) + 1024
 
     def __init__(self, cfg=None):
         self._size = MsgPackNormalizer.MMAP_DEFAULT_SIZE if cfg is None else cfg.max_blob_size

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -32,10 +32,7 @@ from typing import Optional, Any, Dict
 from pytest_server_fixtures.base import get_ephemeral_port
 
 from arcticdb.arctic import Arctic
-from arcticdb.version_store.helper import (
-    create_test_lmdb_cfg,
-    create_test_s3_cfg,
-)
+from arcticdb.version_store.helper import create_test_lmdb_cfg, create_test_s3_cfg
 from arcticdb.config import Defaults
 from arcticdb.util.test import configure_test_logger, apply_lib_cfg
 from arcticdb.version_store.helper import ArcticMemoryConfig
@@ -46,8 +43,9 @@ from arcticdb_ext.storage import KeyType
 configure_test_logger()
 
 BUCKET_ID = 0
-# Use a smaller memory mapped limit for this test, no point memor mapping 2g
+# Use a smaller memory mapped limit for all tests
 MsgPackNormalizer.MMAP_DEFAULT_SIZE = 20 * (1 << 20)
+
 
 def run_server(port):
     werkzeug.run_simple(
@@ -264,7 +262,7 @@ def lmdb_version_store_prune_previous(version_store_factory):
 
 @pytest.fixture
 def lmdb_version_store_big_map(version_store_factory):
-    return version_store_factory(lmdb_config={"map_size": 2**30})
+    return version_store_factory(lmdb_config={"map_size": 2 ** 30})
 
 
 @pytest.fixture
@@ -291,10 +289,6 @@ def lmdb_version_store_tombstones_no_symbol_list(version_store_factory):
 def lmdb_version_store_allows_pickling(version_store_factory, lib_name):
     return version_store_factory(use_norm_failure_handler_known_types=True, dynamic_strings=True)
 
-@pytest.fixture
-@lmdb_version_store_cleanup
-def lmdb_version_store_allows_pickling_max_msg_pack_size(version_store_factory, lib_name):
-    return version_store_factory(use_norm_failure_handler_known_types=True, dynamic_strings=True, max_blob_size=(1 << 32) + 1024) #max size for msgpack obj size
 
 @pytest.fixture
 def lmdb_version_store_no_symbol_list(version_store_factory):
@@ -323,12 +317,12 @@ def lmdb_version_store_ignore_order(version_store_factory):
 
 @pytest.fixture
 def lmdb_version_store_small_segment(version_store_factory):
-    return version_store_factory(column_group_size=1000, segment_row_size=1000, lmdb_config={"map_size": 2**30})
+    return version_store_factory(column_group_size=1000, segment_row_size=1000, lmdb_config={"map_size": 2 ** 30})
 
 
 @pytest.fixture
 def lmdb_version_store_tiny_segment(version_store_factory):
-    return version_store_factory(column_group_size=2, segment_row_size=2, lmdb_config={"map_size": 2**30})
+    return version_store_factory(column_group_size=2, segment_row_size=2, lmdb_config={"map_size": 2 ** 30})
 
 
 @pytest.fixture

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -46,10 +46,8 @@ from arcticdb_ext.storage import KeyType
 configure_test_logger()
 
 BUCKET_ID = 0
-
-# Use a smaller memory mapped limit for all tests
+# Use a smaller memory mapped limit for this test, no point memor mapping 2g
 MsgPackNormalizer.MMAP_DEFAULT_SIZE = 20 * (1 << 20)
-
 
 def run_server(port):
     werkzeug.run_simple(
@@ -293,6 +291,10 @@ def lmdb_version_store_tombstones_no_symbol_list(version_store_factory):
 def lmdb_version_store_allows_pickling(version_store_factory, lib_name):
     return version_store_factory(use_norm_failure_handler_known_types=True, dynamic_strings=True)
 
+@pytest.fixture
+@lmdb_version_store_cleanup
+def lmdb_version_store_allows_pickling_max_msg_pack_size(version_store_factory, lib_name):
+    return version_store_factory(use_norm_failure_handler_known_types=True, dynamic_strings=True, max_blob_size=(1 << 32) + 1024) #max size for msgpack obj size
 
 @pytest.fixture
 def lmdb_version_store_no_symbol_list(version_store_factory):

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -437,3 +437,9 @@ def test_columns_names_series_dynamic(lmdb_version_store_dynamic_schema, sym):
 
     lmdb_version_store_dynamic_schema.write(sym + "dynamic_schema", date_series)
     assert_series_equal(lmdb_version_store_dynamic_schema.read(sym + "dynamic_schema").data, date_series)
+        
+def test_write_max_size_pickled_data(lmdb_version_store_allows_pickling_max_msg_pack_size):
+    symbol = "test_write_max_size_pickled_data"
+    data = bytearray(b'\x24' * ((1 << 32) - 1))
+    lmdb_version_store_allows_pickling_max_msg_pack_size.write(symbol, data, pickle_on_failure=True)
+    assert lmdb_version_store_allows_pickling_max_msg_pack_size.read(symbol).data == data

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -437,9 +437,3 @@ def test_columns_names_series_dynamic(lmdb_version_store_dynamic_schema, sym):
 
     lmdb_version_store_dynamic_schema.write(sym + "dynamic_schema", date_series)
     assert_series_equal(lmdb_version_store_dynamic_schema.read(sym + "dynamic_schema").data, date_series)
-        
-def test_write_max_size_pickled_data(lmdb_version_store_allows_pickling_max_msg_pack_size):
-    symbol = "test_write_max_size_pickled_data"
-    data = bytearray(b'\x24' * ((1 << 32) - 1))
-    lmdb_version_store_allows_pickling_max_msg_pack_size.write(symbol, data, pickle_on_failure=True)
-    assert lmdb_version_store_allows_pickling_max_msg_pack_size.read(symbol).data == data


### PR DESCRIPTION
Related test added and minor fix to ensure 4GB - 1byte can be used in msgpack normalization