### PR TITLE
Implementation for Decimal type with memory layout compatible with pyarrow's memory layout.

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -229,6 +229,7 @@ set(arcticdb_srcs
         util/container_filter_wrapper.hpp
         util/cursored_buffer.hpp
         util/cursor.hpp
+        util/decimal.hpp
         util/encoding_conversion.hpp
         util/exponential_backoff.hpp
         util/flatten_utils.hpp
@@ -339,6 +340,7 @@ set(arcticdb_srcs
         util/allocator.cpp
         util/buffer_pool.cpp
         util/configs_map.cpp
+        util/decimal.cpp
         util/error_code.cpp
         util/global_lifetimes.cpp
         util/offset_string.cpp
@@ -616,6 +618,7 @@ if(${TEST})
             util/test/test_buffer_pool.cpp
             util/test/test_composite.cpp
             util/test/test_cursor.cpp
+            util/test/test_decimal.cpp
             util/test/test_exponential_backoff.cpp
             util/test/test_format_date.cpp
             util/test/test_hash.cpp

--- a/cpp/arcticdb/util/decimal.cpp
+++ b/cpp/arcticdb/util/decimal.cpp
@@ -1,0 +1,328 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/util/decimal.hpp>
+#include <string>
+#include <cassert>
+#include <cmath>
+#include <boost/multiprecision/cpp_int.hpp>
+#include <arcticdb/util/preprocess.hpp>
+#include <arcticdb/util/preconditions.hpp>
+
+namespace arcticdb {
+
+    namespace util {
+        // By word we refer to string of digits, not a CPU word
+        constexpr static int max_digits_per_word = std::numeric_limits<int64_t>::digits10;
+        constexpr static std::array<uint64_t, std::numeric_limits<uint64_t>::digits10 + 1> powers_of_10{
+                1,
+                10,
+                100,
+                1000,
+                10000,
+                100000,
+                1000000,
+                10000000,
+                100000000,
+                1000000000,
+                10000000000,
+                100000000000,
+                1000000000000,
+                10000000000000,
+                100000000000000,
+                1000000000000000,
+                10000000000000000,
+                100000000000000000,
+                1000000000000000000,
+                10000000000000000000ULL
+        };
+
+        [[nodiscard]] static inline bool is_digit(const char c) {
+            return c >= '0' && c <= '9';
+        }
+
+        [[nodiscard]] static inline bool is_exponent_symbol(const char c) {
+            return c == 'E' || c == 'e';
+        }
+
+        static inline void trim_trailing_zeroes(std::string_view& str) {
+            const size_t last_non_zero = str.find_last_not_of('0');
+            if(last_non_zero != std::string::npos) {
+                const size_t zeros_to_remove = str.length() - last_non_zero - 1;
+                str.remove_suffix(zeros_to_remove);
+            }
+        }
+
+        static inline void trim_leading_zeroes(std::string_view& str) {
+            const size_t first_non_zero = str.find_first_not_of('0');
+            if(first_non_zero != std::string::npos) {
+                str.remove_prefix(first_non_zero);
+            }
+        }
+
+        [[nodiscard]] static inline boost::multiprecision::uint128_t to_uint128(
+                const uint64_t most_significant, const uint64_t least_significant) {
+            boost::multiprecision::uint128_t number = most_significant;
+            number <<= 64;
+            number |= least_significant;
+            return number;
+        }
+
+        [[nodiscard]] static inline uint64_t to_uint64_t(std::string_view str) {
+            assert(str.size() < powers_of_10.size());
+            uint64_t result = 0;
+            for(int i = str.size() - 1; i >= 0; --i) {
+                assert(is_digit(str[i]));
+                const int power = str.length() - i - 1;
+                result += (str[i] - '0') * powers_of_10[power];
+            }
+            return result;
+        }
+
+        /**
+         * Take a decimal number with up to 38 significant digits and
+         * extract the exponent, sign and all digits. At the end all
+         * digits (including the zeros from multiplying by 10^exponent)
+         * will be contained in an array, accessible by get_digits().
+         * The array will contain digits only.
+         */
+        class NumberComponents {
+        public:
+            explicit NumberComponents(std::string_view input);
+            [[nodiscard]] bool is_negative() const;
+            [[nodiscard]] bool is_decimal() const;
+            [[nodiscard]] const char* get_digits() const;
+            [[nodiscard]] int get_size() const;
+            constexpr static int max_digits = 38;
+        private:
+            struct SpecialSymbols {
+                int decimal_point_position = -1;
+                int exponent_position = -1;
+            };
+
+            enum NumberComponentsFlags {
+                NEGATIVE = 1,
+                DECIMAL = 1 << 1
+            };
+
+            void handle_sign(std::string_view& input);
+            void handle_exponent(std::string_view& input, int exponent_position);
+            void handle_insignificant_zeros(std::string_view& input) const;
+            SpecialSymbols scan_for_special_symbols(std::string_view input);
+            void expand_exponent(int decimal_point_position);
+            void parse_significant_digits(std::string_view input);
+
+            std::array<char, max_digits + 1> digits_;
+            int exponent_;
+            int size_;
+            unsigned flags_;
+        };
+
+        NumberComponents::NumberComponents(std::string_view input) :
+            digits_{'\0'}, exponent_(0), size_(0), flags_(0) {
+
+            handle_sign(input);
+            trim_leading_zeroes(input);
+            const SpecialSymbols special_symbols = scan_for_special_symbols(input);
+            handle_exponent(input, special_symbols.exponent_position);
+            handle_insignificant_zeros(input);
+            parse_significant_digits(input);
+            expand_exponent(special_symbols.decimal_point_position);
+        }
+
+        void NumberComponents::handle_sign(std::string_view &input) {
+            if(input[0] == '-') {
+                flags_ |= NumberComponentsFlags::NEGATIVE;
+                input.remove_prefix(1);
+            }
+        }
+
+        void NumberComponents::handle_exponent(std::string_view &input, int exponent_position) {
+            if(exponent_position != -1) {
+                size_t processed_digits_count;
+                exponent_ = std::stoi(input.data() + exponent_position + 1, &processed_digits_count);
+                arcticdb::util::check_arg(
+                        exponent_position + processed_digits_count == input.length() - 1,
+                        "Cannot parse decimal from string. Cannot parse exponent.");
+                input = input.substr(0, exponent_position);
+            }
+        }
+
+        NumberComponents::SpecialSymbols NumberComponents::scan_for_special_symbols(std::string_view input) {
+            SpecialSymbols result;
+            for(size_t i = 0; i < input.length(); ++i) {
+                const char current_symbol = input[i];
+                if(current_symbol == '.') {
+                    arcticdb::util::check_arg(
+                            !is_decimal(),
+                            "Cannot parse decimal from string. "
+                            "Invalid character '{}'. More than one decimal points are not allowed.",
+                            current_symbol);
+                    flags_ |= NumberComponentsFlags::DECIMAL;
+                    result.decimal_point_position = i;
+                } else if(is_exponent_symbol(current_symbol)) {
+                    result.exponent_position = i;
+                    break;
+                } else  {
+                    arcticdb::util::check_arg(
+                            is_digit(current_symbol),
+                            "Cannot parse decimal from string. Invalid character '{}'.",
+                            current_symbol);
+                }
+            }
+            return result;
+        }
+
+        void NumberComponents::handle_insignificant_zeros(std::string_view &input) const {
+            if(is_decimal()) {
+                trim_trailing_zeroes(input);
+            }
+        }
+
+        void NumberComponents::parse_significant_digits(std::string_view input) {
+            for(const char symbol : input) {
+                arcticdb::util::check_arg(size_ < max_digits,
+                                          "Cannot parse decimal from string. "
+                                          "Overflow. Input has more than {} significant digits.",
+                                          max_digits);
+                if(ARCTICDB_LIKELY(is_digit(symbol))) {
+                    digits_[size_++] = symbol;
+                } else if(ARCTICDB_UNLIKELY(symbol == '.')) {
+                    continue;
+                }
+            }
+        }
+
+        void NumberComponents::expand_exponent(int decimal_point_position) {
+            arcticdb::util::check_arg(
+                    size_ > 0 || exponent_ == 0,
+                    "Cannot parse decimal from string. "
+                    "There must be at least one digit before the exponent.");
+            const int digits_after_decimal_point = is_decimal() ? size_ - decimal_point_position : 0;
+            const int zeros_to_append = std::max(0, exponent_ - digits_after_decimal_point);
+            arcticdb::util::check_arg(
+                    size_ + zeros_to_append <= max_digits,
+                    "Cannot parse decimal from string. "
+                    "Overflow. Input has more than {} significant digits.",
+                    max_digits);
+            for(int i = 0; i < zeros_to_append; ++i) {
+                digits_[size_++] = '0';
+            }
+        }
+
+        bool NumberComponents::is_negative() const {
+            return flags_ & NumberComponentsFlags::NEGATIVE;
+        }
+
+        bool NumberComponents::is_decimal() const {
+            return flags_ & NumberComponentsFlags::DECIMAL;
+        }
+
+        const char* NumberComponents::get_digits() const {
+            return digits_.data();
+        }
+
+        int NumberComponents::get_size() const {
+            return size_;
+        }
+
+        Decimal::Decimal() : data_{ 0 } {}
+
+        Decimal::Decimal(std::string_view number) : data_{0} {
+            // GCC and Clang have internal 2's complement __uint128_t.
+            // MSVC does not have 128-bit integer, it has __m128, which is for SIMD.
+            // Boost's uint128_t is not in two's complement, so it cannot be reinterpret_cast over the data.
+            // TODO: potential optimization for Clang/GCC would be to load it __uint128_t and reinterpret_cast
+            //  it over the array.
+            const NumberComponents components(number);
+            std::string_view number_to_parse(components.get_digits());
+            while(!number_to_parse.empty()) {
+                const std::string_view chunk = number_to_parse.substr(0, max_digits_per_word);
+                push_chunk(chunk);
+                number_to_parse = number_to_parse.substr(chunk.size());
+            }
+            if(components.is_negative()) {
+                negate();
+            }
+        }
+
+        void Decimal::push_chunk(std::string_view chunk_str) {
+            uint64_t chunk = to_uint64_t(chunk_str);
+            const uint64_t word_exponent = powers_of_10[chunk_str.length()];
+            const uint64_t mask = 0xFFFFFFFFFFFFFFFFULL;
+            for(uint64_t &word : data_) {
+                boost::multiprecision::uint128_t tmp = word;
+                tmp *= word_exponent;
+                tmp += chunk;
+                word = static_cast<uint64_t>(tmp & mask);
+                chunk = static_cast<uint64_t>(tmp >> 64);
+            }
+        }
+
+        std::string Decimal::to_string(int scale) const {
+            if(is_negative()) {
+                const Decimal negated = this->operator-();
+                std::string result = negated.to_string(scale);
+                result.insert(0, "-");
+                return result;
+            }
+            if(data_[0] == 0 && data_[1] == 0) {
+                return "0";
+            }
+
+            boost::multiprecision::uint128_t number = to_uint128(
+                    data_[MOST_SIGNIFICANT_WORD_INDEX],
+                    data_[LEAST_SIGNIFICANT_WORD_INDEX]);
+
+            std::string result;
+            if(scale < 0) {
+                std::fill_n(std::back_inserter(result), -scale, '0');
+                scale = 0;
+            }
+            while(number) {
+                const char digit = static_cast<char>(number % 10) + '0';
+                result.push_back(digit);
+                number /= 10;
+            }
+            if(scale > 0) {
+                const int len = static_cast<int>(result.length());
+                if(len > scale) {
+                    result.insert(scale, ".");
+                } else {
+                    std::fill_n(std::back_inserter(result), std::abs(len-scale), '0');
+                    result.append(".0");
+                }
+            }
+            std::reverse(result.begin(), result.end());
+            return result;
+        }
+
+        bool Decimal::is_negative() const {
+            return static_cast<int64_t>(data_[MOST_SIGNIFICANT_WORD_INDEX]) < 0;
+        }
+
+        void Decimal::negate() {
+            data_[LEAST_SIGNIFICANT_WORD_INDEX] = ~data_[LEAST_SIGNIFICANT_WORD_INDEX];
+            data_[LEAST_SIGNIFICANT_WORD_INDEX] += 1;
+
+            data_[MOST_SIGNIFICANT_WORD_INDEX] = ~data_[MOST_SIGNIFICANT_WORD_INDEX];
+            if(data_[LEAST_SIGNIFICANT_WORD_INDEX] == 0) {
+                data_[LEAST_SIGNIFICANT_WORD_INDEX]++;
+            }
+        }
+
+        Decimal Decimal::operator-() const {
+            Decimal result(*this);
+            result.negate();
+            return result;
+        }
+
+        bool Decimal::operator==(const arcticdb::util::Decimal& other) const {
+            return data_ == other.data_;
+        }
+    }
+}

--- a/cpp/arcticdb/util/decimal.hpp
+++ b/cpp/arcticdb/util/decimal.hpp
@@ -1,0 +1,55 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+#include <array>
+#include <string_view>
+#include <arcticdb/util/constructors.hpp>
+
+namespace arcticdb {
+
+    namespace util {
+        /**
+         * The decimal class is binary compatible with pyarrow's layout for 128 bit decimals. The format keeps
+         * the number as 128 bit integer in two's complement. The scale is not part of the format.
+         * https://github.com/apache/arrow/blob/45918a90a6ca1cf3fd67c256a7d6a240249e555a/cpp/src/arrow/util/decimal.h
+         * https://arrow.apache.org/docs/python/generated/pyarrow.decimal128.html
+         * Little endian order is used for the words and the bits inside each word.
+         */
+        class Decimal {
+        public:
+            Decimal();
+            explicit Decimal(std::string_view number);
+            ARCTICDB_MOVE_COPY_DEFAULT(Decimal);
+
+            /**
+             * Convert decimal to string
+             * @param scale Positive scale means the numbers after the decimal point.
+             *  Negative scale acts as multiplying by 10^(abs(scale))
+             * @example
+             *  Decimal("123").to_string(1) = "12.3"
+             *  Decimal("123").to_string(-1) = "1230"
+             *  Decimal("123").to_string(0) = "123"
+             */
+            [[nodiscard]] std::string to_string(int scale) const;
+            [[nodiscard]] bool is_negative() const;
+            [[nodiscard]] Decimal operator-() const;
+            [[nodiscard]] bool operator==(const Decimal&) const;
+            void negate();
+
+            constexpr static int max_scale = 38;
+        private:
+            void push_chunk(std::string_view);
+
+            enum {
+                LEAST_SIGNIFICANT_WORD_INDEX = 0,
+                MOST_SIGNIFICANT_WORD_INDEX = 1
+            };
+            std::array<uint64_t, 2> data_;
+        };
+    }
+}

--- a/cpp/arcticdb/util/preprocess.hpp
+++ b/cpp/arcticdb/util/preprocess.hpp
@@ -7,11 +7,6 @@
 
 #pragma once
 
-#define stringify(x) #x
-#define static_to_string(x) stringify(x)
-#define source_loc __FILE__ ":" static_to_string(__LINE__)
-#define to_id(x) ([]() constexpr { return x; })
-
 #ifndef _WIN32
 #define ARCTICDB_UNUSED __attribute__((unused))
 #define ARCTICDB_UNREACHABLE  __builtin_unreachable();

--- a/cpp/arcticdb/util/test/test_decimal.cpp
+++ b/cpp/arcticdb/util/test/test_decimal.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+#include "util/decimal.hpp"
+
+TEST(DecimalConstructor, DefaultConstruct) {
+    arcticdb::util::Decimal d;
+    ASSERT_EQ(d.to_string(0), "0");
+}
+
+TEST(DecimalConstructor, FromDecimalString) {
+    EXPECT_EQ(arcticdb::util::Decimal("1.23").to_string(0), "123");
+    EXPECT_EQ(arcticdb::util::Decimal("0.00123").to_string(0), "123");
+    EXPECT_EQ(arcticdb::util::Decimal("100.0023").to_string(0), "1000023");
+    EXPECT_EQ(arcticdb::util::Decimal("123.40000").to_string(0), "1234");
+    EXPECT_EQ(arcticdb::util::Decimal(".123").to_string(0), "123");
+}
+
+TEST(DecimalConstructor, ScientificNotationPositiveExponent) {
+    EXPECT_EQ(arcticdb::util::Decimal("1E10").to_string(0), "10000000000");
+    EXPECT_EQ(arcticdb::util::Decimal("12.3456E2").to_string(0), "123456");
+    EXPECT_EQ(arcticdb::util::Decimal("12.3456E4").to_string(0), "123456");
+    EXPECT_EQ(arcticdb::util::Decimal("12.3456E5").to_string(0), "1234560");
+    EXPECT_EQ(arcticdb::util::Decimal("123.40000E2").to_string(0), "12340");
+    EXPECT_EQ(arcticdb::util::Decimal("-123.456E2").to_string(0), "-123456");
+}
+
+TEST(DecimalConstructor, ScientificNotationNegativeExponent) {
+    EXPECT_EQ(arcticdb::util::Decimal("12.345E-1").to_string(0), "12345");
+    EXPECT_EQ(arcticdb::util::Decimal("12.345E-10").to_string(0), "12345");
+}
+
+TEST(DecimalConstructor, Zero) {
+    EXPECT_EQ(arcticdb::util::Decimal("0").to_string(0), "0");
+    EXPECT_EQ(arcticdb::util::Decimal("00000").to_string(0), "0");
+}
+
+TEST(DecimalConstructor, OneWordUnsigned) {
+    arcticdb::util::Decimal d("1234");
+    ASSERT_EQ(d.to_string(0), "1234");
+}
+
+TEST(DecimalConstructor, LargestOneWordUnsigned) {
+    arcticdb::util::Decimal d("999999999999999999");
+    ASSERT_EQ(d.to_string(0), "999999999999999999");
+}
+
+TEST(DecimalConstructor, SmallestTwoWordUnsigned) {
+    ASSERT_EQ(arcticdb::util::Decimal("1000000000000000000").to_string(0), "1000000000000000000");
+}
+
+TEST(DecimalConstructor, LargestUnsigned) {
+    arcticdb::util::Decimal d("99999999999999999999999999999999999999");
+    ASSERT_EQ(d.to_string(0), "99999999999999999999999999999999999999");
+}
+
+TEST(Decimal, PositiveScale) {
+    arcticdb::util::Decimal d("12345");
+    ASSERT_EQ(d.to_string(2), "123.45");
+    ASSERT_EQ(d.to_string(8), "0.00012345");
+}
+
+TEST(Decimal, NegativeScale) {
+    arcticdb::util::Decimal d("12345");
+    ASSERT_EQ(d.to_string(-2), "1234500");
+}
+
+TEST(Decimal, NegativeNumber) {
+    arcticdb::util::Decimal d("-123");
+    ASSERT_TRUE(d.is_negative());
+    EXPECT_EQ(d.to_string(0), "-123");
+    EXPECT_EQ(d.to_string(3), "-0.123");
+    EXPECT_EQ(d.to_string(1), "-12.3");
+    EXPECT_EQ(d.to_string(-3), "-123000");
+}
+
+TEST(Decimal, InvalidInput) {
+    EXPECT_ANY_THROW(arcticdb::util::Decimal("123a3"));
+    EXPECT_ANY_THROW(arcticdb::util::Decimal("0.123E1E2"));
+    EXPECT_ANY_THROW(arcticdb::util::Decimal("123.123.3"));
+    EXPECT_ANY_THROW(arcticdb::util::Decimal("E123"));
+    EXPECT_ANY_THROW(arcticdb::util::Decimal("111111111111111111111111111111111111111"));
+    EXPECT_ANY_THROW(arcticdb::util::Decimal("1E38"));
+    EXPECT_ANY_THROW(arcticdb::util::Decimal("12.43E1a"));
+}
+
+TEST(Decimal, Compare) {
+    EXPECT_EQ(arcticdb::util::Decimal("123"), arcticdb::util::Decimal("123"));
+    EXPECT_EQ(arcticdb::util::Decimal("123456789101112131415"), arcticdb::util::Decimal("123456789101112131415"));
+
+    EXPECT_EQ(arcticdb::util::Decimal("-123"), arcticdb::util::Decimal("-123"));
+    EXPECT_EQ(arcticdb::util::Decimal("-123456789101112131415"), arcticdb::util::Decimal("-123456789101112131415"));
+
+    EXPECT_FALSE(arcticdb::util::Decimal("123") == arcticdb::util::Decimal("1230"));
+    EXPECT_FALSE(arcticdb::util::Decimal("123456789101112131415") == arcticdb::util::Decimal("12345678910111213141"));
+}

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -42,6 +42,7 @@
     "boost-callable-traits",
     "boost-circular-buffer",
     "boost-optional",
+    "boost-multiprecision",
     "bitmagic",
     {
       "name": "libiconv",
@@ -102,6 +103,7 @@
     { "name": "boost-move", "version": "1.80.0#1" },
     { "name": "boost-mp11", "version": "1.80.0#1" },
     { "name": "boost-mpl", "version": "1.80.0#1" },
+    { "name": "boost-multiprecision", "version": "1.80.0#1" },
     { "name": "boost-multi-index", "version": "1.80.0#1" },
     { "name": "boost-numeric-conversion", "version": "1.80.0#1" },
     { "name": "boost-optional", "version": "1.80.0#1" },


### PR DESCRIPTION
* Load decimal from string
* Convert decimal to string
* Check for equality
* Add unit tests

Implementation is for 128 bit fixed point decimal. The number is stored as two little endian uint64_t variables. The format does not store the position of the decimal point.

TODO:
* Add arithmetic
* Add comparison operators