### PR TITLE
Pin hypothesis to reduce disruptive test failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,4 +48,4 @@ Testing =
     moto
     flask  # Used by moto
     flask-cors
-    hypothesis
+    hypothesis <6.74


### PR DESCRIPTION
Master is failing due to hypothesis 6.74.0 release. We should fix the issues and relax the pin as soon as time allows.

https://github.com/man-group/ArcticDB/actions/runs/4811024777/jobs/8564968291