### PR TITLE
DRAFT: Add folly support to read batch to enable per symbol parallelism

### DIFF
--- a/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
+++ b/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
@@ -218,7 +218,7 @@ TEST_F(IngestionStressStore, ScalarIntDynamicSchema) {
     read_options.set_incompletes(true);
     ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_internal(symbol, read_query, read_options);
+    auto read_result = test_store_->read_dataframe_internal(symbol, read_query, read_options).get();
 }
 
 TEST_F(IngestionStressStore, DynamicSchemaWithStrings) {

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -66,7 +66,7 @@ void mark_index_slices(
     bool dynamic_schema,
     bool column_groups);
 
-folly::Future<std::vector<VariantKey>> fetch_data(
+folly::Future<std::vector<VariantKey>> async_fetch_data(
     const SegmentInMemory& frame,
     const std::shared_ptr<PipelineContext> &context,
     const std::shared_ptr<stream::StreamSource>& ssource,
@@ -89,7 +89,7 @@ void decode_into_frame_dynamic(
 );
 
 void reduce_and_fix_columns(
-        std::shared_ptr<PipelineContext> &context,
+        std::shared_ptr<PipelineContext> context,
         SegmentInMemory &frame,
         const ReadOptions& read_options
 );

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -38,12 +38,12 @@ namespace arcticdb {
             return false;
         }
 
-        std::vector<Composite<ProcessingSegment>> batch_read_uncompressed(
+        folly::Future<std::vector<Composite<ProcessingSegment>>> batch_read_uncompressed(
                 std::vector<Composite<pipelines::SliceAndKey>> &&,
                 const std::shared_ptr<std::vector<Clause>>&,
-                const StreamDescriptor&,
-                const std::shared_ptr<std::unordered_set<std::string>>&,
-                const BatchReadArgs &) override {
+                const StreamDescriptor,
+                const std::shared_ptr<std::unordered_set<std::string>>,
+                const BatchReadArgs) override {
             throw std::runtime_error("Not implemented for tests");
         }
 
@@ -275,9 +275,9 @@ namespace arcticdb {
             throw std::runtime_error("Not implemented");
         }
 
-        std::vector<VariantKey> batch_read_compressed(
+        folly::Future<std::vector<VariantKey>> batch_read_compressed(
                 std::vector<entity::VariantKey> &&keys,
-                std::vector<ReadContinuation> &&,
+                std::vector<std::shared_ptr<ReadContinuation>> &,
                 const BatchReadArgs &
         ) override {
             std::lock_guard lock{mutex_};

--- a/cpp/arcticdb/storage/test/test_memory_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_memory_storage.cpp
@@ -9,7 +9,7 @@
 #include <arcticdb/storage/memory/memory_storage.hpp>
 #include <arcticdb/util/test/generators.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
-
+#include <folly/SpinLock.h>
 
 TEST(InMemory, ReadTwice) {
     using namespace arcticdb;
@@ -28,6 +28,6 @@ TEST(InMemory, ReadTwice) {
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result1 = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    auto read_result2 = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    auto read_result1 = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).get();
+    auto read_result2 = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).get();
 }

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -54,9 +54,9 @@ struct StreamSource {
 
     using ReadContinuation = folly::Function<entity::VariantKey(storage::KeySegmentPair &&)>;
 
-    virtual std::vector<entity::VariantKey> batch_read_compressed(
+    virtual folly::Future<std::vector<entity::VariantKey>> batch_read_compressed(
         std::vector<entity::VariantKey> &&keys,
-        std::vector<ReadContinuation> &&continuations,
+        std::vector<std::shared_ptr<ReadContinuation>> &continuations,
         const BatchReadArgs &args) = 0;
 
     /**
@@ -70,12 +70,12 @@ struct StreamSource {
 
     using DecodeContinuation = folly::Function<folly::Unit(SegmentInMemory &&)>;
 
-    virtual std::vector<Composite<ProcessingSegment>> batch_read_uncompressed(
+    virtual folly::Future<std::vector<Composite<ProcessingSegment>>> batch_read_uncompressed(
         std::vector<Composite<pipelines::SliceAndKey>> &&keys,
         const std::shared_ptr<std::vector<Clause>>& query,
-        const StreamDescriptor& desc,
-        const std::shared_ptr<std::unordered_set<std::string>>& filter_columns,
-        const BatchReadArgs &args) = 0;
+        const StreamDescriptor desc,
+        const std::shared_ptr<std::unordered_set<std::string>> filter_columns,
+        const BatchReadArgs args) = 0;
 
     virtual folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(
         const entity::VariantKey &key,

--- a/cpp/arcticdb/stream/test/mock_stores.hpp
+++ b/cpp/arcticdb/stream/test/mock_stores.hpp
@@ -120,7 +120,7 @@ class NullStore :
         throw std::runtime_error("Not implemented for tests");
     }
 
-    std::vector<folly::Future<storage::KeySegmentPair>>
+    std::vector<folly::SemiFuture<storage::KeySegmentPair>>
     batch_read_compressed(std::vector<entity::VariantKey> &&, const BatchReadArgs &) override {
         throw std::runtime_error("Not implemented for tests");
     }
@@ -131,7 +131,7 @@ class NullStore :
 
         std::vector<folly::Future<VariantKey>>
     batch_read_compressed(
-        std::vector<entity::VariantKey> &&, std::vector<ReadContinuation> &&,
+        std::vector<entity::VariantKey> &&, std::vector<std::shared_ptr<ReadContinuation>> &,
         const BatchReadArgs &
     ) override {
         throw std::runtime_error("Not implemented for tests");

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -19,8 +19,8 @@
 #include <filesystem>
 #include <chrono>
 #include <thread>
-#include <folly/futures/Barrier.h>
 #include <arcticdb/util/test/gtest_utils.hpp>
+#include <folly/SpinLock.h>
 
 struct VersionStoreTest : arcticdb::TestStore {
 protected:
@@ -445,7 +445,7 @@ TEST(VersionStore, UpdateWithin) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).get();
     const auto& seg = read_result.second.frame_;
 
     for(auto i = 0u; i < num_rows; ++i) {
@@ -487,7 +487,7 @@ TEST(VersionStore, UpdateBefore) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).get();
     const auto& seg = read_result.second.frame_;
 
     for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
@@ -529,7 +529,7 @@ TEST(VersionStore, UpdateAfter) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).get();
     const auto& seg = read_result.second.frame_;
 
     for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
@@ -573,7 +573,7 @@ TEST(VersionStore, UpdateIntersectBefore) {
 
     ReadQuery read_query;
     auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).get();
     const auto &seg = read_result.second.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
@@ -617,7 +617,7 @@ TEST(VersionStore, UpdateIntersectAfter) {
 
     ReadQuery read_query;
     auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).get();
     const auto &seg = read_result.second.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
@@ -670,7 +670,7 @@ TEST(VersionStore, UpdateWithinSchemaChange) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options).get();
     const auto &seg = read_result.second.frame_;
 
     for (auto i = 0u;i < num_rows; ++i) {
@@ -731,7 +731,7 @@ TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options).get();
     const auto &seg = read_result.second.frame_;
 
     for (auto i = 0u;i < num_rows; ++i) {

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -99,16 +99,15 @@ ColumnStats get_column_stats_info_impl(
     const std::shared_ptr<Store>& store,
     const VersionedItem& versioned_item);
 
-FrameAndDescriptor read_multi_key(
+folly::Future<FrameAndDescriptor> read_multi_key(
     const std::shared_ptr<Store>& store,
     const SegmentInMemory& index_key_seg);
 
-FrameAndDescriptor read_dataframe_impl(
+folly::Future<FrameAndDescriptor> read_dataframe_impl(
     const std::shared_ptr<Store>& store,
     const std::variant<VersionedItem, StreamId>& version_info,
     ReadQuery & read_query,
-    const ReadOptions& read_options
-    );
+    const ReadOptions& read_options);
 
 FrameAndDescriptor read_index_impl(
     const std::shared_ptr<Store>& store,

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -819,7 +819,8 @@ ReadResult PythonVersionStore::read_dataframe_version(
     const VersionQuery& version_query,
     ReadQuery& read_query,
     const ReadOptions& read_options) {
-    auto [versioned_item, frame_and_descriptor] =  read_dataframe_version_internal(stream_id, version_query, read_query, read_options);
+    auto read_dataframe_future = read_dataframe_version_internal(stream_id, version_query, read_query, read_options);
+    auto [versioned_item, frame_and_descriptor] = std::move(read_dataframe_future).get();
     return create_python_read_result(versioned_item, std::move(frame_and_descriptor));
 }
 

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -17,11 +17,13 @@
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
+#include <folly/SpinLock.h>
 
 namespace arcticdb::version_store {
 
 using namespace arcticdb::entity;
 using namespace arcticdb::pipelines;
+using LockType = folly::SpinLock;
 
 class VersionedEngine {
 
@@ -86,12 +88,12 @@ public:
         const VersionQuery& version_query
         ) = 0;
 
-    virtual FrameAndDescriptor read_dataframe_internal(
+    virtual folly::Future<FrameAndDescriptor> read_dataframe_internal(
         const std::variant<VersionedItem, StreamId>& identifier,
         ReadQuery& read_query,
         const ReadOptions& read_options) = 0;
 
-    virtual std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(
+    virtual folly::Future<std::pair<VersionedItem, FrameAndDescriptor>> read_dataframe_version_internal(
         const StreamId &stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,


### PR DESCRIPTION
This pull request introduces per-symbol parallelism for the read_batch method, which requires significant implementation changes using the Folly Futures API. In addition, per-slice parallelism is already achieved within the independent read methods also by using Folly Futures. The way Folly Futures work requires creating a chain of futures for each independent read, which ultimately converges into a single future containing all the individual reads. This can be visualized as a tree with each individual read representing a branch that has its own independent per-slice read operations, which are also futures. To ensure proper functioning for all read flows, including multi-key, date-ranges, and queries, it's important to avoid intermediate .get() calls from the futures of all these flows. Instead, we must call a SINGLE .get() at the end of the entire futures chain, when they converge; otherwise, the system will deadlock. This change has many implications, which are reflected in this pull request:

- First, all async intermediate methods used by the read must return a future instead of the data itself obtained by calling .get(). This requires significant changes as we currently create ad-hoc methods to implement batching for the IO threads performing independent slice reads. These methods necessitate calling the .get() function, which is precisely what we must remove. The solution we propose is to use the folly::window mechanism, which enables us to do the same without retrieving the data at any time and obtain a single future that converges all the per-slice independent IO reads.

- For the query methods, which use read_and_process method. Inside this method we need to apply each independent task (clause_ of the read query) in a pipelined way. Currently, these tasks are calling the .get method at the end of each, in order to retrieve the actual data and send it to the next task. As stated, we need to remove all these intermediate get() method calls. Instead, we need to have a chain of futures spanning from the first to the last task.

- Another common problem is that, once a task is scheduled to be executed in the future, we cannot capture by reference the variables that are declared in between, since at the time when the future tasks are executed, these captured variables might have already been destroyed (we would have already left the function where these variables were declared). As a solution, we need to capture them by copy or convert them into smart pointers and pass them, depending on the specific case.

- In addition, we need to use the batch_get_versions function at the beginning of each future chain to obtain all the versions for each symbol-version query pair.