### PR TITLE
Pin hypothesis to an older version to avoid disruptive test failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,4 +48,4 @@ Testing =
     moto
     flask  # Used by moto
     flask-cors
-    hypothesis <6.74
+    hypothesis <6.73


### PR DESCRIPTION
`hypothesis` version needs to be `< 6.73` to avoid disruptive test failures for now.