### PR TITLE
Clarify error message

### DIFF
--- a/cpp/arcticdb/entity/ref_key.hpp
+++ b/cpp/arcticdb/entity/ref_key.hpp
@@ -23,7 +23,7 @@ namespace arcticdb::entity {
                 id_(std::move(id)),
                 key_type_(key_type),
                 old_type_(old_type) {
-            util::check(!std::holds_alternative<StringId>(id_) || !std::get<StringId>(id_).empty(), "Empty string id in reference key");
+            util::check(!std::holds_alternative<StringId>(id_) || !std::get<StringId>(id_).empty(), "Empty symbol in reference key");
             util::check(old_type || is_ref_key_class(key_type), "Can't create ref key with non-ref key class keytype {}", key_type);
         }
 

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -637,14 +637,14 @@ struct StreamDescriptor {
         util::variant_match(id,
             [this] (const StringId& str) { data_->set_str_id(str); },
             [this] (const NumericId& n) {
-                util::check(n >= 0, "Negative NumericId is not supported");
+                util::check(n >= 0, "Negative numeric symbol is not supported");
                 data_->set_num_id(n);
             });
     }
 
     static StreamId id_from_proto(Proto proto) {
         if(proto.id_case() == arcticdb::proto::descriptors::StreamDescriptor::kNumId)
-            return safe_convert_to_numeric_id(proto.num_id(), "Numeric StreamId");
+            return safe_convert_to_numeric_id(proto.num_id(), "Numeric symbol");
         else
             return proto.str_id();
     }

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -328,7 +328,7 @@ storage::KeySegmentPair MongoClientImpl::read_segment(const std::string &databas
             );
         } else {
             // find_one returned nothing, if this was an exception it would fall through to the catch below.
-            throw std::runtime_error(fmt::format("Missing key in mongo: {} for stream_id: {}", key, stream_id));
+            throw std::runtime_error(fmt::format("Missing key in mongo: {} for symbol: {}", key, stream_id));
         }
     }
     catch(const std::exception& ex) {

--- a/cpp/arcticdb/stream/stream_writer.hpp
+++ b/cpp/arcticdb/stream/stream_writer.hpp
@@ -119,7 +119,7 @@ class StreamWriter : boost::noncopyable {
         auto verify = [version_id = version_id_, stream_id = stream_id()](const VariantKey &key) {
             util::check_arg(version_id == to_atom(key).version_id(), "Invalid key expected version_id={}, actual={}",
                             version_id, key);
-            util::check_arg(stream_id == to_atom(key).id(), "Invalid key, expected stream_id={}, actual={}",
+            util::check_arg(stream_id == to_atom(key).id(), "Invalid key, expected symbol={}, actual={}",
                             stream_id, key);
         };
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -239,7 +239,7 @@ std::pair<VersionedItem, FrameAndDescriptor> LocalVersionedEngine::read_datafram
             identifier = stream_id;
         }
         else
-            throw storage::NoDataFoundException(fmt::format("read_dataframe_version: version not found for stream '{}'", stream_id));
+            throw storage::NoDataFoundException(fmt::format("read_dataframe_version: version not found for symbol '{}'", stream_id));
     }
     else  {
         identifier = version.value();
@@ -312,7 +312,7 @@ std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
 
 VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool dynamic_schema) {
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
-    util::check(maybe_prev.has_value(), "Cannot delete from non-existent stream {}", stream_id);
+    util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto version_id = get_next_version_from_key(maybe_prev.value());
     auto [index_segment_reader, slice_and_keys] = index::read_index_to_vector(store(), maybe_prev.value());
     if(dynamic_schema) {
@@ -349,7 +349,7 @@ VersionedItem LocalVersionedEngine::delete_range_internal(
     const UpdateQuery & query,
     bool dynamic_schema) {
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
-    util::check(maybe_prev.has_value(), "Cannot delete from non-existent stream {}", stream_id);
+    util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto versioned_item = delete_range_impl(store(),
                                             maybe_prev.value(),
                                             query,
@@ -405,7 +405,7 @@ VersionedItem LocalVersionedEngine::update_internal(
             version_map()->write_version(store(), versioned_item.key_);
             return versioned_item;
         } else {
-            util::raise_rte("Cannot update non-existent stream {}", stream_id);
+            util::raise_rte("Cannot update non-existent symbol {}", stream_id);
         }
     }
 }
@@ -897,7 +897,7 @@ VersionedItem LocalVersionedEngine::append_internal(
             version_map()->write_version(store(), versioned_item.key_);
             return versioned_item;
         } else {
-            util::raise_rte( "Cannot append to non-existent stream {}", stream_id);
+            util::raise_rte( "Cannot append to non-existent symbol {}", stream_id);
         }
     }
 }
@@ -965,7 +965,7 @@ std::map<StreamId, VersionVectorType> get_multiple_sym_versions_from_query(
 std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>> LocalVersionedEngine::batch_restore_version_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries) {
-    util::check(stream_ids.size() == version_queries.size(), "Stream id vs version query size mismatch: {} != {}", stream_ids.size(), version_queries.size());
+    util::check(stream_ids.size() == version_queries.size(), "Symbol vs version query size mismatch: {} != {}", stream_ids.size(), version_queries.size());
     auto sym_versions = get_sym_versions_from_query(stream_ids, version_queries);
     util::check(sym_versions.size() == version_queries.size(), "Restore versions requires specific version to be supplied");
     auto previous = batch_get_latest_version(store(), version_map(), stream_ids, false);
@@ -977,7 +977,7 @@ std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDes
         auto maybe_prev = prev == std::end(*previous) ? std::nullopt : std::make_optional<AtomKey>(to_atom(prev->second));
 
         auto version = versions_to_restore->find(*stream_id);
-        util::check(version != std::end(*versions_to_restore), "Did not find version for stream_id {}", *stream_id);
+        util::check(version != std::end(*versions_to_restore), "Did not find version for symbol {}", *stream_id);
         fut_vec.emplace_back(async::submit_io_task(AsyncRestoreVersionTask{store(), version_map(), *stream_id, to_atom(version->second), maybe_prev}));
     }
     auto output = folly::collect(fut_vec).get();
@@ -996,14 +996,14 @@ timestamp LocalVersionedEngine::get_update_time_internal(
         ) {
     auto version = get_version_to_read(stream_id, version_query);
     if(!version)
-        throw NoDataFoundException(fmt::format("get_update_time: version not found for stream", stream_id));
+        throw NoDataFoundException(fmt::format("get_update_time: version not found for symbol", stream_id));
     return version->key_.creation_ts();
 }
 
 std::vector<timestamp> LocalVersionedEngine::batch_get_update_times(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries) {
-    util::check(stream_ids.size() == version_queries.size(), "Stream id vs version query size mismatch: {} != {}", stream_ids.size(), version_queries.size());
+    util::check(stream_ids.size() == version_queries.size(), "Symbol vs version query size mismatch: {} != {}", stream_ids.size(), version_queries.size());
     std::vector<timestamp> results;
     for(const auto& stream_id : folly::enumerate(stream_ids)) {
         const auto& query = version_queries[stream_id.index];

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -526,13 +526,13 @@ public:
         const VersionMapEntry& entry,
         const StreamId &stream_id) const {
         if (entry.head_) {
-            util::check(entry.head_.value().id() == stream_id, "Id mismatch for entry {} vs stream id {}",
+            util::check(entry.head_.value().id() == stream_id, "Id mismatch for entry {} vs symbol {}",
                         entry.head_.value().id(), stream_id);
             store->remove_key_sync(entry.head_.value());
         }
         std::vector<folly::Future<Store::RemoveKeyResultType>> key_futs;
         for (const auto &key : entry.keys_) {
-            util::check(key.id() == stream_id, "Id mismatch for entry {} vs stream id {}", key.id(), stream_id);
+            util::check(key.id() == stream_id, "Id mismatch for entry {} vs symbol {}", key.id(), stream_id);
             if (key.type() == KeyType::VERSION)
                 key_futs.emplace_back(store->remove_key(key));
         }

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -279,7 +279,7 @@ struct VersionMapEntry {
             id_to_version_id[head_.value().id()].push_back(head_.value().version_id());
         for (const auto& k: keys_)
             id_to_version_id[k.id()].push_back(k.version_id());
-        util::check_rte(id_to_version_id.size() == 1, "Multiple stream_ids in keys: {}", fmt::format("{}", id_to_version_id));
+        util::check_rte(id_to_version_id.size() == 1, "Multiple symbols in keys: {}", fmt::format("{}", id_to_version_id));
     }
 
     void try_set_tombstone_all(const AtomKey& key) {


### PR DESCRIPTION
Replace "stream" and "stream id" with "symbol" in error message printout to reduce ambiguity