### PR TITLE
inline error codec data

### DIFF
--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -75,9 +75,9 @@ struct ErrorCodeData {
 };
 
 template<ErrorCode code>
-constexpr ErrorCodeData error_code_data{};
+inline constexpr ErrorCodeData error_code_data{};
 
-#define ERROR_CODE(code, Name, ...) template<> constexpr ErrorCodeData error_code_data<ErrorCode::Name> \
+#define ERROR_CODE(code, Name, ...) template<> inline constexpr ErrorCodeData error_code_data<ErrorCode::Name> \
     { #Name, "E" #code };
 ARCTIC_ERROR_CODES
 #undef ERROR_CODE


### PR DESCRIPTION

Making ErrorCodecData inline, otherwise I get a lot of duplicated symbols errors
(compiling with clang on macos)