### PR TITLE
added if to avoid an unsued return value warning

### DIFF
--- a/cpp/arcticdb/util/memory_tracing.hpp
+++ b/cpp/arcticdb/util/memory_tracing.hpp
@@ -78,9 +78,11 @@ inline void print_total_mem_usage(const char *file ARCTICDB_UNUSED, int line ARC
         return;
     }
 
-    for(auto i = 0u; i < 7u; ++i)
-        fscanf(statm_file, "%d", &mem_stat[i]);
-
+    for(auto i = 0u; i < 7u; ++i){
+        // https://stackoverflow.com/questions/7271939/warning-ignoring-return-value-of-scanf-declared-with-attribute-warn-unused-r
+        // this "if" is needed to avoid warning of unused return value
+        if(fscanf(statm_file, "%d", &mem_stat[i])){}
+    }
     fclose(statm_file);
     ARCTICDB_DEBUG(log::memory(), "{} ({}:{}) size {} resident {} share {} text {} data/stack {}",
                        file,


### PR DESCRIPTION
without this I get
```
 /home/runner/work/ArcticDB/ArcticDB/cpp/arcticdb/util/memory_tracing.hpp:82:15: error: ignoring return value of ‘int fscanf(FILE*, const char*, ...)’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
         82 |         fscanf(statm_file, "%d", &mem_stat[I]);
```