### PR TITLE
build: Make FindxxHash.cmake portable

### DIFF
--- a/cpp/CMake/FindxxHash.cmake
+++ b/cpp/CMake/FindxxHash.cmake
@@ -7,7 +7,7 @@
 # xxHash_VERSION_PATCH  - The patch version of xxHash
 
 find_path(xxHash_INCLUDE_DIR NAME xxhash.h PATH_SUFFIXES include)
-find_library(xxHash_LIBRARY NAMES libxxhash.a xxhash xxHash PATH_SUFFIXES lib)
+find_library(xxHash_LIBRARY NAMES libxxhash xxhash xxHash PATH_SUFFIXES lib)
 
 mark_as_advanced(xxHash_INCLUDE_DIR)
 


### PR DESCRIPTION
This change has been extracted from https://github.com/man-group/ArcticDB/pull/318.