### PR TITLE
Add compat exception type to bridge to the original, internal, version of this codebase and also add new universal base exception type

### DIFF
--- a/cpp/arcticdb/column_store/test/test_memory_segment.cpp
+++ b/cpp/arcticdb/column_store/test/test_memory_segment.cpp
@@ -21,7 +21,7 @@ TEST(MemSegment, Empty) {
     SegmentInMemory s;
     ASSERT_EQ(s.row_count(), 0);
     ASSERT_EQ(s.num_columns(), 0);
-    ASSERT_THROW(s.column(12), ArcticBaseException<ErrorCategory::INTERNAL>);
+    ASSERT_THROW(s.column(12), ArcticCategorizedException<ErrorCategory::INTERNAL>);
     //  ASSERT_THROW(s.scalar_at<uint16_t>(3, 6), std::invalid_argument);
     ASSERT_NO_THROW(s.clear());
     // Even though this index is out of bounds it will not throw as there are no columns to visit

--- a/cpp/arcticdb/python/normalization_checks.hpp
+++ b/cpp/arcticdb/python/normalization_checks.hpp
@@ -11,7 +11,7 @@
 
 namespace arcticdb {
 
-using NormalizationException = ArcticBaseException<ErrorCategory::NORMALIZATION>;
+using NormalizationException = ArcticCategorizedException<ErrorCategory::NORMALIZATION>;
 
 namespace pipelines {
 struct InputTensorFrame;

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -212,13 +212,13 @@ void register_error_code_ecosystem(py::module& m, py::exception<arcticdb::Arctic
         }
     });
 
-    py::register_exception<NoSuchVersionException>(m, "NoSuchVersionException");
     py::register_exception<NormalizationException>(m, "NormalizationException", compat_exception.ptr());
     py::register_exception<MissingDataException>(m, "MissingDataException", compat_exception.ptr());
     py::register_exception<SchemaException>(m, "SchemaException", compat_exception.ptr());
     py::register_exception<StorageException>(m, "StorageException", compat_exception.ptr());
-    py::register_exception<SortingException>(m, "SortingException", compat_exception.ptr());
-    py::register_exception<UnsortedDataException>(m, "UnsortedDataException", compat_exception.ptr());
+    auto sorting_exception =
+            py::register_exception<SortingException>(m, "SortingException", compat_exception.ptr());
+    py::register_exception<UnsortedDataException>(m, "UnsortedDataException", sorting_exception.ptr());
 }
 
 void reinit_scheduler() {

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<LibraryIndex> create_library_index(const std::string &environmen
     return std::make_shared<LibraryIndex>(EnvironmentName{environment_name}, mem_resolver);
 }
 
-void register_bindings(py::module &m) {
+void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception) {
     auto storage = m.def_submodule("storage", "Segment storage implementation apis");
 
     py::enum_<KeyType>(storage, "KeyType")
@@ -152,9 +152,9 @@ void register_bindings(py::module &m) {
         })
         ;
 
-    py::register_exception<DuplicateKeyException>(storage, "DuplicateKeyException");
-    py::register_exception<NoDataFoundException>(storage, "NoDataFoundException");
-    py::register_exception<PermissionException>(storage, "PermissionException");
+    py::register_exception<DuplicateKeyException>(storage, "DuplicateKeyException", base_exception.ptr());
+    py::register_exception<NoDataFoundException>(storage, "NoDataFoundException", base_exception.ptr());
+    py::register_exception<PermissionException>(storage, "PermissionException", base_exception.ptr());
 }
 
 } // namespace arcticdb::storage::apy

--- a/cpp/arcticdb/storage/python_bindings.hpp
+++ b/cpp/arcticdb/storage/python_bindings.hpp
@@ -12,13 +12,12 @@
 
 #include <arcticdb/entity/key.hpp>
 #include <arcticdb/storage/open_mode.hpp>
+#include <arcticdb/util/error_code.hpp>
 
 namespace arcticdb::storage::apy {
 
 namespace py = pybind11;
 
-void register_bindings(py::module &m);
+void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception);
 
 } // namespace arcticdb
-
-

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -40,19 +40,19 @@ private:
     VariantKey key_;
 };
 
