### PR TITLE
chore: Remove unused TaskScheduler::created_ private field

### DIFF
--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -148,8 +148,7 @@ class TaskScheduler {
      cpu_thread_count_(cpu_thread_count ? cpu_thread_count.value() : ConfigsMap::instance()->get_int("VersionStore.NumCPUThreads", get_default_num_cpus())),
         io_thread_count_(io_thread_count ? io_thread_count.value() : ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", std::min(100, (int) (cpu_thread_count_ * 1.5)))),
         cpu_exec_(cpu_thread_count_, std::make_shared<InstrumentedNamedFactory>("CPUPool")) ,
-        io_exec_(io_thread_count_,  std::make_shared<InstrumentedNamedFactory>("IOPool")),
-        created_(false){
+        io_exec_(io_thread_count_,  std::make_shared<InstrumentedNamedFactory>("IOPool")){
         ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Task scheduler created with {:d} {:d}", cpu_thread_count_, io_thread_count_);
     }
 
@@ -234,7 +233,6 @@ private:
     size_t io_thread_count_;
     SchedulerWrapper<CPUSchedulerType> cpu_exec_;
     SchedulerWrapper<IOSchedulerType> io_exec_;
-    bool created_;
 };
 
 


### PR DESCRIPTION
First observed when compiling using compilers on OSX.