-class NoDataFoundException : public ArcticBaseException<ErrorCategory::MISSING_DATA> {
+class NoDataFoundException : public ArcticCategorizedException<ErrorCategory::MISSING_DATA> {
 public:
     explicit NoDataFoundException(VariantId key) :
-        ArcticBaseException<ErrorCategory::MISSING_DATA>(std::visit([](const auto &key) { return fmt::format("{}", key); }, key)),
-        key_(key){
+            ArcticCategorizedException<ErrorCategory::MISSING_DATA>(std::visit([](const auto &key) { return fmt::format("{}", key); }, key)),
+            key_(key){
     }
 
     explicit NoDataFoundException(const std::string& msg) :
-        ArcticBaseException<ErrorCategory::MISSING_DATA>(msg) {
+            ArcticCategorizedException<ErrorCategory::MISSING_DATA>(msg) {
     }
 
     explicit NoDataFoundException(const char* msg) :
-        ArcticBaseException<ErrorCategory::MISSING_DATA>(std::string(msg)) {
+            ArcticCategorizedException<ErrorCategory::MISSING_DATA>(std::string(msg)) {
     }
 
     [[nodiscard]] const VariantId &key() const {

--- a/cpp/arcticdb/stream/row_builder.hpp
+++ b/cpp/arcticdb/stream/row_builder.hpp
@@ -211,13 +211,13 @@ class RowBuilder {
                     aggregator_.set_scalar(pos, conv_val);
                     nbytes_ += sizeof(RawType);
                 } else {
-                    throw ArcticBaseException<ErrorCategory::INTERNAL>(fmt::format(
+                    throw ArcticCategorizedException<ErrorCategory::INTERNAL>(fmt::format(
                         "Expected type_descriptor={}, type={}; actual value={}, type {}",
                         data_type_from_proto(descriptor().fields(pos).type_desc()), typeid(conv_val).name(),
                         val, typeid(val).name()));
                 }
             } else {
-                throw ArcticBaseException<ErrorCategory::INTERNAL>(fmt::format(
+                throw ArcticCategorizedException<ErrorCategory::INTERNAL>(fmt::format(
                     "Expected type_descriptor={}; actual scalar cpp_type={}, value={}",
                     TypeDescriptor{tag}, typeid(val).name(), val));
             }

--- a/cpp/arcticdb/stream/test/test_row_builder.cpp
+++ b/cpp/arcticdb/stream/test/test_row_builder.cpp
@@ -62,7 +62,7 @@ TEST(RowBuilder, Basic) {
 //    ASSERT_EQ(2, agg.row_count());
 
     // monotonic index
-    ASSERT_THROW(rb.start_row(timestamp{1}), ArcticBaseException<ErrorCategory::INTERNAL>);
+    ASSERT_THROW(rb.start_row(timestamp{1}), ArcticCategorizedException<ErrorCategory::INTERNAL>);
 
     // all fields required by schema
     rb.start_row(timestamp{3});
@@ -74,7 +74,7 @@ TEST(RowBuilder, Basic) {
     ASSERT_EQ(agg.row_count(), 0);
 
     // index survives commit_row
-    ASSERT_THROW(rb.start_row(timestamp{1}), ArcticBaseException<ErrorCategory::INTERNAL>);
+    ASSERT_THROW(rb.start_row(timestamp{1}), ArcticCategorizedException<ErrorCategory::INTERNAL>);
 
     // can still build using a row builder
 

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -14,7 +14,6 @@
 #include <folly/concurrency/ConcurrentHashMap.h>
 #include <arcticdb/util/slab_allocator.hpp>
 #include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/util/trace.hpp>
 #include <folly/ThreadCachedInt.h>
 #include <arcticdb/util/timer.hpp>
 
@@ -137,7 +136,6 @@ struct TracingData {
         total_allocs_calls_++;
         if (size != page_size) {
             total_irregular_allocs_++;
-//            ARCTICDB_TRACE(log::codec(), "Stack during irregular alloc: {}", get_stack());
         }
         ARCTICDB_DEBUG(log::codec(), "Allocated {} to {}:{}, total allocation size {}, total irregular allocs {}/{}",
                             util::MemBytes{size},

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -157,7 +157,7 @@ struct Buffer : public BaseBuffer<Buffer, true> {
                                           bytes_offset + required_bytes
             );
             ARCTICDB_TRACE(log::memory(), err);
-            throw ArcticBaseException<ErrorCategory::INTERNAL>(err);
+            throw ArcticCategorizedException<ErrorCategory::INTERNAL>(err);
         }
 
         return reinterpret_cast<T*>(ptr_ + bytes_offset);

--- a/cpp/arcticdb/util/cursor.hpp
+++ b/cpp/arcticdb/util/cursor.hpp
@@ -12,7 +12,6 @@
 #include <memory>
 #include <vector>
 
-#include <arcticdb/util/trace.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/entity/types.hpp>

--- a/cpp/arcticdb/util/test/test_cursor.cpp
+++ b/cpp/arcticdb/util/test/test_cursor.cpp
@@ -24,11 +24,11 @@ TEST(Cursor, Behaviour) {
     ASSERT_EQ(b.size<uint8_t>(), 100);
     // ASSERT_THROW(b.ensure_bytes( 20), std::invalid_argument); // uncommitted data
     ASSERT_NO_THROW(b.commit());
-    ASSERT_THROW(b.commit(), ArcticBaseException<ErrorCategory::INTERNAL>); //commit called twice
+    ASSERT_THROW(b.commit(), ArcticCategorizedException<ErrorCategory::INTERNAL>); //commit called twice
     ASSERT_EQ(b.size<uint8_t>(), 100);
     ASSERT_NO_THROW(b.ptr_cast<uint64_t>(5, sizeof(uint64_t)));
     ASSERT_NO_THROW(b.ptr_cast<uint64_t>(11, sizeof(uint64_t)));
-    ASSERT_THROW(b.ptr_cast<uint64_t>(13, sizeof(uint64_t)), ArcticBaseException<ErrorCategory::INTERNAL>); // Cursor overflow
+    ASSERT_THROW(b.ptr_cast<uint64_t>(13, sizeof(uint64_t)), ArcticCategorizedException<ErrorCategory::INTERNAL>); // Cursor overflow
     ASSERT_NO_THROW(b.ensure_bytes(20));
     ASSERT_NO_THROW(b.commit());
     ASSERT_EQ(b.size<uint8_t>(), 120);

--- a/cpp/arcticdb/util/test/test_utils.hpp
+++ b/cpp/arcticdb/util/test/test_utils.hpp
@@ -11,7 +11,6 @@
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/native_tensor.hpp>
-#include <arcticdb/util/trace.hpp>
 #include <arcticdb/util/preconditions.hpp>
 
 #include <vector>

--- a/cpp/arcticdb/util/trace.cpp
+++ b/cpp/arcticdb/util/trace.cpp
@@ -9,45 +9,11 @@
 
 #ifndef  _WIN32
 #include <cxxabi.h>
-#include <execinfo.h>
 #endif
 
 #include <iostream>
-#include <sstream>
 
 namespace arcticdb {
-
-    std::string get_stack() {
-#ifndef _WIN32
-        char sep = '\n';
-        void *trace[256];
-        int trace_size = ::backtrace(trace, 256);
-        char **buffer = ::backtrace_symbols(trace, trace_size);
-
-        std::string stack;
-        for (int i = 1; buffer && i < trace_size - 1; i++) {
-            stack += "[#" + std::to_string((trace_size - 1) - i) + "] ";
-            std::string s = buffer[i];
-            std::string mangle = s.substr(s.find('(') + 1, s.find('+') - s.find('(') - 1);
-
-            if (char *demangled = abi::__cxa_demangle(mangle.c_str(), nullptr, nullptr, nullptr)) {
-                std::string dm = demangled;
-                free(demangled);
-                stack += dm;
-            } else stack += mangle;
-
-            stack += sep;
-        }
-
-        if (buffer)
-            free(buffer);
-
-        return stack;
-#else
-        //TODO: Implement get_stack for windows
-        return std::string("");
-#endif
-    }
 
     std::string get_type_name(const std::type_info & ti){
 #ifndef _WIN32
@@ -59,15 +25,6 @@ namespace arcticdb {
         //TODO: Implement get_name_type for windows
         return std::string("");
 #endif
-    }
-
-    void do_assert(const char *assertion, const char *message, const char *file, int line) {
-        throw std::runtime_error(fmt::format("Assertion failed: {}\n{}\n at {}: {}\n{}",
-                                             assertion,
-                                             message,
-                                             file,
-                                             line,
-                                             get_stack()));
     }
 
 }

--- a/cpp/arcticdb/util/trace.hpp
+++ b/cpp/arcticdb/util/trace.hpp
@@ -16,50 +16,6 @@
 
 namespace arcticdb {
 
-std::string get_stack();
 std::string get_type_name(const std::type_info & );
-
-class ArcticNativeCxxException : public std::exception {
-public:
-
-    explicit ArcticNativeCxxException(std::string_view m, bool capture_stack=true) : msg_{m} {
-        if(capture_stack){
-            msg_.append(".\n");
-            msg_.append(get_stack());
-        }
-    }
-
-    explicit ArcticNativeCxxException(const std::exception & exc): ArcticNativeCxxException(exc.what()){
-        msg_.insert(0, " ");
-        msg_.insert(0, arcticdb::get_type_name(typeid(exc)));
-
-    }
-
-    explicit ArcticNativeCxxException(std::string m, const std::exception & exc): ArcticNativeCxxException(m){
-        msg_.insert(0, " ");
-        msg_.insert(0, arcticdb::get_type_name(typeid(exc)));
-
-        if(exc.what()) {
-            msg_.append(".");
-            msg_.append(exc.what());
-        }
-    }
-
-
-    virtual const char * what() const noexcept override {
-        return msg_.c_str();
-    }
-private:
-    std::string msg_;
-};
-
-template<class...Args>
-void throw_native_exception(const char* msg, Args&&...args){
-    throw ArcticNativeCxxException(fmt::format(msg, args...));
-}
-
-inline void rethrow_exception(const std::exception & exc){
-    throw ArcticNativeCxxException(exc);
-}
 
 }

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -25,80 +25,11 @@
 
 namespace arcticdb::version_store {
 
-void register_bindings(py::module &m) {
+void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception) {
     auto version = m.def_submodule("version_store", "Versioned storage implementation apis");
 
-    py::register_exception<NoSuchVersionException>(version, "NoSuchVersionException");
-    py::register_exception<StreamDescriptorMismatch>(version, "StreamDescriptorMismatch");
-
-  /*  class PyFilter: public Filter {
-    public:
-        using Filter::Filter;
-
-        [[nodiscard]] util::BitSet go(const SegmentInMemory &seg) const override {
-            PYBIND11_OVERRIDE_PURE(
-                util::BitSet ,
-                Filter,
-                go,
-                seg
-            );
-        }
-
-        virtual ~PyFilter() = default;
-    };
-
-    py::class_<FilterProcessor, std::shared_ptr<FilterProcessor>>(version, "Processor")
-            .def(py::init<std::shared_ptr<Filter>, std::shared_ptr<FilterProcessor>, std::shared_ptr<FilterProcessor>>())
-            .def("set_left", &FilterProcessor::set_left)
-            .def("set_right", &FilterProcessor::set_right)
-            .def("print", &FilterProcessor::print_tree);
-
-    py::class_<Filter, PyFilter, std::shared_ptr<Filter>>(version, "Filter")
-            .def("filter", &Filter::filter);
-
-    py::class_<EqualsFilter, Filter, std::shared_ptr<EqualsFilter>>(version, "EqualsFilter")
-        .def(py::init<std::string, Value>())
-        .def("filter", &EqualsFilter::filter)
-        ;
-
-    py::class_<NotEqualsFilter, Filter, std::shared_ptr<NotEqualsFilter>>(version, "NotEqualsFilter")
-        .def(py::init<std::string, Value>())
-        .def("filter", &NotEqualsFilter::filter)
-        ;
-
-    py::class_<LessThanFilter, Filter, std::shared_ptr<LessThanFilter>>(version, "LessThanFilter")
-        .def(py::init<std::string, Value>())
-        .def("filter", &LessThanFilter::filter)
-        ;
-
-    py::class_<GreaterThanFilter, Filter, std::shared_ptr<GreaterThanFilter>>(version, "GreaterThanFilter")
-        .def(py::init<std::string, Value>())
-        .def("filter", &GreaterThanFilter::filter)
-        ;
-
-    py::class_<LessThanOrEqualFilter, Filter, std::shared_ptr<LessThanOrEqualFilter>>(version, "LessThanOrEqualFilter")
-        .def(py::init<std::string, Value>())
-        .def("filter", &LessThanOrEqualFilter::filter)
-        ;
-
-    py::class_<GreaterThanOrEqualFilter, Filter, std::shared_ptr<GreaterThanOrEqualFilter>>(version, "GreaterThanOrEqualFilter")
-        .def(py::init<std::string, Value>())
-        .def("filter", &GreaterThanOrEqualFilter::filter)
-        ;
-
-    py::class_<ListMembershipFilter, Filter, std::shared_ptr<ListMembershipFilter>>(version, "ListMembershipFilter")
-        .def(py::init<std::string, ValueList>())
-        .def("filter", &ListMembershipFilter::filter)
-        ;
-
-    py::class_<OrFilter, Filter, std::shared_ptr<OrFilter>>(version, "OrFilter")
-        .def(py::init())
-        ;
-
-    py::class_<AndFilter, Filter, std::shared_ptr<AndFilter>>(version, "AndFilter")
-            .def(py::init())
-    ;
-    */
+    py::register_exception<NoSuchVersionException>(version, "NoSuchVersionException", base_exception.ptr());
+    py::register_exception<StreamDescriptorMismatch>(version, "StreamDescriptorMismatch", base_exception.ptr());
 
     py::class_<AtomKey, std::shared_ptr<AtomKey>>(version, "AtomKey")
     .def(py::init())
@@ -158,11 +89,6 @@ void register_bindings(py::module &m) {
         return std::make_shared<ValueSet>(value_list);
     }))
     ;
-
-   // py::class_<ValueList>(version, "ValueListType")
-   //     .def(py::init<NativeTensor>());
-
-  //  version.def("ValueList", &construct_value_list);
 
     py::class_<ClauseBuilder>(version, "ClauseBuilder")
             .def(py::init())

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -13,14 +13,12 @@
 #include <arcticdb/python/arctic_version.hpp>
 #include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/pipeline/query.hpp>
-#include <folly/Singleton.h>
 #include <arcticdb/storage/mongo/mongo_instance.hpp>
 #include <arcticdb/processing/operation_types.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/execution_context.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
 #include <arcticdb/python/adapt_read_dataframe.hpp>
-#include <arcticdb/version/snapshot.hpp>
 #include <arcticdb/version/schema_checks.hpp>
 
 namespace arcticdb::version_store {

--- a/cpp/arcticdb/version/python_bindings.hpp
+++ b/cpp/arcticdb/version/python_bindings.hpp
@@ -8,11 +8,12 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <arcticdb/util/error_code.hpp>
 
 namespace py = pybind11;
 
 namespace arcticdb::version_store {
 
-void register_bindings(py::module &m);
+void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception);
 
 } //namespace arcticdb::version_store

--- a/docs/mkdocs/docs/error_messages.md
+++ b/docs/mkdocs/docs/error_messages.md
@@ -63,7 +63,7 @@ These errors relate to data being pickled, which limits the operations available
 
 Furthermore, it is not possible to partially read/update/append the data using the ArcticDB API or use the QueryBuilder with pickled symbols. 
 
-All of these errors are of type `ArcticNativeCxxException`.
+All of these errors are of type `arcticdb.exceptions.ArcticException`.
 
 | Error messages | Cause | Resolution |
 |:--------------|:-------|:-----------|
@@ -74,7 +74,7 @@ All of these errors are of type `ArcticNativeCxxException`.
 
 Errors that can be encountered when creating  and deleting snapshots, or trying to read data from a specific snapshot.
 
-All of these errors are of type `ArcticNativeCxxException` unless specified otherwise.
+All of these errors are of type `arcticdb.exceptions.ArcticException`.
 
 | Error messages | Cause | Resolution |
 |:--------------|:-------|:-----------|
@@ -86,7 +86,7 @@ All of these errors are of type `ArcticNativeCxxException` unless specified othe
 
 A select few operations with ArcticDB require the symbol to exist and have at least one live version. These errors occur when this is not the case.
 
-All of these errors are of type `ArcticNativeCxxException`.
+All of these errors are of type `arcticdb.exceptions.ArcticException`.
 
 | Error messages | Cause | Resolution |
 |:--------------|:-------|:-----------|
@@ -96,7 +96,7 @@ All of these errors are of type `ArcticNativeCxxException`.
 
 All calls to `delete_data_in_range` and `update`, and calls to `read` using the `date_range` optional argument, require the existing data to have a *sorted* timestamp index. ArcticDB does not check this condition at write time.
 
-All of these errors are of type `ArcticNativeCxxException`.
+All of these errors are of type `arcticdb.exceptions.ArcticException`.
 
 | Error messages | Cause | Resolution |
 |:--------------|:-------|:-----------|
@@ -111,7 +111,7 @@ Due to the client-only nature of ArcticDB, it is not possible to know if a `Quer
 * Whether a specified column exists
 * What the type of the data held in a specified column is if it does exist
 
-All of these errors are of type `ArcticNativeCxxException`.
+All of these errors are of type `arcticdb.exceptions.ArcticException`.
 
 | Error messages | Cause | Resolution |
 |:--------------|:-------|:-----------|

--- a/python/arcticdb/exceptions.py
+++ b/python/arcticdb/exceptions.py
@@ -5,15 +5,15 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+from arcticdb_ext.exceptions import *
+from arcticdb_ext.exceptions import ArcticException as ArcticNativeException
+from arcticdb_ext.storage import DuplicateKeyException, NoDataFoundException, PermissionException
+from arcticdb_ext.version_store import NoSuchVersionException, StreamDescriptorMismatch
 
 
-class ArcticNativeException(Exception):
+class ArcticNativeNotYetImplemented(ArcticException):
     pass
 
 
-class ArcticNativeNotYetImplemented(Exception):
-    pass
-
-
-class LibraryNotFound(Exception):
+class LibraryNotFound(ArcticException):
     pass

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -15,6 +15,7 @@ from arcticdb.supported_types import Timestamp
 
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.version_store._store import NativeVersionStore, VersionedItem
+from arcticdb_ext.exceptions import ArcticException
 import pandas as pd
 import numpy as np
 import logging
@@ -39,7 +40,7 @@ Library.write: for more documentation on normalisation.
 """
 
 
-class ArcticInvalidApiUsageException(RuntimeError):
+class ArcticInvalidApiUsageException(ArcticException):
     """Exception indicating an invalid call made to the Arctic API."""
 
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -18,18 +18,17 @@ import pytest
 import random
 import string
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime
 from numpy.testing import assert_array_equal
 from pytz import timezone
 
-from arcticdb.config import Defaults
 from arcticdb.exceptions import ArcticNativeNotYetImplemented
 from arcticdb_ext.exceptions import InternalException, NoSuchVersionException
 from arcticdb.flattener import Flattener
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer
 from arcticdb.version_store._store import UNSUPPORTED_S3_CHARS, MAX_SYMBOL_SIZE, VersionedItem
-from arcticdb.version_store.helper import ArcticMemoryConfig, get_lib_cfg
+from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb_ext.version_store import StreamDescriptorMismatch
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata  # Importing from arcticdb dynamically loads arcticc.pb2
@@ -1750,7 +1749,7 @@ def test_diff_long_stream_descriptor_mismatch(lmdb_version_store, method, num):
             lib.update("x", pd.DataFrame(bad_row, index=dr), date_range=dr)
         assert False, "should throw"
     except StreamDescriptorMismatch as e:
-        print(e)
+        assert not isinstance(e, _ArcticLegacyCompatibilityException)
         msg = str(e)
         for i in (1, 2, *(x for x in range(num) if x % 20 == 4), num):
             assert f"col{i}: TD<type=INT64, dim=0>" in msg

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -22,15 +22,13 @@ from datetime import datetime
 from numpy.testing import assert_array_equal
 from pytz import timezone
 
-from arcticdb.exceptions import ArcticNativeNotYetImplemented
-from arcticdb_ext.exceptions import InternalException, NoSuchVersionException
+from arcticdb.exceptions import ArcticNativeNotYetImplemented, InternalException, NoSuchVersionException, StreamDescriptorMismatch
 from arcticdb.flattener import Flattener
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer
 from arcticdb.version_store._store import UNSUPPORTED_S3_CHARS, MAX_SYMBOL_SIZE, VersionedItem
 from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
-from arcticdb_ext.version_store import StreamDescriptorMismatch
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata  # Importing from arcticdb dynamically loads arcticc.pb2
 from arcticdb.util.test import (
     sample_dataframe,

--- a/python/tests/unit/arcticdb/test_errors.py
+++ b/python/tests/unit/arcticdb/test_errors.py
@@ -1,13 +1,81 @@
 import pytest
 
 from arcticdb.util.errors import *
-from arcticdb_ext.exceptions import NormalizationException, get_error_category, ErrorCategory
+import arcticdb_ext.exceptions as ae
+from arcticdb_ext.exceptions import *  # keep as wildcard so all_exception_types below includes everything
+from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException
+from arcticdb_ext.storage import NoDataFoundException
+from arcticdb_ext.version_store import NoSuchVersionException
 
 
 test_raise_params = [(NormalizationError.E_UPDATE_NOT_SUPPORTED, NormalizationException)]
+
+specific_exception_types = [
+    InternalException,
+    NormalizationException,
+    MissingDataException,
+    SchemaException,
+    StorageException,
+    SortingException,
+    UnsortedDataException,
+]
+
+all_exception_types = [
+    globals()[e] for e in dir(ae) if e.endswith("Exception") or e.endswith("Error")
+]
 
 
 @pytest.mark.parametrize("code,exception", test_raise_params)
 def test_raise(code, exception):
     with pytest.raises(exception, match=f"E{code.value} a message$"):
         arcticdb_raise(code, lambda: "a message")
+
+
+@pytest.mark.parametrize("exception_type", all_exception_types)
+def test_base_exception(exception_type):
+    assert issubclass(exception_type, ArcticException)
+
+
+def test_compat_exception():
+    for e in specific_exception_types:
+        assert issubclass(e, _ArcticLegacyCompatibilityException)
+
+
+def test_pickling_error(lmdb_version_store):
+    lmdb_version_store.write("sym", [1, 2, 3])
+    with pytest.raises(InternalException):
+        lmdb_version_store.append("sym", [4, 5, 6])
+
+
+def test_internal_error_is_compat_exception(lmdb_version_store):
+    lmdb_version_store.write("sym", [1, 2, 3])
+    try:
+        lmdb_version_store.append("sym", [4, 5, 6])
+    except _ArcticLegacyCompatibilityException:
+        pass
+    except Exception:
+        pytest.fail("Should have raised a compat exception")
+
+
+def test_snapshot_error(lmdb_version_store):
+    lmdb_version_store.write("sym", [1, 2, 3])
+    lmdb_version_store.snapshot("snap")
+    with pytest.raises(InternalException) as e:
+        lmdb_version_store.snapshot("snap")
+
+def test_symbol_not_found_exception(lmdb_version_store):
+    """Check we match the legacy behaviour where this is not an _ArcticLegacyCompatibilityException"""
+    with pytest.raises(NoDataFoundException) as e:
+        lmdb_version_store.read("non_existent_symbol")
+
+    assert not issubclass(e.type, _ArcticLegacyCompatibilityException)
+    assert issubclass(e.type, ArcticException)
+
+
+def test_no_such_version_exception(lmdb_version_store):
+    """Check we match the legacy behaviour where this is not an _ArcticLegacyCompatibilityException"""
+    lmdb_version_store.write("sym", [1, 2, 3])
+    with pytest.raises(NoSuchVersionException) as e:
+        lmdb_version_store.restore_version("sym", as_of=999)
+    assert not issubclass(e.type, _ArcticLegacyCompatibilityException)
+    assert issubclass(e.type, ArcticException)

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -10,7 +10,7 @@ import time
 from pandas import Timestamp
 import pytest
 
-from arcticdb_ext.exceptions import NoSuchVersionException
+from arcticdb.exceptions import NoSuchVersionException
 
 
 def test_read_descriptor(lmdb_version_store, one_col_df):

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -12,10 +12,8 @@ from itertools import product
 import datetime
 import random
 
-from arcticdb.config import Defaults
-from arcticdb.version_store.helper import ArcticMemoryConfig
 from arcticdb.util.test import random_strings_of_length, random_string, random_floats, assert_frame_equal
-from arcticdb_ext.exceptions import InternalException, SortingException
+from arcticdb.exceptions import InternalException, SortingException
 from tests.util.date import DateRange
 from pandas import MultiIndex
 

--- a/python/tests/unit/arcticdb/version_store/test_write.py
+++ b/python/tests/unit/arcticdb/version_store/test_write.py
@@ -8,7 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import numpy as np
 import pandas as pd
 import pytest
-from arcticdb_ext.exceptions import SortingException, NormalizationException
+from arcticdb.exceptions import SortingException, NormalizationException
 from pandas import MultiIndex
 
 


### PR DESCRIPTION
The HEAD~ commit introduces a compatibility base exception type, similar to our old internal base type.

The HEAD commit then introduces a new, clean base exception type for all our custom C++/Python exceptions, and slightly cleans up exception translation introduced in the HEAD~ commit and some other minor feedback.

I recommend viewing commit-wise since the HEAD commit has a noisy rename from ArcticBaseException to ArcticCategorizedException.
