### PR TITLE
Experiment with clang-format.

### DIFF
--- a/cpp/arcticdb/.clang-format
+++ b/cpp/arcticdb/.clang-format
@@ -1,0 +1,192 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: MultiLine
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 120
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: Never
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  false
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    false
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -22,227 +22,263 @@ namespace arcticdb::async {
 template<class ClockType = util::SysClock>
 class AsyncStore : public Store {
 public:
-    AsyncStore(
-        std::shared_ptr<storage::Library> library,
-        const arcticdb::proto::encoding::VariantCodec &codec) :
-        library_(std::move(library)),
-        codec_(new arcticdb::proto::encoding::VariantCodec{codec}) {
+    AsyncStore(std::shared_ptr<storage::Library> library, const arcticdb::proto::encoding::VariantCodec& codec)
+        : library_(std::move(library)),
+          codec_(new arcticdb::proto::encoding::VariantCodec{codec})
+    {
     }
 
-    folly::Future<entity::VariantKey> write(
-        stream::KeyType key_type,
+    folly::Future<entity::VariantKey> write(stream::KeyType key_type,
         VersionId version_id,
         const StreamId& stream_id,
         IndexValue start_index,
         IndexValue end_index,
-        SegmentInMemory &&segment) override {
+        SegmentInMemory&& segment) override
+    {
 
         util::check(segment.descriptor().id() == stream_id,
-                    "Descriptor id mismatch in atom key {} != {}",
-                    stream_id,
-                    segment.descriptor().id());
+            "Descriptor id mismatch in atom key {} != {}",
+            stream_id,
+            segment.descriptor().id());
 
-        return async::submit_cpu_task(EncodeAtomTask{
-            key_type, version_id, stream_id, start_index, end_index, current_timestamp(),
-            std::move(segment), library_, codec_, size_t(0)
-        })
+        return async::submit_cpu_task(EncodeAtomTask{key_type,
+                                          version_id,
+                                          stream_id,
+                                          start_index,
+                                          end_index,
+                                          current_timestamp(),
+                                          std::move(segment),
+                                          library_,
+                                          codec_,
+                                          size_t(0)})
             .via(&async::io_executor())
             .thenValue(WriteSegmentTask{library_});
     }
 
-    folly::Future<entity::VariantKey> write(
-            stream::KeyType key_type,
-            VersionId version_id,
-            const StreamId& stream_id,
-            timestamp creation_ts,
-            IndexValue start_index,
-            IndexValue end_index,
-            SegmentInMemory &&segment) override {
+    folly::Future<entity::VariantKey> write(stream::KeyType key_type,
+        VersionId version_id,
+        const StreamId& stream_id,
+        timestamp creation_ts,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&& segment) override
+    {
 
         util::check(segment.descriptor().id() == stream_id,
-                    "Descriptor id mismatch in atom key {} != {}",
-                    stream_id,
-                    segment.descriptor().id());
+            "Descriptor id mismatch in atom key {} != {}",
+            stream_id,
+            segment.descriptor().id());
 
-        return async::submit_cpu_task(EncodeAtomTask{
-            key_type, version_id, stream_id, start_index, end_index, creation_ts,
-            std::move(segment), library_, codec_, size_t(0)
-        })
-        .via(&async::io_executor())
-        .thenValue(WriteSegmentTask{library_});
+        return async::submit_cpu_task(EncodeAtomTask{key_type,
+                                          version_id,
+                                          stream_id,
+                                          start_index,
+                                          end_index,
+                                          creation_ts,
+                                          std::move(segment),
+                                          library_,
+                                          codec_,
+                                          size_t(0)})
+            .via(&async::io_executor())
+            .thenValue(WriteSegmentTask{library_});
     }
 
-    folly::Future<VariantKey> write(PartialKey pk, SegmentInMemory &&segment) override {
+    folly::Future<VariantKey> write(PartialKey pk, SegmentInMemory&& segment) override
+    {
         return write(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index, std::move(segment));
     }
 
-    folly::Future<entity::VariantKey> write(
-        KeyType key_type,
-        const StreamId& stream_id,
-        SegmentInMemory &&segment) override {
+    folly::Future<entity::VariantKey>
+    write(KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment) override
+    {
         util::check(is_ref_key_class(key_type), "Expected ref key type got  {}", key_type);
-        return async::submit_cpu_task(EncodeRefTask{
-            key_type, stream_id, std::move(segment), codec_
-        })
+        return async::submit_cpu_task(EncodeRefTask{key_type, stream_id, std::move(segment), codec_})
             .via(&async::io_executor())
             .thenValue(WriteSegmentTask{library_});
     }
 
-    entity::VariantKey write_sync(
-            stream::KeyType key_type,
-            VersionId version_id,
-            const StreamId& stream_id,
-            IndexValue start_index,
-            IndexValue end_index,
-            SegmentInMemory &&segment) override {
+    entity::VariantKey write_sync(stream::KeyType key_type,
+        VersionId version_id,
+        const StreamId& stream_id,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&& segment) override
+    {
 
         util::check(segment.descriptor().id() == stream_id,
-                    "Descriptor id mismatch in atom key {} != {}",
-                    stream_id,
-                    segment.descriptor().id());
+            "Descriptor id mismatch in atom key {} != {}",
+            stream_id,
+            segment.descriptor().id());
 
-        auto encoded = EncodeAtomTask{
-                key_type, version_id, stream_id, start_index, end_index, current_timestamp(),
-                std::move(segment), library_, codec_, size_t(0)
-        }();
+        auto encoded = EncodeAtomTask{key_type,
+            version_id,
+            stream_id,
+            start_index,
+            end_index,
+            current_timestamp(),
+            std::move(segment),
+            library_,
+            codec_,
+            size_t(0)}();
         return WriteSegmentTask{library_}(std::move(encoded));
     }
 
-    entity::VariantKey write_sync(PartialKey pk, SegmentInMemory &&segment) override {
+    entity::VariantKey write_sync(PartialKey pk, SegmentInMemory&& segment) override
+    {
         return write_sync(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index, std::move(segment));
     }
 
-    entity::VariantKey write_sync(
-            KeyType key_type,
-            const StreamId& stream_id,
-            SegmentInMemory &&segment) override {
+    entity::VariantKey write_sync(KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment) override
+    {
         util::check(is_ref_key_class(key_type), "Expected ref key type got  {}", key_type);
         auto encoded = EncodeRefTask{key_type, stream_id, std::move(segment), codec_}();
         return WriteSegmentTask{library_}(std::move(encoded));
     }
 
-    folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&& ks) override {
+    folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&& ks) override
+    {
         return async::submit_io_task(WriteCompressedTask{std::move(ks), library_});
     }
 
-    void write_compressed_sync(storage::KeySegmentPair&& ks) override {
+    void write_compressed_sync(storage::KeySegmentPair&& ks) override
+    {
         library_->write(Composite<storage::KeySegmentPair>{std::move(ks)});
     }
 
-    folly::Future<entity::VariantKey> update(const entity::VariantKey &key, SegmentInMemory &&segment, storage::UpdateOpts opts) override {
+    folly::Future<entity::VariantKey>
+    update(const entity::VariantKey& key, SegmentInMemory&& segment, storage::UpdateOpts opts) override
+    {
         auto stream_id = variant_key_id(key);
         util::check(segment.descriptor().id() == stream_id,
-                    "Descriptor id mismatch in variant key {} != {}",
-                    stream_id,
-                    segment.descriptor().id());
+            "Descriptor id mismatch in variant key {} != {}",
+            stream_id,
+            segment.descriptor().id());
 
-        return async::submit_cpu_task(EncodeSegmentTask{
-            key, std::move(segment), library_, codec_, size_t(0)
-        })
-        .via(&async::io_executor())
-        .thenValue(UpdateSegmentTask{library_, opts});
+        return async::submit_cpu_task(EncodeSegmentTask{key, std::move(segment), library_, codec_, size_t(0)})
+            .via(&async::io_executor())
+            .thenValue(UpdateSegmentTask{library_, opts});
     }
 
-    folly::Future<VariantKey> copy(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) override {
-        return async::submit_io_task(CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_});
+    folly::Future<VariantKey>
+    copy(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) override
+    {
+        return async::submit_io_task(
+            CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_});
     }
 
-    VariantKey copy_sync(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) override {
+    VariantKey
+    copy_sync(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) override
+    {
         return CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_}();
     }
 
-    timestamp current_timestamp() override {
+    timestamp current_timestamp() override
+    {
         return ClockType::nanos_since_epoch();
     }
 
-   void iterate_type(KeyType type, std::function<void(entity::VariantKey &&)> func,
-                                            const std::string &prefix) override {
+    void iterate_type(KeyType type, std::function<void(entity::VariantKey&&)> func, const std::string& prefix) override
+    {
         library_->iterate_type(type, func, prefix);
     }
 
-    folly::Future<std::pair<entity::VariantKey, SegmentInMemory>> read(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
+    folly::Future<std::pair<entity::VariantKey, SegmentInMemory>> read(const entity::VariantKey& key,
+        storage::ReadKeyOpts opts) override
+    {
         return async::submit_io_task(ReadCompressedTask{key, library_, opts})
             .via(&async::cpu_executor())
             .thenValue(DecodeSegmentTask{});
     }
 
-    std::pair<entity::VariantKey, SegmentInMemory> read_sync(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
-        auto read_task =  ReadCompressedTask{key, library_, opts};
+    std::pair<entity::VariantKey, SegmentInMemory> read_sync(const entity::VariantKey& key,
+        storage::ReadKeyOpts opts) override
+    {
+        auto read_task = ReadCompressedTask{key, library_, opts};
         return DecodeSegmentTask{}(read_task());
     }
 
-    folly::Future<storage::KeySegmentPair> read_compressed(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
+    folly::Future<storage::KeySegmentPair> read_compressed(const entity::VariantKey& key,
+        storage::ReadKeyOpts opts) override
+    {
         return async::submit_io_task(ReadCompressedTask{key, library_, opts});
     }
 
     folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>
-    read_metadata(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
+    read_metadata(const entity::VariantKey& key, storage::ReadKeyOpts opts) override
+    {
         return async::submit_io_task(ReadCompressedTask{key, library_, opts})
             .via(&async::cpu_executor())
             .thenValue(DecodeMetadataTask{});
     }
 
     folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto>>
-    read_metadata_and_descriptor(
-        const entity::VariantKey& key,
-        storage::ReadKeyOpts opts) override {
+    read_metadata_and_descriptor(const entity::VariantKey& key, storage::ReadKeyOpts opts) override
+    {
         return async::submit_io_task(ReadCompressedTask{key, library_, opts})
-        .via(&async::cpu_executor())
-        .thenValue(DecodeMetadataAndDescriptorTask{});
+            .via(&async::cpu_executor())
+            .thenValue(DecodeMetadataAndDescriptorTask{});
     }
 
-    folly::Future<bool> key_exists(const entity::VariantKey &key) override {
+    folly::Future<bool> key_exists(const entity::VariantKey& key) override
+    {
         return async::submit_io_task(KeyExistsTask{&key, library_});
     }
 
-    bool key_exists_sync(const entity::VariantKey &key) override {
+    bool key_exists_sync(const entity::VariantKey& key) override
+    {
         return KeyExistsTask{&key, library_}();
     }
 
-    bool supports_prefix_matching() override {
+    bool supports_prefix_matching() override
+    {
         return library_->supports_prefix_matching();
     }
 
-    bool fast_delete() override {
+    bool fast_delete() override
+    {
         return library_->fast_delete();
     }
 
-    void move_storage(KeyType key_type, timestamp horizon, size_t storage_index) override {
+    void move_storage(KeyType key_type, timestamp horizon, size_t storage_index) override
+    {
         library_->move_storage(key_type, horizon, storage_index);
     }
 
-    folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair> kvs) override {
+    folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair> kvs) override
+    {
         return async::submit_io_task(WriteCompressedBatchTask(std::move(kvs), library_));
     }
 
-    folly::Future<RemoveKeyResultType> remove_key(const entity::VariantKey &key, storage::RemoveOpts opts) override {
+    folly::Future<RemoveKeyResultType> remove_key(const entity::VariantKey& key, storage::RemoveOpts opts) override
+    {
         return async::submit_io_task(RemoveTask{key, library_, opts});
     }
 
-    RemoveKeyResultType remove_key_sync(const entity::VariantKey &key, storage::RemoveOpts opts) override {
+    RemoveKeyResultType remove_key_sync(const entity::VariantKey& key, storage::RemoveOpts opts) override
+    {
         return RemoveTask{key, library_, opts}();
     }
 
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(const std::vector<entity::VariantKey> &keys, storage::RemoveOpts opts) override {
-        return keys.size() == 0 ?
-            std::vector<RemoveKeyResultType>() :
-            async::submit_io_task(RemoveBatchTask{keys, library_, opts});
+    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(const std::vector<entity::VariantKey>& keys,
+        storage::RemoveOpts opts) override
+    {
+        return keys.size() == 0 ? std::vector<RemoveKeyResultType>()
+                                : async::submit_io_task(RemoveBatchTask{keys, library_, opts});
     }
 
-    void copy_to_results(
-        std::vector<folly::Future<storage::KeySegmentPair>>& batch,
-        std::vector<storage::KeySegmentPair>& res
-        ) const {
+    void copy_to_results(std::vector<folly::Future<storage::KeySegmentPair>>& batch,
+        std::vector<storage::KeySegmentPair>& res) const
+    {
         auto vec = folly::collect(batch).get();
         res.insert(end(res), std::make_move_iterator(std::begin(vec)), std::make_move_iterator(std::end(vec)));
     }
 
-    void copy_to_results_with_failure(
-        std::vector<folly::Future<storage::KeySegmentPair>>& batch,
+    void copy_to_results_with_failure(std::vector<folly::Future<storage::KeySegmentPair>>& batch,
         std::vector<storage::KeySegmentPair>& res,
-        const std::vector<VariantKey>& keys) const {
+        const std::vector<VariantKey>& keys) const
+    {
         auto collected_kvs = folly::collectAll(batch).get();
-        for(size_t idx = 0; idx != batch.size(); idx++) {
+        for (size_t idx = 0; idx != batch.size(); idx++) {
             if (collected_kvs[idx].hasValue()) {
                 res.emplace_back(std::move(collected_kvs[idx].value()));
             } else {
@@ -251,18 +287,18 @@ public:
         }
     }
 
-    std::vector<storage::KeySegmentPair> batch_read_compressed(
-        std::vector<entity::VariantKey> &&keys,
-        const BatchReadArgs &args,
-        bool may_fail) override {
+    std::vector<storage::KeySegmentPair>
+    batch_read_compressed(std::vector<entity::VariantKey>&& keys, const BatchReadArgs& args, bool may_fail) override
+    {
         std::vector<folly::Future<storage::KeySegmentPair>> batch{};
         batch.reserve(args.batch_size_);
         std::vector<storage::KeySegmentPair> res;
         res.reserve(keys.size());
         for (auto key : keys) {
-            batch.push_back(async::submit_io_task(ReadCompressedTask(std::move(key), library_, storage::ReadKeyOpts{})));
-            if(batch.size() == args.batch_size_) {
-                if(may_fail)
+            batch.push_back(
+                async::submit_io_task(ReadCompressedTask(std::move(key), library_, storage::ReadKeyOpts{})));
+            if (batch.size() == args.batch_size_) {
+                if (may_fail)
                     copy_to_results_with_failure(batch, res, keys);
                 else
                     copy_to_results(batch, res);
@@ -270,8 +306,8 @@ public:
                 batch.clear();
             }
         }
-        if(!batch.empty()) {
-            if(may_fail)
+        if (!batch.empty()) {
+            if (may_fail)
                 copy_to_results_with_failure(batch, res, keys);
             else
                 copy_to_results(batch, res);
@@ -280,32 +316,31 @@ public:
         return res;
     }
 
-    std::vector<VariantKey> batch_read_compressed(
-        std::vector<entity::VariantKey> &&keys,
-        std::vector<ReadContinuation> &&continuations,
-        const BatchReadArgs & args) override {
+    std::vector<VariantKey> batch_read_compressed(std::vector<entity::VariantKey>&& keys,
+        std::vector<ReadContinuation>&& continuations,
+        const BatchReadArgs& args) override
+    {
         util::check(keys.size() == continuations.size(),
-                    "keys and continuations must has then same number of elements");
+            "keys and continuations must has then same number of elements");
         std::vector<folly::Future<VariantKey>> batch;
         batch.reserve(args.batch_size_);
         std::vector<VariantKey> res;
         res.reserve(keys.size());
         for (std::size_t i = 0; i < keys.size(); ++i) {
-            auto &key = keys[i];
-            auto &cont = continuations[i];
-            batch.push_back(
-                async::submit_io_task(ReadCompressedTask(key, library_, storage::ReadKeyOpts{}))
-                    .via(&async::cpu_executor())
-                    .thenValue(SegmentFunctionTask{std::move(cont)}));
+            auto& key = keys[i];
+            auto& cont = continuations[i];
+            batch.push_back(async::submit_io_task(ReadCompressedTask(key, library_, storage::ReadKeyOpts{}))
+                                .via(&async::cpu_executor())
+                                .thenValue(SegmentFunctionTask{std::move(cont)}));
 
-            if(batch.size() == args.batch_size_) {
+            if (batch.size() == args.batch_size_) {
                 auto vec = folly::collect(batch).get();
                 res.insert(end(res), std::make_move_iterator(std::begin(vec)), std::make_move_iterator(std::end(vec)));
                 batch.clear();
             }
         }
 
-        if(!batch.empty()) {
+        if (!batch.empty()) {
             auto vec = folly::collect(batch).get();
             res.insert(end(res), std::make_move_iterator(std::begin(vec)), std::make_move_iterator(std::end(vec)));
         }
@@ -313,11 +348,12 @@ public:
     }
 
     std::vector<Composite<ProcessingSegment>> batch_read_uncompressed(
-        std::vector<Composite<pipelines::SliceAndKey>> &&slice_and_keys,
+        std::vector<Composite<pipelines::SliceAndKey>>&& slice_and_keys,
         const std::shared_ptr<std::vector<Clause>>& query,
         const StreamDescriptor& desc,
         const std::shared_ptr<std::unordered_set<std::string>>& filter_columns,
-        const BatchReadArgs & args) override {
+        const BatchReadArgs& args) override
+    {
 
         std::vector<Composite<ProcessingSegment>> res;
         res.reserve(slice_and_keys.size());
@@ -326,39 +362,43 @@ public:
         for (auto&& s : slice_and_keys) {
             auto sk = std::move(s);
             // By default IO bound work -> IO thread pool, CPU bound work -> CPU thread pool.
-            if(args.scheduler_ == BatchReadArgs::CPU) {
-                batch.push_back(
-                    async::submit_io_task(ReadCompressedSlicesTask(std::move(sk), library_))
-                        .via(&async::cpu_executor())
-                        .thenValue(DecodeSlicesTask{desc, filter_columns})
-                        .thenValue(MemSegmentProcessingTask{shared_from_this(),query}));
+            if (args.scheduler_ == BatchReadArgs::CPU) {
+                batch.push_back(async::submit_io_task(ReadCompressedSlicesTask(std::move(sk), library_))
+                                    .via(&async::cpu_executor())
+                                    .thenValue(DecodeSlicesTask{desc, filter_columns})
+                                    .thenValue(MemSegmentProcessingTask{shared_from_this(), query}));
             }
             // IO option will execute all work in the same Folly thread potentially limiting context switches.
-            else {
-                batch.push_back(
-                    async::submit_io_task(ReadCompressedSlicesTask(std::move(sk), library_))
-                        .thenValue(DecodeSlicesTask{desc, filter_columns})
-                        .thenValue(MemSegmentProcessingTask{shared_from_this(),query}));
+            else
+            {
+                batch.push_back(async::submit_io_task(ReadCompressedSlicesTask(std::move(sk), library_))
+                                    .thenValue(DecodeSlicesTask{desc, filter_columns})
+                                    .thenValue(MemSegmentProcessingTask{shared_from_this(), query}));
             }
 
-            if(++current_size == args.batch_size_) {
+            if (++current_size == args.batch_size_) {
                 auto segments = folly::collect(batch).get();
-                res.insert(std::end(res), std::make_move_iterator(std::begin(segments)), std::make_move_iterator(std::end(segments)));
+                res.insert(std::end(res),
+                    std::make_move_iterator(std::begin(segments)),
+                    std::make_move_iterator(std::end(segments)));
                 current_size = 0;
                 batch.clear();
             }
         }
 
-        if(!batch.empty()) {
+        if (!batch.empty()) {
             auto segments = folly::collect(batch).get();
-            res.insert(std::end(res), std::make_move_iterator(std::begin(segments)), std::make_move_iterator(std::end(segments)));
+            res.insert(std::end(res),
+                std::make_move_iterator(std::begin(segments)),
+                std::make_move_iterator(std::end(segments)));
         }
 
         slice_and_keys.clear();
         return res;
     }
 
-    std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey> &keys) override {
+    std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override
+    {
         std::vector<folly::Future<bool>> res;
         res.reserve(keys.size());
         for (auto itr = keys.cbegin(); itr < keys.cend(); ++itr) {
@@ -367,15 +407,18 @@ public:
         return res;
     }
 
-    bool batch_all_keys_exist_sync(const std::unordered_set<entity::VariantKey> &keys) override {
-        return std::all_of(keys.begin(), keys.end(), [that=this] (const entity::VariantKey& key) {
+    bool batch_all_keys_exist_sync(const std::unordered_set<entity::VariantKey>& keys) override
+    {
+        return std::all_of(keys.begin(), keys.end(), [that = this](const entity::VariantKey& key) {
             return that->key_exists_sync(key);
         });
     }
 
-    folly::Future<std::vector<VariantKey>> batch_write(std::vector<std::pair<PartialKey, SegmentInMemory>> &&key_segments,
-                const std::shared_ptr<DeDupMap>& de_dup_map,
-                const BatchWriteArgs &args) override {
+    folly::Future<std::vector<VariantKey>> batch_write(
+        std::vector<std::pair<PartialKey, SegmentInMemory>>&& key_segments,
+        const std::shared_ptr<DeDupMap>& de_dup_map,
+        const BatchWriteArgs& args) override
+    {
         std::size_t write_count = args.lib_write_count == 0 ? 16ULL : args.lib_write_count;
 
         std::shared_ptr<std::vector<VariantKey>> res = std::make_shared<std::vector<VariantKey>>(key_segments.size());
@@ -389,41 +432,57 @@ public:
             std::vector<folly::Future<folly::Unit>> futs;
             futs.reserve(range.size());
 
-            for(auto& kv : range) {
-                futs.emplace_back(async::submit_cpu_task(
-                    EncodeAtomTask(std::move(kv.first), ClockType::nanos_since_epoch(), std::move(kv.second), library_, codec_, count++))
-                                       .thenValue([de_dup_map, res](auto &&key_seg) {
-                    auto de_dup_key = de_dup_map ? de_dup_map->get_key_if_present(key_seg.atom_key()) : std::nullopt;
+            for (auto& kv : range) {
+                futs.emplace_back(
+                    async::submit_cpu_task(EncodeAtomTask(std::move(kv.first),
+                                               ClockType::nanos_since_epoch(),
+                                               std::move(kv.second),
+                                               library_,
+                                               codec_,
+                                               count++))
+                        .thenValue([de_dup_map, res](auto&& key_seg) {
+                            auto de_dup_key =
+                                de_dup_map ? de_dup_map->get_key_if_present(key_seg.atom_key()) : std::nullopt;
 
-                    if (de_dup_key) {
-                        ARCTICDB_DEBUG(log::version(), "Found existing key with same contents: using existing object {}", de_dup_key.value());
-                        (*res)[key_seg.id()] = (de_dup_key.value());
-                        return std::make_pair(storage::KeySegmentPair{}, false);
-                    } else {
-                        ARCTICDB_DEBUG(log::version(), "No existing key with same contents: writing new object {}", key_seg.atom_key());
-                        (*res)[key_seg.id()] = (key_seg.atom_key());
-                        return std::make_pair(std::forward<storage::KeySegmentPair>(key_seg), true);
-                    }
-                }).thenValue([key_segs=key_segs, key_seg_mutex=key_seg_mutex](auto && pair_key_write) {
-                        if (pair_key_write.second) {
-                            std::lock_guard kl{*key_seg_mutex};
-                            ARCTICDB_DEBUG(log::version(), "Enqueuing {} for write", pair_key_write.first.atom_key());
-                            key_segs->emplace_back(std::move(pair_key_write.first));
-                        }
-                    }));
+                            if (de_dup_key) {
+                                ARCTICDB_DEBUG(log::version(),
+                                    "Found existing key with same contents: using existing object {}",
+                                    de_dup_key.value());
+                                (*res)[key_seg.id()] = (de_dup_key.value());
+                                return std::make_pair(storage::KeySegmentPair{}, false);
+                            } else {
+                                ARCTICDB_DEBUG(log::version(),
+                                    "No existing key with same contents: writing new object {}",
+                                    key_seg.atom_key());
+                                (*res)[key_seg.id()] = (key_seg.atom_key());
+                                return std::make_pair(std::forward<storage::KeySegmentPair>(key_seg), true);
+                            }
+                        })
+                        .thenValue([key_segs = key_segs, key_seg_mutex = key_seg_mutex](auto&& pair_key_write) {
+                            if (pair_key_write.second) {
+                                std::lock_guard kl{*key_seg_mutex};
+                                ARCTICDB_DEBUG(log::version(),
+                                    "Enqueuing {} for write",
+                                    pair_key_write.first.atom_key());
+                                key_segs->emplace_back(std::move(pair_key_write.first));
+                            }
+                        }));
             }
 
-            auto write_fut = folly::collect(std::move(futs)).via(&async::io_executor()).then([lib=library_, key_segs=key_segs](auto &&) {
-                if(!key_segs->empty())
-                    lib->write(Composite<storage::KeySegmentPair>(std::move(*key_segs)));
-            });
+            auto write_fut = folly::collect(std::move(futs))
+                                 .via(&async::io_executor())
+                                 .then([lib = library_, key_segs = key_segs](auto&&) {
+                                     if (!key_segs->empty())
+                                         lib->write(Composite<storage::KeySegmentPair>(std::move(*key_segs)));
+                                 });
             std::move(write_fut).get();
         }
 
         return folly::makeFuture(std::move(*res));
     }
 
-    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &cfg) override {
+    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator& cfg) override
+    {
         library_->set_failure_sim(cfg);
     }
 

--- a/cpp/arcticdb/async/batch_read_args.hpp
+++ b/cpp/arcticdb/async/batch_read_args.hpp
@@ -19,19 +19,25 @@ struct BatchReadArgs {
         CPU
     };
 
-    BatchReadArgs() :
-        batch_size_(ConfigsMap::instance()->get_int("BatchRead.BatchSize", 100)),
-        scheduler_(Scheduler::CPU) {}
+    BatchReadArgs()
+        : batch_size_(ConfigsMap::instance()->get_int("BatchRead.BatchSize", 100)),
+          scheduler_(Scheduler::CPU)
+    {
+    }
 
-    explicit BatchReadArgs(size_t batch_size) :
-        batch_size_(batch_size),
-        scheduler_(Scheduler::CPU) {}
+    explicit BatchReadArgs(size_t batch_size)
+        : batch_size_(batch_size),
+          scheduler_(Scheduler::CPU)
+    {
+    }
 
-    explicit BatchReadArgs(Scheduler scheduler) :
-        batch_size_(ConfigsMap::instance()->get_int("BatchRead.BatchSize", 100)),
-        scheduler_(scheduler) { }
+    explicit BatchReadArgs(Scheduler scheduler)
+        : batch_size_(ConfigsMap::instance()->get_int("BatchRead.BatchSize", 100)),
+          scheduler_(scheduler)
+    {
+    }
 
     size_t batch_size_;
     Scheduler scheduler_;
 };
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/async/python_bindings.cpp
+++ b/cpp/arcticdb/async/python_bindings.cpp
@@ -13,18 +13,18 @@ namespace py = pybind11;
 
 namespace arcticdb::async {
 
-void register_bindings(py::module &m) {
+void register_bindings(py::module& m)
+{
     auto async = m.def_submodule("cpp_async", "Asynchronous processing");
 
     py::class_<TaskScheduler, std::shared_ptr<TaskScheduler>>(async, "TaskScheduler")
-        .def(py::init<>([](py::kwargs &conf) {
+        .def(py::init<>([](py::kwargs& conf) {
             auto thread_count = conf.attr("get")("thread_count", 1).cast<std::size_t>();
             return std::make_shared<TaskScheduler>(thread_count);
-        }), "Number of threads used to execute tasks");
+        }),
+            "Number of threads used to execute tasks");
 
     async.def("print_scheduler_stats", &print_scheduler_stats);
 }
 
 } // namespace arcticdb::async
-
-

--- a/cpp/arcticdb/async/python_bindings.hpp
+++ b/cpp/arcticdb/async/python_bindings.hpp
@@ -13,8 +13,6 @@ namespace py = pybind11;
 
 namespace arcticdb::async {
 
-void register_bindings(py::module &m);
+void register_bindings(py::module& m);
 
 } // namespace arcticdb::async
-
-

--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -9,7 +9,8 @@
 
 namespace arcticdb::async {
 
-TaskScheduler* TaskScheduler::instance() {
+TaskScheduler* TaskScheduler::instance()
+{
     std::call_once(TaskScheduler::init_flag_, &TaskScheduler::init);
     return instance_->ptr_;
 }
@@ -19,54 +20,72 @@ std::once_flag TaskScheduler::init_flag_;
 std::once_flag TaskScheduler::shutdown_flag_;
 bool TaskScheduler::forked_ = false;
 
-void TaskScheduler::destroy_instance() {
+void TaskScheduler::destroy_instance()
+{
     std::call_once(TaskScheduler::shutdown_flag_, &TaskScheduler::stop_and_destroy);
 }
 
-void TaskScheduler::stop_and_destroy() {
-    if(TaskScheduler::instance_) {
+void TaskScheduler::stop_and_destroy()
+{
+    if (TaskScheduler::instance_) {
         TaskScheduler::instance()->stop();
 
         TaskScheduler::instance_.reset();
     }
 }
 
-void TaskScheduler::reattach_instance() {
+void TaskScheduler::reattach_instance()
+{
     if (TaskScheduler::instance_) {
-        ARCTICDB_DEBUG(log::schedule(), "Leaking and reattaching task scheduler instance, currently {}",
-                              uintptr_t(TaskScheduler::instance_->ptr_));
+        ARCTICDB_DEBUG(log::schedule(),
+            "Leaking and reattaching task scheduler instance, currently {}",
+            uintptr_t(TaskScheduler::instance_->ptr_));
         TaskScheduler::instance_->ptr_ = new TaskScheduler;
-        ARCTICDB_DEBUG(log::schedule(), "Attached new task scheduler instance, now {}",
-                              uintptr_t(TaskScheduler::instance_->ptr_));
+        ARCTICDB_DEBUG(log::schedule(),
+            "Attached new task scheduler instance, now {}",
+            uintptr_t(TaskScheduler::instance_->ptr_));
     }
 }
 
-bool TaskScheduler::is_forked() {
+bool TaskScheduler::is_forked()
+{
     return TaskScheduler::forked_;
 }
 
-void TaskScheduler::set_forked(bool val) {
+void TaskScheduler::set_forked(bool val)
+{
     TaskScheduler::forked_ = val;
 }
 
-void TaskScheduler::init(){
+void TaskScheduler::init()
+{
     TaskScheduler::instance_ = std::make_shared<TaskSchedulerPtrWrapper>(new TaskScheduler);
 }
 
-TaskSchedulerPtrWrapper::~TaskSchedulerPtrWrapper() {
+TaskSchedulerPtrWrapper::~TaskSchedulerPtrWrapper()
+{
     delete ptr_;
 }
 
-void print_scheduler_stats() {
+void print_scheduler_stats()
+{
     auto cpu_stats = TaskScheduler::instance()->cpu_exec().getPoolStats();
     log::schedule().info("CPU: Threads: {}\tIdle: {}\tActive: {}\tPending: {}\tTotal: {}\tMaxIdleTime: {}",
-        cpu_stats.threadCount, cpu_stats.idleThreadCount, cpu_stats.activeThreadCount, cpu_stats.pendingTaskCount, cpu_stats.totalTaskCount, cpu_stats.maxIdleTime.count());
+        cpu_stats.threadCount,
+        cpu_stats.idleThreadCount,
+        cpu_stats.activeThreadCount,
+        cpu_stats.pendingTaskCount,
+        cpu_stats.totalTaskCount,
+        cpu_stats.maxIdleTime.count());
 
     auto io_stats = TaskScheduler::instance()->io_exec().getPoolStats();
     log::schedule().info("IO: Threads: {}\tIdle: {}\tActive: {}\tPending: {}\tTotal: {}\tMaxIdleTime: {}",
-        io_stats.threadCount, io_stats.idleThreadCount, io_stats.activeThreadCount, io_stats.pendingTaskCount, io_stats.totalTaskCount, io_stats.maxIdleTime.count());
+        io_stats.threadCount,
+        io_stats.idleThreadCount,
+        io_stats.activeThreadCount,
+        io_stats.pendingTaskCount,
+        io_stats.totalTaskCount,
+        io_stats.maxIdleTime.count());
 }
 
-} // namespace arcticdb
-
-
+} // namespace arcticdb::async

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -31,74 +31,92 @@
 namespace arcticdb::async {
 class TaskScheduler;
 
-struct TaskSchedulerPtrWrapper{
+struct TaskSchedulerPtrWrapper {
     TaskScheduler* ptr_;
 
-    explicit TaskSchedulerPtrWrapper(TaskScheduler* ptr) : ptr_(ptr) {
+    explicit TaskSchedulerPtrWrapper(TaskScheduler* ptr)
+        : ptr_(ptr)
+    {
         util::check(ptr != nullptr, "Null TaskScheduler ptr");
     }
 
-    TaskSchedulerPtrWrapper() : ptr_(nullptr) {
+    TaskSchedulerPtrWrapper()
+        : ptr_(nullptr)
+    {
     }
 
     ~TaskSchedulerPtrWrapper();
 
-    void reset(TaskScheduler* ptr) {
+    void reset(TaskScheduler* ptr)
+    {
         ptr_ = ptr;
     }
 
-    TaskScheduler* operator->() {
+    TaskScheduler* operator->()
+    {
         return ptr_;
     }
 
-    TaskScheduler& operator*() {
+    TaskScheduler& operator*()
+    {
         return *ptr_;
     }
 };
 
-class InstrumentedNamedFactory : public folly::ThreadFactory{
+class InstrumentedNamedFactory : public folly::ThreadFactory {
 public:
-    explicit InstrumentedNamedFactory(folly::StringPiece prefix) : named_factory_(prefix){}
+    explicit InstrumentedNamedFactory(folly::StringPiece prefix)
+        : named_factory_(prefix)
+    {
+    }
 
-    std::thread newThread(folly::Func&& func) override {
-        return named_factory_.newThread(
-                [func = std::move(func)]() mutable {
-                ARCTICDB_SAMPLE_THREAD();
-              func();
-            });
-  }
+    std::thread newThread(folly::Func&& func) override
+    {
+        return named_factory_.newThread([func = std::move(func)]() mutable {
+            ARCTICDB_SAMPLE_THREAD();
+            func();
+        });
+    }
 
 private:
     folly::NamedThreadFactory named_factory_;
 };
 
-template <typename SchedulerType>
+template<typename SchedulerType>
 struct SchedulerWrapper : public SchedulerType {
 
     using SchedulerType::SchedulerType;
 
-    void set_active_threads(size_t n) {
+    void set_active_threads(size_t n)
+    {
         SchedulerType::activeThreads_.store(n);
     }
 
-    void set_max_threads(size_t n) {
+    void set_max_threads(size_t n)
+    {
         SchedulerType::maxThreads_.store(n);
     }
 
-    void set_thread_factory(std::shared_ptr<folly::ThreadFactory> factory) {
+    void set_thread_factory(std::shared_ptr<folly::ThreadFactory> factory)
+    {
         SchedulerType::setThreadFactory(std::move(factory));
     }
 
-    void ensure_active_threads() {
+    void ensure_active_threads()
+    {
         SchedulerType::ensureActiveThreads();
     }
 };
 
-inline int64_t get_cgroup_value(const std::string& cgroup_file) {
-    const auto path = std::filesystem::path{fmt::format("/sys/fs/cgroup/{}",cgroup_file)};
-    if(std::filesystem::exists(path)){
+inline int64_t get_cgroup_value(const std::string& cgroup_file)
+{
+    const auto path = std::filesystem::path{fmt::format("/sys/fs/cgroup/{}", cgroup_file)};
+    if (std::filesystem::exists(path)) {
         std::ifstream strm(path.string());
-        util::check(static_cast<bool>(strm), "Failed to open cgroups cpu file for read at path '{}': {}", path.string(), std::strerror(errno));
+        util::check(static_cast<bool>(strm),
+            "Failed to open cgroups cpu file for read at path '{}': {}",
+            path.string(),
+            std::strerror(errno));
         std::string str;
         std::getline(strm, str);
         return std::stol(str);
@@ -106,27 +124,28 @@ inline int64_t get_cgroup_value(const std::string& cgroup_file) {
     return static_cast<int64_t>(-1);
 }
 
-inline auto get_default_num_cpus() {
+inline auto get_default_num_cpus()
+{
     auto cpu_count = std::thread::hardware_concurrency() == 0 ? 16 : std::thread::hardware_concurrency();
-    #ifdef _WIN32
-        return static_cast<int64_t>(cpu_count);
-    #else
-        auto quota_count = 0;
-        auto limit_count = 0;
-        auto quota = get_cgroup_value("cpu/cpu.cfs_quota_us");
-        auto period = get_cgroup_value("cpu/cpu.cfs_period_us");
+#ifdef _WIN32
+    return static_cast<int64_t>(cpu_count);
+#else
+    auto quota_count = 0;
+    auto limit_count = 0;
+    auto quota = get_cgroup_value("cpu/cpu.cfs_quota_us");
+    auto period = get_cgroup_value("cpu/cpu.cfs_period_us");
 
-        if (quota > -1 && period > 0) {
-            quota_count = ceil(static_cast<double>(quota) / static_cast<double>(period));
-        }
+    if (quota > -1 && period > 0) {
+        quota_count = ceil(static_cast<double>(quota) / static_cast<double>(period));
+    }
 
-        if (quota_count != 0) {
-            limit_count = quota_count;
-        } else {
-            limit_count = cpu_count;
-        }
-        return std::min(static_cast<int64_t>(cpu_count), static_cast<int64_t>(limit_count));
-    #endif
+    if (quota_count != 0) {
+        limit_count = quota_count;
+    } else {
+        limit_count = cpu_count;
+    }
+    return std::min(static_cast<int64_t>(cpu_count), static_cast<int64_t>(limit_count));
+#endif
 }
 
 /*
@@ -140,32 +159,52 @@ inline auto get_default_num_cpus() {
  */
 
 class TaskScheduler {
-  public:
+public:
     using CPUSchedulerType = folly::FutureExecutor<folly::CPUThreadPoolExecutor>;
     using IOSchedulerType = folly::FutureExecutor<folly::IOThreadPoolExecutor>;
 
-     explicit TaskScheduler(const std::optional<size_t>& cpu_thread_count = std::nullopt, const std::optional<size_t>& io_thread_count = std::nullopt) :
-     cpu_thread_count_(cpu_thread_count ? cpu_thread_count.value() : ConfigsMap::instance()->get_int("VersionStore.NumCPUThreads", get_default_num_cpus())),
-        io_thread_count_(io_thread_count ? io_thread_count.value() : ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", std::min(100, (int) (cpu_thread_count_ * 1.5)))),
-        cpu_exec_(cpu_thread_count_, std::make_shared<InstrumentedNamedFactory>("CPUPool")) ,
-        io_exec_(io_thread_count_,  std::make_shared<InstrumentedNamedFactory>("IOPool")),
-        created_(false){
-        ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Task scheduler created with {:d} {:d}", cpu_thread_count_, io_thread_count_);
+    explicit TaskScheduler(const std::optional<size_t>& cpu_thread_count = std::nullopt,
+        const std::optional<size_t>& io_thread_count = std::nullopt)
+        : cpu_thread_count_(
+              cpu_thread_count ? cpu_thread_count.value()
+                               : ConfigsMap::instance()->get_int("VersionStore.NumCPUThreads", get_default_num_cpus())),
+          io_thread_count_(io_thread_count ? io_thread_count.value()
+                                           : ConfigsMap::instance()->get_int("VersionStore.NumIOThreads",
+                                                 std::min(100, (int)(cpu_thread_count_ * 1.5)))),
+          cpu_exec_(cpu_thread_count_, std::make_shared<InstrumentedNamedFactory>("CPUPool")),
+          io_exec_(io_thread_count_, std::make_shared<InstrumentedNamedFactory>("IOPool")),
+          created_(false)
+    {
+        ARCTICDB_RUNTIME_DEBUG(log::schedule(),
+            "Task scheduler created with {:d} {:d}",
+            cpu_thread_count_,
+            io_thread_count_);
     }
 
     ~TaskScheduler() = default;
 
     template<class Task>
-    auto submit_cpu_task(Task &&task) {
+    auto submit_cpu_task(Task&& task)
+    {
         static_assert(std::is_base_of_v<BaseTask, std::decay_t<Task>>, "Only supports Task derived from BaseTask");
-        ARCTICDB_DEBUG(log::schedule(), "{} Submitting CPU task {}: {} of {}", uintptr_t(this), typeid(task).name(), cpu_exec_.getTaskQueueSize(), cpu_exec_.kDefaultMaxQueueSize);
+        ARCTICDB_DEBUG(log::schedule(),
+            "{} Submitting CPU task {}: {} of {}",
+            uintptr_t(this),
+            typeid(task).name(),
+            cpu_exec_.getTaskQueueSize(),
+            cpu_exec_.kDefaultMaxQueueSize);
         return cpu_exec_.addFuture(std::move(task));
     }
 
     template<class Task>
-    auto submit_io_task(Task &&task) {
+    auto submit_io_task(Task&& task)
+    {
         static_assert(std::is_base_of_v<BaseTask, std::decay_t<Task>>, "Only support Tasks derived from BaseTask");
-        ARCTICDB_DEBUG(log::schedule(), "{} Submitting IO task {}: {}", uintptr_t(this), typeid(task).name(), io_exec_.getPendingTaskCount());
+        ARCTICDB_DEBUG(log::schedule(),
+            "{} Submitting IO task {}: {}",
+            uintptr_t(this),
+            typeid(task).name(),
+            io_exec_.getPendingTaskCount());
         return io_exec_.addFuture(std::move(task));
     }
 
@@ -183,42 +222,52 @@ class TaskScheduler {
     static bool is_forked();
     static void set_forked(bool);
 
-    void join() {
+    void join()
+    {
         ARCTICDB_DEBUG(log::schedule(), "Joining task scheduler");
         io_exec_.join();
         cpu_exec_.join();
     }
 
-    void stop() {
+    void stop()
+    {
         ARCTICDB_DEBUG(log::schedule(), "Stopping task scheduler");
         cpu_exec_.stop();
         io_exec_.stop();
     }
 
-    void set_active_threads(size_t n) {
+    void set_active_threads(size_t n)
+    {
         ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Setting CPU and IO thread pools to {} active threads", n);
         cpu_exec_.set_active_threads(n);
         io_exec_.set_active_threads(n);
     }
 
-    void set_max_threads(size_t n) {
+    void set_max_threads(size_t n)
+    {
         ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Setting CPU and IO thread pools to {} max threads", n);
         cpu_exec_.set_max_threads(n);
         io_exec_.set_max_threads(n);
     }
 
-    SchedulerWrapper<CPUSchedulerType>& cpu_exec() {
+    SchedulerWrapper<CPUSchedulerType>& cpu_exec()
+    {
         ARCTICDB_DEBUG(log::schedule(), "Getting CPU executor: {}", cpu_exec_.getTaskQueueSize());
         return cpu_exec_;
     }
 
-    SchedulerWrapper<IOSchedulerType>& io_exec() {
+    SchedulerWrapper<IOSchedulerType>& io_exec()
+    {
         ARCTICDB_DEBUG(log::schedule(), "Getting IO executor: {}", io_exec_.getPendingTaskCount());
         return io_exec_;
     }
 
-    void re_init() {
-        ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Reinitializing task scheduler: {} {}", cpu_thread_count_, io_thread_count_);
+    void re_init()
+    {
+        ARCTICDB_RUNTIME_DEBUG(log::schedule(),
+            "Reinitializing task scheduler: {} {}",
+            cpu_thread_count_,
+            io_thread_count_);
         ARCTICDB_RUNTIME_DEBUG(log::schedule(), "IO exec num threads: {}", io_exec_.numActiveThreads());
         ARCTICDB_RUNTIME_DEBUG(log::schedule(), "CPU exec num threads: {}", cpu_exec_.numActiveThreads());
         set_active_threads(0);
@@ -237,29 +286,33 @@ private:
     bool created_;
 };
 
-
-inline auto& cpu_executor() {
+inline auto& cpu_executor()
+{
     return TaskScheduler::instance()->cpu_exec();
 }
 
-inline auto& io_executor() {
+inline auto& io_executor()
+{
     return TaskScheduler::instance()->io_exec();
 }
 
-template <typename Task>
-inline auto submit_cpu_task(Task&& task) {
+template<typename Task>
+inline auto submit_cpu_task(Task&& task)
+{
     return TaskScheduler::instance()->submit_cpu_task(std::move(task));
 }
 
-
-template <typename Task>
-inline auto submit_io_task(Task&& task) {
+template<typename Task>
+inline auto submit_io_task(Task&& task)
+{
     return TaskScheduler::instance()->submit_io_task(std::move(task));
 }
 
-template <typename Inputs, typename TaskSubmitter, typename ResultHandler>
-inline void submit_tasks_for_range(const Inputs& inputs, TaskSubmitter submitter, ResultHandler result_handler) {
-    using TaskReturn = decltype(submitter(std::declval<std::add_const_t<std::add_lvalue_reference_t<typename Inputs::value_type>>>()));
+template<typename Inputs, typename TaskSubmitter, typename ResultHandler>
+inline void submit_tasks_for_range(const Inputs& inputs, TaskSubmitter submitter, ResultHandler result_handler)
+{
+    using TaskReturn =
+        decltype(submitter(std::declval<std::add_const_t<std::add_lvalue_reference_t<typename Inputs::value_type>>>()));
 
     std::vector<TaskReturn> futs;
     futs.reserve(inputs.size());
@@ -267,18 +320,18 @@ inline void submit_tasks_for_range(const Inputs& inputs, TaskSubmitter submitter
         for (const auto& input : inputs) {
             futs.emplace_back(submitter(input));
         }
-    } catch(...) { // Clean up the Futures that have already been submitted
+    } catch (...) { // Clean up the Futures that have already been submitted
         folly::collectAll(futs).wait();
         throw;
     }
 
     auto fut_itr = futs.begin();
     try {
-        for(auto input_itr = inputs.cbegin(); input_itr != inputs.cend(); ++input_itr, ++fut_itr) {
+        for (auto input_itr = inputs.cbegin(); input_itr != inputs.cend(); ++input_itr, ++fut_itr) {
             auto&& resolved = std::move(*fut_itr).get();
             result_handler(*input_itr, std::move(resolved));
         }
-    } catch(...) {
+    } catch (...) {
         folly::collectAll(fut_itr, futs.end()).wait();
         throw;
     }
@@ -286,4 +339,4 @@ inline void submit_tasks_for_range(const Inputs& inputs, TaskSubmitter submitter
 
 void print_scheduler_stats();
 
-}
+} // namespace arcticdb::async

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -40,43 +40,45 @@ struct EncodeAtomTask : BaseTask {
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta_;
     size_t id_;
 
-    EncodeAtomTask(PartialKey &&pk,
-                   timestamp creation_ts,
-                   SegmentInMemory &&segment,
-                   std::shared_ptr<storage::Library> lib,
-                   std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
-                   size_t id)
+    EncodeAtomTask(PartialKey&& pk,
+        timestamp creation_ts,
+        SegmentInMemory&& segment,
+        std::shared_ptr<storage::Library> lib,
+        std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
+        size_t id)
         : partial_key_(std::move(pk)),
           creation_ts_(creation_ts),
           segment_(std::move(segment)),
           lib_(std::move(lib)),
           codec_meta_(std::move(codec_meta)),
-          id_(id){}
+          id_(id)
+    {
+    }
 
-    EncodeAtomTask(
-        KeyType key_type,
+    EncodeAtomTask(KeyType key_type,
         GenerationId gen_id,
         StreamId stream_id,
         IndexValue start_index,
         IndexValue end_index,
         timestamp creation_ts,
-        SegmentInMemory &&segment,
-        const std::shared_ptr<storage::Library> &lib,
-        const std::shared_ptr<arcticdb::proto::encoding::VariantCodec> &codec_meta,
-        size_t id
-    )
+        SegmentInMemory&& segment,
+        const std::shared_ptr<storage::Library>& lib,
+        const std::shared_ptr<arcticdb::proto::encoding::VariantCodec>& codec_meta,
+        size_t id)
         : EncodeAtomTask(
-                PartialKey{key_type, gen_id, std::move(stream_id), std::move(start_index), std::move(end_index)},
-                creation_ts,
-                std::move(segment),
-                lib,
-                codec_meta,
-                id) {
+              PartialKey{key_type, gen_id, std::move(stream_id), std::move(start_index), std::move(end_index)},
+              creation_ts,
+              std::move(segment),
+              lib,
+              codec_meta,
+              id)
+    {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(EncodeAtomTask)
 
-    storage::KeySegmentPair encode() {
+    storage::KeySegmentPair encode()
+    {
         auto enc_seg = ::arcticdb::encode(std::move(segment_), *codec_meta_);
         auto content_hash = hash_segment_header(enc_seg.header());
 
@@ -84,7 +86,8 @@ struct EncodeAtomTask : BaseTask {
         return {std::move(k), std::move(enc_seg), id_};
     }
 
-    storage::KeySegmentPair operator()() {
+    storage::KeySegmentPair operator()()
+    {
         ARCTICDB_SAMPLE(EncodeAtomTask, 0)
         return encode();
     }
@@ -98,25 +101,28 @@ struct EncodeSegmentTask : BaseTask {
     size_t id_;
 
     EncodeSegmentTask(entity::VariantKey key,
-                      SegmentInMemory &&segment,
-                      std::shared_ptr<storage::Library> lib,
-                      std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
-                      size_t id)
-            : key_(std::move(key)),
-              segment_(std::move(segment)),
-              lib_(std::move(lib)),
-              codec_meta_(std::move(codec_meta)),
-              id_(id){}
-
+        SegmentInMemory&& segment,
+        std::shared_ptr<storage::Library> lib,
+        std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
+        size_t id)
+        : key_(std::move(key)),
+          segment_(std::move(segment)),
+          lib_(std::move(lib)),
+          codec_meta_(std::move(codec_meta)),
+          id_(id)
+    {
+    }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(EncodeSegmentTask)
 
-    storage::KeySegmentPair encode() {
+    storage::KeySegmentPair encode()
+    {
         auto enc_seg = ::arcticdb::encode(std::move(segment_), *codec_meta_);
         return {std::move(key_), std::move(enc_seg), size_t(id_)};
     }
 
-    storage::KeySegmentPair operator()() {
+    storage::KeySegmentPair operator()()
+    {
         ARCTICDB_SAMPLE(EncodeSegmentTask, 0)
         return encode();
     }
@@ -128,27 +134,28 @@ struct EncodeRefTask : BaseTask {
     SegmentInMemory segment_;
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta_;
 
-    EncodeRefTask(
-        KeyType key_type,
+    EncodeRefTask(KeyType key_type,
         StreamId stream_id,
-        SegmentInMemory &&segment,
-        std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta
-    )
+        SegmentInMemory&& segment,
+        std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta)
         : key_type_(key_type),
           id_(std::move(stream_id)),
           segment_(std::move(segment)),
-          codec_meta_(std::move(codec_meta)) {
+          codec_meta_(std::move(codec_meta))
+    {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(EncodeRefTask)
 
-    [[nodiscard]] storage::KeySegmentPair encode() {
+    [[nodiscard]] storage::KeySegmentPair encode()
+    {
         auto enc_seg = ::arcticdb::encode(std::move(segment_), *codec_meta_);
         auto k = RefKey{id_, key_type_};
         return {std::move(k), std::move(enc_seg), size_t(0)};
     }
 
-    storage::KeySegmentPair operator()() {
+    storage::KeySegmentPair operator()()
+    {
         ARCTICDB_SAMPLE(EncodeAtomTask, 0)
         return encode();
     }
@@ -157,13 +164,15 @@ struct EncodeRefTask : BaseTask {
 struct WriteSegmentTask : BaseTask {
     std::shared_ptr<storage::Library> lib_;
 
-    explicit WriteSegmentTask(std::shared_ptr<storage::Library> lib) :
-        lib_(std::move(lib)) {
+    explicit WriteSegmentTask(std::shared_ptr<storage::Library> lib)
+        : lib_(std::move(lib))
+    {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(WriteSegmentTask)
 
-    VariantKey operator()(storage::KeySegmentPair &&key_seg) const {
+    VariantKey operator()(storage::KeySegmentPair&& key_seg) const
+    {
         ARCTICDB_SAMPLE(WriteSegmentTask, 0)
         auto k = key_seg.variant_key();
         lib_->write(Composite<storage::KeySegmentPair>(std::move(key_seg)));
@@ -175,14 +184,16 @@ struct UpdateSegmentTask : BaseTask {
     std::shared_ptr<storage::Library> lib_;
     storage::UpdateOpts opts_;
 
-    explicit UpdateSegmentTask(std::shared_ptr<storage::Library> lib, storage::UpdateOpts opts) :
-        lib_(std::move(lib)),
-        opts_(opts) {
+    explicit UpdateSegmentTask(std::shared_ptr<storage::Library> lib, storage::UpdateOpts opts)
+        : lib_(std::move(lib)),
+          opts_(opts)
+    {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(UpdateSegmentTask)
 
-    VariantKey operator()(storage::KeySegmentPair &&key_seg) const {
+    VariantKey operator()(storage::KeySegmentPair&& key_seg) const
+    {
         ARCTICDB_SAMPLE(UpdateSegmentTask, 0)
         auto k = key_seg.variant_key();
         lib_->update(Composite<storage::KeySegmentPair>(std::move(key_seg)), opts_);
@@ -197,20 +208,24 @@ struct ReadCompressedTask : BaseTask {
 
     ReadCompressedTask(entity::VariantKey key, std::shared_ptr<storage::Library> lib, storage::ReadKeyOpts opts)
         : key_(std::move(key)),
-        lib_(std::move(lib)),
-        opts_(opts) {
-        ARCTICDB_DEBUG(log::storage(), "Creating read compressed task for key {}: {}",
-                             variant_key_type(key_),
-                             variant_key_view(key_));
+          lib_(std::move(lib)),
+          opts_(opts)
+    {
+        ARCTICDB_DEBUG(log::storage(),
+            "Creating read compressed task for key {}: {}",
+            variant_key_type(key_),
+            variant_key_view(key_));
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ReadCompressedTask)
 
-    storage::KeySegmentPair read() {
-        return std::visit([that=this](const auto &key) { return that->lib_->read(key, that->opts_); }, key_);
+    storage::KeySegmentPair read()
+    {
+        return std::visit([that = this](const auto& key) { return that->lib_->read(key, that->opts_); }, key_);
     }
 
-    storage::KeySegmentPair operator()() {
+    storage::KeySegmentPair operator()()
+    {
         ARCTICDB_SAMPLE(ReadCompressed, 0)
         return read();
     }
@@ -221,28 +236,30 @@ struct ReadCompressedSlicesTask : BaseTask {
     std::shared_ptr<storage::Library> lib_;
 
     ReadCompressedSlicesTask(Composite<pipelines::SliceAndKey>&& sk, std::shared_ptr<storage::Library> lib)
-            : slice_and_keys_(std::move(sk)),
-            lib_(std::move(lib)) {
-        ARCTICDB_DEBUG(log::storage(), "Creating read compressed slices task for slice and key {}",
-                             slice_and_keys_);
+        : slice_and_keys_(std::move(sk)),
+          lib_(std::move(lib))
+    {
+        ARCTICDB_DEBUG(log::storage(), "Creating read compressed slices task for slice and key {}", slice_and_keys_);
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ReadCompressedSlicesTask)
 
-     Composite<std::pair<Segment, pipelines::SliceAndKey>> read() {
-        return slice_and_keys_.transform([that=this](const auto &sk){
+    Composite<std::pair<Segment, pipelines::SliceAndKey>> read()
+    {
+        return slice_and_keys_.transform([that = this](const auto& sk) {
             ARCTICDB_DEBUG(log::version(), "Reading key {}", sk.key());
             return std::make_pair(that->lib_->read(sk.key()).release_segment(), sk);
         });
-     }
+    }
 
-    Composite<std::pair<Segment, pipelines::SliceAndKey>> operator()() {
+    Composite<std::pair<Segment, pipelines::SliceAndKey>> operator()()
+    {
         ARCTICDB_SAMPLE(ReadCompressed, 0)
         return read();
     }
 };
 
-template <typename ClockType>
+template<typename ClockType>
 struct CopyCompressedTask : BaseTask {
     entity::VariantKey source_key_;
     KeyType key_type_;
@@ -251,33 +268,45 @@ struct CopyCompressedTask : BaseTask {
     std::shared_ptr<storage::Library> lib_;
 
     CopyCompressedTask(entity::VariantKey source_key,
-                       KeyType key_type,
-                       const StreamId& stream_id,
-                       VersionId version_id,
-                       std::shared_ptr<storage::Library> lib) :
-        source_key_(std::move(source_key)),
-        key_type_(key_type),
-        stream_id_(stream_id),
-        version_id_(version_id),
-        lib_(std::move(lib)) {
-        ARCTICDB_DEBUG(log::storage(), "Creating copy compressed task for key {} -> {} {} {}",
-                             variant_key_view(source_key_),
-                             key_type_, stream_id_, version_id_);
+        KeyType key_type,
+        const StreamId& stream_id,
+        VersionId version_id,
+        std::shared_ptr<storage::Library> lib)
+        : source_key_(std::move(source_key)),
+          key_type_(key_type),
+          stream_id_(stream_id),
+          version_id_(version_id),
+          lib_(std::move(lib))
+    {
+        ARCTICDB_DEBUG(log::storage(),
+            "Creating copy compressed task for key {} -> {} {} {}",
+            variant_key_view(source_key_),
+            key_type_,
+            stream_id_,
+            version_id_);
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(CopyCompressedTask)
 
-    VariantKey copy() {
-        return std::visit([that = this](const auto &source_key) {
-            auto key_seg = that->lib_->read(source_key);
-            auto target_key_seg = stream::make_target_key<ClockType>(that->key_type_, that->stream_id_, that->version_id_, source_key, std::move(key_seg.segment()));
-            auto return_key = target_key_seg.variant_key();
-            that->lib_->write(Composite<storage::KeySegmentPair>{std::move(target_key_seg) });
-            return return_key;
-        }, source_key_);
+    VariantKey copy()
+    {
+        return std::visit(
+            [that = this](const auto& source_key) {
+                auto key_seg = that->lib_->read(source_key);
+                auto target_key_seg = stream::make_target_key<ClockType>(that->key_type_,
+                    that->stream_id_,
+                    that->version_id_,
+                    source_key,
+                    std::move(key_seg.segment()));
+                auto return_key = target_key_seg.variant_key();
+                that->lib_->write(Composite<storage::KeySegmentPair>{std::move(target_key_seg)});
+                return return_key;
+            },
+            source_key_);
     }
 
-    VariantKey operator()() {
+    VariantKey operator()()
+    {
         ARCTICDB_SAMPLE(CopyCompressed, 0)
         return copy();
     }
@@ -288,13 +317,15 @@ struct DecodeSegmentTask : BaseTask {
 
     DecodeSegmentTask() = default;
 
-    std::pair<VariantKey, SegmentInMemory> operator()(storage::KeySegmentPair &&ks) const {
+    std::pair<VariantKey, SegmentInMemory> operator()(storage::KeySegmentPair&& ks) const
+    {
         ARCTICDB_SAMPLE(DecodeAtomTask, 0)
 
         auto key_seg = std::move(ks);
-        ARCTICDB_DEBUG(log::storage(), "ReadAndDecodeAtomTask decoding segment of size {} with key {}",
-                             key_seg.segment().total_segment_size(),
-                             variant_key_view(key_seg.variant_key()));
+        ARCTICDB_DEBUG(log::storage(),
+            "ReadAndDecodeAtomTask decoding segment of size {} with key {}",
+            key_seg.segment().total_segment_size(),
+            variant_key_view(key_seg.variant_key()));
 
         return {key_seg.variant_key(), decode(std::move(key_seg.segment()))};
     }
@@ -306,17 +337,18 @@ struct DecodeSlicesTask : BaseTask {
     StreamDescriptor desc_;
     std::shared_ptr<std::unordered_set<std::string>> filter_columns_;
 
-    DecodeSlicesTask(
-            const StreamDescriptor& desc,
-            const std::shared_ptr<std::unordered_set<std::string>>& filter_columns)  :
-                desc_(desc),
-                filter_columns_(filter_columns) {
-            }
+    DecodeSlicesTask(const StreamDescriptor& desc,
+        const std::shared_ptr<std::unordered_set<std::string>>& filter_columns)
+        : desc_(desc),
+          filter_columns_(filter_columns)
+    {
+    }
 
-    Composite<pipelines::SliceAndKey> operator()(Composite<std::pair<Segment, pipelines::SliceAndKey>> && skp) const {
+    Composite<pipelines::SliceAndKey> operator()(Composite<std::pair<Segment, pipelines::SliceAndKey>>&& skp) const
+    {
         ARCTICDB_SAMPLE(DecodeAtomTask, 0)
         auto sk_pairs = std::move(skp);
-        return sk_pairs.transform([that=this] (auto&& seg_slice_pair){
+        return sk_pairs.transform([that = this](auto&& seg_slice_pair) {
             ARCTICDB_DEBUG(log::version(), "Decoding slice {}", seg_slice_pair.second.key());
             return that->decode_into_slice(std::forward<std::pair<Segment, pipelines::SliceAndKey>>(seg_slice_pair));
         });
@@ -329,14 +361,15 @@ private:
 struct SegmentFunctionTask : BaseTask {
     stream::StreamSource::ReadContinuation func_;
 
-    explicit SegmentFunctionTask(
-        stream::StreamSource::ReadContinuation func) :
-        func_(std::move(func)) {
+    explicit SegmentFunctionTask(stream::StreamSource::ReadContinuation func)
+        : func_(std::move(func))
+    {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(SegmentFunctionTask)
 
-     entity::VariantKey operator()(storage::KeySegmentPair &&key_seg) {
+    entity::VariantKey operator()(storage::KeySegmentPair&& key_seg)
+    {
         ARCTICDB_SAMPLE(SegmentFunctionTask, 0)
         return func_(std::move(key_seg));
     }
@@ -348,20 +381,20 @@ struct MemSegmentPassthroughProcessingTask : BaseTask {
     std::shared_ptr<std::vector<Clause>> clauses_;
     std::optional<Composite<ProcessingSegment>> starting_segments_;
 
-    explicit MemSegmentPassthroughProcessingTask(
-            const std::shared_ptr<Store> store,
-            std::shared_ptr<std::vector<Clause>> clauses,
-            Composite<ProcessingSegment>&& starting_segments) :
-            store_(store),
-            clauses_(std::move(clauses)),
-            starting_segments_(std::move(starting_segments)){
+    explicit MemSegmentPassthroughProcessingTask(const std::shared_ptr<Store> store,
+        std::shared_ptr<std::vector<Clause>> clauses,
+        Composite<ProcessingSegment>&& starting_segments)
+        : store_(store),
+          clauses_(std::move(clauses)),
+          starting_segments_(std::move(starting_segments))
+    {
     }
 
-    [[nodiscard]]
-    Composite<ProcessingSegment> process(Composite<ProcessingSegment>&& proc){
+    [[nodiscard]] Composite<ProcessingSegment> process(Composite<ProcessingSegment>&& proc)
+    {
         auto procs = std::move(proc);
-        for(const auto& clause : *clauses_) {
-            if(clause.requires_repartition())
+        for (const auto& clause : *clauses_) {
+            if (clause.requires_repartition())
                 break;
 
             procs = clause.process(store_, std::move(procs));
@@ -371,7 +404,8 @@ struct MemSegmentPassthroughProcessingTask : BaseTask {
 
     ARCTICDB_MOVE_ONLY_DEFAULT(MemSegmentPassthroughProcessingTask)
 
-    Composite<ProcessingSegment> operator()() {
+    Composite<ProcessingSegment> operator()()
+    {
         return process(std::move(starting_segments_.value()));
     }
 };
@@ -380,25 +414,25 @@ struct MemSegmentProcessingTask : BaseTask {
     std::shared_ptr<Store> store_;
     std::shared_ptr<std::vector<Clause>> clauses_;
 
-    explicit MemSegmentProcessingTask(
-           const std::shared_ptr<Store> store,
-           std::shared_ptr<std::vector<Clause>> clauses) :
-        store_(store),
-        clauses_(std::move(clauses)) {
+    explicit MemSegmentProcessingTask(const std::shared_ptr<Store> store, std::shared_ptr<std::vector<Clause>> clauses)
+        : store_(store),
+          clauses_(std::move(clauses))
+    {
     }
 
-    ProcessingSegment slice_to_segment(Composite<pipelines::SliceAndKey>&& is) {
+    ProcessingSegment slice_to_segment(Composite<pipelines::SliceAndKey>&& is)
+    {
         auto inputs = std::move(is);
         return ProcessingSegment(inputs.as_range());
     }
 
-    [[nodiscard]]
-    Composite<ProcessingSegment> process(Composite<ProcessingSegment>&& proc){
+    [[nodiscard]] Composite<ProcessingSegment> process(Composite<ProcessingSegment>&& proc)
+    {
         auto procs = std::move(proc);
-        for(const auto& clause : *clauses_) {
+        for (const auto& clause : *clauses_) {
             procs = clause.process(store_, std::move(procs));
 
-            if(clause.requires_repartition())
+            if (clause.requires_repartition())
                 break;
         }
         return procs;
@@ -406,23 +440,24 @@ struct MemSegmentProcessingTask : BaseTask {
 
     ARCTICDB_MOVE_ONLY_DEFAULT(MemSegmentProcessingTask)
 
-    Composite<ProcessingSegment> operator()(Composite<pipelines::SliceAndKey>&& sk) {
+    Composite<ProcessingSegment> operator()(Composite<pipelines::SliceAndKey>&& sk)
+    {
         return process(Composite<ProcessingSegment>(slice_to_segment(std::move(sk))));
     }
-
 };
 
 struct MemSegmentFunctionTask : BaseTask {
     stream::StreamSource::DecodeContinuation func_;
 
-    explicit MemSegmentFunctionTask(
-            stream::StreamSource::DecodeContinuation&& func) :
-            func_(std::move(func)) {
+    explicit MemSegmentFunctionTask(stream::StreamSource::DecodeContinuation&& func)
+        : func_(std::move(func))
+    {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(MemSegmentFunctionTask)
 
-    folly::Unit operator()(std::pair<VariantKey, SegmentInMemory> &&seg_pair) {
+    folly::Unit operator()(std::pair<VariantKey, SegmentInMemory>&& seg_pair)
+    {
         func_(std::move(seg_pair.second));
         return folly::Unit{};
     }
@@ -433,11 +468,15 @@ struct DecodeMetadataTask : BaseTask {
 
     DecodeMetadataTask() = default;
 
-    std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> operator()(storage::KeySegmentPair &&ks) const {
+    std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> operator()(
+        storage::KeySegmentPair&& ks) const
+    {
         ARCTICDB_SAMPLE(ReadMetadataTask, 0)
         auto key_seg = std::move(ks);
-        ARCTICDB_DEBUG(log::storage(), "ReadAndDecodeMetadataTask decoding segment of size {} with key {}",
-                             key_seg.segment().total_segment_size(), variant_key_view(key_seg.variant_key()));
+        ARCTICDB_DEBUG(log::storage(),
+            "ReadAndDecodeMetadataTask decoding segment of size {} with key {}",
+            key_seg.segment().total_segment_size(),
+            variant_key_view(key_seg.variant_key()));
 
         auto meta = decode_metadata(key_seg.segment());
         std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> output;
@@ -452,24 +491,28 @@ struct DecodeMetadataAndDescriptorTask : BaseTask {
 
     DecodeMetadataAndDescriptorTask() = default;
 
-    std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto> operator()(storage::KeySegmentPair &&ks) const {
+    std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto> operator()(
+        storage::KeySegmentPair&& ks) const
+    {
         ARCTICDB_SAMPLE(ReadMetadataAndDescriptorTask, 0)
         auto key_seg = std::move(ks);
-        ARCTICDB_DEBUG(log::storage(), "DecodeMetadataAndDescriptorTask decoding segment of size {} with key {}",
-                      key_seg.segment().total_segment_size(), variant_key_view(key_seg.variant_key()));
+        ARCTICDB_DEBUG(log::storage(),
+            "DecodeMetadataAndDescriptorTask decoding segment of size {} with key {}",
+            key_seg.segment().total_segment_size(),
+            variant_key_view(key_seg.variant_key()));
 
         auto meta = decode_metadata(key_seg.segment());
         return std::make_tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto>(
             std::move(key_seg.variant_key()),
             meta ? std::make_optional(std::move(meta.value())) : std::nullopt,
-            std::move(*key_seg.segment().header().mutable_stream_descriptor())
-            );
+            std::move(*key_seg.segment().header().mutable_stream_descriptor()));
     }
 };
 
 template<typename ConstVarKeyGetter,
-        typename=std::enable_if_t<!std::is_reference_v<ConstVarKeyGetter> // Make obvious if iterator& is captured
-                        && std::is_same_v<decltype(*std::declval<ConstVarKeyGetter>()), const entity::VariantKey&>>>
+    typename =
+        std::enable_if_t<!std::is_reference_v<ConstVarKeyGetter> // Make obvious if iterator& is captured
+                         && std::is_same_v<decltype(*std::declval<ConstVarKeyGetter>()), const entity::VariantKey&>>>
 struct KeyExistsTask : BaseTask {
     ConstVarKeyGetter key_;
     std::shared_ptr<storage::Library> lib_;
@@ -477,11 +520,15 @@ struct KeyExistsTask : BaseTask {
     /**
      * @param key Could be a vector iterator or a pointer to a const VariantKey.
      */
-    KeyExistsTask(ConstVarKeyGetter key, std::shared_ptr<storage::Library> lib): key_(key), lib_(std::move(lib)) {
+    KeyExistsTask(ConstVarKeyGetter key, std::shared_ptr<storage::Library> lib)
+        : key_(key),
+          lib_(std::move(lib))
+    {
         ARCTICDB_DEBUG(log::storage(), "Creating key exists task for key {}", variant_key_view(*key_));
     }
 
-    bool operator()() {
+    bool operator()()
+    {
         ARCTICDB_SAMPLE(KeyExistsTask, 0)
         return lib_->key_exists(*key_);
     }
@@ -491,19 +538,23 @@ struct WriteCompressedTask : BaseTask {
     storage::KeySegmentPair kv_;
     std::shared_ptr<storage::Library> lib_;
 
-    WriteCompressedTask(storage::KeySegmentPair &&kv, std::shared_ptr<storage::Library> lib) :
-    kv_(std::move(kv)), lib_(std::move(lib)) {
+    WriteCompressedTask(storage::KeySegmentPair&& kv, std::shared_ptr<storage::Library> lib)
+        : kv_(std::move(kv)),
+          lib_(std::move(lib))
+    {
         ARCTICDB_DEBUG(log::storage(), "Creating write compressed task");
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(WriteCompressedTask)
 
-    folly::Future<folly::Unit> write() {
+    folly::Future<folly::Unit> write()
+    {
         lib_->write(Composite<storage::KeySegmentPair>(std::move(kv_)));
         return folly::makeFuture();
     }
 
-    folly::Future<folly::Unit> operator()() {
+    folly::Future<folly::Unit> operator()()
+    {
         ARCTICDB_SAMPLE(WriteCompressed, 0)
         return write();
     }
@@ -513,8 +564,10 @@ struct WriteCompressedBatchTask : BaseTask {
     std::vector<storage::KeySegmentPair> kvs_;
     std::shared_ptr<storage::Library> lib_;
 
-    WriteCompressedBatchTask(std::vector<storage::KeySegmentPair> &&kvs, std::shared_ptr<storage::Library> lib) : kvs_(
-        std::move(kvs)), lib_(std::move(lib)) {
+    WriteCompressedBatchTask(std::vector<storage::KeySegmentPair>&& kvs, std::shared_ptr<storage::Library> lib)
+        : kvs_(std::move(kvs)),
+          lib_(std::move(lib))
+    {
         util::check(!kvs_.empty(), "WriteCompressedBatch task created with no data");
 
         ARCTICDB_DEBUG(log::storage(), "Creating read and decode task for {} keys", kvs_.size());
@@ -522,12 +575,14 @@ struct WriteCompressedBatchTask : BaseTask {
 
     ARCTICDB_MOVE_ONLY_DEFAULT(WriteCompressedBatchTask)
 
-    folly::Future<folly::Unit> write() {
+    folly::Future<folly::Unit> write()
+    {
         lib_->write(Composite<storage::KeySegmentPair>(std::move(kvs_)));
         return folly::makeFuture();
     }
 
-    folly::Future<folly::Unit> operator()() {
+    folly::Future<folly::Unit> operator()()
+    {
         ARCTICDB_SAMPLE(WriteCompressedBatch, 0)
         return write();
     }
@@ -538,16 +593,21 @@ struct RemoveTask : BaseTask {
     std::shared_ptr<storage::Library> lib_;
     storage::RemoveOpts opts_;
 
-    RemoveTask(const VariantKey &key_, std::shared_ptr<storage::Library> lib_, storage::RemoveOpts opts) :
-            key_(key_),
-            lib_(std::move(lib_)),
-            opts_(opts){
-        ARCTICDB_DEBUG(log::storage(), "Creating remove task for key {}: {}", variant_key_type(key_), variant_key_view(key_));
+    RemoveTask(const VariantKey& key_, std::shared_ptr<storage::Library> lib_, storage::RemoveOpts opts)
+        : key_(key_),
+          lib_(std::move(lib_)),
+          opts_(opts)
+    {
+        ARCTICDB_DEBUG(log::storage(),
+            "Creating remove task for key {}: {}",
+            variant_key_type(key_),
+            variant_key_view(key_));
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(RemoveTask)
 
-    stream::StreamSink::RemoveKeyResultType operator()() {
+    stream::StreamSink::RemoveKeyResultType operator()()
+    {
         lib_->remove(Composite<VariantKey>(std::move(key_)), opts_);
         return {};
     }
@@ -558,22 +618,21 @@ struct RemoveBatchTask : BaseTask {
     std::shared_ptr<storage::Library> lib_;
     storage::RemoveOpts opts_;
 
-    RemoveBatchTask(
-        std::vector<VariantKey> key_,
-        std::shared_ptr<storage::Library> lib_,
-        storage::RemoveOpts opts) :
-        keys_(std::move(key_)),
-        lib_(std::move(lib_)),
-        opts_(opts){
+    RemoveBatchTask(std::vector<VariantKey> key_, std::shared_ptr<storage::Library> lib_, storage::RemoveOpts opts)
+        : keys_(std::move(key_)),
+          lib_(std::move(lib_)),
+          opts_(opts)
+    {
         ARCTICDB_DEBUG(log::storage(), "Creating remove task for {} keys", keys_.size());
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(RemoveBatchTask)
 
-    std::vector<stream::StreamSink::RemoveKeyResultType> operator()() {
+    std::vector<stream::StreamSink::RemoveKeyResultType> operator()()
+    {
         lib_->remove(Composite<VariantKey>(std::move(keys_)), opts_);
         return {};
     }
 };
 
-}
+} // namespace arcticdb::async

--- a/cpp/arcticdb/codec/codec-inl.hpp
+++ b/cpp/arcticdb/codec/codec-inl.hpp
@@ -25,7 +25,6 @@
 #include <arcticdb/util/hash.hpp>
 #include <arcticdb/util/sparse_utils.hpp>
 
-
 #include <google/protobuf/text_format.h>
 
 #include <type_traits>
@@ -35,18 +34,18 @@ namespace arcticdb {
 template<template<typename> class TypedBlock, class TD>
 struct TypedBlockEncoderImpl {
 
-    static size_t max_compressed_size(
-        const arcticdb::proto::encoding::VariantCodec &codec_opts,
-            const TypedBlock<TD> &typed_block) {
+    static size_t max_compressed_size(const arcticdb::proto::encoding::VariantCodec& codec_opts,
+        const TypedBlock<TD>& typed_block)
+    {
         switch (codec_opts.codec_case()) {
-            case arcticdb::proto::encoding::VariantCodec::kZstd:
-                return get_zstd_compressed_size(typed_block);
-            case arcticdb::proto::encoding::VariantCodec::kLz4:
-                return get_lz4_compressed_size(typed_block);
-            case arcticdb::proto::encoding::VariantCodec::kPassthrough :
-                return get_passthrough_compressed_size(typed_block);
-            default:
-                return get_passthrough_compressed_size(typed_block);
+        case arcticdb::proto::encoding::VariantCodec::kZstd:
+            return get_zstd_compressed_size(typed_block);
+        case arcticdb::proto::encoding::VariantCodec::kLz4:
+            return get_lz4_compressed_size(typed_block);
+        case arcticdb::proto::encoding::VariantCodec::kPassthrough:
+            return get_passthrough_compressed_size(typed_block);
+        default:
+            return get_passthrough_compressed_size(typed_block);
         }
     }
     /**
@@ -58,60 +57,75 @@ struct TypedBlockEncoderImpl {
      *          Modified to reflect the position after the last byte written
      * @param opt Option used to dispatch to the appropriate encoder and configure it
      */
-    static void encode(
-        const arcticdb::proto::encoding::VariantCodec &codec_opts,
-       TypedBlock<TD> &typed_block,
-       arcticdb::proto::encoding::EncodedField &field,
-       Buffer &out,
-       std::ptrdiff_t &pos) {
+    static void encode(const arcticdb::proto::encoding::VariantCodec& codec_opts,
+        TypedBlock<TD>& typed_block,
+        arcticdb::proto::encoding::EncodedField& field,
+        Buffer& out,
+        std::ptrdiff_t& pos)
+    {
         switch (codec_opts.codec_case()) {
-            case arcticdb::proto::encoding::VariantCodec::kZstd:
-                encode_zstd(codec_opts.zstd(), typed_block, field, out, pos);
-                break;
-            case arcticdb::proto::encoding::VariantCodec::kLz4:
-                encode_lz4(codec_opts.lz4(), typed_block, field, out, pos);
-                break;
-            case arcticdb::proto::encoding::VariantCodec::kPassthrough :
-                encode_passthrough(typed_block, field, out, pos);
-                break;
-//            case arcticdb::proto::encoding::VariantCodec::kTp4:
-//                encode_tp4(codec_opts.tp4(), field, field, out, pos);
-//                break;
-            default:
-                encode_passthrough(typed_block, field, out, pos);
+        case arcticdb::proto::encoding::VariantCodec::kZstd:
+            encode_zstd(codec_opts.zstd(), typed_block, field, out, pos);
+            break;
+        case arcticdb::proto::encoding::VariantCodec::kLz4:
+            encode_lz4(codec_opts.lz4(), typed_block, field, out, pos);
+            break;
+        case arcticdb::proto::encoding::VariantCodec::kPassthrough:
+            encode_passthrough(typed_block, field, out, pos);
+            break;
+            //            case arcticdb::proto::encoding::VariantCodec::kTp4:
+            //                encode_tp4(codec_opts.tp4(), field, field, out, pos);
+            //                break;
+        default:
+            encode_passthrough(typed_block, field, out, pos);
         }
     }
 
-    static void
-    encode_passthrough(TypedBlock<TD> &typed_block, arcticdb::proto::encoding::EncodedField &field, Buffer &out, std::ptrdiff_t &pos) {
+    static void encode_passthrough(TypedBlock<TD>& typed_block,
+        arcticdb::proto::encoding::EncodedField& field,
+        Buffer& out,
+        std::ptrdiff_t& pos)
+    {
         arcticdb::detail::PassthroughEncoder<TypedBlock, TD>::encode(typed_block, field, out, pos);
     }
 
-    static void encode_zstd(const arcticdb::proto::encoding::VariantCodec::Zstd &opts,
-                            TypedBlock<TD> &typed_block, arcticdb::proto::encoding::EncodedField &field, Buffer &out, std::ptrdiff_t &pos) {
+    static void encode_zstd(const arcticdb::proto::encoding::VariantCodec::Zstd& opts,
+        TypedBlock<TD>& typed_block,
+        arcticdb::proto::encoding::EncodedField& field,
+        Buffer& out,
+        std::ptrdiff_t& pos)
+    {
         arcticdb::detail::ZstdEncoder<TypedBlock, TD>::encode(opts, typed_block, field, out, pos);
     }
 
-    static void encode_lz4(const arcticdb::proto::encoding::VariantCodec::Lz4 &opts,
-                           TypedBlock<TD> &typed_block, arcticdb::proto::encoding::EncodedField &field, Buffer &out, std::ptrdiff_t &pos) {
+    static void encode_lz4(const arcticdb::proto::encoding::VariantCodec::Lz4& opts,
+        TypedBlock<TD>& typed_block,
+        arcticdb::proto::encoding::EncodedField& field,
+        Buffer& out,
+        std::ptrdiff_t& pos)
+    {
         arcticdb::detail::Lz4Encoder<TypedBlock, TD>::encode(opts, typed_block, field, out, pos);
     }
 
-    static size_t get_passthrough_compressed_size(const TypedBlock<TD> &typed_block ) {
+    static size_t get_passthrough_compressed_size(const TypedBlock<TD>& typed_block)
+    {
         return arcticdb::detail::PassthroughEncoder<TypedBlock, TD>::max_compressed_size(typed_block);
     }
 
-    static size_t get_zstd_compressed_size(const TypedBlock<TD> &typed_block) {
+    static size_t get_zstd_compressed_size(const TypedBlock<TD>& typed_block)
+    {
         return arcticdb::detail::ZstdEncoder<TypedBlock, TD>::max_compressed_size(typed_block);
     }
 
-    static size_t get_lz4_compressed_size(const TypedBlock<TD> &typed_block) {
+    static size_t get_lz4_compressed_size(const TypedBlock<TD>& typed_block)
+    {
         return arcticdb::detail::Lz4Encoder<TypedBlock, TD>::max_compressed_size(typed_block);
     }
 };
 
 template<typename T, typename DimTag>
-void decode_block(const arcticdb::proto::encoding::Block &block, const std::uint8_t *input, T *output) {
+void decode_block(const arcticdb::proto::encoding::Block& block, const std::uint8_t* input, T* output)
+{
     ARCTICDB_SUBSAMPLE_AGG(DecodeBlock)
     std::size_t size_to_decode = block.out_bytes();
     std::size_t decoded_size = block.in_bytes();
@@ -121,33 +135,29 @@ void decode_block(const arcticdb::proto::encoding::Block &block, const std::uint
     } else {
         std::uint32_t encoder_version = block.encoder_version();
         switch (block.codec().codec_case()) {
-            case arcticdb::proto::encoding::VariantCodec::kZstd:
-                arcticdb::detail::ZstdDecoder::decode_block<T>(encoder_version,
-                                                     input,
-                                                     size_to_decode,
-                                                     output,
-                                                     decoded_size);
-                break;
-            case arcticdb::proto::encoding::VariantCodec::kLz4:
-                arcticdb::detail::Lz4Decoder::decode_block<T>(encoder_version,
-                                                    input,
-                                                    size_to_decode,
-                                                    output,
-                                                    decoded_size);
-                break;
-            default:
-                util::raise_error_msg("Unsupported block codec {}", block);
+        case arcticdb::proto::encoding::VariantCodec::kZstd:
+            arcticdb::detail::ZstdDecoder::decode_block<T>(encoder_version,
+                input,
+                size_to_decode,
+                output,
+                decoded_size);
+            break;
+        case arcticdb::proto::encoding::VariantCodec::kLz4:
+            arcticdb::detail::Lz4Decoder::decode_block<T>(encoder_version, input, size_to_decode, output, decoded_size);
+            break;
+        default:
+            util::raise_error_msg("Unsupported block codec {}", block);
         }
     }
 }
 
 template<class DS>
-std::size_t decode_ndarray(
-    const TypeDescriptor &td,
-    const arcticdb::proto::encoding::NDArrayEncodedField &field,
-    const std::uint8_t *input,
-    DS &data_sink,
-    std::optional<util::BitMagic>& bv) {
+std::size_t decode_ndarray(const TypeDescriptor& td,
+    const arcticdb::proto::encoding::NDArrayEncodedField& field,
+    const std::uint8_t* input,
+    DS& data_sink,
+    std::optional<util::BitMagic>& bv)
+{
     ARCTICDB_SUBSAMPLE_AGG(DecodeNdArray)
     std::size_t read_bytes = 0;
     td.visit_tag([&](auto type_desc_tag) {
@@ -156,20 +166,25 @@ std::size_t decode_ndarray(
         using D = typename TD::DimensionTag;
 
         auto shape_size = encoding_size::shape_uncompressed_size(field);
-        shape_t *shapes_out = data_sink.allocate_shapes(shape_size);
+        shape_t* shapes_out = data_sink.allocate_shapes(shape_size);
         util::check(td.dimension() == Dimension::Dim0 || field.shapes_size() == field.values_size(),
-                    "Mismatched field and value sizes: {} != {}", field.shapes_size(), field.values_size());
-
+            "Mismatched field and value sizes: {} != {}",
+            field.shapes_size(),
+            field.values_size());
 
         auto data_size = encoding_size::data_uncompressed_size(field);
         // Note that when DS == StringPool (and probably other cases), this will result in a ChunkedBuffer with one massive chunk
-        auto data_begin = static_cast<uint8_t *>(data_sink.allocate_data(data_size));
+        auto data_begin = static_cast<uint8_t*>(data_sink.allocate_data(data_size));
         util::check(data_begin != nullptr, "Failed to allocate data of size {}", data_size);
         auto data_out = data_begin;
         auto data_in = input;
         auto num_blocks = field.values_size();
-        ARCTICDB_TRACE(log::codec(), "Decoding ndarray with type {}, uncompressing {} ({}) bytes in {} blocks",
-            td, data_size, encoding_size::compressed_size(field), num_blocks);
+        ARCTICDB_TRACE(log::codec(),
+            "Decoding ndarray with type {}, uncompressing {} ({}) bytes in {} blocks",
+            td,
+            data_size,
+            encoding_size::compressed_size(field),
+            num_blocks);
 
         for (auto block_num = 0; block_num < num_blocks; ++block_num) {
             if (td.dimension() != Dimension::Dim0) {
@@ -183,16 +198,17 @@ std::size_t decode_ndarray(
             const auto& block_info = field.values(block_num);
             ARCTICDB_TRACE(log::codec(), "Decoding block {} at pos {}", block_num, data_in - input);
             size_t block_inflated_size;
-            decode_block<T, D>(block_info, data_in, reinterpret_cast<T *>(data_out));
+            decode_block<T, D>(block_info, data_in, reinterpret_cast<T*>(data_out));
             block_inflated_size = block_info.in_bytes();
             data_out += block_inflated_size;
             data_sink.advance_data(block_inflated_size);
             data_in += block_info.out_bytes();
         }
 
-        if(field.sparse_map_bytes()) {
+        if (field.sparse_map_bytes()) {
             util::check_magic<util::BitMagicStart>(data_in);
-            const auto bitmap_size =   field.sparse_map_bytes() - (sizeof(util::BitMagicStart) + sizeof(util::BitMagicEnd)); //TODO functions
+            const auto bitmap_size =
+                field.sparse_map_bytes() - (sizeof(util::BitMagicStart) + sizeof(util::BitMagicEnd)); //TODO functions
             bv = util::deserialize_bytes_to_bitmap(data_in, bitmap_size);
             util::check_magic<util::BitMagicEnd>(data_in);
             data_sink.set_allow_sparse(true);
@@ -200,28 +216,30 @@ std::size_t decode_ndarray(
 
         read_bytes = encoding_size::compressed_size(field);
         util::check(data_in - input == intptr_t(read_bytes),
-                    "Decoding compressed size mismatch, expected decode size {} to equal total size {}", data_in - input ,
-                    read_bytes);
+            "Decoding compressed size mismatch, expected decode size {} to equal total size {}",
+            data_in - input,
+            read_bytes);
 
         util::check(data_out - data_begin == intptr_t(data_size),
-                    "Decoding uncompressed size mismatch, expected position {} to be equal to data size {}",
-                    data_out - data_begin, data_size);
+            "Decoding uncompressed size mismatch, expected position {} to be equal to data size {}",
+            data_out - data_begin,
+            data_size);
     });
     return read_bytes;
 }
 
 template<class DS>
-std::size_t decode(
-    const TypeDescriptor &td,
-    const arcticdb::proto::encoding::EncodedField &field,
-    const std::uint8_t *input,
-    DS &data_sink,
-    std::optional<util::BitMagic>& bv) {
+std::size_t decode(const TypeDescriptor& td,
+    const arcticdb::proto::encoding::EncodedField& field,
+    const std::uint8_t* input,
+    DS& data_sink,
+    std::optional<util::BitMagic>& bv)
+{
     switch (field.encoding_case()) {
-        case arcticdb::proto::encoding::EncodedField::kNdarray:
-            return decode_ndarray(td, field.ndarray(), input, data_sink, bv);
-        default:
-            util::raise_error_msg("Unsupported encoding {}", field);
+    case arcticdb::proto::encoding::EncodedField::kNdarray:
+        return decode_ndarray(td, field.ndarray(), input, data_sink, bv);
+    default:
+        util::raise_error_msg("Unsupported encoding {}", field);
     }
 }
 

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -16,9 +16,9 @@
 
 namespace arcticdb {
 
-std::pair<size_t, size_t> ColumnEncoder::max_compressed_size(
-        const arcticdb::proto::encoding::VariantCodec &codec_opts,
-        ColumnData &column_data) {
+std::pair<size_t, size_t> ColumnEncoder::max_compressed_size(const arcticdb::proto::encoding::VariantCodec& codec_opts,
+    ColumnData& column_data)
+{
     return column_data.type().visit_tag([&codec_opts, &column_data](auto type_desc_tag) {
         size_t max_compressed_bytes = 0;
         size_t uncompressed_bytes = 0;
@@ -33,7 +33,7 @@ std::pair<size_t, size_t> ColumnEncoder::max_compressed_size(
             max_compressed_bytes += Encoder::max_compressed_size(codec_opts, block.value());
         }
 
-        if (column_data.bit_vector() != nullptr && column_data.bit_vector()->count() > 0)   {
+        if (column_data.bit_vector() != nullptr && column_data.bit_vector()->count() > 0) {
             bm::serializer<util::BitMagic>::statistics_type stat{};
             column_data.bit_vector()->calc_stat(&stat);
             uncompressed_bytes += stat.memory_used;
@@ -43,12 +43,12 @@ std::pair<size_t, size_t> ColumnEncoder::max_compressed_size(
     });
 }
 
-void ColumnEncoder::encode(
-    const arcticdb::proto::encoding::VariantCodec &codec_opts,
-    ColumnData &column_data,
-    arcticdb::proto::encoding::EncodedField &field,
-    Buffer &out,
-    std::ptrdiff_t &pos) {
+void ColumnEncoder::encode(const arcticdb::proto::encoding::VariantCodec& codec_opts,
+    ColumnData& column_data,
+    arcticdb::proto::encoding::EncodedField& field,
+    Buffer& out,
+    std::ptrdiff_t& pos)
+{
     column_data.type().visit_tag([&codec_opts, &column_data, &field, &out, &pos](auto type_desc_tag) {
         using TDT = decltype(type_desc_tag);
         using Encoder = BlockEncoder<TDT>;
@@ -59,7 +59,7 @@ void ColumnEncoder::encode(
             Encoder::encode(codec_opts, block.value(), field, out, pos);
         }
 
-        if (column_data.bit_vector() != nullptr && column_data.bit_vector()->count() > 0)   {
+        if (column_data.bit_vector() != nullptr && column_data.bit_vector()->count() > 0) {
             ARCTICDB_DEBUG(log::codec(), "Sparse map count = {} pos = {}", column_data.bit_vector()->count(), pos);
             auto sparse_bm_bytes = encode_bitmap(*column_data.bit_vector(), out, pos);
             field.mutable_ndarray()->set_sparse_map_bytes(static_cast<int>(sparse_bm_bytes));
@@ -67,13 +67,14 @@ void ColumnEncoder::encode(
     });
 }
 
-constexpr TypeDescriptor metadata_type_desc() {
-    return TypeDescriptor{
-        DataType::UINT8, Dimension::Dim1
-    };
+constexpr TypeDescriptor metadata_type_desc()
+{
+    return TypeDescriptor{DataType::UINT8, Dimension::Dim1};
 }
 
-std::pair<size_t, size_t> max_compressed_size(const SegmentInMemory &in_mem_seg, const arcticdb::proto::encoding::VariantCodec &codec_opts) {
+std::pair<size_t, size_t> max_compressed_size(const SegmentInMemory& in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec& codec_opts)
+{
     /*
      * This takes an in memory segment with all the metadata, column tensors etc, loops through each column
      * and based on the type of the column, calls the typed block encoder for that column.
@@ -87,15 +88,17 @@ std::pair<size_t, size_t> max_compressed_size(const SegmentInMemory &in_mem_seg,
     if (in_mem_seg.metadata()) {
         auto metadata_bytes = static_cast<shape_t>(in_mem_seg.metadata()->ByteSizeLong());
         uncompressed_bytes += metadata_bytes;
-        max_compressed_bytes += BytesEncoder::max_compressed_size(codec_opts, TypedBlockData<BytesTypeDescriptorTag>(metadata_bytes, &metadata_bytes));
+        max_compressed_bytes += BytesEncoder::max_compressed_size(codec_opts,
+            TypedBlockData<BytesTypeDescriptorTag>(metadata_bytes, &metadata_bytes));
         shape_t shapes_bytes = sizeof(shape_t);
         uncompressed_bytes += shapes_bytes;
-        max_compressed_bytes += BytesEncoder::max_compressed_size(codec_opts, TypedBlockData<BytesTypeDescriptorTag>(shapes_bytes, &shapes_bytes));
+        max_compressed_bytes += BytesEncoder::max_compressed_size(codec_opts,
+            TypedBlockData<BytesTypeDescriptorTag>(shapes_bytes, &shapes_bytes));
         ARCTICDB_TRACE(log::codec(), "Metadata requires {} max_compressed_bytes", max_compressed_bytes);
     }
 
     ColumnEncoder encoder;
-    if(in_mem_seg.row_count() > 0) {
+    if (in_mem_seg.row_count() > 0) {
         for (std::size_t c = 0; c < in_mem_seg.num_columns(); ++c) {
             auto col = in_mem_seg.column_data(c);
             arcticdb::proto::encoding::VariantCodec codec;
@@ -103,7 +106,11 @@ std::pair<size_t, size_t> max_compressed_size(const SegmentInMemory &in_mem_seg,
             const auto [uncompressed, required] = encoder.max_compressed_size(codec_opts, col);
             uncompressed_bytes += uncompressed;
             max_compressed_bytes += required;
-            ARCTICDB_TRACE(log::codec(), "Column {} requires {} max_compressed_bytes, total {}", c, required, max_compressed_bytes);
+            ARCTICDB_TRACE(log::codec(),
+                "Column {} requires {} max_compressed_bytes, total {}",
+                c,
+                required,
+                max_compressed_bytes);
         }
         if (in_mem_seg.has_string_pool()) {
             auto col = in_mem_seg.string_pool_data();
@@ -112,14 +119,18 @@ std::pair<size_t, size_t> max_compressed_size(const SegmentInMemory &in_mem_seg,
             const auto [uncompressed, required] = encoder.max_compressed_size(codec_opts, col);
             uncompressed_bytes += uncompressed;
             max_compressed_bytes += required;
-            ARCTICDB_TRACE(log::codec(), "String pool requires {} max_compressed_bytes, total {}", required, max_compressed_bytes);
+            ARCTICDB_TRACE(log::codec(),
+                "String pool requires {} max_compressed_bytes, total {}",
+                required,
+                max_compressed_bytes);
         }
     }
     ARCTICDB_TRACE(log::codec(), "Max compressed size {}", max_compressed_bytes);
     return std::make_pair(uncompressed_bytes, max_compressed_bytes);
 }
 
-Segment encode(SegmentInMemory&& s, const arcticdb::proto::encoding::VariantCodec &codec_opts) {
+Segment encode(SegmentInMemory&& s, const arcticdb::proto::encoding::VariantCodec& codec_opts)
+{
     /*
      * This takes an in memory segment with all the metadata, column tensors etc, loops through each column
      * and based on the type of the column, calls the typed block encoder for that column.
@@ -139,20 +150,20 @@ Segment encode(SegmentInMemory&& s, const arcticdb::proto::encoding::VariantCode
     ColumnEncoder encoder;
 
     ARCTICDB_TRACE(log::codec(), "Encoding descriptor: {}", segment_header->stream_descriptor().DebugString());
-    auto *tsd = segment_header->mutable_stream_descriptor();
+    auto* tsd = segment_header->mutable_stream_descriptor();
     tsd->set_in_bytes(uncompressed_size);
 
     if (in_mem_seg.metadata()) {
         const auto bytes_count = static_cast<shape_t>(in_mem_seg.metadata()->ByteSizeLong());
         ARCTICDB_TRACE(log::codec(), "Encoding {} bytes of metadata", bytes_count);
-        auto *encoded_field = segment_header->mutable_metadata_field();
+        auto* encoded_field = segment_header->mutable_metadata_field();
         arcticdb::proto::encoding::VariantCodec codec;
         codec.CopyFrom(codec_opts);
 
         constexpr int max_stack_alloc = 1 << 11;
         bool malloced{false};
         uint8_t* meta_ptr{nullptr};
-        if(bytes_count > max_stack_alloc) {
+        if (bytes_count > max_stack_alloc) {
             meta_ptr = reinterpret_cast<uint8_t*>(malloc(bytes_count));
             malloced = true;
         } else {
@@ -165,8 +176,7 @@ Segment encode(SegmentInMemory&& s, const arcticdb::proto::encoding::VariantCode
 
         using BytesTypeDescriptorTag = TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension::Dim1>>;
         using BytesEncoder = BlockEncoder<BytesTypeDescriptorTag>;
-        auto typed_block = TypedBlockData<BytesTypeDescriptorTag>(
-            meta_buffer.data(),
+        auto typed_block = TypedBlockData<BytesTypeDescriptorTag>(meta_buffer.data(),
             &bytes_count,
             bytes_count,
             1u,
@@ -174,23 +184,27 @@ Segment encode(SegmentInMemory&& s, const arcticdb::proto::encoding::VariantCode
 
         BytesEncoder::encode(codec_opts, typed_block, *encoded_field, *out_buffer, pos);
         ARCTICDB_DEBUG(log::codec(), "Encoded metadata to position {}", pos);
-        if(malloced)
+        if (malloced)
             free(meta_ptr);
     }
 
-    if(in_mem_seg.row_count() > 0) {
+    if (in_mem_seg.row_count() > 0) {
         ARCTICDB_TRACE(log::codec(), "Encoding fields");
         for (std::size_t c = 0; c < in_mem_seg.num_columns(); ++c) {
             auto col = in_mem_seg.column_data(c);
             arcticdb::proto::encoding::VariantCodec codec;
             codec.CopyFrom(codec_opts);
-            auto *encoded_field = segment_header->mutable_fields()->Add();
+            auto* encoded_field = segment_header->mutable_fields()->Add();
             encoder.encode(codec_opts, col, *encoded_field, *out_buffer, pos);
-            ARCTICDB_TRACE(log::codec(), "Encoded column {}: ({}) to position {}", c, segment_header->stream_descriptor().fields(c).name(), pos);
+            ARCTICDB_TRACE(log::codec(),
+                "Encoded column {}: ({}) to position {}",
+                c,
+                segment_header->stream_descriptor().fields(c).name(),
+                pos);
         }
         if (in_mem_seg.has_string_pool()) {
             ARCTICDB_TRACE(log::codec(), "Encoding string pool to position {}", pos);
-            auto *encoded_field = segment_header->mutable_string_pool_field();
+            auto* encoded_field = segment_header->mutable_string_pool_field();
             auto col = in_mem_seg.string_pool_data();
             arcticdb::proto::encoding::VariantCodec codec;
             codec.CopyFrom(codec_opts);
@@ -203,51 +217,62 @@ Segment encode(SegmentInMemory&& s, const arcticdb::proto::encoding::VariantCode
     tsd->set_out_bytes(pos);
     ARCTICDB_DEBUG(log::codec(), "Encoded header: {}", tsd->DebugString());
 
-    ARCTICDB_DEBUG(log::codec(), "Block count {} header size {} ratio {}",
-        in_mem_seg.num_blocks(), segment_header->ByteSizeLong(),
+    ARCTICDB_DEBUG(log::codec(),
+        "Block count {} header size {} ratio {}",
+        in_mem_seg.num_blocks(),
+        segment_header->ByteSizeLong(),
         in_mem_seg.num_blocks() ? segment_header->ByteSizeLong() / in_mem_seg.num_blocks() : 0);
     return {std::move(arena), segment_header, std::move(out_buffer)};
 }
 
 namespace {
 class MetaBuffer {
-  public:
+public:
     MetaBuffer() = default;
 
-    shape_t *allocate_shapes(std::size_t bytes) {
+    shape_t* allocate_shapes(std::size_t bytes)
+    {
         util::check_arg(bytes == 8, "expected exactly one shape, actual {}", bytes / sizeof(shape_t));
         return &shape_;
     }
 
-    uint8_t *allocate_data(std::size_t bytes) {
+    uint8_t* allocate_data(std::size_t bytes)
+    {
         buff_.ensure(bytes);
         return buff_.data();
     }
 
-    void advance_data(std::size_t) const {
+    void advance_data(std::size_t) const
+    {
         // Not used
     }
 
-    void advance_shapes(std::size_t) const {
+    void advance_shapes(std::size_t) const
+    {
         // Not used
     }
 
-    void set_allow_sparse(bool) const {
+    void set_allow_sparse(bool) const
+    {
         // Not used
     }
 
-    [[nodiscard]] const Buffer& buffer() const { return buff_; }
+    [[nodiscard]] const Buffer& buffer() const
+    {
+        return buff_;
+    }
 
-  private:
+private:
     Buffer buff_;
     shape_t shape_ = 0;
 };
-}
+} // namespace
 
-size_t encode_bitmap(const util::BitMagic &sparse_map, Buffer &out, std::ptrdiff_t &pos) {
+size_t encode_bitmap(const util::BitMagic& sparse_map, Buffer& out, std::ptrdiff_t& pos)
+{
     ARCTICDB_DEBUG(log::version(), "Encoding sparse map of count: {}", sparse_map.count());
-    bm::serializer<bm::bvector<> > bvs;
-    bm::serializer<bm::bvector<> >::buffer sbuf;
+    bm::serializer<bm::bvector<>> bvs;
+    bm::serializer<bm::bvector<>>::buffer sbuf;
     bvs.serialize(sparse_map, sbuf);
     auto sz = sbuf.size();
     auto total_sz = sz + sizeof(util::BitMagicStart) + sizeof(util::BitMagicEnd);
@@ -262,8 +287,9 @@ size_t encode_bitmap(const util::BitMagic &sparse_map, Buffer &out, std::ptrdiff
     return total_sz;
 }
 
-std::optional<google::protobuf::Any> decode_metadata(const Segment &segment) {
-    auto &hdr = segment.header();
+std::optional<google::protobuf::Any> decode_metadata(const Segment& segment)
+{
+    auto& hdr = segment.header();
     if (!hdr.has_metadata_field())
         return std::nullopt;
 
@@ -271,8 +297,7 @@ std::optional<google::protobuf::Any> decode_metadata(const Segment &segment) {
     MetaBuffer meta_buf;
     std::optional<util::BitMagic> bv;
     decode(meta_type_desc, hdr.metadata_field(), segment.buffer().data(), meta_buf, bv);
-    google::protobuf::io::ArrayInputStream ais(meta_buf.buffer().data(),
-                                               static_cast<int>(meta_buf.buffer().bytes()));
+    google::protobuf::io::ArrayInputStream ais(meta_buf.buffer().data(), static_cast<int>(meta_buf.buffer().bytes()));
 
     google::protobuf::Any any;
     auto success = any.ParseFromZeroCopyStream(&ais);
@@ -281,9 +306,9 @@ std::optional<google::protobuf::Any> decode_metadata(const Segment &segment) {
 }
 
 void decode(const Segment& segment,
-            const arcticdb::proto::encoding::SegmentHeader& hdr,
-            SegmentInMemory& res,
-            const StreamDescriptor::Proto& desc)
+    const arcticdb::proto::encoding::SegmentHeader& hdr,
+    SegmentInMemory& res,
+    const StreamDescriptor::Proto& desc)
 {
     ARCTICDB_SAMPLE(DecodeSegment, 0)
     const uint8_t* data = segment.buffer().data();
@@ -296,17 +321,20 @@ void decode(const Segment& segment,
         MetaBuffer meta_buf;
         std::optional<util::BitMagic> bv;
         data += decode(meta_type_desc, hdr.metadata_field(), data, meta_buf, bv);
-        ARCTICDB_TRACE(log::codec(), "Decoded metadata to position {}", data-begin);
+        ARCTICDB_TRACE(log::codec(), "Decoded metadata to position {}", data - begin);
         google::protobuf::io::ArrayInputStream ais(meta_buf.buffer().data(),
-                                                   static_cast<int>(meta_buf.buffer().bytes()));
+            static_cast<int>(meta_buf.buffer().bytes()));
         google::protobuf::Any any;
         auto success = any.ParseFromZeroCopyStream(&ais);
         util::check(success, "Failed to parse metadata field in decode");
         res.set_metadata(std::move(any));
     }
-    if (data!=end) {
+    if (data != end) {
         const auto fields_size = desc.fields().size();
-        util::check(fields_size == hdr.fields_size(), "Mismatch between descriptor and header field size: {} != {}", fields_size, hdr.fields_size());
+        util::check(fields_size == hdr.fields_size(),
+            "Mismatch between descriptor and header field size: {} != {}",
+            fields_size,
+            hdr.fields_size());
         const auto start_row = res.row_count();
 
         const auto seg_row_count = fields_size ? ssize_t(hdr.fields(0).ndarray().items_count()) : 0LL;
@@ -315,41 +343,46 @@ void decode(const Segment& segment,
         for (std::size_t i = 0; i < static_cast<size_t>(fields_size); ++i) {
             const auto& field = hdr.fields(static_cast<int>(i));
             const auto& field_name = desc.fields(i).name();
-            util::check(data!=end, "Reached end of input block with {} fields to decode", fields_size-i);
-            if(auto col_index = res.column_index(field_name)) {
+            util::check(data != end, "Reached end of input block with {} fields to decode", fields_size - i);
+            if (auto col_index = res.column_index(field_name)) {
                 auto& col = res.column(static_cast<position_t>(*col_index));
-                data += decode(type_desc_from_proto(res.field(*col_index).type_desc()), field, data, col, col.opt_sparse_map());
+                data += decode(type_desc_from_proto(res.field(*col_index).type_desc()),
+                    field,
+                    data,
+                    col,
+                    col.opt_sparse_map());
 
             } else
                 data += encoding_size::compressed_size(field);
 
-            ARCTICDB_TRACE(log::codec(), "Decoded column {} to position {}", i, data-begin);
+            ARCTICDB_TRACE(log::codec(), "Decoded column {} to position {}", i, data - begin);
         }
 
         if (hdr.has_string_pool_field()) {
             ARCTICDB_TRACE(log::codec(), "Decoding string pool");
-            util::check(data!=end, "Reached end of input block with string pool fields to decode");
+            util::check(data != end, "Reached end of input block with string pool fields to decode");
             std::optional<util::BitMagic> bv;
             data += decode(SegmentInMemory::string_pool_descriptor().type_desc(),
-                           hdr.string_pool_field(),
-                           data,
-                           res.string_pool(),
-                           bv);
+                hdr.string_pool_field(),
+                data,
+                res.string_pool(),
+                bv);
 
-            ARCTICDB_TRACE(log::codec(), "Decoded string pool to position {}", data-begin);
+            ARCTICDB_TRACE(log::codec(), "Decoded string pool to position {}", data - begin);
         }
 
-        res.set_row_data(static_cast<ssize_t>(start_row + seg_row_count-1));
+        res.set_row_data(static_cast<ssize_t>(start_row + seg_row_count - 1));
         res.set_compacted(segment.header().compacted());
         auto is_sparse = res.is_sparse();
-        if(is_sparse)
+        if (is_sparse)
             log::version().debug("Brooop");
     }
 }
 
-SegmentInMemory decode(Segment&& s) {
+SegmentInMemory decode(Segment&& s)
+{
     auto segment = std::move(s);
-    auto &hdr = segment.header();
+    auto& hdr = segment.header();
     ARCTICDB_TRACE(log::codec(), "Decoding descriptor: {}", segment.header().stream_descriptor().DebugString());
     StreamDescriptor descriptor(std::move(*segment.header().mutable_stream_descriptor()));
 

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -39,61 +39,52 @@ template<typename TD>
 using BlockEncoder = BlockEncoderHelper<TypedBlockData, TD>;
 
 struct ColumnEncoder {
-    static std::pair<size_t, size_t> max_compressed_size(
-        const arcticdb::proto::encoding::VariantCodec &codec_opts,
-        ColumnData &column_data);
+    static std::pair<size_t, size_t> max_compressed_size(const arcticdb::proto::encoding::VariantCodec& codec_opts,
+        ColumnData& column_data);
 
-    static void encode(
-        const arcticdb::proto::encoding::VariantCodec &codec_opts,
-        ColumnData &f,
-        arcticdb::proto::encoding::EncodedField &field,
-        Buffer &out,
-        std::ptrdiff_t &pos);
+    static void encode(const arcticdb::proto::encoding::VariantCodec& codec_opts,
+        ColumnData& f,
+        arcticdb::proto::encoding::EncodedField& field,
+        Buffer& out,
+        std::ptrdiff_t& pos);
 };
 
-size_t encode_bitmap(
-    const util::BitMagic &sparse_map,
-    Buffer &out,
-    std::ptrdiff_t &pos);
+size_t encode_bitmap(const util::BitMagic& sparse_map, Buffer& out, std::ptrdiff_t& pos);
 
-Segment encode(
-    SegmentInMemory&& in_mem_seg,
-    const arcticdb::proto::encoding::VariantCodec &codec_opts);
+Segment encode(SegmentInMemory&& in_mem_seg, const arcticdb::proto::encoding::VariantCodec& codec_opts);
 
-SegmentInMemory decode(
-    Segment&& segment);
+SegmentInMemory decode(Segment&& segment);
 
-void decode(
-    const Segment& segment,
+void decode(const Segment& segment,
     const arcticdb::proto::encoding::SegmentHeader& hdr,
     SegmentInMemory& res,
     const StreamDescriptor::Proto& desc);
 
 template<class DS>
-std::size_t decode(
-    const TypeDescriptor &td,
-    const arcticdb::proto::encoding::EncodedField &field,
-    const uint8_t *input,
-    DS &data_sink,
+std::size_t decode(const TypeDescriptor& td,
+    const arcticdb::proto::encoding::EncodedField& field,
+    const uint8_t* input,
+    DS& data_sink,
     std::optional<util::BitMagic>& bv);
 
-std::optional<google::protobuf::Any> decode_metadata(
-    const Segment& segment);
+std::optional<google::protobuf::Any> decode_metadata(const Segment& segment);
 
-inline void hash_field(const arcticdb::proto::encoding::EncodedField &field, HashAccum &accum) {
-    auto &n = field.ndarray();
-    for(auto i = 0; i < n.shapes_size(); ++i) {
+inline void hash_field(const arcticdb::proto::encoding::EncodedField& field, HashAccum& accum)
+{
+    auto& n = field.ndarray();
+    for (auto i = 0; i < n.shapes_size(); ++i) {
         auto v = n.shapes(i).hash();
         accum(&v);
     }
 
-    for(auto j = 0; j < n.values_size(); ++j) {
+    for (auto j = 0; j < n.values_size(); ++j) {
         auto v = n.values(j).hash();
         accum(&v);
     }
 }
 
-inline HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader &hdr) {
+inline HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader& hdr)
+{
     HashAccum accum;
     if (hdr.has_metadata_field()) {
         hash_field(hdr.metadata_field(), accum);
@@ -101,7 +92,7 @@ inline HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentH
     for (int i = 0; i < hdr.fields_size(); ++i) {
         hash_field(hdr.fields(i), accum);
     }
-    if(hdr.has_string_pool_field()) {
+    if (hdr.has_string_pool_field()) {
         hash_field(hdr.string_pool_field(), accum);
     }
     return accum.digest();

--- a/cpp/arcticdb/codec/core.hpp
+++ b/cpp/arcticdb/codec/core.hpp
@@ -23,13 +23,15 @@ struct BlockProtobufHelper {
     std::size_t count_;
     std::size_t bytes_;
 
-    void set_pb(arcticdb::proto::encoding::Block &block_pb, HashedValue h, std::size_t encoded_size) const {
+    void set_pb(arcticdb::proto::encoding::Block& block_pb, HashedValue h, std::size_t encoded_size) const
+    {
         block_pb.set_in_bytes(static_cast<uint32_t>(bytes_));
         block_pb.set_out_bytes(static_cast<uint32_t>(encoded_size));
         block_pb.set_hash(h);
     }
 
-    void set_version(arcticdb::proto::encoding::Block &block_pb, std::uint32_t version) const {
+    void set_version(arcticdb::proto::encoding::Block& block_pb, std::uint32_t version) const
+    {
         block_pb.set_encoder_version(version);
     }
 };
@@ -39,29 +41,29 @@ struct NdArrayBlock {
     BlockProtobufHelper shapes_;
     BlockProtobufHelper values_;
 
-    void update_field_size(arcticdb::proto::encoding::NDArrayEncodedField &field) const {
+    void update_field_size(arcticdb::proto::encoding::NDArrayEncodedField& field) const
+    {
         auto existing_items_count = field.items_count();
         field.set_items_count(existing_items_count + static_cast<std::uint32_t>(item_count_));
     }
 
-    void set_pb(
-        arcticdb::proto::encoding::Block* shapes_pb,
+    void set_pb(arcticdb::proto::encoding::Block* shapes_pb,
         arcticdb::proto::encoding::Block* values_pb,
         HashedValue shape_hash,
         std::size_t encoded_shape_bytes,
         HashedValue values_hash,
-        std::size_t encoded_values_bytes
-        ) {
+        std::size_t encoded_values_bytes)
+    {
         ARCTICDB_TRACE(log::codec(), "Setting encoded bytes: {}:{}", encoded_shape_bytes, encoded_values_bytes);
         shapes_.set_pb(*shapes_pb, shape_hash, encoded_shape_bytes);
         values_.set_pb(*values_pb, values_hash, encoded_values_bytes);
     }
 
-    void set_version(
-        arcticdb::proto::encoding::Block* shapes_pb,
+    void set_version(arcticdb::proto::encoding::Block* shapes_pb,
         arcticdb::proto::encoding::Block* values_pb,
         std::uint32_t version,
-        std::uint32_t shape_version) {
+        std::uint32_t shape_version)
+    {
         shapes_.set_version(*shapes_pb, shape_version);
         values_.set_version(*values_pb, version);
     }
@@ -76,32 +78,39 @@ struct NdArrayBlock {
  */
 template<class TD>
 class CodecHelper {
-  public:
+public:
     using DT = typename TD::DataTypeTag;
     using D = typename TD::DimensionTag;
     constexpr static HashedValue seed = 0x42;
     using T = typename DT::raw_type;
     constexpr static Dimension dim = D::value;
 
-    CodecHelper() : hasher_(seed) {}
+    CodecHelper()
+        : hasher_(seed)
+    {
+    }
 
     HashAccum hasher_;
 
-    void ensure_buffer(Buffer &out, std::ptrdiff_t pos, std::size_t bytes_count) {
+    void ensure_buffer(Buffer& out, std::ptrdiff_t pos, std::size_t bytes_count)
+    {
         out.assert_size(pos + bytes_count);
     }
 
-    HashedValue get_digest_and_reset() {
+    HashedValue get_digest_and_reset()
+    {
         HashedValue v = hasher_.digest();
         hasher_.reset(seed);
         return v;
     }
 
-    static BlockProtobufHelper scalar_block(std::size_t elt) {
+    static BlockProtobufHelper scalar_block(std::size_t elt)
+    {
         return {elt, elt * sizeof(T)};
     }
 
-    static NdArrayBlock nd_array_block(std::size_t elt, const shape_t *shape) {
+    static NdArrayBlock nd_array_block(std::size_t elt, const shape_t* shape)
+    {
         std::size_t shape_count = static_cast<std::size_t>(dim) * elt;
         std::size_t total_values_count = 0;
         if constexpr (dim == Dimension::Dim1) {
@@ -133,19 +142,20 @@ template<class BE, class DefaultOpt>
 struct ShapeEncodingFromBlock {
 
     static constexpr decltype(BE::VERSION) VERSION = BE::VERSION;
-    static decltype(BE::max_compressed_size(0)) max_compressed_size(std::size_t s) {
+    static decltype(BE::max_compressed_size(0)) max_compressed_size(std::size_t s)
+    {
         return BE::max_compressed_size(s);
     }
 
     template<class T>
-    static std::size_t encode_block(
-        const T *in,
-        BlockProtobufHelper &block_utils,
-        HashAccum &hasher,
-        T *out,
+    static std::size_t encode_block(const T* in,
+        BlockProtobufHelper& block_utils,
+        HashAccum& hasher,
+        T* out,
         std::size_t out_capacity,
-        std::ptrdiff_t &pos,
-        arcticdb::proto::encoding::VariantCodec &out_codec) {
+        std::ptrdiff_t& pos,
+        arcticdb::proto::encoding::VariantCodec& out_codec)
+    {
         typename BE::Opts opts;
         DefaultOpt::set_shape_defaults(opts);
         return BE::encode_block(opts, in, block_utils, hasher, out, out_capacity, pos, out_codec);
@@ -176,11 +186,10 @@ struct GenericBlockEncoder {
     using ShapeEncoding = SE;
 
     GenericBlockEncoder() = delete;
-    GenericBlockEncoder(GenericBlockEncoder &&enc) = delete;
+    GenericBlockEncoder(GenericBlockEncoder&& enc) = delete;
 
-    static size_t max_compressed_size(
-        const BlockType &block
-    ) {
+    static size_t max_compressed_size(const BlockType& block)
+    {
         Helper helper;
         helper.hasher_.reset(helper.seed);
         std::size_t block_row_count = block.row_count();
@@ -199,18 +208,21 @@ struct GenericBlockEncoder {
             std::size_t comp_data = EncoderType::max_compressed_size(helper_array_block.values_.bytes_);
             std::size_t comp_shapes = ShapeEncoding::max_compressed_size(helper_array_block.shapes_.bytes_);
 
-            ARCTICDB_TRACE(log::codec(), "Array block has {} bytes ({} + {})", comp_data + comp_shapes, comp_shapes, comp_data);
+            ARCTICDB_TRACE(log::codec(),
+                "Array block has {} bytes ({} + {})",
+                comp_data + comp_shapes,
+                comp_shapes,
+                comp_data);
             return comp_data + comp_shapes;
         }
     }
 
-    static void encode(
-        const typename EncoderType::Opts &opts,
-        BlockType &block,
-        arcticdb::proto::encoding::EncodedField &field,
-        Buffer &out,
-        std::ptrdiff_t &pos
-        ) {
+    static void encode(const typename EncoderType::Opts& opts,
+        BlockType& block,
+        arcticdb::proto::encoding::EncodedField& field,
+        Buffer& out,
+        std::ptrdiff_t& pos)
+    {
         Helper helper;
         helper.hasher_.reset(helper.seed);
         std::size_t block_row_count = block.row_count();
@@ -226,21 +238,29 @@ struct GenericBlockEncoder {
 
             // doing copy + hash in one pass, this might have a negative effect on perf
             // since the hashing is path dependent. This is a toy example though so not critical
-            auto t_out = reinterpret_cast<T *>(out.data() + pos);
-            auto *field_nd_array = field.mutable_ndarray();
+            auto t_out = reinterpret_cast<T*>(out.data() + pos);
+            auto* field_nd_array = field.mutable_ndarray();
             const auto total_items_count = field_nd_array->items_count() + block_row_count;
             field_nd_array->set_items_count(total_items_count);
             auto value_pb = field_nd_array->add_values();
 
-           const auto compressed_size = EncoderType::encode_block(opts, block.data(), helper_scalar_block, helper.hasher_, t_out,
-                                                           max_compressed_size, pos, *value_pb->mutable_codec());
+            const auto compressed_size = EncoderType::encode_block(opts,
+                block.data(),
+                helper_scalar_block,
+                helper.hasher_,
+                t_out,
+                max_compressed_size,
+                pos,
+                *value_pb->mutable_codec());
 
             helper_scalar_block.set_pb(*value_pb, helper.hasher_.digest(), compressed_size);
             helper_scalar_block.set_version(*value_pb, EncoderType::VERSION);
         } else {
             auto helper_array_block = Helper::nd_array_block(block_row_count, block.shapes());
 
-            ARCTICDB_TRACE(log::codec(), "Generic block encoder writing ndarray field of {} items", helper_array_block.item_count_);
+            ARCTICDB_TRACE(log::codec(),
+                "Generic block encoder writing ndarray field of {} items",
+                helper_array_block.item_count_);
             std::size_t comp_data = EncoderType::max_compressed_size(helper_array_block.values_.bytes_);
             std::size_t comp_shapes = ShapeEncoding::max_compressed_size(helper_array_block.shapes_.bytes_);
 
@@ -249,27 +269,27 @@ struct GenericBlockEncoder {
             auto shape_pb = field_nd_array->add_shapes();
 
             // write shapes
-            auto s_out = reinterpret_cast<shape_t *>(out.data() + pos);
+            auto s_out = reinterpret_cast<shape_t*>(out.data() + pos);
             const auto shape_comp_size = ShapeEncoding::encode_block(block.shapes(),
-                                                                      helper_array_block.shapes_,
-                                                                      helper.hasher_,
-                                                                      s_out,
-                                                                      comp_shapes,
-                                                                      pos,
-                                                                      *shape_pb->mutable_codec());
+                helper_array_block.shapes_,
+                helper.hasher_,
+                s_out,
+                comp_shapes,
+                pos,
+                *shape_pb->mutable_codec());
             HashedValue shape_hash = helper.get_digest_and_reset();
 
             // write values
             auto value_pb = field_nd_array->add_values();
-            auto t_out = reinterpret_cast<T *>(out.data() + pos);
+            auto t_out = reinterpret_cast<T*>(out.data() + pos);
             const auto values_comp_size = EncoderType::encode_block(opts,
-                                                                        block.data(),
-                                                                        helper_array_block.values_,
-                                                                        helper.hasher_,
-                                                                        t_out,
-                                                                        comp_data,
-                                                                        pos,
-                                                                        *value_pb->mutable_codec());
+                block.data(),
+                helper_array_block.values_,
+                helper.hasher_,
+                t_out,
+                comp_data,
+                pos,
+                *value_pb->mutable_codec());
 
             auto digest = helper.hasher_.digest();
             helper_array_block.update_field_size(*field_nd_array);

--- a/cpp/arcticdb/codec/default_codecs.hpp
+++ b/cpp/arcticdb/codec/default_codecs.hpp
@@ -11,16 +11,18 @@
 
 namespace arcticdb::codec {
 
-inline arcticdb::proto::encoding::VariantCodec default_lz4_codec() {
+inline arcticdb::proto::encoding::VariantCodec default_lz4_codec()
+{
     arcticdb::proto::encoding::VariantCodec codec;
     auto lz4ptr = codec.mutable_lz4();
     lz4ptr->set_acceleration(1);
     return codec;
 }
-inline arcticdb::proto::encoding::VariantCodec default_passthrough_codec() {
+inline arcticdb::proto::encoding::VariantCodec default_passthrough_codec()
+{
     arcticdb::proto::encoding::VariantCodec codec;
     auto lz4ptr = codec.mutable_passthrough();
     lz4ptr->set_mark(true);
     return codec;
 }
-}
+} // namespace arcticdb::codec

--- a/cpp/arcticdb/codec/encoding_sizes.cpp
+++ b/cpp/arcticdb/codec/encoding_sizes.cpp
@@ -11,29 +11,31 @@
 
 namespace arcticdb::encoding_size {
 
-std::size_t compressed_size(const arcticdb::proto::encoding::SegmentHeader &sh) {
+std::size_t compressed_size(const arcticdb::proto::encoding::SegmentHeader& sh)
+{
     std::size_t total = 0;
-    for (auto &field : sh.fields()) {
+    for (auto& field : sh.fields()) {
         switch (field.encoding_case()) {
-            case arcticdb::proto::encoding::EncodedField::kNdarray: {
-                auto compressed_sz = compressed_size(field.ndarray());
-                ARCTICDB_TRACE(log::storage(), "From segment header: compressed: {}", compressed_sz);
-                total += compressed_sz;
-                break;
-            }
-            case arcticdb::proto::encoding::EncodedField::kDictionary:
-                total += compressed_size(field.dictionary());
-                break;
-            default:
-                util::raise_rte("Unsupported encoding in {}",  util::format(field));
+        case arcticdb::proto::encoding::EncodedField::kNdarray: {
+            auto compressed_sz = compressed_size(field.ndarray());
+            ARCTICDB_TRACE(log::storage(), "From segment header: compressed: {}", compressed_sz);
+            total += compressed_sz;
+            break;
+        }
+        case arcticdb::proto::encoding::EncodedField::kDictionary:
+            total += compressed_size(field.dictionary());
+            break;
+        default:
+            util::raise_rte("Unsupported encoding in {}", util::format(field));
         }
     }
     return total;
 }
 
-std::size_t uncompressed_size(const arcticdb::proto::encoding::SegmentHeader &sh) {
+std::size_t uncompressed_size(const arcticdb::proto::encoding::SegmentHeader& sh)
+{
     std::size_t total = 0;
-    for (auto &field : sh.fields()) {
+    for (auto& field : sh.fields()) {
         switch (field.encoding_case()) {
         case arcticdb::proto::encoding::EncodedField::kNdarray: {
             auto uncompressed_sz = uncompressed_size(field.ndarray());
@@ -45,19 +47,20 @@ std::size_t uncompressed_size(const arcticdb::proto::encoding::SegmentHeader &sh
             total += uncompressed_size(field.dictionary());
             break;
         default:
-            util::raise_rte("Unsupported encoding in {}",  util::format(field));
+            util::raise_rte("Unsupported encoding in {}", util::format(field));
         }
     }
     return total;
 }
 
-std::size_t represented_size(const arcticdb::proto::encoding::SegmentHeader& sh, size_t total_rows) {
+std::size_t represented_size(const arcticdb::proto::encoding::SegmentHeader& sh, size_t total_rows)
+{
     std::size_t total = 0;
 
-    for(const auto& field : sh.stream_descriptor().fields()) {
+    for (const auto& field : sh.stream_descriptor().fields()) {
         total += total_rows * get_type_size(entity::data_type_from_proto(field.type_desc()));
     }
 
     return total;
 }
-}
+} // namespace arcticdb::encoding_size

--- a/cpp/arcticdb/codec/encoding_sizes.hpp
+++ b/cpp/arcticdb/codec/encoding_sizes.hpp
@@ -14,60 +14,78 @@
 #include <arcticdb/util/preconditions.hpp>
 
 namespace arcticdb::encoding_size {
-    inline std::size_t shape_compressed_size(const arcticdb::proto::encoding::NDArrayEncodedField &nda) {
-        return std::accumulate(std::begin(nda.shapes()), std::end(nda.shapes()), size_t(0),
-                               [] (size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.out_bytes(); });
-    }
+inline std::size_t shape_compressed_size(const arcticdb::proto::encoding::NDArrayEncodedField& nda)
+{
+    return std::accumulate(std::begin(nda.shapes()),
+        std::end(nda.shapes()),
+        size_t(0),
+        [](size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.out_bytes(); });
+}
 
-    inline std::size_t data_compressed_size(const arcticdb::proto::encoding::NDArrayEncodedField &nda) {
-        return std::accumulate(std::begin(nda.values()), std::end(nda.values()), size_t(0),
-                               [] (size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.out_bytes(); });
-    }
+inline std::size_t data_compressed_size(const arcticdb::proto::encoding::NDArrayEncodedField& nda)
+{
+    return std::accumulate(std::begin(nda.values()),
+        std::end(nda.values()),
+        size_t(0),
+        [](size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.out_bytes(); });
+}
 
-    inline std::size_t shape_uncompressed_size(const arcticdb::proto::encoding::NDArrayEncodedField &nda) {
-        return std::accumulate(std::begin(nda.shapes()), std::end(nda.shapes()), size_t(0),
-                               [] (size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.in_bytes(); });
-    }
+inline std::size_t shape_uncompressed_size(const arcticdb::proto::encoding::NDArrayEncodedField& nda)
+{
+    return std::accumulate(std::begin(nda.shapes()),
+        std::end(nda.shapes()),
+        size_t(0),
+        [](size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.in_bytes(); });
+}
 
-    inline std::size_t data_uncompressed_size(const arcticdb::proto::encoding::NDArrayEncodedField &nda) {
-        return  std::accumulate(std::begin(nda.values()), std::end(nda.values()), size_t(0),
-                               [] (size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.in_bytes(); });
-    }
+inline std::size_t data_uncompressed_size(const arcticdb::proto::encoding::NDArrayEncodedField& nda)
+{
+    return std::accumulate(std::begin(nda.values()),
+        std::end(nda.values()),
+        size_t(0),
+        [](size_t a, const arcticdb::proto::encoding::Block& block) { return a + block.in_bytes(); });
+}
 
-    inline std::size_t bitmap_serialized_size(const arcticdb::proto::encoding::NDArrayEncodedField &nda) {
-        return  nda.sparse_map_bytes();
-    }
+inline std::size_t bitmap_serialized_size(const arcticdb::proto::encoding::NDArrayEncodedField& nda)
+{
+    return nda.sparse_map_bytes();
+}
 
-    inline std::size_t compressed_size(const arcticdb::proto::encoding::NDArrayEncodedField &nda) {
-        return shape_compressed_size(nda) + data_compressed_size(nda) + bitmap_serialized_size(nda);
-    }
+inline std::size_t compressed_size(const arcticdb::proto::encoding::NDArrayEncodedField& nda)
+{
+    return shape_compressed_size(nda) + data_compressed_size(nda) + bitmap_serialized_size(nda);
+}
 
-    inline std::size_t compressed_size(const arcticdb::proto::encoding::DictionaryEncodedField &d) {
-        return (d.has_values() ? compressed_size(d.values()) : 0) +
-            (d.has_positions() ? compressed_size(d.positions()) : 0);
-    }
+inline std::size_t compressed_size(const arcticdb::proto::encoding::DictionaryEncodedField& d)
+{
+    return (d.has_values() ? compressed_size(d.values()) : 0) +
+           (d.has_positions() ? compressed_size(d.positions()) : 0);
+}
 
-inline std::size_t uncompressed_size(const arcticdb::proto::encoding::NDArrayEncodedField &nda) {
+inline std::size_t uncompressed_size(const arcticdb::proto::encoding::NDArrayEncodedField& nda)
+{
     return shape_uncompressed_size(nda) + data_uncompressed_size(nda) + bitmap_serialized_size(nda);
 }
 
-inline std::size_t uncompressed_size(const arcticdb::proto::encoding::DictionaryEncodedField &d) {
+inline std::size_t uncompressed_size(const arcticdb::proto::encoding::DictionaryEncodedField& d)
+{
     return (d.has_values() ? uncompressed_size(d.values()) : 0) +
-        (d.has_positions() ? uncompressed_size(d.positions()) : 0);
+           (d.has_positions() ? uncompressed_size(d.positions()) : 0);
 }
 
-inline std::size_t compressed_size(const arcticdb::proto::encoding::EncodedField &field) {
+inline std::size_t compressed_size(const arcticdb::proto::encoding::EncodedField& field)
+{
     switch (field.encoding_case()) {
-        case arcticdb::proto::encoding::EncodedField::kNdarray:
-            return compressed_size(field.ndarray());
-            default:
-                util::raise_error_msg("Unsupported encoding {}", field);
+    case arcticdb::proto::encoding::EncodedField::kNdarray:
+        return compressed_size(field.ndarray());
+    default:
+        util::raise_error_msg("Unsupported encoding {}", field);
     }
 }
 
-std::size_t compressed_size(const arcticdb::proto::encoding::SegmentHeader &sh);
+std::size_t compressed_size(const arcticdb::proto::encoding::SegmentHeader& sh);
 
-std::size_t uncompressed_size(const arcticdb::proto::encoding::SegmentHeader &sh);
+std::size_t uncompressed_size(const arcticdb::proto::encoding::SegmentHeader& sh);
 
 std::size_t represented_size(const arcticdb::proto::encoding::SegmentHeader& sh, size_t total_rows);
-} // namespace encoding_size
+} // namespace arcticdb::encoding_size

--- a/cpp/arcticdb/codec/lz4.hpp
+++ b/cpp/arcticdb/codec/lz4.hpp
@@ -24,22 +24,30 @@ struct Lz4BlockEncoder {
     using Opts = arcticdb::proto::encoding::VariantCodec::Lz4;
     static constexpr std::uint32_t VERSION = 1;
 
-    static std::size_t max_compressed_size(std::size_t size) {
+    static std::size_t max_compressed_size(std::size_t size)
+    {
         return LZ4_compressBound(static_cast<int>(size));
     }
 
-    static void set_shape_defaults(Opts &opts) {
+    static void set_shape_defaults(Opts& opts)
+    {
         opts.set_acceleration(0);
     }
 
     template<class T>
-    static std::size_t encode_block(const Opts &opts, const T *in, BlockProtobufHelper &block_utils,
-                                    HashAccum &hasher, T *out, std::size_t out_capacity, std::ptrdiff_t &pos,
-                                    arcticdb::proto::encoding::VariantCodec &out_codec) {
-        int compressed_bytes = LZ4_compress_default(
-            reinterpret_cast<const char *>(in),
-            reinterpret_cast<char *>(out),
-            int(block_utils.bytes_), int(out_capacity));
+    static std::size_t encode_block(const Opts& opts,
+        const T* in,
+        BlockProtobufHelper& block_utils,
+        HashAccum& hasher,
+        T* out,
+        std::size_t out_capacity,
+        std::ptrdiff_t& pos,
+        arcticdb::proto::encoding::VariantCodec& out_codec)
+    {
+        int compressed_bytes = LZ4_compress_default(reinterpret_cast<const char*>(in),
+            reinterpret_cast<char*>(out),
+            int(block_utils.bytes_),
+            int(out_capacity));
 
         util::check_arg(compressed_bytes >= 0, "expected compressed bytes >= 0, actual {}", compressed_bytes);
         ARCTICDB_TRACE(log::storage(), "Block of size {} compressed to {} bytes", block_utils.bytes_, compressed_bytes);
@@ -61,21 +69,27 @@ struct Lz4Decoder {
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
     template<typename T>
-    static void decode_block([[maybe_unused]] std::uint32_t encoder_version, const std::uint8_t *in, std::size_t in_bytes, T *t_out,
-                             std::size_t out_bytes) {
+    static void decode_block([[maybe_unused]] std::uint32_t encoder_version,
+        const std::uint8_t* in,
+        std::size_t in_bytes,
+        T* t_out,
+        std::size_t out_bytes)
+    {
 
         ARCTICDB_TRACE(log::codec(), "Lz4 decoder reading block: {} {}", in_bytes, out_bytes);
-        int real_decomp = LZ4_decompress_safe(
-            reinterpret_cast<const char *>(in),
-            reinterpret_cast<char *>(t_out),
+        int real_decomp = LZ4_decompress_safe(reinterpret_cast<const char*>(in),
+            reinterpret_cast<char*>(t_out),
             int(in_bytes),
-            int(out_bytes)
-        );
-        util::check_arg(real_decomp > 0, "Error while decoding with lz4 at address {:x} with size {}. Code {}", uintptr_t(in), in_bytes, real_decomp);
+            int(out_bytes));
+        util::check_arg(real_decomp > 0,
+            "Error while decoding with lz4 at address {:x} with size {}. Code {}",
+            uintptr_t(in),
+            in_bytes,
+            real_decomp);
         util::check_arg(std::size_t(real_decomp) == out_bytes,
-                        "expected out_bytes == lz4 decompressed bytes, actual {} != {}",
-                        out_bytes,
-                        real_decomp);
+            "expected out_bytes == lz4 decompressed bytes, actual {} != {}",
+            out_bytes,
+            real_decomp);
     }
 
 #pragma GCC diagnostic pop

--- a/cpp/arcticdb/codec/passthrough.hpp
+++ b/cpp/arcticdb/codec/passthrough.hpp
@@ -20,7 +20,8 @@ namespace arcticdb::detail {
 template<template<typename> class BlockType, class TD>
 struct PassthroughEncoder {
 
-    static size_t max_compressed_size(const BlockType<TD> &block ) {
+    static size_t max_compressed_size(const BlockType<TD>& block)
+    {
         using Helper = CodecHelper<TD>;
         if constexpr (Helper::dim == entity::Dimension::Dim0) {
             // Only store data, no shapes since dimension is 0
@@ -32,13 +33,15 @@ struct PassthroughEncoder {
         }
     }
 
-    static void encode(BlockType<TD> &block, arcticdb::proto::encoding::EncodedField &field, Buffer &out, std::ptrdiff_t &pos) {
+    static void
+    encode(BlockType<TD>& block, arcticdb::proto::encoding::EncodedField& field, Buffer& out, std::ptrdiff_t& pos)
+    {
         using namespace arcticdb::entity;
         using Helper = CodecHelper<TD>;
         using T = typename Helper::T;
         Helper helper;
         helper.hasher_.reset(helper.seed);
-        const T *d = block.data();
+        const T* d = block.data();
         std::size_t block_row_count = block.row_count();
 
         if constexpr (Helper::dim == entity::Dimension::Dim0) {
@@ -48,10 +51,10 @@ struct PassthroughEncoder {
 
             // doing copy + hash in one pass, this might have a negative effect on perf
             // since the hashing is path dependent. This is a toy example though so not critical
-            T *t_out = out.ptr_cast<T>(pos, v_block.bytes_);
+            T* t_out = out.ptr_cast<T>(pos, v_block.bytes_);
             encode_block(d, v_block, helper.hasher_, t_out, pos);
 
-            auto *nd_array = field.mutable_ndarray();
+            auto* nd_array = field.mutable_ndarray();
             auto total_row_count = nd_array->items_count() + block_row_count;
             nd_array->set_items_count(total_row_count);
             auto values_pb = nd_array->add_values();
@@ -66,19 +69,25 @@ struct PassthroughEncoder {
             HashedValue shape_hash = helper.get_digest_and_reset();
 
             // write values
-            T *t_out = out.ptr_cast<T>(pos, helper_array_block.values_.bytes_);
+            T* t_out = out.ptr_cast<T>(pos, helper_array_block.values_.bytes_);
             encode_block(d, helper_array_block.values_, helper.hasher_, t_out, pos);
             auto field_nd_array = field.mutable_ndarray();
             auto values_pb = field_nd_array->add_values();
             auto shapes_pb = field_nd_array->add_shapes();
             helper_array_block.update_field_size(*field_nd_array);
-            helper_array_block.set_pb(shapes_pb, values_pb, shape_hash, helper_array_block.shapes_.bytes_,
-                                      helper.hasher_.digest(), helper_array_block.values_.bytes_);
+            helper_array_block.set_pb(shapes_pb,
+                values_pb,
+                shape_hash,
+                helper_array_block.shapes_.bytes_,
+                helper.hasher_.digest(),
+                helper_array_block.values_.bytes_);
         }
     }
 
     template<class T>
-    static void encode_block(const T *in, BlockProtobufHelper &block_utils, HashAccum &hasher, T *out, std::ptrdiff_t &pos) {
+    static void
+    encode_block(const T* in, BlockProtobufHelper& block_utils, HashAccum& hasher, T* out, std::ptrdiff_t& pos)
+    {
         memcpy(out, in, block_utils.bytes_);
         hasher(in, block_utils.bytes_ / sizeof(T));
         pos += static_cast<ssize_t>(block_utils.bytes_);
@@ -87,10 +96,12 @@ struct PassthroughEncoder {
 
 struct PassthroughDecoder {
     template<typename T>
-    static void decode_block(const std::uint8_t *in, std::size_t in_bytes, T *t_out,
-                             std::size_t out_bytes) {
-        arcticdb::util::check_arg(in_bytes == out_bytes, "expected  in_bytes==out_bytes, actual {} != {}", in_bytes,
-                                 out_bytes);
+    static void decode_block(const std::uint8_t* in, std::size_t in_bytes, T* t_out, std::size_t out_bytes)
+    {
+        arcticdb::util::check_arg(in_bytes == out_bytes,
+            "expected  in_bytes==out_bytes, actual {} != {}",
+            in_bytes,
+            out_bytes);
         memcpy(t_out, in, in_bytes);
         in += in_bytes;
         t_out += in_bytes / sizeof(T);

--- a/cpp/arcticdb/codec/python_bindings.cpp
+++ b/cpp/arcticdb/codec/python_bindings.cpp
@@ -29,21 +29,23 @@ using namespace arcticdb::python_util;
 namespace arcticdb {
 
 class DynamicFieldBuffer {
-  public:
-
-    DynamicFieldBuffer(const TypeDescriptor &td, const py::buffer& data, const py::buffer& shapes) :
-        td_(td),
-        field_() {
+public:
+    DynamicFieldBuffer(const TypeDescriptor& td, const py::buffer& data, const py::buffer& shapes)
+        : td_(td),
+          field_()
+    {
         auto d_info_ = data.request();
         auto s_info_ = shapes.request();
         util::check_arg(d_info_.ndim == 1, "only support dimension 1 (flattened) data. actual {}", d_info_.ndim);
         util::check_arg(s_info_.ndim == 1, "only support dimension 1 (flattened) shapes. actual {}", s_info_.ndim);
-        util::check_arg(sizeof(shape_t) == s_info_.itemsize, "expected shape itemsize={:d}, actual={:d}",
-                        sizeof(shape_t), s_info_.itemsize);
+        util::check_arg(sizeof(shape_t) == s_info_.itemsize,
+            "expected shape itemsize={:d}, actual={:d}",
+            sizeof(shape_t),
+            s_info_.itemsize);
         util::check_arg(s_info_.size > 0, "does not support empty size.");
         util::check_arg(d_info_.size > 0, "does not support empty data.");
         std::size_t item_count = 0;
-        auto s = reinterpret_cast<shape_t *>(s_info_.ptr);
+        auto s = reinterpret_cast<shape_t*>(s_info_.ptr);
         std::size_t shape_count = s_info_.size;
         std::size_t dim = std::max(static_cast<std::size_t>(1), static_cast<std::size_t>(td.dimension()));
         for (std::size_t i = 0; i < shape_count / dim; ++i) {
@@ -54,8 +56,9 @@ class DynamicFieldBuffer {
             item_count += v;
         }
         util::check_arg(item_count == std::size_t(d_info_.size),
-                        "number of elements e={} and sum of shapes s={} do not match",
-                        item_count, d_info_.size);
+            "number of elements e={} and sum of shapes s={} do not match",
+            item_count,
+            d_info_.size);
 
         auto data_bytes = d_info_.size * d_info_.itemsize;
         auto shape_bytes = s_info_.size * s_info_.itemsize;
@@ -75,11 +78,12 @@ class DynamicFieldBuffer {
         }
     }
 
-    std::shared_ptr<ColumnData> as_field() {
+    std::shared_ptr<ColumnData> as_field()
+    {
         return field_;
     }
 
-  private:
+private:
     CursoredBuffer<Buffer> shapes_;
     CursoredBuffer<ChunkedBuffer> data_;
     TypeDescriptor td_;
@@ -88,14 +92,17 @@ class DynamicFieldBuffer {
 
 struct FieldEncodingResult {
     FieldEncodingResult() = default;
-    FieldEncodingResult(std::shared_ptr<Buffer> buffer, proto::encoding::EncodedField encoded_field):
-    buffer_(std::move(buffer)),
-    encoded_field_(encoded_field) {}
+    FieldEncodingResult(std::shared_ptr<Buffer> buffer, proto::encoding::EncodedField encoded_field)
+        : buffer_(std::move(buffer)),
+          encoded_field_(encoded_field)
+    {
+    }
     std::shared_ptr<Buffer> buffer_;
     proto::encoding::EncodedField encoded_field_;
 };
 
-FieldEncodingResult py_encode_field(py::object &opts, DynamicFieldBuffer &field_buffer) {
+FieldEncodingResult py_encode_field(py::object& opts, DynamicFieldBuffer& field_buffer)
+{
     proto::encoding::VariantCodec opts_cpp;
     python_util::pb_from_python(opts, opts_cpp);
 
@@ -109,62 +116,78 @@ FieldEncodingResult py_encode_field(py::object &opts, DynamicFieldBuffer &field_
     return FieldEncodingResult{buffer, encoded_field};
 }
 
-Segment encode_segment(SegmentInMemory segment_in_memory, const py::object &opts) {
+Segment encode_segment(SegmentInMemory segment_in_memory, const py::object& opts)
+{
     proto::encoding::VariantCodec opts_cpp;
     python_util::pb_from_python(opts, opts_cpp);
     return encode(std::move(segment_in_memory), opts_cpp);
 }
 
-SegmentInMemory decode_segment(Segment segment) {
+SegmentInMemory decode_segment(Segment segment)
+{
     return decode(std::move(segment));
 }
 
 class BufferPairDataSink {
-  public:
-    BufferPairDataSink() :
-        values_(std::make_shared<Buffer>()),
-        shapes_(std::make_shared<Buffer>()) {
+public:
+    BufferPairDataSink()
+        : values_(std::make_shared<Buffer>()),
+          shapes_(std::make_shared<Buffer>())
+    {
     }
 
-    void *allocate_data(std::size_t size) {
+    void* allocate_data(std::size_t size)
+    {
         values_->ensure(size);
         return values_->data();
     }
 
-    shape_t *allocate_shapes(std::size_t size) {
+    shape_t* allocate_shapes(std::size_t size)
+    {
         shapes_->ensure(size);
-        return reinterpret_cast<shape_t *>(shapes_->data());
+        return reinterpret_cast<shape_t*>(shapes_->data());
     }
 
-    void advance_shapes(std::size_t) {}
+    void advance_shapes(std::size_t)
+    {
+    }
 
-    void advance_data(std::size_t) {}
+    void advance_data(std::size_t)
+    {
+    }
 
-    void set_allow_sparse(bool) {}
+    void set_allow_sparse(bool)
+    {
+    }
 
-    std::shared_ptr<Buffer> values() {
+    std::shared_ptr<Buffer> values()
+    {
         return values_;
     }
 
-    std::shared_ptr<Buffer> shapes() {
+    std::shared_ptr<Buffer> shapes()
+    {
         return shapes_;
     }
 
-  private:
+private:
     std::shared_ptr<Buffer> values_;
     std::shared_ptr<Buffer> shapes_;
 };
 
 struct FieldDecodingResult {
     FieldDecodingResult() = default;
-    FieldDecodingResult(std::shared_ptr<Buffer> shape_buffer, std::shared_ptr<Buffer> values_buffer):
-            shape_buffer_(std::move(shape_buffer)),
-            values_buffer_(std::move(values_buffer)) {}
+    FieldDecodingResult(std::shared_ptr<Buffer> shape_buffer, std::shared_ptr<Buffer> values_buffer)
+        : shape_buffer_(std::move(shape_buffer)),
+          values_buffer_(std::move(values_buffer))
+    {
+    }
     std::shared_ptr<Buffer> shape_buffer_;
     std::shared_ptr<Buffer> values_buffer_;
 };
 
-FieldDecodingResult py_decode_field(const TypeDescriptor &td, py::object &encoded_field, py::buffer &buffer) {
+FieldDecodingResult py_decode_field(const TypeDescriptor& td, py::object& encoded_field, py::buffer& buffer)
+{
     proto::encoding::EncodedField enc_field;
     python_util::pb_from_python(encoded_field, enc_field);
     auto info = buffer.request();
@@ -172,50 +195,45 @@ FieldDecodingResult py_decode_field(const TypeDescriptor &td, py::object &encode
 
     BufferPairDataSink ds;
     std::optional<util::BitMagic> bv;
-    decode(td, enc_field, reinterpret_cast<std::uint8_t *>(info.ptr), ds, bv);
+    decode(td, enc_field, reinterpret_cast<std::uint8_t*>(info.ptr), ds, bv);
     return FieldDecodingResult{ds.shapes(), ds.values()};
 }
 
-void register_codec(py::module &m) {
+void register_codec(py::module& m)
+{
     py::class_<DynamicFieldBuffer>(m, "DynamicFieldBuffer")
         .def(py::init<TypeDescriptor, py::buffer, py::buffer>())
         .def("as_field", &DynamicFieldBuffer::as_field);
 
     py::class_<FieldEncodingResult, std::shared_ptr<FieldEncodingResult>>(m, "FieldEncodingResult")
         .def(py::init<>())
-        .def_property_readonly("buffer", [](const FieldEncodingResult& self) {
-            return self.buffer_;
-        })
-        .def_property_readonly("encoded_field", [](const FieldEncodingResult& self) {
-            return python_util::pb_to_python(self.encoded_field_);
-        });
+        .def_property_readonly("buffer", [](const FieldEncodingResult& self) { return self.buffer_; })
+        .def_property_readonly("encoded_field",
+            [](const FieldEncodingResult& self) { return python_util::pb_to_python(self.encoded_field_); });
 
     py::class_<FieldDecodingResult, std::shared_ptr<FieldDecodingResult>>(m, "FieldDecodingResult")
         .def(py::init<>())
-        .def_property_readonly("shape_buffer", [](const FieldDecodingResult& self) {
-            return self.shape_buffer_;
-        })
-        .def_property_readonly("values_buffer", [](const FieldDecodingResult& self) {
-            return self.values_buffer_;
-        });
+        .def_property_readonly("shape_buffer", [](const FieldDecodingResult& self) { return self.shape_buffer_; })
+        .def_property_readonly("values_buffer", [](const FieldDecodingResult& self) { return self.values_buffer_; });
 
     py::class_<Buffer, std::shared_ptr<Buffer>>(m, "Buffer", py::buffer_protocol())
         .def(py::init())
         .def("size", &Buffer::bytes)
-        .def_buffer([](Buffer &buffer) {
-            return py::buffer_info{
-                buffer.data(), 1, py::format_descriptor<std::uint8_t>::format(), 1, {buffer.bytes()}, {1}
-            };
+        .def_buffer([](Buffer& buffer) {
+            return py::buffer_info{buffer.data(),
+                1,
+                py::format_descriptor<std::uint8_t>::format(),
+                1,
+                {buffer.bytes()},
+                {1}};
         });
 
     py::class_<Segment>(m, "Segment")
-            .def(py::init<>())
-            .def_property_readonly("header", [](const Segment& self) {
-                return pb_to_python(self.header());
-            })
-            .def_property_readonly("bytes", [](const Segment& self) {
-                return py::bytes(reinterpret_cast<char *>(self.buffer().data()), self.buffer().bytes());
-            });
+        .def(py::init<>())
+        .def_property_readonly("header", [](const Segment& self) { return pb_to_python(self.header()); })
+        .def_property_readonly("bytes", [](const Segment& self) {
+            return py::bytes(reinterpret_cast<char*>(self.buffer().data()), self.buffer().bytes());
+        });
 
     m.def("encode_segment", &encode_segment);
     m.def("decode_segment", &decode_segment, py::return_value_policy::move);
@@ -224,4 +242,3 @@ void register_codec(py::module &m) {
 }
 
 } // namespace arcticdb
-

--- a/cpp/arcticdb/codec/python_bindings.hpp
+++ b/cpp/arcticdb/codec/python_bindings.hpp
@@ -11,10 +11,11 @@
 namespace py = pybind11;
 
 namespace arcticdb {
-void register_codec(py::module &m);
+void register_codec(py::module& m);
 
 namespace codec {
-inline void register_bindings(py::module &m) {
+inline void register_bindings(py::module& m)
+{
     auto arcticdb_codec = m.def_submodule("codec", R"pydoc(
     Encoding / decoding of in memory segments for storage
     -----------------------------------------------------
@@ -23,6 +24,5 @@ inline void register_bindings(py::module &m) {
     arcticdb::register_codec(arcticdb_codec);
 }
 
-} // namespace arcticdb::codec
+} // namespace codec
 } // namespace arcticdb
-

--- a/cpp/arcticdb/codec/segment.cpp
+++ b/cpp/arcticdb/codec/segment.cpp
@@ -13,39 +13,43 @@
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/util/dump_bytes.hpp>
 
-
 namespace arcticdb {
 
-Segment Segment::from_bytes(std::uint8_t* src, std::size_t readable_size, bool copy_data /* = false */) {
+Segment Segment::from_bytes(std::uint8_t* src, std::size_t readable_size, bool copy_data /* = false */)
+{
     ARCTICDB_SAMPLE(SegmentFromBytes, 0)
     auto* fixed_hdr = reinterpret_cast<Segment::FixedHeader*>(src);
-    util::check_arg(fixed_hdr->magic_number == MAGIC_NUMBER, "expected first 2 bytes: {}, actual {}",
-                    MAGIC_NUMBER, fixed_hdr->magic_number);
+    util::check_arg(fixed_hdr->magic_number == MAGIC_NUMBER,
+        "expected first 2 bytes: {}, actual {}",
+        MAGIC_NUMBER,
+        fixed_hdr->magic_number);
     util::check_arg(fixed_hdr->encoding_version == ENCODING_VERSION,
-                    "expected encoding_version {}, actual {}",
-                    ENCODING_VERSION, fixed_hdr->encoding_version);
+        "expected encoding_version {}, actual {}",
+        ENCODING_VERSION,
+        fixed_hdr->encoding_version);
 
     ARCTICDB_SUBSAMPLE(ReadHeaderAndSegment, 0)
     auto header_bytes ARCTICDB_UNUSED = arcticdb::Segment::FIXED_HEADER_SIZE + fixed_hdr->header_bytes;
-    ARCTICDB_DEBUG(log::codec(), "Reading header: {} + {} = {}",
-                       arcticdb::Segment::FIXED_HEADER_SIZE,
-                       fixed_hdr->header_bytes,
-                       header_bytes);
+    ARCTICDB_DEBUG(log::codec(),
+        "Reading header: {} + {} = {}",
+        arcticdb::Segment::FIXED_HEADER_SIZE,
+        fixed_hdr->header_bytes,
+        header_bytes);
     google::protobuf::io::ArrayInputStream ais(src + arcticdb::Segment::FIXED_HEADER_SIZE, fixed_hdr->header_bytes);
     auto arena = std::make_unique<google::protobuf::Arena>();
     auto seg_hdr = google::protobuf::Arena::CreateMessage<arcticdb::proto::encoding::SegmentHeader>(arena.get());
     seg_hdr->ParseFromZeroCopyStream(&ais);
 
-    const auto[string_pool_size, buffer_bytes] = segment_size::compressed(*seg_hdr);
+    const auto [string_pool_size, buffer_bytes] = segment_size::compressed(*seg_hdr);
     ARCTICDB_DEBUG(log::codec(), "Reading string pool {} and buffer bytes {}", string_pool_size, buffer_bytes);
     util::check(arcticdb::Segment::FIXED_HEADER_SIZE + fixed_hdr->header_bytes + buffer_bytes <= readable_size,
-                "Size disparity, fixed header size {} + variable header size {} + buffer size {}  (string pool size {}) >= total size {}",
-                arcticdb::Segment::FIXED_HEADER_SIZE,
-                fixed_hdr->header_bytes,
-                buffer_bytes,
-                string_pool_size,
-                readable_size
-    );
+        "Size disparity, fixed header size {} + variable header size {} + buffer size {}  (string pool size {}) >= "
+        "total size {}",
+        arcticdb::Segment::FIXED_HEADER_SIZE,
+        fixed_hdr->header_bytes,
+        buffer_bytes,
+        string_pool_size,
+        readable_size);
 
     ARCTICDB_SUBSAMPLE(CreateBufferView, 0)
     if (copy_data) {
@@ -59,84 +63,104 @@ Segment Segment::from_bytes(std::uint8_t* src, std::size_t readable_size, bool c
     }
 }
 
-
-Segment Segment::from_buffer(std::shared_ptr<Buffer>&& buffer) {
+Segment Segment::from_buffer(std::shared_ptr<Buffer>&& buffer)
+{
     ARCTICDB_SAMPLE(SegmentFromBytes, 0)
     auto* fixed_hdr = reinterpret_cast<Segment::FixedHeader*>(buffer->data());
     auto readable_size = buffer->bytes();
-    util::check_arg(fixed_hdr->magic_number == MAGIC_NUMBER, "expected first 2 bytes: {}, actual {}",
-                    MAGIC_NUMBER, fixed_hdr->magic_number);
+    util::check_arg(fixed_hdr->magic_number == MAGIC_NUMBER,
+        "expected first 2 bytes: {}, actual {}",
+        MAGIC_NUMBER,
+        fixed_hdr->magic_number);
     util::check_arg(fixed_hdr->encoding_version == ENCODING_VERSION,
-                    "expected encoding_version {}, actual {}",
-                    ENCODING_VERSION, fixed_hdr->encoding_version);
+        "expected encoding_version {}, actual {}",
+        ENCODING_VERSION,
+        fixed_hdr->encoding_version);
 
     ARCTICDB_SUBSAMPLE(ReadHeaderAndSegment, 0)
     auto header_bytes ARCTICDB_UNUSED = arcticdb::Segment::FIXED_HEADER_SIZE + fixed_hdr->header_bytes;
-    ARCTICDB_DEBUG(log::codec(), "Reading header: {} + {} = {}",
-                  arcticdb::Segment::FIXED_HEADER_SIZE,
-                  fixed_hdr->header_bytes,
-                  header_bytes);
-    google::protobuf::io::ArrayInputStream ais(buffer->data() + arcticdb::Segment::FIXED_HEADER_SIZE, fixed_hdr->header_bytes);
+    ARCTICDB_DEBUG(log::codec(),
+        "Reading header: {} + {} = {}",
+        arcticdb::Segment::FIXED_HEADER_SIZE,
+        fixed_hdr->header_bytes,
+        header_bytes);
+    google::protobuf::io::ArrayInputStream ais(buffer->data() + arcticdb::Segment::FIXED_HEADER_SIZE,
+        fixed_hdr->header_bytes);
     auto arena = std::make_unique<google::protobuf::Arena>();
     auto seg_hdr = google::protobuf::Arena::CreateMessage<arcticdb::proto::encoding::SegmentHeader>(arena.get());
     seg_hdr->ParseFromZeroCopyStream(&ais);
 
-    const auto[string_pool_size, buffer_bytes] = segment_size::compressed(*seg_hdr);
+    const auto [string_pool_size, buffer_bytes] = segment_size::compressed(*seg_hdr);
     ARCTICDB_DEBUG(log::codec(), "Reading string pool {} and buffer bytes {}", string_pool_size, buffer_bytes);
     util::check(arcticdb::Segment::FIXED_HEADER_SIZE + fixed_hdr->header_bytes + buffer_bytes <= readable_size,
-                "Size disparity, fixed header size {} + variable header size {} + buffer size {}  (string pool size {}) >= total size {}",
-                arcticdb::Segment::FIXED_HEADER_SIZE,
-                fixed_hdr->header_bytes,
-                buffer_bytes,
-                string_pool_size,
-                readable_size
-    );
+        "Size disparity, fixed header size {} + variable header size {} + buffer size {}  (string pool size {}) >= "
+        "total size {}",
+        arcticdb::Segment::FIXED_HEADER_SIZE,
+        fixed_hdr->header_bytes,
+        buffer_bytes,
+        string_pool_size,
+        readable_size);
 
     buffer->set_preamble(arcticdb::Segment::FIXED_HEADER_SIZE + fixed_hdr->header_bytes);
     ARCTICDB_SUBSAMPLE(CreateSegment, 0)
-    return{std::move(arena), seg_hdr, std::move(buffer)};
-
+    return {std::move(arena), seg_hdr, std::move(buffer)};
 }
 
-void Segment::write_header(uint8_t* dst, size_t hdr_size) {
+void Segment::write_header(uint8_t* dst, size_t hdr_size)
+{
     FixedHeader hdr = {MAGIC_NUMBER, ENCODING_VERSION, std::uint32_t(hdr_size)};
     hdr.write(dst);
     google::protobuf::io::ArrayOutputStream aos(dst + FIXED_HEADER_SIZE, static_cast<int>(hdr_size));
     header_->SerializeToZeroCopyStream(&aos);
 }
 
-std::pair<uint8_t*, size_t> Segment::try_internal_write(std::shared_ptr<Buffer>& tmp, size_t hdr_size) {
+std::pair<uint8_t*, size_t> Segment::try_internal_write(std::shared_ptr<Buffer>& tmp, size_t hdr_size)
+{
     auto total_hdr_size = hdr_size + FIXED_HEADER_SIZE;
-    if(std::holds_alternative<std::shared_ptr<Buffer>>(buffer_) && std::get<std::shared_ptr<Buffer>>(buffer_)->preamble_bytes() >= total_hdr_size) {
+    if (std::holds_alternative<std::shared_ptr<Buffer>>(buffer_) &&
+        std::get<std::shared_ptr<Buffer>>(buffer_)->preamble_bytes() >= total_hdr_size)
+    {
         auto& buffer = std::get<std::shared_ptr<Buffer>>(buffer_);
         auto base_ptr = buffer->preamble() + (buffer->preamble_bytes() - total_hdr_size);
-        util::check(base_ptr + total_hdr_size == buffer->data(), "Expected base ptr to align with data ptr, {} != {}", fmt::ptr(base_ptr + total_hdr_size), fmt::ptr(buffer->data()));
-        ARCTICDB_TRACE(log::codec(), "Buffer contents before header write: {}", dump_bytes(buffer->data(), buffer->bytes(), 100u));
+        util::check(base_ptr + total_hdr_size == buffer->data(),
+            "Expected base ptr to align with data ptr, {} != {}",
+            fmt::ptr(base_ptr + total_hdr_size),
+            fmt::ptr(buffer->data()));
+        ARCTICDB_TRACE(log::codec(),
+            "Buffer contents before header write: {}",
+            dump_bytes(buffer->data(), buffer->bytes(), 100u));
         write_header(base_ptr, hdr_size);
-        ARCTICDB_TRACE(log::storage(), "Header fits in internal buffer {:x} with {} bytes space: {}", uintptr_t (base_ptr), buffer->preamble_bytes() - total_hdr_size, dump_bytes(buffer->data(), buffer->bytes(), 100u));
+        ARCTICDB_TRACE(log::storage(),
+            "Header fits in internal buffer {:x} with {} bytes space: {}",
+            uintptr_t(base_ptr),
+            buffer->preamble_bytes() - total_hdr_size,
+            dump_bytes(buffer->data(), buffer->bytes(), 100u));
         return std::make_pair(base_ptr, total_segment_size(hdr_size));
-    }
-    else {
+    } else {
         tmp = std::make_shared<Buffer>();
-        ARCTICDB_DEBUG(log::storage(), "Header doesn't fit in internal buffer, needed {} bytes but had {}, writing to temp buffer at {:x}", hdr_size, std::get<std::shared_ptr<Buffer>>(buffer_)->preamble_bytes(), uintptr_t(tmp->data()));
+        ARCTICDB_DEBUG(log::storage(),
+            "Header doesn't fit in internal buffer, needed {} bytes but had {}, writing to temp buffer at {:x}",
+            hdr_size,
+            std::get<std::shared_ptr<Buffer>>(buffer_)->preamble_bytes(),
+            uintptr_t(tmp->data()));
         tmp->ensure(total_segment_size(hdr_size));
         write_to(tmp->preamble(), hdr_size);
         return std::make_pair(tmp->preamble(), total_segment_size(hdr_size));
     }
 }
 
-void Segment::write_to(std::uint8_t* dst, std::size_t hdr_sz) {
+void Segment::write_to(std::uint8_t* dst, std::size_t hdr_sz)
+{
     ARCTICDB_SAMPLE(SegmentWriteToStorage, RMTSF_Aggregate)
     ARCTICDB_SUBSAMPLE(SegmentWriteHeader, RMTSF_Aggregate)
     write_header(dst, hdr_sz);
     ARCTICDB_SUBSAMPLE(SegmentWriteBody, RMTSF_Aggregate)
-    ARCTICDB_DEBUG(log::codec(), "Writing {} bytes to body at offset {}",
-                       buffer().bytes(),
-                       arcticdb::Segment::FIXED_HEADER_SIZE + hdr_sz);
+    ARCTICDB_DEBUG(log::codec(),
+        "Writing {} bytes to body at offset {}",
+        buffer().bytes(),
+        arcticdb::Segment::FIXED_HEADER_SIZE + hdr_sz);
 
-    std::memcpy(dst + arcticdb::Segment::FIXED_HEADER_SIZE + hdr_sz,
-                buffer().data(),
-                buffer().bytes());
+    std::memcpy(dst + arcticdb::Segment::FIXED_HEADER_SIZE + hdr_sz, buffer().data(), buffer().bytes());
 }
 
 } //namespace arcticdb

--- a/cpp/arcticdb/codec/slice_data_sink.hpp
+++ b/cpp/arcticdb/codec/slice_data_sink.hpp
@@ -13,32 +13,49 @@ namespace arcticdb {
 
 struct SliceDataSink {
     // Just an interface for Column / ...
-    SliceDataSink(uint8_t *data, std::size_t size) : data_(data), shape_(0), current_size_(0), total_size_(size) {
+    SliceDataSink(uint8_t* data, std::size_t size)
+        : data_(data),
+          shape_(0),
+          current_size_(0),
+          total_size_(size)
+    {
     }
 
-    shape_t *allocate_shapes(std::size_t s) ARCTICDB_UNUSED {
-        if (s == 0) return nullptr;
+    shape_t* allocate_shapes(std::size_t s) ARCTICDB_UNUSED
+    {
+        if (s == 0)
+            return nullptr;
         util::check_arg(s == 8, "expected exactly one shape, actual {}", s / sizeof(shape_t));
         return &shape_;
     }
 
-    uint8_t *allocate_data(std::size_t size) ARCTICDB_UNUSED {
-        util::check_arg(current_size_ + size <= total_size_, "Data sink overflow trying to allocate {} bytes in a buffer of {} with {} remaining",
-                        size, total_size_, total_size_ - current_size_);
+    uint8_t* allocate_data(std::size_t size) ARCTICDB_UNUSED
+    {
+        util::check_arg(current_size_ + size <= total_size_,
+            "Data sink overflow trying to allocate {} bytes in a buffer of {} with {} remaining",
+            size,
+            total_size_,
+            total_size_ - current_size_);
 
         return data_ + current_size_;
     }
 
-    void advance_data(std::size_t) ARCTICDB_UNUSED {}
+    void advance_data(std::size_t) ARCTICDB_UNUSED
+    {
+    }
 
-    void advance_shapes(std::size_t) ARCTICDB_UNUSED {}
+    void advance_shapes(std::size_t) ARCTICDB_UNUSED
+    {
+    }
 
-    void set_allow_sparse(bool) ARCTICDB_UNUSED {}
+    void set_allow_sparse(bool) ARCTICDB_UNUSED
+    {
+    }
 
 private:
-    uint8_t *data_;
+    uint8_t* data_;
     shape_t shape_;
     std::size_t current_size_;
     std::size_t total_size_;
 };
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/codec/test/test_codec.cpp
+++ b/cpp/arcticdb/codec/test/test_codec.cpp
@@ -18,16 +18,14 @@
 
 using namespace arcticdb;
 
-TEST(FieldEncoderTest, PassthroughDim0) {
+TEST(FieldEncoderTest, PassthroughDim0)
+{
 
-    using TD = TypeDescriptorTag<
-        DataTypeTag<DataType::FLOAT64>,
-        DimensionTag<Dimension::Dim0>
-    >;
+    using TD = TypeDescriptorTag<DataTypeTag<DataType::FLOAT64>, DimensionTag<Dimension::Dim0>>;
     using Encoder = BlockEncoder<TD>;
 
     std::vector<double> v{0.1, 0.2, 0.3};
-    const shape_t *shape = nullptr;
+    const shape_t* shape = nullptr;
     using Field = Encoder::FieldType;
 
     Field f(v.data(), shape, v.size() * sizeof(double), v.size(), nullptr);
@@ -40,19 +38,20 @@ TEST(FieldEncoderTest, PassthroughDim0) {
 
     Encoder::encode(opt, f, field, out, pos);
 
-    auto &nd = field.ndarray();
+    auto& nd = field.ndarray();
     ASSERT_EQ(nd.items_count(), 3);
     ASSERT_FALSE(nd.shapes_size() > 0);
-    auto &vals = nd.values();
+    auto& vals = nd.values();
 
     auto expected_bytes = v.size() * sizeof(TD::DataTypeTag::raw_type);
     ASSERT_EQ(vals[0].in_bytes(), expected_bytes);
     ASSERT_EQ(vals[0].out_bytes(), expected_bytes);
     ASSERT_NE(0, vals[0].hash());
-    ASSERT_EQ(pos , expected_bytes);
+    ASSERT_EQ(pos, expected_bytes);
 }
 
-TEST(FieldEncoderTest, PassthroughDim0_Dynamic) {
+TEST(FieldEncoderTest, PassthroughDim0_Dynamic)
+{
     TypeDescriptor td{DataType::FLOAT64, Dimension::Dim0};
     std::vector<double> v{0.1};
     ChunkedBuffer cbuf;
@@ -72,10 +71,10 @@ TEST(FieldEncoderTest, PassthroughDim0_Dynamic) {
     f.reset();
     enc.encode(opt, f, field, out, pos);
 
-    auto &nd = field.ndarray();
+    auto& nd = field.ndarray();
     ASSERT_EQ(nd.items_count(), 1);
     ASSERT_FALSE(nd.shapes_size() > 0);
-    auto &vals = nd.values();
+    auto& vals = nd.values();
 
     auto expected_bytes = v.size() * sizeof(v[0]);
     ASSERT_EQ(vals[0].in_bytes(), expected_bytes);
@@ -84,11 +83,9 @@ TEST(FieldEncoderTest, PassthroughDim0_Dynamic) {
     ASSERT_EQ(pos, expected_bytes);
 }
 
-TEST(FieldEncoderTest, PassthroughDim1) {
-    using TD = TypeDescriptorTag<
-        DataTypeTag<DataType::FLOAT64>,
-        DimensionTag<Dimension::Dim1>
-    >;
+TEST(FieldEncoderTest, PassthroughDim1)
+{
+    using TD = TypeDescriptorTag<DataTypeTag<DataType::FLOAT64>, DimensionTag<Dimension::Dim1>>;
 
     using Encoder = BlockEncoder<TD>;
     using Field = Encoder::FieldType;
@@ -105,16 +102,16 @@ TEST(FieldEncoderTest, PassthroughDim1) {
 
     Encoder::encode(opt, f, field, out, pos);
 
-    auto &nd = field.ndarray();
+    auto& nd = field.ndarray();
     ASSERT_EQ(nd.items_count(), 2);
-    auto &shapes = nd.shapes();
+    auto& shapes = nd.shapes();
     auto shapes_bytes = 2 * sizeof(shape_t);
 
     ASSERT_EQ(shapes[0].in_bytes(), shapes_bytes);
     ASSERT_EQ(shapes[0].out_bytes(), shapes_bytes);
     ASSERT_NE(0, shapes[0].hash());
 
-    auto &vals = nd.values();
+    auto& vals = nd.values();
     auto expected_bytes = v.size() * sizeof(TD::DataTypeTag::raw_type);
     ASSERT_EQ(vals[0].in_bytes(), expected_bytes);
     ASSERT_EQ(vals[0].out_bytes(), expected_bytes);
@@ -122,7 +119,8 @@ TEST(FieldEncoderTest, PassthroughDim1) {
     ASSERT_EQ(pos, expected_bytes + shapes_bytes);
 }
 
-TEST(SegmentencoderTest, EncodeStringsBasic) {
+TEST(SegmentencoderTest, EncodeStringsBasic)
+{
     const auto tsd = create_tsd<DataTypeTag<DataType::ASCII_DYNAMIC64>, Dimension::Dim0>();
     SegmentInMemory s(StreamDescriptor{tsd});
     s.set_scalar(0, timestamp(123));
@@ -153,7 +151,8 @@ TEST(SegmentencoderTest, EncodeStringsBasic) {
 using namespace arcticdb;
 namespace as = arcticdb::stream;
 
-TEST(SegmentEncoderTest, StressTestString) {
+TEST(SegmentEncoderTest, StressTestString)
+{
     const size_t NumTests = 100000;
     const size_t VectorSize = 0x1000;
     const size_t NumColumns = 7;
@@ -162,23 +161,24 @@ TEST(SegmentEncoderTest, StressTestString) {
 
     SegmentsSink sink;
     auto index = as::TimeseriesIndex::default_index();
-    as::FixedSchema schema{
-        index.create_stream_descriptor(123, {
-            scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_1"),
-            scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_2"),
-            scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_3"),
-            scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_4"),
-            scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_5"),
-            scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_6"),
-            }), index
-    };
+    as::FixedSchema schema{index.create_stream_descriptor(123,
+                               {
+                                   scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_1"),
+                                   scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_2"),
+                                   scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_3"),
+                                   scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_4"),
+                                   scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_5"),
+                                   scalar_field_proto(DataType::ASCII_DYNAMIC64, "col_6"),
+                               }),
+        index};
 
-    TestAggregator agg(std::move(schema), [&](SegmentInMemory &&mem) {
-        sink.segments_.push_back(std::move(mem));
-    }, as::NeverSegmentPolicy{});
+    TestAggregator agg(
+        std::move(schema),
+        [&](SegmentInMemory&& mem) { sink.segments_.push_back(std::move(mem)); },
+        as::NeverSegmentPolicy{});
 
     for (size_t i = 0; i < NumTests; ++i) {
-        agg.start_row(timestamp(i))([&](auto &rb) {
+        agg.start_row(timestamp(i))([&](auto& rb) {
             for (size_t j = 1; j < NumColumns; ++j)
                 rb.set_string(timestamp(j), strings[(i + j) & (VectorSize - 1)]);
         });

--- a/cpp/arcticdb/codec/tp4.hpp
+++ b/cpp/arcticdb/codec/tp4.hpp
@@ -22,7 +22,8 @@ struct TurboPForBase {
     using Opts = arcticdb::proto::encoding::VariantCodec::TurboPfor;
     static constexpr std::uint32_t VERSION = 1;
 
-    static std::size_t max_compressed_size(std::size_t size) {
+    static std::size_t max_compressed_size(std::size_t size)
+    {
         return (size * 3) / 2;
     }
 };
@@ -34,17 +35,19 @@ template<>
 struct TurboPForBlockCodec<arcticdb::proto::encoding::VariantCodec::TurboPfor::FP_DELTA> : TurboPForBase {
 
     template<class T>
-    inline static std::size_t encode_block(const T *in, Block &block,
-                                           HashAccum &hasher, T *t_out, std::size_t out_capacity, std::ptrdiff_t &pos) {
+    inline static std::size_t
+    encode_block(const T* in, Block& block, HashAccum& hasher, T* t_out, std::size_t out_capacity, std::ptrdiff_t& pos)
+    {
         hasher(in, block.count);
-        auto *out = reinterpret_cast<std::uint8_t *>(t_out);
+        auto* out = reinterpret_cast<std::uint8_t*>(t_out);
         std::size_t compressed_bytes = encode_block_(in, block, out);
         pos += compressed_bytes;
         return compressed_bytes;
     }
 
     template<class T>
-    inline static std::size_t encode_block_(T *in, Block &block, std::uint8_t *out) {
+    inline static std::size_t encode_block_(T* in, Block& block, std::uint8_t* out)
+    {
         std::size_t compressed_bytes = 0;
         if constexpr (std::is_integral_v<T>) {
             if constexpr (std::is_unsigned_v<T>) {
@@ -59,26 +62,26 @@ struct TurboPForBlockCodec<arcticdb::proto::encoding::VariantCodec::TurboPfor::F
                 }
             } else if constexpr (std::is_signed_v<T>) {
                 using Unsigned_T = std::make_unsigned_t<T>;
-                auto u_in = reinterpret_cast<const Unsigned_T *>(in);
+                auto u_in = reinterpret_cast<const Unsigned_T*>(in);
                 compressed_bytes = encode_block_(u_in, block, out);
             }
         } else if constexpr (std::is_floating_point_v<T>) {
             if constexpr (std::is_same_v<T, double>) {
-                auto *u_in = reinterpret_cast<const std::uint64_t *>(in);
+                auto* u_in = reinterpret_cast<const std::uint64_t*>(in);
                 encode_block_(u_in, block, out);
             } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-                auto *u_in = reinterpret_cast<const std::uint32_t *>(in);
+                auto* u_in = reinterpret_cast<const std::uint32_t*>(in);
                 encode_block_(u_in, block, out);
             }
         }
         return compressed_bytes;
     }
     template<class T>
-    static void decode_block(const std::uint8_t *in, std::size_t in_count,
-                             T *t_out, std::size_t out_bytes) {
+    static void decode_block(const std::uint8_t* in, std::size_t in_count, T* t_out, std::size_t out_bytes)
+    {
         if constexpr (std::is_integral_v<T>) {
             if constexpr (std::is_unsigned_v<T>) {
-                std::uint8_t *in_nc = (std::uint8_t *) in;
+                std::uint8_t* in_nc = (std::uint8_t*)in;
                 std::size_t decompressed_bytes = 0;
                 if constexpr (std::is_same_v<T, std::uint64_t>) {
                     decompressed_bytes = fppdec64(in_nc, in_count, t_out, 0);
@@ -90,20 +93,20 @@ struct TurboPForBlockCodec<arcticdb::proto::encoding::VariantCodec::TurboPfor::F
                     decompressed_bytes = fppdec8(in_nc, in_count, t_out, 0);
                 }
                 util::check_arg(decompressed_bytes == out_bytes,
-                                "expected out_bytes == decompressed bytes, actual {} != {}",
-                                out_bytes,
-                                decompressed_bytes);
+                    "expected out_bytes == decompressed bytes, actual {} != {}",
+                    out_bytes,
+                    decompressed_bytes);
             } else if constexpr (std::is_signed_v<T>) {
                 using Unsigned_T = std::make_unsigned_t<T>;
-                auto u_out = reinterpret_cast<Unsigned_T *>(t_out);
+                auto u_out = reinterpret_cast<Unsigned_T*>(t_out);
                 decode_block(in, in_count, u_out, out_bytes);
             }
         } else if constexpr (std::is_floating_point_v<T>) {
             if constexpr (std::is_same_v<T, double>) {
-                auto *u_out = reinterpret_cast<const std::uint64_t *>(t_out);
+                auto* u_out = reinterpret_cast<const std::uint64_t*>(t_out);
                 decode_block(in, in_count, u_out, out_bytes);
             } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-                auto *u_out = reinterpret_cast<const std::uint32_t *>(t_out);
+                auto* u_out = reinterpret_cast<const std::uint32_t*>(t_out);
                 decode_block(in, in_count, u_out, out_bytes);
             }
         }
@@ -118,30 +121,41 @@ struct ShapeEncoder : TurboPForBlockCodec<arcticdb::proto::encoding::VariantCode
     using Parent = TurboPForBlockCodec<arcticdb::proto::encoding::VariantCodec::TurboPfor::FP_DELTA>;
 
     template<class T>
-    static std::size_t encode_block(const T *in, Block &block,
-                                    HashAccum &hasher, T *out, std::size_t out_capacity, std::ptrdiff_t &pos,
-                                    arcticdb::proto::encoding::VariantCodec &out_codec) {
+    static std::size_t encode_block(const T* in,
+        Block& block,
+        HashAccum& hasher,
+        T* out,
+        std::size_t out_capacity,
+        std::ptrdiff_t& pos,
+        arcticdb::proto::encoding::VariantCodec& out_codec)
+    {
         std::size_t compressed_size = Parent::encode_block(in, block, hasher, out, out_capacity, pos);
 
         out_codec.mutable_tp4()->set_sub_codec(arcticdb::proto::encoding::VariantCodec::TurboPfor::FP_DELTA);
         return compressed_size;
     }
-
 };
 
 struct TurboPForBlockEncoder : TurboPForBase {
 
     template<class T>
-    static std::size_t encode_block(const Opts &opts, const T *in, Block &block,
-                                    HashAccum &hasher, T *out, std::size_t out_capacity, std::ptrdiff_t &pos,
-                                    arcticdb::proto::encoding::VariantCodec &out_codec) {
+    static std::size_t encode_block(const Opts& opts,
+        const T* in,
+        Block& block,
+        HashAccum& hasher,
+        T* out,
+        std::size_t out_capacity,
+        std::ptrdiff_t& pos,
+        arcticdb::proto::encoding::VariantCodec& out_codec)
+    {
         std::size_t compressed_size = 0;
         switch (opts.sub_codec()) {
-            case Opts::FP_DELTA:
-                compressed_size = TurboPForBlockCodec<Opts::FP_DELTA>::encode_block(
-                    in, block, hasher, out, out_capacity, pos);
-                break;
-            default:raise_unsupported_msg("Unsupported tp4 subcodec {}", opts);
+        case Opts::FP_DELTA:
+            compressed_size =
+                TurboPForBlockCodec<Opts::FP_DELTA>::encode_block(in, block, hasher, out, out_capacity, pos);
+            break;
+        default:
+            raise_unsupported_msg("Unsupported tp4 subcodec {}", opts);
         }
         out_codec.mutable_tp4()->MergeFrom(opts);
         return compressed_size;
@@ -154,14 +168,21 @@ using TurboPForEncoder = GenericBlockEncoder<F<TD>, TD, TurboPForBlockEncoder, S
 struct TurboPForDecoder {
 
     template<typename T>
-    static void decode_block(const arcticdb::proto::encoding::Block &block, const std::uint8_t *in, std::size_t in_bytes, T *t_out,
-                             std::size_t out_bytes) {
+    static void decode_block(const arcticdb::proto::encoding::Block& block,
+        const std::uint8_t* in,
+        std::size_t in_bytes,
+        T* t_out,
+        std::size_t out_bytes)
+    {
         switch (block.codec().tp4().sub_codec()) {
-            case arcticdb::proto::encoding::VariantCodec::TurboPfor::FP_DELTA:
-                TurboPForBlockCodec<arcticdb::proto::encoding::VariantCodec::TurboPfor::FP_DELTA>::decode_block(
-                    in, in_bytes, t_out, out_bytes);
-                break;
-            default:raise_unsupported_msg("Unsupported tp4 block {}", block);
+        case arcticdb::proto::encoding::VariantCodec::TurboPfor::FP_DELTA:
+            TurboPForBlockCodec<arcticdb::proto::encoding::VariantCodec::TurboPfor::FP_DELTA>::decode_block(in,
+                in_bytes,
+                t_out,
+                out_bytes);
+            break;
+        default:
+            raise_unsupported_msg("Unsupported tp4 block {}", block);
         }
     }
 };

--- a/cpp/arcticdb/codec/zstd.hpp
+++ b/cpp/arcticdb/codec/zstd.hpp
@@ -22,18 +22,26 @@ struct ZstdBlockEncoder {
     using Opts = arcticdb::proto::encoding::VariantCodec::Zstd;
     static constexpr std::uint32_t VERSION = 1;
 
-    static std::size_t max_compressed_size(std::size_t size) {
+    static std::size_t max_compressed_size(std::size_t size)
+    {
         return ZSTD_compressBound(size);
     }
 
-    static void set_shape_defaults(Opts &opts) {
+    static void set_shape_defaults(Opts& opts)
+    {
         opts.set_level(0);
     }
 
     template<class T>
-    static std::size_t encode_block(const Opts &opts, const T *in, BlockProtobufHelper &block_utils,
-                                    HashAccum &hasher, T *out, std::size_t out_capacity, std::ptrdiff_t &pos,
-                                    arcticdb::proto::encoding::VariantCodec &out_codec) {
+    static std::size_t encode_block(const Opts& opts,
+        const T* in,
+        BlockProtobufHelper& block_utils,
+        HashAccum& hasher,
+        T* out,
+        std::size_t out_capacity,
+        std::ptrdiff_t& pos,
+        arcticdb::proto::encoding::VariantCodec& out_codec)
+    {
         std::size_t compressed_bytes = ZSTD_compress(out, out_capacity, in, block_utils.bytes_, opts.level());
         hasher(in, block_utils.count_);
         pos += compressed_bytes;
@@ -54,15 +62,23 @@ struct ZstdDecoder {
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
     template<typename T>
-    static void decode_block(std::uint32_t encoder_version, const std::uint8_t *in, std::size_t in_bytes, T *t_out,
-                             std::size_t out_bytes) {
+    static void decode_block(std::uint32_t encoder_version,
+        const std::uint8_t* in,
+        std::size_t in_bytes,
+        T* t_out,
+        std::size_t out_bytes)
+    {
 
         const std::size_t decomp_size = ZSTD_getDecompressedSize(in, in_bytes);
-        util::check_arg(decomp_size == out_bytes, "expected out_bytes == ztd deduced bytes, actual {} != {}",
-                        out_bytes, decomp_size);
+        util::check_arg(decomp_size == out_bytes,
+            "expected out_bytes == ztd deduced bytes, actual {} != {}",
+            out_bytes,
+            decomp_size);
         std::size_t real_decomp = ZSTD_decompress(t_out, out_bytes, in, in_bytes);
-        util::check_arg(real_decomp == out_bytes, "expected out_bytes == ztd decompressed bytes, actual {} != {}",
-                        out_bytes, real_decomp);
+        util::check_arg(real_decomp == out_bytes,
+            "expected out_bytes == ztd decompressed bytes, actual {} != {}",
+            out_bytes,
+            real_decomp);
     }
 #pragma GCC diagnostic pop
 };

--- a/cpp/arcticdb/column_store/block.hpp
+++ b/cpp/arcticdb/column_store/block.hpp
@@ -21,7 +21,6 @@
 #include <vector>
 #include <numeric>
 
-
 namespace arcticdb {
 
 struct MemBlock {
@@ -31,104 +30,128 @@ struct MemBlock {
     using magic_t = arcticdb::util::MagicNum<'M', 'e', 'm', 'b'>;
     magic_t magic_;
 
-    template<size_t DefaultBlockSize> friend
-    class ChunkedBufferImpl;
+    template<size_t DefaultBlockSize>
+    friend class ChunkedBufferImpl;
 
-    explicit MemBlock(size_t capacity, size_t offset, entity::timestamp ts) :
-            bytes_(0),
-            capacity_(capacity),
-            external_data_(nullptr),
-            offset_(offset),
-            ts_(ts) {
+    explicit MemBlock(size_t capacity, size_t offset, entity::timestamp ts)
+        : bytes_(0),
+          capacity_(capacity),
+          external_data_(nullptr),
+          offset_(offset),
+          ts_(ts)
+    {
 #ifdef DEBUG_BUILD
         memset(data_, 'c', capacity_); // For identifying unwritten-to block portions
 #endif
     }
 
-    MemBlock(const uint8_t *data, size_t size, size_t offset, entity::timestamp ts) :
-            bytes_(size),
-            capacity_(size),
-            external_data_(data),
-            offset_(offset),
-            ts_(ts) {
+    MemBlock(const uint8_t* data, size_t size, size_t offset, entity::timestamp ts)
+        : bytes_(size),
+          capacity_(size),
+          external_data_(data),
+          offset_(offset),
+          ts_(ts)
+    {
     }
 
-    bool is_external() const {
+    bool is_external() const
+    {
         return external_data_ != nullptr;
     }
 
-    static constexpr size_t alloc_size(size_t requested_size) noexcept {
+    static constexpr size_t alloc_size(size_t requested_size) noexcept
+    {
         return HeaderSize + requested_size;
     }
 
-    static constexpr size_t raw_size(size_t total_size) noexcept {
+    static constexpr size_t raw_size(size_t total_size) noexcept
+    {
         return total_size - HeaderSize;
     }
 
-    void resize(size_t size) {
-        arcticdb::util::check_arg(size <= capacity_, "Buffer overflow, size {} is greater than capacity {}", size,
-                                 capacity_);
+    void resize(size_t size)
+    {
+        arcticdb::util::check_arg(size <= capacity_,
+            "Buffer overflow, size {} is greater than capacity {}",
+            size,
+            capacity_);
         bytes_ = size;
     }
 
-    size_t bytes() const {
+    size_t bytes() const
+    {
         return bytes_;
     }
 
-    size_t capacity() const {
+    size_t capacity() const
+    {
         return capacity_;
     }
 
-    const uint8_t& operator[](size_t pos) const {
+    const uint8_t& operator[](size_t pos) const
+    {
         return data()[pos];
     }
 
-    const uint8_t* internal_ptr(size_t pos) const {
+    const uint8_t* internal_ptr(size_t pos) const
+    {
         return &data_[pos];
     }
 
-    void copy_to(uint8_t *target) {
+    void copy_to(uint8_t* target)
+    {
         memcpy(target, data(), bytes_);
     }
 
-    void copy_from(const uint8_t *src, size_t bytes, size_t pos) {
-        arcticdb::util::check_arg(pos + bytes <= capacity_, "Copying more bytes: {} is greater than capacity {}", bytes,
-                                 capacity_);
+    void copy_from(const uint8_t* src, size_t bytes, size_t pos)
+    {
+        arcticdb::util::check_arg(pos + bytes <= capacity_,
+            "Copying more bytes: {} is greater than capacity {}",
+            bytes,
+            capacity_);
         memcpy(data_ + pos, src, bytes);
     }
 
-    uint8_t &operator[](size_t pos) {
-        return const_cast<uint8_t *>(data())[pos];
+    uint8_t& operator[](size_t pos)
+    {
+        return const_cast<uint8_t*>(data())[pos];
     }
 
-    bool empty() { return bytes_ == 0; }
+    bool empty()
+    {
+        return bytes_ == 0;
+    }
 
-    const uint8_t *data() const { return is_external() ? external_data_ : data_; }
+    const uint8_t* data() const
+    {
+        return is_external() ? external_data_ : data_;
+    }
 
-    uint8_t *end() const { return const_cast<uint8_t*>(&data()[bytes_]); }
+    uint8_t* end() const
+    {
+        return const_cast<uint8_t*>(&data()[bytes_]);
+    }
 
-    size_t free_space() const {
+    size_t free_space() const
+    {
         arcticdb::util::check(bytes_ <= capacity_, "Block overflow: {} > {}", bytes_, capacity_);
         return capacity_ - bytes_;
     }
 
     size_t bytes_;
     size_t capacity_;
-    const uint8_t *external_data_;
+    const uint8_t* external_data_;
     size_t offset_;
     entity::timestamp ts_;
 
-    static const size_t HeaderDataSize =
-            sizeof(magic_) +   // 8 bytes
-            sizeof(bytes_) +   // 8 bytes
-            sizeof(capacity_) +   // 8 bytes
-            sizeof(external_data_) +
-            sizeof(offset_) +
-            sizeof(ts_);      // 8 bytes
+    static const size_t HeaderDataSize = sizeof(magic_) +                                        // 8 bytes
+                                         sizeof(bytes_) +                                        // 8 bytes
+                                         sizeof(capacity_) +                                     // 8 bytes
+                                         sizeof(external_data_) + sizeof(offset_) + sizeof(ts_); // 8 bytes
 
     uint8_t pad[Align - HeaderDataSize];
     static const size_t HeaderSize = HeaderDataSize + sizeof(pad);
     static_assert(HeaderSize == Align);
     uint8_t data_[MinSize];
 };
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/column_store/chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.cpp
@@ -9,26 +9,31 @@
 
 namespace arcticdb {
 
-template <size_t BlockSize>
-std::vector<ChunkedBufferImpl<BlockSize>> split(const ChunkedBufferImpl<BlockSize>& input, size_t nbytes) {
+template<size_t BlockSize>
+std::vector<ChunkedBufferImpl<BlockSize>> split(const ChunkedBufferImpl<BlockSize>& input, size_t nbytes)
+{
     const auto output_size = std::ceil(double(input.bytes()) / nbytes);
     std::vector<ChunkedBufferImpl<BlockSize>> output;
     output.reserve(static_cast<size_t>(output_size));
     ARCTICDB_DEBUG(log::version(), "Split buffer of size {} into chunks of {}", input.bytes(), nbytes);
     auto remaining_current_bytes = std::min(nbytes, input.bytes());
     auto remaining_total_bytes = input.bytes();
-    ARCTICDB_DEBUG(log::version(), "Remaining total: {} Remaining current: {}", remaining_total_bytes, remaining_current_bytes);
-    std::optional<ChunkedBufferImpl<BlockSize>> current_buf = ChunkedBufferImpl<BlockSize>::presized_in_blocks(std::min(nbytes, remaining_current_bytes));
+    ARCTICDB_DEBUG(log::version(),
+        "Remaining total: {} Remaining current: {}",
+        remaining_total_bytes,
+        remaining_current_bytes);
+    std::optional<ChunkedBufferImpl<BlockSize>> current_buf =
+        ChunkedBufferImpl<BlockSize>::presized_in_blocks(std::min(nbytes, remaining_current_bytes));
     auto target_block = current_buf.value().blocks().begin();
     auto target_pos = 0u;
     auto block_num ARCTICDB_UNUSED = 0u;
-    for(const auto block : input.blocks()) {
+    for (const auto block : input.blocks()) {
         ARCTICDB_DEBUG(log::version(), "## Block {}", block_num++);
         auto source_pos = 0u;
         util::check(block->bytes(), "Zero-sized block");
         auto source_bytes = block->bytes() - (source_pos == 0 ? 0 : source_pos - 1);
-        while(source_bytes != 0) {
-            if(!current_buf) {
+        while (source_bytes != 0) {
+            if (!current_buf) {
                 remaining_current_bytes = std::min(nbytes, remaining_total_bytes);
                 current_buf = ChunkedBufferImpl<BlockSize>::presized_in_blocks(remaining_current_bytes);
                 ARCTICDB_DEBUG(log::version(), "Creating new buffer with size {}", remaining_current_bytes);
@@ -36,32 +41,51 @@ std::vector<ChunkedBufferImpl<BlockSize>> split(const ChunkedBufferImpl<BlockSiz
             }
             const auto remaining_block_bytes = (*target_block)->bytes() - target_pos;
             const auto this_write = std::min({remaining_current_bytes, source_bytes, remaining_block_bytes});
-            ARCTICDB_DEBUG(log::version(), "Calculated this write = {} ({}, {}, {})", this_write, remaining_current_bytes, source_bytes, remaining_block_bytes);
+            ARCTICDB_DEBUG(log::version(),
+                "Calculated this write = {} ({}, {}, {})",
+                this_write,
+                remaining_current_bytes,
+                source_bytes,
+                remaining_block_bytes);
             util::check(target_block != current_buf->blocks().end(), "Went past end of blocks");
-            ARCTICDB_DEBUG(log::version(), "Copying {} bytes from pos {} to pos {}", this_write, source_pos, target_pos);
+            ARCTICDB_DEBUG(log::version(),
+                "Copying {} bytes from pos {} to pos {}",
+                this_write,
+                source_pos,
+                target_pos);
             (*target_block)->copy_from(&(*block)[source_pos], this_write, target_pos);
             source_pos += this_write;
             source_bytes -= this_write;
             target_pos += this_write;
             remaining_current_bytes -= this_write;
             remaining_total_bytes -= this_write;
-            ARCTICDB_DEBUG(log::version(), "Adjusted values source_pos {} source_bytes {} target_pos {} remaining_current {} remaining_total {}",
-                                source_pos, source_bytes, target_pos, remaining_current_bytes, remaining_total_bytes);
+            ARCTICDB_DEBUG(log::version(),
+                "Adjusted values source_pos {} source_bytes {} target_pos {} remaining_current {} remaining_total {}",
+                source_pos,
+                source_bytes,
+                target_pos,
+                remaining_current_bytes,
+                remaining_total_bytes);
 
-            if(static_cast<size_t>((*target_block)->bytes()) == nbytes || target_pos == static_cast<size_t>((*target_block)->bytes())) {
+            if (static_cast<size_t>((*target_block)->bytes()) == nbytes ||
+                target_pos == static_cast<size_t>((*target_block)->bytes()))
+            {
                 ARCTICDB_DEBUG(log::version(), "Incrementing block as nbytes == target block bytes: {}", nbytes);
                 ++target_block;
                 target_pos = 0;
             }
 
-            if(remaining_current_bytes == 0) {
+            if (remaining_current_bytes == 0) {
                 ARCTICDB_DEBUG(log::version(), "Pushing buffer");
                 output.push_back(std::move(current_buf.value()));
                 current_buf.reset();
             }
         }
     }
-    util::check(output.size() == output_size, "Unexpected size in chunked buffer split {} != {}", output.size(), output_size);
+    util::check(output.size() == output_size,
+        "Unexpected size in chunked buffer split {} != {}",
+        output.size(),
+        output_size);
     return output;
 }
 

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -34,7 +34,7 @@ class ChunkedBufferImpl {
     static_assert(sizeof(BlockType) == BlockType::Align + BlockType::MinSize);
     static_assert(DefaultBlockSize >= BlockType::MinSize);
 
-  public:
+public:
     struct Iterator {
         ChunkedBufferImpl* parent_;
         BlockType* block_ = nullptr;
@@ -43,12 +43,11 @@ class ChunkedBufferImpl {
         size_t type_size_;
         bool end_ = false;
 
-        Iterator(
-            ChunkedBufferImpl* parent,
-            size_t type_size) :
-                parent_(parent),
-                type_size_(type_size) {
-            if(parent_->empty()) {
+        Iterator(ChunkedBufferImpl* parent, size_t type_size)
+            : parent_(parent),
+              type_size_(type_size)
+        {
+            if (parent_->empty()) {
                 end_ = true;
                 return;
             }
@@ -56,19 +55,22 @@ class ChunkedBufferImpl {
             block_ = parent_->blocks_[0];
         }
 
-        [[nodiscard]] bool finished() const {
+        [[nodiscard]] bool finished() const
+        {
             return end_;
         }
 
-        [[nodiscard]] uint8_t* value() const {
+        [[nodiscard]] uint8_t* value() const
+        {
             return &(*block_)[pos_];
         }
 
-        void next() {
+        void next()
+        {
             pos_ += type_size_;
 
-            if(pos_ >= block_->bytes()) {
-                if(block_num_ + 1 >= parent_->blocks_.size()) {
+            if (pos_ >= block_->bytes()) {
+                if (block_num_ + 1 >= parent_->blocks_.size()) {
                     end_ = true;
                     return;
                 }
@@ -81,24 +83,27 @@ class ChunkedBufferImpl {
 
     ChunkedBufferImpl() = default;
 
-    explicit ChunkedBufferImpl(size_t size) {
+    explicit ChunkedBufferImpl(size_t size)
+    {
         add_block(size ? size : DefaultBlockSize, 0u);
         block_offsets_.push_back(0);
     }
 
-    ChunkedBufferImpl &operator=(ChunkedBufferImpl &&other) noexcept {
+    ChunkedBufferImpl& operator=(ChunkedBufferImpl&& other) noexcept
+    {
         using std::swap;
         swap(*this, other);
         other.clear();
         return *this;
     }
 
-    ChunkedBufferImpl clone() const {
+    ChunkedBufferImpl clone() const
+    {
         ChunkedBufferImpl output;
         output.bytes_ = bytes_;
         output.regular_sized_until_ = regular_sized_until_;
 
-        for(auto block : blocks_) {
+        for (auto block : blocks_) {
             output.add_block(block->capacity_, block->offset_);
             (*output.blocks_.rbegin())->copy_from(block->data(), block->bytes(), 0);
             (*output.blocks_.rbegin())->resize(block->bytes());
@@ -108,24 +113,28 @@ class ChunkedBufferImpl {
         return output;
     }
 
-    Iterator iterator(size_t size = 1) {
+    Iterator iterator(size_t size = 1)
+    {
         return Iterator(this, size);
     }
 
-    ChunkedBufferImpl(ChunkedBufferImpl&& other) noexcept {
+    ChunkedBufferImpl(ChunkedBufferImpl&& other) noexcept
+    {
         *this = std::move(other);
     }
 
-    static auto presized(size_t size) {
+    static auto presized(size_t size)
+    {
         ChunkedBufferImpl output(size);
         output.ensure(size);
         return output;
     }
 
-    static auto presized_in_blocks(size_t size) {
+    static auto presized_in_blocks(size_t size)
+    {
         ChunkedBufferImpl output;
         auto remaining = size;
-        while(remaining != 0) {
+        while (remaining != 0) {
             const auto alloc = std::min(remaining, DefaultBlockSize);
             output.ensure(output.bytes() + alloc);
             remaining -= alloc;
@@ -135,11 +144,13 @@ class ChunkedBufferImpl {
 
     ARCTICDB_NO_COPY(ChunkedBufferImpl)
 
-    ~ChunkedBufferImpl() {
+    ~ChunkedBufferImpl()
+    {
         clear();
     }
 
-    friend void swap(ChunkedBufferImpl &left, ChunkedBufferImpl &right) noexcept {
+    friend void swap(ChunkedBufferImpl& left, ChunkedBufferImpl& right) noexcept
+    {
         using std::swap;
         swap(left.bytes_, right.bytes_);
         swap(left.regular_sized_until_, right.regular_sized_until_);
@@ -147,11 +158,15 @@ class ChunkedBufferImpl {
         swap(left.block_offsets_, right.block_offsets_);
     }
 
-    const auto &blocks() const { return blocks_; }
+    const auto& blocks() const
+    {
+        return blocks_;
+    }
 
-    void resize_first(size_t requested_size) {
+    void resize_first(size_t requested_size)
+    {
         util::check(num_blocks() == 1, "resize_first called on buffer with {} blocks", num_blocks());
-        if(requested_size <= blocks_[0]->capacity())
+        if (requested_size <= blocks_[0]->capacity())
             return;
 
         free_last_block();
@@ -163,7 +178,8 @@ class ChunkedBufferImpl {
     // set to true, the current last block will be padded with zeros, and a new default sized block added. This allows
     // the buffer to stay regular sized for as long as possible, which greatly improves random access performance, and
     // will also be beneficial with the slab allocator.
-    uint8_t* ensure(size_t requested_size, bool aligned=false) {
+    uint8_t* ensure(size_t requested_size, bool aligned = false)
+    {
         if (requested_size == 0 || requested_size <= bytes_)
             return last_block().end();
 
@@ -192,7 +208,7 @@ class ChunkedBufferImpl {
                 // Already irregular sized
                 size_t last_off = last_offset();
                 util::check(regular_sized_until_ == *block_offsets_.begin(),
-                            "Gap between regular sized blocks and irregular block offsets");
+                    "Gap between regular sized blocks and irregular block offsets");
                 if (last_block().empty()) {
                     free_last_block();
                 } else {
@@ -212,23 +228,25 @@ class ChunkedBufferImpl {
         MemBlock* block_;
         size_t offset_;
 
-        BlockAndOffset(MemBlock* block, size_t offset) :
-            block_(block),
-            offset_(offset){
+        BlockAndOffset(MemBlock* block, size_t offset)
+            : block_(block),
+              offset_(offset)
+        {
         }
     };
 
-    BlockAndOffset block_and_offset(size_t pos_bytes) const {
-        if(blocks_.size() == 1u)
+    BlockAndOffset block_and_offset(size_t pos_bytes) const
+    {
+        if (blocks_.size() == 1u)
             return BlockAndOffset(blocks_[0], pos_bytes);
 
         if (is_regular_sized() || pos_bytes < regular_sized_until_) {
             size_t block_offset = pos_bytes / DefaultBlockSize;
             util::check(block_offset < blocks_.size(),
-                        "Request for out of range block {}, only have {} blocks",
-                        block_offset,
-                        blocks_.size());
-            MemBlock *block = blocks_[block_offset];
+                "Request for out of range block {}, only have {} blocks",
+                block_offset,
+                blocks_.size());
+            MemBlock* block = blocks_[block_offset];
             block->magic_.check();
             return BlockAndOffset(block, pos_bytes % DefaultBlockSize);
         }
@@ -244,128 +262,157 @@ class ChunkedBufferImpl {
         return BlockAndOffset(block, pos_bytes - *block_offset);
     }
 
-    uint8_t &operator[](size_t pos_bytes) {
+    uint8_t& operator[](size_t pos_bytes)
+    {
         auto [block, pos] = block_and_offset(pos_bytes);
         return (*block)[pos];
     }
 
-    const uint8_t &operator[](size_t pos_bytes) const {
-        return const_cast<ChunkedBufferImpl *>(this)->operator[](pos_bytes);
+    const uint8_t& operator[](size_t pos_bytes) const
+    {
+        return const_cast<ChunkedBufferImpl*>(this)->operator[](pos_bytes);
     }
 
     template<typename T>
-    T &cast(size_t pos) {
-        return reinterpret_cast<T &>(operator[](pos * sizeof(T)));
+    T& cast(size_t pos)
+    {
+        return reinterpret_cast<T&>(operator[](pos * sizeof(T)));
     }
 
-    [[nodiscard]] size_t num_blocks() const {
+    [[nodiscard]] size_t num_blocks() const
+    {
         return blocks_.size();
     }
 
-    [[nodiscard]] const uint8_t* data() const {
+    [[nodiscard]] const uint8_t* data() const
+    {
         util::check(blocks_.size() == 1, "Taking a pointer to the beginning of a non-contiguous buffer");
         blocks_[0]->magic_.check();
         return blocks_[0]->data();
     }
 
-    [[nodiscard]] uint8_t* data() {
+    [[nodiscard]] uint8_t* data()
+    {
         return const_cast<uint8_t*>(const_cast<const ChunkedBufferImpl*>(this)->data());
     }
 
-    void check_bytes(size_t pos_bytes, size_t required_bytes) const {
+    void check_bytes(size_t pos_bytes, size_t required_bytes) const
+    {
         if (pos_bytes + required_bytes > bytes()) {
-            std::string err = fmt::format("Cursor overflow in chunked_buffer ptr_cast, cannot read {} bytes from a buffer of size {} with cursor "
-                                          "at {}, as it would required {} bytes. ",
-                                          required_bytes,
-                                          bytes(),
-                                          pos_bytes,
-                                          pos_bytes + required_bytes
-                                          );
+            std::string err = fmt::format(
+                "Cursor overflow in chunked_buffer ptr_cast, cannot read {} bytes from a buffer of size {} with cursor "
+                "at {}, as it would required {} bytes. ",
+                required_bytes,
+                bytes(),
+                pos_bytes,
+                pos_bytes + required_bytes);
             ARCTICDB_DEBUG(log::storage(), err);
             throw std::invalid_argument(err);
         }
     }
 
     template<typename T>
-    T *ptr_cast(size_t pos_bytes, size_t required_bytes) {
+    T* ptr_cast(size_t pos_bytes, size_t required_bytes)
+    {
         check_bytes(pos_bytes, required_bytes);
-        return reinterpret_cast<T *>(&operator[](pos_bytes));
+        return reinterpret_cast<T*>(&operator[](pos_bytes));
     }
 
     template<typename T>
-    const T *ptr_cast(size_t pos_bytes, size_t required_bytes) const {
+    const T* ptr_cast(size_t pos_bytes, size_t required_bytes) const
+    {
         return (const_cast<ChunkedBufferImpl*>(this)->ptr_cast<T>(pos_bytes, required_bytes));
     }
 
     template<typename T>
-    const T* internal_ptr_cast(size_t pos_bytes, size_t required_bytes) const {
+    const T* internal_ptr_cast(size_t pos_bytes, size_t required_bytes) const
+    {
         check_bytes(required_bytes, pos_bytes);
         auto [block, pos] = block_and_offset(pos_bytes);
         return reinterpret_cast<const T*>(block->internal_ptr(pos));
     }
 
-    void add_block(size_t capacity, size_t offset) {
+    void add_block(size_t capacity, size_t offset)
+    {
         auto [ptr, ts] = Allocator::aligned_alloc(BlockType::alloc_size(capacity));
-        new(ptr) MemBlock(capacity, offset, ts);
+        new (ptr) MemBlock(capacity, offset, ts);
         blocks_.emplace_back(reinterpret_cast<BlockType*>(ptr));
     }
 
-    void add_external_block(const uint8_t* data, size_t size, size_t offset) {
+    void add_external_block(const uint8_t* data, size_t size, size_t offset)
+    {
         if (!no_blocks() && last_block().empty())
             free_last_block();
 
         auto [ptr, ts] = Allocator::aligned_alloc(sizeof(MemBlock));
-        new(ptr) MemBlock(data, size, offset, ts);
+        new (ptr) MemBlock(data, size, offset, ts);
         blocks_.emplace_back(reinterpret_cast<BlockType*>(ptr));
         bytes_ += size;
     }
 
-    bool empty() const { return bytes_ == 0; }
+    bool empty() const
+    {
+        return bytes_ == 0;
+    }
 
-    void clear() {
+    void clear()
+    {
         bytes_ = 0;
-        for(auto block : blocks_)
+        for (auto block : blocks_)
             free_block(block);
 
         blocks_.clear();
         block_offsets_.clear();
     }
 
-    bool is_regular_sized() const { return block_offsets_.empty(); }
+    bool is_regular_sized() const
+    {
+        return block_offsets_.empty();
+    }
 
-    size_t bytes() const { return bytes_; }
+    size_t bytes() const
+    {
+        return bytes_;
+    }
 
     friend struct BufferView;
-    BlockType &last_block() {
+    BlockType& last_block()
+    {
         return **blocks_.rbegin();
     }
 
-    [[nodiscard]] size_t free_space() const {
+    [[nodiscard]] size_t free_space() const
+    {
         return no_blocks() ? 0 : last_block().free_space();
     }
 
-    [[nodiscard]] size_t last_offset() const {
+    [[nodiscard]] size_t last_offset() const
+    {
         return block_offsets_.empty() ? 0 : *block_offsets_.rbegin();
     }
 
-    inline void assert_size(size_t bytes) const {
+    inline void assert_size(size_t bytes) const
+    {
         util::check(bytes <= bytes_, "Expected allocation size {} smaller than actual allocation {}", bytes, bytes_);
     }
 
-  private:
-    void free_block(BlockType* block) const {
+private:
+    void free_block(BlockType* block) const
+    {
         ARCTICDB_TRACE(log::storage(), "Freeing block at address {:x}", uintptr_t(block));
         block->magic_.check();
-        Allocator::free(std::make_pair(reinterpret_cast<uint8_t *>(block), block->ts_));
+        Allocator::free(std::make_pair(reinterpret_cast<uint8_t*>(block), block->ts_));
     }
 
-    void free_last_block() {
+    void free_last_block()
+    {
         ARCTICDB_TRACE(log::inmem(), "Freeing last empty block from the buffer");
         free_block(&last_block());
         blocks_.pop_back();
     }
 
-    void handle_transition_to_irregular() {
+    void handle_transition_to_irregular()
+    {
         if (!no_blocks() && last_block().empty()) {
             free_last_block();
         }
@@ -387,18 +434,22 @@ class ChunkedBufferImpl {
         }
     }
 
-    const BlockType &last_block() const {
+    const BlockType& last_block() const
+    {
         util::check(!blocks_.empty(), "There should never be no blocks");
         return **blocks_.rbegin();
     }
 
-    [[nodiscard]] bool no_blocks() const { return blocks_.empty(); }
+    [[nodiscard]] bool no_blocks() const
+    {
+        return blocks_.empty();
+    }
 
     size_t bytes_ = 0;
     size_t regular_sized_until_ = 0;
 
 #ifndef DEBUG_BUILD
-    boost::container::small_vector<BlockType *, 1> blocks_;
+    boost::container::small_vector<BlockType*, 1> blocks_;
     boost::container::small_vector<size_t, 1> block_offsets_;
 #else
     std::vector<BlockType*> blocks_;
@@ -410,6 +461,6 @@ constexpr size_t PageSize = 4096;
 constexpr size_t BufferSize = MemBlock::raw_size(PageSize);
 using ChunkedBuffer = ChunkedBufferImpl<BufferSize>;
 
-template <size_t BlockSize>
+template<size_t BlockSize>
 std::vector<ChunkedBufferImpl<BlockSize>> split(const ChunkedBufferImpl<BlockSize>& input, size_t nbytes);
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -40,7 +40,7 @@ namespace arcticdb {
 // this is needed to make templates of templates work
 // since py::array_t has more than one template parameter
 // (the rest are defaulted)
-template< class T>
+template<class T>
 using py_array_t = py::array_t<T>;
 
 /// @endcond
@@ -50,12 +50,15 @@ using namespace arcticdb::entity;
 // N.B. this will not catch all the things that C++ considers to be narrowing conversions, because
 // it doesn't take into account integral promotion, however we don't care about that for the
 // purpose for which it is used in this file.
-template <typename SourceType, typename TargetType>
-constexpr bool is_narrowing_conversion() {
-    if(sizeof(TargetType) < sizeof(SourceType))
+template<typename SourceType, typename TargetType>
+constexpr bool is_narrowing_conversion()
+{
+    if (sizeof(TargetType) < sizeof(SourceType))
         return true;
 
-    if(sizeof(SourceType) == sizeof(TargetType) && std::is_integral_v<TargetType> && std::is_unsigned_v<SourceType> && std::is_signed_v<TargetType>) {
+    if (sizeof(SourceType) == sizeof(TargetType) && std::is_integral_v<TargetType> && std::is_unsigned_v<SourceType> &&
+        std::is_signed_v<TargetType>)
+    {
         return true;
     }
 
@@ -63,10 +66,11 @@ constexpr bool is_narrowing_conversion() {
 }
 
 struct JiveTable {
-    explicit JiveTable(size_t num_rows) :
-        orig_pos_(num_rows),
-        sorted_pos_(num_rows),
-        unsorted_rows_(bv_size(num_rows)) {
+    explicit JiveTable(size_t num_rows)
+        : orig_pos_(num_rows),
+          sorted_pos_(num_rows),
+          unsorted_rows_(bv_size(num_rows))
+    {
     }
 
     std::vector<uint32_t> orig_pos_;
@@ -77,30 +81,34 @@ struct JiveTable {
 
 class Column;
 
-template <typename T>
+template<typename T>
 JiveTable create_jive_table(const Column& col);
 
 class Column {
 public:
     template<typename TDT, typename ValueType>
-    class TypedColumnIterator :  public boost::iterator_facade<TypedColumnIterator<TDT, ValueType>, ValueType, boost::random_access_traversal_tag> {
-        using RawType =  std::decay_t<typename TDT::DataTypeTag::raw_type>;
+    class TypedColumnIterator : public boost::iterator_facade<TypedColumnIterator<TDT, ValueType>,
+                                    ValueType,
+                                    boost::random_access_traversal_tag> {
+        using RawType = std::decay_t<typename TDT::DataTypeTag::raw_type>;
         static constexpr size_t type_size = sizeof(RawType);
 
-        ColumnData  parent_;
+        ColumnData parent_;
         std::optional<TypedBlockData<TDT>> block_;
         typename TypedBlockData<TDT>::template TypedColumnBlockIterator<const ValueType> block_pos_;
         typename TypedBlockData<TDT>::template TypedColumnBlockIterator<const ValueType> block_end_;
 
-        void set_block_range() {
-            if(block_) {
+        void set_block_range()
+        {
+            if (block_) {
                 block_pos_ = std::begin(block_.value());
                 block_end_ = std::end(block_.value());
             }
         }
 
-        void set_next_block() {
-            if(auto block  = parent_.next<TDT>(); block)
+        void set_next_block()
+        {
+            if (auto block = parent_.next<TDT>(); block)
                 block_.emplace(std::move(block.value()));
             else
                 block_ = std::nullopt;
@@ -109,25 +117,28 @@ public:
         }
 
     public:
-        TypedColumnIterator(const Column& col, bool begin) :
-        parent_(col.data()),
-        block_(begin ? parent_.next<TDT>() : std::nullopt) {
-            if(begin)
+        TypedColumnIterator(const Column& col, bool begin)
+            : parent_(col.data()),
+              block_(begin ? parent_.next<TDT>() : std::nullopt)
+        {
+            if (begin)
                 set_block_range();
         }
 
+        template<class OtherValue>
+        explicit TypedColumnIterator(const TypedColumnIterator<TDT, OtherValue>& other)
+            : parent_(other.parent_),
+              block_(other.block_),
+              block_pos_(other.block_pos_),
+              block_end_(other.block_end_)
+        {
+        }
 
-        template <class OtherValue>
-        explicit TypedColumnIterator(const TypedColumnIterator<TDT, OtherValue>& other) :
-        parent_(other.parent_),
-        block_(other.block_),
-        block_pos_(other.block_pos_),
-        block_end_(other.block_end_){ }
-
-        template <class OtherValue>
-        bool equal(const TypedColumnIterator<TDT, OtherValue>& other) const{
-            if(block_) {
-                if(!other.block_)
+        template<class OtherValue>
+        bool equal(const TypedColumnIterator<TDT, OtherValue>& other) const
+        {
+            if (block_) {
+                if (!other.block_)
                     return false;
 
                 return block_.value() == other.block_.value() && block_pos_ == other.block_pos_;
@@ -135,20 +146,23 @@ public:
             return !other.block_;
         }
 
-        ssize_t distance_to(const TypedColumnIterator& other) const {
+        ssize_t distance_to(const TypedColumnIterator& other) const
+        {
             return other.get_offset() - get_offset();
         }
 
-        void increment(){
+        void increment()
+        {
             ++block_pos_;
-            if(block_pos_ == block_end_)
+            if (block_pos_ == block_end_)
                 set_next_block();
         }
 
-        void decrement(){
-            if(!block_) {
+        void decrement()
+        {
+            if (!block_) {
                 block_ = parent_.last<TDT>();
-                if(block_) {
+                if (block_) {
                     block_pos_ = block_->begin();
                     std::advance(block_pos_, block_->row_count() - 1);
                 }
@@ -161,8 +175,9 @@ public:
             }
         }
 
-        [[nodiscard]] ssize_t get_offset() const {
-            if(!block_)
+        [[nodiscard]] ssize_t get_offset() const
+        {
+            if (!block_)
                 return parent_.buffer().bytes() / type_size;
 
             const auto off = block_.value().offset();
@@ -170,7 +185,8 @@ public:
             return off + dist;
         }
 
-        void set_offset(size_t offset) {
+        void set_offset(size_t offset)
+        {
             const auto bytes = offset * type_size;
             auto block_and_offset = parent_.buffer().block_and_offset(bytes);
             block_ = ColumnData::make_typed_block<TDT>(block_and_offset.block_);
@@ -179,13 +195,15 @@ public:
             block_end_ = std::end(block_.value());
         }
 
-        void advance(ptrdiff_t n){
+        void advance(ptrdiff_t n)
+        {
             auto offset = get_offset();
             offset += n;
             set_offset(offset);
         }
 
-        const ValueType& dereference() const {
+        const ValueType& dereference() const
+        {
             return *block_pos_;
         }
     };
@@ -193,41 +211,45 @@ public:
     struct StringArrayData {
         ssize_t num_strings_;
         ssize_t string_size_;
-        const char *data_;
+        const char* data_;
 
-        StringArrayData(ssize_t n, ssize_t s, const char *d) :
-                num_strings_(n),
-                string_size_(s),
-                data_(d) {
+        StringArrayData(ssize_t n, ssize_t s, const char* d)
+            : num_strings_(n),
+              string_size_(s),
+              data_(d)
+        {
         }
     };
 
-    Column() : type_(null_type_descriptor()) {}
-
-    Column(TypeDescriptor type, bool allow_sparse) :
-        Column(type, 0, false, allow_sparse) {
+    Column()
+        : type_(null_type_descriptor())
+    {
     }
 
-    Column(TypeDescriptor type, bool allow_sparse, ChunkedBuffer&& buffer) :
-        data_(std::move(buffer)),
-        type_(type),
-        allow_sparse_(allow_sparse) {
+    Column(TypeDescriptor type, bool allow_sparse)
+        : Column(type, 0, false, allow_sparse)
+    {
     }
 
-    Column(
-        TypeDescriptor type,
-        size_t expected_rows,
-        bool presize,
-        bool allow_sparse) :
-            data_(expected_rows * get_type_size(type.data_type()), presize),
-            type_(type),
-            allow_sparse_(allow_sparse){
+    Column(TypeDescriptor type, bool allow_sparse, ChunkedBuffer&& buffer)
+        : data_(std::move(buffer)),
+          type_(type),
+          allow_sparse_(allow_sparse)
+    {
+    }
+
+    Column(TypeDescriptor type, size_t expected_rows, bool presize, bool allow_sparse)
+        : data_(expected_rows * get_type_size(type.data_type()), presize),
+          type_(type),
+          allow_sparse_(allow_sparse)
+    {
         ARCTICDB_TRACE(log::inmem(), "Creating column with descriptor {}", type);
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(Column)
 
-    Column clone() const {
+    Column clone() const
+    {
         Column output;
 
         output.data_ = data_.clone();
@@ -244,7 +266,8 @@ public:
         return output;
     }
 
-    friend bool operator==(const Column& left, const Column& right) {
+    friend bool operator==(const Column& left, const Column& right)
+    {
         if (left.row_count() != right.row_count())
             return false;
 
@@ -252,17 +275,17 @@ public:
             return false;
 
         return left.type_.visit_tag([&left, &right](auto l_impl) {
-            using LeftType= std::decay_t<decltype(l_impl)>;
+            using LeftType = std::decay_t<decltype(l_impl)>;
             using LeftRawType = typename LeftType::DataTypeTag::raw_type;
 
             return right.type_.visit_tag([&left, &right](auto r_impl) {
-                using RightType= std::decay_t<decltype(r_impl)>;
+                using RightType = std::decay_t<decltype(r_impl)>;
                 using RightRawType = typename RightType::DataTypeTag::raw_type;
 
-                if constexpr(std::is_same_v < LeftRawType, RightRawType>) {
+                if constexpr (std::is_same_v<LeftRawType, RightRawType>) {
                     for (auto i = 0u; i < left.row_count(); ++i) {
-                        auto left_val =left.scalar_at<LeftRawType>(i);
-                        auto right_val =right.scalar_at<RightRawType>(i);
+                        auto left_val = left.scalar_at<LeftRawType>(i);
+                        auto right_val = right.scalar_at<RightRawType>(i);
                         if (left_val != right_val)
                             return false;
                     }
@@ -274,52 +297,63 @@ public:
         });
     }
 
-    friend bool operator!=(const Column& left, const Column& right) {
+    friend bool operator!=(const Column& left, const Column& right)
+    {
         return !(left == right);
     }
 
-    bool is_sparse() const {
-        if(last_logical_row_ != last_physical_row_) {
-            util::check(static_cast<bool>(sparse_map_), "Expected sparse map in column with logical row {} and physical row {}", last_logical_row_, last_physical_row_);
+    bool is_sparse() const
+    {
+        if (last_logical_row_ != last_physical_row_) {
+            util::check(static_cast<bool>(sparse_map_),
+                "Expected sparse map in column with logical row {} and physical row {}",
+                last_logical_row_,
+                last_physical_row_);
             return true;
         }
         return false;
     }
 
-    bool sparse_permitted() const {
+    bool sparse_permitted() const
+    {
         return allow_sparse_;
     }
 
     template<typename TagType>
-    auto begin() const {
-            using RawType = typename TagType::DataTypeTag::raw_type;
-            return TypedColumnIterator<TagType, const RawType>(*this, true);
+    auto begin() const
+    {
+        using RawType = typename TagType::DataTypeTag::raw_type;
+        return TypedColumnIterator<TagType, const RawType>(*this, true);
     }
 
     template<typename TagType>
-    auto end() const {
+    auto end() const
+    {
         using RawType = typename TagType::DataTypeTag::raw_type;
         return TypedColumnIterator<TagType, const RawType>(*this, false);
     }
 
-    void backfill_sparse_map(ssize_t to_row) {
+    void backfill_sparse_map(ssize_t to_row)
+    {
         ARCTICDB_TRACE(log::version(), "Backfilling sparse map to position {}", to_row);
         sparse_map().set_range(0, bv_size(to_row), true);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_scalar(ssize_t row_offset, T val) {
-        util::check(sizeof(T) == get_type_size(type_.data_type()), "Type mismatch in set_scalar, expected {}",
-                    get_type_size(type_.data_type()));
+    void set_scalar(ssize_t row_offset, T val)
+    {
+        util::check(sizeof(T) == get_type_size(type_.data_type()),
+            "Type mismatch in set_scalar, expected {}",
+            get_type_size(type_.data_type()));
 
         auto prev_logical_row = last_logical_row_;
         last_logical_row_ = row_offset;
         ++last_physical_row_;
 
-        if(row_offset != prev_logical_row + 1) {
-            if(sparse_permitted()) {
-                if(!sparse_map_) {
-                    if(prev_logical_row != -1)
+        if (row_offset != prev_logical_row + 1) {
+            if (sparse_permitted()) {
+                if (!sparse_map_) {
+                    if (prev_logical_row != -1)
                         backfill_sparse_map(prev_logical_row);
                     else
                         (void)sparse_map();
@@ -329,7 +363,7 @@ public:
             }
         }
 
-        if(is_sparse()) {
+        if (is_sparse()) {
             ARCTICDB_TRACE(log::version(), "setting sparse bit at position {}", last_logical_row_);
             set_sparse_bit_for_row(last_logical_row_);
         }
@@ -344,65 +378,84 @@ public:
     }
 
     template<class T>
-    void push_back(T val) {
+    void push_back(T val)
+    {
         set_scalar(last_logical_row_ + 1, val);
     }
 
-    std::optional<util::BitMagic>& opt_sparse_map() {
+    std::optional<util::BitMagic>& opt_sparse_map()
+    {
         return sparse_map_;
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    inline void set_external_block(ssize_t row_offset, T *val, size_t size) {
-        util::check_arg(last_logical_row_ + 1 == row_offset, "set_external_block expected row {}, actual {} ", last_logical_row_ + 1, row_offset);
+    inline void set_external_block(ssize_t row_offset, T* val, size_t size)
+    {
+        util::check_arg(last_logical_row_ + 1 == row_offset,
+            "set_external_block expected row {}, actual {} ",
+            last_logical_row_ + 1,
+            row_offset);
         auto bytes = sizeof(T) * size;
-        const_cast<ChunkedBuffer&>(data_.buffer()).add_external_block(reinterpret_cast<const uint8_t*>(val), bytes, data_.buffer().last_offset());
+        const_cast<ChunkedBuffer&>(data_.buffer())
+            .add_external_block(reinterpret_cast<const uint8_t*>(val), bytes, data_.buffer().last_offset());
         last_logical_row_ += static_cast<ssize_t>(size);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    inline void set_sparse_block(ssize_t row_offset, T *ptr, size_t rows_to_write) {
+    inline void set_sparse_block(ssize_t row_offset, T* ptr, size_t rows_to_write)
+    {
         util::check(row_offset == 0, "Cannot write sparse column  with existing data");
         auto new_buffer = util::scan_floating_point_to_sparse(ptr, rows_to_write, sparse_map());
         std::swap(data_.buffer(), new_buffer);
     }
 
-    inline void set_sparse_block(ChunkedBuffer&& buffer, util::BitSet&& bitset) {
+    inline void set_sparse_block(ChunkedBuffer&& buffer, util::BitSet&& bitset)
+    {
         data_.buffer() = std::move(buffer);
         sparse_map_ = std::move(bitset);
     }
 
-    inline void set_sparse_block(ChunkedBuffer&& buffer, Buffer&& shapes, util::BitSet&& bitset) {
+    inline void set_sparse_block(ChunkedBuffer&& buffer, Buffer&& shapes, util::BitSet&& bitset)
+    {
         data_.buffer() = std::move(buffer);
         shapes_.buffer() = std::move(shapes);
         sparse_map_ = std::move(bitset);
     }
 
-    template<class T, template<class> class Tensor, std::enable_if_t<
-            std::is_integral_v<T> || std::is_floating_point_v<T>,
-            int> = 0>
-    void set_array(ssize_t row_offset, Tensor<T> &val) {
+    template<class T,
+        template<class>
+        class Tensor,
+        std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    void set_array(ssize_t row_offset, Tensor<T>& val)
+    {
         ARCTICDB_SAMPLE(ColumnSetArray, RMTSF_Aggregate)
         magic_.check();
-        util::check_arg(last_logical_row_ + 1 == row_offset, "set_array expected row {}, actual {} ", last_logical_row_ + 1, row_offset);
+        util::check_arg(last_logical_row_ + 1 == row_offset,
+            "set_array expected row {}, actual {} ",
+            last_logical_row_ + 1,
+            row_offset);
         data_.ensure_bytes(val.nbytes());
         shapes_.ensure<shape_t>(val.ndim());
         memcpy(shapes_.ptr(), val.shape(), val.ndim() * sizeof(shape_t));
         auto info = val.request();
         util::FlattenHelper flatten(val);
         auto data_ptr = reinterpret_cast<T*>(data_.ptr());
-        flatten.flatten(data_ptr, reinterpret_cast<const T *>(info.ptr));
+        flatten.flatten(data_ptr, reinterpret_cast<const T*>(info.ptr));
         update_offsets(val.nbytes());
         data_.commit();
         shapes_.commit();
         ++last_logical_row_;
     }
 
-    template<class T, std::enable_if_t< std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_array(ssize_t row_offset, py::array_t<T>& val) {
+    template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    void set_array(ssize_t row_offset, py::array_t<T>& val)
+    {
         ARCTICDB_SAMPLE(ColumnSetArray, RMTSF_Aggregate)
-            magic_.check();
-        util::check_arg(last_logical_row_ + 1 == row_offset, "set_array expected row {}, actual {} ", last_logical_row_ + 1, row_offset);
+        magic_.check();
+        util::check_arg(last_logical_row_ + 1 == row_offset,
+            "set_array expected row {}, actual {} ",
+            last_logical_row_ + 1,
+            row_offset);
         data_.ensure_bytes(val.nbytes());
         shapes_.ensure<shape_t>(val.ndim());
         memcpy(shapes_.ptr(), val.shape(), val.ndim() * sizeof(shape_t));
@@ -416,39 +469,48 @@ public:
         ++last_logical_row_;
     }
 
-    ssize_t last_row() const {
+    ssize_t last_row() const
+    {
         return last_logical_row_;
     }
 
-    void check_magic() const {
+    void check_magic() const
+    {
         magic_.check();
     }
 
-    void unsparsify(size_t num_rows) {
-        if(!sparse_map_)
+    void unsparsify(size_t num_rows)
+    {
+        if (!sparse_map_)
             return;
 
-        type_.visit_tag([that=this, num_rows] (const auto tdt) {
+        type_.visit_tag([that = this, num_rows](const auto tdt) {
             using TagType = decltype(tdt);
             using RawType = typename TagType::DataTypeTag::raw_type;
             const auto dest_bytes = num_rows * sizeof(RawType);
             auto dest = ChunkedBuffer::presized(dest_bytes);
             util::default_initialize<TagType>(dest.data(), dest_bytes);
-            util::expand_dense_buffer_using_bitmap<RawType>(that->sparse_map_.value(), that->data_.buffer().data(), dest.data());
+            util::expand_dense_buffer_using_bitmap<RawType>(that->sparse_map_.value(),
+                that->data_.buffer().data(),
+                dest.data());
             std::swap(dest, that->data_.buffer());
         });
         sparse_map_ = std::nullopt;
         last_logical_row_ = last_physical_row_ = static_cast<ssize_t>(num_rows) - 1;
 
-        ARCTICDB_DEBUG(log::version(), "Unsparsify: last_logical_row_: {} last_physical_row_: {}", last_logical_row_, last_physical_row_);
+        ARCTICDB_DEBUG(log::version(),
+            "Unsparsify: last_logical_row_: {} last_physical_row_: {}",
+            last_logical_row_,
+            last_physical_row_);
     }
 
-    void sparsify() {
-        type().visit_tag([that=this](auto type_desc_tag) {
+    void sparsify()
+    {
+        type().visit_tag([that = this](auto type_desc_tag) {
             using TDT = decltype(type_desc_tag);
             using RawType = typename TDT::DataTypeTag::raw_type;
-            if constexpr(is_floating_point_type(TDT::DataTypeTag::data_type)) {
-                auto raw_ptr =reinterpret_cast<const RawType*>(that->ptr());
+            if constexpr (is_floating_point_type(TDT::DataTypeTag::data_type)) {
+                auto raw_ptr = reinterpret_cast<const RawType*>(that->ptr());
                 auto buffer = util::scan_floating_point_to_sparse(raw_ptr, that->row_count(), that->sparse_map());
                 std::swap(that->data().buffer(), buffer);
                 that->last_physical_row_ = that->sparse_map().count() - 1;
@@ -456,26 +518,29 @@ public:
         });
     }
 
-    void string_array_prologue(ssize_t row_offset, size_t num_strings) {
-        util::check_arg(last_logical_row_ + 1 == row_offset, "string_array_prologue expected row {}, actual {} ", last_logical_row_ + 1, row_offset);
+    void string_array_prologue(ssize_t row_offset, size_t num_strings)
+    {
+        util::check_arg(last_logical_row_ + 1 == row_offset,
+            "string_array_prologue expected row {}, actual {} ",
+            last_logical_row_ + 1,
+            row_offset);
         shapes_.ensure<shape_t>();
-        auto shape_cursor = reinterpret_cast<shape_t *>(shapes_.ptr());
+        auto shape_cursor = reinterpret_cast<shape_t*>(shapes_.ptr());
         *shape_cursor = shape_t(num_strings);
         data_.ensure<StringPool::offset_t>(num_strings);
     }
 
-    void string_array_epilogue(size_t num_strings) {
+    void string_array_epilogue(size_t num_strings)
+    {
         data_.commit();
         shapes_.commit();
         update_offsets(num_strings * sizeof(StringPool::offset_t));
         ++last_logical_row_;
     }
 
-    void set_string_array(ssize_t row_offset,
-                          size_t string_size,
-                          size_t num_strings,
-                          char *input,
-                          StringPool &string_pool) {
+    void
+    set_string_array(ssize_t row_offset, size_t string_size, size_t num_strings, char* input, StringPool& string_pool)
+    {
         string_array_prologue(row_offset, num_strings);
         auto data_ptr = reinterpret_cast<StringPool::offset_t*>(data_.ptr());
         for (size_t i = 0; i < num_strings; ++i) {
@@ -486,32 +551,37 @@ public:
         string_array_epilogue(num_strings);
     }
 
-    void set_string_list(ssize_t row_offset, const std::vector<std::string> &input, StringPool &string_pool) {
+    void set_string_list(ssize_t row_offset, const std::vector<std::string>& input, StringPool& string_pool)
+    {
         string_array_prologue(row_offset, input.size());
-        auto data_ptr = reinterpret_cast<StringPool::offset_t *>(data_.ptr());
-        for (const auto &str : input) {
+        auto data_ptr = reinterpret_cast<StringPool::offset_t*>(data_.ptr());
+        for (const auto& str : input) {
             auto off = string_pool.get(str.data());
             *data_ptr++ = off.offset();
         }
         string_array_epilogue(input.size());
     }
 
-    inline shape_t *allocate_shapes(std::size_t bytes) {
+    inline shape_t* allocate_shapes(std::size_t bytes)
+    {
         shapes_.ensure_bytes(bytes);
-        return reinterpret_cast<shape_t *>(shapes_.ptr());
+        return reinterpret_cast<shape_t*>(shapes_.ptr());
     }
 
-    inline uint8_t *allocate_data(std::size_t bytes) {
+    inline uint8_t* allocate_data(std::size_t bytes)
+    {
         util::check(bytes != 0, "Allocate data called with zero size");
         data_.ensure_bytes(bytes);
         return data_.ptr();
     }
 
-    inline void advance_data(std::size_t size) {
+    inline void advance_data(std::size_t size)
+    {
         data_.advance(position_t(size));
     }
 
-    inline void advance_shapes(std::size_t size) {
+    inline void advance_shapes(std::size_t size)
+    {
         shapes_.advance(position_t(size));
     }
 
@@ -521,9 +591,10 @@ public:
 
     void sort_external(const JiveTable& jive_table);
 
-    void mark_absent_rows(size_t start_pos, size_t num_rows) {
-        if(sparse_permitted()) {
-            if(!sparse_map_ && last_logical_row_ != -1)
+    void mark_absent_rows(size_t start_pos, size_t num_rows)
+    {
+        if (sparse_permitted()) {
+            if (!sparse_map_ && last_logical_row_ != -1)
                 backfill_sparse_map(last_logical_row_);
 
             last_logical_row_ += static_cast<ssize_t>(num_rows);
@@ -532,19 +603,20 @@ public:
         }
     }
 
-    void default_initialize_rows(size_t start_pos, size_t num_rows, bool ensure_alloc) {
-        type_.visit_tag([that=this, start_pos, num_rows, ensure_alloc](auto tag) {
-            using T= std::decay_t<decltype(tag)>;
+    void default_initialize_rows(size_t start_pos, size_t num_rows, bool ensure_alloc)
+    {
+        type_.visit_tag([that = this, start_pos, num_rows, ensure_alloc](auto tag) {
+            using T = std::decay_t<decltype(tag)>;
             using RawType = typename T::DataTypeTag::raw_type;
             const auto bytes = (num_rows * sizeof(RawType));
 
-            if(ensure_alloc)
+            if (ensure_alloc)
                 that->data_.ensure<uint8_t>(bytes);
 
             auto type_ptr = that->data_.ptr_cast<RawType>(start_pos, bytes);
             util::default_initialize<T>(reinterpret_cast<uint8_t*>(type_ptr), bytes);
 
-            if(ensure_alloc)
+            if (ensure_alloc)
                 that->data_.commit();
 
             that->last_logical_row_ += static_cast<ssize_t>(num_rows);
@@ -552,26 +624,30 @@ public:
         });
     }
 
-    void set_row_data(size_t row_id) {
+    void set_row_data(size_t row_id)
+    {
         last_logical_row_ = row_id;
         const auto last_stored_row = row_count() - 1;
-        if(sparse_map_) {
+        if (sparse_map_) {
             last_physical_row_ = sparse_map_.value().count() - 1;
-        }
-        else if (last_logical_row_ != last_stored_row) {
+        } else if (last_logical_row_ != last_stored_row) {
             last_physical_row_ = last_stored_row;
             backfill_sparse_map(last_stored_row);
         } else {
             last_physical_row_ = last_logical_row_;
         }
-        ARCTICDB_TRACE(log::version(), "Set row data: last_logical_row_: {}, last_physical_row_: {}", last_logical_row_, last_physical_row_);
+        ARCTICDB_TRACE(log::version(),
+            "Set row data: last_logical_row_: {}, last_physical_row_: {}",
+            last_logical_row_,
+            last_physical_row_);
     }
 
-    size_t get_physical_offset(size_t row) const {
-        if(!is_sparse())
+    size_t get_physical_offset(size_t row) const
+    {
+        if (!is_sparse())
             return row;
 
-        if(row == 0u)
+        if (row == 0u)
             return 0u;
 
         // TODO: cache index
@@ -580,66 +656,77 @@ public:
         return sparse_map().count_to(bv_size(row - 1), *rs);
     }
 
-    void set_sparse_map(util::BitSet&& bitset) {
+    void set_sparse_map(util::BitSet&& bitset)
+    {
         sparse_map_ = std::move(bitset);
     }
 
-    std::optional<position_t> get_physical_row(position_t row) const {
-        if(row > last_logical_row_) {
-            if(sparse_permitted())
+    std::optional<position_t> get_physical_row(position_t row) const
+    {
+        if (row > last_logical_row_) {
+            if (sparse_permitted())
                 return std::nullopt;
             else
                 util::raise_rte("Scalar index {} out of bounds in column of size {}", row, row_count());
         }
 
         util::check_arg(is_scalar(), "get_scalar requested on non-scalar column");
-        if(is_sparse() && !sparse_map().get_bit(bv_size(row)))
+        if (is_sparse() && !sparse_map().get_bit(bv_size(row)))
             return std::nullopt;
 
         return get_physical_offset(row);
     }
 
     template<typename T>
-    std::optional<T> scalar_at(position_t row) const {
+    std::optional<T> scalar_at(position_t row) const
+    {
         auto physical_row = get_physical_row(row);
-        if(!physical_row)
+        if (!physical_row)
             return std::nullopt;
 
         return *data_.buffer().ptr_cast<T>(bytes_offset(physical_row.value()), sizeof(T));
     }
 
-    bool has_value_at(position_t row) const {
+    bool has_value_at(position_t row) const
+    {
         return !is_sparse() || sparse_map().get_bit(bv_size(row));
     }
 
     // N.B. returning a value not a reference here, so it will need to be pre-checked when data is sparse or it
     // will likely 'splode.
     template<typename T>
-    T& reference_at(position_t row)  {
-        util::check_arg(row < row_count(), "Scalar reference index {} out of bounds in column of size {}", row, row_count());
+    T& reference_at(position_t row)
+    {
+        util::check_arg(row < row_count(),
+            "Scalar reference index {} out of bounds in column of size {}",
+            row,
+            row_count());
         util::check_arg(is_scalar(), "get_reference requested on non-scalar column");
         return *data_.buffer().ptr_cast<T>(bytes_offset(row), sizeof(T));
     }
 
     template<typename T>
-    std::optional<TensorType<T>> tensor_at(position_t idx) const {
+    std::optional<TensorType<T>> tensor_at(position_t idx) const
+    {
         util::check_arg(idx < row_count(), "Tensor index out of bounds in column");
         util::check_arg(type_.dimension() != Dimension::Dim0, "tensor_at called on scalar column");
-        const shape_t *shape_ptr = shape_index(idx);
+        const shape_t* shape_ptr = shape_index(idx);
         auto ndim = ssize_t(type_.dimension());
-        return TensorType<T>(
-                shape_ptr,
-                ndim,
-                type().data_type(),
-                get_type_size(type().data_type()),
-                reinterpret_cast<const T*>(data_.buffer().ptr_cast<uint8_t>(bytes_offset(idx), calc_elements(shape_ptr, ndim))));
+        return TensorType<T>(shape_ptr,
+            ndim,
+            type().data_type(),
+            get_type_size(type().data_type()),
+            reinterpret_cast<const T*>(
+                data_.buffer().ptr_cast<uint8_t>(bytes_offset(idx), calc_elements(shape_ptr, ndim))));
     }
 
-    void set_allow_sparse(bool value) {
+    void set_allow_sparse(bool value)
+    {
         allow_sparse_ = value;
     }
 
-    void set_shapes_buffer(size_t row_count) {
+    void set_shapes_buffer(size_t row_count)
+    {
         CursoredBuffer<Buffer> shapes;
         shapes.ensure<shape_t>();
         shape_t rc(row_count);
@@ -650,18 +737,18 @@ public:
 
     // The following two methods inflate (reduplicate) numpy string arrays that are potentially multi-dimensional,
     // i.e where the value is not a string but an array of strings
-    void inflate_string_array(
-            const TensorType<OffsetString::offset_t> &string_refs,
-            CursoredBuffer<ChunkedBuffer> &data,
-            CursoredBuffer<Buffer> &shapes,
-            std::vector<position_t> &offsets,
-            const StringPool &string_pool) {
+    void inflate_string_array(const TensorType<OffsetString::offset_t>& string_refs,
+        CursoredBuffer<ChunkedBuffer>& data,
+        CursoredBuffer<Buffer>& shapes,
+        std::vector<position_t>& offsets,
+        const StringPool& string_pool)
+    {
         ssize_t max_size = 0;
         for (int i = 0; i < string_refs.size(); ++i)
             max_size = std::max(max_size, static_cast<ssize_t>(string_pool.get_const_view(string_refs.at(i)).size()));
 
         size_t data_size = static_cast<size_t>(max_size) * string_refs.size();
-        data.ensure<uint8_t >(data_size);
+        data.ensure<uint8_t>(data_size);
         shapes.ensure<shape_t>();
         auto str_data = data.cursor();
         memset(str_data, 0, data_size);
@@ -677,7 +764,8 @@ public:
         shapes.commit();
     }
 
-    void inflate_string_arrays(const StringPool &string_pool) {
+    void inflate_string_arrays(const StringPool& string_pool)
+    {
         util::check_arg(is_fixed_string_type(type().data_type()), "Can only inflate fixed string array types");
         util::check_arg(type().dimension() == Dimension::Dim1, "Fixed string inflation is for array types only");
 
@@ -685,8 +773,8 @@ public:
         CursoredBuffer<Buffer> shapes;
         std::vector<position_t> offsets;
         for (position_t row = 0; row < row_count(); ++row) {
-          auto string_refs = tensor_at<OffsetString::offset_t>(row).value();
-          inflate_string_array(string_refs, data, shapes, offsets, string_pool);
+            auto string_refs = tensor_at<OffsetString::offset_t>(row).value();
+            inflate_string_array(string_refs, data, shapes, offsets, string_pool);
         }
 
         using std::swap;
@@ -698,59 +786,67 @@ public:
 
     // Used when the column has been inflated externally, i.e. because it has be done
     // in a pipeline of tiled sub-segments
-    void set_inflated(size_t inflated_count) {
+    void set_inflated(size_t inflated_count)
+    {
         set_shapes_buffer(inflated_count);
         inflated_ = true;
     }
 
-    bool is_inflated() const {
+    bool is_inflated() const
+    {
         return inflated_;
     }
 
-    std::optional<StringArrayData> string_array_at(position_t idx, const StringPool &string_pool) {
+    std::optional<StringArrayData> string_array_at(position_t idx, const StringPool& string_pool)
+    {
         util::check_arg(idx < row_count(), "String array index out of bounds in column");
         util::check_arg(type_.dimension() == Dimension::Dim1, "String array should always be one dimensional");
         if (!inflated_)
             inflate_string_arrays(string_pool);
 
-        const shape_t *shape_ptr = shape_index(idx);
+        const shape_t* shape_ptr = shape_index(idx);
         auto num_strings = *shape_ptr;
         ssize_t string_size = offsets_[idx] / num_strings;
-        return StringArrayData{num_strings, string_size, data_.ptr_cast<char>(bytes_offset(idx), num_strings * string_size)};
+        return StringArrayData{num_strings,
+            string_size,
+            data_.ptr_cast<char>(bytes_offset(idx), num_strings * string_size)};
     }
 
     template<typename T>
-    const T *ptr_cast(position_t idx, size_t required_bytes) const {
+    const T* ptr_cast(position_t idx, size_t required_bytes) const
+    {
         return data_.buffer().ptr_cast<T>(bytes_offset(idx), required_bytes);
     }
 
     template<typename T>
-    T *ptr_cast(position_t idx, size_t required_bytes) {
+    T* ptr_cast(position_t idx, size_t required_bytes)
+    {
         return const_cast<T*>(const_cast<const Column*>(this)->ptr_cast<T>(idx, required_bytes));
     }
 
-    void change_type(DataType target_type, const std::shared_ptr<StringPool>& /*string_pool*/) {
+    void change_type(DataType target_type, const std::shared_ptr<StringPool>& /*string_pool*/)
+    {
         util::check(shapes_.empty(), "Can't change type on multi-dimensional column with type {}", type_);
-        if(type_.data_type() == target_type)
+        if (type_.data_type() == target_type)
             return;
 
         CursoredBuffer<ChunkedBuffer> buf;
-        for(const auto& block : data_.buffer().blocks()) {
-            details::visit_type(type_.data_type(), [&buf, &block, type=type_, target_type] (auto&& source_dtt) {
+        for (const auto& block : data_.buffer().blocks()) {
+            details::visit_type(type_.data_type(), [&buf, &block, type = type_, target_type](auto&& source_dtt) {
                 using source_raw_type = typename std::decay_t<decltype(source_dtt)>::raw_type;
-                details::visit_type(target_type, [&buf, &block, &type, target_type] (auto&& target_dtt) {
+                details::visit_type(target_type, [&buf, &block, &type, target_type](auto&& target_dtt) {
                     using target_raw_type = typename std::decay_t<decltype(target_dtt)>::raw_type;
 
                     if constexpr (!is_narrowing_conversion<source_raw_type, target_raw_type>() &&
-                            !std::is_same_v<source_raw_type, bool>) {
+                                  !std::is_same_v<source_raw_type, bool>)
+                    {
                         auto num_values = block->bytes() / sizeof(source_raw_type);
                         buf.ensure<target_raw_type>(num_values);
-                        auto src = reinterpret_cast<const source_raw_type *>(block->data());
-                        auto dest = reinterpret_cast<target_raw_type *>(buf.cursor());
+                        auto src = reinterpret_cast<const source_raw_type*>(block->data());
+                        auto dest = reinterpret_cast<target_raw_type*>(buf.cursor());
                         for (auto i = 0u; i < num_values; ++i)
                             dest[i] = target_raw_type(src[i]);
-                    }
-                    else {
+                    } else {
                         util::raise_rte("Cannot narrow column type from {} to {}", type, target_type);
                     }
                 });
@@ -762,7 +858,8 @@ public:
 
     //TODO this will need to be more efficient - index each block?
     template<typename T>
-    std::optional<position_t> index_of(T val) const {
+    std::optional<position_t> index_of(T val) const
+    {
         util::check_arg(is_scalar(), "Cannot index on multidimensional values");
         for (position_t i = 0; i < row_count(); ++i) {
             if (val == *ptr_cast<T>(i, sizeof(T)))
@@ -771,109 +868,133 @@ public:
         return std::nullopt;
     }
 
-    ChunkedBuffer::Iterator get_iterator() const {
+    ChunkedBuffer::Iterator get_iterator() const
+    {
         return {const_cast<ChunkedBuffer*>(&data_.buffer()), get_type_size(type_.data_type())};
     }
 
-    position_t row_count() const {
-        if(!is_scalar()) {
+    position_t row_count() const
+    {
+        if (!is_scalar()) {
             // TODO check with strings as well
             return num_shapes() / shape_t(type_.dimension());
         }
 
-        if(is_sequence_type(type().data_type()) && inflated_ && is_fixed_string_type(type().data_type()))
+        if (is_sequence_type(type().data_type()) && inflated_ && is_fixed_string_type(type().data_type()))
             return inflated_row_count();
 
         return data_.bytes() / size_t(item_size());
     }
 
-    size_t bytes() const {
+    size_t bytes() const
+    {
         return data_.bytes();
     }
 
-    ColumnData data() const {
+    ColumnData data() const
+    {
         return ColumnData(&data_.buffer(), &shapes_.buffer(), type_, sparse_map_ ? &sparse_map_.value() : nullptr);
     }
 
-    const uint8_t* ptr() const {
+    const uint8_t* ptr() const
+    {
         return data_.buffer().data();
     }
 
-    uint8_t* ptr() {
+    uint8_t* ptr()
+    {
         return data_.buffer().data();
     }
 
-    TypeDescriptor type() const { return type_; }
+    TypeDescriptor type() const
+    {
+        return type_;
+    }
 
-    size_t num_blocks() const  {
+    size_t num_blocks() const
+    {
         return data_.buffer().num_blocks();
     }
 
-    const shape_t* shape_ptr() const {
+    const shape_t* shape_ptr() const
+    {
         return shapes_.ptr_cast<shape_t>(0, num_shapes());
     }
 
-    void set_orig_type(const TypeDescriptor& desc) {
+    void set_orig_type(const TypeDescriptor& desc)
+    {
         orig_type_ = desc;
     }
 
-    bool has_orig_type() const {
+    bool has_orig_type() const
+    {
         return static_cast<bool>(orig_type_);
     }
 
-    const TypeDescriptor& orig_type() const  {
+    const TypeDescriptor& orig_type() const
+    {
         return orig_type_.value();
     }
 
-    void set_secondary_type(TypeDescriptor type) {
+    void set_secondary_type(TypeDescriptor type)
+    {
         secondary_type_ = std::move(type);
     }
 
-    bool has_secondary_type() const {
+    bool has_secondary_type() const
+    {
         return secondary_type_.has_value();
     }
 
-    const TypeDescriptor& secondary_type() const {
+    const TypeDescriptor& secondary_type() const
+    {
         util::check(secondary_type_.has_value(), "Requesting secondary type in a column that does not have one");
         return *secondary_type_;
     }
 
-    void compact_blocks() {
+    void compact_blocks()
+    {
         data_.compact_blocks();
     }
 
-    const auto& blocks() const {
+    const auto& blocks() const
+    {
         return data_.buffer().blocks();
     }
 
     static std::vector<std::shared_ptr<Column>> split(const std::shared_ptr<Column>& column, size_t num_rows);
 
 private:
-    position_t last_offset() const {
+    position_t last_offset() const
+    {
         return offsets_.empty() ? 0 : *offsets_.rbegin();
     }
 
-    void update_offsets(size_t nbytes) {
+    void update_offsets(size_t nbytes)
+    {
         offsets_.push_back(last_offset() + nbytes);
     }
 
-    bool is_scalar() const {
+    bool is_scalar() const
+    {
         return type().dimension() == Dimension(0);
     }
 
-    const shape_t *shape_index(position_t idx) const {
+    const shape_t* shape_index(position_t idx) const
+    {
         if (is_scalar())
             return nullptr;
 
         return shapes_.buffer().ptr_cast<shape_t>(idx * size_t(type_.dimension()) * sizeof(shape_t), sizeof(shape_t));
     }
 
-    position_t bytes_offset(position_t idx) const {
+    position_t bytes_offset(position_t idx) const
+    {
         regenerate_offsets();
         util::check_arg(idx < row_count(),
-                        "bytes_offset index {} out of bounds in column of size {}",
-                        idx,
-                        row_count());
+            "bytes_offset index {} out of bounds in column of size {}",
+            idx,
+            row_count());
 
         if (idx == 0)
             return 0;
@@ -881,61 +1002,74 @@ private:
         if (is_scalar())
             return scalar_offset(idx);
 
-        util::check(size_t(idx - 1) < offsets_.size(), "Offset {} out of range, only have {}", idx - 1, offsets_.size());
+        util::check(size_t(idx - 1) < offsets_.size(),
+            "Offset {} out of range, only have {}",
+            idx - 1,
+            offsets_.size());
         return offsets_[idx - 1];
     }
 
-    position_t scalar_offset(position_t idx) const {
+    position_t scalar_offset(position_t idx) const
+    {
         return idx * item_size();
     }
 
-    size_t item_size() const {
-        if(is_sequence_type(type().data_type()) && inflated_ && is_fixed_string_type(type().data_type())) {
+    size_t item_size() const
+    {
+        if (is_sequence_type(type().data_type()) && inflated_ && is_fixed_string_type(type().data_type())) {
             return data_.bytes() / inflated_row_count();
         }
 
         return get_type_size(type().data_type());
     }
 
-    size_t inflated_row_count() const {
+    size_t inflated_row_count() const
+    {
         // using the content of shapes since the item size
         // from the datatype is no longer reliable
         return *reinterpret_cast<const size_t*>(shapes_.data());
     }
 
-    size_t num_shapes() const  {
+    size_t num_shapes() const
+    {
         return shapes_.bytes() / sizeof(shape_t);
     }
 
-    void set_sparse_bit_for_row(size_t sparse_location) {
+    void set_sparse_bit_for_row(size_t sparse_location)
+    {
         sparse_map()[bv_size(sparse_location)] = true;
     }
 
-    util::BitMagic& sparse_map() {
-        if(!sparse_map_)
+    util::BitMagic& sparse_map()
+    {
+        if (!sparse_map_)
             sparse_map_ = std::make_optional<util::BitMagic>();
 
         return sparse_map_.value();
     }
 
-    bool empty() const {
+    bool empty() const
+    {
         return row_count() == 0;
     }
 
-    const util::BitMagic& sparse_map() const {
+    const util::BitMagic& sparse_map() const
+    {
         util::check(static_cast<bool>(sparse_map_), "Expected sparse map when it was not set");
         return sparse_map_.value();
     }
 
-    void regenerate_offsets() const {
+    void regenerate_offsets() const
+    {
         if (ARCTICDB_LIKELY(is_scalar() || !offsets_.empty()))
             return;
 
         position_t pos = 0;
         for (position_t i = 0, j = i + position_t(type_.dimension()); j < position_t(num_shapes());
-             i = j, j += position_t(type_.dimension())) {
+             i = j, j += position_t(type_.dimension()))
+        {
             auto num_elements =
-                    position_t(std::accumulate(shape_index(i), shape_index(j), shape_t(1), std::multiplies<>()));
+                position_t(std::accumulate(shape_index(i), shape_index(j), shape_t(1), std::multiplies<>()));
             auto offset = num_elements * get_type_size(type_.data_type());
             offsets_.push_back(pos + offset);
             pos += offset;
@@ -959,22 +1093,23 @@ private:
     util::MagicNum<'D', 'C', 'o', 'l'> magic_;
 };
 
-template <typename T>
-JiveTable create_jive_table(const Column& col) {
+template<typename T>
+JiveTable create_jive_table(const Column& col)
+{
     JiveTable output(col.row_count());
     std::iota(std::begin(output.orig_pos_), std::end(output.orig_pos_), 0);
     std::iota(std::begin(output.sorted_pos_), std::end(output.sorted_pos_), 0);
 
-    std::sort(std::begin(output.orig_pos_), std::end(output.orig_pos_),[&](const auto& a, const auto& b) -> bool {
+    std::sort(std::begin(output.orig_pos_), std::end(output.orig_pos_), [&](const auto& a, const auto& b) -> bool {
         return col.template scalar_at<T>(a) < col.template scalar_at<T>(b);
     });
 
-    std::sort(std::begin(output.sorted_pos_), std::end(output.sorted_pos_),[&](const auto& a, const auto& b) -> bool {
+    std::sort(std::begin(output.sorted_pos_), std::end(output.sorted_pos_), [&](const auto& a, const auto& b) -> bool {
         return output.orig_pos_[a] < output.orig_pos_[b];
     });
 
-    for(auto pos : folly::enumerate(output.sorted_pos_)) {
-        if(pos.index != *pos) {
+    for (auto pos : folly::enumerate(output.sorted_pos_)) {
+        if (pos.index != *pos) {
             output.unsorted_rows_.set(bv_size(pos.index), true);
             ++output.num_unsorted_;
         }

--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/buffer.hpp>
 #include <arcticdb/column_store/chunked_buffer.hpp>
@@ -27,49 +26,66 @@ struct TypedBlockData {
      * Thin layer that helps create an iterator over the elements of the block taking the size of data and
      * shape into account. Maybe a bit too much overkill given how thin this is?
      */
-    template <class ValueType>
-    class TypedColumnBlockIterator :  public boost::iterator_facade<TypedColumnBlockIterator<ValueType>, ValueType, boost::random_access_traversal_tag> {
-      public:
+    template<class ValueType>
+    class TypedColumnBlockIterator : public boost::iterator_facade<TypedColumnBlockIterator<ValueType>,
+                                         ValueType,
+                                         boost::random_access_traversal_tag> {
+    public:
         TypedColumnBlockIterator(ValueType* ptr)
-            :  ptr_(ptr) { }
+            : ptr_(ptr)
+        {
+        }
 
         TypedColumnBlockIterator(const TypedColumnBlockIterator& other)
-            : ptr_(other.ptr_) {}
+            : ptr_(other.ptr_)
+        {
+        }
 
-        template <class OtherValue>
+        template<class OtherValue>
         explicit TypedColumnBlockIterator(const TypedColumnBlockIterator<OtherValue>& other)
-            : ptr_(other.ptr_){}
+            : ptr_(other.ptr_)
+        {
+        }
 
         TypedColumnBlockIterator()
-            :  ptr_(nullptr) { }
+            : ptr_(nullptr)
+        {
+        }
 
-        TypedColumnBlockIterator& operator=(const TypedColumnBlockIterator& other) {
+        TypedColumnBlockIterator& operator=(const TypedColumnBlockIterator& other)
+        {
             ptr_ = other.ptr_;
             return *this;
         }
 
-        template <class OtherValue>
-        bool equal(const TypedColumnBlockIterator<OtherValue>& other) const {
+        template<class OtherValue>
+        bool equal(const TypedColumnBlockIterator<OtherValue>& other) const
+        {
             return ptr_ == other.ptr_;
         }
 
-        ssize_t distance_to(const TypedColumnBlockIterator& other) const {
+        ssize_t distance_to(const TypedColumnBlockIterator& other) const
+        {
             return other.ptr_ - ptr_;
         }
 
-        void increment(){
+        void increment()
+        {
             ++ptr_;
         }
 
-        void decrement(){
+        void decrement()
+        {
             --ptr_;
         }
 
-        void advance(ptrdiff_t n){
+        void advance(ptrdiff_t n)
+        {
             ptr_ += n;
         }
 
-        ValueType& dereference() const {
+        ValueType& dereference() const
+        {
             return *ptr_;
         }
 
@@ -80,157 +96,191 @@ struct TypedBlockData {
 
     ARCTICDB_MOVE_COPY_DEFAULT(TypedBlockData)
 
-    TypedBlockData(const raw_type *data, const shape_t *shapes, size_t nbytes, size_t row_count, MemBlock *block) :
-        data_(data),
-        shapes_(shapes),
-        nbytes_(nbytes),
-        row_count_(row_count),
-        block_(block)
-        {}
+    TypedBlockData(const raw_type* data, const shape_t* shapes, size_t nbytes, size_t row_count, MemBlock* block)
+        : data_(data),
+          shapes_(shapes),
+          nbytes_(nbytes),
+          row_count_(row_count),
+          block_(block)
+    {
+    }
 
+    TypedBlockData(size_t nbytes, shape_t* shapes)
+        : data_(nullptr),
+          shapes_(shapes),
+          nbytes_(nbytes),
+          row_count_(1u),
+          block_(nullptr)
+    {
+    }
 
-    TypedBlockData(size_t nbytes, shape_t* shapes) :
-        data_(nullptr),
-        shapes_(shapes),
-        nbytes_(nbytes),
-        row_count_(1u),
-        block_(nullptr)
-    {}
+    std::size_t nbytes() const
+    {
+        return nbytes_;
+    }
+    std::size_t row_count() const
+    {
+        return row_count_;
+    }
+    TypeDescriptor type() const
+    {
+        return static_cast<TypeDescriptor>(TDT());
+    }
+    const shape_t* shapes() const
+    {
+        return shapes_;
+    }
+    const raw_type* data() const
+    {
+        return data_;
+    }
+    const MemBlock* mem_block() const
+    {
+        return block_;
+    }
 
-    std::size_t nbytes() const { return nbytes_; }
-    std::size_t row_count() const { return row_count_; }
-    TypeDescriptor type() const { return static_cast<TypeDescriptor>(TDT()); }
-    const shape_t *shapes() const { return shapes_; }
-    const raw_type *data() const { return data_; }
-    const MemBlock *mem_block() const { return block_; }
-
-    raw_type operator[](size_t pos) const {
+    raw_type operator[](size_t pos) const
+    {
         return reinterpret_cast<const raw_type*>(block_->data())[pos];
     }
 
-    auto begin() const {
+    auto begin() const
+    {
         return TypedColumnBlockIterator<const raw_type>(data_);
     }
 
-    auto end() const {
+    auto end() const
+    {
         return TypedColumnBlockIterator<const raw_type>(data_ + row_count_);
     }
 
-    size_t offset() const {
+    size_t offset() const
+    {
         return block_->offset_;
     }
 
-    friend bool operator==(const TypedBlockData& left, const TypedBlockData& right) {
+    friend bool operator==(const TypedBlockData& left, const TypedBlockData& right)
+    {
         return left.block_ == right.block_;
     }
 
 private:
-    const raw_type *data_;
-    const shape_t *shapes_;
+    const raw_type* data_;
+    const shape_t* shapes_;
     size_t nbytes_;
     size_t row_count_;
-    const MemBlock *block_;  // pointer to the parent memblock from which this was created from.
+    const MemBlock* block_; // pointer to the parent memblock from which this was created from.
 };
 
 struct ColumnData {
-/*
+    /*
  * ColumnData is just a thin wrapper that helps in iteration over all the blocks in the column
  */
 
-  public:
-    ColumnData(
-        const ChunkedBuffer*data,
+public:
+    ColumnData(const ChunkedBuffer* data,
         const Buffer* shapes,
-        const TypeDescriptor &type,
-        const util::BitMagic* bit_vector) :
-        data_(data),
-        shapes_(shapes),
-        pos_(0),
-        shape_pos_(0),
-        type_(type),
-        bit_vector_(bit_vector){}
+        const TypeDescriptor& type,
+        const util::BitMagic* bit_vector)
+        : data_(data),
+          shapes_(shapes),
+          pos_(0),
+          shape_pos_(0),
+          type_(type),
+          bit_vector_(bit_vector)
+    {
+    }
 
     ARCTICDB_MOVE_COPY_DEFAULT(ColumnData)
 
-    TypeDescriptor type() const {
+    TypeDescriptor type() const
+    {
         return type_;
     }
 
-    const ChunkedBuffer &buffer() const {
+    const ChunkedBuffer& buffer() const
+    {
         return *data_;
     }
 
-    const util::BitMagic* bit_vector() const {
+    const util::BitMagic* bit_vector() const
+    {
         return bit_vector_;
     }
 
-    ChunkedBuffer &buffer()  {
+    ChunkedBuffer& buffer()
+    {
         return *const_cast<ChunkedBuffer*>(data_);
     }
 
-    shape_t next_shape() {
+    shape_t next_shape()
+    {
         auto shape = *shapes_->ptr_cast<shape_t>(shape_pos_, sizeof(shape_t));
         shape_pos_ += sizeof(shape_t);
         return shape;
     }
 
-    size_t num_blocks() const {
+    size_t num_blocks() const
+    {
         return data_->blocks().size();
     }
 
-    void reset() {
+    void reset()
+    {
         pos_ = 0;
         shape_pos_ = 0;
     }
 
     template<typename TDT>
-    std::optional<TypedBlockData<TDT>>  next() {
+    std::optional<TypedBlockData<TDT>> next()
+    {
         MemBlock* block = nullptr;
         do {
             if (pos_ == num_blocks())
                 return std::nullopt;
 
-             block = data_->blocks().at(pos_++);
-        } while(!block);
+            block = data_->blocks().at(pos_++);
+        } while (!block);
 
         return next_typed_block<TDT>(block);
     }
 
     template<typename TDT>
-    std::optional<TypedBlockData<TDT>>  last()  {
-       if(data_->blocks().empty())
-           return std::nullopt;
+    std::optional<TypedBlockData<TDT>> last()
+    {
+        if (data_->blocks().empty())
+            return std::nullopt;
 
-        pos_ = num_blocks() -1;
+        pos_ = num_blocks() - 1;
         auto block = data_->blocks().at(pos_);
         return next_typed_block<TDT>(block);
     }
 
     template<typename TDT>
-    static TypedBlockData<TDT> make_typed_block(MemBlock* block) {
+    static TypedBlockData<TDT> make_typed_block(MemBlock* block)
+    {
         if constexpr (TDT::DimensionTag::value != Dimension::Dim0) {
             util::raise_rte("Random access block in multi-dimentional column");
         }
 
-        return TypedBlockData<TDT>{
-            reinterpret_cast<const typename TDT::DataTypeTag::raw_type *>(block->data()),
+        return TypedBlockData<TDT>{reinterpret_cast<const typename TDT::DataTypeTag::raw_type*>(block->data()),
             nullptr,
             block->bytes(),
             block->bytes() / get_type_size(TDT::DataTypeTag::data_type),
-            block
-        };
+            block};
     }
 
-  private:
+private:
     template<typename TDT>
-    TypedBlockData<TDT> next_typed_block(MemBlock* block) {
+    TypedBlockData<TDT> next_typed_block(MemBlock* block)
+    {
         size_t num_elements = 0;
-        const shape_t *shape_ptr = nullptr;
+        const shape_t* shape_ptr = nullptr;
 
         constexpr auto dim = TDT::DimensionTag::value;
-        if constexpr (dim == Dimension::Dim0){
+        if constexpr (dim == Dimension::Dim0) {
             num_elements = block->bytes() / get_type_size(type_.data_type());
-        }  else {
+        } else {
             if (shapes_->empty()) {
                 num_elements = block->bytes() / get_type_size(type_.data_type());
             } else {
@@ -245,17 +295,18 @@ struct ColumnData {
                     ++num_elements;
                 }
 
-                util::check(size == block->bytes(), "Element size vs block size overrun: {} > {}", size, block->bytes());
+                util::check(size == block->bytes(),
+                    "Element size vs block size overrun: {} > {}",
+                    size,
+                    block->bytes());
             }
         }
 
-        return TypedBlockData<TDT>{
-            reinterpret_cast<const typename TDT::DataTypeTag::raw_type *>(block->data()),
+        return TypedBlockData<TDT>{reinterpret_cast<const typename TDT::DataTypeTag::raw_type*>(block->data()),
             shape_ptr,
             block->bytes(),
             num_elements,
-            block
-        };
+            block};
     }
 
     const ChunkedBuffer* data_;
@@ -266,4 +317,4 @@ struct ColumnData {
     const util::BitMagic* bit_vector_;
 };
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/column_store/column_map.hpp
+++ b/cpp/arcticdb/column_store/column_map.hpp
@@ -25,29 +25,35 @@ class ColumnMap {
     StringPool pool_;
 
 public:
-    ColumnMap(size_t size) :
-        column_offsets_(size) {}
+    ColumnMap(size_t size)
+        : column_offsets_(size)
+    {
+    }
 
-    void clear() {
+    void clear()
+    {
         column_offsets_.clear();
         pool_.clear();
     }
 
-    void insert(std::string_view name, size_t index) {
+    void insert(std::string_view name, size_t index)
+    {
         auto off_str = pool_.get(name);
         column_offsets_.insert(robin_hood::pair<std::string_view, size_t>(pool_.get_view(off_str.offset()), index));
         column_offsets_[pool_.get_view(off_str.offset())] = index;
     }
 
-    void set_from_descriptor(const StreamDescriptor& descriptor) {
-        for(const auto& field : folly::enumerate(descriptor.fields())) {
+    void set_from_descriptor(const StreamDescriptor& descriptor)
+    {
+        for (const auto& field : folly::enumerate(descriptor.fields())) {
             insert(field->name(), field.index);
         }
     }
 
-    std::optional<std::size_t> column_index(std::string_view name) {
+    std::optional<std::size_t> column_index(std::string_view name)
+    {
         auto it = column_offsets_.find(name);
-        if(it != column_offsets_.end())
+        if (it != column_offsets_.end())
             return it->second;
         else {
             ARCTICDB_TRACE(log::version(), "Column {} not found in map of size {}", name, column_offsets_.size());

--- a/cpp/arcticdb/column_store/column_utils.hpp
+++ b/cpp/arcticdb/column_store/column_utils.hpp
@@ -15,21 +15,21 @@
 
 namespace arcticdb::detail {
 
-inline py::array array_at(const SegmentInMemory& frame, std::size_t col_pos, py::object &anchor) {
+inline py::array array_at(const SegmentInMemory& frame, std::size_t col_pos, py::object& anchor)
+{
     ARCTICDB_SAMPLE_DEFAULT(PythonOutputFrameArrayAt)
     if (frame.empty()) {
-        return visit_field(frame.field(col_pos), [] (auto &&tag) {
+        return visit_field(frame.field(col_pos), [](auto&& tag) {
             using TypeTag = std::decay_t<decltype(tag)>;
             constexpr auto data_type = TypeTag::DataTypeTag::data_type;
             std::string dtype;
             py::array::ShapeContainer shapes{0};
             ssize_t esize = get_type_size(data_type);
             if constexpr (is_sequence_type(data_type)) {
-                if(is_fixed_string_type(data_type)) {
+                if (is_fixed_string_type(data_type)) {
                     dtype = data_type == DataType::ASCII_FIXED64 ? "<S0" : "<U0";
                     esize = 1;
-                }
-                else {
+                } else {
                     dtype = "O";
                 }
             } else {
@@ -45,10 +45,10 @@ inline py::array array_at(const SegmentInMemory& frame, std::size_t col_pos, py:
             return py::array{py::dtype{dtype}, std::move(shapes), std::move(strides)};
         });
     }
-    return visit_field(frame.field(col_pos), [&, frame=frame, col_pos=col_pos] (auto &&tag) {
+    return visit_field(frame.field(col_pos), [&, frame = frame, col_pos = col_pos](auto&& tag) {
         using TypeTag = std::decay_t<decltype(tag)>;
         constexpr auto dt = TypeTag::DataTypeTag::data_type;
-        auto &buffer = frame.column(col_pos).data().buffer();
+        auto& buffer = frame.column(col_pos).data().buffer();
         std::string dtype;
         std::vector<shape_t> shapes;
         shapes.push_back(frame.row_count());
@@ -82,7 +82,8 @@ inline py::array array_at(const SegmentInMemory& frame, std::size_t col_pos, py:
     });
 }
 
-inline std::shared_ptr<pipelines::FrameDataWrapper> initialize_array(const SegmentInMemory& frame, py::object &ref) {
+inline std::shared_ptr<pipelines::FrameDataWrapper> initialize_array(const SegmentInMemory& frame, py::object& ref)
+{
     auto output = std::make_shared<pipelines::FrameDataWrapper>(frame.fields().size());
     ARCTICDB_SAMPLE(InitializeArrays, 0);
     ARCTICDB_DEBUG(log::memory(), "Initializing arrays");
@@ -94,4 +95,4 @@ inline std::shared_ptr<pipelines::FrameDataWrapper> initialize_array(const Segme
     return output;
 }
 
-}
+} // namespace arcticdb::detail

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -34,370 +34,474 @@ public:
     using iterator = SegmentInMemoryImpl::iterator;
     using const_iterator = SegmentInMemoryImpl::const_iterator;
 
-    SegmentInMemory() :
-            impl_(std::make_shared<SegmentInMemoryImpl>()) {
+    SegmentInMemory()
+        : impl_(std::make_shared<SegmentInMemoryImpl>())
+    {
     }
 
-    explicit SegmentInMemory(
-        const StreamDescriptor &tsd,
+    explicit SegmentInMemory(const StreamDescriptor& tsd,
         size_t expected_column_size = 0,
         bool presize = false,
-        bool allow_sparse = false) :
-            impl_(std::make_shared<SegmentInMemoryImpl>(tsd, expected_column_size, presize, allow_sparse)){
+        bool allow_sparse = false)
+        : impl_(std::make_shared<SegmentInMemoryImpl>(tsd, expected_column_size, presize, allow_sparse))
+    {
     }
 
-    explicit SegmentInMemory(
-        const StreamDescriptor&& tsd,
+    explicit SegmentInMemory(const StreamDescriptor&& tsd,
         size_t expected_column_size = 0,
         bool presize = false,
-        bool allow_sparse = false) :
-        impl_(std::make_shared<SegmentInMemoryImpl>(std::move(tsd), expected_column_size, presize, allow_sparse)){
+        bool allow_sparse = false)
+        : impl_(std::make_shared<SegmentInMemoryImpl>(std::move(tsd), expected_column_size, presize, allow_sparse))
+    {
     }
 
-    friend void swap(SegmentInMemory& left, SegmentInMemory& right) {
+    friend void swap(SegmentInMemory& left, SegmentInMemory& right)
+    {
         std::swap(left.impl_, right.impl_);
     }
 
     ARCTICDB_MOVE_COPY_DEFAULT(SegmentInMemory)
 
-    auto begin() { return impl_->begin(); }
+    auto begin()
+    {
+        return impl_->begin();
+    }
 
-    auto end() { return impl_->end(); }
+    auto end()
+    {
+        return impl_->end();
+    }
 
-    auto begin() const { return impl_->begin(); }
+    auto begin() const
+    {
+        return impl_->begin();
+    }
 
-    auto end() const { return impl_->end(); }
+    auto end() const
+    {
+        return impl_->end();
+    }
 
-    void push_back(const Row& row) {
+    void push_back(const Row& row)
+    {
         impl_->push_back(row);
     }
 
-    auto column_descriptor(size_t col) const {
+    auto column_descriptor(size_t col) const
+    {
         return impl_->column_descriptor(col);
     }
 
-    void end_row() const {
+    void end_row() const
+    {
         impl_->end_row();
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_scalar(position_t idx, T val) {
+    void set_scalar(position_t idx, T val)
+    {
         impl_->set_scalar(idx, val);
     }
 
     template<class T, std::enable_if_t<std::is_same_v<std::decay_t<T>, std::string>, int> = 0>
-    void set_scalar(position_t idx, T val) {
+    void set_scalar(position_t idx, T val)
+    {
         impl_->set_string(idx, val);
     }
 
-    friend bool operator==(const SegmentInMemory& left, const SegmentInMemory& right) {
+    friend bool operator==(const SegmentInMemory& left, const SegmentInMemory& right)
+    {
         return *left.impl_ == *right.impl_;
     }
 
-    const auto& fields() const {
+    const auto& fields() const
+    {
         return impl_->fields();
     }
 
-    const auto& field(size_t index) const {
+    const auto& field(size_t index) const
+    {
         return impl_->field(index);
     }
 
-    std::optional<std::size_t> column_index(std::string_view name) const {
+    std::optional<std::size_t> column_index(std::string_view name) const
+    {
         return impl_->column_index(name);
     }
 
-    void init_column_map() const  {
+    void init_column_map() const
+    {
         impl_->init_column_map();
     }
 
-    template<class T, template<class> class Tensor, std::enable_if_t<
-            std::is_integral_v<T> || std::is_floating_point_v<T>,
-            int> = 0>
-    void set_array(position_t pos, Tensor<T> &val) {
+    template<class T,
+        template<class>
+        class Tensor,
+        std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    void set_array(position_t pos, Tensor<T>& val)
+    {
         impl_->set_array(pos, val);
     }
 
-    template<class T, std::enable_if_t<
-        std::is_integral_v<T> || std::is_floating_point_v<T>,
-        int> = 0>
-    void set_array(position_t pos, py::array_t<T>& val) {
+    template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    void set_array(position_t pos, py::array_t<T>& val)
+    {
         impl_->set_array(pos, val);
     }
 
-    void set_string(position_t pos, std::string_view str) {
+    void set_string(position_t pos, std::string_view str)
+    {
         impl_->set_string(pos, str);
     }
 
-    void set_string_at(position_t col, position_t row, const char* str, size_t size) {
+    void set_string_at(position_t col, position_t row, const char* str, size_t size)
+    {
         impl_->set_string_at(col, row, str, size);
     }
 
-    void set_no_string_at(position_t col, position_t row, OffsetString::offset_t placeholder) {
+    void set_no_string_at(position_t col, position_t row, OffsetString::offset_t placeholder)
+    {
         impl_->set_no_string_at(col, row, placeholder);
     }
 
-    void set_string_array(position_t idx, size_t string_size, size_t num_strings, char *data) {
+    void set_string_array(position_t idx, size_t string_size, size_t num_strings, char* data)
+    {
         impl_->set_string_array(idx, string_size, num_strings, data);
     }
 
-    void set_string_list(position_t idx, const std::vector<std::string> &input) {
+    void set_string_list(position_t idx, const std::vector<std::string>& input)
+    {
         impl_->set_string_list(idx, input);
     }
 
-    void set_value(position_t idx, const SegmentInMemoryImpl::Location& loc) {
+    void set_value(position_t idx, const SegmentInMemoryImpl::Location& loc)
+    {
         impl_->set_value(idx, loc);
     }
 
     //pybind11 can't resolve const and non-const version of column()
-    Column &column_ref(position_t idx) {
+    Column& column_ref(position_t idx)
+    {
         return impl_->column_ref(idx);
     }
 
-    Column &column(position_t idx) {
+    Column& column(position_t idx)
+    {
         return impl_->column(idx);
     }
 
-    const Column &column(position_t idx) const {
+    const Column& column(position_t idx) const
+    {
         return impl_->column(idx);
     }
 
-    std::vector<std::shared_ptr<Column>>& columns() {
+    std::vector<std::shared_ptr<Column>>& columns()
+    {
         return impl_->columns();
     }
 
-    const std::vector<std::shared_ptr<Column>>& columns() const {
+    const std::vector<std::shared_ptr<Column>>& columns() const
+    {
         return impl_->columns();
     }
 
-    position_t add_column(const FieldDescriptor::Proto &field, size_t num_rows, bool presize) {
+    position_t add_column(const FieldDescriptor::Proto& field, size_t num_rows, bool presize)
+    {
         return impl_->add_column(field, num_rows, presize);
     }
 
-    position_t add_column(const FieldDescriptor::Proto &field, const std::shared_ptr<Column>& column) {
+    position_t add_column(const FieldDescriptor::Proto& field, const std::shared_ptr<Column>& column)
+    {
         return impl_->add_column(field, column);
     }
 
-    size_t num_blocks() const {
+    size_t num_blocks() const
+    {
         return impl_->num_blocks();
     }
 
-    void append(const SegmentInMemory& other) {
+    void append(const SegmentInMemory& other)
+    {
         impl_->append(*other.impl_);
     }
 
-    util::BitSet get_duplicates_bitset(SegmentInMemory& other) {
+    util::BitSet get_duplicates_bitset(SegmentInMemory& other)
+    {
         return impl_->get_duplicates_bitset(*other.impl_);
     }
 
-    void drop_column(position_t column) {
+    void drop_column(position_t column)
+    {
         impl_->drop_column(column);
     }
 
     template<typename T>
-    std::optional<T> scalar_at(position_t row, position_t col) const {
+    std::optional<T> scalar_at(position_t row, position_t col) const
+    {
         return impl_->scalar_at<T>(row, col);
     }
 
     template<typename T>
-    std::optional<TensorType<T>> tensor_at(position_t row, position_t col) const {
+    std::optional<TensorType<T>> tensor_at(position_t row, position_t col) const
+    {
         return impl_->tensor_at<T>(row, col);
     }
 
-    std::optional<std::string_view> string_at(position_t row, position_t col) const {
+    std::optional<std::string_view> string_at(position_t row, position_t col) const
+    {
         return impl_->string_at(row, col);
     }
 
-    std::optional<Column::StringArrayData> string_array_at(position_t row, position_t col) {
+    std::optional<Column::StringArrayData> string_array_at(position_t row, position_t col)
+    {
         return impl_->string_array_at(row, col);
     }
 
-    size_t num_columns() const { return impl_->num_columns(); }
+    size_t num_columns() const
+    {
+        return impl_->num_columns();
+    }
 
-    size_t num_fields() const { return impl_->num_fields(); }
+    size_t num_fields() const
+    {
+        return impl_->num_fields();
+    }
 
-    size_t row_count() const { return impl_->row_count(); }
+    size_t row_count() const
+    {
+        return impl_->row_count();
+    }
 
-    void unsparsify() {
+    void unsparsify()
+    {
         impl_->unsparsify();
     }
 
-    void sparsify() {
+    void sparsify()
+    {
         impl_->sparsify();
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_external_block(position_t idx, T *val, size_t size) {
+    void set_external_block(position_t idx, T* val, size_t size)
+    {
         impl_->set_external_block(idx, val, size);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_sparse_block(position_t idx, T *val, size_t rows_to_write) {
+    void set_sparse_block(position_t idx, T* val, size_t rows_to_write)
+    {
         impl_->set_sparse_block(idx, val, rows_to_write);
     }
 
-    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, Buffer&& shapes, util::BitSet&& bitset) {
+    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, Buffer&& shapes, util::BitSet&& bitset)
+    {
         impl_->set_sparse_block(idx, std::move(buffer), std::move(shapes), std::move(bitset));
     }
 
-    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, util::BitSet&& bitset) {
+    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, util::BitSet&& bitset)
+    {
         impl_->set_sparse_block(idx, std::move(buffer), std::move(bitset));
     }
 
-    void set_secondary_type(position_t idx, TypeDescriptor type) {
+    void set_secondary_type(position_t idx, TypeDescriptor type)
+    {
         impl_->set_secondary_type(idx, type);
     }
 
-    void set_offset(ssize_t offset) {
+    void set_offset(ssize_t offset)
+    {
         impl_->set_offset(offset);
     }
 
-    ssize_t offset() const {
+    ssize_t offset() const
+    {
         return impl_->offset();
     }
 
-    void clear() {
+    void clear()
+    {
         impl_->clear();
     }
 
-    void end_block_write(size_t size) {
+    void end_block_write(size_t size)
+    {
         impl_->end_block_write(size);
     }
 
-    size_t string_pool_size() const { return impl_->string_pool_size(); }
+    size_t string_pool_size() const
+    {
+        return impl_->string_pool_size();
+    }
 
-    bool has_string_pool() const { return impl_->has_string_pool(); }
+    bool has_string_pool() const
+    {
+        return impl_->has_string_pool();
+    }
 
-    static FieldDescriptor string_pool_descriptor() {
+    static FieldDescriptor string_pool_descriptor()
+    {
         return SegmentInMemoryImpl::string_pool_descriptor();
     }
 
-    ColumnData string_pool_data() const {
+    ColumnData string_pool_data() const
+    {
         return impl_->string_pool_data();
     }
 
-    ColumnData column_data(size_t col) const {
+    ColumnData column_data(size_t col) const
+    {
         return impl_->column_data(col);
     }
 
-    const StreamDescriptor &descriptor() const {
+    const StreamDescriptor& descriptor() const
+    {
         return impl_->descriptor();
     }
 
-    StreamDescriptor &descriptor() {
+    StreamDescriptor& descriptor()
+    {
         return impl_->descriptor();
     }
 
-    const std::shared_ptr<StreamDescriptor>& descriptor_ptr() const {
+    const std::shared_ptr<StreamDescriptor>& descriptor_ptr() const
+    {
         return impl_->descriptor_ptr();
     }
-    StringPool &string_pool() {
+    StringPool& string_pool()
+    {
         return impl_->string_pool();
     }
 
-    void string_pool_assign(const SegmentInMemory& other) {
+    void string_pool_assign(const SegmentInMemory& other)
+    {
         impl_->string_pool_assign(*other.impl_);
     }
 
-    const StringPool &const_string_pool() const {
+    const StringPool& const_string_pool() const
+    {
         return impl_->string_pool();
     }
 
-    const std::shared_ptr<StringPool>& string_pool_ptr() const {
+    const std::shared_ptr<StringPool>& string_pool_ptr() const
+    {
         return impl_->string_pool_ptr();
     }
 
-    void set_metadata(google::protobuf::Any &&meta) {
+    void set_metadata(google::protobuf::Any&& meta)
+    {
         impl_->set_metadata(std::move(meta));
     }
 
-    void override_metadata(google::protobuf::Any &&meta) {
+    void override_metadata(google::protobuf::Any&& meta)
+    {
         impl_->override_metadata(std::move(meta));
     }
 
-    ssize_t get_row_id() {
+    ssize_t get_row_id()
+    {
         return impl_->get_row_id();
     }
 
-    void set_row_id(ssize_t rid) {
+    void set_row_id(ssize_t rid)
+    {
         impl_->set_row_id(rid);
     }
 
-    void set_row_data(ssize_t rid) {
+    void set_row_data(ssize_t rid)
+    {
         impl_->set_row_data(rid);
     }
 
-    const google::protobuf::Any *metadata() const {
+    const google::protobuf::Any* metadata() const
+    {
         return impl_->metadata();
     }
 
-    bool is_index_sorted() const {
+    bool is_index_sorted() const
+    {
         return impl_->is_index_sorted();
     }
 
-    void sort(const std::string& column) {
+    void sort(const std::string& column)
+    {
         impl_->sort(column);
     }
 
-    void sort(position_t column) {
+    void sort(position_t column)
+    {
         impl_->sort(column);
     }
 
-    SegmentInMemory clone() {
+    SegmentInMemory clone()
+    {
         return SegmentInMemory(std::make_shared<SegmentInMemoryImpl>(impl_->clone()));
     }
 
-    void set_string_pool(const std::shared_ptr<StringPool>& string_pool) {
+    void set_string_pool(const std::shared_ptr<StringPool>& string_pool)
+    {
         impl_->set_string_pool(string_pool);
     }
 
-    SegmentInMemory filter(const util::BitSet& filter_bitset,
-                           bool filter_down_stringpool=false,
-                           bool validate=false) const{
+    SegmentInMemory
+    filter(const util::BitSet& filter_bitset, bool filter_down_stringpool = false, bool validate = false) const
+    {
         return SegmentInMemory(impl_->filter(filter_bitset, filter_down_stringpool, validate));
     }
 
-    bool empty() const {
+    bool empty() const
+    {
         return is_null() || impl_->empty();
     }
 
-    bool is_null() const {
+    bool is_null() const
+    {
         return !static_cast<bool>(impl_);
     }
 
-    size_t num_bytes() const {
+    size_t num_bytes() const
+    {
         return impl_->num_bytes();
     }
 
-    bool compacted() const  {
+    bool compacted() const
+    {
         return impl_->compacted();
     }
 
-    void set_compacted(bool val) {
+    void set_compacted(bool val)
+    {
         impl_->set_compacted(val);
     }
 
-    void change_schema(const StreamDescriptor& descriptor) {
+    void change_schema(const StreamDescriptor& descriptor)
+    {
         return impl_->change_schema(descriptor);
     }
 
-    SegmentInMemoryImpl* impl() {
+    SegmentInMemoryImpl* impl()
+    {
         return impl_.get();
     }
 
-    void check_magic() const {
+    void check_magic() const
+    {
         impl_->check_magic();
     }
 
-    void compact_blocks() {
+    void compact_blocks()
+    {
         impl_->compact_blocks();
     }
 
-    std::shared_ptr<Column> column_ptr(position_t idx) {
+    std::shared_ptr<Column> column_ptr(position_t idx)
+    {
         return impl_->column_ptr(idx);
     }
 
-    template <typename RowType>
-    RowType make_row_ref(std::size_t row_id) {
+    template<typename RowType>
+    RowType make_row_ref(std::size_t row_id)
+    {
         if constexpr (std::is_same_v<RowType, Row>) {
             return RowType(impl(), row_id);
         } else {
@@ -405,29 +509,33 @@ public:
         }
     }
 
-    bool allow_sparse() const {
+    bool allow_sparse() const
+    {
         return impl_->allow_sparse();
     }
 
-
-    bool is_sparse() const {
+    bool is_sparse() const
+    {
         return impl_->is_sparse();
     }
 
-    [[nodiscard]] std::vector<SegmentInMemory> split(size_t rows) const {
+    [[nodiscard]] std::vector<SegmentInMemory> split(size_t rows) const
+    {
         std::vector<SegmentInMemory> output;
         auto new_impls = impl_->split(rows);
-        for(const auto& impl : new_impls)
+        for (const auto& impl : new_impls)
             output.push_back(SegmentInMemory{impl});
 
         return output;
     }
 
 private:
-    explicit SegmentInMemory(std::shared_ptr<SegmentInMemoryImpl> impl) :
-            impl_(std::move(impl)) {}
+    explicit SegmentInMemory(std::shared_ptr<SegmentInMemoryImpl> impl)
+        : impl_(std::move(impl))
+    {
+    }
 
     std::shared_ptr<SegmentInMemoryImpl> impl_;
 };
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -35,105 +35,124 @@ class SegmentInMemoryImpl;
 namespace {
 inline std::shared_ptr<SegmentInMemoryImpl> allocate_sparse_segment(const StreamId& id, const IndexDescriptor& index);
 
-inline std::shared_ptr<SegmentInMemoryImpl> allocate_dense_segment(const StreamDescriptor& descriptor, size_t row_count);
+inline std::shared_ptr<SegmentInMemoryImpl> allocate_dense_segment(const StreamDescriptor& descriptor,
+    size_t row_count);
 
 inline void check_output_bitset(const arcticdb::util::BitSet& output,
-                                const arcticdb::util::BitSet& filter,
-                                const arcticdb::util::BitSet& column_bitset
-                                ){
+    const arcticdb::util::BitSet& filter,
+    const arcticdb::util::BitSet& column_bitset)
+{
     // The logic here is that the filter bitset defines how the output bitset should look
     // The set bits in filter decides the row ids in the output. The corresponding values in sparse_map
     // should match output bitset
     auto filter_iter = filter.first();
     arcticdb::util::BitSetSizeType output_pos = 0;
-    while(filter_iter != filter.end()) {
+    while (filter_iter != filter.end()) {
         arcticdb::util::check_rte(column_bitset.test(*(filter_iter++)) == output.test(output_pos++),
-                                 "Mismatch in output bitset in filter_segment");
+            "Mismatch in output bitset in filter_segment");
     }
 }
 } // namespace
 
-inline bool operator==(const FieldDescriptor::Proto& left, const FieldDescriptor::Proto& right) {
+inline bool operator==(const FieldDescriptor::Proto& left, const FieldDescriptor::Proto& right)
+{
     google::protobuf::util::MessageDifferencer diff;
     return diff.Compare(left, right);
 }
 
-inline bool operator<(const FieldDescriptor::Proto& left, const FieldDescriptor::Proto& right) {
+inline bool operator<(const FieldDescriptor::Proto& left, const FieldDescriptor::Proto& right)
+{
     return left.name() < right.name();
 }
 
 class SegmentInMemoryImpl {
 public:
     struct Location {
-        Location(SegmentInMemoryImpl *parent,
-                 ssize_t row_id_,
-                 size_t column_id) :
-                 parent_(parent),
-                 row_id_(row_id_),
-                 column_id_(column_id) {
+        Location(SegmentInMemoryImpl* parent, ssize_t row_id_, size_t column_id)
+            : parent_(parent),
+              row_id_(row_id_),
+              column_id_(column_id)
+        {
         }
 
         template<class Callable>
-            auto visit(Callable &&c) const {
-            return entity::visit_field(parent_->descriptor().field(column_id_), [that=this, c=std::forward<Callable>(c)](auto type_desc_tag) {
-                using RawType = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag::raw_type;
-                return c(that->parent_->scalar_at<RawType>(that->row_id_, that->column_id_));
-            });
+        auto visit(Callable&& c) const
+        {
+            return entity::visit_field(parent_->descriptor().field(column_id_),
+                [that = this, c = std::forward<Callable>(c)](auto type_desc_tag) {
+                    using RawType = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag::raw_type;
+                    return c(that->parent_->scalar_at<RawType>(that->row_id_, that->column_id_));
+                });
         }
 
         template<class Callable>
-            auto visit_string(Callable &&c) const {
-            return entity::visit_field(parent_->descriptor().field(column_id_), [that=this, c = std::forward<Callable>(c)](auto type_desc_tag) {
-                using DTT = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag;
-                if constexpr(is_sequence_type(DTT::data_type))
-                return c(that->parent_->string_at(that->row_id_, position_t(that->column_id_)));
-            });
+        auto visit_string(Callable&& c) const
+        {
+            return entity::visit_field(parent_->descriptor().field(column_id_),
+                [that = this, c = std::forward<Callable>(c)](auto type_desc_tag) {
+                    using DTT = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag;
+                    if constexpr (is_sequence_type(DTT::data_type))
+                        return c(that->parent_->string_at(that->row_id_, position_t(that->column_id_)));
+                });
         }
 
         template<class Callable>
-            auto visit_field(Callable &&c) const {
+        auto visit_field(Callable&& c) const
+        {
             const auto& field = parent_->descriptor().field(column_id_);
-            return entity::visit_field(parent_->descriptor().field(column_id_), [&field, that=this, c = std::forward<Callable>(c)](auto type_desc_tag) {
-                using DataTypeTag = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag;
-                using RawType = typename DataTypeTag::raw_type;
-                if constexpr (is_sequence_type(DataTypeTag::data_type))
-                return c(that->parent_->string_at(that->row_id_, position_t(that->column_id_)), std::string_view{field.name()}, type_desc_from_proto(field.type_desc()));
-                else
-                    return c(that->parent_->scalar_at<RawType>(that->row_id_, that->column_id_), std::string_view{field.name()}, type_desc_from_proto(field.type_desc()));
-            });
+            return entity::visit_field(parent_->descriptor().field(column_id_),
+                [&field, that = this, c = std::forward<Callable>(c)](auto type_desc_tag) {
+                    using DataTypeTag = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag;
+                    using RawType = typename DataTypeTag::raw_type;
+                    if constexpr (is_sequence_type(DataTypeTag::data_type))
+                        return c(that->parent_->string_at(that->row_id_, position_t(that->column_id_)),
+                            std::string_view{field.name()},
+                            type_desc_from_proto(field.type_desc()));
+                    else
+                        return c(that->parent_->scalar_at<RawType>(that->row_id_, that->column_id_),
+                            std::string_view{field.name()},
+                            type_desc_from_proto(field.type_desc()));
+                });
         }
 
         template<class Callable>
-            auto visit(Callable &&c) {
-            return entity::visit_field(parent_->descriptor().field(column_id_), [that=this, c=std::forward<Callable>(c)](auto type_desc_tag) {
-                using RawType = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag::raw_type;
-                return c(that->parent_->reference_at<RawType>(that->row_id_, that->column_id_));
-            });
+        auto visit(Callable&& c)
+        {
+            return entity::visit_field(parent_->descriptor().field(column_id_),
+                [that = this, c = std::forward<Callable>(c)](auto type_desc_tag) {
+                    using RawType = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag::raw_type;
+                    return c(that->parent_->reference_at<RawType>(that->row_id_, that->column_id_));
+                });
         }
 
-        [[nodiscard]] bool has_value() const {
+        [[nodiscard]] bool has_value() const
+        {
             return parent_->has_value_at(row_id_, position_t(column_id_));
         }
 
         template<typename RawType>
-        RawType &value() {
+        RawType& value()
+        {
             return parent_->reference_at<RawType>(row_id_, column_id_);
         }
 
         template<typename RawType>
-        [[nodiscard]] const RawType &value() const {
+        [[nodiscard]] const RawType& value() const
+        {
             return parent_->reference_at<RawType>(row_id_, column_id_);
         }
 
-        [[nodiscard]] auto get_field() const {
+        [[nodiscard]] auto get_field() const
+        {
             return parent_->descriptor().field(column_id_);
         }
 
-        bool operator==(const Location &other) const {
+        bool operator==(const Location& other) const
+        {
             return row_id_ == other.row_id_ && column_id_ == other.column_id_;
         }
 
-        SegmentInMemoryImpl *const parent_;
+        SegmentInMemoryImpl* const parent_;
         ssize_t row_id_;
         size_t column_id_;
     };
@@ -145,48 +164,59 @@ public:
      * As a result this is probably not what you want unless you *know* that it is what you want.
      */
     template<class ValueType>
-        class RowIterator
-            : public boost::iterator_facade<RowIterator<ValueType>, ValueType, boost::random_access_traversal_tag> {
-        public:
-            RowIterator(SegmentInMemoryImpl *parent,
-                        ssize_t row_id_,
-                        size_t column_id) :
-                        location_(parent, row_id_, column_id) {
-            }
+    class RowIterator
+        : public boost::iterator_facade<RowIterator<ValueType>, ValueType, boost::random_access_traversal_tag> {
+    public:
+        RowIterator(SegmentInMemoryImpl* parent, ssize_t row_id_, size_t column_id)
+            : location_(parent, row_id_, column_id)
+        {
+        }
 
-            RowIterator(SegmentInMemoryImpl *parent,
-                        ssize_t row_id_) :
-                        location_(parent, row_id_, 0) {
-            }
+        RowIterator(SegmentInMemoryImpl* parent, ssize_t row_id_)
+            : location_(parent, row_id_, 0)
+        {
+        }
 
-            template<class OtherValue>
-                explicit RowIterator(const RowIterator<OtherValue> &other)
-                : location_(other.location_) {}
+        template<class OtherValue>
+        explicit RowIterator(const RowIterator<OtherValue>& other)
+            : location_(other.location_)
+        {
+        }
 
+    private:
+        friend class boost::iterator_core_access;
 
-        private:
-            friend class boost::iterator_core_access;
+        template<class>
+        friend class SegmentIterator;
 
-            template<class> friend
-                class SegmentIterator;
+        template<class OtherValue>
+        bool equal(const RowIterator<OtherValue>& other) const
+        {
+            return location_ == other.location_;
+        }
 
-            template<class OtherValue>
-                bool equal(const RowIterator<OtherValue> &other) const {
-                    return location_ == other.location_;
-                }
+        void increment()
+        {
+            ++location_.column_id_;
+        }
 
-                void increment() { ++location_.column_id_; }
+        void decrement()
+        {
+            --location_.column_id_;
+        }
 
-                void decrement() { --location_.column_id_; }
+        void advance(ptrdiff_t n)
+        {
+            location_.column_id_ += n;
+        }
 
-                void advance(ptrdiff_t n) { location_.column_id_ += n; }
+        ValueType& dereference() const
+        {
+            return location_;
+        }
 
-                ValueType &dereference() const {
-                    return location_;
-                }
-
-                mutable Location location_;
-        };
+        mutable Location location_;
+    };
 
     struct Row {
         Row() = default;
@@ -194,132 +224,162 @@ public:
         ~Row() = default;
         Row(const Row& other) = default;
 
-        Row(SegmentInMemoryImpl *parent, ssize_t row_id_) :
-        parent_(parent),
-        row_id_(row_id_) {}
+        Row(SegmentInMemoryImpl* parent, ssize_t row_id_)
+            : parent_(parent),
+              row_id_(row_id_)
+        {
+        }
 
         template<typename Callable>
-        auto visit_field(size_t field_num, Callable &&c) const {
+        auto visit_field(size_t field_num, Callable&& c) const
+        {
             return type_desc_from_proto(descriptor()[field_num].type_desc()).visit_tag(std::forward<Callable>(c));
         }
 
         template<typename Callable>
-        auto visit_scalar(size_t field_num, Callable &&c) const {
-            return type_desc_from_proto(descriptor()[field_num].type_desc()).visit_tag([field_num, that=this, c = std::forward<Callable>(c)](auto type_desc_tag) {
-                using RawType =  typename decltype(type_desc_tag)::DataTypeTag::raw_type;
-                return c(that->parent_->scalar_at<RawType>(that->row_id_, field_num));
-            });
+        auto visit_scalar(size_t field_num, Callable&& c) const
+        {
+            return type_desc_from_proto(descriptor()[field_num].type_desc())
+                .visit_tag([field_num, that = this, c = std::forward<Callable>(c)](auto type_desc_tag) {
+                    using RawType = typename decltype(type_desc_tag)::DataTypeTag::raw_type;
+                    return c(that->parent_->scalar_at<RawType>(that->row_id_, field_num));
+                });
         }
 
         template<typename Callable, typename RestrictType>
-        auto visit_scalar_type(size_t field_num, const RestrictType &, Callable &&c) const {
-            return type_desc_from_proto(descriptor()[field_num].type_desc()).visit_tag([field_num, that=this, c = std::forward<Callable>(c)](auto type_desc_tag) {
-                using RawType =  typename decltype(type_desc_tag)::DataTypeTag::raw_type;
-                if constexpr(std::is_same_v<RawType, RestrictType>)
-                return c(that->parent_->scalar_at<RawType>(that->row_id_, field_num));
-            });
+        auto visit_scalar_type(size_t field_num, const RestrictType&, Callable&& c) const
+        {
+            return type_desc_from_proto(descriptor()[field_num].type_desc())
+                .visit_tag([field_num, that = this, c = std::forward<Callable>(c)](auto type_desc_tag) {
+                    using RawType = typename decltype(type_desc_tag)::DataTypeTag::raw_type;
+                    if constexpr (std::is_same_v<RawType, RestrictType>)
+                        return c(that->parent_->scalar_at<RawType>(that->row_id_, field_num));
+                });
         }
 
         template<typename Callable>
-        auto visit_string(size_t field_num, Callable &&c) const {
-            return type_desc_from_proto(descriptor()[field_num].type_desc()).visit_tag([field_num, that=this, c = std::forward<Callable>(c)](auto type_desc_tag) {
-                using DTT =  typename decltype(type_desc_tag)::DataTypeTag;
-                if constexpr(is_sequence_type(DTT::data_type))
-                return c(that->parent_->string_at(that->row_id_, position_t(field_num)));
-                else
-                    util::raise_rte("Invalid type {} in visit_string", DTT::data_type);
-            });
+        auto visit_string(size_t field_num, Callable&& c) const
+        {
+            return type_desc_from_proto(descriptor()[field_num].type_desc())
+                .visit_tag([field_num, that = this, c = std::forward<Callable>(c)](auto type_desc_tag) {
+                    using DTT = typename decltype(type_desc_tag)::DataTypeTag;
+                    if constexpr (is_sequence_type(DTT::data_type))
+                        return c(that->parent_->string_at(that->row_id_, position_t(field_num)));
+                    else
+                        util::raise_rte("Invalid type {} in visit_string", DTT::data_type);
+                });
         }
 
-        [[nodiscard]] SegmentInMemoryImpl& segment() const {
+        [[nodiscard]] SegmentInMemoryImpl& segment() const
+        {
             return *parent_;
         }
 
-        [[nodiscard]] const StreamDescriptor &descriptor() const {
+        [[nodiscard]] const StreamDescriptor& descriptor() const
+        {
             return parent_->descriptor();
         }
 
-        bool operator<(const Row &other) const {
-            return visit_field(0, [that=this, &other](auto type_desc_tag) {
-                using RawType =  typename decltype(type_desc_tag)::DataTypeTag::raw_type;
+        bool operator<(const Row& other) const
+        {
+            return visit_field(0, [that = this, &other](auto type_desc_tag) {
+                using RawType = typename decltype(type_desc_tag)::DataTypeTag::raw_type;
                 return that->parent_->scalar_at<RawType>(that->row_id_, 0) <
-                other.parent_->scalar_at<RawType>(other.row_id_, 0);
+                       other.parent_->scalar_at<RawType>(other.row_id_, 0);
             });
         }
 
-        [[nodiscard]] size_t col_count() const { return parent_->num_columns(); }
+        [[nodiscard]] size_t col_count() const
+        {
+            return parent_->num_columns();
+        }
 
-        [[nodiscard]] size_t row_pos() const { return row_id_; }
+        [[nodiscard]] size_t row_pos() const
+        {
+            return row_id_;
+        }
 
         template<class IndexType>
-            auto index() {
-            using RawType =  typename IndexType::TypeDescTag::DataTypeTag::raw_type;
+        auto index()
+        {
+            using RawType = typename IndexType::TypeDescTag::DataTypeTag::raw_type;
             return parent_->scalar_at<RawType>(row_id_, 0).value();
         }
 
         template<class IndexType>
-            auto index() const {
-            using RawType =  typename IndexType::TypeDescTag::DataTypeTag::raw_type;
+        auto index() const
+        {
+            using RawType = typename IndexType::TypeDescTag::DataTypeTag::raw_type;
             return parent_->scalar_at<RawType>(row_id_, 0).value();
         }
 
-        friend void swap(Row &left, Row &right) noexcept {
+        friend void swap(Row& left, Row& right) noexcept
+        {
             using std::swap;
 
             auto a = left.begin();
             auto b = right.begin();
             for (; a != left.end(); ++a, ++b) {
                 util::check(a->has_value() && b->has_value(), "Can't swap sparse column values, unsparsify first?");
-                a->visit([&b](auto &val) {
+                a->visit([&b](auto& val) {
                     using ValType = std::decay_t<decltype(val)>;
                     swap(val, b->value<ValType>());
                 });
             }
         }
 
-        Row &operator=(const Row &other) = default;
+        Row& operator=(const Row& other) = default;
 
-        Location operator[](int pos) const {
+        Location operator[](int pos) const
+        {
             return Location{parent_, row_id_, size_t(pos)};
         }
 
         using iterator = RowIterator<Location>;
         using const_iterator = RowIterator<const Location>;
 
-        iterator begin() {
+        iterator begin()
+        {
             return {parent_, row_id_};
         }
 
-        iterator end() {
+        iterator end()
+        {
             return {parent_, row_id_, size_t(parent_->descriptor().fields().size())};
         }
 
-        [[nodiscard]] const_iterator begin() const {
+        [[nodiscard]] const_iterator begin() const
+        {
             return {parent_, row_id_};
         }
 
-        [[nodiscard]] const_iterator end() const {
+        [[nodiscard]] const_iterator end() const
+        {
             return {parent_, row_id_, size_t(parent_->descriptor().fields().size())};
         }
 
-        bool operator==(const Row &other) const {
+        bool operator==(const Row& other) const
+        {
             return row_id_ == other.row_id_ && parent_ == other.parent_;
         }
 
-        void assert_same_parent(const Row &other) const {
+        void assert_same_parent(const Row& other) const
+        {
             util::check(parent_ == other.parent_, "Invalid iterator comparison, different parents");
         }
 
-        void swap_parent(const Row &other) {
+        void swap_parent(const Row& other)
+        {
             parent_ = other.parent_;
         }
 
         template<class S>
-            std::optional<S> scalar_at(std::size_t col) const {
+        std::optional<S> scalar_at(std::size_t col) const
+        {
             parent_->check_magic();
             const auto type_desc = type_desc_from_proto(parent_->column_descriptor(col).type_desc());
             std::optional<S> val;
-            type_desc.visit_tag([that=this, col, &val](auto impl) {
+            type_desc.visit_tag([that = this, col, &val](auto impl) {
                 using T = std::decay_t<decltype(impl)>;
                 using RawType = typename T::DataTypeTag::raw_type;
                 if constexpr (T::DimensionTag::value == Dimension::Dim0) {
@@ -327,8 +387,8 @@ public:
                         // test only for now
                         throw std::runtime_error("string type not implemented");
                     } else {
-                        if constexpr(std::is_same_v<RawType, S>)
-                        val = that->parent_->scalar_at<RawType>(that->row_id_, col);
+                        if constexpr (std::is_same_v<RawType, S>)
+                            val = that->parent_->scalar_at<RawType>(that->row_id_, col);
                         else
                             util::raise_rte("Type mismatch in scalar access");
                     }
@@ -339,128 +399,163 @@ public:
             return val;
         }
 
-        [[nodiscard]] std::optional<std::string_view> string_at(std::size_t col) const {
+        [[nodiscard]] std::optional<std::string_view> string_at(std::size_t col) const
+        {
             return parent_->string_at(row_id_, col);
         }
 
-        SegmentInMemoryImpl *parent_;
+        SegmentInMemoryImpl* parent_;
         ssize_t row_id_;
     };
 
     template<class ValueType>
-        class SegmentIterator
-            : public boost::iterator_facade<SegmentIterator<ValueType>, ValueType, boost::random_access_traversal_tag> {
-        public:
-            using value_type = ValueType;
+    class SegmentIterator
+        : public boost::iterator_facade<SegmentIterator<ValueType>, ValueType, boost::random_access_traversal_tag> {
+    public:
+        using value_type = ValueType;
 
-            explicit SegmentIterator(SegmentInMemoryImpl *parent) :
-            row_(parent, 0) {
-            }
+        explicit SegmentIterator(SegmentInMemoryImpl* parent)
+            : row_(parent, 0)
+        {
+        }
 
-            ~SegmentIterator() = default;
+        ~SegmentIterator() = default;
 
-            SegmentIterator(const SegmentIterator& other) = default;
+        SegmentIterator(const SegmentIterator& other) = default;
 
-            SegmentIterator &operator=(const SegmentIterator &other) {
-                row_.swap_parent(other.row_);
-                row_.row_id_ = other.row_.row_id_;
-                return *this;
-            }
+        SegmentIterator& operator=(const SegmentIterator& other)
+        {
+            row_.swap_parent(other.row_);
+            row_.row_id_ = other.row_.row_id_;
+            return *this;
+        }
 
-            SegmentIterator(SegmentInMemoryImpl *parent, ssize_t row_id_) :
-            row_(parent, row_id_) {
-            }
+        SegmentIterator(SegmentInMemoryImpl* parent, ssize_t row_id_)
+            : row_(parent, row_id_)
+        {
+        }
 
-            template<class OtherValue>
-                explicit SegmentIterator(const SegmentIterator<OtherValue> &other)
-                : row_(other.row_) {}
+        template<class OtherValue>
+        explicit SegmentIterator(const SegmentIterator<OtherValue>& other)
+            : row_(other.row_)
+        {
+        }
 
-        private:
-            friend class boost::iterator_core_access;
+    private:
+        friend class boost::iterator_core_access;
 
-            template<class> friend
-                class SegmentIterator;
+        template<class>
+        friend class SegmentIterator;
 
-            template<class OtherValue>
-                bool equal(const SegmentIterator<OtherValue> &other) const {
-                    return row_ == other.row_;
-                }
+        template<class OtherValue>
+        bool equal(const SegmentIterator<OtherValue>& other) const
+        {
+            return row_ == other.row_;
+        }
 
-                std::ptrdiff_t distance_to(const SegmentIterator &other) const {
-                    return other.row_.row_id_ - row_.row_id_;
-                }
+        std::ptrdiff_t distance_to(const SegmentIterator& other) const
+        {
+            return other.row_.row_id_ - row_.row_id_;
+        }
 
-                void increment() { ++row_.row_id_; }
+        void increment()
+        {
+            ++row_.row_id_;
+        }
 
-                void decrement() { --row_.row_id_; }
+        void decrement()
+        {
+            --row_.row_id_;
+        }
 
-                void advance(ptrdiff_t n) { row_.row_id_ += n; }
+        void advance(ptrdiff_t n)
+        {
+            row_.row_id_ += n;
+        }
 
-                ValueType &dereference() const {
-                    return row_;
-                }
+        ValueType& dereference() const
+        {
+            return row_;
+        }
 
-                mutable Row row_;
-        };
+        mutable Row row_;
+    };
 
     using iterator = SegmentIterator<Row>;
     using const_iterator = SegmentIterator<const Row>;
 
     SegmentInMemoryImpl() = default;
 
-    explicit SegmentInMemoryImpl(
-        const StreamDescriptor &desc,
+    explicit SegmentInMemoryImpl(const StreamDescriptor& desc,
         size_t expected_column_size,
         bool presize,
-        bool allow_sparse) :
-        descriptor_(std::make_shared<StreamDescriptor>(StreamDescriptor{desc.id(), desc.index(), {}})),
-        allow_sparse_(allow_sparse) {
+        bool allow_sparse)
+        : descriptor_(std::make_shared<StreamDescriptor>(StreamDescriptor{desc.id(), desc.index(), {}})),
+          allow_sparse_(allow_sparse)
+    {
         on_descriptor_change(desc, expected_column_size, presize, allow_sparse);
     }
 
-    ~SegmentInMemoryImpl() {
+    ~SegmentInMemoryImpl()
+    {
         ARCTICDB_TRACE(log::version(), "Destroying segment in memory");
     }
 
-    iterator begin() { return iterator{this}; }
+    iterator begin()
+    {
+        return iterator{this};
+    }
 
-    iterator end() {
+    iterator end()
+    {
         util::check(row_id_ != -1, "End iterator called with negative row id, iterator will never terminate");
         return iterator{this, row_id_ + 1};
     }
 
-    const_iterator begin() const {
+    const_iterator begin() const
+    {
         return const_iterator{const_cast<SegmentInMemoryImpl*>(this)};
     }
 
-    const_iterator end() const {
+    const_iterator end() const
+    {
         util::check(row_id_ != -1, "End iterator called with negative row id, iterator will never terminate");
-        return const_iterator{const_cast<SegmentInMemoryImpl*>(this), row_id_} ;
+        return const_iterator{const_cast<SegmentInMemoryImpl*>(this), row_id_};
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT_EXCEPT(SegmentInMemoryImpl)
 
-    void generate_column_map() const {
+    void generate_column_map() const
+    {
         if (column_map_) {
             column_map_->clear();
             column_map_->set_from_descriptor(*descriptor_);
         }
     }
 
-    void create_columns(size_t old_size, size_t expected_column_size, bool presize, bool allow_sparse) {
+    void create_columns(size_t old_size, size_t expected_column_size, bool presize, bool allow_sparse)
+    {
         columns_.reserve(descriptor_->field_count());
         for (size_t i = old_size; i < size_t(descriptor_->field_count()); ++i) {
             auto type = type_desc_from_proto(descriptor_->fields(i).type_desc());
             util::check(type.data_type() != DataType::UNKNOWN, "Can't create column with unknown data type");
-            columns_.emplace_back(
-                std::make_shared<Column>(type_desc_from_proto(descriptor_->fields(i).type_desc()), expected_column_size, presize, allow_sparse));
+            columns_.emplace_back(std::make_shared<Column>(type_desc_from_proto(descriptor_->fields(i).type_desc()),
+                expected_column_size,
+                presize,
+                allow_sparse));
         }
         generate_column_map();
     }
 
-    size_t on_descriptor_change(const StreamDescriptor &descriptor, size_t expected_column_size, bool presize, bool allow_sparse) {
-        ARCTICDB_TRACE(log::storage(), "Entering descriptor change: descriptor is currently {}, incoming descriptor '{}'",
-                      *descriptor_, descriptor);
+    size_t on_descriptor_change(const StreamDescriptor& descriptor,
+        size_t expected_column_size,
+        bool presize,
+        bool allow_sparse)
+    {
+        ARCTICDB_TRACE(log::storage(),
+            "Entering descriptor change: descriptor is currently {}, incoming descriptor '{}'",
+            *descriptor_,
+            descriptor);
 
         std::size_t old_size = descriptor_->fields().size();
         *descriptor_ = descriptor;
@@ -469,170 +564,202 @@ public:
         return old_size;
     }
 
-    std::optional<std::size_t> column_index(std::string_view name) const {
+    std::optional<std::size_t> column_index(std::string_view name) const
+    {
         util::check(!name.empty(), "Cannot get index of empty column name");
         util::check(static_cast<bool>(column_map_), "Uninitialized column map");
         return column_map_->column_index(name);
     }
 
-    const FieldDescriptor::Proto& column_descriptor(size_t col) {
+    const FieldDescriptor::Proto& column_descriptor(size_t col)
+    {
         return (*descriptor_)[col];
     }
 
-    void end_row() {
+    void end_row()
+    {
         row_id_++;
     }
 
-    void end_block_write(ssize_t size) {
+    void end_block_write(ssize_t size)
+    {
         row_id_ += size;
     }
 
-    void set_offset(ssize_t offset) {
+    void set_offset(ssize_t offset)
+    {
         offset_ = offset;
     }
 
-    ssize_t offset() const {
+    ssize_t offset() const
+    {
         return offset_;
     }
 
-    void push_back(const Row &row) {
+    void push_back(const Row& row)
+    {
         for (auto it : folly::enumerate(row)) {
-            it->visit([&it, that=this](const auto &val) {
-                if(val)
+            it->visit([&it, that = this](const auto& val) {
+                if (val)
                     that->set_scalar(it.index, val.value());
             });
         }
         end_row();
     }
 
-    void set_value(position_t idx, const Location &loc) {
-        loc.visit([that=this, idx](const auto& val) {
-            if(val)
+    void set_value(position_t idx, const Location& loc)
+    {
+        loc.visit([that = this, idx](const auto& val) {
+            if (val)
                 that->set_scalar(idx, val.value());
         });
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-        void set_scalar(position_t idx, T val) {
+    void set_scalar(position_t idx, T val)
+    {
         ARCTICDB_TRACE(log::version(), "Segment setting scalar {} at row {} column {}", val, row_id_ + 1, idx);
         column(idx).set_scalar(row_id_ + 1, val);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-        void set_external_block(position_t idx, T *val, size_t size) {
+    void set_external_block(position_t idx, T* val, size_t size)
+    {
         column_unchecked(idx).set_external_block(row_id_ + 1, val, size);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_sparse_block(position_t idx, T *val,  size_t rows_to_write) {
+    void set_sparse_block(position_t idx, T* val, size_t rows_to_write)
+    {
         column_unchecked(idx).set_sparse_block(row_id_ + 1, val, rows_to_write);
     }
 
-    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, util::BitSet&& bitset) {
+    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, util::BitSet&& bitset)
+    {
         column_unchecked(idx).set_sparse_block(std::move(buffer), std::move(bitset));
     }
 
-    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, Buffer&& shapes, util::BitSet&& bitset) {
+    void set_sparse_block(position_t idx, ChunkedBuffer&& buffer, Buffer&& shapes, util::BitSet&& bitset)
+    {
         column_unchecked(idx).set_sparse_block(std::move(buffer), std::move(shapes), std::move(bitset));
     }
 
-    void set_secondary_type(position_t idx, TypeDescriptor type) {
+    void set_secondary_type(position_t idx, TypeDescriptor type)
+    {
         column_unchecked(idx).set_secondary_type(type);
     }
 
     template<class T, std::enable_if_t<std::is_same_v<std::decay_t<T>, std::string>, int> = 0>
-        void set_scalar(position_t idx, T val) {
+    void set_scalar(position_t idx, T val)
+    {
         set_string(idx, val);
     }
 
-    template<class T, template<class> class Tensor, std::enable_if_t<
-        std::is_integral_v<T> || std::is_floating_point_v<T>,
-        int> = 0>
-            void set_array(position_t pos, Tensor<T> &val) {
+    template<class T,
+        template<class>
+        class Tensor,
+        std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    void set_array(position_t pos, Tensor<T>& val)
+    {
         magic_.check();
         ARCTICDB_SAMPLE(MemorySegmentSetArray, 0)
         column_unchecked(pos).set_array(row_id_ + 1, val);
     }
 
-    template<class T, std::enable_if_t<
-        std::is_integral_v<T> || std::is_floating_point_v<T>,
-        int> = 0>
-    void set_array(position_t pos, py::array_t<T>& val) {
+    template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    void set_array(position_t pos, py::array_t<T>& val)
+    {
         magic_.check();
         ARCTICDB_SAMPLE(MemorySegmentSetArray, 0)
-            column_unchecked(pos).set_array(row_id_ + 1, val);
+        column_unchecked(pos).set_array(row_id_ + 1, val);
     }
 
-    void set_string(position_t pos, std::string_view str) {
+    void set_string(position_t pos, std::string_view str)
+    {
         ARCTICDB_TRACE(log::version(), "Segment setting string {} at row {} column {}", str, row_id_ + 1, pos);
         OffsetString ofstr = string_pool_->get(str);
         column_unchecked(pos).set_scalar(row_id_ + 1, ofstr.offset());
     }
 
-    void set_string_at(position_t col, position_t row, const char *str, size_t size) {
+    void set_string_at(position_t col, position_t row, const char* str, size_t size)
+    {
         OffsetString ofstr = string_pool_->get(str, size);
         column_unchecked(col).set_scalar(row, ofstr.offset());
     }
 
-    void set_no_string_at(position_t col, position_t row, OffsetString::offset_t placeholder) {
+    void set_no_string_at(position_t col, position_t row, OffsetString::offset_t placeholder)
+    {
         column_unchecked(col).set_scalar(row, placeholder);
     }
 
-    void set_string_array(position_t idx, size_t string_size, size_t num_strings, char *data) {
+    void set_string_array(position_t idx, size_t string_size, size_t num_strings, char* data)
+    {
         check_column_index(idx);
         column_unchecked(idx).set_string_array(row_id_ + 1, string_size, num_strings, data, string_pool());
     }
 
-    void set_string_list(position_t idx, const std::vector<std::string> &input) {
+    void set_string_list(position_t idx, const std::vector<std::string>& input)
+    {
         check_column_index(idx);
         column_unchecked(idx).set_string_list(row_id_ + 1, input, string_pool());
     }
 
-    Column &column_ref(position_t idx) {
+    Column& column_ref(position_t idx)
+    {
         return column(idx);
     }
 
-    Column &column(position_t idx) {
+    Column& column(position_t idx)
+    {
         check_column_index(idx);
         return column_unchecked(idx);
     }
 
-    const Column &column(position_t idx) const {
+    const Column& column(position_t idx) const
+    {
         check_column_index(idx);
         return column_unchecked(idx);
     }
 
-    Column &column_unchecked(position_t idx) {
+    Column& column_unchecked(position_t idx)
+    {
         return *columns_[idx];
     }
 
-    std::shared_ptr<Column> column_ptr(position_t idx) {
+    std::shared_ptr<Column> column_ptr(position_t idx)
+    {
         return columns_[idx];
     }
 
-    const Column &column_unchecked(position_t idx) const {
+    const Column& column_unchecked(position_t idx) const
+    {
         return *columns_[idx];
     }
 
-    std::vector<std::shared_ptr<Column>> &columns() {
+    std::vector<std::shared_ptr<Column>>& columns()
+    {
         return columns_;
     }
 
-    const std::vector<std::shared_ptr<Column>> &columns() const {
+    const std::vector<std::shared_ptr<Column>>& columns() const
+    {
         return columns_;
     }
 
-    bool empty() const {
+    bool empty() const
+    {
         return row_count() <= 0 && !metadata();
     }
 
-    void unsparsify() const {
-        for(const auto& column : columns_)
+    void unsparsify() const
+    {
+        for (const auto& column : columns_)
             column->unsparsify(row_count());
     }
 
-    void sparsify() const {
-        for(const auto& column : columns_)
+    void sparsify() const
+    {
+        for (const auto& column : columns_)
             column->sparsify();
     }
 
@@ -644,36 +771,38 @@ public:
     void sort(const std::string& column);
     void sort(position_t idx);
 
+    position_t add_column(const FieldDescriptor::Proto& field, const std::shared_ptr<Column>& column);
 
+    position_t add_column(const FieldDescriptor::Proto& field, size_t num_rows, bool presize);
 
-    position_t add_column(const FieldDescriptor::Proto &field, const std::shared_ptr<Column>& column);
+    position_t add_column(const FieldDescriptor& field, size_t num_rows, bool presize);
 
-    position_t add_column(const FieldDescriptor::Proto &field, size_t num_rows, bool presize);
-
-    position_t add_column(const FieldDescriptor &field, size_t num_rows, bool presize);
-
-    position_t add_column(const FieldDescriptor &field, const std::shared_ptr<Column>& column);
+    position_t add_column(const FieldDescriptor& field, const std::shared_ptr<Column>& column);
 
     void change_schema(StreamDescriptor descriptor);
 
     template<typename T>
-    std::optional<T> scalar_at(position_t row, position_t col) const {
+    std::optional<T> scalar_at(position_t row, position_t col) const
+    {
         util::check_arg(size_t(row) < row_count(), "Segment index {} out of bounds in scalar", row);
         return column(col).scalar_at<T>(row);
     }
 
-    bool has_value_at(position_t row, position_t col) const {
+    bool has_value_at(position_t row, position_t col) const
+    {
         return column(col).has_value_at(row);
     }
 
     template<typename T>
-    T &reference_at(position_t row, position_t col) {
+    T& reference_at(position_t row, position_t col)
+    {
         util::check_arg(size_t(row) < row_count(), "Segment index {} out of bounds in scalar ref", row);
         return column(col).reference_at<T>(row);
     }
 
     template<typename T>
-    std::optional<TensorType<T>> tensor_at(position_t row, position_t col) const {
+    std::optional<TensorType<T>> tensor_at(position_t row, position_t col) const
+    {
         util::check_arg(size_t(row) < row_count(), "Segment index {} out of bounds in tensor", row);
         return column(col).tensor_at<T>(row);
     }
@@ -686,77 +815,103 @@ public:
 
     size_t num_bytes() const;
 
-    size_t num_columns() const { return columns_.size(); }
+    size_t num_columns() const
+    {
+        return columns_.size();
+    }
 
-    size_t num_fields() const { return descriptor().field_count(); }
+    size_t num_fields() const
+    {
+        return descriptor().field_count();
+    }
 
-    size_t row_count() const { return size_t(row_id_ + 1); }
+    size_t row_count() const
+    {
+        return size_t(row_id_ + 1);
+    }
 
-    void clear() {
+    void clear()
+    {
         columns_.clear();
         string_pool_->clear();
     }
 
-    size_t string_pool_size() const { return string_pool_->size(); }
+    size_t string_pool_size() const
+    {
+        return string_pool_->size();
+    }
 
-    bool has_string_pool() const { return string_pool_size() > 0; }
+    bool has_string_pool() const
+    {
+        return string_pool_size() > 0;
+    }
 
-    const std::shared_ptr<StringPool>& string_pool_ptr() const {
+    const std::shared_ptr<StringPool>& string_pool_ptr() const
+    {
         return string_pool_;
     }
 
-    void check_column_index(position_t idx) const {
+    void check_column_index(position_t idx) const
+    {
         util::check_arg(idx < position_t(columns_.size()), "Column index {} out of bounds", idx);
     }
 
-    static FieldDescriptor string_pool_descriptor() {
+    static FieldDescriptor string_pool_descriptor()
+    {
         return FieldDescriptor{field_proto<Dimension::Dim1>(DataType::UINT8, std::string_view{"__string_pool__"})};
     }
 
-    void init_column_map() const {
+    void init_column_map() const
+    {
         std::lock_guard lock{*column_map_mutex_};
-        if(column_map_)
+        if (column_map_)
             return;
 
         column_map_ = std::make_shared<ColumnMap>(descriptor().field_count());
         column_map_->set_from_descriptor(descriptor());
     }
 
-    ColumnData string_pool_data() const {
-        return ColumnData{
-            &string_pool_->data(),
+    ColumnData string_pool_data() const
+    {
+        return ColumnData{&string_pool_->data(),
             &string_pool_->shapes(),
             string_pool_descriptor().type_desc(),
-            nullptr
-        };
+            nullptr};
     }
 
-    void compact_blocks() const {
-        for(const auto& column : columns_)
+    void compact_blocks() const
+    {
+        for (const auto& column : columns_)
             column->compact_blocks();
     }
 
-    const auto &fields() const {
+    const auto& fields() const
+    {
         return descriptor().fields();
     }
 
-    ColumnData column_data(size_t col) const {
+    ColumnData column_data(size_t col) const
+    {
         return columns_[col]->data();
     }
 
-    const StreamDescriptor &descriptor() const {
+    const StreamDescriptor& descriptor() const
+    {
         return *descriptor_;
     }
 
-    StreamDescriptor &descriptor() {
+    StreamDescriptor& descriptor()
+    {
         return *descriptor_;
     }
 
-    const std::shared_ptr<StreamDescriptor>& descriptor_ptr() const {
+    const std::shared_ptr<StreamDescriptor>& descriptor_ptr() const
+    {
         return descriptor_;
     }
 
-    void drop_column(position_t column) {
+    void drop_column(position_t column)
+    {
         util::check(column < position_t(columns_.size()), "Column index out of range in drop_column");
         auto it = std::begin(columns_);
         std::advance(it, column);
@@ -764,46 +919,58 @@ public:
         descriptor_->erase_field(column);
     }
 
-    const FieldDescriptor::Proto& field(size_t index) const {
+    const FieldDescriptor::Proto& field(size_t index) const
+    {
         return descriptor()[index];
     }
 
-    void set_row_id(ssize_t rid) {
+    void set_row_id(ssize_t rid)
+    {
         row_id_ = rid;
     }
 
-    ssize_t get_row_id() {
+    ssize_t get_row_id()
+    {
         return row_id_;
     }
 
-    void set_row_data(ssize_t rid) {
+    void set_row_data(ssize_t rid)
+    {
         set_row_id(rid);
-        for(const auto& column : columns())
+        for (const auto& column : columns())
             column->set_row_data(row_id_);
     }
 
-    void string_pool_assign(const SegmentInMemoryImpl& other) {
+    void string_pool_assign(const SegmentInMemoryImpl& other)
+    {
         string_pool_ = other.string_pool_;
     }
 
-    StringPool &string_pool() { return *string_pool_; } //TODO protected
+    StringPool& string_pool()
+    {
+        return *string_pool_;
+    } //TODO protected
 
-    void set_metadata(google::protobuf::Any &&meta) {
+    void set_metadata(google::protobuf::Any&& meta)
+    {
         util::check_arg(!metadata_, "Cannot override previously set metadata");
         if (meta.ByteSizeLong())
             metadata_ = std::make_unique<google::protobuf::Any>(std::move(meta));
     }
 
-    void override_metadata(google::protobuf::Any &&meta) {
+    void override_metadata(google::protobuf::Any&& meta)
+    {
         if (meta.ByteSizeLong())
             metadata_ = std::make_unique<google::protobuf::Any>(std::move(meta));
     }
 
-    const google::protobuf::Any *metadata() const {
+    const google::protobuf::Any* metadata() const
+    {
         return metadata_.get();
     }
 
-    bool is_index_sorted() const {
+    bool is_index_sorted() const
+    {
         timestamp idx = 0;
         for (auto it = begin(); it != end(); ++it) {
             auto val = it->begin()->value<timestamp>();
@@ -815,41 +982,43 @@ public:
         return true;
     }
 
-    bool compacted() const {
+    bool compacted() const
+    {
         return compacted_;
     }
 
-    void set_compacted(bool value) {
+    void set_compacted(bool value)
+    {
         compacted_ = value;
     }
 
-    void check_magic() const {
+    void check_magic() const
+    {
         magic_.check();
     }
 
-    friend bool operator==(const SegmentInMemoryImpl& left, const SegmentInMemoryImpl& right) {
-        if(*left.descriptor_ != *right.descriptor_ ||
-        left.offset_ != right.offset_)
+    friend bool operator==(const SegmentInMemoryImpl& left, const SegmentInMemoryImpl& right)
+    {
+        if (*left.descriptor_ != *right.descriptor_ || left.offset_ != right.offset_)
             return false;
 
-        if(left.columns_.size() != right.columns_.size())
+        if (left.columns_.size() != right.columns_.size())
             return false;
 
-        for(auto col = 0u; col < left.columns_.size(); ++col) {
-            if(is_sequence_type(left.column(col).type().data_type())) {
+        for (auto col = 0u; col < left.columns_.size(); ++col) {
+            if (is_sequence_type(left.column(col).type().data_type())) {
                 const auto& left_col = left.column(col);
                 const auto& right_col = right.column(col);
-                if(left_col.type() != right_col.type())
+                if (left_col.type() != right_col.type())
                     return false;
 
-                if(left_col.row_count() != right_col.row_count())
+                if (left_col.row_count() != right_col.row_count())
                     return false;
 
-                for(auto row = 0u; row < left_col.row_count(); ++row)
-                    if(left.string_at(row, col) != right.string_at(row, col))
+                for (auto row = 0u; row < left_col.row_count(); ++row)
+                    if (left.string_at(row, col) != right.string_at(row, col))
                         return false;
-            }
-            else {
+            } else {
                 if (left.column(col) != right.column(col))
                     return false;
             }
@@ -857,29 +1026,30 @@ public:
         return true;
     }
 
-    bool allow_sparse() const{
+    bool allow_sparse() const
+    {
         return allow_sparse_;
     }
 
     // TODO: Potentially slow, fix this by storing it in protobuf
-    bool is_sparse() const {
-        return std::any_of(std::begin(columns_), std::end(columns_), [] (const auto& c) {
-            return c->is_sparse();
-        });
+    bool is_sparse() const
+    {
+        return std::any_of(std::begin(columns_), std::end(columns_), [](const auto& c) { return c->is_sparse(); });
     }
 
-    SegmentInMemoryImpl clone() const {
+    SegmentInMemoryImpl clone() const
+    {
         SegmentInMemoryImpl output{};
         output.row_id_ = row_id_;
         *output.descriptor_ = descriptor_->clone();
 
-        for(const auto& column : columns_) {
+        for (const auto& column : columns_) {
             output.columns_.push_back(std::make_shared<Column>(column->clone()));
         }
 
         output.string_pool_ = string_pool_->clone();
         output.offset_ = offset_;
-        if(metadata_) {
+        if (metadata_) {
             google::protobuf::Any metadata;
             metadata.CopyFrom(*metadata_);
             output.metadata_ = std::make_unique<google::protobuf::Any>(std::move(metadata));
@@ -889,31 +1059,33 @@ public:
         return output;
     }
 
-    void set_string_pool(const std::shared_ptr<StringPool>& string_pool) {
+    void set_string_pool(const std::shared_ptr<StringPool>& string_pool)
+    {
         string_pool_ = string_pool;
     }
 
     // TODO Handle sparse and reinstate
     // This implementation of split is incorrect Column::split doesn't work for sparse columns
     // Will use filter_segment for now - which should do the same amount of copying as this implementation
-    std::vector<std::shared_ptr<SegmentInMemoryImpl>> old_split(size_t rows) {
+    std::vector<std::shared_ptr<SegmentInMemoryImpl>> old_split(size_t rows)
+    {
         std::vector<std::shared_ptr<SegmentInMemoryImpl>> output;
         const auto output_size = std::ceil(double(row_count()) / double(rows));
-        for(auto i = 0u; i < output_size; ++i) {
+        for (auto i = 0u; i < output_size; ++i) {
             output.push_back(std::make_shared<SegmentInMemoryImpl>());
-            if(has_string_pool())
+            if (has_string_pool())
                 (*output.rbegin())->set_string_pool(string_pool_);
         }
 
-        for(const auto& column : folly::enumerate(columns_)) {
+        for (const auto& column : folly::enumerate(columns_)) {
             auto split_columns = Column::split(*column, rows);
-            for(auto split_col : folly::enumerate(split_columns)) {
+            for (auto split_col : folly::enumerate(split_columns)) {
                 output[split_col.index]->add_column(descriptor_->field(column.index), *split_col);
             }
         }
 
         auto remaining_rows = row_count();
-        for(const auto& seg : output) {
+        for (const auto& seg : output) {
             const auto current_rows = std::min(remaining_rows, rows);
             seg->set_row_data(static_cast<ssize_t>(current_rows) - 1);
             remaining_rows -= current_rows;
@@ -923,7 +1095,8 @@ public:
         return output;
     }
 
-    std::shared_ptr<SegmentInMemoryImpl> get_output_segment(size_t num_values, bool pre_allocate=true) const {
+    std::shared_ptr<SegmentInMemoryImpl> get_output_segment(size_t num_values, bool pre_allocate = true) const
+    {
         std::shared_ptr<SegmentInMemoryImpl> output;
         if (is_sparse()) {
             output = allocate_sparse_segment(descriptor().id(), descriptor().index());
@@ -931,18 +1104,22 @@ public:
             if (pre_allocate)
                 output = allocate_dense_segment(descriptor(), num_values);
             else
-                output = allocate_dense_segment(StreamDescriptor(descriptor().id(), descriptor().index(), {}), num_values);
+                output =
+                    allocate_dense_segment(StreamDescriptor(descriptor().id(), descriptor().index(), {}), num_values);
         }
         return output;
     }
 
-    inline std::shared_ptr<SegmentInMemoryImpl> filter(const util::BitSet& filter_bitset,
-                                                       bool filter_down_stringpool=false,
-                                                       bool validate=false) const {
+    inline std::shared_ptr<SegmentInMemoryImpl>
+    filter(const util::BitSet& filter_bitset, bool filter_down_stringpool = false, bool validate = false) const
+    {
         bool is_input_sparse = is_sparse();
-        util::check(is_input_sparse || row_count() == filter_bitset.size(), "Filter input sizes do not match: {} != {}", row_count(), filter_bitset.size());
+        util::check(is_input_sparse || row_count() == filter_bitset.size(),
+            "Filter input sizes do not match: {} != {}",
+            row_count(),
+            filter_bitset.size());
         auto num_values = filter_bitset.count();
-        if(num_values == 0)
+        if (num_values == 0)
             return std::shared_ptr<SegmentInMemoryImpl>{};
 
         auto output = get_output_segment(num_values);
@@ -953,8 +1130,8 @@ public:
 
         // Index is built to make rank queries faster
         std::unique_ptr<util::BitIndex> filter_idx;
-        for(const auto& column : folly::enumerate(columns())) {
-            (*column)->type().visit_tag([&] (auto type_desc_tag){
+        for (const auto& column : folly::enumerate(columns())) {
+            (*column)->type().visit_tag([&](auto type_desc_tag) {
                 using TypeDescriptorTag = decltype(type_desc_tag);
                 using ColumnTagType = typename TypeDescriptorTag::DataTypeTag;
                 using RawType = typename ColumnTagType::raw_type;
@@ -984,7 +1161,7 @@ public:
                 if (sparse_map)
                     output_col.opt_sparse_map() = std::make_optional<util::BitSet>();
                 auto output_ptr = reinterpret_cast<RawType*>(output_col.ptr());
-                auto input_data =  (*column)->data();
+                auto input_data = (*column)->data();
 
                 auto bitset_iter = final_bitset.first();
                 auto row_count_so_far = 0;
@@ -992,12 +1169,12 @@ public:
                 // Defines the position in output sparse column where we want to write data next (only used in sparse)
                 // For dense, we just do +1
                 util::BitSetSizeType pos_output = 0;
-                while(auto block = input_data.next<TypeDescriptorTag>()) {
+                while (auto block = input_data.next<TypeDescriptorTag>()) {
                     if (bitset_iter == final_bitset.end())
                         break;
                     auto input_ptr = block.value().data();
                     if (sparse_map) {
-                        while(bitset_iter != final_bitset.end()) {
+                        while (bitset_iter != final_bitset.end()) {
                             auto rank_in_filter = filter_bitset.rank(*bitset_iter, *filter_idx);
                             if (rank_in_filter - 1 != pos_output) {
                                 // setting sparse_map - marking all rows in output as NULL until this point
@@ -1006,16 +1183,18 @@ public:
                             }
                             auto offset = sparse_map.value().rank(*bitset_iter, *sparse_idx) - row_count_so_far - 1;
                             auto value = *(input_ptr + offset);
-                            if constexpr(is_sequence_type(ColumnTagType::data_type)) {
+                            if constexpr (is_sequence_type(ColumnTagType::data_type)) {
                                 if (filter_down_stringpool) {
                                     if (auto it = input_to_output_offsets.find(value);
-                                    it != input_to_output_offsets.end()) {
+                                        it != input_to_output_offsets.end())
+                                    {
                                         *output_ptr = it->second;
                                     } else {
                                         auto str = string_pool_->get_const_view(value);
                                         auto output_string_pool_offset = output_string_pool->get(str, false).offset();
                                         *output_ptr = output_string_pool_offset;
-                                        input_to_output_offsets.insert_unique(std::move(value), std::move(output_string_pool_offset));
+                                        input_to_output_offsets.insert_unique(std::move(value),
+                                            std::move(output_string_pool_offset));
                                     }
                                 } else {
                                     *output_ptr = value;
@@ -1036,16 +1215,18 @@ public:
                                 break;
 
                             auto value = *(input_ptr + offset);
-                            if constexpr(is_sequence_type(ColumnTagType::data_type)) {
+                            if constexpr (is_sequence_type(ColumnTagType::data_type)) {
                                 if (filter_down_stringpool) {
                                     if (auto it = input_to_output_offsets.find(value);
-                                    it != input_to_output_offsets.end()) {
+                                        it != input_to_output_offsets.end())
+                                    {
                                         *output_ptr = it->second;
                                     } else {
                                         auto str = string_pool_->get_const_view(value);
                                         auto output_string_pool_offset = output_string_pool->get(str, false).offset();
                                         *output_ptr = output_string_pool_offset;
-                                        input_to_output_offsets.insert_unique(std::move(value), std::move(output_string_pool_offset));
+                                        input_to_output_offsets.insert_unique(std::move(value),
+                                            std::move(output_string_pool_offset));
                                     }
                                 } else {
                                     *output_ptr = value;
@@ -1077,13 +1258,13 @@ public:
         return output;
     }
 
-
-    std::vector<std::shared_ptr<SegmentInMemoryImpl>> split(size_t rows) const{
+    std::vector<std::shared_ptr<SegmentInMemoryImpl>> split(size_t rows) const
+    {
         std::vector<std::shared_ptr<SegmentInMemoryImpl>> output;
         util::check(rows > 0, "rows supplied in SegmentInMemoryImpl.split() is non positive");
         auto total_rows = row_count();
         util::BitSetSizeType start = 0;
-        for(; start < total_rows; start += rows) {
+        for (; start < total_rows; start += rows) {
             util::BitSet bitset(total_rows);
             util::BitSetSizeType end = std::min(start + rows, total_rows);
             // set_range is close interval on [left, right]
@@ -1108,13 +1289,15 @@ private:
 };
 
 namespace {
-inline std::shared_ptr<SegmentInMemoryImpl> allocate_sparse_segment(const StreamId& id, const IndexDescriptor& index) {
+inline std::shared_ptr<SegmentInMemoryImpl> allocate_sparse_segment(const StreamId& id, const IndexDescriptor& index)
+{
     return std::make_shared<SegmentInMemoryImpl>(StreamDescriptor{id, index, {}}, 0, false, true);
 }
 
-inline std::shared_ptr<SegmentInMemoryImpl> allocate_dense_segment(const StreamDescriptor& descriptor, size_t row_count) {
+inline std::shared_ptr<SegmentInMemoryImpl> allocate_dense_segment(const StreamDescriptor& descriptor, size_t row_count)
+{
     return std::make_shared<SegmentInMemoryImpl>(descriptor, row_count, true, false);
 }
-} // namespace anon
+} // namespace
 
 } // namespace arcticdb

--- a/cpp/arcticdb/column_store/python_bindings.cpp
+++ b/cpp/arcticdb/column_store/python_bindings.cpp
@@ -16,14 +16,12 @@ namespace py = pybind11;
 
 namespace arcticdb::column_store {
 
-void register_column_store(py::module &m) {
+void register_column_store(py::module& m)
+{
 
-    py::class_<Column>(m, "Column")
-        .def(py::init<>())
-        .def_property_readonly("row_count", &Column::row_count);
+    py::class_<Column>(m, "Column").def(py::init<>()).def_property_readonly("row_count", &Column::row_count);
 
-    py::class_<ColumnData>(m, "ColumnData")
-        .def_property_readonly("type", &ColumnData::type);
+    py::class_<ColumnData>(m, "ColumnData").def_property_readonly("type", &ColumnData::type);
 
     py::class_<StringPool>(m, "StringPool")
         .def(py::init())
@@ -31,5 +29,4 @@ void register_column_store(py::module &m) {
         .def("as_buffer_info", &StringPool::as_buffer_info);
 }
 
-} // namespace arcticc::column_store
-
+} // namespace arcticdb::column_store

--- a/cpp/arcticdb/column_store/python_bindings.hpp
+++ b/cpp/arcticdb/column_store/python_bindings.hpp
@@ -12,9 +12,10 @@ namespace py = pybind11;
 
 namespace arcticdb::column_store {
 
-void register_column_store(py::module &m);
+void register_column_store(py::module& m);
 
-inline void register_bindings(py::module &m) {
+inline void register_bindings(py::module& m)
+{
     auto arcticdb_column_store = m.def_submodule("column_store", R"pydoc(
     In memory column store
     ----------------------
@@ -23,5 +24,4 @@ inline void register_bindings(py::module &m) {
     register_column_store(arcticdb_column_store);
 }
 
-} // namespace arcticc::column_store
-
+} // namespace arcticdb::column_store

--- a/cpp/arcticdb/column_store/row_ref.hpp
+++ b/cpp/arcticdb/column_store/row_ref.hpp
@@ -15,23 +15,26 @@ namespace arcticdb {
 // Deprecated - use SegmentInMemoryImp::Row
 class RowRef {
 public:
-
     RowRef() = default;
 
-    RowRef(size_t row_pos, SegmentInMemory segment) :
-            row_pos_(row_pos),
-            segment_(std::move(segment)) {}
+    RowRef(size_t row_pos, SegmentInMemory segment)
+        : row_pos_(row_pos),
+          segment_(std::move(segment))
+    {
+    }
 
     template<class S>
-    std::optional<S> scalar_at(std::size_t col) const {
+    std::optional<S> scalar_at(std::size_t col) const
+    {
         std::optional<S> res;
         const auto& type_desc = segment_.column_descriptor(col);
-        visit_field(type_desc, [&segment=segment_, row_pos=row_pos_, col=col, &res](auto impl) {
+        visit_field(type_desc, [&segment = segment_, row_pos = row_pos_, col = col, &res](auto impl) {
             using T = std::decay_t<decltype(impl)>;
             using RawType = typename T::DataTypeTag::raw_type;
             if constexpr (T::DimensionTag::value == Dimension::Dim0) {
-                if constexpr (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64
-                        || T::DataTypeTag::data_type == DataType::ASCII_FIXED64) {
+                if constexpr (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64 ||
+                              T::DataTypeTag::data_type == DataType::ASCII_FIXED64)
+                {
                     // test only for now
                     util::raise_rte("not implemented");
                 } else {
@@ -44,35 +47,46 @@ public:
         return res;
     }
 
-    [[nodiscard]] size_t col_count() const { return segment_.num_columns(); }
+    [[nodiscard]] size_t col_count() const
+    {
+        return segment_.num_columns();
+    }
 
-    [[nodiscard]] size_t row_pos() const { return row_pos_; }
+    [[nodiscard]] size_t row_pos() const
+    {
+        return row_pos_;
+    }
 
-    SegmentInMemory &segment() { return segment_; }
+    SegmentInMemory& segment()
+    {
+        return segment_;
+    }
 
-    [[nodiscard]] std::optional<std::string_view> string_at(std::size_t col) const {
+    [[nodiscard]] std::optional<std::string_view> string_at(std::size_t col) const
+    {
         return segment_.string_at(row_pos_, static_cast<ssize_t>(col));
     }
+
 private:
-    static py::buffer_info from_string_array(const Column::StringArrayData &data) {
+    static py::buffer_info from_string_array(const Column::StringArrayData& data)
+    {
         std::vector<ssize_t> shapes{data.num_strings_};
         std::vector<ssize_t> strides{data.string_size_};
 
-        return py::buffer_info{
-                (void *) data.data_,
-                data.string_size_,
-                std::string(fmt::format("{}{}", data.string_size_, 's')),
-                ssize_t(Dimension::Dim1),
-                shapes,
-                strides
-        };
+        return py::buffer_info{(void*)data.data_,
+            data.string_size_,
+            std::string(fmt::format("{}{}", data.string_size_, 's')),
+            ssize_t(Dimension::Dim1),
+            shapes,
+            strides};
     }
 
     size_t row_pos_ = 0u;
     SegmentInMemory segment_;
 };
 
-inline RowRef last_row(const SegmentInMemory& segment) {
+inline RowRef last_row(const SegmentInMemory& segment)
+{
     util::check(segment.row_count() > 0, "Can't do last row on an empty segment");
     return RowRef{segment.row_count(), segment};
 }

--- a/cpp/arcticdb/column_store/segment_utils.hpp
+++ b/cpp/arcticdb/column_store/segment_utils.hpp
@@ -14,12 +14,13 @@
 #include <arcticdb/util/configs_map.hpp>
 
 namespace arcticdb {
-emilib::HashSet<StringPool::offset_t> unique_values_for_string_column(const Column &column) {
+emilib::HashSet<StringPool::offset_t> unique_values_for_string_column(const Column& column)
+{
     auto column_data = column.data();
     return column_data.type().visit_tag([&](auto type_desc_tag) -> emilib::HashSet<StringPool::offset_t> {
         using TDT = decltype(type_desc_tag);
         using DTT = typename TDT::DataTypeTag;
-        if constexpr(is_sequence_type(DTT::data_type)) {
+        if constexpr (is_sequence_type(DTT::data_type)) {
             using RawType = typename TDT::DataTypeTag::raw_type;
             emilib::HashSet<StringPool::offset_t> output;
             // Guessing that unique values is a third of the column length
@@ -27,7 +28,7 @@ emilib::HashSet<StringPool::offset_t> unique_values_for_string_column(const Colu
             output.reserve(column.row_count() / map_reserve_ratio);
 
             while (auto block = column_data.next<TDT>()) {
-                auto ptr = reinterpret_cast<const RawType *>(block.value().data());
+                auto ptr = reinterpret_cast<const RawType*>(block.value().data());
                 const auto row_count = block->row_count();
                 for (auto i = 0u; i < row_count; ++i) {
                     output.insert(*ptr++);
@@ -40,4 +41,4 @@ emilib::HashSet<StringPool::offset_t> unique_values_for_string_column(const Colu
     });
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -12,85 +12,93 @@
 #include <arcticdb/util/third_party/robin_hood.hpp>
 
 namespace arcticdb {
-py::buffer_info StringPool::as_buffer_info() const {
-    return py::buffer_info{
-        (void *) block_.at(0).data(),
+py::buffer_info StringPool::as_buffer_info() const
+{
+    return py::buffer_info{(void*)block_.at(0).data(),
         1,
         py::format_descriptor<char>::format(),
-        ssize_t(block_.at(0).size())
-    };
+        ssize_t(block_.at(0).size())};
 }
 
-bool StringPool::string_exists(const std::string_view& str) {
-    return map_.find(str)  != map_.end();
+bool StringPool::string_exists(const std::string_view& str)
+{
+    return map_.find(str) != map_.end();
 }
 
-OffsetString StringPool::get(const std::string_view &s, bool deduplicate) {
-    if(deduplicate) {
+OffsetString StringPool::get(const std::string_view& s, bool deduplicate)
+{
+    if (deduplicate) {
         if (auto it = map_.find(s); it != map_.end())
             return OffsetString(it->second, this);
     }
 
     OffsetString str(block_.insert(s.data(), s.size()), this);
 
-    if(deduplicate)
+    if (deduplicate)
         map_.insert(robin_hood::pair(block_.at(str.offset()), str.offset()));
 
     return str;
 }
 
-OffsetString StringPool::get(const char *data, size_t size, bool deduplicate) {
+OffsetString StringPool::get(const char* data, size_t size, bool deduplicate)
+{
     StringType s(data, size);
-    if(deduplicate) {
+    if (deduplicate) {
         if (auto it = map_.find(s); it != map_.end())
             return OffsetString(it->second, this);
     }
 
     OffsetString str(block_.insert(s.data(), s.size()), this);
-    if(deduplicate)
+    if (deduplicate)
         map_.insert(robin_hood::pair(StringType(str), str.offset()));
 
     return str;
 }
 
-std::string_view StringPool::get_view(const offset_t &o) {
+std::string_view StringPool::get_view(const offset_t& o)
+{
     return block_.at(o);
 }
 
-std::string_view StringPool::get_const_view(const offset_t &o) const {
+std::string_view StringPool::get_const_view(const offset_t& o) const
+{
     return block_.const_at(o);
 }
 
-std::optional<position_t> StringPool::get_offset_for_column(std::string_view string, const Column& column) {
+std::optional<position_t> StringPool::get_offset_for_column(std::string_view string, const Column& column)
+{
     auto unique_values = unique_values_for_string_column(column);
     remove_nones_and_nans(unique_values);
     robin_hood::unordered_flat_map<std::string_view, offset_t> col_values;
     col_values.reserve(unique_values.size());
-    for(auto pos : unique_values) {
+    for (auto pos : unique_values) {
         col_values.emplace(block_.const_at(pos), pos);
     }
 
     std::optional<position_t> output;
-    if(auto loc = col_values.find(string); loc != col_values.end())
+    if (auto loc = col_values.find(string); loc != col_values.end())
         output = loc->second;
     return output;
 }
 
-emilib::HashSet<position_t> StringPool::get_offsets_for_column(const std::shared_ptr<std::unordered_set<std::string>>& strings, const Column& column) {
+emilib::HashSet<position_t> StringPool::get_offsets_for_column(
+    const std::shared_ptr<std::unordered_set<std::string>>& strings,
+    const Column& column)
+{
     auto unique_values = unique_values_for_string_column(column);
     remove_nones_and_nans(unique_values);
     robin_hood::unordered_flat_map<std::string_view, offset_t> col_values;
     col_values.reserve(unique_values.size());
-    for(auto pos : unique_values) {
+    for (auto pos : unique_values) {
         col_values.emplace(block_.const_at(pos), pos);
     }
 
     emilib::HashSet<position_t> output;
-    for(const auto& string : *strings) {
+    for (const auto& string : *strings) {
         auto loc = col_values.find(string);
-        if(loc != col_values.end())
+        if (loc != col_values.end())
             output.insert(loc->second);
     }
     return output;
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -36,45 +36,62 @@ class StringBlock {
         ARCTICDB_NO_MOVE_OR_COPY(StringHead)
 
         static const size_t DataBytes = 4;
-        static size_t calc_size(size_t size) { return std::max(sizeof(size_) + size, sizeof(StringHead)); }
+        static size_t calc_size(size_t size)
+        {
+            return std::max(sizeof(size_) + size, sizeof(StringHead));
+        }
 
-        void copy(const char *str, size_t size) {
-            size_ = static_cast<uint32_t>( size );
+        void copy(const char* str, size_t size)
+        {
+            size_ = static_cast<uint32_t>(size);
             memset(data_, 0, DataBytes);
             memcpy(data(), str, size);
         }
 
-        [[nodiscard]] size_t size() const { return static_cast<size_t>( size_); }
-        char *data() { return data_; }
-        [[nodiscard]] const char *data() const { return data_; }
+        [[nodiscard]] size_t size() const
+        {
+            return static_cast<size_t>(size_);
+        }
+        char* data()
+        {
+            return data_;
+        }
+        [[nodiscard]] const char* data() const
+        {
+            return data_;
+        }
 
-      private:
+    private:
         uint32_t size_ = 0;
         char data_[DataBytes] = {};
     };
 
-  public:
+public:
     StringBlock() = default;
-    StringBlock(StringBlock &&that) noexcept :
-        data_(std::move(that.data_)) {
+    StringBlock(StringBlock&& that) noexcept
+        : data_(std::move(that.data_))
+    {
     }
 
-    StringBlock &operator=(StringBlock &&that) noexcept {
+    StringBlock& operator=(StringBlock&& that) noexcept
+    {
         data_ = std::move(that.data_);
         return *this;
     }
 
-    StringBlock &operator=(const StringBlock &) = delete;
+    StringBlock& operator=(const StringBlock&) = delete;
 
-    StringBlock(const StringBlock &) = delete;
+    StringBlock(const StringBlock&) = delete;
 
-    [[nodiscard]] StringBlock clone() const {
+    [[nodiscard]] StringBlock clone() const
+    {
         StringBlock output;
         output.data_ = data_.clone();
         return output;
     }
 
-    position_t insert(const char *str, size_t size) {
+    position_t insert(const char* str, size_t size)
+    {
         auto bytes_required = StringHead::calc_size(size);
         auto ptr = data_.ensure_aligned_bytes(bytes_required);
         reinterpret_cast<StringHead*>(ptr)->copy(str, size);
@@ -82,77 +99,90 @@ class StringBlock {
         return data_.cursor_pos() - bytes_required;
     }
 
-    std::string_view at(position_t pos) {
+    std::string_view at(position_t pos)
+    {
         auto head(head_at(pos));
         return {head->data(), head->size()};
     }
 
-    [[nodiscard]] std::string_view const_at(position_t pos) const {
+    [[nodiscard]] std::string_view const_at(position_t pos) const
+    {
         auto head(const_head_at(pos));
         return {head->data(), head->size()};
     }
 
-    StringHead *head_at(position_t pos) {
+    StringHead* head_at(position_t pos)
+    {
         auto data = data_.buffer().ptr_cast<uint8_t>(pos, sizeof(StringHead));
-        return reinterpret_cast<StringHead *>(data);
+        return reinterpret_cast<StringHead*>(data);
     }
 
-    [[nodiscard]] const StringHead* const_head_at(position_t pos) const {
+    [[nodiscard]] const StringHead* const_head_at(position_t pos) const
+    {
         auto data = data_.buffer().internal_ptr_cast<uint8_t>(pos, sizeof(StringHead));
-        return reinterpret_cast<const StringHead *>(data);
+        return reinterpret_cast<const StringHead*>(data);
     }
 
-    void reset() {
+    void reset()
+    {
         data_.reset();
     }
 
-    void clear() {
+    void clear()
+    {
         data_.clear();
     }
 
-    void allocate(size_t size) {
+    void allocate(size_t size)
+    {
         data_.ensure_bytes(size);
     }
 
-    [[nodiscard]] position_t cursor_pos() const {
+    [[nodiscard]] position_t cursor_pos() const
+    {
         return data_.cursor_pos();
     }
 
-    void advance(size_t size) {
+    void advance(size_t size)
+    {
         data_.advance(size);
     }
 
-    [[nodiscard]] size_t size() const {
+    [[nodiscard]] size_t size() const
+    {
         return data_.size<uint8_t>();
     }
 
-    [[nodiscard]] const ChunkedBuffer &buffer() const {
+    [[nodiscard]] const ChunkedBuffer& buffer() const
+    {
         return data_.buffer();
     }
 
-    uint8_t * pos_data(size_t required_size) {
+    uint8_t* pos_data(size_t required_size)
+    {
         return data_.pos_cast<uint8_t>(required_size);
     }
 
-  private:
+private:
     CursoredBuffer<ChunkedBuffer> data_;
 };
 
 class OffsetString;
 
 class StringPool {
-  public:
+public:
     using offset_t = position_t;
     using StringType = std::string_view;
     using MapType = robin_hood::unordered_flat_map<StringType, offset_t>;
 
     StringPool() = default;
     ~StringPool() = default;
-    StringPool &operator=(const StringPool &) = delete;
-    StringPool(const StringPool &) = delete;
-    StringPool(StringPool &&that) = delete;
+    StringPool& operator=(const StringPool&) = delete;
+    StringPool(const StringPool&) = delete;
+    StringPool(StringPool&& that) = delete;
 
-    std::shared_ptr<StringPool> clone() const {
+    std::shared_ptr<StringPool> clone() const
+    {
         auto output = std::make_shared<StringPool>();
         output->block_ = block_.clone();
         output->map_ = map_;
@@ -160,7 +190,8 @@ class StringPool {
         return output;
     }
 
-    StringPool &operator=(StringPool &&that) noexcept {
+    StringPool& operator=(StringPool&& that) noexcept
+    {
         if (this != &that) {
             block_ = std::move(that.block_);
             map_ = std::move(that.map_);
@@ -169,68 +200,81 @@ class StringPool {
         return *this;
     }
 
-    OffsetString get(const char *data, size_t size, bool deduplicate = true);
+    OffsetString get(const char* data, size_t size, bool deduplicate = true);
 
-    shape_t *allocate_shapes(size_t size) {
+    shape_t* allocate_shapes(size_t size)
+    {
         shapes_.ensure_bytes(size);
         return shapes_.pos_cast<shape_t>(size);
     }
 
-    uint8_t *allocate_data(size_t size) {
+    uint8_t* allocate_data(size_t size)
+    {
         block_.allocate(size);
         return block_.pos_data(size);
     }
 
-    void advance_shapes(size_t) {
+    void advance_shapes(size_t)
+    {
         // Not used
     }
 
-    void advance_data(size_t size) {
+    void advance_data(size_t size)
+    {
         block_.advance(size);
     }
 
-    void set_allow_sparse(bool) {
+    void set_allow_sparse(bool)
+    {
         // Not used
     }
 
-    OffsetString get(const std::string_view &s, bool deduplicate = true);
+    OffsetString get(const std::string_view& s, bool deduplicate = true);
 
-    const ChunkedBuffer &data() const {
+    const ChunkedBuffer& data() const
+    {
         return block_.buffer();
     }
 
-    std::string_view get_view(const offset_t &o);
+    std::string_view get_view(const offset_t& o);
 
-    std::string_view get_const_view(const offset_t &o) const;
+    std::string_view get_const_view(const offset_t& o) const;
 
     bool string_exists(const std::string_view& str);
 
-    void clear() {
+    void clear()
+    {
         map_.clear();
         block_.clear();
     }
 
-    const auto &shapes() const {
+    const auto& shapes() const
+    {
         auto& blocks = block_.buffer().blocks();
         shapes_.ensure_bytes(blocks.size() * sizeof(shape_t));
         auto ptr = shapes_.buffer().ptr_cast<shape_t>(0, sizeof(shape_t));
-        for(auto& block : blocks) {
+        for (auto& block : blocks) {
             *ptr++ = static_cast<shape_t>(block->bytes());
         }
         ARCTICDB_TRACE(log::inmem(), "String pool shapes array has {} blocks", blocks.size());
         return shapes_.buffer();
     }
 
-    size_t size() const { return block_.size(); }
+    size_t size() const
+    {
+        return block_.size();
+    }
 
     py::buffer_info as_buffer_info() const;
 
     std::optional<position_t> get_offset_for_column(std::string_view str, const Column& column);
-    emilib::HashSet<position_t> get_offsets_for_column(const std::shared_ptr<std::unordered_set<std::string>>& strings, const Column& column);
-  private:
+    emilib::HashSet<position_t> get_offsets_for_column(const std::shared_ptr<std::unordered_set<std::string>>& strings,
+        const Column& column);
+
+private:
     MapType map_;
     mutable StringBlock block_;
-    mutable CursoredBuffer<Buffer> shapes_;  //TODO MemBlock::MinSize
+    mutable CursoredBuffer<Buffer> shapes_; //TODO MemBlock::MinSize
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/column_store/test/rapidcheck_chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_chunked_buffer.cpp
@@ -14,7 +14,8 @@
 #include <vector>
 #include <algorithm>
 
-TEST(ChunkedBuffer, Basic) {
+TEST(ChunkedBuffer, Basic)
+{
     using namespace arcticdb;
     ChunkedBuffer cb;
     cb.ensure(4);
@@ -23,7 +24,8 @@ TEST(ChunkedBuffer, Basic) {
     ASSERT_EQ(out, std::numeric_limits<uint64_t>::max());
 }
 
-RC_GTEST_PROP(ChunkedBuffer, ReadWriteRegular, (const std::vector<uint8_t> &input, uint8_t chunk_size)) {
+RC_GTEST_PROP(ChunkedBuffer, ReadWriteRegular, (const std::vector<uint8_t>& input, uint8_t chunk_size))
+{
     using namespace arcticdb;
     RC_PRE(input.size() > 0u);
     RC_PRE(chunk_size > 0u);
@@ -43,7 +45,8 @@ RC_GTEST_PROP(ChunkedBuffer, ReadWriteRegular, (const std::vector<uint8_t> &inpu
     }
 }
 
-RC_GTEST_PROP(ChunkedBuffer, SplitBuffer, (const std::vector<uint8_t> &input, uint8_t chunk_size, uint32_t split_size)) {
+RC_GTEST_PROP(ChunkedBuffer, SplitBuffer, (const std::vector<uint8_t>& input, uint8_t chunk_size, uint32_t split_size))
+{
     using namespace arcticdb;
     RC_PRE(input.size() > 0u);
     RC_PRE(chunk_size > 0u);
@@ -66,18 +69,19 @@ RC_GTEST_PROP(ChunkedBuffer, SplitBuffer, (const std::vector<uint8_t> &input, ui
         auto left = buf->cast<uint8_t>(where);
         auto right = input[i];
         auto& buf_obj = *buf;
-        if(buf_obj.cast<uint8_t>(where) != input[i])
+        if (buf_obj.cast<uint8_t>(where) != input[i])
             log::version().info("Mismatch at {} ({}), {} != {}", i, where, left, right);
         RC_ASSERT(left == right);
-        if(((i + 1) % split_size) == 0)
+        if (((i + 1) % split_size) == 0)
             ++buf;
     }
 }
 
-RC_GTEST_PROP(ChunkedBuffer, ReadWriteIrregular, (const std::vector<std::vector<uint64_t>> &inputs)) {
+RC_GTEST_PROP(ChunkedBuffer, ReadWriteIrregular, (const std::vector<std::vector<uint64_t>>& inputs))
+{
     using namespace arcticdb;
     CursoredBuffer<ChunkedBufferImpl<64>> cb;
-    for (auto &vec : inputs) {
+    for (auto& vec : inputs) {
         if (vec.empty())
             continue;
 
@@ -88,7 +92,7 @@ RC_GTEST_PROP(ChunkedBuffer, ReadWriteIrregular, (const std::vector<std::vector<
     }
 
     size_t count = 0;
-    for (auto &vec : inputs) {
+    for (auto& vec : inputs) {
         for (auto val : vec) {
             auto pos = count * sizeof(uint64_t);
             RC_ASSERT(*cb.buffer().ptr_cast<uint64_t>(pos, sizeof(uint64_t)) == val);
@@ -99,8 +103,9 @@ RC_GTEST_PROP(ChunkedBuffer, ReadWriteIrregular, (const std::vector<std::vector<
 }
 
 RC_GTEST_PROP(ChunkedBuffer,
-              ReadWriteTransition,
-              (const std::vector<std::vector<uint64_t>> &inputs, uint8_t regular_chunks)) {
+    ReadWriteTransition,
+    (const std::vector<std::vector<uint64_t>>& inputs, uint8_t regular_chunks))
+{
     using namespace arcticdb;
     CursoredBuffer<ChunkedBufferImpl<64>> cb;
     for (uint8_t i = 0; i < regular_chunks; ++i) {
@@ -111,7 +116,7 @@ RC_GTEST_PROP(ChunkedBuffer,
         cb.commit();
     }
 
-    for (auto &vec : inputs) {
+    for (auto& vec : inputs) {
         if (vec.empty())
             continue;
 
@@ -131,7 +136,7 @@ RC_GTEST_PROP(ChunkedBuffer,
 
     auto irregular_start_pos = regular_chunks * 64;
     size_t next_count = 0;
-    for (auto &vec : inputs) {
+    for (auto& vec : inputs) {
         for (auto val : vec) {
             const auto pos = irregular_start_pos + (next_count * sizeof(uint64_t));
             RC_ASSERT(*cb.buffer().ptr_cast<uint64_t>(pos, sizeof(uint64_t)) == val);
@@ -139,4 +144,3 @@ RC_GTEST_PROP(ChunkedBuffer,
         }
     }
 }
-

--- a/cpp/arcticdb/column_store/test/rapidcheck_column.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column.cpp
@@ -22,17 +22,20 @@ struct ColumnModel {
 struct ColumnAppend : rc::state::Command<ColumnModel, arcticdb::Column> {
     uint64_t value_;
 
-    void apply(ColumnModel &s0) const override {
+    void apply(ColumnModel& s0) const override
+    {
         s0.data.push_back(value_);
     }
 
-    void run(const ColumnModel &, arcticdb::Column &sut) const override {
+    void run(const ColumnModel&, arcticdb::Column& sut) const override
+    {
         auto next_row_id = sut.last_row() + 1;
         sut.set_scalar<uint64_t>(next_row_id, value_);
         RC_ASSERT(*sut.ptr_cast<uint64_t>(next_row_id, sizeof(uint64_t)) == value_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "Append(" << value_ << ")";
     }
 };
@@ -40,7 +43,8 @@ struct ColumnAppend : rc::state::Command<ColumnModel, arcticdb::Column> {
 struct ColumnLowerBound : rc::state::Command<ColumnModel, arcticdb::Column> {
     uint64_t value_;
 
-    void run(const ColumnModel& m, arcticdb::Column &sut) const override {
+    void run(const ColumnModel& m, arcticdb::Column& sut) const override
+    {
         using namespace arcticdb;
         using TagType = TypeDescriptorTag<DataTypeTag<DataType::UINT64>, DimensionTag<Dimension::Dim0>>;
         const auto model_it = std::lower_bound(std::begin(m.data), std::end(m.data), value_);
@@ -48,7 +52,8 @@ struct ColumnLowerBound : rc::state::Command<ColumnModel, arcticdb::Column> {
         RC_ASSERT(std::distance(std::begin(m.data), model_it) == std::distance(sut.template begin<TagType>(), sut_it));
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "Append(" << value_ << ")";
     }
 };
@@ -56,7 +61,8 @@ struct ColumnLowerBound : rc::state::Command<ColumnModel, arcticdb::Column> {
 struct ColumnUpperBound : rc::state::Command<ColumnModel, arcticdb::Column> {
     uint64_t value_;
 
-    void run(const ColumnModel& m, arcticdb::Column &sut) const override {
+    void run(const ColumnModel& m, arcticdb::Column& sut) const override
+    {
         using namespace arcticdb;
         using TagType = TypeDescriptorTag<DataTypeTag<DataType::UINT64>, DimensionTag<Dimension::Dim0>>;
         const auto model_it = std::upper_bound(std::begin(m.data), std::end(m.data), value_);
@@ -64,22 +70,26 @@ struct ColumnUpperBound : rc::state::Command<ColumnModel, arcticdb::Column> {
         RC_ASSERT(std::distance(std::begin(m.data), model_it) == std::distance(sut.template begin<TagType>(), sut_it));
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "Append(" << value_ << ")";
     }
 };
 struct ColumnRead : rc::state::Command<ColumnModel, arcticdb::Column> {
     uint64_t position_;
 
-    void checkPreconditions(const ColumnModel &s0) const override {
+    void checkPreconditions(const ColumnModel& s0) const override
+    {
         RC_PRE(position_ < s0.data.size());
     }
 
-    void run(const ColumnModel &s0, arcticdb::Column &sut) const override {
+    void run(const ColumnModel& s0, arcticdb::Column& sut) const override
+    {
         RC_ASSERT(*sut.ptr_cast<uint64_t>(position_, sizeof(uint64_t)) == s0.data[position_]);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "Get(" << position_ << ")";
     }
 };
@@ -87,12 +97,13 @@ struct ColumnRead : rc::state::Command<ColumnModel, arcticdb::Column> {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-RC_GTEST_PROP(Column, Rapidcheck, ()) {
+RC_GTEST_PROP(Column, Rapidcheck, ())
+{
     ColumnModel initial_state;
     arcticdb::Column sut(TypeDescriptor(DataType::UINT64, Dimension::Dim0), 0, false, false);
     rc::state::check(initial_state,
-                     sut,
-                     &rc::state::gen::execOneOf<ColumnAppend, ColumnRead, ColumnLowerBound, ColumnUpperBound>);
+        sut,
+        &rc::state::gen::execOneOf<ColumnAppend, ColumnRead, ColumnLowerBound, ColumnUpperBound>);
 }
 
 #pragma GCC diagnostic pop

--- a/cpp/arcticdb/column_store/test/rapidcheck_column_map.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column_map.cpp
@@ -16,9 +16,11 @@ using namespace arcticdb;
 namespace {
 
 std::optional<size_t> test_find_column_index_by_name(const StreamDescriptor::FieldsCollection& frame_fields,
-                                                     const std::string &name) {
-    auto col_in_frame_it = std::find_if(frame_fields.begin(), frame_fields.end(),
-                                        [name](FieldDescriptor::Proto f) { return f.name() == name; });
+    const std::string& name)
+{
+    auto col_in_frame_it = std::find_if(frame_fields.begin(), frame_fields.end(), [name](FieldDescriptor::Proto f) {
+        return f.name() == name;
+    });
 
     if (col_in_frame_it != frame_fields.end()) {
         return std::distance(frame_fields.begin(), col_in_frame_it);
@@ -27,14 +29,15 @@ std::optional<size_t> test_find_column_index_by_name(const StreamDescriptor::Fie
     return std::nullopt;
 }
 
-}
+} // namespace
 
-RC_GTEST_PROP(ColumnMap, FromDescriptor, (const arcticdb::entity::StreamDescriptor& desc)) {
+RC_GTEST_PROP(ColumnMap, FromDescriptor, (const arcticdb::entity::StreamDescriptor& desc))
+{
     ColumnMap column_map{desc.field_count()};
     column_map.set_from_descriptor(desc);
     for (const auto& field : desc.fields()) {
         auto col_index = column_map.column_index(field.name());
         auto check_col_index = test_find_column_index_by_name(desc.fields(), field.name());
-       RC_ASSERT(col_index == check_col_index);
+        RC_ASSERT(col_index == check_col_index);
     }
 }

--- a/cpp/arcticdb/column_store/test/rapidcheck_column_store.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column_store.cpp
@@ -14,25 +14,26 @@
 #include <arcticdb/util/test/rapidcheck_generators.hpp>
 #include <arcticdb/storage/test/in_memory_store.hpp>
 
-RC_GTEST_PROP(ColumnStore, RapidCheck, (std::map<std::string, TestDataFrame>
-    data_frames)) {
+RC_GTEST_PROP(ColumnStore, RapidCheck, (std::map<std::string, TestDataFrame> data_frames))
+{
     using namespace arcticdb;
 
     auto store = std::make_shared<InMemoryStore>();
     std::vector<folly::Future<AtomKey>> futs;
-    for (auto &data_frame : data_frames) {
-        auto fut = write_test_frame(StringId(data_frame.first), data_frame.second, store)
-                        .thenValue([](VariantKey key) { return to_atom(key); });
+    for (auto& data_frame : data_frames) {
+        auto fut = write_test_frame(StringId(data_frame.first), data_frame.second, store).thenValue([](VariantKey key) {
+            return to_atom(key);
+        });
         futs.push_back(std::move(fut));
     }
 
     auto keys = folly::collectAll(futs.begin(), futs.end()).get();
 
     size_t count = 0;
-    for (auto &data_frame : data_frames) {
+    for (auto& data_frame : data_frames) {
         std::vector<std::string> errors;
         auto result = check_test_frame(data_frame.second, keys[count++].value(), store, errors);
-        for (auto &err : errors)
+        for (auto& err : errors)
             log::root().warn(err);
         RC_ASSERT(result);
     }

--- a/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
@@ -9,7 +9,8 @@
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
 
-TEST(ChunkedBuffer, Iterator) {
+TEST(ChunkedBuffer, Iterator)
+{
     using namespace arcticdb;
 
     auto buff = CursoredBuffer<ChunkedBufferImpl<64>>{};
@@ -22,13 +23,14 @@ TEST(ChunkedBuffer, Iterator) {
     auto it = buff.buffer().iterator(8);
     uint64_t count = 0;
     while (!it.finished()) {
-        ASSERT_EQ(*reinterpret_cast<uint64_t *>(it.value()), count++);
+        ASSERT_EQ(*reinterpret_cast<uint64_t*>(it.value()), count++);
         it.next();
     }
 
     ASSERT_EQ(count, 10000);
 }
-TEST(ChunkedBuffer, Split) {
+TEST(ChunkedBuffer, Split)
+{
     using namespace arcticdb;
     std::vector<uint8_t> input{1, 0, 0};
     auto chunk_size = 1;
@@ -53,7 +55,8 @@ TEST(ChunkedBuffer, Split) {
     }
 }
 
-TEST(ChunkedBuffer, RapidCheckRepro) {
+TEST(ChunkedBuffer, RapidCheckRepro)
+{
     std::vector<uint8_t> input(64);
     using namespace arcticdb;
     auto chunk_size = 5u;
@@ -75,10 +78,10 @@ TEST(ChunkedBuffer, RapidCheckRepro) {
         auto left = buf->cast<uint8_t>(where);
         auto right = input[i];
         auto& buf_obj = *buf;
-        if(buf_obj.cast<uint8_t>(where) != input[i])
+        if (buf_obj.cast<uint8_t>(where) != input[i])
             std::cout << "Blarf";
         ASSERT_EQ(left, right);
-        if(((i + 1) % split_size) == 0)
+        if (((i + 1) % split_size) == 0)
             ++buf;
     }
 }

--- a/cpp/arcticdb/column_store/test/test_column.cpp
+++ b/cpp/arcticdb/column_store/test/test_column.cpp
@@ -15,7 +15,8 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
 
-TEST(Column, Empty) {
+TEST(Column, Empty)
+{
     using namespace arcticdb;
 
     Column c(TypeDescriptor(DataType::UINT16, Dimension(2)), 0, false, false);
@@ -23,7 +24,8 @@ TEST(Column, Empty) {
 }
 
 template<typename TDT>
-void test_column_type(size_t num_values = 20, size_t num_tests = 50) {
+void test_column_type(size_t num_values = 20, size_t num_tests = 50)
+{
     using namespace arcticdb;
     using TypeDescriptorTag = TDT;
     using DTT = typename TypeDescriptorTag::DataTypeTag;
@@ -64,14 +66,15 @@ void test_column_type(size_t num_values = 20, size_t num_tests = 50) {
             auto t = v.value();
             ASSERT_TRUE(testValue.check_tensor(t));
         }
-//TODO fix visitation with proper tensor
-//        raw_type val = 0;
-//        ASSERT_NO_THROW(column.visit(index, [&](auto &&x) { assign(*x.data(), val); }));
-//        ASSERT_EQ(val, start);
+        //TODO fix visitation with proper tensor
+        //        raw_type val = 0;
+        //        ASSERT_NO_THROW(column.visit(index, [&](auto &&x) { assign(*x.data(), val); }));
+        //        ASSERT_EQ(val, start);
     }
 }
 
-TEST(Column, ScalarTypes) {
+TEST(Column, ScalarTypes)
+{
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension::Dim0>>>();
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::UINT16>, DimensionTag<Dimension::Dim0>>>();
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::UINT32>, DimensionTag<Dimension::Dim0>>>();
@@ -84,7 +87,8 @@ TEST(Column, ScalarTypes) {
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::FLOAT64>, DimensionTag<Dimension::Dim0>>>();
 }
 
-TEST(Column, TensorTypes) {
+TEST(Column, TensorTypes)
+{
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension ::Dim1>>>();
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::UINT16>, DimensionTag<Dimension ::Dim1>>>();
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::UINT32>, DimensionTag<Dimension ::Dim1>>>();
@@ -108,10 +112,11 @@ TEST(Column, TensorTypes) {
     test_column_type<TypeDescriptorTag<DataTypeTag<DataType::FLOAT64>, DimensionTag<Dimension ::Dim2>>>();
 }
 
-TEST(Column, IterateData) {
+TEST(Column, IterateData)
+{
     using TDT = TypeDescriptorTag<DataTypeTag<DataType::UINT16>, DimensionTag<Dimension ::Dim0>>;
     Column column(static_cast<TypeDescriptor>(TDT{}), 0, false, false);
-    for(auto i= 0; i < 10; ++i) {
+    for (auto i = 0; i < 10; ++i) {
         column.set_scalar<uint16_t>(i, i);
     }
 
@@ -124,15 +129,16 @@ TEST(Column, IterateData) {
     }
 
     ASSERT_EQ(output.size(), 10u);
-    for(auto i= 0; i < 10; ++i) {
+    for (auto i = 0; i < 10; ++i) {
         ASSERT_EQ(output[i], i);
     }
 }
 
-TEST(Column, ChangeType) {
+TEST(Column, ChangeType)
+{
     using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
     Column column(static_cast<TypeDescriptor>(TDT{}), 0, false, false);
-    for(auto i= 0; i < 10; ++i) {
+    for (auto i = 0; i < 10; ++i) {
         column.set_scalar<int64_t>(i, i);
     }
 
@@ -141,49 +147,54 @@ TEST(Column, ChangeType) {
 
     ASSERT_EQ(column.row_count(), 10u);
     ASSERT_EQ(column.type(), expected);
-    for(auto i= 0; i < 10; ++i) {
+    for (auto i = 0; i < 10; ++i) {
         ASSERT_EQ(column.scalar_at<double>(i), i);
     }
 }
 
-std::unique_ptr<Column> get_sparse_column(size_t offset = 0, size_t start = 0, size_t num_rows = 10) {
+std::unique_ptr<Column> get_sparse_column(size_t offset = 0, size_t start = 0, size_t num_rows = 10)
+{
     using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
     auto column = std::make_unique<Column>(static_cast<TypeDescriptor>(TDT{}), 0, false, true);
-    for(auto i = start; i < start + num_rows; i += 2) {
+    for (auto i = start; i < start + num_rows; i += 2) {
         column->set_scalar<int64_t>(i, i + offset);
     }
     return column;
 }
 
-std::unique_ptr<Column> get_dense_column(size_t offset = 0, size_t start = 0, size_t num_rows = 10) {
+std::unique_ptr<Column> get_dense_column(size_t offset = 0, size_t start = 0, size_t num_rows = 10)
+{
     using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
     auto column = std::make_unique<Column>(static_cast<TypeDescriptor>(TDT{}), 0, false, true);
-    for(auto i = start; i < start + num_rows; ++i) {
+    for (auto i = start; i < start + num_rows; ++i) {
         column->set_scalar<int64_t>(i, i + offset);
     }
     return column;
 }
 
-TEST(Column, Dense) {
+TEST(Column, Dense)
+{
     auto column = get_dense_column();
 
     ASSERT_EQ(column->row_count(), 10u);
-    for(auto i= 0; i < 10; ++i) {
+    for (auto i = 0; i < 10; ++i) {
         check_value(column->scalar_at<int64_t>(i), i);
     }
 }
 
-TEST(Column, Sparse) {
+TEST(Column, Sparse)
+{
     auto column = get_sparse_column();
 
     ASSERT_EQ(column->row_count(), 5u);
-    for(auto i= 0; i < 10; i += 2) {
+    for (auto i = 0; i < 10; i += 2) {
         check_value(column->scalar_at<int64_t>(i), i);
         check_value(column->scalar_at<int64_t>(i + 1), std::nullopt);
     }
 }
 
-TEST(Column, SparseChangeType) {
+TEST(Column, SparseChangeType)
+{
     auto column = get_sparse_column();
 
     column->change_type(DataType::FLOAT64, std::shared_ptr<StringPool>());
@@ -191,92 +202,98 @@ TEST(Column, SparseChangeType) {
 
     ASSERT_EQ(column->row_count(), 5u);
     ASSERT_EQ(column->type(), expected);
-    for(auto i= 0; i < 10; i += 2) {
+    for (auto i = 0; i < 10; i += 2) {
         check_value(column->scalar_at<double>(i), i);
         check_value(column->scalar_at<double>(i + 1), std::nullopt);
     }
 }
 
-TEST(Column, AppendDenseToDense) {
+TEST(Column, AppendDenseToDense)
+{
     auto col1 = get_dense_column();
     auto col2 = get_dense_column(10);
 
     col1->append(*col2, col1->row_count());
 
-    ASSERT_EQ(col1->row_count(),20u);
-    for(auto i= 0; i < 20; ++i) {
+    ASSERT_EQ(col1->row_count(), 20u);
+    for (auto i = 0; i < 20; ++i) {
         check_value(col1->scalar_at<int64_t>(i), i);
     }
 }
 
-TEST(Column, AppendSparseToDense) {
+TEST(Column, AppendSparseToDense)
+{
     auto dense_column = get_dense_column();
     auto sparse_column = get_sparse_column(10);
 
     dense_column->append(*sparse_column, dense_column->row_count());
 
-    ASSERT_EQ(dense_column->row_count(),15u);
-    for(auto i= 0; i < 10; ++i) {
+    ASSERT_EQ(dense_column->row_count(), 15u);
+    for (auto i = 0; i < 10; ++i) {
         check_value(dense_column->scalar_at<int64_t>(i), i);
     }
 
-    for(auto j= 10; j < 20; j += 2) {
+    for (auto j = 10; j < 20; j += 2) {
         check_value(dense_column->scalar_at<int64_t>(j), j);
         check_value(dense_column->scalar_at<int64_t>(j + 1), std::nullopt);
     }
 }
 
-TEST(Column, AppendDenseToSparse) {
+TEST(Column, AppendDenseToSparse)
+{
     auto sparse_column = get_sparse_column();
     auto dense_column = get_dense_column(10);
 
     sparse_column->append(*dense_column, 10);
 
-    ASSERT_EQ(sparse_column->row_count(),15u);
-    for(auto i= 0; i < 10; i += 2) {
+    ASSERT_EQ(sparse_column->row_count(), 15u);
+    for (auto i = 0; i < 10; i += 2) {
         check_value(sparse_column->scalar_at<uint64_t>(i), i);
         check_value(sparse_column->scalar_at<uint64_t>(i + 1), std::nullopt);
     }
 
-    for(auto i= 10; i < 20; ++i) {
+    for (auto i = 10; i < 20; ++i) {
         check_value(sparse_column->scalar_at<int64_t>(i), i);
     }
 }
 
-TEST(Column, AppendSparseToSparse) {
+TEST(Column, AppendSparseToSparse)
+{
     auto col1 = get_sparse_column();
     auto col2 = get_sparse_column(10);
 
     col1->append(*col2, 10);
 
-    ASSERT_EQ(col1->row_count(),10u);
-    for(auto i= 0; i < 20; i += 2) {
+    ASSERT_EQ(col1->row_count(), 10u);
+    for (auto i = 0; i < 20; i += 2) {
         check_value(col1->scalar_at<uint64_t>(i), i);
         check_value(col1->scalar_at<uint64_t>(i + 1), std::nullopt);
     }
 }
 
-TEST(ColumnData, Iterator) {
+TEST(ColumnData, Iterator)
+{
     using namespace arcticdb;
 
     using TDT = TypeDescriptorTag<DataTypeTag<DataType::UINT16>, DimensionTag<Dimension ::Dim0>>;
     Column column(static_cast<TypeDescriptor>(TDT{}), 0, false, false);
-    for(auto i= 0; i < 10; ++i) {
+    for (auto i = 0; i < 10; ++i) {
         column.set_scalar<uint16_t>(i, i);
     }
 
     auto count = 0;
-    for(auto val = column.begin<TDT>(); val != column.end<TDT>(); ++val) {
+    for (auto val = column.begin<TDT>(); val != column.end<TDT>(); ++val) {
         ASSERT_EQ(*val, count++);
     }
 }
 
-TEST(ColumnData, LowerBound) {
+TEST(ColumnData, LowerBound)
+{
     using namespace arcticdb;
 
     using TDT = TypeDescriptorTag<DataTypeTag<DataType::UINT16>, DimensionTag<Dimension ::Dim0>>;
     Column column(static_cast<TypeDescriptor>(TDT{}), 0, false, false);
-    for(auto i= 0; i < 10; ++i) {
+    for (auto i = 0; i < 10; ++i) {
         column.set_scalar<uint16_t>(i, i * 2);
     }
 

--- a/cpp/arcticdb/column_store/test/test_memory_segment.cpp
+++ b/cpp/arcticdb/column_store/test/test_memory_segment.cpp
@@ -15,7 +15,8 @@
 #include <folly/container/Enumerate.h>
 #include <arcticdb/util/test/generators.hpp>
 
-TEST(MemSegment, Empty) {
+TEST(MemSegment, Empty)
+{
     using namespace arcticdb;
 
     SegmentInMemory s;
@@ -25,11 +26,12 @@ TEST(MemSegment, Empty) {
     //  ASSERT_THROW(s.scalar_at<uint16_t>(3, 6), std::invalid_argument);
     ASSERT_NO_THROW(s.clear());
     // Even though this index is out of bounds it will not throw as there are no columns to visit
-//    ASSERT_NO_THROW(s.visit(5, [] (auto&& ) { std::cout << "testing" << std::endl;}));
+    //    ASSERT_NO_THROW(s.visit(5, [] (auto&& ) { std::cout << "testing" << std::endl;}));
 }
 
 template<typename TDT>
-void test_segment_type(size_t num_values = 20, size_t num_tests = 50, size_t num_columns = 4) {
+void test_segment_type(size_t num_values = 20, size_t num_tests = 50, size_t num_columns = 4)
+{
     using namespace arcticdb;
     using TypeDescriptorTag = TDT;
     using DTT = typename TypeDescriptorTag::DataTypeTag;
@@ -44,7 +46,7 @@ void test_segment_type(size_t num_values = 20, size_t num_tests = 50, size_t num
         TestRow<decltype(typeDescriptorTag)> test_row{ts, num_columns, raw_type(i), num_values};
         s.set_scalar(0, ts);
         for (size_t j = 1; j < num_columns; ++j) {
-            if constexpr(dimensions == Dimension::Dim0) {
+            if constexpr (dimensions == Dimension::Dim0) {
                 auto v = test_row[j - 1].get_scalar();
                 s.set_scalar(j, v);
             } else {
@@ -62,7 +64,7 @@ void test_segment_type(size_t num_values = 20, size_t num_tests = 50, size_t num
         TestRow<decltype(typeDescriptorTag)> test_row{ts, num_columns, raw_type(i)};
         ASSERT_EQ(s.scalar_at<timestamp>(i, 0), i);
         for (size_t j = 1; j < num_columns; ++j) {
-            if constexpr  (dimensions == Dimension::Dim0) {
+            if constexpr (dimensions == Dimension::Dim0) {
                 auto v = s.scalar_at<raw_type>(i, j);
                 ASSERT_FALSE(v == std::nullopt);
                 ASSERT_EQ(v.value(), test_row[j - 1].get_scalar());
@@ -75,7 +77,8 @@ void test_segment_type(size_t num_values = 20, size_t num_tests = 50, size_t num
     }
 }
 
-TEST(MemSegment, Scalar) {
+TEST(MemSegment, Scalar)
+{
     test_segment_type<TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension::Dim0>>>();
     test_segment_type<TypeDescriptorTag<DataTypeTag<DataType::UINT16>, DimensionTag<Dimension::Dim0>>>();
     test_segment_type<TypeDescriptorTag<DataTypeTag<DataType::UINT32>, DimensionTag<Dimension::Dim0>>>();
@@ -88,30 +91,31 @@ TEST(MemSegment, Scalar) {
     test_segment_type<TypeDescriptorTag<DataTypeTag<DataType::FLOAT64>, DimensionTag<Dimension::Dim0>>>();
 }
 
-TEST(MemSegment, Iteration) {
+TEST(MemSegment, Iteration)
+{
     auto frame_wrapper = get_test_timeseries_frame("test_iteration", 100, 0);
     auto& segment = frame_wrapper.segment_;
 
     auto count ARCTICDB_UNUSED = 0u;
-    for(auto it = segment.begin(); it != segment.end(); ++it) {
+    for (auto it = segment.begin(); it != segment.end(); ++it) {
         ASSERT_EQ(it->row_id_, count++);
     }
     ASSERT_EQ(count, 100);
 }
 
-TEST(MemSegment, IterateAndGetValues) {
+TEST(MemSegment, IterateAndGetValues)
+{
     auto frame_wrapper = get_test_timeseries_frame("test_get_values", 100, 0);
     auto& segment = frame_wrapper.segment_;
 
-    for( auto row : folly::enumerate(segment)) {
-        for(auto value : folly::enumerate(*row)) {
-            value->visit([&] (const auto& val) {
+    for (auto row : folly::enumerate(segment)) {
+        for (auto value : folly::enumerate(*row)) {
+            value->visit([&](const auto& val) {
                 using ValType = std::decay_t<decltype(val)>;
-                if( value.index == 0) {
+                if (value.index == 0) {
                     ASSERT_EQ(static_cast<ValType>(row.index), val);
-                }
-                else {
-                    if constexpr(std::is_integral_v<ValType>) {
+                } else {
+                    if constexpr (std::is_integral_v<ValType>) {
                         ASSERT_EQ(val, get_integral_value_for_offset<ValType>(0, row.index));
                     }
                     if constexpr (std::is_floating_point_v<ValType>) {
@@ -123,21 +127,21 @@ TEST(MemSegment, IterateAndGetValues) {
     }
 }
 
-TEST(MemSegment, CopyViaIterator) {
+TEST(MemSegment, CopyViaIterator)
+{
     auto frame_wrapper = get_test_timeseries_frame("test_get_values", 100, 0);
-    auto& source =frame_wrapper.segment_;
+    auto& source = frame_wrapper.segment_;
     auto target = get_test_empty_timeseries_segment("to_sort", 0u);
     std::copy(std::begin(source), std::end(source), std::back_inserter(target));
 
-    for( auto row : folly::enumerate(target)) {
-        for(auto value : folly::enumerate(*row)) {
-            value->visit([&] (const auto& val) {
+    for (auto row : folly::enumerate(target)) {
+        for (auto value : folly::enumerate(*row)) {
+            value->visit([&](const auto& val) {
                 using ValType = std::decay_t<decltype(val)>;
-                if( value.index == 0) {
+                if (value.index == 0) {
                     ASSERT_EQ(static_cast<ValType>(row.index), val);
-                }
-                else {
-                    if constexpr(std::is_integral_v<ValType>) {
+                } else {
+                    if constexpr (std::is_integral_v<ValType>) {
                         ASSERT_EQ(val, get_integral_value_for_offset<ValType>(0, row.index));
                     }
                     if constexpr (std::is_floating_point_v<ValType>) {
@@ -149,24 +153,25 @@ TEST(MemSegment, CopyViaIterator) {
     }
 }
 
-TEST(MemSegment, ModifyViaIterator) {
+TEST(MemSegment, ModifyViaIterator)
+{
     auto num_rows = 100u;
     auto frame_wrapper = get_test_timeseries_frame("modify", num_rows, 0);
-    auto &segment = frame_wrapper.segment_;
-    for (auto &row : segment) {
-        for (auto &value : row) {
-            value.visit([](auto &v) { v += 1; });
+    auto& segment = frame_wrapper.segment_;
+    for (auto& row : segment) {
+        for (auto& value : row) {
+            value.visit([](auto& v) { v += 1; });
         }
     }
 
     for (auto row : folly::enumerate(segment)) {
         for (auto value : folly::enumerate(*row)) {
-            value->visit([&](const auto &val) {
+            value->visit([&](const auto& val) {
                 using ValType = std::decay_t<decltype(val)>;
                 if (value.index == 0) {
                     ASSERT_EQ(static_cast<ValType>(row.index + 1), val);
                 } else {
-                    if constexpr(std::is_integral_v<ValType>) {
+                    if constexpr (std::is_integral_v<ValType>) {
                         ASSERT_EQ(val, get_integral_value_for_offset<ValType>(0, row.index) + 1);
                     }
                     if constexpr (std::is_floating_point_v<ValType>) {
@@ -178,78 +183,89 @@ TEST(MemSegment, ModifyViaIterator) {
     }
 }
 
-TEST(MemSegment, StdFindIf) {
+TEST(MemSegment, StdFindIf)
+{
     auto num_rows = 100u;
     auto frame_wrapper = get_test_timeseries_frame("modify", num_rows, 0);
-    auto &segment = frame_wrapper.segment_;
-    auto it = std::find_if(std::begin(segment), std::end(segment), [] (auto& row) { return row.template index<TimeseriesIndex>() == 50; });
+    auto& segment = frame_wrapper.segment_;
+    auto it = std::find_if(std::begin(segment), std::end(segment), [](auto& row) {
+        return row.template index<TimeseriesIndex>() == 50;
+    });
     auto val_it = it->begin();
     ASSERT_EQ(it->index<TimeseriesIndex>(), 50);
     std::advance(val_it, 1);
     ASSERT_EQ(val_it->value<uint8_t>(), get_integral_value_for_offset<uint8_t>(0, 50));
 }
 
-TEST(MemSegment, LowerBound) {
+TEST(MemSegment, LowerBound)
+{
     auto num_rows = 100u;
     auto frame_wrapper = get_test_timeseries_frame("modify", num_rows, 0);
-    auto &segment = frame_wrapper.segment_;
+    auto& segment = frame_wrapper.segment_;
     auto odds_segment = SegmentInMemory{segment.descriptor(), num_rows / 2};
     std::copy_if(std::begin(segment), std::end(segment), std::back_inserter(odds_segment), [](auto& row) {
         return row.template index<TimeseriesIndex>() & 1;
     });
-    auto lb = std::lower_bound(std::begin(odds_segment), std::end(odds_segment), timestamp(50), [] (auto& row, timestamp t) {return row.template index<TimeseriesIndex>() < t; });
+    auto lb =
+        std::lower_bound(std::begin(odds_segment), std::end(odds_segment), timestamp(50), [](auto& row, timestamp t) {
+            return row.template index<TimeseriesIndex>() < t;
+        });
     ASSERT_EQ(lb->index<TimeseriesIndex>(), 51);
 }
 
-TEST(MemSegment, CloneAndCompare) {
+TEST(MemSegment, CloneAndCompare)
+{
     auto segment = get_standard_timeseries_segment("test_clone");
     auto copied = segment.clone();
     bool equal = segment == copied;
     ASSERT_EQ(equal, true);
 }
 
-TEST(MemSegment, SplitSegment) {
+TEST(MemSegment, SplitSegment)
+{
     auto segment = get_standard_timeseries_segment("test_clone", 100);
     auto split_segs = segment.split(10);
 
-    for(const auto& split : split_segs)
+    for (const auto& split : split_segs)
         ASSERT_EQ(split.row_count(), 10);
 
-    for(auto i = 0u; i < 100; ++i) {
+    for (auto i = 0u; i < 100; ++i) {
         ASSERT_EQ(split_segs[i / 10].scalar_at<int8_t>(i % 10, 1), segment.scalar_at<int8_t>(i, 1));
         ASSERT_EQ(split_segs[i / 10].scalar_at<uint64_t>(i % 10, 2), segment.scalar_at<uint64_t>(i, 2));
         ASSERT_EQ(split_segs[i / 10].string_at(i % 10, 3), segment.string_at(i, 3));
     }
 }
 
-TEST(MemSegment, SplitSparseSegment) {
+TEST(MemSegment, SplitSparseSegment)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     const std::string stream_id("test_sparse");
 
     const auto index = TimeseriesIndex::default_index();
-    DynamicSchema schema{
-        index.create_stream_descriptor(stream_id, {}), index
-    };
+    DynamicSchema schema{index.create_stream_descriptor(stream_id, {}), index};
     SegmentInMemory sparse_segment;
-    DynamicAggregator aggregator(std::move(schema), [&](SegmentInMemory &&segment) {
-            sparse_segment = std::move(segment);
-        }, RowCountSegmentPolicy{});
+    DynamicAggregator aggregator(
+        std::move(schema),
+        [&](SegmentInMemory&& segment) { sparse_segment = std::move(segment); },
+        RowCountSegmentPolicy{});
 
     constexpr timestamp num_rows = 100;
 
-    for(timestamp i = 0; i < num_rows; i ++) {
+    for (timestamp i = 0; i < num_rows; i++) {
         aggregator.start_row(timestamp{i})([&](auto& rb) {
             rb.set_scalar_by_name("first", uint32_t(i * 2), make_scalar_type(DataType::UINT32));
             rb.set_scalar_by_name("third", uint64_t(i * 4), make_scalar_type(DataType::UINT64));
-            if (i%4 == 0) {
+            if (i % 4 == 0) {
                 rb.set_scalar_by_name("second", uint64_t(i * 3), make_scalar_type(DataType::UINT64));
             }
-            if (i%4 == 2) {
-                rb.set_scalar_by_name("strings", std::string_view{"keep_me" + std::to_string(i)},
-                                      TypeDescriptor(DataType::ASCII_DYNAMIC64, Dimension::Dim0));
+            if (i % 4 == 2) {
+                rb.set_scalar_by_name("strings",
+                    std::string_view{"keep_me" + std::to_string(i)},
+                    TypeDescriptor(DataType::ASCII_DYNAMIC64, Dimension::Dim0));
             }
         });
     }
@@ -258,10 +274,10 @@ TEST(MemSegment, SplitSparseSegment) {
 
     auto split_segs = sparse_segment.split(10);
 
-    for(const auto& split : split_segs)
+    for (const auto& split : split_segs)
         ASSERT_EQ(split.row_count(), 10);
 
-    for(auto i = 0u; i < 100; ++i) {
+    for (auto i = 0u; i < 100; ++i) {
         ASSERT_EQ(split_segs[i / 10].scalar_at<uint32_t>(i % 10, 1), sparse_segment.scalar_at<uint32_t>(i, 1));
         ASSERT_EQ(split_segs[i / 10].scalar_at<uint64_t>(i % 10, 2), sparse_segment.scalar_at<uint64_t>(i, 2));
         if (i % 4 == 0) {
@@ -274,11 +290,11 @@ TEST(MemSegment, SplitSparseSegment) {
         } else {
             ASSERT_FALSE(static_cast<bool>(split_segs[i / 10].string_at(i % 10, 4)));
         }
-
     }
 }
 
-TEST(MemSegment, ShuffleAndSort) {
+TEST(MemSegment, ShuffleAndSort)
+{
     auto segment = get_standard_timeseries_segment("test_clone");
     std::random_device rng;
     std::mt19937 urng(rng());
@@ -290,7 +306,8 @@ TEST(MemSegment, ShuffleAndSort) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(MemSegment, ShuffleAndSortStress) {
+TEST(MemSegment, ShuffleAndSortStress)
+{
     auto segment = get_standard_timeseries_segment("test_clone", 100000);
     std::random_device rng;
     std::mt19937 urng(rng());
@@ -302,7 +319,8 @@ TEST(MemSegment, ShuffleAndSortStress) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(MemSegment, SortSorted) {
+TEST(MemSegment, SortSorted)
+{
     auto segment = get_standard_timeseries_segment("test_clone");
     auto copied = segment.clone();
     segment.sort("time");
@@ -310,7 +328,8 @@ TEST(MemSegment, SortSorted) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(MemSegment, DoubleReverse) {
+TEST(MemSegment, DoubleReverse)
+{
     auto segment = get_standard_timeseries_segment("test_clone");
     auto copied = segment.clone();
     ASSERT_EQ(segment.is_index_sorted(), true);
@@ -321,7 +340,8 @@ TEST(MemSegment, DoubleReverse) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(MemSegment, SortReversed) {
+TEST(MemSegment, SortReversed)
+{
     auto segment = get_standard_timeseries_segment("test_clone");
     auto copied = segment.clone();
     std::reverse(segment.begin(), segment.end());
@@ -331,7 +351,8 @@ TEST(MemSegment, SortReversed) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(MemSegment, SparsifyUnsparsify) {
+TEST(MemSegment, SparsifyUnsparsify)
+{
     auto segment = get_sparse_timeseries_segment_floats("test_shuffle_sparse");
     auto copied = segment.clone();
     segment.unsparsify();
@@ -340,7 +361,8 @@ TEST(MemSegment, SparsifyUnsparsify) {
     ASSERT_EQ(equals, true);
 }
 
-TEST(MemSegment, ShuffleSparse) {
+TEST(MemSegment, ShuffleSparse)
+{
     auto segment = get_sparse_timeseries_segment_floats("test_shuffle_sparse");
     auto copied = segment.clone();
     std::random_device rng;
@@ -351,7 +373,8 @@ TEST(MemSegment, ShuffleSparse) {
     ASSERT_EQ(segment.is_index_sorted(), false);
 }
 
-TEST(MemSegment, ShuffleAndSortSparse) {
+TEST(MemSegment, ShuffleAndSortSparse)
+{
     auto segment = get_sparse_timeseries_segment_floats("test_shuffle_sparse");
     auto copied = segment.clone();
     std::random_device rng;
@@ -365,61 +388,59 @@ TEST(MemSegment, ShuffleAndSortSparse) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(MemSegment, Append) {
-    StreamDescriptor descriptor{stream_descriptor(StreamId("test"), TimeseriesIndex::default_index(), {
-        scalar_field_proto(DataType::UINT8, "thing2"),
-        scalar_field_proto(DataType::UINT32, "thing3")
-    })};
+TEST(MemSegment, Append)
+{
+    StreamDescriptor descriptor{stream_descriptor(StreamId("test"),
+        TimeseriesIndex::default_index(),
+        {scalar_field_proto(DataType::UINT8, "thing2"), scalar_field_proto(DataType::UINT32, "thing3")})};
     SegmentInMemory s1(descriptor);
-    for(int row = 0; row < 10; ++row) {
-        for(int col = 0; col < 3; ++col) {
-            switch(col) {
-                case 0:
-                    s1.set_scalar<timestamp>(col, row + col);
-                    break;
-                case 1:
-                    s1.set_scalar<uint8_t>(col, row + col);
-                    break;
-                case 2:
-                    s1.set_scalar<uint32_t>(col, row + col);
-                    break;
-                default:
-                    break;
+    for (int row = 0; row < 10; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            switch (col) {
+            case 0:
+                s1.set_scalar<timestamp>(col, row + col);
+                break;
+            case 1:
+                s1.set_scalar<uint8_t>(col, row + col);
+                break;
+            case 2:
+                s1.set_scalar<uint32_t>(col, row + col);
+                break;
+            default:
+                break;
             }
-
         }
         s1.end_row();
     }
 
     SegmentInMemory s2(descriptor);
-    for(int row = 10; row < 20; ++row) {
-        for(int col = 0; col < 3; ++col) {
-            switch(col) {
-                case 0:
-                    s2.set_scalar<timestamp>(col, row + col);
-                    break;
-                case 1:
-                    s2.set_scalar<uint8_t>(col, row + col);
-                    break;
-                case 2:
-                    s2.set_scalar<uint32_t>(col, row + col);
-                    break;
-                default:
-                    break;
+    for (int row = 10; row < 20; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            switch (col) {
+            case 0:
+                s2.set_scalar<timestamp>(col, row + col);
+                break;
+            case 1:
+                s2.set_scalar<uint8_t>(col, row + col);
+                break;
+            case 2:
+                s2.set_scalar<uint32_t>(col, row + col);
+                break;
+            default:
+                break;
             }
         }
         s2.end_row();
     }
 
     s1.append(s2);
-    for(int row = 0; row < 20; ++row) {
+    for (int row = 0; row < 20; ++row) {
         ASSERT_EQ(s1.scalar_at<timestamp>(row, 0).value(), row);
     }
-    for(int row = 0; row < 20; ++row) {
+    for (int row = 0; row < 20; ++row) {
         ASSERT_EQ(s1.scalar_at<uint8_t>(row, 1).value(), row + 1);
     }
-    for(int row = 0; row < 20; ++row) {
+    for (int row = 0; row < 20; ++row) {
         ASSERT_EQ(s1.scalar_at<uint32_t>(row, 2).value(), row + 2);
     }
 }
-

--- a/cpp/arcticdb/entity/atom_key.hpp
+++ b/cpp/arcticdb/entity/atom_key.hpp
@@ -18,48 +18,95 @@
 namespace arcticdb::entity {
 
 class AtomKeyImpl {
-  public:
-
+public:
     template<class IndexValueType>
-    AtomKeyImpl(
-        StreamId id,
+    AtomKeyImpl(StreamId id,
         VersionId version_id,
         timestamp creation_ts,
         ContentHash content_hash,
         const IndexValueType start_index,
         const IndexValueType end_index,
         KeyType key_type)
-        :
-        id_(std::move(id)),
-        version_id_(version_id),
-        creation_ts_(creation_ts),
-        content_hash_(content_hash),
-        key_type_(key_type),
-        index_start_(std::move(start_index)),
-        index_end_(std::move(end_index)),
-        str_() { }
+        : id_(std::move(id)),
+          version_id_(version_id),
+          creation_ts_(creation_ts),
+          content_hash_(content_hash),
+          key_type_(key_type),
+          index_start_(std::move(start_index)),
+          index_end_(std::move(end_index)),
+          str_()
+    {
+    }
 
     AtomKeyImpl() = default;
-    AtomKeyImpl(const AtomKeyImpl &other) = default;
-    AtomKeyImpl &operator=(const AtomKeyImpl &other) = default;
-    AtomKeyImpl(AtomKeyImpl &&other) = default;
-    AtomKeyImpl &operator=(AtomKeyImpl &&other) = default;
+    AtomKeyImpl(const AtomKeyImpl& other) = default;
+    AtomKeyImpl& operator=(const AtomKeyImpl& other) = default;
+    AtomKeyImpl(AtomKeyImpl&& other) = default;
+    AtomKeyImpl& operator=(AtomKeyImpl&& other) = default;
 
-    const auto& id() const { return id_; }
-    const auto& version_id() const { return version_id_; }
-    const auto& gen_id() const { return version_id_; }
-    const auto& creation_ts() const { return creation_ts_; }
-    TimestampRange time_range() const { return {start_time(), end_time()}; }
-    timestamp start_time() const { if (std::holds_alternative<timestamp>(index_start_)) return std::get<timestamp>(index_start_); else return 0LL; }
-    timestamp end_time() const { if (std::holds_alternative<timestamp>(index_end_)) return std::get<timestamp>(index_end_); else return 0LL; }
-    const auto& content_hash() const { return content_hash_; }
-    const auto& type() const { return key_type_; }
-    auto& type() { return key_type_; }
-    const IndexValue &start_index() const { return index_start_; }
-    const IndexValue &end_index() const { return index_end_; }
-    IndexRange index_range() const { IndexRange ir = {index_start_, index_end_}; ir.end_closed_ = false; return ir;}
+    const auto& id() const
+    {
+        return id_;
+    }
+    const auto& version_id() const
+    {
+        return version_id_;
+    }
+    const auto& gen_id() const
+    {
+        return version_id_;
+    }
+    const auto& creation_ts() const
+    {
+        return creation_ts_;
+    }
+    TimestampRange time_range() const
+    {
+        return {start_time(), end_time()};
+    }
+    timestamp start_time() const
+    {
+        if (std::holds_alternative<timestamp>(index_start_))
+            return std::get<timestamp>(index_start_);
+        else
+            return 0LL;
+    }
+    timestamp end_time() const
+    {
+        if (std::holds_alternative<timestamp>(index_end_))
+            return std::get<timestamp>(index_end_);
+        else
+            return 0LL;
+    }
+    const auto& content_hash() const
+    {
+        return content_hash_;
+    }
+    const auto& type() const
+    {
+        return key_type_;
+    }
+    auto& type()
+    {
+        return key_type_;
+    }
+    const IndexValue& start_index() const
+    {
+        return index_start_;
+    }
+    const IndexValue& end_index() const
+    {
+        return index_end_;
+    }
+    IndexRange index_range() const
+    {
+        IndexRange ir = {index_start_, index_end_};
+        ir.end_closed_ = false;
+        return ir;
+    }
 
-    auto change_type(KeyType new_type) {
+    auto change_type(KeyType new_type)
+    {
         key_type_ = new_type;
         reset_cached();
     }
@@ -69,52 +116,65 @@ class AtomKeyImpl {
      * @param id Will be moved.
      * @return The old id moved out.
      */
-    StreamId change_id(StreamId id) {
+    StreamId change_id(StreamId id)
+    {
         auto out = std::move(id_);
         id_ = std::move(id);
         reset_cached();
         return out;
     }
 
-    friend bool operator==(const AtomKeyImpl &l, const AtomKeyImpl &r) {
-        return l.version_id() == r.version_id()
-            && l.creation_ts() == r.creation_ts()
-            && l.content_hash() == r.content_hash()
-            && l.start_index() == r.start_index()
-            && l.end_index() == r.end_index()
-            && l.type() == r.type()
-            && l.id() == r.id();
+    friend bool operator==(const AtomKeyImpl& l, const AtomKeyImpl& r)
+    {
+        return l.version_id() == r.version_id() && l.creation_ts() == r.creation_ts() &&
+               l.content_hash() == r.content_hash() && l.start_index() == r.start_index() &&
+               l.end_index() == r.end_index() && l.type() == r.type() && l.id() == r.id();
     }
 
-    friend bool operator!=(const AtomKeyImpl &l, const AtomKeyImpl &r) {
+    friend bool operator!=(const AtomKeyImpl& l, const AtomKeyImpl& r)
+    {
         return !(l == r);
     }
 
-    friend bool operator<(const AtomKeyImpl &l, const AtomKeyImpl &r) {
+    friend bool operator<(const AtomKeyImpl& l, const AtomKeyImpl& r)
+    {
         auto lt = std::tie(l.id_, l.version_id_, l.index_start_, l.index_end_, l.creation_ts_);
         auto rt = std::tie(r.id_, r.version_id_, r.index_start_, r.index_end_, r.creation_ts_);
         return lt < rt;
     }
 
-    friend bool operator>(const AtomKeyImpl &l, const AtomKeyImpl &r) {
+    friend bool operator>(const AtomKeyImpl& l, const AtomKeyImpl& r)
+    {
         return !(l < r) && (l != r);
     }
 
-    size_t get_cached_hash() const {
+    size_t get_cached_hash() const
+    {
         if (!hash_) {
             // arcticdb::commutative_hash_combine needs extra template specialisations for our variant types, folly's
             // built-in variant forwards to std::hash which should be good enough for these simple types
-            hash_ = folly::hash::hash_combine(id_, version_id_, creation_ts_, content_hash_, key_type_, index_start_,
-                    index_end_);
+            hash_ = folly::hash::hash_combine(id_,
+                version_id_,
+                creation_ts_,
+                content_hash_,
+                key_type_,
+                index_start_,
+                index_end_);
         }
         return hash_.value();
     }
 
-    void set_string() const {
+    void set_string() const
+    {
         str_ = fmt::format("{}", *this);
     }
 
-    std::string_view view() const { if(str_.empty()) set_string(); return {str_}; }
+    std::string_view view() const
+    {
+        if (str_.empty())
+            set_string();
+        return {str_};
+    }
 
 private:
     StreamId id_;
@@ -127,7 +187,8 @@ private:
     mutable std::string str_; //TODO internalized string
     mutable std::optional<size_t> hash_;
 
-    void reset_cached() {
+    void reset_cached()
+    {
         str_.clear();
         hash_.reset();
     }
@@ -141,56 +202,61 @@ private:
  * @tparam StringViewable
  */
 class AtomKeyBuilder {
-  public:
-    auto &version_id(VersionId v) {
+public:
+    auto& version_id(VersionId v)
+    {
         version_id_ = v;
         return *this;
     }
 
-    auto &gen_id(VersionId v) {
+    auto& gen_id(VersionId v)
+    {
         util::check_arg(version_id_ == 0, "Should not set both version_id and version id on a key");
         version_id_ = v;
         return *this;
     }
 
-    auto &creation_ts(timestamp v) {
+    auto& creation_ts(timestamp v)
+    {
         creation_ts_ = v;
         return *this;
     }
 
-    auto &string_index(const std::string &s) {
+    auto& string_index(const std::string& s)
+    {
         index_start_ = s;
         return *this;
     }
-    auto &start_index(const IndexValue &iv) {
+    auto& start_index(const IndexValue& iv)
+    {
         index_start_ = iv;
         return *this;
     }
 
-    auto &end_index(const IndexValue &iv) {
+    auto& end_index(const IndexValue& iv)
+    {
         index_end_ = iv;
         return *this;
     }
 
-    auto &content_hash(ContentHash v) {
+    auto& content_hash(ContentHash v)
+    {
         content_hash_ = v;
         return *this;
     }
 
     template<KeyType KT>
-    AtomKeyImpl build(StreamId id) {
-        return {
-            std::move(id), version_id_, creation_ts_, content_hash_, index_start_, index_end_, KT
-        };
+    AtomKeyImpl build(StreamId id)
+    {
+        return {std::move(id), version_id_, creation_ts_, content_hash_, index_start_, index_end_, KT};
     }
 
-    AtomKeyImpl build(StreamId id, KeyType key_type) {
-        return {
-            std::move(id), version_id_, creation_ts_, content_hash_, index_start_, index_end_, key_type
-        };
+    AtomKeyImpl build(StreamId id, KeyType key_type)
+    {
+        return {std::move(id), version_id_, creation_ts_, content_hash_, index_start_, index_end_, key_type};
     }
 
-  private:
+private:
     VersionId version_id_ = 0;
     arcticdb::entity::timestamp creation_ts_ = 0;
     ContentHash content_hash_ = 0;
@@ -206,16 +272,17 @@ using AtomKey = AtomKeyImpl;
  */
 using IndexTypeKey = AtomKey;
 
-inline auto atom_key_builder() {
+inline auto atom_key_builder()
+{
     return AtomKeyBuilder{};
 }
 
-inline AtomKey null_key() {
+inline AtomKey null_key()
+{
     return atom_key_builder().build("", KeyType::UNDEFINED);
 }
 
 } // namespace arcticdb::entity
-
 
 // The formatting below deals with the display of keys in logs etc., i.e. in a human-readable
 // format. Transformation of keys for persistence is handled elsewhere.
@@ -224,39 +291,52 @@ namespace fmt {
 using namespace arcticdb::entity;
 
 template<class FormatTag>
-struct formatter<FormattableRef < AtomKey, FormatTag>> {
-template<typename ParseContext>
-constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+struct formatter<FormattableRef<AtomKey, FormatTag>> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
-template<typename FormatContext>
-auto format(const FormattableRef <arcticdb::entity::AtomKey, FormatTag> &f, FormatContext &ctx) const {
-    const auto &key = f.ref;
-    return format_to(ctx.out(), FMT_STRING(FormatTag::format),
-                    key.type(), key.id(), key.version_id(),
-                     key.content_hash(), key.creation_ts(), tokenized_index(key.start_index()), tokenized_index(key.end_index()));
-}
-
+    template<typename FormatContext>
+    auto format(const FormattableRef<arcticdb::entity::AtomKey, FormatTag>& f, FormatContext& ctx) const
+    {
+        const auto& key = f.ref;
+        return format_to(ctx.out(),
+            FMT_STRING(FormatTag::format),
+            key.type(),
+            key.id(),
+            key.version_id(),
+            key.content_hash(),
+            key.creation_ts(),
+            tokenized_index(key.start_index()),
+            tokenized_index(key.end_index()));
+    }
 };
 
 template<>
 struct formatter<AtomKey> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::AtomKey &key, FormatContext &ctx) const {
-        formatter<FormattableRef < arcticdb::entity::AtomKey, DefaultAtomKeyFormat>>
-        f;
+    auto format(const arcticdb::entity::AtomKey& key, FormatContext& ctx) const
+    {
+        formatter<FormattableRef<arcticdb::entity::AtomKey, DefaultAtomKeyFormat>> f;
         return f.format(formattable(key), ctx);
     }
 };
-}
+} // namespace fmt
 
 namespace std {
 template<>
 struct hash<arcticdb::entity::AtomKeyImpl> {
-    inline arcticdb::HashedValue operator()(const arcticdb::entity::AtomKeyImpl &k) const noexcept {
+    inline arcticdb::HashedValue operator()(const arcticdb::entity::AtomKeyImpl& k) const noexcept
+    {
         return k.get_cached_hash();
     }
 };
-}
+} // namespace std

--- a/cpp/arcticdb/entity/index_range.hpp
+++ b/cpp/arcticdb/entity/index_range.hpp
@@ -26,22 +26,21 @@ using IndexValue = std::variant<NumericIndex, StringIndex>;
 
 /** The IndexValue variant holds NumericIndex=timestamp=int64_t but is also used to store sizes up to uint64, so needs
     safe conversion. See also safe_convert_to_numeric_id. */
-inline NumericIndex safe_convert_to_numeric_index(uint64_t input, const char* input_name) {
+inline NumericIndex safe_convert_to_numeric_index(uint64_t input, const char* input_name)
+{
     util::check(input <= static_cast<uint64_t>(std::numeric_limits<NumericIndex>::max()),
-        "{} greater than 2^63 is not supported.", input_name);
+        "{} greater than 2^63 is not supported.",
+        input_name);
     return static_cast<NumericIndex>(input);
 }
 
-inline std::string tokenized_index(const IndexValue& val) {
-    return util::variant_match(val,
-                               [] (const NumericIndex& num) {
-        return fmt::format("{}", *reinterpret_cast<const uint64_t*>(&num));
-        },
-        [](const StringIndex& str) {
-        return str;
-    });
+inline std::string tokenized_index(const IndexValue& val)
+{
+    return util::variant_match(
+        val,
+        [](const NumericIndex& num) { return fmt::format("{}", *reinterpret_cast<const uint64_t*>(&num)); },
+        [](const StringIndex& str) { return str; });
 }
-
 
 struct IndexRange {
     IndexValue start_;
@@ -51,27 +50,35 @@ struct IndexRange {
     bool start_closed_;
     bool end_closed_;
 
-    IndexRange() : specified_(false), start_closed_(true), end_closed_(true) {}
-
-    IndexRange(IndexValue start, IndexValue end) :
-        start_(std::move(start)),
-        end_(std::move(end)),
-        specified_(true),
-        start_closed_(true),
-        end_closed_(true) {
+    IndexRange()
+        : specified_(false),
+          start_closed_(true),
+          end_closed_(true)
+    {
     }
 
-    explicit IndexRange(const TimestampRange &rg) :
-        start_(rg.first),
-        end_(rg.second),
-        specified_(true),
-        start_closed_(true),
-        end_closed_(true) {
+    IndexRange(IndexValue start, IndexValue end)
+        : start_(std::move(start)),
+          end_(std::move(end)),
+          specified_(true),
+          start_closed_(true),
+          end_closed_(true)
+    {
+    }
+
+    explicit IndexRange(const TimestampRange& rg)
+        : start_(rg.first),
+          end_(rg.second),
+          specified_(true),
+          start_closed_(true),
+          end_closed_(true)
+    {
     }
 
     // Indices of non-matching types will always be excluded, might want to assert though
     // as this should never happen
-    bool accept(const IndexValue &index) {
+    bool accept(const IndexValue& index)
+    {
         if (!specified_)
             return true;
 
@@ -85,72 +92,85 @@ struct IndexRange {
     }
 
     // N.B. Convenience function, variant construction will be too expensive for tight loops
-    friend bool intersects(const IndexRange &left, const IndexRange& right) {
+    friend bool intersects(const IndexRange& left, const IndexRange& right)
+    {
         if (!left.specified_ || !right.specified_)
             return true;
 
         return left.start_ <= right.end_ && left.end_ >= right.start_;
     }
 
-    friend bool intersects(const IndexRange &rg, const IndexValue &start, const IndexValue &end) {
+    friend bool intersects(const IndexRange& rg, const IndexValue& start, const IndexValue& end)
+    {
         if (!rg.specified_)
             return true;
 
         return rg.start_ <= end && rg.end_ >= start;
     }
 
-    friend bool overlaps(const IndexRange &left, const IndexRange& right) {
+    friend bool overlaps(const IndexRange& left, const IndexRange& right)
+    {
         if (!left.specified_ || !right.specified_)
             return true;
 
         return left.start_ == right.start_ && left.end_ == right.end_;
     }
 
-    void adjust_start(const IndexValue &index_value) {
-        std::visit(util::overload{
-                [that = this](const auto &start, const auto &val) {
-                    if constexpr(std::is_same_v<std::decay_t<decltype(start)>, std::decay_t<decltype(val)>>) {
-                        that->start_ = std::min(start, val);
-                    } else {
-                        util::raise_rte("Type mismatch in update");
-                    }
-                }}, start_, index_value);
+    void adjust_start(const IndexValue& index_value)
+    {
+        std::visit(util::overload{[that = this](const auto& start, const auto& val) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(start)>, std::decay_t<decltype(val)>>) {
+                that->start_ = std::min(start, val);
+            } else {
+                util::raise_rte("Type mismatch in update");
+            }
+        }},
+            start_,
+            index_value);
     }
 
-    void adjust_end(const IndexValue &index_value) {
-        std::visit(util::overload{
-                [that = this](const auto &end, const auto &val) {
-                    if constexpr(std::is_same_v<std::decay_t<decltype(end)>, std::decay_t<decltype(val)>>) {
-                        that->end_ = std::min(end, val);
-                    } else {
-                        util::raise_rte("Type mismatch in update");
-                    }
-                }}, end_, index_value);
+    void adjust_end(const IndexValue& index_value)
+    {
+        std::visit(util::overload{[that = this](const auto& end, const auto& val) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(end)>, std::decay_t<decltype(val)>>) {
+                that->end_ = std::min(end, val);
+            } else {
+                util::raise_rte("Type mismatch in update");
+            }
+        }},
+            end_,
+            index_value);
     }
 
-    void adjust_open_closed_interval() {
-        util::variant_match(start_,
-                            [that = this](const NumericIndex &start) mutable {
-                                if (!that->start_closed_)
-                                    that->start_ = IndexValue{start + 1};
-                            },
-                            [](const auto &) {
-                            });
+    void adjust_open_closed_interval()
+    {
+        util::variant_match(
+            start_,
+            [that = this](const NumericIndex& start) mutable {
+                if (!that->start_closed_)
+                    that->start_ = IndexValue{start + 1};
+            },
+            [](const auto&) {});
 
-        util::variant_match(end_,
-                            [that = this](const NumericIndex &end) {
-                                if (!that->end_closed_)
-                                    that->end_ = IndexValue{end - 1};
-                            },
-                            [](const auto &) {
-                            }
-        );
+        util::variant_match(
+            end_,
+            [that = this](const NumericIndex& end) {
+                if (!that->end_closed_)
+                    that->end_ = IndexValue{end - 1};
+            },
+            [](const auto&) {});
     }
 };
 
-inline IndexRange unspecified_range() { return {}; }
+inline IndexRange unspecified_range()
+{
+    return {};
+}
 
-inline IndexRange universal_range(){ return IndexRange{std::numeric_limits<timestamp>::min(), std::numeric_limits<timestamp>::max()} ;}
+inline IndexRange universal_range()
+{
+    return IndexRange{std::numeric_limits<timestamp>::min(), std::numeric_limits<timestamp>::max()};
+}
 
 } //namespace arcticdb::entity
 
@@ -160,10 +180,14 @@ using namespace arcticdb::entity;
 template<>
 struct formatter<TimestampRange> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const TimestampRange &r, FormatContext &ctx) const {
+    auto format(const TimestampRange& r, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}-{}", r.first, r.second);
     }
 };
@@ -171,10 +195,14 @@ struct formatter<TimestampRange> {
 template<>
 struct formatter<IndexRange> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const IndexRange &r, FormatContext &ctx) const {
+    auto format(const IndexRange& r, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}-{}", r.start_, r.end_);
     }
 };

--- a/cpp/arcticdb/entity/key.cpp
+++ b/cpp/arcticdb/entity/key.cpp
@@ -11,21 +11,27 @@
 namespace arcticdb::entity {
 
 struct KeyData {
-    KeyData() :
-        long_name_("undefined"),
-        short_name_('u'),
-        variant_type_(VariantType::UNKNOWN_TYPE),
-        key_class_(KeyClass::UNKNOWN_CLASS),
-        description_()
-        {}
+    KeyData()
+        : long_name_("undefined"),
+          short_name_('u'),
+          variant_type_(VariantType::UNKNOWN_TYPE),
+          key_class_(KeyClass::UNKNOWN_CLASS),
+          description_()
+    {
+    }
 
-    KeyData(const char* long_name, char short_name, VariantType variant_type, KeyClass key_class, const char* description) :
-        long_name_(long_name),
-        short_name_(short_name),
-        variant_type_(variant_type),
-        key_class_(key_class),
-        description_(description){}
-
+    KeyData(const char* long_name,
+        char short_name,
+        VariantType variant_type,
+        KeyClass key_class,
+        const char* description)
+        : long_name_(long_name),
+          short_name_(short_name),
+          variant_type_(variant_type),
+          key_class_(key_class),
+          description_(description)
+    {
+    }
 
     const char* long_name_;
     char short_name_;
@@ -34,14 +40,16 @@ struct KeyData {
     const char* description_;
 };
 
-const KeyData& get_key_data(KeyType key_type) {
-    struct KeyMapTag{};
+const KeyData& get_key_data(KeyType key_type)
+{
+    struct KeyMapTag {};
     using KeyMap = semi::static_map<int, KeyData, KeyMapTag>;
 
 #define KEY_ID(x) []() constexpr { return static_cast<int>(x); }
-#define NUMERIC_KEY(kt, name, c) KeyMap::get(KEY_ID(kt)) = { #name, c, VariantType::NUMERIC_TYPE, KeyClass::ATOM_KEY, #kt };
-#define STRING_KEY(kt, name, c) KeyMap::get(KEY_ID(kt)) = { #name, c, VariantType::STRING_TYPE, KeyClass::ATOM_KEY, #kt};
-#define STRING_REF(kt, name, c) KeyMap::get(KEY_ID(kt)) = { #name, c, VariantType::STRING_TYPE, KeyClass::REF_KEY,  #kt };
+#define NUMERIC_KEY(kt, name, c)                                                                                       \
+    KeyMap::get(KEY_ID(kt)) = {#name, c, VariantType::NUMERIC_TYPE, KeyClass::ATOM_KEY, #kt};
+#define STRING_KEY(kt, name, c) KeyMap::get(KEY_ID(kt)) = {#name, c, VariantType::STRING_TYPE, KeyClass::ATOM_KEY, #kt};
+#define STRING_REF(kt, name, c) KeyMap::get(KEY_ID(kt)) = {#name, c, VariantType::STRING_TYPE, KeyClass::REF_KEY, #kt};
 
     NUMERIC_KEY(KeyType::STREAM_GROUP, sg, 'g')
     NUMERIC_KEY(KeyType::GENERATION, gen, 'G')
@@ -69,33 +77,39 @@ const KeyData& get_key_data(KeyType key_type) {
     STRING_KEY(KeyType::TOMBSTONE_ALL, tall, 'q')
     STRING_REF(KeyType::LIBRARY_CONFIG, cref, 'C')
 
-    const auto& data =  KeyMap::get(int(key_type));
+    const auto& data = KeyMap::get(int(key_type));
     util::check(data.short_name_ != 'u', "Could not get data for key_type {}", static_cast<int>(key_type));
     return data;
 }
 
-const char* key_type_long_name(KeyType key_type) {
+const char* key_type_long_name(KeyType key_type)
+{
     return get_key_data(key_type).long_name_;
 }
 
-char key_type_short_name(KeyType key_type) {
+char key_type_short_name(KeyType key_type)
+{
     return get_key_data(key_type).short_name_;
 }
 
-VariantType variant_type_from_key_type(KeyType key_type) {
+VariantType variant_type_from_key_type(KeyType key_type)
+{
     return get_key_data(key_type).variant_type_;
 }
 
-KeyClass key_class_from_key_type(KeyType key_type) {
+KeyClass key_class_from_key_type(KeyType key_type)
+{
     return get_key_data(key_type).key_class_;
 }
 
-bool is_string_key_type(KeyType key_type){
+bool is_string_key_type(KeyType key_type)
+{
     return variant_type_from_key_type(key_type) == VariantType::STRING_TYPE;
 }
 
-bool is_ref_key_class(KeyType key_type){
+bool is_ref_key_class(KeyType key_type)
+{
     return key_class_from_key_type(key_type) == KeyClass::REF_KEY;
 }
 
-}
+} // namespace arcticdb::entity

--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -17,201 +17,220 @@ using namespace prometheus;
 
 namespace arcticdb {
 
-    std::shared_ptr<PrometheusInstance> PrometheusInstance::instance(){
-        std::call_once(PrometheusInstance::init_flag_, &PrometheusInstance::init);
-        return PrometheusInstance::instance_;
-    }
-
-    std::shared_ptr<PrometheusInstance> PrometheusInstance::instance_;
-    std::once_flag PrometheusInstance::init_flag_;
-
-    std::shared_ptr<PrometheusConfigInstance> PrometheusConfigInstance::instance(){
-        std::call_once(PrometheusConfigInstance::init_flag_, &PrometheusConfigInstance::init);
-        return PrometheusConfigInstance::instance_;
-    }
-
-    std::shared_ptr<PrometheusConfigInstance> PrometheusConfigInstance::instance_;
-    std::once_flag PrometheusConfigInstance::init_flag_;
-
-    PrometheusInstance::PrometheusInstance() {
-
-        auto cfg = PrometheusConfigInstance::instance()->config;
-
-        if (cfg.prometheus_model() == PrometheusConfigInstance::Proto::PUSH) {
-            // PUSH MODE
-            if (cfg.instance().empty() || cfg.host().empty() || cfg.port().empty() || cfg.job_name().empty()) {
-                util::raise_rte( "Invalid Push PrometheusConfig {}", arcticdb::util::format(cfg));
-            }
-
-            // IMP: This is the GROUPING_KEY - every push overwrites the previous grouping key
-            auto labels = prometheus::Gateway::GetInstanceLabel(getHostName());
-            mongo_instance_ = cfg.instance();
-            labels.insert(std::pair<std::string, std::string>(MONGO_INSTANCE_LABEL, mongo_instance_));
-            labels.insert(std::pair<std::string, std::string>(PROMETHEUS_ENV_LABEL, cfg.prometheus_env()));
-            gateway_= std::make_shared<prometheus::Gateway>(cfg.host(), cfg.port(), cfg.job_name(), labels);
-            registry_ = std::make_shared<prometheus::Registry>();
-            gateway_->RegisterCollectable(registry_);
-
-            arcticdb::log::version().info("Prometheus Push created with settings {}", arcticdb::util::format(cfg));
-
-        } else if (cfg.prometheus_model()  == PrometheusConfigInstance::Proto::WEB) {
-
-            // WEB SERVER MODE
-            if (cfg.port().empty()) {
-                util::raise_rte( "PrometheusConfig web mode port not set {}", arcticdb::util::format(cfg));
-            }
-
-            // create an http server ie "http://hostname:"+port()+"/metrics"
-            std::string hostname = getHostName();
-            std::string endpoint = hostname + ":" + cfg.port();
-
-            // default to 2 threads
-            exposer_ = std::make_shared<prometheus::Exposer>(endpoint, 2);
-
-            // create a metrics registry with component=main labels applied to all its
-            registry_ = std::make_shared<prometheus::Registry>();
-
-            // 2nd arg defaults to /metrics, make explicit or parameterise
-            exposer_->RegisterCollectable(registry_, "/metrics");
-
-            arcticdb::log::version().info("Prometheus endpoint created on {}/metrics", endpoint);
-        }
-        else {
-            arcticdb::log::version().info("Prometheus not configured {}", arcticdb::util::format(cfg));
-        }
-    }
-
-    // new mechanism, labels at runtime
-    void PrometheusInstance::registerMetric(
-            prometheus::MetricType type,
-            const std::string& name,
-            const std::string& help,
-            const std::map<std::string, std::string>& staticLabels,
-            const std::vector<double>& buckets_list
-    ) {
-        if (registry_.use_count() == 0) {
-            return;
-        }
-
-        if (type == prometheus::MetricType::Counter) {
-            // Counter is actually a unique_ptr object which has a life of registry
-            map_counter_[name] = &prometheus::BuildCounter()
-                    .Name(name)
-                    .Help(help)
-                    .Labels(staticLabels)
-                    .Register(*registry_);
-        } else if (type == prometheus::MetricType::Gauge) {
-            map_gauge_[name] = &prometheus::BuildGauge()
-                    .Name(name)
-                    .Help(help)
-                    .Labels(staticLabels)
-                    .Register(*registry_);
-        } else if (type == prometheus::MetricType::Histogram) {
-            map_histogram_[name].histogram = &prometheus::BuildHistogram()
-                    .Name(name)
-                    .Help(help)
-                    .Labels(staticLabels)
-                    .Register(*registry_);
-            map_histogram_[name].buckets_list = buckets_list;
-        } else if (type == prometheus::MetricType::Summary) {
-            map_summary_[name] = &prometheus::BuildSummary()
-                    .Name(name)
-                    .Help(help)
-                    .Labels(staticLabels)
-                    .Register(*registry_);
-        } else {
-            arcticdb::log::version().warn("Unsupported metric type");
-        }
+std::shared_ptr<PrometheusInstance> PrometheusInstance::instance()
+{
+    std::call_once(PrometheusInstance::init_flag_, &PrometheusInstance::init);
+    return PrometheusInstance::instance_;
 }
 
-    // update new cardinal counter
-    void PrometheusInstance::incrementCounter(const std::string& name, const std::map<std::string, std::string>& labels) {
-        if (registry_.use_count() == 0)
-            return;
+std::shared_ptr<PrometheusInstance> PrometheusInstance::instance_;
+std::once_flag PrometheusInstance::init_flag_;
 
-        if (map_counter_.count(name) != 0) {
-            // Add returns Counter&
-            map_counter_[name]->Add(labels).Increment();
-        } else {
-            arcticdb::log::version().warn("Unregistered counter metric {}", name);
-        }
-    }
-    void PrometheusInstance::incrementCounter(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
-        if (registry_.use_count() == 0)
-            return;
+std::shared_ptr<PrometheusConfigInstance> PrometheusConfigInstance::instance()
+{
+    std::call_once(PrometheusConfigInstance::init_flag_, &PrometheusConfigInstance::init);
+    return PrometheusConfigInstance::instance_;
+}
 
-        if (map_counter_.count(name) != 0) {
-            // Add returns Counter&
-            map_counter_[name]->Add(labels).Increment(value);
-        } else {
-            arcticdb::log::version().warn("Unregistered counter metric {}", name);
-        }
-    }
-    void PrometheusInstance::setGauge(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
-        if (registry_.use_count() == 0)
-            return;
+std::shared_ptr<PrometheusConfigInstance> PrometheusConfigInstance::instance_;
+std::once_flag PrometheusConfigInstance::init_flag_;
 
-        if (map_gauge_.count(name) != 0) {
-            map_gauge_[name]->Add(labels).Set(value);
-        } else {
-            arcticdb::log::version().warn("Unregistered gauge metric {}", name);
-        }
-    }
-    void PrometheusInstance::setGaugeCurrentTime(const std::string& name, const std::map<std::string, std::string>& labels) {
-        if (registry_.use_count() == 0)
-            return;
+PrometheusInstance::PrometheusInstance()
+{
 
-        if (map_gauge_.count(name) != 0) {
-            map_gauge_[name]->Add(labels).SetToCurrentTime();
-        } else {
-            arcticdb::log::version().warn("Unregistered gauge metric {}", name);
-        }
-    }
-    void PrometheusInstance::observeHistogram(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
-        if (registry_.use_count() == 0)
-            return;
-        if (auto it=map_histogram_.find(name); it != map_histogram_.end()) {
-            it->second.histogram->Add(labels, it->second.buckets_list).Observe(value);
-        } else {
-            arcticdb::log::version().warn("Unregistered Histogram metric {}", name);
-        }
-    }
-    void PrometheusInstance::DeleteHistogram(const std::string& name, const std::map<std::string, std::string>& labels) {
-        if (registry_.use_count() == 0)
-            return;
+    auto cfg = PrometheusConfigInstance::instance()->config;
 
-        if (auto it=map_histogram_.find(name); it != map_histogram_.end()) {
-            it->second.histogram->Remove(&it->second.histogram->Add(labels, it->second.buckets_list));
-        } else {
-            arcticdb::log::version().warn("Unregistered Histogram metric {}", name);
+    if (cfg.prometheus_model() == PrometheusConfigInstance::Proto::PUSH) {
+        // PUSH MODE
+        if (cfg.instance().empty() || cfg.host().empty() || cfg.port().empty() || cfg.job_name().empty()) {
+            util::raise_rte("Invalid Push PrometheusConfig {}", arcticdb::util::format(cfg));
         }
-    }
-    void PrometheusInstance::observeSummary(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
-        if (registry_.use_count() == 0)
-            return;
 
-        if (map_summary_.count(name) != 0) {
-            //TODO DMK quantiles
-            map_summary_[name]->Add(labels,Summary::Quantiles{ {0.1, 0.05}, {0.2, 0.05}, {0.3, 0.05}, {0.4, 0.05}, {0.5, 0.05}, {0.6, 0.05}, {0.7, 0.05}, {0.8, 0.05}, {0.9, 0.05}, {0.9, 0.05}, {1.0, 0.05}}, std::chrono::seconds{SUMMARY_MAX_AGE}, SUMMARY_AGE_BUCKETS).Observe(value);
-        } else {
-            arcticdb::log::version().warn("Unregistered summary metric {}", name);
+        // IMP: This is the GROUPING_KEY - every push overwrites the previous grouping key
+        auto labels = prometheus::Gateway::GetInstanceLabel(getHostName());
+        mongo_instance_ = cfg.instance();
+        labels.insert(std::pair<std::string, std::string>(MONGO_INSTANCE_LABEL, mongo_instance_));
+        labels.insert(std::pair<std::string, std::string>(PROMETHEUS_ENV_LABEL, cfg.prometheus_env()));
+        gateway_ = std::make_shared<prometheus::Gateway>(cfg.host(), cfg.port(), cfg.job_name(), labels);
+        registry_ = std::make_shared<prometheus::Registry>();
+        gateway_->RegisterCollectable(registry_);
+
+        arcticdb::log::version().info("Prometheus Push created with settings {}", arcticdb::util::format(cfg));
+
+    } else if (cfg.prometheus_model() == PrometheusConfigInstance::Proto::WEB) {
+
+        // WEB SERVER MODE
+        if (cfg.port().empty()) {
+            util::raise_rte("PrometheusConfig web mode port not set {}", arcticdb::util::format(cfg));
         }
+
+        // create an http server ie "http://hostname:"+port()+"/metrics"
+        std::string hostname = getHostName();
+        std::string endpoint = hostname + ":" + cfg.port();
+
+        // default to 2 threads
+        exposer_ = std::make_shared<prometheus::Exposer>(endpoint, 2);
+
+        // create a metrics registry with component=main labels applied to all its
+        registry_ = std::make_shared<prometheus::Registry>();
+
+        // 2nd arg defaults to /metrics, make explicit or parameterise
+        exposer_->RegisterCollectable(registry_, "/metrics");
+
+        arcticdb::log::version().info("Prometheus endpoint created on {}/metrics", endpoint);
+    } else {
+        arcticdb::log::version().info("Prometheus not configured {}", arcticdb::util::format(cfg));
     }
-    std::string PrometheusInstance::getHostName() {
-        char hostname[1024];
-        if (::gethostname(hostname, sizeof(hostname))) {
-            return {};
-        }
-        return hostname;
+}
+
+// new mechanism, labels at runtime
+void PrometheusInstance::registerMetric(prometheus::MetricType type,
+    const std::string& name,
+    const std::string& help,
+    const std::map<std::string, std::string>& staticLabels,
+    const std::vector<double>& buckets_list)
+{
+    if (registry_.use_count() == 0) {
+        return;
     }
 
-    int PrometheusInstance::push() {
-        if (gateway_.use_count() > 0) {
-            return gateway_->PushAdd();
-        } else {
-            return 0;
-        }
+    if (type == prometheus::MetricType::Counter) {
+        // Counter is actually a unique_ptr object which has a life of registry
+        map_counter_[name] =
+            &prometheus::BuildCounter().Name(name).Help(help).Labels(staticLabels).Register(*registry_);
+    } else if (type == prometheus::MetricType::Gauge) {
+        map_gauge_[name] = &prometheus::BuildGauge().Name(name).Help(help).Labels(staticLabels).Register(*registry_);
+    } else if (type == prometheus::MetricType::Histogram) {
+        map_histogram_[name].histogram =
+            &prometheus::BuildHistogram().Name(name).Help(help).Labels(staticLabels).Register(*registry_);
+        map_histogram_[name].buckets_list = buckets_list;
+    } else if (type == prometheus::MetricType::Summary) {
+        map_summary_[name] =
+            &prometheus::BuildSummary().Name(name).Help(help).Labels(staticLabels).Register(*registry_);
+    } else {
+        arcticdb::log::version().warn("Unsupported metric type");
     }
+}
+
+// update new cardinal counter
+void PrometheusInstance::incrementCounter(const std::string& name, const std::map<std::string, std::string>& labels)
+{
+    if (registry_.use_count() == 0)
+        return;
+
+    if (map_counter_.count(name) != 0) {
+        // Add returns Counter&
+        map_counter_[name]->Add(labels).Increment();
+    } else {
+        arcticdb::log::version().warn("Unregistered counter metric {}", name);
+    }
+}
+void PrometheusInstance::incrementCounter(const std::string& name,
+    double value,
+    const std::map<std::string, std::string>& labels)
+{
+    if (registry_.use_count() == 0)
+        return;
+
+    if (map_counter_.count(name) != 0) {
+        // Add returns Counter&
+        map_counter_[name]->Add(labels).Increment(value);
+    } else {
+        arcticdb::log::version().warn("Unregistered counter metric {}", name);
+    }
+}
+void PrometheusInstance::setGauge(const std::string& name,
+    double value,
+    const std::map<std::string, std::string>& labels)
+{
+    if (registry_.use_count() == 0)
+        return;
+
+    if (map_gauge_.count(name) != 0) {
+        map_gauge_[name]->Add(labels).Set(value);
+    } else {
+        arcticdb::log::version().warn("Unregistered gauge metric {}", name);
+    }
+}
+void PrometheusInstance::setGaugeCurrentTime(const std::string& name, const std::map<std::string, std::string>& labels)
+{
+    if (registry_.use_count() == 0)
+        return;
+
+    if (map_gauge_.count(name) != 0) {
+        map_gauge_[name]->Add(labels).SetToCurrentTime();
+    } else {
+        arcticdb::log::version().warn("Unregistered gauge metric {}", name);
+    }
+}
+void PrometheusInstance::observeHistogram(const std::string& name,
+    double value,
+    const std::map<std::string, std::string>& labels)
+{
+    if (registry_.use_count() == 0)
+        return;
+    if (auto it = map_histogram_.find(name); it != map_histogram_.end()) {
+        it->second.histogram->Add(labels, it->second.buckets_list).Observe(value);
+    } else {
+        arcticdb::log::version().warn("Unregistered Histogram metric {}", name);
+    }
+}
+void PrometheusInstance::DeleteHistogram(const std::string& name, const std::map<std::string, std::string>& labels)
+{
+    if (registry_.use_count() == 0)
+        return;
+
+    if (auto it = map_histogram_.find(name); it != map_histogram_.end()) {
+        it->second.histogram->Remove(&it->second.histogram->Add(labels, it->second.buckets_list));
+    } else {
+        arcticdb::log::version().warn("Unregistered Histogram metric {}", name);
+    }
+}
+void PrometheusInstance::observeSummary(const std::string& name,
+    double value,
+    const std::map<std::string, std::string>& labels)
+{
+    if (registry_.use_count() == 0)
+        return;
+
+    if (map_summary_.count(name) != 0) {
+        //TODO DMK quantiles
+        map_summary_[name]
+            ->Add(labels,
+                Summary::Quantiles{{0.1, 0.05},
+                    {0.2, 0.05},
+                    {0.3, 0.05},
+                    {0.4, 0.05},
+                    {0.5, 0.05},
+                    {0.6, 0.05},
+                    {0.7, 0.05},
+                    {0.8, 0.05},
+                    {0.9, 0.05},
+                    {0.9, 0.05},
+                    {1.0, 0.05}},
+                std::chrono::seconds{SUMMARY_MAX_AGE},
+                SUMMARY_AGE_BUCKETS)
+            .Observe(value);
+    } else {
+        arcticdb::log::version().warn("Unregistered summary metric {}", name);
+    }
+}
+std::string PrometheusInstance::getHostName()
+{
+    char hostname[1024];
+    if (::gethostname(hostname, sizeof(hostname))) {
+        return {};
+    }
+    return hostname;
+}
+
+int PrometheusInstance::push()
+{
+    if (gateway_.use_count() > 0) {
+        return gateway_->PushAdd();
+    } else {
+        return 0;
+    }
+}
 
 } // Namespace arcticdb
-

--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -13,7 +13,8 @@
 
 namespace arcticdb::entity {
 
-inline ssize_t calc_elements(const shape_t* shape, ssize_t ndim) {
+inline ssize_t calc_elements(const shape_t* shape, ssize_t ndim)
+{
     return std::accumulate(shape, shape + ndim, ssize_t(1), std::multiplies<ssize_t>());
 }
 
@@ -21,52 +22,53 @@ struct NativeTensor {
     static constexpr ssize_t MaxDimensions = 2;
     using StrideContainer = std::array<stride_t, MaxDimensions>;
 
-    NativeTensor(
-               ssize_t nbytes,
-               ssize_t ndim,
-               const stride_t *strides,
-               const shape_t *shapes,
-               DataType dt,
-               ssize_t elsize,
-               const void *ptr) :
-        nbytes_(nbytes),
-        ndim_(ndim),
-        dt_(dt),
-        elsize_(elsize),
-        ptr(ptr) {
+    NativeTensor(ssize_t nbytes,
+        ssize_t ndim,
+        const stride_t* strides,
+        const shape_t* shapes,
+        DataType dt,
+        ssize_t elsize,
+        const void* ptr)
+        : nbytes_(nbytes),
+          ndim_(ndim),
+          dt_(dt),
+          elsize_(elsize),
+          ptr(ptr)
+    {
         util::check(shapes != nullptr, "Unexpected null shapes ptr");
-        if(shapes[0] == 0)
+        if (shapes[0] == 0)
             ARCTICDB_DEBUG(log::version(), "Supplied tensor is empty");
-        
+
         strides_[ndim - 1] = static_cast<ssize_t>(get_type_size(dt_));
-        for(ssize_t i = 0; i < std::min(MaxDimensions, ndim); ++i)
+        for (ssize_t i = 0; i < std::min(MaxDimensions, ndim); ++i)
             shapes_[i] = shapes[i];
 
-        if(strides == nullptr) {
+        if (strides == nullptr) {
             strides_[ndim - 1] = static_cast<ssize_t>(get_type_size(dt_));
-            if(ndim == 2)
+            if (ndim == 2)
                 strides_[0] = strides_[1] * shapes_[1];
-        }
-        else {
-            for(ssize_t i = 0; i < std::min(MaxDimensions, ndim); ++i)
+        } else {
+            for (ssize_t i = 0; i < std::min(MaxDimensions, ndim); ++i)
                 strides_[i] = strides[i];
         }
     }
 
-    NativeTensor(const NativeTensor& other) :
-    nbytes_(other.nbytes_),
-    ndim_(other.ndim_),
-    dt_(other.dt_),
-    elsize_(other.elsize_),
-    ptr(other.ptr) {
+    NativeTensor(const NativeTensor& other)
+        : nbytes_(other.nbytes_),
+          ndim_(other.ndim_),
+          dt_(other.dt_),
+          elsize_(other.elsize_),
+          ptr(other.ptr)
+    {
         for (ssize_t i = 0; i < std::min(MaxDimensions, ndim_); ++i)
             shapes_[i] = other.shapes_[i];
 
-        for(ssize_t i = 0; i < std::min(MaxDimensions, ndim_); ++i)
+        for (ssize_t i = 0; i < std::min(MaxDimensions, ndim_); ++i)
             strides_[i] = other.strides_[i];
     }
 
-    friend void swap(NativeTensor& left, NativeTensor& right) {
+    friend void swap(NativeTensor& left, NativeTensor& right)
+    {
         using std::swap;
         swap(left.magic_, right.magic_);
         swap(left.nbytes_, right.nbytes_);
@@ -74,77 +76,127 @@ struct NativeTensor {
         swap(left.dt_, right.dt_);
         swap(left.elsize_, right.elsize_);
         swap(left.ptr, right.ptr);
-        for(ssize_t i = 0; i < MaxDimensions; ++i) {
+        for (ssize_t i = 0; i < MaxDimensions; ++i) {
             swap(left.shapes_[i], right.shapes_[i]);
             swap(left.strides_[i], right.strides_[i]);
         }
     }
 
-    NativeTensor& operator=(const NativeTensor& other) {
+    NativeTensor& operator=(const NativeTensor& other)
+    {
         NativeTensor temp(other);
         swap(*this, temp);
         return *this;
     }
 
-    [[nodiscard]] ssize_t nbytes() const { return nbytes_; }
-    [[nodiscard]] ssize_t ndim() const { return ndim_; }
-    [[nodiscard]] stride_t strides(size_t pos) const { return strides_[pos]; }
-    [[nodiscard]] const stride_t* strides() const { return strides_.data(); };
-    [[nodiscard]] shape_t shape(size_t pos) const { return shapes_[pos]; }
-    [[nodiscard]] ssize_t elsize() const { return elsize_; }
-    [[nodiscard]] const shape_t* shape() const { return shapes_.data(); }
-    [[nodiscard]] DataType data_type() const { return dt_; }
-    [[nodiscard]] const void* data() const { magic_.check(); return ptr; }
-    [[nodiscard]] ssize_t extent(ssize_t dim) const { return shapes_[dim] * strides_[dim]; }
+    [[nodiscard]] ssize_t nbytes() const
+    {
+        return nbytes_;
+    }
+    [[nodiscard]] ssize_t ndim() const
+    {
+        return ndim_;
+    }
+    [[nodiscard]] stride_t strides(size_t pos) const
+    {
+        return strides_[pos];
+    }
+    [[nodiscard]] const stride_t* strides() const
+    {
+        return strides_.data();
+    };
+    [[nodiscard]] shape_t shape(size_t pos) const
+    {
+        return shapes_[pos];
+    }
+    [[nodiscard]] ssize_t elsize() const
+    {
+        return elsize_;
+    }
+    [[nodiscard]] const shape_t* shape() const
+    {
+        return shapes_.data();
+    }
+    [[nodiscard]] DataType data_type() const
+    {
+        return dt_;
+    }
+    [[nodiscard]] const void* data() const
+    {
+        magic_.check();
+        return ptr;
+    }
+    [[nodiscard]] ssize_t extent(ssize_t dim) const
+    {
+        return shapes_[dim] * strides_[dim];
+    }
 
     template<typename T>
-    const T *ptr_cast(size_t pos) const {
+    const T* ptr_cast(size_t pos) const
+    {
         bool dimension_condition = ndim() == 1;
         bool elsize_condition = elsize_ != 0;
         bool strides_condition = strides_[0] % elsize_ == 0;
         util::warn(dimension_condition, "Cannot safely ptr_cast matrices in NativeTensor");
         util::warn(elsize_condition, "Cannot safely ptr_cast when elsize_ is zero in NativeTensor");
         util::warn(strides_condition,
-                   "Cannot safely ptr_cast to type of size {} when strides ({}) is not a multiple of elsize ({}) in NativeTensor with dtype {}",
-                   sizeof(T), strides_[0], elsize_, data_type());
+            "Cannot safely ptr_cast to type of size {} when strides ({}) is not a multiple of elsize ({}) in "
+            "NativeTensor with dtype {}",
+            sizeof(T),
+            strides_[0],
+            elsize_,
+            data_type());
         int64_t signed_pos = pos;
         if (dimension_condition && elsize_condition && strides_condition) {
             signed_pos *= strides_[0] / elsize_;
         }
-        return (&(reinterpret_cast<const T *>(ptr)[signed_pos]));
+        return (&(reinterpret_cast<const T*>(ptr)[signed_pos]));
     }
 
     // returns number of elements, not bytesize
-    ssize_t size() const {
+    ssize_t size() const
+    {
         return calc_elements(shape(), ndim());
     }
 
-    NativeTensor &request() { return *this; }
+    NativeTensor& request()
+    {
+        return *this;
+    }
 
-    util::MagicNum<'T','n','s','r'> magic_;
+    util::MagicNum<'T', 'n', 's', 'r'> magic_;
     ssize_t nbytes_;
     ssize_t ndim_;
     StrideContainer strides_ = {};
     StrideContainer shapes_ = {};
     DataType dt_;
     ssize_t elsize_;
-    const void *ptr;
+    const void* ptr;
 };
 
-template <ssize_t> ssize_t byte_offset_impl(const stride_t* ) { return 0; }
-template <ssize_t Dim = 0, typename... Ix>
-ssize_t byte_offset_impl(const stride_t* strides, ssize_t i, Ix... index) {
+template<ssize_t>
+ssize_t byte_offset_impl(const stride_t*)
+{
+    return 0;
+}
+template<ssize_t Dim = 0, typename... Ix>
+ssize_t byte_offset_impl(const stride_t* strides, ssize_t i, Ix... index)
+{
     return i * strides[Dim] + byte_offset_impl<Dim + 1>(strides, index...);
 }
 
 //TODO is the conversion to a typed tensor really necessary for the codec part?
 template<typename T>
 struct TypedTensor : public NativeTensor {
-    static size_t itemsize() { return sizeof(T); }
+    static size_t itemsize()
+    {
+        return sizeof(T);
+    }
 
-    std::array<stride_t, 2> f_style_strides() {
+    std::array<stride_t, 2> f_style_strides()
+    {
         std::array<stride_t, 2> strides = {};
-        if(std::any_of(std::begin(shapes_),std::end(shapes_), [] (auto x) { return x == 0; })) {
+        if (std::any_of(std::begin(shapes_), std::end(shapes_), [](auto x) { return x == 0; })) {
             static constexpr auto default_stride = static_cast<stride_t>(itemsize());
             strides = {default_stride, default_stride};
         } else {
@@ -157,52 +209,58 @@ struct TypedTensor : public NativeTensor {
         return strides;
     }
 
-    bool is_f_style() {
+    bool is_f_style()
+    {
         auto col_major = f_style_strides();
         return col_major == strides_;
     }
 
-    template<typename... Ix> ssize_t byte_offset(Ix... index) const {
+    template<typename... Ix>
+    ssize_t byte_offset(Ix... index) const
+    {
         return byte_offset_impl(strides(), ssize_t(index)...);
     }
 
-    template<typename... Ix> const T& at(Ix... index) const {
+    template<typename... Ix>
+    const T& at(Ix... index) const
+    {
         return *(static_cast<const T*>(NativeTensor::data()) + byte_offset(ssize_t(index)...) / itemsize());
     }
 
-    TypedTensor(const shape_t* shapes, ssize_t ndim, DataType dt,  ssize_t elsize, const T* data) :
-        NativeTensor(calc_elements(shapes, ndim) * itemsize(), ndim, nullptr, shapes, dt, elsize, data) {
-    }
-
-    explicit TypedTensor(const NativeTensor& tensor) :
-        NativeTensor(tensor)
+    TypedTensor(const shape_t* shapes, ssize_t ndim, DataType dt, ssize_t elsize, const T* data)
+        : NativeTensor(calc_elements(shapes, ndim) * itemsize(), ndim, nullptr, shapes, dt, elsize, data)
     {
     }
 
-    TypedTensor(const NativeTensor& tensor, ssize_t slice_num, ssize_t regular_slice_size, ssize_t nvalues) :
-            NativeTensor(
-                    nvalues * itemsize(),
-                    tensor.ndim(),
-                    tensor.strides(),
-                    tensor.shape(),
-                    tensor.data_type(),
-                    tensor.elsize(),
-                    nullptr
-                    ) {
+    explicit TypedTensor(const NativeTensor& tensor)
+        : NativeTensor(tensor)
+    {
+    }
+
+    TypedTensor(const NativeTensor& tensor, ssize_t slice_num, ssize_t regular_slice_size, ssize_t nvalues)
+        : NativeTensor(nvalues * itemsize(),
+              tensor.ndim(),
+              tensor.strides(),
+              tensor.shape(),
+              tensor.data_type(),
+              tensor.elsize(),
+              nullptr)
+    {
 
         ssize_t stride_offset;
-        if(ndim() > 1) {
+        if (ndim() > 1) {
             // Check that we can evenly subdivide a matrix into n rows (otherwise we'd have to have
             // extra state to track how far along a row we were
             util::check(nvalues >= shape(0) && nvalues % shape(0) == 0,
-                        "Cannot subdivide a tensor of width {} into {}-sized sections", shape(0), nvalues);
+                "Cannot subdivide a tensor of width {} into {}-sized sections",
+                shape(0),
+                nvalues);
 
             // Adjust the column shape
             auto divisor = calc_elements(shape(), ndim()) / nvalues;
             shapes_[0] /= divisor;
             stride_offset = strides(0) * (shape(0));
-        }
-        else {
+        } else {
             shapes_[0] = nvalues;
             stride_offset = regular_slice_size * strides(0);
         }
@@ -211,16 +269,18 @@ struct TypedTensor : public NativeTensor {
 
         ptr = reinterpret_cast<const uint8_t*>(tensor.data()) + (slice_num * stride_offset);
         util::check(ptr < static_cast<const uint8_t*>(tensor.ptr) + std::abs(tensor.extent(0)),
-                "Tensor overflow, cannot put slice pointer at byte {} in a tensor of {} bytes",
-                slice_num * stride_offset, tensor.extent(0));
+            "Tensor overflow, cannot put slice pointer at byte {} in a tensor of {} bytes",
+            slice_num * stride_offset,
+            tensor.extent(0));
     }
 };
 template<typename T>
-py::array to_py_array(const TypedTensor<T>& tensor) {
+py::array to_py_array(const TypedTensor<T>& tensor)
+{
     return py::array({tensor.shape(), tensor.shape() + tensor.ndim()}, reinterpret_cast<const T*>(tensor.data()));
 }
 
 template<typename T>
 using TensorType = TypedTensor<T>;
 
-}//namespace arcticdb
+} // namespace arcticdb::entity

--- a/cpp/arcticdb/entity/performance_tracing.cpp
+++ b/cpp/arcticdb/entity/performance_tracing.cpp
@@ -13,7 +13,8 @@
 #include <arcticdb/util/preprocess.hpp>
 #include <arcticdb/util/pb_util.hpp>
 
-std::shared_ptr<RemoteryInstance> RemoteryInstance::instance(){
+std::shared_ptr<RemoteryInstance> RemoteryInstance::instance()
+{
     std::call_once(RemoteryInstance::init_flag_, &RemoteryInstance::init);
     return RemoteryInstance::instance_;
 }
@@ -21,7 +22,8 @@ std::shared_ptr<RemoteryInstance> RemoteryInstance::instance(){
 std::shared_ptr<RemoteryInstance> RemoteryInstance::instance_;
 std::once_flag RemoteryInstance::init_flag_;
 
-std::shared_ptr<RemoteryConfigInstance> RemoteryConfigInstance::instance(){
+std::shared_ptr<RemoteryConfigInstance> RemoteryConfigInstance::instance()
+{
     std::call_once(RemoteryConfigInstance::init_flag_, &RemoteryConfigInstance::init);
     return RemoteryConfigInstance::instance_;
 }
@@ -29,14 +31,15 @@ std::shared_ptr<RemoteryConfigInstance> RemoteryConfigInstance::instance(){
 std::shared_ptr<RemoteryConfigInstance> RemoteryConfigInstance::instance_;
 std::once_flag RemoteryConfigInstance::init_flag_;
 
-RemoteryInstance::RemoteryInstance() {
+RemoteryInstance::RemoteryInstance()
+{
     auto cfg = RemoteryConfigInstance::instance()->config;
-    auto * settings = rmt_Settings();
+    auto* settings = rmt_Settings();
     settings->port = cfg.port() ? cfg.port() : 17815;
     settings->reuse_open_port = !cfg.do_not_reuse_open_port();
     settings->limit_connections_to_localhost = cfg.limit_connections_to_localhost();
-    auto set_if = [](auto* dst, auto src){
-        if(src){
+    auto set_if = [](auto* dst, auto src) {
+        if (src) {
             *dst = src;
         }
     };
@@ -44,41 +47,51 @@ RemoteryInstance::RemoteryInstance() {
     set_if(&settings->messageQueueSizeInBytes, cfg.message_queue_size_in_bytes());
     set_if(&settings->maxNbMessagesPerUpdate, cfg.max_nb_messages_per_update());
     auto rc = rmt_CreateGlobalInstance(&rmt_);
-    if(rc){
-        ARCTICDB_DEBUG(arcticdb:: log::version(), "Remotery creation with settings '{}' failed, rc={}", arcticdb::util::format(cfg), rc);
+    if (rc) {
+        ARCTICDB_DEBUG(arcticdb::log::version(),
+            "Remotery creation with settings '{}' failed, rc={}",
+            arcticdb::util::format(cfg),
+            rc);
         rmt_ = nullptr;
     } else {
         ARCTICDB_DEBUG(arcticdb::log::version(), "Remotery created with settings {}", arcticdb::util::format(cfg));
     }
 }
 
-RemoteryInstance::~RemoteryInstance() {
-    if(rmt_) {
+RemoteryInstance::~RemoteryInstance()
+{
+    if (rmt_) {
         rmt_DestroyGlobalInstance(rmt_);
         rmt_ = nullptr;
     }
 }
 
 namespace arcticdb::detail {
-    struct ThreadNameCache {
-        folly::F14FastMap<const char *, std::string> fqn_by_task_name_;
-        std::string thread_name_;
+struct ThreadNameCache {
+    folly::F14FastMap<const char*, std::string> fqn_by_task_name_;
+    std::string thread_name_;
 
-        ThreadNameCache():fqn_by_task_name_(),thread_name_(folly::getCurrentThreadName().value_or("Thread")){}
+    ThreadNameCache()
+        : fqn_by_task_name_(),
+          thread_name_(folly::getCurrentThreadName().value_or("Thread"))
+    {
+    }
 
-        std::string_view get_thread_name(const char * task_name){
-            if(auto fqn_it = fqn_by_task_name_.find(task_name); fqn_it != fqn_by_task_name_.end()){
-                return fqn_it->second;
-            }
-            auto [fqn_it, inserted] = fqn_by_task_name_.emplace(task_name, fmt::format("{}/{}", thread_name_, task_name));
+    std::string_view get_thread_name(const char* task_name)
+    {
+        if (auto fqn_it = fqn_by_task_name_.find(task_name); fqn_it != fqn_by_task_name_.end()) {
             return fqn_it->second;
         }
-    };
-}
+        auto [fqn_it, inserted] = fqn_by_task_name_.emplace(task_name, fmt::format("{}/{}", thread_name_, task_name));
+        return fqn_it->second;
+    }
+};
+} // namespace arcticdb::detail
 
 #ifdef USE_REMOTERY
 
-void set_remotery_thread_name(const char* task_name){
+void set_remotery_thread_name(const char* task_name)
+{
     static thread_local arcticdb::detail::ThreadNameCache tnc;
     auto name = tnc.get_thread_name(task_name);
     rmt_SetCurrentThreadName(name.data());

--- a/cpp/arcticdb/entity/performance_tracing.hpp
+++ b/cpp/arcticdb/entity/performance_tracing.hpp
@@ -17,96 +17,89 @@
 struct Remotery;
 
 class RemoteryInstance {
-  public:
+public:
     static std::shared_ptr<RemoteryInstance> instance();
     RemoteryInstance();
     ~RemoteryInstance();
     static std::shared_ptr<RemoteryInstance> instance_;
     static std::once_flag init_flag_;
-    static void destroy_instance(){instance_.reset();}
-    Remotery *rmt_ = nullptr;
+    static void destroy_instance()
+    {
+        instance_.reset();
+    }
+    Remotery* rmt_ = nullptr;
 
-    static void init(){
+    static void init()
+    {
         instance_ = std::make_shared<RemoteryInstance>();
     }
 };
 
 class RemoteryConfigInstance {
-  public:
+public:
     static std::shared_ptr<RemoteryConfigInstance> instance();
     arcticdb::proto::utils::RemoteryConfig config;
     static std::shared_ptr<RemoteryConfigInstance> instance_;
     static std::once_flag init_flag_;
 
-    static void init(){
+    static void init()
+    {
         instance_ = std::make_shared<RemoteryConfigInstance>();
     }
 };
 
-#define ARCTICDB_RUNTIME_SAMPLE(name, flags) \
-bool _scoped_timer_active_ = ConfigsMap::instance()->get_int("Logging.timings", 0) == 1 || ConfigsMap::instance()->get_int("Logging.ALL", 0) == 1; \
-arcticdb::ScopedTimer runtime_timer = !_scoped_timer_active_ ? arcticdb::ScopedTimer() : arcticdb::ScopedTimer(#name, [](auto msg) { \
-    log::timings().debug(msg); \
-});
+#define ARCTICDB_RUNTIME_SAMPLE(name, flags)                                                                           \
+    bool _scoped_timer_active_ = ConfigsMap::instance()->get_int("Logging.timings", 0) == 1 ||                         \
+                                 ConfigsMap::instance()->get_int("Logging.ALL", 0) == 1;                               \
+    arcticdb::ScopedTimer runtime_timer =                                                                              \
+        !_scoped_timer_active_ ? arcticdb::ScopedTimer()                                                               \
+                               : arcticdb::ScopedTimer(#name, [](auto msg) { log::timings().debug(msg); });
 
-#define ARCTICDB_RUNTIME_SUBSAMPLE(name, flags) \
-bool _scoped_subtimer_##name_active_ = ConfigsMap::instance()->get_int("Logging.timer", 0) == 1; \
-arcticdb::ScopedTimer runtime_sub_timer_##name = !_scoped_subtimer_##name_active_ ? arcticdb::ScopedTimer() : arcticdb::ScopedTimer(#name, [](auto msg) { \
-    log::timings().debug(msg); \
-});
+#define ARCTICDB_RUNTIME_SUBSAMPLE(name, flags)                                                                        \
+    bool _scoped_subtimer_##name_active_ = ConfigsMap::instance()->get_int("Logging.timer", 0) == 1;                   \
+    arcticdb::ScopedTimer runtime_sub_timer_##name =                                                                   \
+        !_scoped_subtimer_##name_active_ ? arcticdb::ScopedTimer()                                                     \
+                                         : arcticdb::ScopedTimer(#name, [](auto msg) { log::timings().debug(msg); });
 
 //#define USE_REMOTERY
 //#define ARCTICDB_LOG_PERFORMANCE
 
 #if defined(USE_REMOTERY)
 
-#define ARCTICDB_SAMPLE(name, flags) \
-        auto instance = RemoteryInstance::instance();  \
-        rmt_ScopedCPUSample(name, flags);
+#define ARCTICDB_SAMPLE(name, flags)                                                                                   \
+    auto instance = RemoteryInstance::instance();                                                                      \
+    rmt_ScopedCPUSample(name, flags);
 
-#define ARCTICDB_SUBSAMPLE(name, flags) \
-        rmt_ScopedCPUSample(name, flags);
+#define ARCTICDB_SUBSAMPLE(name, flags) rmt_ScopedCPUSample(name, flags);
 
-#define ARCTICDB_SAMPLE_DEFAULT(name) \
-        ARCTICDB_SAMPLE(name, 0)
+#define ARCTICDB_SAMPLE_DEFAULT(name) ARCTICDB_SAMPLE(name, 0)
 
-#define ARCTICDB_SUBSAMPLE_DEFAULT(name) \
-        ARCTICDB_SUBSAMPLE(name, 0)
+#define ARCTICDB_SUBSAMPLE_DEFAULT(name) ARCTICDB_SUBSAMPLE(name, 0)
 
-#define ARCTICDB_SUBSAMPLE_AGG(name) \
-        rmt_ScopedCPUSample(name, RMTSF_Aggregate);
+#define ARCTICDB_SUBSAMPLE_AGG(name) rmt_ScopedCPUSample(name, RMTSF_Aggregate);
 
 void set_remotery_thread_name(const char* task_name);
 
 #define ARCTICDB_SAMPLE_THREAD() set_remotery_thread_name("Arcticdb")
 
-#define ARCTICDB_SAMPLE_LOG(task_name) \
-        rmt_LogText(task_name);
+#define ARCTICDB_SAMPLE_LOG(task_name) rmt_LogText(task_name);
 
 #elif defined(ARCTICDB_LOG_PERFORMANCE)
-#define ARCTICDB_SAMPLE(name, flags) \
-arcticdb::ScopedTimer timer{#name, [](auto msg) { \
-    std::cout << msg; \
-}};
+#define ARCTICDB_SAMPLE(name, flags) arcticdb::ScopedTimer timer{#name, [](auto msg) { std::cout << msg; }};
 
-#define ARCTICDB_SUBSAMPLE(name, flags) \
-arcticdb::ScopedTimer sub_timer_##name{#name, [](auto msg) { \
-std::cout << msg; \
-}};
+#define ARCTICDB_SUBSAMPLE(name, flags)                                                                                \
+    arcticdb::ScopedTimer sub_timer_##name{#name, [](auto msg) { std::cout << msg; }};
 
-#define ARCTICDB_SAMPLE_DEFAULT(name) \
-arcticdb::ScopedTimer default_timer{#name, [](auto msg) { \
-std::cout << msg; \
-}};
+#define ARCTICDB_SAMPLE_DEFAULT(name) arcticdb::ScopedTimer default_timer{#name, [](auto msg) { std::cout << msg; }};
 
-#define ARCTICDB_SUBSAMPLE_DEFAULT(name) \
-arcticdb::ScopedTimer sub_timer_##name{#name, [](auto msg) { \
-std::cout << msg; \
-}};
+#define ARCTICDB_SUBSAMPLE_DEFAULT(name)                                                                               \
+    arcticdb::ScopedTimer sub_timer_##name{#name, [](auto msg) { std::cout << msg; }};
 
 #define ARCTICDB_SUBSAMPLE_AGG(name)
 
-inline void set_remotery_thread_name(const char* ) { }
+inline void set_remotery_thread_name(const char*)
+{
+}
 
 #define ARCTICDB_SAMPLE_THREAD() set_remotery_thread_name("Arcticdb")
 
@@ -124,7 +117,9 @@ inline void set_remotery_thread_name(const char* ) { }
 
 #define ARCTICDB_SUBSAMPLE_AGG(name)
 
-inline void set_remotery_thread_name(const char* ) { }
+inline void set_remotery_thread_name(const char*)
+{
+}
 
 #define ARCTICDB_SAMPLE_THREAD() set_remotery_thread_name("Arcticdb")
 

--- a/cpp/arcticdb/entity/protobuf_mappings.hpp
+++ b/cpp/arcticdb/entity/protobuf_mappings.hpp
@@ -11,43 +11,50 @@
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/util/variant.hpp>
 
-
 namespace arcticdb {
 
 using namespace arcticdb::entity;
 
-inline arcticdb::proto::descriptors::AtomKey encode_key(const AtomKey &key) {
+inline arcticdb::proto::descriptors::AtomKey encode_key(const AtomKey& key)
+{
     arcticdb::proto::descriptors::AtomKey output;
-    util::variant_match(key.id(),
-                        [&](const StringId &id) { output.set_string_id(id); },
-                        [&](const NumericId &id) { output.set_numeric_id(id); });
+    util::variant_match(
+        key.id(),
+        [&](const StringId& id) { output.set_string_id(id); },
+        [&](const NumericId& id) { output.set_numeric_id(id); });
     output.set_version_id(key.version_id());
     output.set_creation_ts(key.creation_ts());
     output.set_content_hash(key.content_hash());
 
-    util::variant_match(key.start_index(),
-                        [&](const StringId &id) { output.set_string_start(id); },
-                        [&](const NumericId &id) { output.set_numeric_start(id); });
-    util::variant_match(key.end_index(),
-                        [&](const StringId &id) { output.set_string_end(id); },
-                        [&](const NumericId &id) { output.set_numeric_end(id); });
+    util::variant_match(
+        key.start_index(),
+        [&](const StringId& id) { output.set_string_start(id); },
+        [&](const NumericId& id) { output.set_numeric_start(id); });
+    util::variant_match(
+        key.end_index(),
+        [&](const StringId& id) { output.set_string_end(id); },
+        [&](const NumericId& id) { output.set_numeric_end(id); });
 
-    output.set_key_type(arcticdb::proto::descriptors::KeyType (int(key.type())));
+    output.set_key_type(arcticdb::proto::descriptors::KeyType(int(key.type())));
     return output;
 }
 
-inline AtomKey decode_key(const arcticdb::proto::descriptors::AtomKey& input) {
-    StreamId stream_id = input.id_case() == input.kNumericId ? StreamId(input.numeric_id()) : StreamId(input.string_id());
-    IndexValue index_start = input.index_start_case() == input.kNumericStart ? IndexValue(input.numeric_start()) : IndexValue(input.string_start());
-    IndexValue index_end = input.index_end_case() == input.kNumericEnd ? IndexValue(input.numeric_end() ): IndexValue(input.string_end());
+inline AtomKey decode_key(const arcticdb::proto::descriptors::AtomKey& input)
+{
+    StreamId stream_id =
+        input.id_case() == input.kNumericId ? StreamId(input.numeric_id()) : StreamId(input.string_id());
+    IndexValue index_start = input.index_start_case() == input.kNumericStart ? IndexValue(input.numeric_start())
+                                                                             : IndexValue(input.string_start());
+    IndexValue index_end =
+        input.index_end_case() == input.kNumericEnd ? IndexValue(input.numeric_end()) : IndexValue(input.string_end());
 
     return atom_key_builder()
-         .version_id(input.version_id())
-         .creation_ts(timestamp(input.creation_ts()))
-         .content_hash(input.content_hash())
-         .start_index(index_start)
-         .end_index(index_end)
-         .build(stream_id, KeyType(input.key_type()));
+        .version_id(input.version_id())
+        .creation_ts(timestamp(input.creation_ts()))
+        .content_hash(input.content_hash())
+        .start_index(index_start)
+        .end_index(index_end)
+        .build(stream_id, KeyType(input.key_type()));
 }
 
 } //namespace arcticdb

--- a/cpp/arcticdb/entity/protobufs.hpp
+++ b/cpp/arcticdb/entity/protobufs.hpp
@@ -20,16 +20,16 @@
 #include <utils.pb.h>
 
 namespace arcticdb::proto {
-    namespace encoding = arcticc::pb2::encoding_pb2;
-    namespace storage = arcticc::pb2::storage_pb2;
-    namespace descriptors = arcticc::pb2::descriptors_pb2;
-    namespace s3_storage = arcticc::pb2::s3_storage_pb2;
-    namespace lmdb_storage = arcticc::pb2::lmdb_storage_pb2;
-    namespace mongo_storage = arcticc::pb2::mongo_storage_pb2;
-    namespace memory_storage = arcticc::pb2::in_memory_storage_pb2;
-    namespace config = arcticc::pb2::config_pb2;
-    namespace nfs_backed_storage = arcticc::pb2::nfs_backed_storage_pb2;
-    namespace logger = arcticc::pb2::logger_pb2;
-    namespace utils = arcticc::pb2::utils_pb2;
+namespace encoding = arcticc::pb2::encoding_pb2;
+namespace storage = arcticc::pb2::storage_pb2;
+namespace descriptors = arcticc::pb2::descriptors_pb2;
+namespace s3_storage = arcticc::pb2::s3_storage_pb2;
+namespace lmdb_storage = arcticc::pb2::lmdb_storage_pb2;
+namespace mongo_storage = arcticc::pb2::mongo_storage_pb2;
+namespace memory_storage = arcticc::pb2::in_memory_storage_pb2;
+namespace config = arcticc::pb2::config_pb2;
+namespace nfs_backed_storage = arcticc::pb2::nfs_backed_storage_pb2;
+namespace logger = arcticc::pb2::logger_pb2;
+namespace utils = arcticc::pb2::utils_pb2;
 
-} //namespace arcticdb
+} // namespace arcticdb::proto

--- a/cpp/arcticdb/entity/read_result.hpp
+++ b/cpp/arcticdb/entity/read_result.hpp
@@ -12,46 +12,48 @@
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/frame_and_descriptor.hpp>
-#include <arcticdb/pipeline//python_output_frame.hpp>
+#include <arcticdb/pipeline //python_output_frame.hpp>
 
 #include <vector>
 
 namespace arcticdb {
 
 struct ARCTICDB_VISIBILITY_HIDDEN ReadResult {
-    ReadResult(
-            const VersionedItem& versioned_item,
-            pipelines::PythonOutputFrame&& frame_data,
-            const arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
-            const arcticdb::proto::descriptors::UserDefinedMetadata& user_meta,
-            const arcticdb::proto::descriptors::UserDefinedMetadata& multi_key_meta,
-            std::vector<entity::AtomKey>&& multi_keys) :
-            item(versioned_item),
-            frame_data(std::move(frame_data)),
-            norm_meta(norm_meta),
-            user_meta(user_meta),
-            multi_key_meta(multi_key_meta),
-            multi_keys(std::move(multi_keys)) {
-
+    ReadResult(const VersionedItem& versioned_item,
+        pipelines::PythonOutputFrame&& frame_data,
+        const arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
+        const arcticdb::proto::descriptors::UserDefinedMetadata& user_meta,
+        const arcticdb::proto::descriptors::UserDefinedMetadata& multi_key_meta,
+        std::vector<entity::AtomKey>&& multi_keys)
+        : item(versioned_item),
+          frame_data(std::move(frame_data)),
+          norm_meta(norm_meta),
+          user_meta(user_meta),
+          multi_key_meta(multi_key_meta),
+          multi_keys(std::move(multi_keys))
+    {
     }
     VersionedItem item;
     pipelines::PythonOutputFrame frame_data;
     arcticdb::proto::descriptors::NormalizationMetadata norm_meta;
     arcticdb::proto::descriptors::UserDefinedMetadata user_meta;
     arcticdb::proto::descriptors::UserDefinedMetadata multi_key_meta;
-    std::vector <entity::AtomKey> multi_keys;
+    std::vector<entity::AtomKey> multi_keys;
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ReadResult)
 };
 
-inline ReadResult create_python_read_result(
-    const VersionedItem& version,
-    FrameAndDescriptor&& fd) {
+inline ReadResult create_python_read_result(const VersionedItem& version, FrameAndDescriptor&& fd)
+{
     auto result = std::move(fd);
     auto python_frame = pipelines::PythonOutputFrame{result.frame_, result.buffers_};
     util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
 
-    return {version, std::move(python_frame), result.desc_.normalization(),
-            result.desc_.user_meta(), result.desc_.multi_key_meta(), std::move(result.keys_)};
+    return {version,
+        std::move(python_frame),
+        result.desc_.normalization(),
+        result.desc_.user_meta(),
+        result.desc_.multi_key_meta(),
+        std::move(result.keys_)};
 }
 } //namespace arcticdb

--- a/cpp/arcticdb/entity/ref_key.hpp
+++ b/cpp/arcticdb/entity/ref_key.hpp
@@ -12,73 +12,95 @@
 #include <arcticdb/entity/key.hpp>
 
 namespace arcticdb::entity {
-    class RefKey {
-    public:
+class RefKey {
+public:
+    RefKey(StreamId id, KeyType key_type, bool old_type = false)
+        : id_(std::move(id)),
+          key_type_(key_type),
+          old_type_(old_type)
+    {
+        util::check(!std::holds_alternative<StringId>(id_) || !std::get<StringId>(id_).empty(),
+            "Empty symbol in reference key");
+        util::check(old_type || is_ref_key_class(key_type),
+            "Can't create ref key with non-ref key class keytype {}",
+            key_type);
+    }
 
-        RefKey(
-                StreamId id,
-                KeyType key_type,
-                bool old_type = false)
-                :
-                id_(std::move(id)),
-                key_type_(key_type),
-                old_type_(old_type) {
-            util::check(!std::holds_alternative<StringId>(id_) || !std::get<StringId>(id_).empty(), "Empty symbol in reference key");
-            util::check(old_type || is_ref_key_class(key_type), "Can't create ref key with non-ref key class keytype {}", key_type);
-        }
+    RefKey() = default;
+    RefKey(const RefKey& other) = default;
+    RefKey& operator=(const RefKey& other) = default;
+    RefKey(RefKey&& other) = default;
+    RefKey& operator=(RefKey&& other) = default;
 
-        RefKey() = default;
-        RefKey(const RefKey &other) = default;
-        RefKey &operator=(const RefKey &other) = default;
-        RefKey(RefKey &&other) = default;
-        RefKey &operator=(RefKey &&other) = default;
+    const StreamId& id() const
+    {
+        return id_;
+    }
+    const auto& type() const
+    {
+        return key_type_;
+    }
+    auto& type()
+    {
+        return key_type_;
+    }
+    auto is_old_type() const
+    {
+        return old_type_;
+    }
+    void change_type(KeyType new_type)
+    {
+        key_type_ = new_type;
+    }
 
-        const StreamId& id() const { return id_; }
-        const auto& type() const { return key_type_; }
-        auto& type() { return key_type_; }
-        auto is_old_type() const { return old_type_; }
-        void change_type(KeyType new_type) {
-            key_type_ = new_type;
-        }
+    friend bool operator==(const RefKey& l, const RefKey& r)
+    {
+        return l.type() == r.type() && l.id() == r.id();
+    }
 
-        friend bool operator==(const RefKey &l, const RefKey &r) {
-            return l.type() == r.type()
-                   && l.id() == r.id();
-        }
+    friend bool operator!=(const RefKey& l, const RefKey& r)
+    {
+        return !(l == r);
+    }
 
-        friend bool operator!=(const RefKey &l, const RefKey &r) {
-            return !(l == r);
-        }
+    //TODO Neither key sorts by type
+    friend bool operator<(const RefKey& l, const RefKey& r)
+    {
+        return l.id() < r.id();
+    }
 
-        //TODO Neither key sorts by type
-        friend bool operator<(const RefKey &l, const RefKey &r) {
-            return l.id() < r.id();
-        }
+    std::string_view view() const
+    {
+        if (str_.empty())
+            set_string();
+        return std::string_view{str_};
+    }
 
-        std::string_view view() const { if(str_.empty()) set_string(); return std::string_view{str_}; }
+    void set_string() const
+    {
+        str_ = fmt::format("{}", *this);
+    }
 
-        void set_string() const {
-            str_ = fmt::format("{}", *this);
-        }
-    private:
-
-        StreamId id_;
-        KeyType key_type_ = KeyType::UNDEFINED;
-        mutable std::string str_;
-        bool old_type_;
-
-    };
+private:
+    StreamId id_;
+    KeyType key_type_ = KeyType::UNDEFINED;
+    mutable std::string str_;
+    bool old_type_;
+};
 } // namespace arcticdb::entity
-
 
 namespace fmt {
 template<>
 struct formatter<RefKey> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const RefKey &k, FormatContext &ctx) const {
+    auto format(const RefKey& k, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}:{}", k.type(), k.id());
     }
 };
@@ -89,9 +111,10 @@ struct formatter<RefKey> {
 namespace std {
 template<>
 struct hash<arcticdb::entity::RefKey> {
-    inline arcticdb::HashedValue operator()(const arcticdb::entity::RefKey &k) const noexcept {
+    inline arcticdb::HashedValue operator()(const arcticdb::entity::RefKey& k) const noexcept
+    {
         auto view = k.view();
-        return arcticdb::hash(const_cast<uint8_t * >(reinterpret_cast<const uint8_t *>(view.data())), view.size());
+        return arcticdb::hash(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(view.data())), view.size());
     }
 };
-}
+} // namespace std

--- a/cpp/arcticdb/entity/serialized_key.hpp
+++ b/cpp/arcticdb/entity/serialized_key.hpp
@@ -24,11 +24,24 @@
 namespace arcticdb::entity {
 
 enum class OldKeyField {
-    id, version_id, creation_ts, content_hash, index_type, start_index, end_index, num_key_fields
+    id,
+    version_id,
+    creation_ts,
+    content_hash,
+    index_type,
+    start_index,
+    end_index,
+    num_key_fields
 };
 
 enum class NewKeyField {
-    id, version_id, creation_ts, content_hash, start_index, end_index, num_key_fields
+    id,
+    version_id,
+    creation_ts,
+    content_hash,
+    start_index,
+    end_index,
+    num_key_fields
 };
 
 constexpr char OldKeyDelimiter = '|';
@@ -36,49 +49,54 @@ constexpr char NewKeyDelimiter = '*';
 constexpr size_t NumOldKeyFields = size_t(OldKeyField::num_key_fields);
 constexpr size_t NumNewKeyFields = size_t(NewKeyField::num_key_fields);
 
-
-inline VariantId variant_id_from_token(const std::string_view &strv, VariantType variant_type) {
+inline VariantId variant_id_from_token(const std::string_view& strv, VariantType variant_type)
+{
     switch (variant_type) {
-        case VariantType::STRING_TYPE:
-            return VariantId(std::string(strv));
-        case VariantType::NUMERIC_TYPE:
-            return VariantId(util::num_from_strv(strv));
-        default: // This may occur here because generation segments don't set an index type
-            return VariantId();
+    case VariantType::STRING_TYPE:
+        return VariantId(std::string(strv));
+    case VariantType::NUMERIC_TYPE:
+        return VariantId(util::num_from_strv(strv));
+    default: // This may occur here because generation segments don't set an index type
+        return VariantId();
     }
 }
 
-inline VariantType variant_type_from_index_type(IndexDescriptor::Type index_type) {
+inline VariantType variant_type_from_index_type(IndexDescriptor::Type index_type)
+{
     switch (index_type) {
-        case IndexDescriptor::TIMESTAMP:
-        case IndexDescriptor::ROWCOUNT:
-            return VariantType::NUMERIC_TYPE;
-        case IndexDescriptor::STRING:
-            return VariantType::STRING_TYPE;
-        default:
-            return VariantType::UNKNOWN_TYPE;
+    case IndexDescriptor::TIMESTAMP:
+    case IndexDescriptor::ROWCOUNT:
+        return VariantType::NUMERIC_TYPE;
+    case IndexDescriptor::STRING:
+        return VariantType::STRING_TYPE;
+    default:
+        return VariantType::UNKNOWN_TYPE;
     }
 }
 
 template<typename FieldIndex>
-AtomKey atom_key_from_tokens(std::array<std::string_view, size_t(FieldIndex::num_key_fields)> arr, VariantType id_type,
-                             VariantType index_type, KeyType key_type) {
+AtomKey atom_key_from_tokens(std::array<std::string_view, size_t(FieldIndex::num_key_fields)> arr,
+    VariantType id_type,
+    VariantType index_type,
+    KeyType key_type)
+{
     auto start_index = variant_id_from_token(arr[int(FieldIndex::start_index)], index_type);
     auto end_index = variant_id_from_token(arr[int(FieldIndex::end_index)], index_type);
     auto id = variant_id_from_token(arr[int(FieldIndex::id)], id_type);
     return AtomKeyBuilder()
-            .version_id(util::num_from_strv(arr[int(FieldIndex::version_id)]))
-            .creation_ts(util::num_from_strv(arr[int(FieldIndex::creation_ts)]))
-            .content_hash(util::num_from_strv(arr[int(FieldIndex::content_hash)]))
-            .start_index(start_index)
-            .end_index(end_index)
-            .build(id, key_type);
+        .version_id(util::num_from_strv(arr[int(FieldIndex::version_id)]))
+        .creation_ts(util::num_from_strv(arr[int(FieldIndex::creation_ts)]))
+        .content_hash(util::num_from_strv(arr[int(FieldIndex::content_hash)]))
+        .start_index(start_index)
+        .end_index(end_index)
+        .build(id, key_type);
 }
 
 // This was the original way of doing it; we need to be able to read this kind but we don't want to
 // write them any more
-inline AtomKey key_from_old_style_bytes(const uint8_t *data, size_t size, KeyType key_type) {
-    auto cursor = std::string_view(reinterpret_cast<const char *>(data), size);
+inline AtomKey key_from_old_style_bytes(const uint8_t* data, size_t size, KeyType key_type)
+{
+    auto cursor = std::string_view(reinterpret_cast<const char*>(data), size);
     auto arr = util::split_to_array<NumOldKeyFields>(cursor, OldKeyDelimiter);
     auto id_variant_type = variant_type_from_key_type(key_type);
     auto index_type = IndexDescriptor::Type(util::num_from_strv(arr[int(OldKeyField::index_type)]));
@@ -86,8 +104,9 @@ inline AtomKey key_from_old_style_bytes(const uint8_t *data, size_t size, KeyTyp
     return atom_key_from_tokens<OldKeyField>(arr, id_variant_type, index_variant_type, key_type);
 }
 
-template <typename T>
-inline void serialize_string(const std::string &str, CursoredBuffer<T> &output) {
+template<typename T>
+inline void serialize_string(const std::string& str, CursoredBuffer<T>& output)
+{
     util::check_arg(str.size() < std::numeric_limits<uint8_t>::max(), "String too long for serialization type");
     output.ensure_bytes(str.size() + sizeof(uint8_t));
     auto data = output.ptr();
@@ -96,46 +115,53 @@ inline void serialize_string(const std::string &str, CursoredBuffer<T> &output) 
     output.commit();
 }
 
-inline std::string unserialize_string(const uint8_t *&data) {
+inline std::string unserialize_string(const uint8_t*& data)
+{
     uint8_t size = *data++;
-    auto output = std::string{reinterpret_cast<const char *>(data), size};
+    auto output = std::string{reinterpret_cast<const char*>(data), size};
     data += size;
     return output;
 }
 
-template <typename T>
-inline void serialize_number(uint64_t n, CursoredBuffer<T> &output) {
+template<typename T>
+inline void serialize_number(uint64_t n, CursoredBuffer<T>& output)
+{
     output.template ensure<uint64_t>();
-    *reinterpret_cast<uint64_t *>(output.cursor()) = n;
+    *reinterpret_cast<uint64_t*>(output.cursor()) = n;
     output.commit();
 }
 
-template <typename T>
-inline T unserialize_number(const uint8_t *&data) {
-    auto n = reinterpret_cast<const T *>(data);
+template<typename T>
+inline T unserialize_number(const uint8_t*& data)
+{
+    auto n = reinterpret_cast<const T*>(data);
     data += sizeof(T);
     return *n;
 }
 
 static constexpr char SerializedKeyIdentifier = 42;
 
-inline bool is_serialized_key(const uint8_t *data) {
+inline bool is_serialized_key(const uint8_t* data)
+{
     return *data == SerializedKeyIdentifier;
 }
 
-inline VariantType variant_type_from_id(const VariantId &id) {
+inline VariantType variant_type_from_id(const VariantId& id)
+{
     return std::holds_alternative<NumericId>(id) ? VariantType::NUMERIC_TYPE : VariantType::STRING_TYPE;
 }
 
-template <typename T>
-inline void serialize_variant_type(VariantId id, CursoredBuffer<T> &output) {
+template<typename T>
+inline void serialize_variant_type(VariantId id, CursoredBuffer<T>& output)
+{
     if (std::holds_alternative<NumericId>(id))
         serialize_number(std::get<NumericId>(id), output);
     else
         serialize_string(std::get<std::string>(id), output);
 }
 
-inline VariantId unserialize_variant_type(VariantType type, const uint8_t *&data) {
+inline VariantId unserialize_variant_type(VariantType type, const uint8_t*& data)
+{
     if (type == VariantType::NUMERIC_TYPE)
         return VariantId(unserialize_number<timestamp>(data));
     else
@@ -144,30 +170,34 @@ inline VariantId unserialize_variant_type(VariantType type, const uint8_t *&data
 
 enum class FormatType : char {
     OPAQUE =
-    'o', // This is an efficient type (i.e. numbers as numbers), for things that don't required string-like keys
+        'o', // This is an efficient type (i.e. numbers as numbers), for things that don't required string-like keys
     TOKENIZED =
-    't', // This is a readable type, with delimiters, for things that require keys to consist of printable characters
+        't', // This is a readable type, with delimiters, for things that require keys to consist of printable characters
 };
 
 struct KeyDescriptor {
-    explicit KeyDescriptor(const AtomKey &key, FormatType format_type) :
-            identifier(SerializedKeyIdentifier),
-            id_type(variant_type_from_id(key.id())),
-            index_type(to_type_char(stream::get_index_value_type(key))),
-            format_type(format_type) {
+    explicit KeyDescriptor(const AtomKey& key, FormatType format_type)
+        : identifier(SerializedKeyIdentifier),
+          id_type(variant_type_from_id(key.id())),
+          index_type(to_type_char(stream::get_index_value_type(key))),
+          format_type(format_type)
+    {
     }
 
-    KeyDescriptor(const StringId id, IndexDescriptor::Type index_type, FormatType format_type) :
-            identifier(SerializedKeyIdentifier),
-            id_type(variant_type_from_id(id)),
-            index_type(to_type_char(index_type)),
-            format_type(format_type) {}
+    KeyDescriptor(const StringId id, IndexDescriptor::Type index_type, FormatType format_type)
+        : identifier(SerializedKeyIdentifier),
+          id_type(variant_type_from_id(id)),
+          index_type(to_type_char(index_type)),
+          format_type(format_type)
+    {
+    }
 
-    KeyDescriptor(const RefKey &key, FormatType format_type) :
-            identifier(SerializedKeyIdentifier),
-            id_type(variant_type_from_id(key.id())),
-            index_type(to_type_char(IndexDescriptor::UNKNOWN)),
-            format_type(format_type) {
+    KeyDescriptor(const RefKey& key, FormatType format_type)
+        : identifier(SerializedKeyIdentifier),
+          id_type(variant_type_from_id(key.id())),
+          index_type(to_type_char(IndexDescriptor::UNKNOWN)),
+          format_type(format_type)
+    {
     }
 
     char identifier;
@@ -182,12 +212,20 @@ namespace fmt {
 template<>
 struct formatter<KeyDescriptor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const KeyDescriptor &kd, FormatContext &ctx) const {
-        return format_to(ctx.out(), "{}{}{}{}", kd.identifier, char(kd.id_type), char(kd.index_type),
-                         char(kd.format_type));
+    auto format(const KeyDescriptor& kd, FormatContext& ctx) const
+    {
+        return format_to(ctx.out(),
+            "{}{}{}{}",
+            kd.identifier,
+            char(kd.id_type),
+            char(kd.index_type),
+            char(kd.format_type));
     }
 };
 
@@ -195,10 +233,11 @@ struct formatter<KeyDescriptor> {
 
 namespace arcticdb::entity {
 
-inline std::string to_serialized_key(const AtomKey &key) {
+inline std::string to_serialized_key(const AtomKey& key)
+{
     CursoredBuffer<Buffer> output;
     output.ensure<KeyDescriptor>();
-    (void) new(output.ptr()) KeyDescriptor(key, FormatType::OPAQUE);
+    (void)new (output.ptr()) KeyDescriptor(key, FormatType::OPAQUE);
     output.commit();
 
     serialize_variant_type(key.id(), output);
@@ -207,81 +246,90 @@ inline std::string to_serialized_key(const AtomKey &key) {
     serialize_number(key.content_hash(), output);
     serialize_variant_type(key.start_index(), output);
     serialize_variant_type(key.end_index(), output);
-    return std::string(reinterpret_cast<const char *>(output.data()), output.bytes());
+    return std::string(reinterpret_cast<const char*>(output.data()), output.bytes());
 }
 
-inline std::string to_serialized_key(const RefKey &key) {
+inline std::string to_serialized_key(const RefKey& key)
+{
     CursoredBuffer<Buffer> output;
     output.ensure<KeyDescriptor>();
-    (void) new(output.ptr()) KeyDescriptor(key, FormatType::OPAQUE);
+    (void)new (output.ptr()) KeyDescriptor(key, FormatType::OPAQUE);
     output.commit();
 
     serialize_variant_type(key.id(), output);
-    return std::string(reinterpret_cast<const char *>(output.data()), output.bytes());
+    return std::string(reinterpret_cast<const char*>(output.data()), output.bytes());
 }
 
-inline std::string to_serialized_key(const entity::VariantKey &key) {
-    return std::visit([&](const auto &key) { return to_serialized_key(key); }, key);
+inline std::string to_serialized_key(const entity::VariantKey& key)
+{
+    return std::visit([&](const auto& key) { return to_serialized_key(key); }, key);
 }
 
-inline AtomKey from_serialized_atom_key(const uint8_t *data, KeyType key_type) {
-    const auto *descr = reinterpret_cast<const KeyDescriptor *>(data);
+inline AtomKey from_serialized_atom_key(const uint8_t* data, KeyType key_type)
+{
+    const auto* descr = reinterpret_cast<const KeyDescriptor*>(data);
     util::check(descr->identifier == SerializedKeyIdentifier, "Read invalid serialized key");
     data += sizeof(KeyDescriptor);
     VariantId stream_id = unserialize_variant_type(descr->id_type, data);
     auto variant_type = variant_type_from_index_type(from_type_char(descr->index_type));
     return atom_key_builder()
-            .version_id(unserialize_number<uint64_t>(data))
-            .creation_ts(unserialize_number<uint64_t>(data))
-            .content_hash(unserialize_number<uint64_t>(data))
-            .start_index(unserialize_variant_type(variant_type, data))
-            .end_index(unserialize_variant_type(variant_type, data))
-            .build(stream_id, key_type);
+        .version_id(unserialize_number<uint64_t>(data))
+        .creation_ts(unserialize_number<uint64_t>(data))
+        .content_hash(unserialize_number<uint64_t>(data))
+        .start_index(unserialize_variant_type(variant_type, data))
+        .end_index(unserialize_variant_type(variant_type, data))
+        .build(stream_id, key_type);
 }
 
-inline RefKey from_serialized_ref_key(const uint8_t *data, KeyType key_type) {
-    const auto *descr = reinterpret_cast<const KeyDescriptor *>(data);
+inline RefKey from_serialized_ref_key(const uint8_t* data, KeyType key_type)
+{
+    const auto* descr = reinterpret_cast<const KeyDescriptor*>(data);
     util::check(descr->identifier == SerializedKeyIdentifier, "Read invalid serialized key");
     data += sizeof(KeyDescriptor);
     VariantId stream_id = unserialize_variant_type(descr->id_type, data);
     return RefKey{stream_id, key_type};
 }
 
-inline std::string to_tokenized_key(const AtomKey &key) {
+inline std::string to_tokenized_key(const AtomKey& key)
+{
     KeyDescriptor kd{key, FormatType::TOKENIZED};
     return fmt::format("{}*{}*{}*{}*{}*{}*{}",
-                       kd,
-                       key.id(),
-                       key.version_id(),
-                       key.creation_ts(),
-                       key.content_hash(),
-                       tokenized_index(key.start_index()),
-                       tokenized_index(key.end_index()));
+        kd,
+        key.id(),
+        key.version_id(),
+        key.creation_ts(),
+        key.content_hash(),
+        tokenized_index(key.start_index()),
+        tokenized_index(key.end_index()));
 }
 
-inline std::string to_tokenized_key(const RefKey &key) {
+inline std::string to_tokenized_key(const RefKey& key)
+{
     KeyDescriptor kd{key, FormatType::TOKENIZED};
-    return fmt::format("{}*{}",
-                       kd,
-                       key.id());
+    return fmt::format("{}*{}", kd, key.id());
 }
 
-inline std::string to_tokenized_key(const entity::VariantKey &key) {
-    return std::visit([&](const auto &key) { return to_tokenized_key(key); }, key);
+inline std::string to_tokenized_key(const entity::VariantKey& key)
+{
+    return std::visit([&](const auto& key) { return to_tokenized_key(key); }, key);
 }
 
-inline AtomKey from_tokenized_atom_key(const uint8_t *data, size_t size, KeyType key_type) {
-    const auto *descr = reinterpret_cast<const KeyDescriptor *>(data);
+inline AtomKey from_tokenized_atom_key(const uint8_t* data, size_t size, KeyType key_type)
+{
+    const auto* descr = reinterpret_cast<const KeyDescriptor*>(data);
     util::check(descr->identifier == SerializedKeyIdentifier, "Read invalid serialized key");
-    std::string_view cursor(reinterpret_cast<const char *>(data) + sizeof(KeyDescriptor), size - sizeof(KeyDescriptor));
+    std::string_view cursor(reinterpret_cast<const char*>(data) + sizeof(KeyDescriptor), size - sizeof(KeyDescriptor));
     auto tokens = std::count(std::begin(cursor), std::end(cursor), NewKeyDelimiter);
     auto index_variant_type = variant_type_from_index_type(from_type_char(descr->index_type));
-    if(tokens == NumNewKeyFields) {
+    if (tokens == NumNewKeyFields) {
         auto arr = util::split_to_array<NumNewKeyFields>(cursor, NewKeyDelimiter);
         return atom_key_from_tokens<NewKeyField>(arr, descr->id_type, index_variant_type, key_type);
     } else {
         auto vec = util::split_to_vector(cursor, NewKeyDelimiter);
-        util::check(vec.size() > NumNewKeyFields, "Expected number of key fields {} to be greater than expected: {}", vec.size(), NumNewKeyFields);
+        util::check(vec.size() > NumNewKeyFields,
+            "Expected number of key fields {} to be greater than expected: {}",
+            vec.size(),
+            NumNewKeyFields);
         auto extra = vec.size() - NumNewKeyFields;
         std::array<std::string_view, NumNewKeyFields> fixup;
 
@@ -290,7 +338,7 @@ inline AtomKey from_tokenized_atom_key(const uint8_t *data, size_t size, KeyType
         std::ostringstream strm;
         strm << *it++;
 
-        for(auto j = 0ULL; j < extra; ++j) {
+        for (auto j = 0ULL; j < extra; ++j) {
             strm << NewKeyDelimiter << *it;
             it = vec.erase(it);
         }
@@ -305,28 +353,31 @@ inline AtomKey from_tokenized_atom_key(const uint8_t *data, size_t size, KeyType
     }
 }
 
-inline RefKey from_tokenized_ref_key(const uint8_t *data, size_t size, KeyType key_type) {
-    const auto *descr = reinterpret_cast<const KeyDescriptor *>(data);
+inline RefKey from_tokenized_ref_key(const uint8_t* data, size_t size, KeyType key_type)
+{
+    const auto* descr = reinterpret_cast<const KeyDescriptor*>(data);
     util::check(descr->identifier == SerializedKeyIdentifier, "Read invalid serialized key");
     // data looks like: "*sUt*snapshot" and the descr for ref key is "*"
     auto prefix = sizeof(KeyDescriptor) + 1;
-    std::string_view cursor(reinterpret_cast<const char *>(data) + prefix, size - prefix);
+    std::string_view cursor(reinterpret_cast<const char*>(data) + prefix, size - prefix);
     auto id = variant_id_from_token(cursor, descr->id_type);
     return RefKey{id, key_type};
 }
 
-inline VariantKey from_tokenized_variant_key(const uint8_t *data, size_t size, KeyType key_type)  {
-    if(is_ref_key_class(key_type))
+inline VariantKey from_tokenized_variant_key(const uint8_t* data, size_t size, KeyType key_type)
+{
+    if (is_ref_key_class(key_type))
         return from_tokenized_ref_key(data, size, key_type);
     else
         return from_tokenized_atom_key(data, size, key_type);
 }
 
-inline AtomKey atom_key_from_bytes(const uint8_t *data, size_t size, KeyType key_type) {
+inline AtomKey atom_key_from_bytes(const uint8_t* data, size_t size, KeyType key_type)
+{
     if (!is_serialized_key(data))
         return key_from_old_style_bytes(data, size, key_type);
 
-    const auto *descr = reinterpret_cast<const KeyDescriptor *>(data);
+    const auto* descr = reinterpret_cast<const KeyDescriptor*>(data);
     if (descr->format_type == FormatType::OPAQUE)
         return from_serialized_atom_key(data, key_type);
     else if (descr->format_type == FormatType::TOKENIZED)
@@ -335,8 +386,9 @@ inline AtomKey atom_key_from_bytes(const uint8_t *data, size_t size, KeyType key
     util::raise_rte("Unrecognized key format '{}", char(descr->format_type));
 }
 
-inline RefKey ref_key_from_bytes(const uint8_t* data, size_t size, KeyType key_type) {
-    const auto *descr = reinterpret_cast<const KeyDescriptor *>(data);
+inline RefKey ref_key_from_bytes(const uint8_t* data, size_t size, KeyType key_type)
+{
+    const auto* descr = reinterpret_cast<const KeyDescriptor*>(data);
     if (descr->format_type == FormatType::OPAQUE)
         return from_serialized_ref_key(data, key_type);
     else if (descr->format_type == FormatType::TOKENIZED)
@@ -345,12 +397,12 @@ inline RefKey ref_key_from_bytes(const uint8_t* data, size_t size, KeyType key_t
     util::raise_rte("Unrecognized key format '{}", char(descr->format_type));
 }
 
-inline VariantKey variant_key_from_bytes(const uint8_t* data, size_t size, KeyType key_type) {
-    if(is_ref_key_class(key_type))
+inline VariantKey variant_key_from_bytes(const uint8_t* data, size_t size, KeyType key_type)
+{
+    if (is_ref_key_class(key_type))
         return ref_key_from_bytes(data, size, key_type);
     else
         return atom_key_from_bytes(data, size, key_type);
 }
 
 } //namespace arcticdb::entity
-

--- a/cpp/arcticdb/entity/test/test_atom_key.cpp
+++ b/cpp/arcticdb/entity/test/test_atom_key.cpp
@@ -17,7 +17,8 @@
 
 using namespace arcticdb::entity;
 
-TEST(Key, Basic) {
+TEST(Key, Basic)
+{
     using namespace arcticdb::entity;
     using namespace arcticdb::storage;
 
@@ -28,50 +29,66 @@ TEST(Key, Basic) {
     KeyType numeric_data_key_type(KeyType::TABLE_DATA);
     IndexValue timestamp_start(33);
     IndexValue timestamp_end(57);
-    AtomKey construct_numeric_key
-        (numeric_id, version_id, creation_ts, content_hash, timestamp_start, timestamp_end, numeric_data_key_type);
+    AtomKey construct_numeric_key(numeric_id,
+        version_id,
+        creation_ts,
+        content_hash,
+        timestamp_start,
+        timestamp_end,
+        numeric_data_key_type);
 
-    auto build_numeric_key =
-        atom_key_builder().version_id(version_id).creation_ts(creation_ts).content_hash(content_hash).start_index(
-            timestamp_start).end_index(timestamp_end).build(numeric_id, numeric_data_key_type);
+    auto build_numeric_key = atom_key_builder()
+                                 .version_id(version_id)
+                                 .creation_ts(creation_ts)
+                                 .content_hash(content_hash)
+                                 .start_index(timestamp_start)
+                                 .end_index(timestamp_end)
+                                 .build(numeric_id, numeric_data_key_type);
 
     ASSERT_EQ(construct_numeric_key, build_numeric_key);
 
     std::string numeric_key_string(to_tokenized_key(build_numeric_key));
-    auto numeric_key_from_bytes =
-        atom_key_from_bytes(reinterpret_cast<uint8_t *>(numeric_key_string.data()),
-                            numeric_key_string.size(),
-                            numeric_data_key_type);
+    auto numeric_key_from_bytes = atom_key_from_bytes(reinterpret_cast<uint8_t*>(numeric_key_string.data()),
+        numeric_key_string.size(),
+        numeric_data_key_type);
     ASSERT_EQ(build_numeric_key, numeric_key_from_bytes);
 
     StringId string_id("Geebles");
     KeyType string_data_key_type(KeyType::TABLE_DATA);
-    AtomKey construct_string_key
-        (string_id, version_id, creation_ts, content_hash, timestamp_start, timestamp_end, string_data_key_type);
+    AtomKey construct_string_key(string_id,
+        version_id,
+        creation_ts,
+        content_hash,
+        timestamp_start,
+        timestamp_end,
+        string_data_key_type);
     std::string string_key_string(to_serialized_key(construct_string_key));
-    auto string_key_from_bytes =
-        atom_key_from_bytes(reinterpret_cast<uint8_t *>(string_key_string.data()),
-                            string_key_string.size(),
-                            string_data_key_type);
+    auto string_key_from_bytes = atom_key_from_bytes(reinterpret_cast<uint8_t*>(string_key_string.data()),
+        string_key_string.size(),
+        string_data_key_type);
 
     ASSERT_EQ(construct_string_key, string_key_from_bytes);
 
     IndexValue string_start("Foffbot");
     IndexValue string_end("Xoffbot");
-    auto build_numeric_key_string_index =
-        atom_key_builder().version_id(version_id).creation_ts(creation_ts).content_hash(content_hash).start_index(
-            string_start).end_index(string_end).build(numeric_id, numeric_data_key_type);
+    auto build_numeric_key_string_index = atom_key_builder()
+                                              .version_id(version_id)
+                                              .creation_ts(creation_ts)
+                                              .content_hash(content_hash)
+                                              .start_index(string_start)
+                                              .end_index(string_end)
+                                              .build(numeric_id, numeric_data_key_type);
 
     std::string string_index_key_string(to_tokenized_key(build_numeric_key_string_index));
-    auto string_index_from_bytes =
-        atom_key_from_bytes(reinterpret_cast<uint8_t *>(string_index_key_string.data()),
-                            string_index_key_string.size(),
-                            numeric_data_key_type);
+    auto string_index_from_bytes = atom_key_from_bytes(reinterpret_cast<uint8_t*>(string_index_key_string.data()),
+        string_index_key_string.size(),
+        numeric_data_key_type);
 
     ASSERT_EQ(build_numeric_key_string_index, string_index_from_bytes);
 }
 
-TEST(Key, StringViewable) {
+TEST(Key, StringViewable)
+{
     using namespace arcticdb::storage;
 
     DefaultStringViewable sv{"toto"};
@@ -79,10 +96,10 @@ TEST(Key, StringViewable) {
 
     ASSERT_EQ(sv.hash(), sv2.hash());
     ASSERT_EQ(sv, sv2);
-
 }
 
-TEST(Key, Library) {
+TEST(Key, Library)
+{
     using namespace arcticdb::storage;
 
     LibraryPath lib{"a", "b"};
@@ -105,10 +122,10 @@ struct AlternativeFormat {
     static constexpr char format[] = "t={},id={},g={:d},h=0x{:x},c={:d},s={},e={}";
 };
 
-TEST(Key, Formatting) {
+TEST(Key, Formatting)
+{
 
-    AtomKey k{
-        StreamId{999},
+    AtomKey k{StreamId{999},
         VersionId(123),
         timestamp(123000000LL),
         0x789456321ULL,
@@ -120,9 +137,13 @@ TEST(Key, Formatting) {
 
     ASSERT_EQ(k2, k);
 
-    auto k3 = atom_key_builder().gen_id(123).creation_ts(123000000)
-        .start_index(timestamp(122000000)).end_index(timestamp(122000999))
-        .content_hash(0x789456321).build<KeyType::TABLE_DATA>(999);
+    auto k3 = atom_key_builder()
+                  .gen_id(123)
+                  .creation_ts(123000000)
+                  .start_index(timestamp(122000000))
+                  .end_index(timestamp(122000999))
+                  .content_hash(0x789456321)
+                  .build<KeyType::TABLE_DATA>(999);
 
     ASSERT_EQ(k3, k2);
 
@@ -140,13 +161,13 @@ TEST(Key, Formatting) {
     // Overload key formatting with a tag to avoid strings all over the place
     auto alt = fmt::format("{}", formattable<AtomKey, AlternativeFormat>(k));
     ASSERT_EQ("t=d,id=999,g=123,h=0x789456321,c=123000000,s=122000000,e=122000999", alt);
-
 }
 
-
-TEST(AtomKey, ProtobufRoundtrip) {
-    auto key = atom_key_builder().version_id(0).content_hash(1).creation_ts(2).start_index(3)
-    .end_index(4).build(StreamId{"Natbag"}, KeyType::TABLE_INDEX);
+TEST(AtomKey, ProtobufRoundtrip)
+{
+    auto key = atom_key_builder().version_id(0).content_hash(1).creation_ts(2).start_index(3).end_index(4).build(
+        StreamId{"Natbag"},
+        KeyType::TABLE_INDEX);
 
     auto pb_key = arcticdb::encode_key(key);
     auto decoded_key = arcticdb::decode_key(pb_key);

--- a/cpp/arcticdb/entity/test/test_key_serialization.cpp
+++ b/cpp/arcticdb/entity/test/test_key_serialization.cpp
@@ -10,19 +10,21 @@
 #include <arcticdb/entity/serialized_key.hpp>
 
 namespace arcticdb {
-    std::string old_style_key(const AtomKey& key) {
-        return fmt::format("{}|{}|{}|{}|{}|{}|{}",
-                    key.id(),
-                           key.version_id(),
-                           key.creation_ts(),
-                           key.content_hash(),
-                           stream::get_index_value_type(key),
-                           key.start_index(),
-                           key.end_index());
-    }
+std::string old_style_key(const AtomKey& key)
+{
+    return fmt::format("{}|{}|{}|{}|{}|{}|{}",
+        key.id(),
+        key.version_id(),
+        key.creation_ts(),
+        key.content_hash(),
+        stream::get_index_value_type(key),
+        key.start_index(),
+        key.end_index());
 }
+} // namespace arcticdb
 
-TEST(KeySerialize, RoundtripStringidNumericIndex) {
+TEST(KeySerialize, RoundtripStringidNumericIndex)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
 
@@ -33,12 +35,13 @@ TEST(KeySerialize, RoundtripStringidNumericIndex) {
     auto start_index = IndexValue(1234);
     auto end_index = IndexValue(4321);
 
-    auto key = atom_key_builder().version_id(version_id)
-        .creation_ts(version_id)
-        .content_hash(content_hash)
-        .start_index(start_index)
-        .end_index(end_index)
-        .build(stream_id, key_type);
+    auto key = atom_key_builder()
+                   .version_id(version_id)
+                   .creation_ts(version_id)
+                   .content_hash(content_hash)
+                   .start_index(start_index)
+                   .end_index(end_index)
+                   .build(stream_id, key_type);
 
     std::string serialized = to_serialized_key(key);
     auto data = reinterpret_cast<const uint8_t*>(serialized.data());
@@ -57,7 +60,8 @@ TEST(KeySerialize, RoundtripStringidNumericIndex) {
     auto test_key5 = atom_key_from_bytes(data, old_style.size(), key_type);
 }
 
-TEST(KeySerialize, RoundtripNumericIdNumericIndex) {
+TEST(KeySerialize, RoundtripNumericIdNumericIndex)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
 
@@ -68,12 +72,13 @@ TEST(KeySerialize, RoundtripNumericIdNumericIndex) {
     auto start_index = IndexValue(1234);
     auto end_index = IndexValue(4321);
 
-    auto key = atom_key_builder().version_id(version_id)
-        .creation_ts(version_id)
-        .content_hash(content_hash)
-        .start_index(start_index)
-        .end_index(end_index)
-        .build(stream_id, key_type);
+    auto key = atom_key_builder()
+                   .version_id(version_id)
+                   .creation_ts(version_id)
+                   .content_hash(content_hash)
+                   .start_index(start_index)
+                   .end_index(end_index)
+                   .build(stream_id, key_type);
 
     std::string serialized = to_serialized_key(key);
     auto data = reinterpret_cast<const uint8_t*>(serialized.data());
@@ -92,7 +97,8 @@ TEST(KeySerialize, RoundtripNumericIdNumericIndex) {
     auto test_key5 = atom_key_from_bytes(data, old_style.size(), key_type);
 }
 
-TEST(KeySerialize, RoundtripStringidStringIndex) {
+TEST(KeySerialize, RoundtripStringidStringIndex)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
 
@@ -103,12 +109,13 @@ TEST(KeySerialize, RoundtripStringidStringIndex) {
     auto start_index = IndexValue("aaaaa");
     auto end_index = IndexValue("zzzzzz");
 
-    auto key = atom_key_builder().version_id(version_id)
-        .creation_ts(version_id)
-        .content_hash(content_hash)
-        .start_index(start_index)
-        .end_index(end_index)
-        .build(stream_id, key_type);
+    auto key = atom_key_builder()
+                   .version_id(version_id)
+                   .creation_ts(version_id)
+                   .content_hash(content_hash)
+                   .start_index(start_index)
+                   .end_index(end_index)
+                   .build(stream_id, key_type);
 
     std::string serialized = to_serialized_key(key);
     auto data = reinterpret_cast<const uint8_t*>(serialized.data());
@@ -127,7 +134,8 @@ TEST(KeySerialize, RoundtripStringidStringIndex) {
     auto test_key5 = atom_key_from_bytes(data, old_style.size(), key_type);
 }
 
-TEST(KeySerialize, RefKeyTokenized) {
+TEST(KeySerialize, RefKeyTokenized)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     auto ref_key = RefKey{StreamId{"thing"}, KeyType::SNAPSHOT_REF};
@@ -136,16 +144,18 @@ TEST(KeySerialize, RefKeyTokenized) {
     ASSERT_EQ(ref_key, out_key);
 }
 
-TEST(KeySerialize, RefKeySerialized) {
+TEST(KeySerialize, RefKeySerialized)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     auto ref_key = RefKey{StreamId{"thing"}, KeyType::SNAPSHOT_REF};
     auto str = to_serialized_key(ref_key);
-    auto out_key = from_serialized_ref_key((const uint8_t*)str.data(),  KeyType::SNAPSHOT_REF);
+    auto out_key = from_serialized_ref_key((const uint8_t*)str.data(), KeyType::SNAPSHOT_REF);
     ASSERT_EQ(ref_key, out_key);
 }
 
-TEST(SerializeNumber, SignedNumbers) {
+TEST(SerializeNumber, SignedNumbers)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     auto stream_id = StreamId("happy");
@@ -155,12 +165,13 @@ TEST(SerializeNumber, SignedNumbers) {
     auto start_index = IndexValue(-123456789);
     auto end_index = IndexValue(-987654321);
 
-    auto key = atom_key_builder().version_id(version_id)
-        .creation_ts(version_id)
-        .content_hash(content_hash)
-        .start_index(start_index)
-        .end_index(end_index)
-        .build(stream_id, key_type);
+    auto key = atom_key_builder()
+                   .version_id(version_id)
+                   .creation_ts(version_id)
+                   .content_hash(content_hash)
+                   .start_index(start_index)
+                   .end_index(end_index)
+                   .build(stream_id, key_type);
 
     auto tokenized = to_tokenized_key(key);
     auto new_key = from_tokenized_atom_key((const uint8_t*)tokenized.data(), tokenized.size(), key_type);
@@ -171,7 +182,8 @@ TEST(SerializeNumber, SignedNumbers) {
     ASSERT_EQ(key, new_key);
 }
 
-TEST(KeySerialize, RoundtripStringidSpecialCharacter) {
+TEST(KeySerialize, RoundtripStringidSpecialCharacter)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
 
@@ -182,15 +194,16 @@ TEST(KeySerialize, RoundtripStringidSpecialCharacter) {
     auto start_index = IndexValue(1234);
     auto end_index = IndexValue(4321);
 
-    auto key = atom_key_builder().version_id(version_id)
-        .creation_ts(version_id)
-        .content_hash(content_hash)
-        .start_index(start_index)
-        .end_index(end_index)
-        .build(stream_id, key_type);
+    auto key = atom_key_builder()
+                   .version_id(version_id)
+                   .creation_ts(version_id)
+                   .content_hash(content_hash)
+                   .start_index(start_index)
+                   .end_index(end_index)
+                   .build(stream_id, key_type);
 
     std::string tokenized = to_tokenized_key(key);
-    auto data = reinterpret_cast<const uint8_t *>(tokenized.data());
+    auto data = reinterpret_cast<const uint8_t*>(tokenized.data());
     auto test_key = from_tokenized_atom_key(data, tokenized.size(), key_type);
     ASSERT_EQ(key, test_key);
 }

--- a/cpp/arcticdb/entity/test/test_ref_key.cpp
+++ b/cpp/arcticdb/entity/test/test_ref_key.cpp
@@ -8,9 +8,10 @@
 #include <gtest/gtest.h>
 #include <arcticdb/entity/ref_key.hpp>
 
-TEST(RefKey, Basic) {
+TEST(RefKey, Basic)
+{
     using namespace arcticdb::entity;
-    RefKey rk{ "HelloWorld", KeyType::STORAGE_INFO};
+    RefKey rk{"HelloWorld", KeyType::STORAGE_INFO};
     ASSERT_EQ(rk.id(), VariantId("HelloWorld"));
     ASSERT_EQ(rk.type(), KeyType::STORAGE_INFO);
 }

--- a/cpp/arcticdb/entity/test/test_tensor.cpp
+++ b/cpp/arcticdb/entity/test/test_tensor.cpp
@@ -9,14 +9,15 @@
 #include <arcticdb/entity/native_tensor.hpp>
 #include <arcticdb/util/flatten_utils.hpp>
 
-auto get_f_tensor(size_t num_rows) {
+auto get_f_tensor(size_t num_rows)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows);
-    const std::vector<stride_t>  strides = {4u, 40u};
+    const std::vector<stride_t> strides = {4u, 40u};
     const std::vector<shape_t> shapes = {10u, 10u};
     size_t count = 0;
-    for(auto i = 0u; i < shapes[0]; ++i) {
+    for (auto i = 0u; i < shapes[0]; ++i) {
         auto row = i * (strides[0] / sizeof(data_t));
         for (auto j = 0u; j < shapes[1]; ++j) {
             auto pos = row + (j * (strides[1] / sizeof(data_t)));
@@ -28,34 +29,47 @@ auto get_f_tensor(size_t num_rows) {
     const auto ndim = 2;
     const DataType dt = DataType::UINT32;
 
-    NativeTensor tensor{nbytes, ndim, strides.data(), shapes.data(), dt, get_type_size(dt), static_cast<const void*>(data->data())};
+    NativeTensor tensor{nbytes,
+        ndim,
+        strides.data(),
+        shapes.data(),
+        dt,
+        get_type_size(dt),
+        static_cast<const void*>(data->data())};
     return std::make_pair(data, tensor);
 }
 
-auto get_c_tensor(size_t num_rows) {
+auto get_c_tensor(size_t num_rows)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows);
-    const std::vector<stride_t>  strides = {40u, 4u};
+    const std::vector<stride_t> strides = {40u, 4u};
     const std::vector<shape_t> shapes = {10u, 10u};
-    for(auto i = 0u; i < num_rows; ++i) {
-            (*data)[i] = i;
+    for (auto i = 0u; i < num_rows; ++i) {
+        (*data)[i] = i;
     }
 
     const ssize_t nbytes = data->size() * sizeof(data_t);
     const auto ndim = 2;
     const DataType dt = DataType::UINT32;
 
-    NativeTensor tensor{nbytes, ndim, strides.data(), shapes.data(), dt, get_type_size(dt), static_cast<const void*>(data->data())};
+    NativeTensor tensor{nbytes,
+        ndim,
+        strides.data(),
+        shapes.data(),
+        dt,
+        get_type_size(dt),
+        static_cast<const void*>(data->data())};
     return std::make_pair(data, tensor);
 }
 
-
-TEST(ColumnMajorTensor, Flatten) {
+TEST(ColumnMajorTensor, Flatten)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_f_tensor(num_rows);
+    auto [data, tensor] = get_f_tensor(num_rows);
     TypedTensor<data_t> typed_tensor{tensor};
     std::vector<data_t> output(num_rows);
 
@@ -65,16 +79,17 @@ TEST(ColumnMajorTensor, Flatten) {
     uint32_t* ptr = output.data();
     f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-TEST(RowMajorTensor, Flatten) {
+TEST(RowMajorTensor, Flatten)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_c_tensor(num_rows);
+    auto [data, tensor] = get_c_tensor(num_rows);
     TypedTensor<data_t> typed_tensor{tensor};
     std::vector<data_t> output(num_rows);
 
@@ -84,74 +99,76 @@ TEST(RowMajorTensor, Flatten) {
     uint32_t* ptr = output.data();
     f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-
-TEST(ColumnMajorTensor, SubDivide) {
+TEST(ColumnMajorTensor, SubDivide)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_f_tensor(num_rows);
+    auto [data, tensor] = get_f_tensor(num_rows);
     std::vector<data_t> output(num_rows);
 
     ssize_t nvalues = 20;
-    std::vector<TypedTensor<data_t >> tensors;
+    std::vector<TypedTensor<data_t>> tensors;
     ssize_t slice = 0;
-    for(auto div = 0u; div < num_rows; div += nvalues) {
+    for (auto div = 0u; div < num_rows; div += nvalues) {
         TypedTensor<data_t> typed_tensor{tensor, slice++, nvalues, nvalues};
         tensors.push_back(typed_tensor);
     }
 
     uint32_t* ptr = output.data();
-    for(auto& typed_tensor : tensors) {
+    for (auto& typed_tensor : tensors) {
         arcticdb::util::FlattenHelper f{typed_tensor};
         auto info = typed_tensor.request();
         f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
     }
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-TEST(RowMajorTensor, SubDivide) {
+TEST(RowMajorTensor, SubDivide)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_c_tensor(num_rows);
+    auto [data, tensor] = get_c_tensor(num_rows);
     std::vector<data_t> output(num_rows);
 
     ssize_t nvalues = 20;
-    std::vector<TypedTensor<data_t >> tensors;
+    std::vector<TypedTensor<data_t>> tensors;
     ssize_t slice = 0;
-    for(auto div = 0u; div < num_rows; div += nvalues) {
+    for (auto div = 0u; div < num_rows; div += nvalues) {
         TypedTensor<data_t> typed_tensor{tensor, slice++, nvalues, nvalues};
         tensors.push_back(typed_tensor);
     }
 
     uint32_t* ptr = output.data();
-    for(auto& typed_tensor : tensors) {
+    for (auto& typed_tensor : tensors) {
         arcticdb::util::FlattenHelper f{typed_tensor};
         auto info = typed_tensor.request();
         f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
     }
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-auto get_sparse_array(size_t num_rows) {
+auto get_sparse_array(size_t num_rows)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows * 2);
-    const std::vector<stride_t>  strides = {8u, 0u};
+    const std::vector<stride_t> strides = {8u, 0u};
     const std::vector<shape_t> shapes = {100u, 0u};
 
-    for(auto i = 0u; i < num_rows; ++i) {
+    for (auto i = 0u; i < num_rows; ++i) {
         (*data)[i * 2] = i;
     }
 
@@ -159,15 +176,22 @@ auto get_sparse_array(size_t num_rows) {
     const auto ndim = 1;
     const DataType dt = DataType::UINT32;
 
-    NativeTensor tensor{nbytes, ndim, strides.data(), shapes.data(), dt, get_type_size(dt), static_cast<const void*>(data->data())};
+    NativeTensor tensor{nbytes,
+        ndim,
+        strides.data(),
+        shapes.data(),
+        dt,
+        get_type_size(dt),
+        static_cast<const void*>(data->data())};
     return std::make_pair(data, tensor);
 }
 
-TEST(SparseArray, Flatten) {
+TEST(SparseArray, Flatten)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_sparse_array(num_rows);
+    auto [data, tensor] = get_sparse_array(num_rows);
     TypedTensor<data_t> typed_tensor{tensor};
     std::vector<data_t> output(num_rows);
 
@@ -177,63 +201,72 @@ TEST(SparseArray, Flatten) {
     uint32_t* ptr = output.data();
     f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-TEST(SparseArray, SubDivide) {
+TEST(SparseArray, SubDivide)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_sparse_array(num_rows);
+    auto [data, tensor] = get_sparse_array(num_rows);
     std::vector<data_t> output(num_rows);
 
     ssize_t nvalues = 20;
-    std::vector<TypedTensor<data_t >> tensors;
+    std::vector<TypedTensor<data_t>> tensors;
     ssize_t slice = 0;
-    for(auto div = 0u; div < num_rows; div += nvalues) {
+    for (auto div = 0u; div < num_rows; div += nvalues) {
         TypedTensor<data_t> typed_tensor{tensor, slice++, nvalues, nvalues};
         tensors.push_back(typed_tensor);
     }
 
     uint32_t* ptr = output.data();
-    for(auto& typed_tensor : tensors) {
+    for (auto& typed_tensor : tensors) {
         arcticdb::util::FlattenHelper f{typed_tensor};
         auto info = typed_tensor.request();
         f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
     }
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-auto get_sparse_array_funky_strides() {
+auto get_sparse_array_funky_strides()
+{
     using namespace arcticdb::entity;
     const auto num_rows = 100u;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<uint8_t>>(num_rows * 19 * sizeof(data_t));
-    const std::vector<stride_t>  strides = {19u, 0u};
+    const std::vector<stride_t> strides = {19u, 0u};
     const std::vector<shape_t> shapes = {100u, 0u};
 
-    for(auto i = 0u; i < num_rows; ++i) {
-        *reinterpret_cast<data_t*>(&(*data)[i * 19] )= i;
+    for (auto i = 0u; i < num_rows; ++i) {
+        *reinterpret_cast<data_t*>(&(*data)[i * 19]) = i;
     }
 
     const ssize_t nbytes = num_rows * sizeof(data_t);
     const auto ndim = 1;
     const DataType dt = DataType::UINT32;
 
-    NativeTensor tensor{nbytes, ndim, strides.data(), shapes.data(), dt, get_type_size(dt), static_cast<const void*>(data->data())};
+    NativeTensor tensor{nbytes,
+        ndim,
+        strides.data(),
+        shapes.data(),
+        dt,
+        get_type_size(dt),
+        static_cast<const void*>(data->data())};
     return std::make_pair(data, tensor);
 }
 
-TEST(SparseArrayFunkyStrides, Flatten) {
+TEST(SparseArrayFunkyStrides, Flatten)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_sparse_array_funky_strides();
+    auto [data, tensor] = get_sparse_array_funky_strides();
     TypedTensor<data_t> typed_tensor{tensor};
     std::vector<data_t> output(num_rows);
 
@@ -243,46 +276,48 @@ TEST(SparseArrayFunkyStrides, Flatten) {
     uint32_t* ptr = output.data();
     f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-TEST(SparseArrayFunkyStrides, SubDivide) {
+TEST(SparseArrayFunkyStrides, SubDivide)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 100;
-    auto [data, tensor]  = get_sparse_array_funky_strides();
+    auto [data, tensor] = get_sparse_array_funky_strides();
     std::vector<data_t> output(num_rows);
 
     ssize_t nvalues = 20;
-    std::vector<TypedTensor<data_t >> tensors;
+    std::vector<TypedTensor<data_t>> tensors;
     ssize_t slice = 0;
-    for(auto div = 0u; div < num_rows; div += nvalues) {
+    for (auto div = 0u; div < num_rows; div += nvalues) {
         TypedTensor<data_t> typed_tensor{tensor, slice++, nvalues, nvalues};
         tensors.push_back(typed_tensor);
     }
 
     uint32_t* ptr = output.data();
-    for(auto& typed_tensor : tensors) {
+    for (auto& typed_tensor : tensors) {
         arcticdb::util::FlattenHelper f{typed_tensor};
         auto info = typed_tensor.request();
         f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
     }
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }
 
-auto get_sparse_array_uneven(size_t num_rows) {
+auto get_sparse_array_uneven(size_t num_rows)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows * 2);
-    const std::vector<stride_t>  strides = {8u, 0u};
+    const std::vector<stride_t> strides = {8u, 0u};
     const std::vector<shape_t> shapes = {109u, 0u};
 
-    for(auto i = 0u; i < num_rows; ++i) {
+    for (auto i = 0u; i < num_rows; ++i) {
         (*data)[i * 2] = i;
     }
 
@@ -290,34 +325,41 @@ auto get_sparse_array_uneven(size_t num_rows) {
     const auto ndim = 1;
     const DataType dt = DataType::UINT32;
 
-    NativeTensor tensor{nbytes, ndim, strides.data(), shapes.data(), dt, get_type_size(dt), static_cast<const void*>(data->data())};
+    NativeTensor tensor{nbytes,
+        ndim,
+        strides.data(),
+        shapes.data(),
+        dt,
+        get_type_size(dt),
+        static_cast<const void*>(data->data())};
     return std::make_pair(data, tensor);
 }
 
-TEST(SparseArray, SubDivideUneven) {
+TEST(SparseArray, SubDivideUneven)
+{
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     constexpr size_t num_rows = 109;
-    auto [data, tensor]  = get_sparse_array_uneven(num_rows);
+    auto [data, tensor] = get_sparse_array_uneven(num_rows);
     std::vector<data_t> output(num_rows);
 
     ssize_t nvalues = 20;
-    std::vector<TypedTensor<data_t >> tensors;
+    std::vector<TypedTensor<data_t>> tensors;
     ssize_t slice = 0;
     auto remaining = num_rows;
-    for(auto div = 0u; div < num_rows; div += nvalues, remaining -= nvalues) {
+    for (auto div = 0u; div < num_rows; div += nvalues, remaining -= nvalues) {
         TypedTensor<data_t> typed_tensor{tensor, slice++, nvalues, std::min(static_cast<ssize_t>(remaining), nvalues)};
         tensors.push_back(typed_tensor);
     }
 
     uint32_t* ptr = output.data();
-    for(auto& typed_tensor : tensors) {
+    for (auto& typed_tensor : tensors) {
         arcticdb::util::FlattenHelper f{typed_tensor};
         auto info = typed_tensor.request();
         f.flatten(ptr, reinterpret_cast<const data_t*>(info.ptr));
     }
 
-    for(uint32_t x = 0; x < num_rows; ++x) {
+    for (uint32_t x = 0; x < num_rows; ++x) {
         ASSERT_EQ(output[x], x);
     }
 }

--- a/cpp/arcticdb/entity/type_conversion.hpp
+++ b/cpp/arcticdb/entity/type_conversion.hpp
@@ -11,140 +11,132 @@
 
 namespace arcticdb {
 
-    template<size_t size>
-    struct UnsignedPromoteImpl;
+template<size_t size>
+struct UnsignedPromoteImpl;
 
-    template <>
-    struct UnsignedPromoteImpl<8> {
-        using type = int64_t;
-    };
+template<>
+struct UnsignedPromoteImpl<8> {
+    using type = int64_t;
+};
 
-    template <>
-    struct UnsignedPromoteImpl<4> {
-        using type = int64_t;
-    };
+template<>
+struct UnsignedPromoteImpl<4> {
+    using type = int64_t;
+};
 
-    template <>
-    struct UnsignedPromoteImpl<2> {
-        using type = int32_t;
-    };
+template<>
+struct UnsignedPromoteImpl<2> {
+    using type = int32_t;
+};
 
-    template <>
-    struct UnsignedPromoteImpl<1> {
-        using type = int16_t;
-    };
+template<>
+struct UnsignedPromoteImpl<1> {
+    using type = int16_t;
+};
 
-    template<typename T>
-    struct UnsignedPromote {
-        using type = typename UnsignedPromoteImpl<sizeof(T)>::type;
-    };
+template<typename T>
+struct UnsignedPromote {
+    using type = typename UnsignedPromoteImpl<sizeof(T)>::type;
+};
 
-    template <typename T, typename U>
-    struct Comparable {
-        using left_type = typename std::conditional<
-                std::is_signed_v<T> == std::is_signed_v<U>,
-                std::common_type_t<T, U>,
-                typename std::conditional<
-                std::is_signed_v<T>, T, typename UnsignedPromote<T>::type
-                >::type
-                >::type;
+template<typename T, typename U>
+struct Comparable {
+    using left_type = typename std::conditional<std::is_signed_v<T> == std::is_signed_v<U>,
+        std::common_type_t<T, U>,
+        typename std::conditional<std::is_signed_v<T>, T, typename UnsignedPromote<T>::type>::type>::type;
 
-        using right_type = typename std::conditional<
-                std::is_signed_v<T> == std::is_signed_v<U>,
-                std::common_type_t<T, U>,
-                typename std::conditional<
-                std::is_signed_v<U>, U, typename UnsignedPromote<U>::type
-                >::type
-                >::type;
-    };
+    using right_type = typename std::conditional<std::is_signed_v<T> == std::is_signed_v<U>,
+        std::common_type_t<T, U>,
+        typename std::conditional<std::is_signed_v<U>, U, typename UnsignedPromote<U>::type>::type>::type;
+};
 
-    template <>
-    struct Comparable<double, double> {
-        using left_type = double;
-        using right_type = double;
-    };
+template<>
+struct Comparable<double, double> {
+    using left_type = double;
+    using right_type = double;
+};
 
-    template <>
-    struct Comparable<double, float> {
-        using left_type = double;
-        using right_type = double;
-    };
+template<>
+struct Comparable<double, float> {
+    using left_type = double;
+    using right_type = double;
+};
 
-    template <>
-    struct Comparable<float, double> {
-        using left_type = double;
-        using right_type = double;
-    };
+template<>
+struct Comparable<float, double> {
+    using left_type = double;
+    using right_type = double;
+};
 
-    template <>
-    struct Comparable<float, float> {
-        using left_type = float;
-        using right_type = float;
-    };
+template<>
+struct Comparable<float, float> {
+    using left_type = float;
+    using right_type = float;
+};
 
-    template <>
-    struct Comparable<double, uint64_t> {
-        using left_type = double;
-        using right_type = double;
-    };
+template<>
+struct Comparable<double, uint64_t> {
+    using left_type = double;
+    using right_type = double;
+};
 
-    template <>
-    struct Comparable<uint64_t, double> {
-        using left_type = double;
-        using right_type = double;
-    };
+template<>
+struct Comparable<uint64_t, double> {
+    using left_type = double;
+    using right_type = double;
+};
 
-    template <>
-    struct Comparable<float, uint64_t> {
-        using left_type = float;
-        using right_type = float;
-    };
+template<>
+struct Comparable<float, uint64_t> {
+    using left_type = float;
+    using right_type = float;
+};
 
-    template <>
-    struct Comparable<uint64_t, float> {
-        using left_type = float;
-        using right_type = float;
-    };
+template<>
+struct Comparable<uint64_t, float> {
+    using left_type = float;
+    using right_type = float;
+};
 
-    template <>
-    struct Comparable<uint64_t, uint64_t> {
-        using left_type = uint64_t;
-        using right_type = uint64_t;
-    };
+template<>
+struct Comparable<uint64_t, uint64_t> {
+    using left_type = uint64_t;
+    using right_type = uint64_t;
+};
 
-    template <typename T>
-    struct Comparable<T, double> {
-        using left_type = double;
-        using right_type = double;
-    };
+template<typename T>
+struct Comparable<T, double> {
+    using left_type = double;
+    using right_type = double;
+};
 
-    template <typename T>
-    struct Comparable<double, T> {
-        using left_type = double;
-        using right_type = double;
-    };
+template<typename T>
+struct Comparable<double, T> {
+    using left_type = double;
+    using right_type = double;
+};
 
-    template <typename T>
-    struct Comparable<T, float> {
-        using left_type = float;
-        using right_type = float;
-    };
+template<typename T>
+struct Comparable<T, float> {
+    using left_type = float;
+    using right_type = float;
+};
 
-    template <typename T>
-    struct Comparable<float, T> {
-        using left_type = float;
-        using right_type = float;
-    };
+template<typename T>
+struct Comparable<float, T> {
+    using left_type = float;
+    using right_type = float;
+};
 
-    template <typename T>
-    struct Comparable<uint64_t, T> {
-        using left_type = uint64_t;
-        using right_type = typename std::conditional<std::is_signed_v<T>, int64_t, T>::type;
-    };
+template<typename T>
+struct Comparable<uint64_t, T> {
+    using left_type = uint64_t;
+    using right_type = typename std::conditional<std::is_signed_v<T>, int64_t, T>::type;
+};
 
-    template <typename T>
-    struct Comparable<T, uint64_t> {
-        using left_type = typename std::conditional<std::is_signed_v<T>, int64_t, T>::type;
-        using right_type = uint64_t;
-    };
-}
+template<typename T>
+struct Comparable<T, uint64_t> {
+    using left_type = typename std::conditional<std::is_signed_v<T>, int64_t, T>::type;
+    using right_type = uint64_t;
+};
+} // namespace arcticdb

--- a/cpp/arcticdb/entity/type_utils.hpp
+++ b/cpp/arcticdb/entity/type_utils.hpp
@@ -11,28 +11,33 @@
 
 namespace arcticdb {
 
-inline bool trivially_compatible_types(entity::TypeDescriptor left, entity::TypeDescriptor right) {
-    if(left == right)
+inline bool trivially_compatible_types(entity::TypeDescriptor left, entity::TypeDescriptor right)
+{
+    if (left == right)
         return true;
 
-    if(is_sequence_type(left.data_type()) && is_sequence_type(right.data_type())) {
+    if (is_sequence_type(left.data_type()) && is_sequence_type(right.data_type())) {
         //TODO coercion of utf strings is not always safe, should allow safe conversion and reinstate the
         //stronger requirement for trivial conversion below.
-//        if(!is_utf_type(slice_value_type(left.data_type)) && !is_utf_type(slice_value_type(right.data_type)))
-//            return true;
+        //        if(!is_utf_type(slice_value_type(left.data_type)) && !is_utf_type(slice_value_type(right.data_type)))
+        //            return true;
 
-        return is_utf_type(slice_value_type(left.data_type()))  == is_utf_type(slice_value_type(right.data_type()));
+        return is_utf_type(slice_value_type(left.data_type())) == is_utf_type(slice_value_type(right.data_type()));
     }
 
     return false;
 }
 
-inline bool trivially_compatible_types(const arcticdb::proto::descriptors::TypeDescriptor& left, const arcticdb::proto::descriptors::TypeDescriptor& right) {
+inline bool trivially_compatible_types(const arcticdb::proto::descriptors::TypeDescriptor& left,
+    const arcticdb::proto::descriptors::TypeDescriptor& right)
+{
     return trivially_compatible_types(entity::type_desc_from_proto(left), entity::type_desc_from_proto(right));
 }
 
-inline std::optional<entity::TypeDescriptor> has_valid_type_promotion(entity::TypeDescriptor source, entity::TypeDescriptor target) {
-    if(source.dimension() != target.dimension())
+inline std::optional<entity::TypeDescriptor> has_valid_type_promotion(entity::TypeDescriptor source,
+    entity::TypeDescriptor target)
+{
+    if (source.dimension() != target.dimension())
         return std::nullopt;
 
     auto source_type = source.data_type();
@@ -93,7 +98,9 @@ inline std::optional<entity::TypeDescriptor> has_valid_type_promotion(entity::Ty
     return entity::TypeDescriptor{combine_data_type(slice_value_type(target_type), target_size), target.dimension()};
 }
 
-inline std::optional<entity::TypeDescriptor> has_valid_common_type(entity::TypeDescriptor left, entity::TypeDescriptor right) {
+inline std::optional<entity::TypeDescriptor> has_valid_common_type(entity::TypeDescriptor left,
+    entity::TypeDescriptor right)
+{
     auto maybe_common_type = has_valid_type_promotion(left, right);
     if (!maybe_common_type) {
         maybe_common_type = has_valid_type_promotion(right, left);
@@ -101,4 +108,4 @@ inline std::optional<entity::TypeDescriptor> has_valid_common_type(entity::TypeD
     return maybe_common_type;
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/entity/types-inl.hpp
+++ b/cpp/arcticdb/entity/types-inl.hpp
@@ -18,9 +18,11 @@ namespace arcticdb::entity {
 namespace details {
 
 template<class DimType, class Callable>
-auto visit_dim(DataType dt, Callable &&c) {
+auto visit_dim(DataType dt, Callable&& c)
+{
     switch (dt) {
-#define DT_CASE(__T__) case DataType::__T__: \
+#define DT_CASE(__T__)                                                                                                 \
+    case DataType::__T__:                                                                                              \
         return c(TypeDescriptorTag<DataTypeTag<DataType::__T__>, DimType>());
         DT_CASE(UINT8)
         DT_CASE(UINT16)
@@ -39,15 +41,18 @@ auto visit_dim(DataType dt, Callable &&c) {
         DT_CASE(UTF_FIXED64)
         DT_CASE(UTF_DYNAMIC64)
 #undef DT_CASE
-    default: util::raise_rte("Invalid dtype '{}' in visit dim", datatype_to_str(dt));
+    default:
+        util::raise_rte("Invalid dtype '{}' in visit dim", datatype_to_str(dt));
     }
 }
 
 template<class Callable>
-auto visit_type(DataType dt, Callable &&c) {
+auto visit_type(DataType dt, Callable&& c)
+{
     switch (dt) {
-#define DT_CASE(__T__) case DataType::__T__: \
-    return c(DataTypeTag<DataType::__T__>());
+#define DT_CASE(__T__)                                                                                                 \
+    case DataType::__T__:                                                                                              \
+        return c(DataTypeTag<DataType::__T__>());
         DT_CASE(UINT8)
         DT_CASE(UINT16)
         DT_CASE(UINT32)
@@ -65,39 +70,48 @@ auto visit_type(DataType dt, Callable &&c) {
         DT_CASE(UTF_FIXED64)
         DT_CASE(UTF_DYNAMIC64)
 #undef DT_CASE
-    default: util::raise_rte("Invalid dtype '{}' in visit type", datatype_to_str(dt));
+    default:
+        util::raise_rte("Invalid dtype '{}' in visit type", datatype_to_str(dt));
     }
 }
 
 } // namespace details
 
 template<class Callable>
-auto TypeDescriptor::visit_tag(Callable &&callable) const {
+auto TypeDescriptor::visit_tag(Callable&& callable) const
+{
     switch (dimension_) {
-#define DIM_CASE(__D__) case Dimension::__D__: \
-    return details::visit_dim<DimensionTag<Dimension::__D__>>(data_type_, callable)
+#define DIM_CASE(__D__)                                                                                                \
+    case Dimension::__D__:                                                                                             \
+        return details::visit_dim<DimensionTag<Dimension::__D__>>(data_type_, callable)
         DIM_CASE(Dim0);
         DIM_CASE(Dim1);
         DIM_CASE(Dim2);
 #undef DIM_CASE
-        default:throw std::invalid_argument(fmt::format("Invalid dimension %d", static_cast<uint32_t>(dimension_)));
+    default:
+        throw std::invalid_argument(fmt::format("Invalid dimension %d", static_cast<uint32_t>(dimension_)));
     }
 }
 
-constexpr TypeDescriptor null_type_descriptor() {
+constexpr TypeDescriptor null_type_descriptor()
+{
     return {DataType(ValueType::UNKNOWN_VALUE_TYPE), Dimension::Dim0};
 }
 
-} // namespace arcticdb
+} // namespace arcticdb::entity
 
 namespace fmt {
 template<>
 struct formatter<arcticdb::entity::DataType> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(arcticdb::entity::DataType dt, FormatContext &ctx) const {
+    auto format(arcticdb::entity::DataType dt, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), datatype_to_str(dt));
     }
 };
@@ -105,21 +119,29 @@ struct formatter<arcticdb::entity::DataType> {
 template<>
 struct formatter<arcticdb::entity::Dimension> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(arcticdb::entity::Dimension dim, FormatContext &ctx) const {
-        return format_to(ctx.out(), "{}", static_cast<uint32_t >(dim));
+    auto format(arcticdb::entity::Dimension dim, FormatContext& ctx) const
+    {
+        return format_to(ctx.out(), "{}", static_cast<uint32_t>(dim));
     }
 };
 
 template<>
 struct formatter<arcticdb::entity::TypeDescriptor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::TypeDescriptor &td, FormatContext &ctx) const {
+    auto format(const arcticdb::entity::TypeDescriptor& td, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "TD<type={}, dim={}>", td.data_type_, td.dimension_);
     }
 };
@@ -127,25 +149,32 @@ struct formatter<arcticdb::entity::TypeDescriptor> {
 template<>
 struct formatter<arcticdb::entity::FieldDescriptor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::FieldDescriptor &fd, FormatContext &ctx) const {
+    auto format(const arcticdb::entity::FieldDescriptor& fd, FormatContext& ctx) const
+    {
         if (!fd.name().empty())
             return format_to(ctx.out(), "FD<name={}, type={}>", fd.name(), fd.type_desc());
         else
             return format_to(ctx.out(), "FD<type={}>", fd.type_desc());
-
     }
 };
 
 template<>
 struct formatter<arcticdb::entity::IndexDescriptor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::IndexDescriptor &idx, FormatContext &ctx) const {
+    auto format(const arcticdb::entity::IndexDescriptor& idx, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "IDX<size={}, kind={}>", idx.field_count(), static_cast<char>(idx.type()));
     }
 };
@@ -153,10 +182,14 @@ struct formatter<arcticdb::entity::IndexDescriptor> {
 template<>
 struct formatter<arcticdb::entity::StreamDescriptor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::StreamDescriptor &sd, FormatContext &ctx) const {
+    auto format(const arcticdb::entity::StreamDescriptor& sd, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "TSD<tsid={}, idx={}, fields={}>", sd.id(), sd.index(), sd.fields());
     }
 };
@@ -164,33 +197,43 @@ struct formatter<arcticdb::entity::StreamDescriptor> {
 template<>
 struct formatter<arcticdb::entity::StreamDescriptor::Proto> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::StreamDescriptor::Proto &sd, FormatContext &ctx) const {
+    auto format(const arcticdb::entity::StreamDescriptor::Proto& sd, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}", sd.DebugString());
     }
 };
 template<>
 struct formatter<arcticdb::entity::StreamId> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::StreamId &tsid, FormatContext &ctx) const {
-        return std::visit([&ctx](auto &&val) {
-            return format_to(ctx.out(), "{}", val);
-        }, tsid);
+    auto format(const arcticdb::entity::StreamId& tsid, FormatContext& ctx) const
+    {
+        return std::visit([&ctx](auto&& val) { return format_to(ctx.out(), "{}", val); }, tsid);
     }
 };
 
 template<>
 struct formatter<arcticdb::proto::descriptors::TypeDescriptor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::proto::descriptors::TypeDescriptor& type_desc, FormatContext &ctx) const {
+    auto format(const arcticdb::proto::descriptors::TypeDescriptor& type_desc, FormatContext& ctx) const
+    {
         auto td = arcticdb::entity::type_desc_from_proto(type_desc);
         return format_to(ctx.out(), "{}", td);
     }
@@ -199,11 +242,16 @@ struct formatter<arcticdb::proto::descriptors::TypeDescriptor> {
 template<>
 struct formatter<arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor& field_desc, FormatContext &ctx) const {
+    auto format(const arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor& field_desc,
+        FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}: {}", field_desc.name(), field_desc.type_desc());
     }
 };
-}
+} // namespace fmt

--- a/cpp/arcticdb/entity/types.cpp
+++ b/cpp/arcticdb/entity/types.cpp
@@ -9,16 +9,20 @@
 
 namespace arcticdb::entity {
 
-Dimension as_dim_checked(uint8_t d) {
+Dimension as_dim_checked(uint8_t d)
+{
     if (d > static_cast<uint8_t>(Dimension::Dim2)) {
         throw std::invalid_argument(fmt::format("Invalid dimension %d", static_cast<uint32_t>(d)));
     }
     return static_cast<Dimension>(d);
 }
 
-std::string_view datatype_to_str(const DataType dt) {
+std::string_view datatype_to_str(const DataType dt)
+{
     switch (dt) {
-#define TO_STR(ARG) case DataType::ARG: return std::string_view(#ARG);
+#define TO_STR(ARG)                                                                                                    \
+    case DataType::ARG:                                                                                                \
+        return std::string_view(#ARG);
         TO_STR(UINT8)
         TO_STR(UINT16)
         TO_STR(UINT32)
@@ -37,11 +41,11 @@ std::string_view datatype_to_str(const DataType dt) {
         TO_STR(UTF_DYNAMIC64)
         //    TO_STR(UTF8_STRING)
 //     TO_STR(BYTES)
-        //    TO_STR(PICKLE)
+//    TO_STR(PICKLE)
 #undef TO_STR
-        default:return std::string_view("UNKNOWN");
+    default:
+        return std::string_view("UNKNOWN");
     }
 }
 
-} // namespace arcticdb
-
+} // namespace arcticdb::entity

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -39,7 +39,7 @@ namespace arcticdb::entity {
  * coupling of implementation to proto
  */
 
- enum class SortedValue : uint8_t {
+enum class SortedValue : uint8_t {
     UNKNOWN = 0,
     UNSORTED = 1,
     ASCENDING = 2,
@@ -59,21 +59,22 @@ using stride_t = ssize_t;
 using position_t = ssize_t;
 
 /** The VariantId holds int64 (NumericId) but is also used to store sizes up to uint64, so needs safe conversion */
-inline NumericId safe_convert_to_numeric_id(uint64_t input, const char* input_name) {
+inline NumericId safe_convert_to_numeric_id(uint64_t input, const char* input_name)
+{
     util::check(input <= static_cast<uint64_t>(std::numeric_limits<NumericId>::max()),
-        "{} greater than 2^63 is not supported.", input_name);
+        "{} greater than 2^63 is not supported.",
+        input_name);
     return static_cast<NumericId>(input);
 }
 
 namespace py = pybind11;
-
 
 // See https://sourceforge.net/p/numpy/mailman/numpy-discussion/thread/1139250278.7538.52.camel%40localhost.localdomain/#msg11998404
 constexpr size_t UNICODE_WIDTH = sizeof(Py_UNICODE);
 constexpr size_t ASCII_WIDTH = 1;
 //TODO: Fix unicode width for windows
 #ifndef _WIN32
-    static_assert(UNICODE_WIDTH == 4, "Only support python platforms where unicode width is 4");
+static_assert(UNICODE_WIDTH == 4, "Only support python platforms where unicode width is 4");
 #endif
 
 // Beware, all the enum values of the field must match exactly the values
@@ -87,10 +88,10 @@ enum class ValueType : uint8_t {
     BOOL = 4,
     MICROS_UTC = 5,
 
-//    SYMBOL = 6, // categorical string of low cardinality suitable for dictionary encoding
+    //    SYMBOL = 6, // categorical string of low cardinality suitable for dictionary encoding
     ASCII_FIXED = 7, // fixed size string when dim > 1, inputs of type uint8_t, no encoding
-    UTF8_FIXED = 8, // fixed size string when dim > 1, inputs of type uint8_t, utf8 encoding
-    BYTES = 9, // implies fixed size bytes array when dim > 1, opaque
+    UTF8_FIXED = 8,  // fixed size string when dim > 1, inputs of type uint8_t, utf8 encoding
+    BYTES = 9,       // implies fixed size bytes array when dim > 1, opaque
     // PICKLE = 12, // BYTES + pickle specific encoding
 
     UTF_DYNAMIC = 11,
@@ -98,37 +99,43 @@ enum class ValueType : uint8_t {
 };
 
 // Sequence types are composed of more than one element
-constexpr bool is_sequence_type(ValueType v){
-    return uint8_t(v) >= uint8_t(ValueType::ASCII_FIXED) &&
-    uint8_t(v) <= uint8_t(ValueType::ASCII_DYNAMIC);
+constexpr bool is_sequence_type(ValueType v)
+{
+    return uint8_t(v) >= uint8_t(ValueType::ASCII_FIXED) && uint8_t(v) <= uint8_t(ValueType::ASCII_DYNAMIC);
 }
 
-constexpr bool is_numeric_type(ValueType v){
+constexpr bool is_numeric_type(ValueType v)
+{
     return v == ValueType::MICROS_UTC ||
-    (uint8_t(v) >= uint8_t(ValueType::UINT) &&
-    uint8_t(v) <= uint8_t(ValueType::FLOAT));
+           (uint8_t(v) >= uint8_t(ValueType::UINT) && uint8_t(v) <= uint8_t(ValueType::FLOAT));
 }
 
-constexpr bool is_floating_point_type(ValueType v){
+constexpr bool is_floating_point_type(ValueType v)
+{
     return uint8_t(v) == uint8_t(ValueType::FLOAT);
 }
 
-constexpr bool is_time_type(ValueType v){
+constexpr bool is_time_type(ValueType v)
+{
     return uint8_t(v) == uint8_t(ValueType::MICROS_UTC);
 }
 
-constexpr bool is_integer_type(ValueType v){
+constexpr bool is_integer_type(ValueType v)
+{
     return uint8_t(v) == uint8_t(ValueType::INT) || uint8_t(v) == uint8_t(ValueType::UINT);
 }
 
-constexpr bool is_fixed_string_type(ValueType v){
+constexpr bool is_fixed_string_type(ValueType v)
+{
     return v == ValueType::ASCII_FIXED || v == ValueType::UTF8_FIXED;
 }
 
-constexpr bool is_dynamic_string_type(ValueType v){
+constexpr bool is_dynamic_string_type(ValueType v)
+{
     return is_sequence_type(v) && !is_fixed_string_type(v);
 }
-constexpr bool is_utf_type(ValueType v) {
+constexpr bool is_utf_type(ValueType v)
+{
     return v == ValueType::UTF8_FIXED || v == ValueType::UTF_DYNAMIC;
 }
 
@@ -140,22 +147,28 @@ enum class SizeBits : uint8_t {
     S64 = 4,
 };
 
-constexpr SizeBits get_size_bits(uint8_t size) {
+constexpr SizeBits get_size_bits(uint8_t size)
+{
     switch (size) {
-        case 2:return SizeBits::S16;
-        case 4:return SizeBits::S32;
-        case 8:return SizeBits::S64;
-        default:return SizeBits::S8;
+    case 2:
+        return SizeBits::S16;
+    case 4:
+        return SizeBits::S32;
+    case 8:
+        return SizeBits::S64;
+    default:
+        return SizeBits::S8;
     }
 }
 
-namespace detail{
+namespace detail {
 
-constexpr uint8_t combine_val_bits(ValueType v, SizeBits b = SizeBits::UNKNOWN_SIZE_BITS) {
+constexpr uint8_t combine_val_bits(ValueType v, SizeBits b = SizeBits::UNKNOWN_SIZE_BITS)
+{
     return (static_cast<uint8_t>(v) << 3u) | static_cast<uint8_t>(b);
 }
 
-} // namespace anonymous
+} // namespace detail
 
 enum class DataType : uint8_t {
 #define DT_COMBINE(TYPE, SIZE) TYPE = combine_val_bits(ValueType::TYPE, SizeBits::SIZE)
@@ -182,18 +195,20 @@ enum class DataType : uint8_t {
 
 std::string_view datatype_to_str(DataType dt);
 
-constexpr DataType combine_data_type(ValueType v, SizeBits b = SizeBits::UNKNOWN_SIZE_BITS) {
+constexpr DataType combine_data_type(ValueType v, SizeBits b = SizeBits::UNKNOWN_SIZE_BITS)
+{
     return static_cast<DataType>(detail::combine_val_bits(v, b));
 }
 
 // Constructs the corresponding DataType from a given primitive arithmetic type (u/int8_t, float, or double)
-template <typename T>
-constexpr DataType data_type_from_raw_type() {
+template<typename T>
+constexpr DataType data_type_from_raw_type()
+{
     static_assert(std::is_arithmetic_v<T>);
     if constexpr (std::is_floating_point_v<T>) {
         return combine_data_type(ValueType::FLOAT, get_size_bits(sizeof(T)));
     }
-    if constexpr(std::is_signed_v<T>) {
+    if constexpr (std::is_signed_v<T>) {
         return combine_data_type(ValueType::INT, get_size_bits(sizeof(T)));
     }
     return combine_data_type(ValueType::UINT, get_size_bits(sizeof(T)));
@@ -201,64 +216,79 @@ constexpr DataType data_type_from_raw_type() {
 
 constexpr ValueType get_value_type(char specifier) noexcept;
 
-constexpr DataType get_data_type(char specifier, SizeBits size) noexcept {
+constexpr DataType get_data_type(char specifier, SizeBits size) noexcept
+{
     return combine_data_type(get_value_type(specifier), size);
 }
 
-constexpr ValueType slice_value_type(DataType dt) noexcept {
+constexpr ValueType slice_value_type(DataType dt) noexcept
+{
     return static_cast<ValueType>(static_cast<uint8_t>(dt) >> 3u);
 }
 
-constexpr SizeBits slice_bit_size(DataType dt) noexcept {
+constexpr SizeBits slice_bit_size(DataType dt) noexcept
+{
     return static_cast<SizeBits>(static_cast<uint8_t>(dt) & 0x7u);
 }
 
-constexpr size_t get_type_size(DataType dt) noexcept {
+constexpr size_t get_type_size(DataType dt) noexcept
+{
     auto s = slice_bit_size(dt);
     return size_t(1) << (size_t(s) - 1);
 }
 
-constexpr bool is_sequence_type(DataType v){
+constexpr bool is_sequence_type(DataType v)
+{
     return is_sequence_type(slice_value_type(v));
 }
 
-constexpr bool is_numeric_type(DataType v){
+constexpr bool is_numeric_type(DataType v)
+{
     return is_numeric_type(slice_value_type(v));
 }
 
-constexpr bool is_bool_type(DataType dt) {
+constexpr bool is_bool_type(DataType dt)
+{
     return slice_value_type(dt) == ValueType::BOOL;
 }
 
-constexpr bool is_unsigned_type(DataType dt) {
+constexpr bool is_unsigned_type(DataType dt)
+{
     return slice_value_type(dt) == ValueType::UINT;
 }
 
-constexpr bool is_signed_type(DataType dt) {
+constexpr bool is_signed_type(DataType dt)
+{
     return slice_value_type(dt) == ValueType::INT;
 }
 
-constexpr bool is_floating_point_type(DataType v){
+constexpr bool is_floating_point_type(DataType v)
+{
     return is_floating_point_type(slice_value_type(v));
 }
 
-constexpr bool is_time_type(DataType v){
+constexpr bool is_time_type(DataType v)
+{
     return is_time_type(slice_value_type(v));
 }
 
-constexpr bool is_integer_type(DataType v){
+constexpr bool is_integer_type(DataType v)
+{
     return is_integer_type(slice_value_type(v));
 }
 
-constexpr bool is_fixed_string_type(DataType v){
+constexpr bool is_fixed_string_type(DataType v)
+{
     return is_fixed_string_type(slice_value_type(v));
 }
 
-constexpr bool is_dynamic_string_type(DataType v){
+constexpr bool is_dynamic_string_type(DataType v)
+{
     return is_dynamic_string_type(slice_value_type(v));
 }
 
-constexpr bool is_utf_type(DataType v){
+constexpr bool is_utf_type(DataType v)
+{
     return is_utf_type(slice_value_type(v));
 }
 
@@ -266,37 +296,56 @@ static_assert(slice_value_type((DataType::UINT16)) == ValueType(1));
 static_assert(get_type_size(DataType::UINT32) == 4);
 static_assert(get_type_size(DataType::UINT64) == 8);
 
-constexpr  ValueType get_value_type(char specifier) noexcept {
-    switch(specifier){
-        case 'u': return ValueType::UINT; //  unsigned integer
-        case 'i': return ValueType::INT; //  signed integer
-        case 'f': return ValueType::FLOAT; //  floating-point
-        case 'b': return ValueType::BOOL; //  boolean
-        case 'M': return ValueType::MICROS_UTC; //  datetime // numpy doesn't support the buffer protocol for datetime64
-        case 'U': return ValueType::UTF8_FIXED; //  Unicode
-        case 'S': return ValueType::ASCII_FIXED; //  (byte-)string
-        case 'O': return ValueType::BYTES; // Fishy, an actual type might be better
-        default:
-            return ValueType::UNKNOWN_VALUE_TYPE;    // Unknown
+constexpr ValueType get_value_type(char specifier) noexcept
+{
+    switch (specifier) {
+    case 'u':
+        return ValueType::UINT; //  unsigned integer
+    case 'i':
+        return ValueType::INT; //  signed integer
+    case 'f':
+        return ValueType::FLOAT; //  floating-point
+    case 'b':
+        return ValueType::BOOL; //  boolean
+    case 'M':
+        return ValueType::MICROS_UTC; //  datetime // numpy doesn't support the buffer protocol for datetime64
+    case 'U':
+        return ValueType::UTF8_FIXED; //  Unicode
+    case 'S':
+        return ValueType::ASCII_FIXED; //  (byte-)string
+    case 'O':
+        return ValueType::BYTES; // Fishy, an actual type might be better
+    default:
+        return ValueType::UNKNOWN_VALUE_TYPE; // Unknown
     }
 }
 
-constexpr char get_dtype_specifier(ValueType vt){
-    switch(vt){
-        case ValueType::UINT: return 'u';
-        case ValueType::INT:  return 'i';
-        case ValueType::FLOAT: return 'f';
-        case ValueType::BOOL: return 'b';
-        case ValueType::MICROS_UTC: return 'M';
-        case ValueType::UTF8_FIXED: return 'U';
-        case ValueType::ASCII_FIXED: return 'S';
-        case ValueType::BYTES: return 'O';
-        default:
-            return 'x';
+constexpr char get_dtype_specifier(ValueType vt)
+{
+    switch (vt) {
+    case ValueType::UINT:
+        return 'u';
+    case ValueType::INT:
+        return 'i';
+    case ValueType::FLOAT:
+        return 'f';
+    case ValueType::BOOL:
+        return 'b';
+    case ValueType::MICROS_UTC:
+        return 'M';
+    case ValueType::UTF8_FIXED:
+        return 'U';
+    case ValueType::ASCII_FIXED:
+        return 'S';
+    case ValueType::BYTES:
+        return 'O';
+    default:
+        return 'x';
     }
 }
 
-constexpr char get_dtype_specifier(DataType dt){
+constexpr char get_dtype_specifier(DataType dt)
+{
     return get_dtype_specifier(slice_value_type(dt));
 }
 
@@ -305,21 +354,19 @@ static_assert(get_value_type('u') == ValueType::UINT);
 struct DataTypeTagBase {};
 
 template<DataType DT>
-struct DataTypeTag {
-};
+struct DataTypeTag {};
 
-#define DATA_TYPE_TAG(__DT__, __T__)  \
-template<> \
-struct DataTypeTag<DataType::__DT__> : public DataTypeTagBase { \
-    static constexpr DataType data_type = DataType::__DT__; \
-    static constexpr ValueType value_type = slice_value_type(DataType::__DT__); \
-    static constexpr SizeBits size_bits = slice_bit_size(DataType::__DT__); \
-    using raw_type = __T__; \
-}; \
-using TAG_##__DT__ = DataTypeTag<DataType::__DT__>;
+#define DATA_TYPE_TAG(__DT__, __T__)                                                                                   \
+    template<>                                                                                                         \
+    struct DataTypeTag<DataType::__DT__> : public DataTypeTagBase {                                                    \
+        static constexpr DataType data_type = DataType::__DT__;                                                        \
+        static constexpr ValueType value_type = slice_value_type(DataType::__DT__);                                    \
+        static constexpr SizeBits size_bits = slice_bit_size(DataType::__DT__);                                        \
+        using raw_type = __T__;                                                                                        \
+    };                                                                                                                 \
+    using TAG_##__DT__ = DataTypeTag<DataType::__DT__>;
 
 using timestamp = int64_t;
-
 
 DATA_TYPE_TAG(UINT8, std::uint8_t)
 DATA_TYPE_TAG(UINT16, std::uint16_t)
@@ -345,17 +392,16 @@ enum class Dimension : uint8_t {
     Dim2 = 2,
 };
 
-struct DimensionTagBase {
-};
+struct DimensionTagBase {};
 
 template<Dimension dim>
-struct DimensionTag {
-};
+struct DimensionTag {};
 
-#define DIMENSION(__D__) template<> \
-struct DimensionTag<Dimension::Dim##__D__> : public DimensionTagBase { \
-    static constexpr Dimension value = Dimension::Dim##__D__; \
-}
+#define DIMENSION(__D__)                                                                                               \
+    template<>                                                                                                         \
+    struct DimensionTag<Dimension::Dim##__D__> : public DimensionTagBase {                                             \
+        static constexpr Dimension value = Dimension::Dim##__D__;                                                      \
+    }
 DIMENSION(0);
 DIMENSION(1);
 DIMENSION(2);
@@ -363,13 +409,12 @@ DIMENSION(2);
 
 Dimension as_dim_checked(uint8_t d);
 
-inline void set_data_type(DataType data_type, arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-    type_desc.set_size_bits(
-            static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
-                    static_cast<std::uint8_t>(slice_bit_size(data_type))));
-    type_desc.set_value_type(
-            static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
-                    static_cast<std::uint8_t>(slice_value_type(data_type))));
+inline void set_data_type(DataType data_type, arcticdb::proto::descriptors::TypeDescriptor& type_desc)
+{
+    type_desc.set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
+        static_cast<std::uint8_t>(slice_bit_size(data_type))));
+    type_desc.set_value_type(static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
+        static_cast<std::uint8_t>(slice_value_type(data_type))));
 }
 
 struct TypeDescriptor {
@@ -378,40 +423,60 @@ struct TypeDescriptor {
 
     using Proto = arcticdb::proto::descriptors::TypeDescriptor;
 
-    TypeDescriptor(DataType dt, uint8_t dim) : data_type_(dt), dimension_(as_dim_checked(dim)) {}
-    constexpr TypeDescriptor(DataType dt, Dimension dim) : data_type_(dt), dimension_(dim) {}
-    constexpr TypeDescriptor(ValueType v, SizeBits b, Dimension dim) :
-        data_type_(combine_data_type(v, b)), dimension_(dim) {}
+    TypeDescriptor(DataType dt, uint8_t dim)
+        : data_type_(dt),
+          dimension_(as_dim_checked(dim))
+    {
+    }
+    constexpr TypeDescriptor(DataType dt, Dimension dim)
+        : data_type_(dt),
+          dimension_(dim)
+    {
+    }
+    constexpr TypeDescriptor(ValueType v, SizeBits b, Dimension dim)
+        : data_type_(combine_data_type(v, b)),
+          dimension_(dim)
+    {
+    }
 
-    TypeDescriptor() : data_type_(DataType::UINT8), dimension_(Dimension::Dim0) {}
+    TypeDescriptor()
+        : data_type_(DataType::UINT8),
+          dimension_(Dimension::Dim0)
+    {
+    }
 
     ARCTICDB_MOVE_COPY_DEFAULT(TypeDescriptor)
 
     template<typename Callable>
-    auto visit_tag(Callable &&callable) const;
+    auto visit_tag(Callable&& callable) const;
 
-
-    bool operator==(const TypeDescriptor &o) const {
+    bool operator==(const TypeDescriptor& o) const
+    {
         return data_type_ == o.data_type_ && dimension_ == o.dimension_;
     }
 
-    bool operator!=(const TypeDescriptor &o) const {
+    bool operator!=(const TypeDescriptor& o) const
+    {
         return !(*this == o);
     }
 
-    [[nodiscard]] DataType data_type() const {
+    [[nodiscard]] DataType data_type() const
+    {
         return data_type_;
     }
 
-    [[nodiscard]] Dimension dimension() const {
+    [[nodiscard]] Dimension dimension() const
+    {
         return dimension_;
     }
 
-    explicit operator Proto() const {
+    explicit operator Proto() const
+    {
         return proto();
     }
 
-    Proto proto() const {
+    Proto proto() const
+    {
         arcticdb::proto::descriptors::TypeDescriptor output;
         output.set_dimension(static_cast<std::uint32_t>(dimension_));
         set_data_type(data_type_, output);
@@ -420,7 +485,8 @@ struct TypeDescriptor {
     }
 };
 
-inline TypeDescriptor make_scalar_type(DataType dt) {
+inline TypeDescriptor make_scalar_type(DataType dt)
+{
     return TypeDescriptor{dt, Dimension::Dim0};
 }
 
@@ -430,41 +496,41 @@ struct TypeDescriptorTag {
     static_assert(std::is_base_of_v<DimensionTagBase, D>);
     using DataTypeTag = DT;
     using DimensionTag = D;
-    explicit constexpr operator TypeDescriptor() const {
+    explicit constexpr operator TypeDescriptor() const
+    {
         return TypeDescriptor{DataTypeTag::data_type, DimensionTag::value};
     }
 };
 
-inline DataType get_data_type(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-    return combine_data_type(
-        static_cast<ValueType>(static_cast<uint8_t >(type_desc.value_type())),
-        static_cast<SizeBits>(static_cast<uint8_t >(type_desc.size_bits()))
-        );
+inline DataType get_data_type(const arcticdb::proto::descriptors::TypeDescriptor& type_desc)
+{
+    return combine_data_type(static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
+        static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits())));
 }
 
-inline TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::TypeDescriptor type_desc) {
-    return {
-        combine_data_type(
-            static_cast<ValueType>(static_cast<uint8_t >(type_desc.value_type())),
-            static_cast<SizeBits>(static_cast<uint8_t >(type_desc.size_bits()))
-        ),
-        static_cast<Dimension>(static_cast<uint8_t>(type_desc.dimension()))
-    };
+inline TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::TypeDescriptor type_desc)
+{
+    return {combine_data_type(static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
+                static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits()))),
+        static_cast<Dimension>(static_cast<uint8_t>(type_desc.dimension()))};
 }
 
-inline DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor type_desc) {
+inline DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor type_desc)
+{
     return type_desc_from_proto((type_desc)).data_type();
 }
 
-template <typename DTT>
+template<typename DTT>
 using ScalarTagType = TypeDescriptorTag<DTT, DimensionTag<Dimension::Dim0>>;
 
 struct FieldDescriptor {
-    TypeDescriptor type_desc() const {
+    TypeDescriptor type_desc() const
+    {
         return type_desc_from_proto(data_.type_desc());
     }
 
-    const std::string& name() const {
+    const std::string& name() const
+    {
         return data_.name();
     }
 
@@ -472,24 +538,31 @@ struct FieldDescriptor {
 
     Proto data_;
 
-    const auto& proto() const { return data_; }
+    const auto& proto() const
+    {
+        return data_;
+    }
 
-    explicit operator const Proto&()  const {
+    explicit operator const Proto&() const
+    {
         return proto();
     }
 
     FieldDescriptor() = default;
 
-    explicit FieldDescriptor(const TypeDescriptor &td, const std::string& n = std::string()) {
+    explicit FieldDescriptor(const TypeDescriptor& td, const std::string& n = std::string())
+    {
         data_.mutable_type_desc()->CopyFrom(static_cast<arcticdb::proto::descriptors::TypeDescriptor>(td));
         data_.set_name(n);
     }
 
-    explicit FieldDescriptor(Proto&& data) :
-        data_(std::move(data)) {
+    explicit FieldDescriptor(Proto&& data)
+        : data_(std::move(data))
+    {
     }
 
-    friend bool operator<(const FieldDescriptor &l, const FieldDescriptor &r) {
+    friend bool operator<(const FieldDescriptor& l, const FieldDescriptor& r)
+    {
         const auto l_data_type = get_data_type(l.data_.type_desc());
         const auto r_data_type = get_data_type(r.data_.type_desc());
         const auto l_dim = l.data_.type_desc().dimension();
@@ -502,52 +575,57 @@ struct FieldDescriptor {
     ARCTICDB_MOVE_COPY_DEFAULT(FieldDescriptor)
 };
 
-template <typename Callable>
-auto visit_field(const FieldDescriptor::Proto& field, Callable&& c) {
+template<typename Callable>
+auto visit_field(const FieldDescriptor::Proto& field, Callable&& c)
+{
     auto td = type_desc_from_proto(field.type_desc());
     return td.template visit_tag<>(std::forward<Callable>(c));
 }
 
-inline bool operator==(const FieldDescriptor &l, const FieldDescriptor &r) {
+inline bool operator==(const FieldDescriptor& l, const FieldDescriptor& r)
+{
     return l.type_desc() == r.type_desc() && l.name() == r.name();
 }
 
-template <Dimension dim>
-FieldDescriptor::Proto field_proto(DataType dt, std::string_view name) {
+template<Dimension dim>
+FieldDescriptor::Proto field_proto(DataType dt, std::string_view name)
+{
     using namespace arcticdb::proto::descriptors;
     StreamDescriptor_FieldDescriptor output;
-    if(!name.empty())
+    if (!name.empty())
         output.set_name(name.data(), name.size());
 
     output.mutable_type_desc()->set_dimension(static_cast<uint32_t>(dim));
     output.mutable_type_desc()->set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
-                                                  static_cast<std::uint8_t>(slice_bit_size(dt))));
+        static_cast<std::uint8_t>(slice_bit_size(dt))));
 
-    output.mutable_type_desc()->set_value_type(
-        static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
-            static_cast<std::uint8_t>(slice_value_type(dt))));
+    output.mutable_type_desc()->set_value_type(static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
+        static_cast<std::uint8_t>(slice_value_type(dt))));
 
     return output;
 }
 
-inline auto scalar_field_proto (DataType dt, std::string_view name) {
+inline auto scalar_field_proto(DataType dt, std::string_view name)
+{
     return field_proto<Dimension::Dim0>(dt, name);
 }
 
-inline auto scalar_field_proto(TypeDescriptor::Proto&& proto, std::string_view name = std::string_view()) {
+inline auto scalar_field_proto(TypeDescriptor::Proto&& proto, std::string_view name = std::string_view())
+{
     using namespace arcticdb::proto::descriptors;
     StreamDescriptor_FieldDescriptor output;
-    if(!name.empty())
+    if (!name.empty())
         output.set_name(name.data(), name.size());
 
     *output.mutable_type_desc() = std::move(proto);
     return output;
 }
 
-inline auto scalar_field_proto(const TypeDescriptor::Proto& proto, std::string_view name = std::string_view()) {
+inline auto scalar_field_proto(const TypeDescriptor::Proto& proto, std::string_view name = std::string_view())
+{
     using namespace arcticdb::proto::descriptors;
     StreamDescriptor_FieldDescriptor output;
-    if(!name.empty())
+    if (!name.empty())
         output.set_name(name.data(), name.size());
 
     output.mutable_type_desc()->CopyFrom(proto);
@@ -555,7 +633,7 @@ inline auto scalar_field_proto(const TypeDescriptor::Proto& proto, std::string_v
 }
 
 struct IndexDescriptor {
-        using Proto = arcticdb::proto::descriptors::IndexDescriptor;
+    using Proto = arcticdb::proto::descriptors::IndexDescriptor;
 
     Proto data_;
     using Type = arcticdb::proto::descriptors::IndexDescriptor::Type;
@@ -567,61 +645,80 @@ struct IndexDescriptor {
 
     using TypeChar = char;
 
-
     IndexDescriptor() = default;
-    IndexDescriptor(size_t field_count, Type type) {
+    IndexDescriptor(size_t field_count, Type type)
+    {
         data_.set_kind(type);
         data_.set_field_count(static_cast<uint32_t>(field_count));
     }
 
     explicit IndexDescriptor(const arcticdb::proto::descriptors::IndexDescriptor& data)
-        : data_(data) {
+        : data_(data)
+    {
     }
 
-    bool uninitialized() const {
+    bool uninitialized() const
+    {
         return data_.field_count() == 0 && data_.kind() == Type::IndexDescriptor_Type_UNKNOWN;
     }
 
-    const Proto& proto() const  {
+    const Proto& proto() const
+    {
         return data_;
     }
 
-    size_t field_count() const {
+    size_t field_count() const
+    {
         return static_cast<size_t>(data_.field_count());
     }
 
-    Type type() const {
+    Type type() const
+    {
         return data_.kind();
     }
 
-    void set_type(Type type) {
+    void set_type(Type type)
+    {
         data_.set_kind(type);
     }
 
     ARCTICDB_MOVE_COPY_DEFAULT(IndexDescriptor)
 
-    friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right) {
+    friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right)
+    {
         return left.type() == right.type();
     }
 };
 
-constexpr IndexDescriptor::TypeChar to_type_char(IndexDescriptor::Type type) {
+constexpr IndexDescriptor::TypeChar to_type_char(IndexDescriptor::Type type)
+{
     switch (type) {
-    case IndexDescriptor::TIMESTAMP:return 'T';
-    case IndexDescriptor::ROWCOUNT:return 'R';
-    case IndexDescriptor::STRING:return 'S';
-    case IndexDescriptor::UNKNOWN:return 'U';
-    default:util::raise_rte("Unknown index type: {}", type);
+    case IndexDescriptor::TIMESTAMP:
+        return 'T';
+    case IndexDescriptor::ROWCOUNT:
+        return 'R';
+    case IndexDescriptor::STRING:
+        return 'S';
+    case IndexDescriptor::UNKNOWN:
+        return 'U';
+    default:
+        util::raise_rte("Unknown index type: {}", type);
     }
 }
 
-constexpr IndexDescriptor::Type from_type_char(IndexDescriptor::TypeChar type) {
+constexpr IndexDescriptor::Type from_type_char(IndexDescriptor::TypeChar type)
+{
     switch (type) {
-    case 'T': return IndexDescriptor::TIMESTAMP;
-    case 'R': return IndexDescriptor::ROWCOUNT;
-    case 'S': return IndexDescriptor::STRING;
-    case 'U': return IndexDescriptor::UNKNOWN;
-    default:util::raise_rte("Unknown index type: {}", type);
+    case 'T':
+        return IndexDescriptor::TIMESTAMP;
+    case 'R':
+        return IndexDescriptor::ROWCOUNT;
+    case 'S':
+        return IndexDescriptor::STRING;
+    case 'U':
+        return IndexDescriptor::UNKNOWN;
+    default:
+        util::raise_rte("Unknown index type: {}", type);
     }
 }
 
@@ -633,232 +730,285 @@ struct StreamDescriptor {
     StreamDescriptor() = default;
     ~StreamDescriptor() = default;
 
-    void set_id(const StreamId& id) {
-        util::variant_match(id,
-            [this] (const StringId& str) { data_->set_str_id(str); },
-            [this] (const NumericId& n) {
+    void set_id(const StreamId& id)
+    {
+        util::variant_match(
+            id,
+            [this](const StringId& str) { data_->set_str_id(str); },
+            [this](const NumericId& n) {
                 util::check(n >= 0, "Negative numeric symbol is not supported");
                 data_->set_num_id(n);
             });
     }
 
-    static StreamId id_from_proto(Proto proto) {
-        if(proto.id_case() == arcticdb::proto::descriptors::StreamDescriptor::kNumId)
+    static StreamId id_from_proto(Proto proto)
+    {
+        if (proto.id_case() == arcticdb::proto::descriptors::StreamDescriptor::kNumId)
             return safe_convert_to_numeric_id(proto.num_id(), "Numeric symbol");
         else
             return proto.str_id();
     }
 
-    StreamId id() const {
-      return id_from_proto(*data_);
+    StreamId id() const
+    {
+        return id_from_proto(*data_);
     }
 
-    IndexDescriptor index() const {
+    IndexDescriptor index() const
+    {
         return IndexDescriptor(data_->index());
     }
 
-    void set_index(const IndexDescriptor& idx) {
+    void set_index(const IndexDescriptor& idx)
+    {
         data_->mutable_index()->CopyFrom(idx.data_);
     }
 
-    void set_sorted(SortedValue sorted) {
+    void set_sorted(SortedValue sorted)
+    {
         switch (sorted) {
-            case SortedValue::UNSORTED:data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::UNSORTED);break;
-            case SortedValue::DESCENDING:data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::DESCENDING);break;
-            case SortedValue::ASCENDING:data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::ASCENDING);break;
-            default:data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::UNKNOWN);
+        case SortedValue::UNSORTED:
+            data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::UNSORTED);
+            break;
+        case SortedValue::DESCENDING:
+            data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::DESCENDING);
+            break;
+        case SortedValue::ASCENDING:
+            data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::ASCENDING);
+            break;
+        default:
+            data_->set_sorted(arcticc::pb2::descriptors_pb2::SortedValue::UNKNOWN);
         }
     }
-    arcticc::pb2::descriptors_pb2::SortedValue get_sorted() {
+    arcticc::pb2::descriptors_pb2::SortedValue get_sorted()
+    {
         return data_->sorted();
     }
-    void set_index_type(const IndexDescriptor::Type type) {
+    void set_index_type(const IndexDescriptor::Type type)
+    {
         data_->mutable_index()->set_kind(type);
     }
 
-    void set_index_field_count(size_t size) {
+    void set_index_field_count(size_t size)
+    {
         data_->mutable_index()->set_field_count(size);
     }
 
-    explicit StreamDescriptor(const StreamId& id) {
+    explicit StreamDescriptor(const StreamId& id)
+    {
         set_id(id);
     }
 
-    void add_scalar_field(DataType data_type, std::string_view name) {
+    void add_scalar_field(DataType data_type, std::string_view name)
+    {
         auto* new_field = data_->mutable_fields()->Add();
         new_field->CopyFrom(scalar_field_proto(data_type, name));
     }
 
     using FieldsCollection = std::decay_t<decltype(data_->fields())>;
 
-    StreamDescriptor(const StreamId& id, const IndexDescriptor &idx, FieldsCollection&& f) {
+    StreamDescriptor(const StreamId& id, const IndexDescriptor& idx, FieldsCollection&& f)
+    {
         set_id(id);
         set_index(idx);
         *data_->mutable_fields() = std::move(f);
     }
 
-    explicit StreamDescriptor(arcticdb::proto::descriptors::StreamDescriptor&& data) :
-        data_(std::make_shared<Proto>(std::move(data))) {
+    explicit StreamDescriptor(arcticdb::proto::descriptors::StreamDescriptor&& data)
+        : data_(std::make_shared<Proto>(std::move(data)))
+    {
     }
 
-    explicit StreamDescriptor(const arcticdb::proto::descriptors::StreamDescriptor& data) {
+    explicit StreamDescriptor(const arcticdb::proto::descriptors::StreamDescriptor& data)
+    {
         data_->CopyFrom(data);
     }
 
     StreamDescriptor(const StreamDescriptor& other) = default;
 
-    friend void swap(StreamDescriptor& left, StreamDescriptor& right) noexcept {
+    friend void swap(StreamDescriptor& left, StreamDescriptor& right) noexcept
+    {
         using std::swap;
 
-        if(&left == &right)
+        if (&left == &right)
             return;
 
         swap(left.data_, right.data_);
     }
 
-    StreamDescriptor& operator=(StreamDescriptor other) {
+    StreamDescriptor& operator=(StreamDescriptor other)
+    {
         swap(*this, other);
         return *this;
     }
 
     StreamDescriptor(StreamDescriptor&& other) noexcept
-        : StreamDescriptor() {
+        : StreamDescriptor()
+    {
         swap(*this, other);
     }
 
-    StreamDescriptor clone() const {
+    StreamDescriptor clone() const
+    {
         Proto proto;
         proto.CopyFrom(*data_);
         return StreamDescriptor{std::move(proto)};
     };
 
-    const FieldsCollection& fields() const {
+    const FieldsCollection& fields() const
+    {
         return data_->fields();
     }
 
-    const FieldDescriptor::Proto& fields(size_t pos) const {
+    const FieldDescriptor::Proto& fields(size_t pos) const
+    {
         util::check(static_cast<int>(pos) < fields().size(), "Field index {} out of range", pos);
         return data_->fields(static_cast<int>(pos));
     }
 
-    const FieldDescriptor::Proto& operator[](std::size_t pos) const {
+    const FieldDescriptor::Proto& operator[](std::size_t pos) const
+    {
         return fields(pos);
     }
 
-    const FieldDescriptor::Proto& add_field(const FieldDescriptor::Proto& field) {
-        util::check(type_desc_from_proto(field.type_desc()).data_type() != DataType::UNKNOWN, "Can't create column with unknown data type");
+    const FieldDescriptor::Proto& add_field(const FieldDescriptor::Proto& field)
+    {
+        util::check(type_desc_from_proto(field.type_desc()).data_type() != DataType::UNKNOWN,
+            "Can't create column with unknown data type");
         auto new_field = data_->mutable_fields()->Add();
         new_field->CopyFrom(field);
         return *new_field;
     }
 
-    decltype(auto) begin() {
+    decltype(auto) begin()
+    {
         return fields().begin();
     }
 
-    decltype(auto) end() {
+    decltype(auto) end()
+    {
         return fields().end();
     }
 
-    decltype(auto) cbegin() const {
+    decltype(auto) cbegin() const
+    {
         return fields().cbegin();
     }
 
-    decltype(auto) cend() const {
+    decltype(auto) cend() const
+    {
         return fields().cend();
     }
 
-    size_t field_count() const {
+    size_t field_count() const
+    {
         return fields().size();
     }
 
-    bool empty() const {
+    bool empty() const
+    {
         return fields().empty();
     }
 
-    std::optional<std::size_t> find_field(std::string_view view) const {
-        auto it = std::find_if(cbegin(), cend(), [&](const auto& field) {
-            return field.name() == view;
-        });
+    std::optional<std::size_t> find_field(std::string_view view) const
+    {
+        auto it = std::find_if(cbegin(), cend(), [&](const auto& field) { return field.name() == view; });
 
-        if (it == cend()) return std::nullopt;
+        if (it == cend())
+            return std::nullopt;
         return std::distance(cbegin(), it);
     }
 
-    friend bool operator==(const StreamDescriptor& left, const StreamDescriptor& right) {
+    friend bool operator==(const StreamDescriptor& left, const StreamDescriptor& right)
+    {
         google::protobuf::util::MessageDifferencer diff;
         return diff.Compare(*left.data_, *right.data_);
     }
 
-    friend bool operator !=(const StreamDescriptor& left, const StreamDescriptor& right) {
+    friend bool operator!=(const StreamDescriptor& left, const StreamDescriptor& right)
+    {
         return !(left == right);
     }
 
-    void erase_field(position_t field) {
+    void erase_field(position_t field)
+    {
         util::check(field < position_t(fields().size()), "Column index out of range in drop_column");
         auto it = begin();
         std::advance(it, field);
         data_->mutable_fields()->erase(it);
     }
 
-    std::optional<FieldDescriptor::Proto> field_at(size_t pos) {
-        if (UNLIKELY(pos >= static_cast<size_t>(fields().size()))) return std::nullopt;
+    std::optional<FieldDescriptor::Proto> field_at(size_t pos)
+    {
+        if (UNLIKELY(pos >= static_cast<size_t>(fields().size())))
+            return std::nullopt;
         return fields(pos);
     }
 
-    FieldsCollection& mutable_fields() {
+    FieldsCollection& mutable_fields()
+    {
         return *data_->mutable_fields();
     }
 
-    const FieldDescriptor::Proto& field(size_t pos) const {
+    const FieldDescriptor::Proto& field(size_t pos) const
+    {
         return data_->fields(static_cast<int>(pos));
     }
 
-    FieldDescriptor::Proto& field(size_t pos) {
+    FieldDescriptor::Proto& field(size_t pos)
+    {
         return mutable_fields()[static_cast<int>(pos)];
     }
 
-    const Proto& proto() const {
+    const Proto& proto() const
+    {
         return *data_;
     }
 
-    Proto& mutable_proto() {
+    Proto& mutable_proto()
+    {
         return *data_;
     }
 
-    void print_proto_debug_str() const {
+    void print_proto_debug_str() const
+    {
         data_->PrintDebugString();
     }
 };
 
-inline void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id) {
-    std::visit([&pb_desc](auto &&arg) {
-        using IdType = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<IdType, NumericId>)
-            pb_desc.set_num_id(arg);
-        else if constexpr (std::is_same_v<IdType, StringId>)
-            pb_desc.set_str_id(arg);
-        else
-            util::raise_rte("Encoding unknown descriptor type");
-    }, id);
+inline void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id)
+{
+    std::visit(
+        [&pb_desc](auto&& arg) {
+            using IdType = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<IdType, NumericId>)
+                pb_desc.set_num_id(arg);
+            else if constexpr (std::is_same_v<IdType, StringId>)
+                pb_desc.set_str_id(arg);
+            else
+                util::raise_rte("Encoding unknown descriptor type");
+        },
+        id);
 }
 
-template <class IndexType>
-inline void set_index(arcticdb::proto::descriptors::StreamDescriptor &stream_desc) {
+template<class IndexType>
+inline void set_index(arcticdb::proto::descriptors::StreamDescriptor& stream_desc)
+{
     auto& pb_desc = *stream_desc.mutable_index();
     pb_desc.set_field_count(std::uint32_t(IndexType::field_count()));
-    pb_desc.set_kind(static_cast<arcticdb::proto::descriptors::IndexDescriptor_Type>(
-                         static_cast<int>(IndexType::type())));
+    pb_desc.set_kind(
+        static_cast<arcticdb::proto::descriptors::IndexDescriptor_Type>(static_cast<int>(IndexType::type())));
 }
 
-template <typename IndexType, typename RangeType>
-arcticdb::proto::descriptors::StreamDescriptor index_descriptor(StreamId stream_id, IndexType, RangeType fields) {
+template<typename IndexType, typename RangeType>
+arcticdb::proto::descriptors::StreamDescriptor index_descriptor(StreamId stream_id, IndexType, RangeType fields)
+{
     arcticdb::proto::descriptors::StreamDescriptor output;
 
     set_id(output, stream_id);
     set_index<IndexType>(output);
     output.mutable_fields()->Reserve(fields.size());
-    for(auto&& field : fields) {
+    for (auto&& field : fields) {
         auto new_field = output.mutable_fields()->Add();
         *new_field = std::move(field); //TODO move?
     }
@@ -866,27 +1016,31 @@ arcticdb::proto::descriptors::StreamDescriptor index_descriptor(StreamId stream_
     return output;
 }
 
-template <typename IndexType>
-StreamDescriptor::Proto index_descriptor(StreamId stream_id, IndexType index_type,
-                                          std::initializer_list<FieldDescriptor::Proto> fields) {
+template<typename IndexType>
+StreamDescriptor::Proto
+index_descriptor(StreamId stream_id, IndexType index_type, std::initializer_list<FieldDescriptor::Proto> fields)
+{
     std::vector<FieldDescriptor::Proto> vec{fields};
     return index_descriptor(stream_id, index_type, folly::range(vec));
 }
 
-template <typename IndexType, typename RangeType>
-arcticdb::proto::descriptors::StreamDescriptor stream_descriptor(StreamId stream_id, IndexType idx, RangeType fields) {
+template<typename IndexType, typename RangeType>
+arcticdb::proto::descriptors::StreamDescriptor stream_descriptor(StreamId stream_id, IndexType idx, RangeType fields)
+{
     arcticdb::proto::descriptors::StreamDescriptor output;
 
-    util::check(fields.empty() || IndexType::field_count()== 0 || fields[0].name() != idx.field_proto(0).proto().name(), "Index fields already set");
+    util::check(fields.empty() || IndexType::field_count() == 0 ||
+                    fields[0].name() != idx.field_proto(0).proto().name(),
+        "Index fields already set");
 
     set_id(output, stream_id);
     set_index<IndexType>(output);
-    for(auto i = 0u; i < IndexType::field_count(); ++i) {
+    for (auto i = 0u; i < IndexType::field_count(); ++i) {
         auto idx_field = output.mutable_fields()->Add();
         idx_field->CopyFrom(idx.field_proto(i).proto()); //TODO move?
     }
 
-    for(auto&& field : fields) {
+    for (auto&& field : fields) {
         auto new_field = output.mutable_fields()->Add();
         new_field->CopyFrom(field); //TODO move?
     }
@@ -894,28 +1048,31 @@ arcticdb::proto::descriptors::StreamDescriptor stream_descriptor(StreamId stream
     return output;
 }
 
-template <typename IndexType>
-StreamDescriptor::Proto stream_descriptor(StreamId stream_id, IndexType index_type,
-                                           std::initializer_list<FieldDescriptor::Proto> fields) {
+template<typename IndexType>
+StreamDescriptor::Proto
+stream_descriptor(StreamId stream_id, IndexType index_type, std::initializer_list<FieldDescriptor::Proto> fields)
+{
     std::vector<FieldDescriptor::Proto> vec{fields};
     return stream_descriptor(stream_id, index_type, folly::range(vec));
 }
 
-inline TypeDescriptor stream_id_descriptor(const StreamId &stream_id) {
-    return std::holds_alternative<NumericId>(stream_id) ?
-           TypeDescriptor(DataType::UINT64, 0) :
-           TypeDescriptor(DataType::ASCII_DYNAMIC64, 0);
+inline TypeDescriptor stream_id_descriptor(const StreamId& stream_id)
+{
+    return std::holds_alternative<NumericId>(stream_id) ? TypeDescriptor(DataType::UINT64, 0)
+                                                        : TypeDescriptor(DataType::ASCII_DYNAMIC64, 0);
 }
 
-inline DataType stream_id_data_type(const StreamId &stream_id) {
+inline DataType stream_id_data_type(const StreamId& stream_id)
+{
     return std::holds_alternative<NumericId>(stream_id) ? DataType::UINT64 : DataType::ASCII_DYNAMIC64;
 }
 
 // N.B. this is inefficient and retained for testing
-template <typename RangeType>
-StreamDescriptor::FieldsCollection fields_proto_from_range(const RangeType& fields) {
+template<typename RangeType>
+StreamDescriptor::FieldsCollection fields_proto_from_range(const RangeType& fields)
+{
     StreamDescriptor::FieldsCollection output;
-    for(const auto& field : fields) {
+    for (const auto& field : fields) {
         auto ptr = output.Add();
         ptr->CopyFrom(field.proto());
     }
@@ -924,14 +1081,15 @@ StreamDescriptor::FieldsCollection fields_proto_from_range(const RangeType& fiel
 
 using UnicodeType = Py_UNICODE;
 
-} // namespace arcticdb
+} // namespace arcticdb::entity
 
 // StreamId ordering - numbers before strings
 namespace std {
 template<>
 struct less<arcticdb::entity::StreamId> {
 
-    bool operator()(const arcticdb::entity::StreamId &left, const arcticdb::entity::StreamId &right) const {
+    bool operator()(const arcticdb::entity::StreamId& left, const arcticdb::entity::StreamId& right) const
+    {
         using namespace arcticdb::entity;
         if (std::holds_alternative<NumericId>(left)) {
             if (std::holds_alternative<NumericId>(right))
@@ -946,7 +1104,7 @@ struct less<arcticdb::entity::StreamId> {
         }
     }
 };
-}
+} // namespace std
 
 #define ARCTICDB_TYPES_H_
 #include <arcticdb/entity/types-inl.hpp>

--- a/cpp/arcticdb/entity/variant_key.hpp
+++ b/cpp/arcticdb/entity/variant_key.hpp
@@ -23,42 +23,53 @@ using VariantKey = std::variant<entity::AtomKey, entity::RefKey>;
 /** Should be a SNAPSHOT_REF key or the legacy SNAPSHOT AtomKey. */
 using SnapshotVariantKey = VariantKey;
 
-inline AtomKey& to_atom(VariantKey& vk) {
+inline AtomKey& to_atom(VariantKey& vk)
+{
     return std::get<AtomKey>(vk);
 }
 
-inline const AtomKey& to_atom(const VariantKey& vk) {
+inline const AtomKey& to_atom(const VariantKey& vk)
+{
     return std::get<AtomKey>(vk);
 }
 
-inline AtomKey to_atom(VariantKey&& vk) {
+inline AtomKey to_atom(VariantKey&& vk)
+{
     return std::get<AtomKey>(std::move(vk));
 }
 
-inline RefKey& to_ref(VariantKey& vk) {
+inline RefKey& to_ref(VariantKey& vk)
+{
     return std::get<RefKey>(vk);
 }
 
-inline const RefKey& to_ref(const VariantKey& vk) {
+inline const RefKey& to_ref(const VariantKey& vk)
+{
     return std::get<RefKey>(vk);
 }
 
-inline std::string_view variant_key_view(const VariantKey &vk) {
-    return std::visit([](const auto &key) { return key.view(); }, vk);
+inline std::string_view variant_key_view(const VariantKey& vk)
+{
+    return std::visit([](const auto& key) { return key.view(); }, vk);
 }
 
-inline KeyType variant_key_type(const VariantKey &vk) {
-    return std::visit([](const auto &key) { return key.type(); }, vk);
+inline KeyType variant_key_type(const VariantKey& vk)
+{
+    return std::visit([](const auto& key) { return key.type(); }, vk);
 }
 
-inline const StreamId& variant_key_id(const VariantKey &vk) {
-    return std::visit([](const auto &key) -> const StreamId& { return key.id(); }, vk);
+inline const StreamId& variant_key_id(const VariantKey& vk)
+{
+    return std::visit([](const auto& key) -> const StreamId& { return key.id(); }, vk);
 }
 
-inline bool variant_key_id_empty(const VariantKey &vk) {
-    return std::visit([](const auto &key) {
-        return !std::holds_alternative<NumericId>(key.id()) && std::get<StringId>(key.id()).empty();
-    }, vk);
+inline bool variant_key_id_empty(const VariantKey& vk)
+{
+    return std::visit(
+        [](const auto& key) {
+            return !std::holds_alternative<NumericId>(key.id()) && std::get<StringId>(key.id()).empty();
+        },
+        vk);
 }
 
 } // namespace arcticdb::entity
@@ -69,10 +80,14 @@ using namespace arcticdb::entity;
 template<>
 struct formatter<arcticdb::entity::VariantKey> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::VariantKey &k, FormatContext &ctx) const {
+    auto format(const arcticdb::entity::VariantKey& k, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}", variant_key_view(k));
     }
 };

--- a/cpp/arcticdb/entity/versioned_item.hpp
+++ b/cpp/arcticdb/entity/versioned_item.hpp
@@ -11,22 +11,29 @@
 #include <fmt/format.h>
 #include <string>
 
-
 namespace arcticdb {
 struct VersionedItem {
-    VersionedItem(entity::AtomKey &&key) :
-        key_(std::move(key)) {
+    VersionedItem(entity::AtomKey&& key)
+        : key_(std::move(key))
+    {
     }
 
-    VersionedItem(const entity::AtomKey& key) :
-        key_(key) {
+    VersionedItem(const entity::AtomKey& key)
+        : key_(key)
+    {
     }
 
     VersionedItem() = default;
 
     entity::AtomKey key_;
 
-    std::string symbol() const { return fmt::format("{}", key_.id()); }
-    uint64_t version() const { return key_.version_id(); }
+    std::string symbol() const
+    {
+        return fmt::format("{}", key_.id());
+    }
+    uint64_t version() const
+    {
+        return key_.version_id();
+    }
 };
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -21,47 +21,58 @@ namespace arcticdb::log {
 
 static const char* DefaultLogPattern = "%Y%m%d %H:%M:%S.%f %t %L %n | %v";
 
-constexpr auto get_default_log_level() {
+constexpr auto get_default_log_level()
+{
     return spdlog::level::info;
 }
 
-spdlog::logger &storage() {
+spdlog::logger& storage()
+{
     return Loggers::instance()->storage();
 }
 
-spdlog::logger &inmem() {
+spdlog::logger& inmem()
+{
     return Loggers::instance()->inmem();
 }
 
-spdlog::logger &codec() {
+spdlog::logger& codec()
+{
     return Loggers::instance()->codec();
 }
 
-spdlog::logger &root() {
+spdlog::logger& root()
+{
     return Loggers::instance()->root();
 }
 
-spdlog::logger &memory() {
+spdlog::logger& memory()
+{
     return Loggers::instance()->memory();
 }
 
-spdlog::logger &version() {
+spdlog::logger& version()
+{
     return Loggers::instance()->version();
 }
 
-spdlog::logger &timings() {
+spdlog::logger& timings()
+{
     return Loggers::instance()->timings();
 }
 
-spdlog::logger &lock() {
+spdlog::logger& lock()
+{
     return Loggers::instance()->lock();
 }
 
-spdlog::logger &schedule() {
+spdlog::logger& schedule()
+{
     return Loggers::instance()->schedule();
 }
 
-spdlog::logger &message() {
+spdlog::logger& message()
+{
     return Loggers::instance()->message();
 }
 
@@ -69,59 +80,80 @@ namespace fs = std::filesystem;
 
 using SinkConf = arcticdb::proto::logger::SinkConfig;
 
-Loggers::Loggers() : config_mutex_(), sink_by_id_(),
-                     unconfigured_(std::make_unique<spdlog::logger>("arcticdb",
-                                                                    std::make_shared<spdlog::sinks::stderr_sink_mt>())),
-                     root_(), storage_(), inmem_(), codec_(), version_(), thread_pool_(), periodic_worker_() {
+Loggers::Loggers()
+    : config_mutex_(),
+      sink_by_id_(),
+      unconfigured_(std::make_unique<spdlog::logger>("arcticdb", std::make_shared<spdlog::sinks::stderr_sink_mt>())),
+      root_(),
+      storage_(),
+      inmem_(),
+      codec_(),
+      version_(),
+      thread_pool_(),
+      periodic_worker_()
+{
     unconfigured_->set_level(get_default_log_level());
 }
 
-spdlog::logger &Loggers::logger_ref(std::unique_ptr<spdlog::logger>  &src) {
-    if (ARCTICDB_LIKELY(bool(src))) return *src;
+spdlog::logger& Loggers::logger_ref(std::unique_ptr<spdlog::logger>& src)
+{
+    if (ARCTICDB_LIKELY(bool(src)))
+        return *src;
     return *unconfigured_;
 }
 
-spdlog::logger &Loggers::storage() {
+spdlog::logger& Loggers::storage()
+{
     return logger_ref(storage_);
 }
 
-spdlog::logger &Loggers::inmem() {
+spdlog::logger& Loggers::inmem()
+{
     return logger_ref(inmem_);
 }
 
-spdlog::logger &Loggers::codec() {
+spdlog::logger& Loggers::codec()
+{
     return logger_ref(codec_);
 }
 
-spdlog::logger &Loggers::version() {
+spdlog::logger& Loggers::version()
+{
     return logger_ref(version_);
 }
 
-spdlog::logger &Loggers::memory() {
+spdlog::logger& Loggers::memory()
+{
     return logger_ref(memory_);
 }
 
-spdlog::logger &Loggers::timings() {
+spdlog::logger& Loggers::timings()
+{
     return logger_ref(timings_);
 }
 
-spdlog::logger &Loggers::lock() {
+spdlog::logger& Loggers::lock()
+{
     return logger_ref(lock_);
 }
 
-spdlog::logger &Loggers::schedule() {
+spdlog::logger& Loggers::schedule()
+{
     return logger_ref(schedule_);
 }
 
-spdlog::logger &Loggers::message() {
+spdlog::logger& Loggers::message()
+{
     return logger_ref(message_);
 }
 
-spdlog::logger &Loggers::root() {
+spdlog::logger& Loggers::root()
+{
     return logger_ref(root_);
 }
 
-void Loggers::flush_all() {
+void Loggers::flush_all()
+{
     root().flush();
     storage().flush();
     inmem().flush();
@@ -134,26 +166,28 @@ void Loggers::flush_all() {
     message().flush();
 }
 
-
-std::shared_ptr<Loggers> Loggers::instance() {
+std::shared_ptr<Loggers> Loggers::instance()
+{
     std::call_once(Loggers::init_flag_, &Loggers::init);
     return instance_;
 }
 
-void Loggers::destroy_instance() {
+void Loggers::destroy_instance()
+{
     Loggers::instance_.reset();
 }
 
-void Loggers::init() {
+void Loggers::init()
+{
     Loggers::instance_ = std::make_shared<Loggers>();
 }
-
 
 std::shared_ptr<Loggers> Loggers::instance_;
 std::once_flag Loggers::init_flag_;
 
 namespace {
-std::string make_parent_dir(const std::string &p_str, const std::string_view &def_p_str) {
+std::string make_parent_dir(const std::string& p_str, const std::string_view& def_p_str)
+{
     fs::path p;
     if (p_str.empty()) {
         p = fs::path(def_p_str);
@@ -165,75 +199,73 @@ std::string make_parent_dir(const std::string &p_str, const std::string_view &de
     }
     return p.generic_string();
 }
-}
-bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool force) {
+} // namespace
+bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig& conf, bool force)
+{
     auto lock = std::scoped_lock(config_mutex_);
     if (!force && root_)
         return false;
 
     // Configure async behavior
     if (conf.has_async()) {
-        thread_pool_ = std::make_shared<spdlog::details::thread_pool>(
-            util::as_opt(conf.async().queue_size()).value_or(8192),
-            util::as_opt(conf.async().thread_pool_size()).value_or(1)
-        );
+        thread_pool_ =
+            std::make_shared<spdlog::details::thread_pool>(util::as_opt(conf.async().queue_size()).value_or(8192),
+                util::as_opt(conf.async().thread_pool_size()).value_or(1));
     }
 
     // Configure the sinks
-    for (auto &&[sink_id, sink_conf] : conf.sink_by_id()) {
+    for (auto&& [sink_id, sink_conf] : conf.sink_by_id()) {
         switch (sink_conf.sink_case()) {
-            case SinkConf::kConsole:
-                if (sink_conf.console().has_color()) {
-                    if (sink_conf.console().std_err()) {
-                        sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
-                    } else {
-                        sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
-                    }
+        case SinkConf::kConsole:
+            if (sink_conf.console().has_color()) {
+                if (sink_conf.console().std_err()) {
+                    sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
                 } else {
-                    if (sink_conf.console().std_err()) {
-                        sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stderr_sink_mt>());
-                    } else {
-                        sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stdout_sink_mt>());
-                    }
+                    sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
                 }
-                break;
-            case SinkConf::kFile:
-                sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-                    make_parent_dir(sink_conf.file().path(), "./arcticdb.basic.log")
-                ));
-                break;
-            case SinkConf::kRotFile:
-                sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+            } else {
+                if (sink_conf.console().std_err()) {
+                    sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stderr_sink_mt>());
+                } else {
+                    sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::stdout_sink_mt>());
+                }
+            }
+            break;
+        case SinkConf::kFile:
+            sink_by_id_.emplace(sink_id,
+                std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+                    make_parent_dir(sink_conf.file().path(), "./arcticdb.basic.log")));
+            break;
+        case SinkConf::kRotFile:
+            sink_by_id_.emplace(sink_id,
+                std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
                     make_parent_dir(sink_conf.rot_file().path(), "./arcticdb.rot.log"),
-                    util::as_opt(sink_conf.rot_file().max_size_bytes()).value_or(64ULL* (1ULL<< 20)),
-                    util::as_opt(sink_conf.rot_file().max_file_count()).value_or(8)
-                ));
-                break;
-            case SinkConf::kDailyFile:
-                sink_by_id_.emplace(sink_id, std::make_shared<spdlog::sinks::daily_file_sink_mt>(
+                    util::as_opt(sink_conf.rot_file().max_size_bytes()).value_or(64ULL * (1ULL << 20)),
+                    util::as_opt(sink_conf.rot_file().max_file_count()).value_or(8)));
+            break;
+        case SinkConf::kDailyFile:
+            sink_by_id_.emplace(sink_id,
+                std::make_shared<spdlog::sinks::daily_file_sink_mt>(
                     make_parent_dir(sink_conf.daily_file().path(), "./arcticdb.daily.log"),
                     util::as_opt(sink_conf.daily_file().utc_rotation_hour()).value_or(0),
-                    util::as_opt(sink_conf.daily_file().utc_rotation_minute()).value_or(0)
-                ));
-                break;
-            default:util::raise_error_msg("Unsupported sink_conf {}", sink_conf);
+                    util::as_opt(sink_conf.daily_file().utc_rotation_minute()).value_or(0)));
+            break;
+        default:
+            util::raise_error_msg("Unsupported sink_conf {}", sink_conf);
         }
     }
 
     // Now associate loggers with sinks
-    auto check_and_configure = [&](
-        const std::string &name,
-        const std::string &fallback,
-        std::unique_ptr<spdlog::logger> &logger) {
-        if (auto it = conf.logger_by_id().find(name); it != conf.logger_by_id().end()) {
-            configure_logger(it->second, name, logger);
-        } else {
-            if (fallback.empty())
-                throw std::invalid_argument(fmt::format(
-                    "missing conf for logger {} without fallback", name));
-            configure_logger(conf.logger_by_id().find(fallback)->second, name, logger);
-        }
-    };
+    auto check_and_configure =
+        [&](const std::string& name, const std::string& fallback, std::unique_ptr<spdlog::logger>& logger) {
+            if (auto it = conf.logger_by_id().find(name); it != conf.logger_by_id().end()) {
+                configure_logger(it->second, name, logger);
+            } else {
+                if (fallback.empty())
+                    throw std::invalid_argument(fmt::format("missing conf for logger {} without fallback", name));
+                configure_logger(conf.logger_by_id().find(fallback)->second, name, logger);
+            }
+        };
 
     check_and_configure("root", std::string(), root_);
     check_and_configure("storage", "root", storage_);
@@ -253,15 +285,16 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool
                 if (auto l = loggers.lock()) {
                     l->flush_all();
                 }
-            }, std::chrono::seconds(flush_sec));
+            },
+            std::chrono::seconds(flush_sec));
     }
     return true;
 }
 
-void Loggers::configure_logger(
-        const arcticdb::proto::logger::LoggerConfig &conf,
-        const std::string &name,
-        std::unique_ptr<spdlog::logger> &logger) {
+void Loggers::configure_logger(const arcticdb::proto::logger::LoggerConfig& conf,
+    const std::string& name,
+    std::unique_ptr<spdlog::logger>& logger)
+{
     std::vector<spdlog::sink_ptr> sink_ptrs;
     for (const auto& sink_id : conf.sink_ids()) {
         if (auto it = sink_by_id_.find(sink_id); it != sink_by_id_.end()) {
@@ -273,19 +306,21 @@ void Loggers::configure_logger(
     auto fq_name = fmt::format("arcticdb.{}", name);
     if (thread_pool_) {
         // async logger
-        logger = std::make_unique<spdlog::async_logger>(fq_name, sink_ptrs.begin(), sink_ptrs.end(),
-                                                        thread_pool_, spdlog::async_overflow_policy::block);
+        logger = std::make_unique<spdlog::async_logger>(fq_name,
+            sink_ptrs.begin(),
+            sink_ptrs.end(),
+            thread_pool_,
+            spdlog::async_overflow_policy::block);
     } else {
         logger = std::make_unique<spdlog::logger>(fq_name, sink_ptrs.begin(), sink_ptrs.end());
     }
 
     if (!conf.pattern().empty()) {
         logger->set_pattern(conf.pattern());
-    }
-    else {
+    } else {
         logger->set_pattern(DefaultLogPattern);
     }
-    
+
     if (conf.level() != 0) {
         logger->set_level(static_cast<spdlog::level::level_enum>(conf.level() - 1));
     } else {
@@ -293,4 +328,4 @@ void Loggers::configure_logger(
     }
 }
 
-}
+} // namespace arcticdb::log

--- a/cpp/arcticdb/log/log.hpp
+++ b/cpp/arcticdb/log/log.hpp
@@ -31,7 +31,7 @@
 
 namespace arcticdb::log {
 class Loggers : public std::enable_shared_from_this<Loggers> {
-  public:
+public:
     Loggers();
 
     static std::shared_ptr<Loggers> instance_;
@@ -47,28 +47,27 @@ class Loggers : public std::enable_shared_from_this<Loggers> {
      * @param conf
      * @return true if configuration occurred
      */
-    bool configure(const arcticdb::proto::logger::LoggersConfig &conf, bool force=false);
+    bool configure(const arcticdb::proto::logger::LoggersConfig& conf, bool force = false);
 
-    spdlog::logger &storage();
-    spdlog::logger &inmem();
-    spdlog::logger &codec();
-    spdlog::logger &root();
-    spdlog::logger &memory();
-    spdlog::logger &version();
-    spdlog::logger &timings();
-    spdlog::logger &lock();
-    spdlog::logger &schedule();
-    spdlog::logger &message();
+    spdlog::logger& storage();
+    spdlog::logger& inmem();
+    spdlog::logger& codec();
+    spdlog::logger& root();
+    spdlog::logger& memory();
+    spdlog::logger& version();
+    spdlog::logger& timings();
+    spdlog::logger& lock();
+    spdlog::logger& schedule();
+    spdlog::logger& message();
 
     void flush_all();
 
-  private:
+private:
+    void configure_logger(const arcticdb::proto::logger::LoggerConfig& conf,
+        const std::string& name,
+        std::unique_ptr<spdlog::logger>& logger);
 
-    void configure_logger(const arcticdb::proto::logger::LoggerConfig &conf,
-                          const std::string &name,
-                          std::unique_ptr<spdlog::logger> &logger);
-
-    spdlog::logger &logger_ref(std::unique_ptr<spdlog::logger> &src);
+    spdlog::logger& logger_ref(std::unique_ptr<spdlog::logger>& src);
 
     std::mutex config_mutex_;
     std::unordered_map<std::string, spdlog::sink_ptr> sink_by_id_;
@@ -89,20 +88,20 @@ class Loggers : public std::enable_shared_from_this<Loggers> {
 
 // N.B. If you add a new logger type here you need to add it to the dict of python loggers
 // in log.py
-spdlog::logger &storage();
-spdlog::logger &inmem();
-spdlog::logger &codec();
-spdlog::logger &root();
-spdlog::logger &version();
-spdlog::logger &memory();
-spdlog::logger &timings();
-spdlog::logger &lock();
-spdlog::logger &schedule();
-spdlog::logger &message();
+spdlog::logger& storage();
+spdlog::logger& inmem();
+spdlog::logger& codec();
+spdlog::logger& root();
+spdlog::logger& version();
+spdlog::logger& memory();
+spdlog::logger& timings();
+spdlog::logger& lock();
+spdlog::logger& schedule();
+spdlog::logger& message();
 
-inline std::unordered_map<std::string, spdlog::logger*> get_loggers_by_name() {
-    return {
-        {"root", &root()},
+inline std::unordered_map<std::string, spdlog::logger*> get_loggers_by_name()
+{
+    return {{"root", &root()},
         {"storage", &storage()},
         {"inmem", &inmem()},
         {"codec", &codec()},
@@ -111,27 +110,28 @@ inline std::unordered_map<std::string, spdlog::logger*> get_loggers_by_name() {
         {"timings", &timings()},
         {"lock", &lock()},
         {"schedule", &schedule()},
-        {"message", &message()}
-    };
+        {"message", &message()}};
 }
 
-inline void set_levels(spdlog::level::level_enum default_level, std::unordered_map<std::string, spdlog::level::level_enum> specific_log_levels) {
+inline void set_levels(spdlog::level::level_enum default_level,
+    std::unordered_map<std::string, spdlog::level::level_enum> specific_log_levels)
+{
     auto log_cfgs = arcticdb::proto::logger::LoggersConfig{};
 
     auto sink_config = arcticdb::proto::logger::SinkConfig{};
     sink_config.mutable_console()->set_std_err(true);
     log_cfgs.mutable_sink_by_id()->insert({std::string{"console"}, sink_config});
 
-
     auto logger_by_name = get_loggers_by_name();
-    for(const auto& entry : logger_by_name) {
+    for (const auto& entry : logger_by_name) {
         const auto& logger_name = entry.first;
         auto it = specific_log_levels.find(logger_name);
         auto level_to_set = (it == specific_log_levels.end() ? default_level : it->second);
         auto logger = arcticdb::proto::logger::LoggerConfig{};
         sink_config.mutable_console()->set_std_err(true);
         logger.set_level(arcticdb::proto::logger::LoggerConfig_Level(int(level_to_set)));
-        auto logger_id = fmt::format("{}",  logger_name != "root" ? fmt::format("arcticdb.{}", logger_name) : "arcticdb");
+        auto logger_id =
+            fmt::format("{}", logger_name != "root" ? fmt::format("arcticdb.{}", logger_name) : "arcticdb");
         logger.set_pattern(fmt::format("%Y%m%d_%H%M%S.%f %t %L %n %P | %v", logger_id));
         log_cfgs.mutable_logger_by_id()->insert({logger_name, logger});
     }

--- a/cpp/arcticdb/log/test/test_log.cpp
+++ b/cpp/arcticdb/log/test/test_log.cpp
@@ -11,11 +11,13 @@
 #include <google/protobuf/text_format.h>
 #include <arcticdb/util/format_bytes.hpp>
 
-TEST(TestLog, SmokeTest) {
+TEST(TestLog, SmokeTest)
+{
     arcticdb::log::root().info("Some msg");
 }
 
-TEST(TestLog, ConfigureSingleton) {
+TEST(TestLog, ConfigureSingleton)
+{
     std::string txt_conf = R"pb(
 sink_by_id {
     key: "console"
@@ -40,7 +42,8 @@ logger_by_id {
     arcticdb::log::root().info("Some msg");
 }
 
-TEST(TestLog, TestFormatBytes) {
+TEST(TestLog, TestFormatBytes)
+{
     auto s = arcticdb::format_bytes(12345678);
     ASSERT_EQ(s, "12.35MB");
 }

--- a/cpp/arcticdb/log/trace.hpp
+++ b/cpp/arcticdb/log/trace.hpp
@@ -10,9 +10,9 @@
 #ifdef ARCTICDB_TRACE_ON
 #define ARCTICDB_STR_H(x) #x
 #define ARCTICDB_STR_HELPER(x) ARCTICDB_STR_H(x)
-#define ARCTICDB_TRACE(logger, ...)                                                                                                          \
-    logger.trace("[ " __FILE__ ":" ARCTICDB_STR_HELPER(__LINE__) " ]"                                                                       \
-                                                                " " __VA_ARGS__)
+#define ARCTICDB_TRACE(logger, ...)                                                                                    \
+    logger.trace("[ " __FILE__ ":" ARCTICDB_STR_HELPER(__LINE__) " ]"                                                  \
+                                                                 " " __VA_ARGS__)
 #else
 #define ARCTICDB_TRACE(logger, ...) (void)0
 #endif

--- a/cpp/arcticdb/pipeline/column_mapping.hpp
+++ b/cpp/arcticdb/pipeline/column_mapping.hpp
@@ -9,7 +9,8 @@
 
 namespace arcticdb {
 
-inline std::size_t sizeof_datatype(const TypeDescriptor &td) {
+inline std::size_t sizeof_datatype(const TypeDescriptor& td)
+{
     return td.visit_tag([](auto dt) {
         using RawType = typename std::decay_t<decltype(dt)>::DataTypeTag::raw_type;
         return sizeof(RawType);
@@ -26,15 +27,16 @@ struct ColumnMapping {
     const size_t offset_bytes_;
     const size_t dest_bytes_;
 
-    ColumnMapping(SegmentInMemory &frame, size_t dst_col, size_t field_col, pipelines::PipelineContextRow &context) :
-        source_type_desc_(type_desc_from_proto(context.descriptor().fields(field_col).type_desc())),
-        dest_type_desc_(type_desc_from_proto(frame.field(dst_col).type_desc())),
-        frame_field_descriptor_(frame.field(dst_col)),
-        dest_size_(sizeof_datatype(dest_type_desc_)),
-        num_rows_(context.slice_and_key().slice_.row_range.diff()),
-        first_row_(context.slice_and_key().slice_.row_range.first - frame.offset()),
-        offset_bytes_(dest_size_ * first_row_),
-        dest_bytes_(dest_size_ * num_rows_) {
+    ColumnMapping(SegmentInMemory& frame, size_t dst_col, size_t field_col, pipelines::PipelineContextRow& context)
+        : source_type_desc_(type_desc_from_proto(context.descriptor().fields(field_col).type_desc())),
+          dest_type_desc_(type_desc_from_proto(frame.field(dst_col).type_desc())),
+          frame_field_descriptor_(frame.field(dst_col)),
+          dest_size_(sizeof_datatype(dest_type_desc_)),
+          num_rows_(context.slice_and_key().slice_.row_range.diff()),
+          first_row_(context.slice_and_key().slice_.row_range.first - frame.offset()),
+          offset_bytes_(dest_size_ * first_row_),
+          dest_bytes_(dest_size_ * num_rows_)
+    {
     }
 };
 
@@ -49,54 +51,59 @@ struct StaticColumnMappingIterator {
     size_t dst_col_ = 0;
     bool invalid_ = false;
     const std::optional<util::BitSet>& bit_set_;
-    
-    StaticColumnMappingIterator(pipelines::PipelineContextRow& context, size_t index_fieldcount) :
-        index_fieldcount_(index_fieldcount),
-        field_count_(context.slice_and_key().slice_.col_range.diff() + index_fieldcount),
-        first_slice_col_offset_(context.slice_and_key().slice_.col_range.first),
-        last_slice_col_offset_(context.slice_and_key().slice_.col_range.second),
-        bit_set_(context.get_selected_columns()) {
-            prev_col_offset_ = first_slice_col_offset_ - 1;
-            if(bit_set_) {
-                source_col_ = bit_set_.value()[bv_size(first_slice_col_offset_)] ? first_slice_col_offset_ : bit_set_->get_next(bv_size(first_slice_col_offset_));
-                if (bit_set_.value()[bv_size(first_slice_col_offset_)]) {
-                    source_col_ = first_slice_col_offset_;
-                } else {
-                    auto next_pos = bit_set_->get_next(bv_size(first_slice_col_offset_));
-                    // We have to do this extra check in bitmagic, get_next returns 0 in case no next present
-                    if (next_pos == 0 && bit_set_->size() > 0 && !bit_set_->test(0))
-                        invalid_ = true;
-                    else
-                        source_col_ = next_pos;
-                }
-                if(source_col_ < first_slice_col_offset_)
-                    invalid_ = true;
 
-            } else {
+    StaticColumnMappingIterator(pipelines::PipelineContextRow& context, size_t index_fieldcount)
+        : index_fieldcount_(index_fieldcount),
+          field_count_(context.slice_and_key().slice_.col_range.diff() + index_fieldcount),
+          first_slice_col_offset_(context.slice_and_key().slice_.col_range.first),
+          last_slice_col_offset_(context.slice_and_key().slice_.col_range.second),
+          bit_set_(context.get_selected_columns())
+    {
+        prev_col_offset_ = first_slice_col_offset_ - 1;
+        if (bit_set_) {
+            source_col_ = bit_set_.value()[bv_size(first_slice_col_offset_)]
+                              ? first_slice_col_offset_
+                              : bit_set_->get_next(bv_size(first_slice_col_offset_));
+            if (bit_set_.value()[bv_size(first_slice_col_offset_)]) {
                 source_col_ = first_slice_col_offset_;
+            } else {
+                auto next_pos = bit_set_->get_next(bv_size(first_slice_col_offset_));
+                // We have to do this extra check in bitmagic, get_next returns 0 in case no next present
+                if (next_pos == 0 && bit_set_->size() > 0 && !bit_set_->test(0))
+                    invalid_ = true;
+                else
+                    source_col_ = next_pos;
             }
+            if (source_col_ < first_slice_col_offset_)
+                invalid_ = true;
 
-            dst_col_ = bit_set_ ? bit_set_->count_range(0, bv_size(source_col_)) - 1 : source_col_;
-            source_field_pos_ = (source_col_ - first_slice_col_offset_) + index_fieldcount_;
+        } else {
+            source_col_ = first_slice_col_offset_;
+        }
+
+        dst_col_ = bit_set_ ? bit_set_->count_range(0, bv_size(source_col_)) - 1 : source_col_;
+        source_field_pos_ = (source_col_ - first_slice_col_offset_) + index_fieldcount_;
     }
 
-    std::optional<size_t> get_next_source_col() const {
-        if(!bit_set_) {
+    std::optional<size_t> get_next_source_col() const
+    {
+        if (!bit_set_) {
             return source_col_ + 1;
         } else {
             auto next_pos = bit_set_->get_next(bv_size(source_col_));
-            if(next_pos == 0)
+            if (next_pos == 0)
                 return std::nullopt;
             else
                 return next_pos;
         }
     }
 
-    void advance() {
+    void advance()
+    {
         ++dst_col_;
         prev_col_offset_ = source_col_;
         auto new_source_col = get_next_source_col();
-        if(new_source_col) {
+        if (new_source_col) {
             source_col_ = new_source_col.value();
             source_field_pos_ = (source_col_ - first_slice_col_offset_) + index_fieldcount_;
         } else {
@@ -105,54 +112,65 @@ struct StaticColumnMappingIterator {
         }
     }
 
-    bool invalid() const {
+    bool invalid() const
+    {
         return invalid_;
     }
 
-    bool has_next() const {
+    bool has_next() const
+    {
         return source_field_pos_ < field_count_;
     }
 
-    bool at_end_of_selected() const {
+    bool at_end_of_selected() const
+    {
         return !source_col_ || source_col_ >= last_slice_col_offset_;
     }
 
-    size_t remaining_fields() const {
+    size_t remaining_fields() const
+    {
         return field_count_ - source_field_pos_;
     }
 
-    size_t prev_col_offset() const {
+    size_t prev_col_offset() const
+    {
         return prev_col_offset_;
     }
 
-    size_t source_field_pos() const {
+    size_t source_field_pos() const
+    {
         return source_field_pos_;
     }
 
-    size_t source_col() const {
+    size_t source_col() const
+    {
         return source_col_;
     }
 
-    size_t first_slice_col_offset() const {
+    size_t first_slice_col_offset() const
+    {
         return first_slice_col_offset_;
     }
 
-    size_t last_slice_col_offset() const {
+    size_t last_slice_col_offset() const
+    {
         return last_slice_col_offset_;
     }
 
-    size_t dest_col() const {
+    size_t dest_col() const
+    {
         return dst_col_;
     }
 
-    size_t field_count() const {
+    size_t field_count() const
+    {
         return field_count_;
     }
 
-    size_t index_fieldcount() const {
+    size_t index_fieldcount() const
+    {
         return index_fieldcount_;
     }
 };
-
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/execution.hpp
+++ b/cpp/arcticdb/pipeline/execution.hpp
@@ -20,22 +20,25 @@ namespace arcticdb {
 
 struct PlusOperator {
     template<typename T, typename U, typename V>
-    static V go(T t, U u) {
+    static V go(T t, U u)
+    {
         return t + u;
     }
 };
 
 struct MinusOperator {
     template<typename T, typename U, typename V>
-    static V go(T t, U u) {
+    static V go(T t, U u)
+    {
         return t - u;
     }
 };
 
 struct TimesOperator {
     template<typename T, typename U, typename V>
-    static V go(T t, U u) {
-        if constexpr(std::is_same_v<V, bool>) {
+    static V go(T t, U u)
+    {
+        if constexpr (std::is_same_v<V, bool>) {
             return t && u;
         } else {
             return t * u;
@@ -44,14 +47,23 @@ struct TimesOperator {
 };
 
 struct IIterable {
-    template <class Base>
+    template<class Base>
     struct Interface : Base {
-        bool finished() const { return folly::poly_call<0>(*this); }
-        uint8_t* value() const { return folly::poly_call<1>(*this); }
-        void next() { folly::poly_call<2>(*this); }
+        bool finished() const
+        {
+            return folly::poly_call<0>(*this);
+        }
+        uint8_t* value() const
+        {
+            return folly::poly_call<1>(*this);
+        }
+        void next()
+        {
+            folly::poly_call<2>(*this);
+        }
     };
 
-    template <class T>
+    template<class T>
     using Members = folly::PolyMembers<&T::finished, &T::value, &T::next>;
 };
 
@@ -59,21 +71,27 @@ using Iterable = folly::Poly<IIterable>;
 
 template<typename T, typename U, typename V, typename Operator>
 struct CombiningIterator {
-    CombiningIterator(Iterable l_pos,  Iterable r_pos_) :
-        l_pos_(l_pos),
-        r_pos_(r_pos_) {
+    CombiningIterator(Iterable l_pos, Iterable r_pos_)
+        : l_pos_(l_pos),
+          r_pos_(r_pos_)
+    {
     }
 
-    bool finished() const { return l_pos_.finished() || r_pos_.finished(); }
+    bool finished() const
+    {
+        return l_pos_.finished() || r_pos_.finished();
+    }
 
-    uint8_t* value() const {
+    uint8_t* value() const
+    {
         auto left_val = *reinterpret_cast<const T*>(l_pos_.value());
-        auto right_val =  *reinterpret_cast<const U*>(r_pos_.value());
+        auto right_val = *reinterpret_cast<const U*>(r_pos_.value());
         value_ = Operator::template go<T, U, V>(left_val, right_val);
         return reinterpret_cast<uint8_t*>(&value_);
     }
 
-    void next() {
+    void next()
+    {
         l_pos_.next();
         r_pos_.next();
     }
@@ -84,13 +102,19 @@ struct CombiningIterator {
 };
 
 struct IIterableContainer {
-    template <class Base>
+    template<class Base>
     struct Interface : Base {
-        Iterable get_iterator() const { return folly::poly_call<0>(*this); }
-        TypeDescriptor type() const { return folly::poly_call<1>(*this);}
+        Iterable get_iterator() const
+        {
+            return folly::poly_call<0>(*this);
+        }
+        TypeDescriptor type() const
+        {
+            return folly::poly_call<1>(*this);
+        }
     };
 
-    template <class T>
+    template<class T>
     using Members = folly::PolyMembers<&T::get_iterator, &T::type>;
 };
 
@@ -98,29 +122,37 @@ using IterableContainer = folly::Poly<IIterableContainer&>;
 
 template<typename OperatorType>
 struct ColumnExpression {
-    TypeDescriptor type() {
+    TypeDescriptor type()
+    {
         return type_;
     }
 
-    ColumnExpression(const IterableContainer& left, const IterableContainer& right) :
-        left_(left),
-        right_(right) {
+    ColumnExpression(const IterableContainer& left, const IterableContainer& right)
+        : left_(left),
+          right_(right)
+    {
         auto promoted_type = has_valid_type_promotion(left_->type(), right_->type());
-        util::check(static_cast<bool>(promoted_type), "Cannot promote from type {} and type {} in column expression", left_->type(), right_->type());
+        util::check(static_cast<bool>(promoted_type),
+            "Cannot promote from type {} and type {} in column expression",
+            left_->type(),
+            right_->type());
         type_ = promoted_type.value();
     }
 
-    Iterable get_iterator() {
-        return details::visit_type(left_->type().data_type, [&] (auto left_dtt) {
+    Iterable get_iterator()
+    {
+        return details::visit_type(left_->type().data_type, [&](auto left_dtt) {
             using left_raw_type = typename decltype(left_dtt)::raw_type;
 
-            return details::visit_type(right_->type().data_type, [&] (auto right_dtt) {
+            return details::visit_type(right_->type().data_type, [&](auto right_dtt) {
                 using right_raw_type = typename decltype(right_dtt)::raw_type;
 
-                return details::visit_type(type().data_type, [&] (auto target_dtt) {
+                return details::visit_type(type().data_type, [&](auto target_dtt) {
                     using target_raw_type = typename decltype(target_dtt)::raw_type;
 
-                    return Iterable{CombiningIterator<left_raw_type, right_raw_type, target_raw_type, OperatorType>(left_->get_iterator(), right_->get_iterator())};
+                    return Iterable{CombiningIterator<left_raw_type, right_raw_type, target_raw_type, OperatorType>(
+                        left_->get_iterator(),
+                        right_->get_iterator())};
                 });
             });
         });
@@ -131,22 +163,21 @@ struct ColumnExpression {
     TypeDescriptor type_;
 };
 
-
 struct StreamFilter {
-    void go(std::shared_ptr<pipelines::PipelineContext> /*context*/) {
-
+    void go(std::shared_ptr<pipelines::PipelineContext> /*context*/)
+    {
     }
 };
 
-struct StreamAggregation{
-    void go(std::shared_ptr<pipelines::PipelineContext> /*context*/) {
-
+struct StreamAggregation {
+    void go(std::shared_ptr<pipelines::PipelineContext> /*context*/)
+    {
     }
 };
 
-struct  StreamProjection {
-    void go(std::shared_ptr<pipelines::PipelineContext> /*context*/) {
-
+struct StreamProjection {
+    void go(std::shared_ptr<pipelines::PipelineContext> /*context*/)
+    {
     }
 };
 
@@ -158,7 +189,8 @@ struct ProcessingNode {
     std::shared_ptr<ProcessingNode> right_;
 };
 
-void postorder_traverse(std::shared_ptr<ProcessingNode> root, std::shared_ptr<pipelines::PipelineContext> context) {
+void postorder_traverse(std::shared_ptr<ProcessingNode> root, std::shared_ptr<pipelines::PipelineContext> context)
+{
     if (!root)
         return;
 
@@ -176,12 +208,10 @@ void postorder_traverse(std::shared_ptr<ProcessingNode> root, std::shared_ptr<pi
             stack.push(node->left_);
     }
 
-    while(!result.empty()) {
+    while (!result.empty()) {
         auto curr = result.top();
         result.pop();
-        util::variant_match(curr->operation_, [&context] (auto& op) {
-            op.go(context);
-        });
+        util::variant_match(curr->operation_, [&context](auto& op) { op.go(context); });
     }
 }
 

--- a/cpp/arcticdb/pipeline/filter_segment.hpp
+++ b/cpp/arcticdb/pipeline/filter_segment.hpp
@@ -15,9 +15,10 @@
 namespace arcticdb {
 
 inline SegmentInMemory filter_segment(const SegmentInMemory& input,
-                                      const util::BitSet& filter_bitset,
-                                      bool filter_down_stringpool=false,
-                                      bool validate=false) {
+    const util::BitSet& filter_bitset,
+    bool filter_down_stringpool = false,
+    bool validate = false)
+{
     return input.filter(filter_bitset, filter_down_stringpool, validate);
 }
 

--- a/cpp/arcticdb/pipeline/frame_data_wrapper.hpp
+++ b/cpp/arcticdb/pipeline/frame_data_wrapper.hpp
@@ -22,14 +22,18 @@ namespace arcticdb::pipelines {
 
 namespace py = pybind11;
 
-struct ARCTICDB_VISIBILITY_HIDDEN FrameDataWrapper{
-    explicit FrameDataWrapper(size_t size) : data_(size) {}
+struct ARCTICDB_VISIBILITY_HIDDEN FrameDataWrapper {
+    explicit FrameDataWrapper(size_t size)
+        : data_(size)
+    {
+    }
 
-    const std::vector<py::array>& data() const {
+    const std::vector<py::array>& data() const
+    {
         return data_;
     }
 
     std::vector<py::array> data_;
 };
 
-} // arcticdb::pipelines
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/frame_slice.cpp
+++ b/cpp/arcticdb/pipeline/frame_slice.cpp
@@ -11,31 +11,35 @@
 #include <arcticdb/storage/store.hpp>
 
 namespace arcticdb::pipelines {
- FrameSlice::FrameSlice(const SegmentInMemory& seg) :
-    col_range(get_index_field_count(seg), seg.descriptor().field_count()),
-    row_range(0, seg.row_count()),
-    desc_(std::make_shared<entity::StreamDescriptor>(seg.descriptor()))
+FrameSlice::FrameSlice(const SegmentInMemory& seg)
+    : col_range(get_index_field_count(seg), seg.descriptor().field_count()),
+      row_range(0, seg.row_count()),
+      desc_(std::make_shared<entity::StreamDescriptor>(seg.descriptor()))
 {
 }
 
-void SliceAndKey::ensure_segment(const std::shared_ptr<Store>& store) const {
-     if(!segment_)
-         segment_ = store->read(*key_).get().second;
- }
+void SliceAndKey::ensure_segment(const std::shared_ptr<Store>& store) const
+{
+    if (!segment_)
+        segment_ = store->read(*key_).get().second;
+}
 
- SegmentInMemory& SliceAndKey::segment(const std::shared_ptr<Store>& store) {
-     ensure_segment(store);
-     return *segment_;
- }
+SegmentInMemory& SliceAndKey::segment(const std::shared_ptr<Store>& store)
+{
+    ensure_segment(store);
+    return *segment_;
+}
 
- SegmentInMemory&& SliceAndKey::release_segment(const std::shared_ptr<Store>& store) const {
-     ensure_segment(store);
-     return std::move(*segment_);
- }
+SegmentInMemory&& SliceAndKey::release_segment(const std::shared_ptr<Store>& store) const
+{
+    ensure_segment(store);
+    return std::move(*segment_);
+}
 
- const SegmentInMemory& SliceAndKey::segment(const std::shared_ptr<Store>& store) const {
-     ensure_segment(store);
-     return *segment_;
- }
+const SegmentInMemory& SliceAndKey::segment(const std::shared_ptr<Store>& store) const
+{
+    ensure_segment(store);
+    return *segment_;
+}
 
-} //namespace arcticdb:;pipelines
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/frame_slice_map.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice_map.hpp
@@ -22,20 +22,21 @@ struct FrameSliceMap {
     robin_hood::unordered_flat_map<std::string_view, std::map<RowRange, ContextData>> columns_;
     std::shared_ptr<PipelineContext> context_;
 
-    FrameSliceMap(const std::shared_ptr<PipelineContext>& context, bool dynamic_schema) :
-        context_(std::move(context)) {
+    FrameSliceMap(const std::shared_ptr<PipelineContext>& context, bool dynamic_schema)
+        : context_(std::move(context))
+    {
 
-        for (const auto &context_row: *context_) {
+        for (const auto& context_row : *context_) {
             const auto& row_range = context_row.slice_and_key().slice_.row_range;
 
             const auto& fields = context_row.descriptor().fields();
-            for(const auto& field : folly::enumerate(fields)) {
+            for (const auto& field : folly::enumerate(fields)) {
                 if (!context_->is_in_filter_columns_set(field->name())) {
                     ARCTICDB_DEBUG(log::version(), "{} not present in filtered columns, skipping", field->name());
                     continue;
                 }
 
-                if(!dynamic_schema && !is_sequence_type(type_desc_from_proto(field->type_desc()).data_type())) {
+                if (!dynamic_schema && !is_sequence_type(type_desc_from_proto(field->type_desc()).data_type())) {
                     ARCTICDB_DEBUG(log::version(), "{} not a string type in dynamic schema, skipping", field->name());
                     continue;
                 }

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -11,15 +11,15 @@
 
 namespace arcticdb {
 
-arcticdb::proto::descriptors::TimeSeriesDescriptor get_timeseries_descriptor(
-    const StreamDescriptor& descriptor,
+arcticdb::proto::descriptors::TimeSeriesDescriptor get_timeseries_descriptor(const StreamDescriptor& descriptor,
     size_t total_rows,
     const std::optional<AtomKey>& next_key,
-    arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta) {
+    arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta)
+{
 
     arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
     tsd.set_total_rows(total_rows);
-    if(next_key)
+    if (next_key)
         tsd.mutable_next_key()->CopyFrom(encode_key(next_key.value()));
 
     tsd.mutable_normalization()->CopyFrom(norm_meta);
@@ -28,11 +28,11 @@ arcticdb::proto::descriptors::TimeSeriesDescriptor get_timeseries_descriptor(
     return tsd;
 }
 
-google::protobuf::Any pack_timeseries_descriptor(
-        StreamDescriptor&& descriptor,
-        size_t total_rows,
-        const std::optional<AtomKey>& next_key,
-        arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta) {
+google::protobuf::Any pack_timeseries_descriptor(StreamDescriptor&& descriptor,
+    size_t total_rows,
+    const std::optional<AtomKey>& next_key,
+    arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta)
+{
 
     auto tsd = get_timeseries_descriptor(descriptor, total_rows, next_key, std::move(norm_meta));
     google::protobuf::Any any;
@@ -40,12 +40,11 @@ google::protobuf::Any pack_timeseries_descriptor(
     return any;
 }
 
-SegmentInMemory segment_from_frame(
-        pipelines::InputTensorFrame&& frame,
-        size_t existing_rows,
-        std::optional<entity::AtomKey>&& prev_key,
-        bool allow_sparse
-) {
+SegmentInMemory segment_from_frame(pipelines::InputTensorFrame&& frame,
+    size_t existing_rows,
+    std::optional<entity::AtomKey>&& prev_key,
+    bool allow_sparse)
+{
     using namespace arcticdb::stream;
 
     auto offset_in_frame = 0;
@@ -57,77 +56,99 @@ SegmentInMemory segment_from_frame(
     SegmentInMemory output;
     auto field_tensors = std::move(frame.field_tensors);
 
-    std::visit([&](const auto& idx) {
-        using IdxType = std::decay_t<decltype(idx)>;
-        using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
+    std::visit(
+        [&](const auto& idx) {
+            using IdxType = std::decay_t<decltype(idx)>;
+            using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
 
-        auto timeseries_desc = descriptor_from_frame(pipelines::InputTensorFrame{frame}, existing_rows, std::move(prev_key));
-        auto norm_meta = timeseries_desc.normalization();
-        StreamDescriptor descriptor(std::move(*timeseries_desc.mutable_stream_descriptor()));
-        SingleSegmentAggregator agg{FixedSchema{descriptor, idx}, [&](auto&& segment) {
-            auto any = pack_timeseries_descriptor(std::move(descriptor), existing_rows + num_rows, prev_key, std::move(norm_meta));
-            segment.set_metadata(std::move(any));
-            output = std::forward<SegmentInMemory>(segment);
-        }};
+            auto timeseries_desc =
+                descriptor_from_frame(pipelines::InputTensorFrame{frame}, existing_rows, std::move(prev_key));
+            auto norm_meta = timeseries_desc.normalization();
+            StreamDescriptor descriptor(std::move(*timeseries_desc.mutable_stream_descriptor()));
+            SingleSegmentAggregator agg{FixedSchema{descriptor, idx}, [&](auto&& segment) {
+                                            auto any = pack_timeseries_descriptor(std::move(descriptor),
+                                                existing_rows + num_rows,
+                                                prev_key,
+                                                std::move(norm_meta));
+                                            segment.set_metadata(std::move(any));
+                                            output = std::forward<SegmentInMemory>(segment);
+                                        }};
 
-        if (has_index) {
-            util::check(static_cast<bool>(index_tensor), "Expected index tensor for index type {}", agg.descriptor().index());
-            aggregator_set_data(type_desc_from_proto(agg.descriptor().field(0).type_desc()), index_tensor.value(), agg, 0, num_rows, offset_in_frame, slice_num_for_column,
-                                num_rows, allow_sparse);
-        }
+            if (has_index) {
+                util::check(static_cast<bool>(index_tensor),
+                    "Expected index tensor for index type {}",
+                    agg.descriptor().index());
+                aggregator_set_data(type_desc_from_proto(agg.descriptor().field(0).type_desc()),
+                    index_tensor.value(),
+                    agg,
+                    0,
+                    num_rows,
+                    offset_in_frame,
+                    slice_num_for_column,
+                    num_rows,
+                    allow_sparse);
+            }
 
-        for(auto col = 0u; col < field_tensors.size(); ++col) {
-            auto dest_col = col + agg.descriptor().index().field_count();
-            auto &tensor = field_tensors[col];
-            aggregator_set_data(type_desc_from_proto(agg.descriptor().field(dest_col).type_desc()), tensor, agg, dest_col, num_rows, offset_in_frame, slice_num_for_column,
-                                num_rows, allow_sparse);
-        }
+            for (auto col = 0u; col < field_tensors.size(); ++col) {
+                auto dest_col = col + agg.descriptor().index().field_count();
+                auto& tensor = field_tensors[col];
+                aggregator_set_data(type_desc_from_proto(agg.descriptor().field(dest_col).type_desc()),
+                    tensor,
+                    agg,
+                    dest_col,
+                    num_rows,
+                    offset_in_frame,
+                    slice_num_for_column,
+                    num_rows,
+                    allow_sparse);
+            }
 
-        agg.end_block_write(num_rows);
-        agg.commit();
-    }, index);
+            agg.end_block_write(num_rows);
+            agg.commit();
+        },
+        index);
 
-    ARCTICDB_DEBUG(log::version(), "Constructed segment from frame of {} rows and {} columns at offset {}", output.row_count(), output.num_columns(), output.offset());
+    ARCTICDB_DEBUG(log::version(),
+        "Constructed segment from frame of {} rows and {} columns at offset {}",
+        output.row_count(),
+        output.num_columns(),
+        output.offset());
     return output;
 }
 
-arcticdb::proto::descriptors::TimeSeriesDescriptor make_descriptor(
-        size_t rows,
-        StreamDescriptor&& desc,
-        arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
-        std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>&& um,
-        std::optional<AtomKey>&& prev_key,
-        bool bucketize_dynamic
-    ) {
+arcticdb::proto::descriptors::TimeSeriesDescriptor make_descriptor(size_t rows,
+    StreamDescriptor&& desc,
+    arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
+    std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>&& um,
+    std::optional<AtomKey>&& prev_key,
+    bool bucketize_dynamic)
+{
 
     arcticdb::proto::descriptors::TimeSeriesDescriptor metadata;
     metadata.set_total_rows(rows);
     *metadata.mutable_stream_descriptor() = desc.proto();
     metadata.mutable_normalization()->CopyFrom(norm_meta);
     auto user_meta = std::move(um);
-    if(user_meta)
+    if (user_meta)
         *metadata.mutable_user_meta() = std::move(*user_meta);
 
-    if(prev_key) {
+    if (prev_key) {
         auto pb_key = encode_key(prev_key.value());
         *metadata.mutable_next_key() = std::move(pb_key);
     }
-    if(bucketize_dynamic)
+    if (bucketize_dynamic)
         metadata.mutable_column_groups()->set_enabled(true);
 
     //TODO maybe need ensure_norm_meta?
     return metadata;
 }
 
-
-arcticdb::proto::descriptors::TimeSeriesDescriptor make_descriptor(
-    size_t rows,
+arcticdb::proto::descriptors::TimeSeriesDescriptor make_descriptor(size_t rows,
     pipelines::index::IndexSegmentReader&& index_segment_reader,
     std::optional<AtomKey>&& prev_key,
-    bool bucketize_dynamic
-) {
-    return make_descriptor(
-        rows,
+    bool bucketize_dynamic)
+{
+    return make_descriptor(rows,
         StreamDescriptor{std::move(*index_segment_reader.mutable_tsd().mutable_stream_descriptor())},
         *index_segment_reader.mutable_tsd().mutable_normalization(),
         std::move(*index_segment_reader.mutable_tsd().mutable_user_meta()),
@@ -137,23 +158,22 @@ arcticdb::proto::descriptors::TimeSeriesDescriptor make_descriptor(
 arcticdb::proto::descriptors::TimeSeriesDescriptor make_descriptor(
     const std::shared_ptr<pipelines::PipelineContext>& pipeline_context,
     std::optional<AtomKey>&& prev_key,
-    bool bucketize_dynamic) {
-    return make_descriptor(
-        pipeline_context->total_rows_,
+    bool bucketize_dynamic)
+{
+    return make_descriptor(pipeline_context->total_rows_,
         StreamDescriptor{std::move(pipeline_context->desc_->mutable_proto())},
         *pipeline_context->norm_meta_,
-        pipeline_context->user_meta_ ? std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>(std::move(*pipeline_context->user_meta_)) : std::nullopt,
+        pipeline_context->user_meta_ ? std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>(
+                                           std::move(*pipeline_context->user_meta_))
+                                     : std::nullopt,
         std::move(prev_key),
-        bucketize_dynamic
-        );
+        bucketize_dynamic);
 }
-arcticdb::proto::descriptors::TimeSeriesDescriptor descriptor_from_frame(
-        pipelines::InputTensorFrame&& frame,
-        size_t existing_rows,
-        std::optional<entity::AtomKey>&& prev_key
-) {
-    return make_descriptor(
-        frame.num_rows + existing_rows,
+arcticdb::proto::descriptors::TimeSeriesDescriptor descriptor_from_frame(pipelines::InputTensorFrame&& frame,
+    size_t existing_rows,
+    std::optional<entity::AtomKey>&& prev_key)
+{
+    return make_descriptor(frame.num_rows + existing_rows,
         StreamDescriptor{std::move(frame.desc.mutable_proto())},
         frame.norm_meta,
         std::move(frame.user_meta),
@@ -161,14 +181,16 @@ arcticdb::proto::descriptors::TimeSeriesDescriptor descriptor_from_frame(
         frame.bucketize_dynamic);
 }
 
-void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& pipeline_context) {
-    if(pipeline_context->slice_and_keys_.empty())
+void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& pipeline_context)
+{
+    if (pipeline_context->slice_and_keys_.empty())
         return;
 
     pipeline_context->total_rows_ = adjust_slice_rowcounts(pipeline_context->slice_and_keys_);
 }
 
-size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys) {
+size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey>& slice_and_keys)
+{
     using namespace arcticdb::pipelines;
     auto current_col = slice_and_keys[0].slice_.col_range.first;
     size_t offset = 0u;
@@ -185,7 +207,8 @@ size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_ke
     return offset;
 }
 
-size_t get_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys) {
+size_t get_slice_rowcounts(std::vector<pipelines::SliceAndKey>& slice_and_keys)
+{
     auto current_col = slice_and_keys[0].slice_.col_range.first;
     size_t rowcount = 0u;
     for (auto& slice_and_key : slice_and_keys) {
@@ -199,15 +222,18 @@ size_t get_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys)
     return rowcount;
 }
 
-std::pair<size_t, size_t> offset_and_row_count(const std::shared_ptr<pipelines::PipelineContext>& context) {
+std::pair<size_t, size_t> offset_and_row_count(const std::shared_ptr<pipelines::PipelineContext>& context)
+{
     // count rows
     std::size_t row_count = 0ULL;
-    for(auto s = 0u; s < context->slice_and_keys_.size(); ++s) {
+    for (auto s = 0u; s < context->slice_and_keys_.size(); ++s) {
         if (context->fetch_index_[s]) {
             row_count += context->slice_and_keys_[s].slice_.row_range.diff();
             ARCTICDB_DEBUG(log::version(), "Adding {} rows", context->slice_and_keys_[s].slice_.row_range.diff());
         } else {
-            ARCTICDB_DEBUG(log::version(), "Fetch index false for this slice, would have added {} rows", context->slice_and_keys_[s].slice_.row_range.diff());
+            ARCTICDB_DEBUG(log::version(),
+                "Fetch index false for this slice, would have added {} rows",
+                context->slice_and_keys_[s].slice_.row_range.diff());
         }
     }
 
@@ -216,4 +242,4 @@ std::pair<size_t, size_t> offset_and_row_count(const std::shared_ptr<pipelines::
     return std::make_pair(offset, row_count);
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/pipeline/index_fields.hpp
+++ b/cpp/arcticdb/pipeline/index_fields.hpp
@@ -9,12 +9,31 @@
 
 namespace arcticdb::pipelines::index {
 enum class Fields : uint32_t {
-    start_index = 0, end_index, version_id, stream_id, creation_ts, content_hash, index_type, key_type,
-    start_col, end_col, start_row, end_row, hash_bucket, num_buckets
+    start_index = 0,
+    end_index,
+    version_id,
+    stream_id,
+    creation_ts,
+    content_hash,
+    index_type,
+    key_type,
+    start_col,
+    end_col,
+    start_row,
+    end_row,
+    hash_bucket,
+    num_buckets
 };
 
 enum class LegacyFields : uint32_t {
-    version_id = 0, stream_id, creation_ts, content_hash, index_type, start_index, end_index, key_type
+    version_id = 0,
+    stream_id,
+    creation_ts,
+    content_hash,
+    index_type,
+    start_index,
+    end_index,
+    key_type
 };
 
-}
+} // namespace arcticdb::pipelines::index

--- a/cpp/arcticdb/pipeline/index_segment_reader.hpp
+++ b/cpp/arcticdb/pipeline/index_segment_reader.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 
 namespace arcticdb {
-    class Store;
+class Store;
 }
 
 namespace arcticdb::pipelines::index {
@@ -25,11 +25,13 @@ namespace arcticdb::pipelines::index {
 struct IndexSegmentIterator;
 
 struct IndexSegmentReader {
-    const SegmentInMemory& seg() const {
+    const SegmentInMemory& seg() const
+    {
         return seg_;
     }
 
-    friend void swap(IndexSegmentReader& left, IndexSegmentReader& right) noexcept {
+    friend void swap(IndexSegmentReader& left, IndexSegmentReader& right) noexcept
+    {
         using std::swap;
 
         swap(left.seg_, right.seg_);
@@ -40,7 +42,7 @@ struct IndexSegmentReader {
 
     explicit IndexSegmentReader(SegmentInMemory&& s);
 
-    const Column &column(Fields field) const;
+    const Column& column(Fields field) const;
 
     SliceAndKey row(std::size_t i) const;
 
@@ -60,11 +62,13 @@ struct IndexSegmentReader {
 
     bool bucketize_dynamic() const;
 
-    const arcticdb::proto::descriptors::TimeSeriesDescriptor& tsd() const {
+    const arcticdb::proto::descriptors::TimeSeriesDescriptor& tsd() const
+    {
         return tsd_;
     }
 
-    arcticdb::proto::descriptors::TimeSeriesDescriptor& mutable_tsd() {
+    arcticdb::proto::descriptors::TimeSeriesDescriptor& mutable_tsd()
+    {
         return tsd_;
     }
 
@@ -84,54 +88,63 @@ public:
     using iterator_category = std::bidirectional_iterator_tag;
     using value_type = SliceAndKey;
     using difference_type = std::ptrdiff_t;
-    using pointer = SliceAndKey *;
-    using reference = SliceAndKey &;
+    using pointer = SliceAndKey*;
+    using reference = SliceAndKey&;
 
-    explicit IndexSegmentIterator(const IndexSegmentReader *reader) : reader_(reader) {}
+    explicit IndexSegmentIterator(const IndexSegmentReader* reader)
+        : reader_(reader)
+    {
+    }
 
-    IndexSegmentIterator(const IndexSegmentReader *reader, difference_type diff) : reader_(reader), diff_(diff) {}
+    IndexSegmentIterator(const IndexSegmentReader* reader, difference_type diff)
+        : reader_(reader),
+          diff_(diff)
+    {
+    }
 
-    IndexSegmentIterator &operator++() {
+    IndexSegmentIterator& operator++()
+    {
         ++diff_;
         return *this;
     }
 
-    IndexSegmentIterator operator++(int) {
+    IndexSegmentIterator operator++(int)
+    {
         IndexSegmentIterator tmp(reader_, diff_);
         ++*this;
         return tmp;
     }
 
-    reference operator*() {
+    reference operator*()
+    {
         value_ = reader_->row(diff_);
         return value_;
     }
 
-    pointer operator->() {
+    pointer operator->()
+    {
         value_ = reader_->row(diff_);
         return &value_;
     }
 
-    friend bool operator==(const IndexSegmentIterator &left, const IndexSegmentIterator &right) {
+    friend bool operator==(const IndexSegmentIterator& left, const IndexSegmentIterator& right)
+    {
         return left.diff_ == right.diff_;
     }
 
-    friend bool operator!=(const IndexSegmentIterator &left, const IndexSegmentIterator &right) {
+    friend bool operator!=(const IndexSegmentIterator& left, const IndexSegmentIterator& right)
+    {
         return !(left == right);
     }
 
 private:
-    const IndexSegmentReader *reader_;
+    const IndexSegmentReader* reader_;
     difference_type diff_ = 0;
     SliceAndKey value_;
 };
 
-index::IndexSegmentReader get_index_reader(
-    const AtomKey &prev_index,
-    const std::shared_ptr<Store> &store);
+index::IndexSegmentReader get_index_reader(const AtomKey& prev_index, const std::shared_ptr<Store>& store);
 
-IndexRange get_index_segment_range(
-    const AtomKey &prev_index,
-    const std::shared_ptr<Store> &store);
+IndexRange get_index_segment_range(const AtomKey& prev_index, const std::shared_ptr<Store>& store);
 
 } // namespace arcticdb::pipelines::index

--- a/cpp/arcticdb/pipeline/index_utils.cpp
+++ b/cpp/arcticdb/pipeline/index_utils.cpp
@@ -12,67 +12,63 @@
 
 namespace arcticdb::pipelines::index {
 
-template <class IndexType>
-    folly::Future<entity::AtomKey> write_index(
-        arcticdb::proto::descriptors::TimeSeriesDescriptor &&metadata,
-        std::vector<SliceAndKey> &&sk,
-        const IndexPartialKey &partial_key,
-        const std::shared_ptr<stream::StreamSink> &sink
-        ) {
-        auto slice_and_keys = std::move(sk);
-        IndexWriter<IndexType> writer(sink, partial_key, std::move(metadata));
-        for (const auto &slice_and_key : slice_and_keys) {
-            writer.add(slice_and_key.key(), slice_and_key.slice_);
-        }
-        return writer.commit();
+template<class IndexType>
+folly::Future<entity::AtomKey> write_index(arcticdb::proto::descriptors::TimeSeriesDescriptor&& metadata,
+    std::vector<SliceAndKey>&& sk,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink)
+{
+    auto slice_and_keys = std::move(sk);
+    IndexWriter<IndexType> writer(sink, partial_key, std::move(metadata));
+    for (const auto& slice_and_key : slice_and_keys) {
+        writer.add(slice_and_key.key(), slice_and_key.slice_);
     }
+    return writer.commit();
+}
 
-    folly::Future<entity::AtomKey> write_index(
-        const stream::Index& index,
-        arcticdb::proto::descriptors::TimeSeriesDescriptor &&metadata,
-        std::vector<SliceAndKey> &&sk,
-        const IndexPartialKey &partial_key,
-        const std::shared_ptr<stream::StreamSink> &sink
-        ) {
-        return util::variant_match(index, [&] (auto idx) {
-            using IndexType = decltype(idx);
-            return write_index<IndexType>(std::move(metadata), std::move(sk), partial_key, sink);
-        });
-    }
+folly::Future<entity::AtomKey> write_index(const stream::Index& index,
+    arcticdb::proto::descriptors::TimeSeriesDescriptor&& metadata,
+    std::vector<SliceAndKey>&& sk,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink)
+{
+    return util::variant_match(index, [&](auto idx) {
+        using IndexType = decltype(idx);
+        return write_index<IndexType>(std::move(metadata), std::move(sk), partial_key, sink);
+    });
+}
 
-    folly::Future<entity::AtomKey> write_index(
-        InputTensorFrame&& frame,
-        std::vector<SliceAndKey> &&slice_and_keys,
-        const IndexPartialKey &partial_key,
-        const std::shared_ptr<stream::StreamSink> &sink
-        ) {
-        auto offset = frame.offset;
-        auto index = stream::index_type_from_descriptor(frame.desc);
-        auto metadata = descriptor_from_frame(std::move(frame), offset);
-        return write_index(index, std::move(metadata), std::move(slice_and_keys), partial_key, sink);
-    }
+folly::Future<entity::AtomKey> write_index(InputTensorFrame&& frame,
+    std::vector<SliceAndKey>&& slice_and_keys,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink)
+{
+    auto offset = frame.offset;
+    auto index = stream::index_type_from_descriptor(frame.desc);
+    auto metadata = descriptor_from_frame(std::move(frame), offset);
+    return write_index(index, std::move(metadata), std::move(slice_and_keys), partial_key, sink);
+}
 
-    folly::Future<entity::AtomKey> write_index(
-        InputTensorFrame&& frame,
-        std::vector<folly::Future<SliceAndKey>> &&slice_and_keys,
-        const IndexPartialKey &partial_key,
-        const std::shared_ptr<stream::StreamSink> &sink
-        ) {
-        auto keys_fut = folly::collect(std::move(slice_and_keys));
-        auto slice_and_keys_vals = keys_fut.wait().value();
-        return write_index(std::move(frame), std::move(slice_and_keys_vals), partial_key, sink);
-    }
+folly::Future<entity::AtomKey> write_index(InputTensorFrame&& frame,
+    std::vector<folly::Future<SliceAndKey>>&& slice_and_keys,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink)
+{
+    auto keys_fut = folly::collect(std::move(slice_and_keys));
+    auto slice_and_keys_vals = keys_fut.wait().value();
+    return write_index(std::move(frame), std::move(slice_and_keys_vals), partial_key, sink);
+}
 
-    std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vector(
-        const std::shared_ptr<Store> &store,
-        const AtomKey &index_key) {
-        auto [_, index_seg] = store->read_sync(index_key);
-        index::IndexSegmentReader index_segment_reader(std::move(index_seg));
-        std::vector<SliceAndKey> slice_and_keys;
-        for (auto row : index_segment_reader)
-            slice_and_keys.push_back(row);
+std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vector(const std::shared_ptr<Store>& store,
+    const AtomKey& index_key)
+{
+    auto [_, index_seg] = store->read_sync(index_key);
+    index::IndexSegmentReader index_segment_reader(std::move(index_seg));
+    std::vector<SliceAndKey> slice_and_keys;
+    for (auto row : index_segment_reader)
+        slice_and_keys.push_back(row);
 
-        return {std::move(index_segment_reader), std::move(slice_and_keys)};
-    }
+    return {std::move(index_segment_reader), std::move(slice_and_keys)};
+}
 
 } //namespace arcticdb::pipelines::index

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -23,10 +23,11 @@ struct StreamSink;
 namespace pipelines {
 struct InputTensorFrame;
 }
-}
+} // namespace arcticdb
 
 namespace arcticdb::pipelines::index {
-inline std::vector<SliceAndKey> unfiltered_index(const index::IndexSegmentReader &index_segment_reader) {
+inline std::vector<SliceAndKey> unfiltered_index(const index::IndexSegmentReader& index_segment_reader)
+{
     ARCTICDB_SAMPLE_DEFAULT(FilterIndex)
     std::vector<SliceAndKey> output;
     std::copy(std::cbegin(index_segment_reader), std::cend(index_segment_reader), std::back_inserter(output));
@@ -34,106 +35,103 @@ inline std::vector<SliceAndKey> unfiltered_index(const index::IndexSegmentReader
 }
 
 template<typename RowType>
-std::optional<IndexValue> index_value_from_row(const RowType &row, IndexDescriptor::Type index_type, int field_num) {
+std::optional<IndexValue> index_value_from_row(const RowType& row, IndexDescriptor::Type index_type, int field_num)
+{
     std::optional<IndexValue> index_value;
     switch (index_type) {
     case IndexDescriptor::TIMESTAMP:
-        case IndexDescriptor::ROWCOUNT:
-            index_value = row.template scalar_at<timestamp>(field_num);
-            break;
-            case IndexDescriptor::STRING: {
-                auto opt = row.string_at(field_num);
-                index_value = opt ? std::make_optional<IndexValue>(std::string(opt.value())) : std::nullopt;
-                break;
-            }
-            default:
-                util::raise_rte("Unknown index type {} for column {}", int(index_type), field_num);
+    case IndexDescriptor::ROWCOUNT:
+        index_value = row.template scalar_at<timestamp>(field_num);
+        break;
+    case IndexDescriptor::STRING: {
+        auto opt = row.string_at(field_num);
+        index_value = opt ? std::make_optional<IndexValue>(std::string(opt.value())) : std::nullopt;
+        break;
+    }
+    default:
+        util::raise_rte("Unknown index type {} for column {}", int(index_type), field_num);
     }
     return index_value;
 }
 
 template<typename RowType>
-std::optional<IndexValue> index_start_from_row(const RowType &row, IndexDescriptor::Type index_type) {
+std::optional<IndexValue> index_start_from_row(const RowType& row, IndexDescriptor::Type index_type)
+{
     return index_value_from_row(row, index_type, 0);
 }
 
-template<typename SegmentType, typename FieldType=pipelines::index::Fields>
-    IndexValue index_value_from_segment(const SegmentType &seg, size_t row_id, FieldType field) {
+template<typename SegmentType, typename FieldType = pipelines::index::Fields>
+IndexValue index_value_from_segment(const SegmentType& seg, size_t row_id, FieldType field)
+{
     auto index_type = seg.template scalar_at<uint8_t>(row_id, int(FieldType::index_type));
     IndexValue index_value;
     switch (index_type.value()) {
     case IndexDescriptor::TIMESTAMP:
-        case IndexDescriptor::ROWCOUNT:
-            index_value = seg.template scalar_at<timestamp>(row_id, int(field)).value();
-            break;
-            case IndexDescriptor::STRING:
-                index_value = std::string(seg.string_at(row_id, int(field)).value());
-                break;
-                default:
-                    util::raise_rte("Unknown index type {} for column {} and row {}",
-                                    uint32_t(index_type.value()), uint32_t(field), row_id);
+    case IndexDescriptor::ROWCOUNT:
+        index_value = seg.template scalar_at<timestamp>(row_id, int(field)).value();
+        break;
+    case IndexDescriptor::STRING:
+        index_value = std::string(seg.string_at(row_id, int(field)).value());
+        break;
+    default:
+        util::raise_rte("Unknown index type {} for column {} and row {}",
+            uint32_t(index_type.value()),
+            uint32_t(field),
+            row_id);
     }
     return index_value;
 }
 
 template<typename SegmentType, typename FieldType>
-IndexValue index_start_from_segment(const SegmentType &seg, size_t row_id) {
+IndexValue index_start_from_segment(const SegmentType& seg, size_t row_id)
+{
     return index_value_from_segment(seg, row_id, FieldType::start_index);
 }
 
 template<typename SegmentType, typename FieldType>
-IndexValue index_end_from_segment(const SegmentType &seg, size_t row_id) {
+IndexValue index_end_from_segment(const SegmentType& seg, size_t row_id)
+{
     return index_value_from_segment(seg, row_id, FieldType::end_index);
 }
 
 template<class IndexType>
-    folly::Future<entity::AtomKey> write_index(
-        arcticdb::proto::descriptors::TimeSeriesDescriptor&& metadata,
-        std::vector<SliceAndKey>&& slice_and_keys,
-        const IndexPartialKey& partial_key,
-        const std::shared_ptr<stream::StreamSink>& sink);
+folly::Future<entity::AtomKey> write_index(arcticdb::proto::descriptors::TimeSeriesDescriptor&& metadata,
+    std::vector<SliceAndKey>&& slice_and_keys,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink);
 
-folly::Future<entity::AtomKey> write_index(
-    const stream::Index& index,
-    arcticdb::proto::descriptors::TimeSeriesDescriptor &&metadata,
-    std::vector<SliceAndKey> &&sk,
-    const IndexPartialKey &partial_key,
-    const std::shared_ptr<stream::StreamSink> &sink
-    );
+folly::Future<entity::AtomKey> write_index(const stream::Index& index,
+    arcticdb::proto::descriptors::TimeSeriesDescriptor&& metadata,
+    std::vector<SliceAndKey>&& sk,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink);
 
-folly::Future<entity::AtomKey> write_index(
-    InputTensorFrame&& frame,
-    std::vector<folly::Future<SliceAndKey>> &&slice_and_keys,
-    const IndexPartialKey &partial_key,
-    const std::shared_ptr<stream::StreamSink> &sink
-    );
+folly::Future<entity::AtomKey> write_index(InputTensorFrame&& frame,
+    std::vector<folly::Future<SliceAndKey>>&& slice_and_keys,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink);
 
-folly::Future<entity::AtomKey> write_index(
-    InputTensorFrame&& frame,
-    std::vector<SliceAndKey> &&slice_and_keys,
-    const IndexPartialKey &partial_key,
-    const std::shared_ptr<stream::StreamSink> &sink
-    );
+folly::Future<entity::AtomKey> write_index(InputTensorFrame&& frame,
+    std::vector<SliceAndKey>&& slice_and_keys,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink);
 
-inline folly::Future<VersionedItem> index_and_version(
-    const stream::Index& index,
+inline folly::Future<VersionedItem> index_and_version(const stream::Index& index,
     const std::shared_ptr<stream::StreamSink>& store,
     arcticdb::proto::descriptors::TimeSeriesDescriptor time_series,
     std::vector<SliceAndKey> slice_and_keys,
     const StreamId& stream_id,
-    VersionId version_id) {
-    return write_index(
-        index,
+    VersionId version_id)
+{
+    return write_index(index,
         std::move(time_series),
         std::move(slice_and_keys),
         IndexPartialKey{stream_id, version_id},
-        store).thenValue([] (auto&& version_key) {
-            return VersionedItem(to_atom(std::move(version_key)));
-        });
+        store)
+        .thenValue([](auto&& version_key) { return VersionedItem(to_atom(std::move(version_key))); });
 }
 
-std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vector(
-    const std::shared_ptr<Store>& store,
+std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vector(const std::shared_ptr<Store>& store,
     const AtomKey& index_key);
 
 } //namespace arcticdb::pipelines::index

--- a/cpp/arcticdb/pipeline/index_writer.hpp
+++ b/cpp/arcticdb/pipeline/index_writer.hpp
@@ -27,51 +27,55 @@ class IndexWriter : boost::noncopyable {
     using Desc = stream::IndexSliceDescriptor<AggregatorIndexType>;
 
 public:
-    IndexWriter(std::shared_ptr<stream::StreamSink> sink, IndexPartialKey partial_key, TimeSeriesDescriptor &&meta, const std::optional<KeyType>& key_type = std::nullopt) :
-            bucketize_columns_(meta.has_column_groups() && meta.column_groups().enabled()),
-            partial_key_(std::move(partial_key)),
-            meta_(std::move(meta)),
-            agg_(Desc::schema(partial_key_.id, bucketize_columns_),
-            [&](auto &&segment) {
-            on_segment(std::forward<SegmentInMemory>(segment));
-            },
-            stream::NeverSegmentPolicy{}),
-            sink_(std::move(sink)),
-            key_being_committed_(folly::Future<AtomKey>::makeEmpty()),
-            key_type_(key_type){
+    IndexWriter(std::shared_ptr<stream::StreamSink> sink,
+        IndexPartialKey partial_key,
+        TimeSeriesDescriptor&& meta,
+        const std::optional<KeyType>& key_type = std::nullopt)
+        : bucketize_columns_(meta.has_column_groups() && meta.column_groups().enabled()),
+          partial_key_(std::move(partial_key)),
+          meta_(std::move(meta)),
+          agg_(
+              Desc::schema(partial_key_.id, bucketize_columns_),
+              [&](auto&& segment) { on_segment(std::forward<SegmentInMemory>(segment)); },
+              stream::NeverSegmentPolicy{}),
+          sink_(std::move(sink)),
+          key_being_committed_(folly::Future<AtomKey>::makeEmpty()),
+          key_type_(key_type)
+    {
 
         google::protobuf::Any any;
         any.PackFrom(meta_);
         agg_.segment().set_metadata(std::move(any));
     }
 
-    void add(const arcticdb::entity::AtomKey &key, const FrameSlice &slice) {
+    void add(const arcticdb::entity::AtomKey& key, const FrameSlice& slice)
+    {
         // ensure sorted by col group then row group, this is normally the case but in append scenario,
         // one will need to ensure that this holds, otherwise the assumptions in the read pipeline will be
         // broken.
         ARCTICDB_DEBUG(log::version(), "Wriiting key {} to the index", key);
         util::check_arg(!current_col_.has_value() || current_col_.value() <= slice.col_range.first,
-                        "expected increasing column group, last col range left value {}, arg {}",
-                        current_col_.value_or(-1), slice.col_range
-        );
+            "expected increasing column group, last col range left value {}, arg {}",
+            current_col_.value_or(-1),
+            slice.col_range);
 
         bool new_col_group = !current_col_.has_value() || current_col_.value() < slice.col_range.first;
-        util::check_arg(!current_row_.has_value() || new_col_group
-                        ||
-                        (current_col_.value() == slice.col_range.first && current_row_.value() < slice.row_range.first),
-                        "expected increasing row group, last col range left value {}, arg {}",
-                        current_col_.value_or(-1), slice.col_range
-        );
-        auto add_to_row ARCTICDB_UNUSED = [&](auto &rb) {
+        util::check_arg(
+            !current_row_.has_value() || new_col_group ||
+                (current_col_.value() == slice.col_range.first && current_row_.value() < slice.row_range.first),
+            "expected increasing row group, last col range left value {}, arg {}",
+            current_col_.value_or(-1),
+            slice.col_range);
+        auto add_to_row ARCTICDB_UNUSED = [&](auto& rb) {
             rb.set_scalar(int(Fields::version_id), key.version_id());
             rb.set_scalar(int(Fields::creation_ts), key.creation_ts());
             rb.set_scalar(int(Fields::content_hash), key.content_hash());
             rb.set_scalar(int(Fields::index_type), static_cast<uint8_t>(stream::get_index_value_type(key)));
 
-            std::visit([&rb](auto &&val) { rb.set_scalar(int(Fields::stream_id), val); }, key.id());
+            std::visit([&rb](auto&& val) { rb.set_scalar(int(Fields::stream_id), val); }, key.id());
 
             // note that we don't se the start index since its presence is index type specific
-            std::visit([&rb](auto &&val) { rb.set_scalar(int(Fields::end_index), val); }, key.end_index());
+            std::visit([&rb](auto&& val) { rb.set_scalar(int(Fields::end_index), val); }, key.end_index());
 
             rb.set_scalar(int(Fields::key_type), static_cast<char>(key.type()));
 
@@ -80,16 +84,16 @@ public:
             rb.set_scalar(int(Fields::start_row), slice.row_range.first);
             rb.set_scalar(int(Fields::end_row), slice.row_range.second);
 
-            if(bucketize_columns_) {
+            if (bucketize_columns_) {
                 util::check(static_cast<bool>(slice.hash_bucket()) && static_cast<bool>(slice.num_buckets()),
-                            "Found no hash bucket in an index writer with bucketizing");
+                    "Found no hash bucket in an index writer with bucketizing");
                 rb.set_scalar(int(Fields::hash_bucket), *slice.hash_bucket());
                 rb.set_scalar(int(Fields::num_buckets), *slice.num_buckets());
             }
         };
 
-        agg_.start_row()([&](auto &rb) {
-            std::visit([&rb](auto &&val) { rb.set_scalar(int(Fields::start_index), val); }, key.start_index());
+        agg_.start_row()([&](auto& rb) {
+            std::visit([&rb](auto&& val) { rb.set_scalar(int(Fields::start_index), val); }, key.start_index());
             add_to_row(rb);
         });
 
@@ -99,28 +103,35 @@ public:
         current_row_ = slice.row_range.first;
     }
 
-    folly::Future<arcticdb::entity::AtomKey> commit() {
+    folly::Future<arcticdb::entity::AtomKey> commit()
+    {
         agg_.commit();
         return std::move(key_being_committed_);
     }
 
 private:
-    IndexValue segment_start(const SegmentInMemory &segment) const {
+    IndexValue segment_start(const SegmentInMemory& segment) const
+    {
         return Index::start_value_for_keys_segment(segment);
     }
 
-    IndexValue segment_end(const SegmentInMemory &segment) const {
+    IndexValue segment_end(const SegmentInMemory& segment) const
+    {
         return Index::end_value_for_keys_segment(segment);
     }
 
-    void on_segment(SegmentInMemory &&s) {
+    void on_segment(SegmentInMemory&& s)
+    {
         auto seg = std::move(s);
         auto key_type = key_type_ ? key_type_.value() : get_key_type_for_index_stream(partial_key_.id);
-        key_being_committed_ = sink_->write(
-            key_type, partial_key_.version_id, partial_key_.id,
-                segment_start(seg), segment_end(seg), std::move(seg)).thenValue([] (auto&& variant_key) {
-                    return to_atom(variant_key);
-                });
+        key_being_committed_ = sink_
+                                   ->write(key_type,
+                                       partial_key_.version_id,
+                                       partial_key_.id,
+                                       segment_start(seg),
+                                       segment_end(seg),
+                                       std::move(seg))
+                                   .thenValue([](auto&& variant_key) { return to_atom(variant_key); });
     }
 
     bool bucketize_columns_ = false;
@@ -134,5 +145,4 @@ private:
     std::optional<KeyType> key_type_ = std::nullopt;
 };
 
-
-} //namespace arcticdb::pipeline::index
+} // namespace arcticdb::pipelines::index

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -22,12 +22,13 @@ struct InputTensorFrame {
 
     template<class T>
     static constexpr bool is_valid_index_v =
-        std::is_same_v<T, stream::TimeseriesIndex> ||
-        std::is_same_v<T, stream::RowCountIndex> ||
+        std::is_same_v<T, stream::TimeseriesIndex> || std::is_same_v<T, stream::RowCountIndex> ||
         std::is_same_v<T, stream::TableIndex>;
 
-    InputTensorFrame() :
-        index(stream::empty_index()) {}
+    InputTensorFrame()
+        : index(stream::empty_index())
+    {
+    }
 
     StreamDescriptor desc;
     mutable arcticdb::proto::descriptors::NormalizationMetadata norm_meta;
@@ -40,42 +41,49 @@ struct InputTensorFrame {
     mutable ssize_t offset = 0;
     mutable bool bucketize_dynamic = 0;
 
-    void set_offset(ssize_t off) const {
+    void set_offset(ssize_t off) const
+    {
         offset = off;
     }
 
-    void set_sorted(SortedValue sorted) {
+    void set_sorted(SortedValue sorted)
+    {
         desc.set_sorted(sorted);
     }
 
-    void set_bucketize_dynamic(bool bucketize) const {
+    void set_bucketize_dynamic(bool bucketize) const
+    {
         bucketize_dynamic = bucketize;
     }
 
-    bool has_index() const { return desc.index().field_count() != 0ULL; }
+    bool has_index() const
+    {
+        return desc.index().field_count() != 0ULL;
+    }
 
-    void set_index_range() {
-            // Fill index range
-            // Note RowCountIndex will normally have an index field count of 0
-            if (desc.index().field_count() == 1) {
-                visit_field(desc.field(0), [&](auto &&tag) {
-                    using DT = std::decay_t<decltype(tag)>;
-                    using RawType = typename DT::DataTypeTag::raw_type;
-                    if constexpr (std::is_integral_v<RawType> || std::is_floating_point_v<RawType>) {
-                        util::check(static_cast<bool>(index_tensor), "Got null index tensor in set_index_range");
-                        auto &tensor = index_tensor.value();
-                        auto start_t = tensor.ptr_cast<RawType>(0);
-                        auto end_t = tensor.ptr_cast<RawType>(static_cast<size_t>(tensor.shape(0) - 1));
-                        index_range.start_  = IndexValue(static_cast<timestamp>(*start_t));
-                        index_range.end_ = IndexValue(static_cast<timestamp>(*end_t));
-                    } else
-                        throw std::runtime_error("Unsupported non-integral index type");
-                });
-            } else {
-                index_range.start_  = IndexValue{0};
-                index_range.end_ = IndexValue{static_cast<timestamp>(num_rows) - 1};
-            }
+    void set_index_range()
+    {
+        // Fill index range
+        // Note RowCountIndex will normally have an index field count of 0
+        if (desc.index().field_count() == 1) {
+            visit_field(desc.field(0), [&](auto&& tag) {
+                using DT = std::decay_t<decltype(tag)>;
+                using RawType = typename DT::DataTypeTag::raw_type;
+                if constexpr (std::is_integral_v<RawType> || std::is_floating_point_v<RawType>) {
+                    util::check(static_cast<bool>(index_tensor), "Got null index tensor in set_index_range");
+                    auto& tensor = index_tensor.value();
+                    auto start_t = tensor.ptr_cast<RawType>(0);
+                    auto end_t = tensor.ptr_cast<RawType>(static_cast<size_t>(tensor.shape(0) - 1));
+                    index_range.start_ = IndexValue(static_cast<timestamp>(*start_t));
+                    index_range.end_ = IndexValue(static_cast<timestamp>(*end_t));
+                } else
+                    throw std::runtime_error("Unsupported non-integral index type");
+            });
+        } else {
+            index_range.start_ = IndexValue{0};
+            index_range.end_ = IndexValue{static_cast<timestamp>(num_rows) - 1};
         }
+    }
 };
 
 } //namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/pipeline_common.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_common.hpp
@@ -17,4 +17,4 @@ struct IndexPartialKey {
     StreamId id;
     VersionId version_id;
 };
-}
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -13,8 +13,9 @@
 
 namespace arcticdb::pipelines {
 
-PipelineContext::PipelineContext(SegmentInMemory& frame, const AtomKey& key) :
-    desc_(frame.descriptor()){
+PipelineContext::PipelineContext(SegmentInMemory& frame, const AtomKey& key)
+    : desc_(frame.descriptor())
+{
     SliceAndKey sk{FrameSlice{frame}, key};
     slice_and_keys_.emplace_back(std::move(sk));
     util::BitSet bitset(1);
@@ -31,78 +32,95 @@ PipelineContext::PipelineContext(SegmentInMemory& frame, const AtomKey& key) :
     segment_descriptors_[0] = (std::move(descriptor));
 }
 
-void PipelineContext::set_selected_columns(const std::vector<std::string>& columns) {
+void PipelineContext::set_selected_columns(const std::vector<std::string>& columns)
+{
     util::check(static_cast<bool>(desc_), "Descriptor not set in set_selected_columns");
     selected_columns_ = requested_column_bitset_including_index(desc_->proto(), columns);
 }
 
-bool PipelineContextRow::selected_columns(size_t n) const {
+bool PipelineContextRow::selected_columns(size_t n) const
+{
     return !parent_->selected_columns_ || parent_->selected_columns_.value()[n];
 }
 
-const std::optional<util::BitSet>& PipelineContextRow::get_selected_columns() const {
+const std::optional<util::BitSet>& PipelineContextRow::get_selected_columns() const
+{
     return parent_->selected_columns_;
 }
 
-const StringPool &PipelineContextRow::string_pool() const {
+const StringPool& PipelineContextRow::string_pool() const
+{
     return *parent_->string_pools_[index_];
 }
 
-StringPool &PipelineContextRow::string_pool() {
+StringPool& PipelineContextRow::string_pool()
+{
     return *parent_->string_pools_[index_];
 }
 
-void PipelineContextRow::allocate_string_pool() {
+void PipelineContextRow::allocate_string_pool()
+{
     parent_->string_pools_[index_] = std::make_shared<StringPool>();
 }
 
-
-void PipelineContextRow::set_string_pool(const std::shared_ptr<StringPool>& pool) {
+void PipelineContextRow::set_string_pool(const std::shared_ptr<StringPool>& pool)
+{
     parent_->string_pools_[index_] = pool;
 }
 
-const SliceAndKey &PipelineContextRow::slice_and_key() const {
+const SliceAndKey& PipelineContextRow::slice_and_key() const
+{
     return parent_->slice_and_keys_[index_];
 }
 
-SliceAndKey &PipelineContextRow::slice_and_key()  {
+SliceAndKey& PipelineContextRow::slice_and_key()
+{
     return parent_->slice_and_keys_[index_];
 }
 
-bool PipelineContextRow::fetch_index() {
+bool PipelineContextRow::fetch_index()
+{
     return parent_->fetch_index_[index_];
 }
 
-size_t PipelineContextRow::index() const {
+size_t PipelineContextRow::index() const
+{
     return index_;
 }
 
-bool PipelineContextRow::has_string_pool() const {
+bool PipelineContextRow::has_string_pool() const
+{
     return static_cast<bool>(parent_->string_pools_[index_]);
 }
-const StreamDescriptor& PipelineContextRow::descriptor() const {
+const StreamDescriptor& PipelineContextRow::descriptor() const
+{
     util::check(index_ < parent_->segment_descriptors_.size(), "Descriptor out of bounds for index {}", index_);
     util::check(static_cast<bool>(parent_->segment_descriptors_[index_]), "Null descriptor at index {}", index_);
     return *parent_->segment_descriptors_[index_];
 }
 
-void PipelineContextRow::set_descriptor(std::shared_ptr<StreamDescriptor>&& desc) {
+void PipelineContextRow::set_descriptor(std::shared_ptr<StreamDescriptor>&& desc)
+{
     parent_->segment_descriptors_[index_] = std::move(desc);
 }
 
-void PipelineContextRow::set_descriptor(const std::shared_ptr<StreamDescriptor>& desc) {
+void PipelineContextRow::set_descriptor(const std::shared_ptr<StreamDescriptor>& desc)
+{
     parent_->segment_descriptors_[index_] = desc;
 }
 
-void PipelineContextRow::set_compacted(bool val) {
+void PipelineContextRow::set_compacted(bool val)
+{
     parent_->compacted_[index_] = val;
 }
 
-bool PipelineContextRow::compacted() const {
+bool PipelineContextRow::compacted() const
+{
     return parent_->compacted_[index_];
 }
 
-void PipelineContextRow::set_descriptor(arcticdb::proto::descriptors::StreamDescriptor&& proto_desc) {
+void PipelineContextRow::set_descriptor(arcticdb::proto::descriptors::StreamDescriptor&& proto_desc)
+{
     auto desc = std::make_shared<StreamDescriptor>(std::move(proto_desc));
     set_descriptor(std::move(desc));
 }

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -23,9 +23,11 @@ struct PipelineContextRow {
     std::shared_ptr<PipelineContext> parent_;
     size_t index_;
 
-    PipelineContextRow(const std::shared_ptr<PipelineContext>& parent, size_t index) :
-        parent_(parent),
-        index_(index) { }
+    PipelineContextRow(const std::shared_ptr<PipelineContext>& parent, size_t index)
+        : parent_(parent),
+          index_(index)
+    {
+    }
 
     PipelineContextRow() = default;
 
@@ -54,32 +56,51 @@ struct PipelineContextRow {
  */
 struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
-    template <class ValueType>
-    class PipelineContextIterator :  public boost::iterator_facade<PipelineContextIterator<ValueType>, ValueType, boost::random_access_traversal_tag> {
+    template<class ValueType>
+    class PipelineContextIterator : public boost::iterator_facade<PipelineContextIterator<ValueType>,
+                                        ValueType,
+                                        boost::random_access_traversal_tag> {
         std::shared_ptr<PipelineContext> parent_;
-        size_t  index_;
+        size_t index_;
+
     public:
         PipelineContextIterator(std::shared_ptr<PipelineContext> parent, size_t index)
-            :  parent_(std::move(parent)), index_(index) { }
+            : parent_(std::move(parent)),
+              index_(index)
+        {
+        }
 
-        template <class OtherValue>
+        template<class OtherValue>
         explicit PipelineContextIterator(const PipelineContextIterator<OtherValue>& other)
-            : parent_(other.parent_), index_(other.index_){}
+            : parent_(other.parent_),
+              index_(other.index_)
+        {
+        }
 
-        template <class OtherValue>
+        template<class OtherValue>
         bool equal(const PipelineContextIterator<OtherValue>& other) const
         {
             util::check(parent_ == other.parent_, "Invalid context iterator comparison");
             return index_ == other.index_;
         }
 
-        void increment(){ ++index_; }
+        void increment()
+        {
+            ++index_;
+        }
 
-        void decrement(){ --index_; }
+        void decrement()
+        {
+            --index_;
+        }
 
-        void advance(ptrdiff_t n){ index_ += n; }
+        void advance(ptrdiff_t n)
+        {
+            index_ += n;
+        }
 
-        ValueType& dereference() const {
+        ValueType& dereference() const
+        {
             row_ = PipelineContextRow{parent_, index_};
             return row_;
         }
@@ -89,8 +110,10 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
     PipelineContext() = default;
 
-    explicit PipelineContext(StreamDescriptor desc) :
-        desc_(std::move(desc)) {}
+    explicit PipelineContext(StreamDescriptor desc)
+        : desc_(std::move(desc))
+    {
+    }
 
     explicit PipelineContext(SegmentInMemory& frame, const AtomKey& key);
 
@@ -125,45 +148,54 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     std::optional<size_t> incompletes_after_;
     bool bucketize_dynamic_ = false;
 
-    PipelineContextRow operator[](size_t num) {
+    PipelineContextRow operator[](size_t num)
+    {
         return PipelineContextRow{shared_from_this(), num};
     }
 
-    size_t last_slice_row() const {
+    size_t last_slice_row() const
+    {
         return slice_and_keys_.empty() ? 0 : slice_and_keys_.rbegin()->slice_.row_range.second;
     }
 
-    size_t first_slice_row() const {
+    size_t first_slice_row() const
+    {
         return slice_and_keys_.empty() ? 0 : slice_and_keys_.begin()->slice_.row_range.first;
     }
 
-    size_t calc_rows() const {
+    size_t calc_rows() const
+    {
         return last_slice_row() - first_slice_row();
     }
 
-    const StreamDescriptor& descriptor() const {
+    const StreamDescriptor& descriptor() const
+    {
         util::check(static_cast<bool>(desc_), "Stream descriptor not found in pipeline context");
         return *desc_;
     }
 
-    void set_descriptor(StreamDescriptor&& desc) {
+    void set_descriptor(StreamDescriptor&& desc)
+    {
         desc_ = std::move(desc);
     }
 
-    void set_descriptor(const StreamDescriptor& desc) {
+    void set_descriptor(const StreamDescriptor& desc)
+    {
         desc_ = desc;
     }
 
     void set_selected_columns(const std::vector<std::string>& columns);
 
-    IndexRange index_range() const {
-        if(slice_and_keys_.empty())
+    IndexRange index_range() const
+    {
+        if (slice_and_keys_.empty())
             return unspecified_range();
 
-        return IndexRange{ slice_and_keys_.begin()->key().start_index(), slice_and_keys_.rbegin()->key().end_index() };
+        return IndexRange{slice_and_keys_.begin()->key().start_index(), slice_and_keys_.rbegin()->key().end_index()};
     }
 
-    friend void swap(PipelineContext& left, PipelineContext& right) noexcept {
+    friend void swap(PipelineContext& left, PipelineContext& right) noexcept
+    {
         using std::swap;
 
         swap(left.desc_, right.desc_);
@@ -183,21 +215,33 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
     using iterator = PipelineContextIterator<PipelineContextRow>;
     using const_iterator = PipelineContextIterator<const PipelineContextRow>;
-    iterator begin() { return iterator{shared_from_this(), size_t(0)}; }
-
-    iterator incompletes_begin() { return iterator{shared_from_this(), incompletes_after() }; }
-
-    size_t incompletes_after() const { return incompletes_after_.value_or(slice_and_keys_.size());  }
-
-    iterator end() {
-        return iterator{shared_from_this(),  slice_and_keys_.size()};
+    iterator begin()
+    {
+        return iterator{shared_from_this(), size_t(0)};
     }
 
-    bool is_in_filter_columns_set(std::string_view name) {
+    iterator incompletes_begin()
+    {
+        return iterator{shared_from_this(), incompletes_after()};
+    }
+
+    size_t incompletes_after() const
+    {
+        return incompletes_after_.value_or(slice_and_keys_.size());
+    }
+
+    iterator end()
+    {
+        return iterator{shared_from_this(), slice_and_keys_.size()};
+    }
+
+    bool is_in_filter_columns_set(std::string_view name)
+    {
         return !filter_columns_set_ || filter_columns_set_.value().find(name) != filter_columns_set_.value().end();
     }
 
-    void clear_vectors() {
+    void clear_vectors()
+    {
         slice_and_keys_.clear();
         fetch_index_.clear();
         string_pools_.clear();
@@ -205,7 +249,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
         compacted_.clear();
     }
 
-    void ensure_vectors() {
+    void ensure_vectors()
+    {
         util::check(slice_and_keys_.size() == fetch_index_.size(), "Size mismatch in pipeline context index vector");
         auto size = slice_and_keys_.size();
         string_pools_.resize(size);
@@ -213,10 +258,12 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
         compacted_.resize(size);
     }
 
-    bool is_pickled() const {
+    bool is_pickled() const
+    {
         util::check(static_cast<bool>(norm_meta_), "No normalization metadata defined");
-        return norm_meta_->input_type_case() == arcticdb::proto::descriptors::NormalizationMetadata::InputTypeCase::kMsgPackFrame;
+        return norm_meta_->input_type_case() ==
+               arcticdb::proto::descriptors::NormalizationMetadata::InputTypeCase::kMsgPackFrame;
     }
 };
 
-}
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -15,9 +15,10 @@
 
 namespace arcticdb::pipelines {
 
-inline ReadResult make_read_result_from_frame(FrameAndDescriptor& frame_and_desc, const AtomKey& key) {
+inline ReadResult make_read_result_from_frame(FrameAndDescriptor& frame_and_desc, const AtomKey& key)
+{
     auto pipeline_context = std::make_shared<PipelineContext>(frame_and_desc.frame_.descriptor());
-    SliceAndKey sk{FrameSlice{frame_and_desc.frame_},key};
+    SliceAndKey sk{FrameSlice{frame_and_desc.frame_}, key};
     pipeline_context->slice_and_keys_.emplace_back(std::move(sk));
     util::BitSet bitset(1);
     bitset.flip();
@@ -33,4 +34,4 @@ inline ReadResult make_read_result_from_frame(FrameAndDescriptor& frame_and_desc
     return create_python_read_result(VersionedItem{key}, std::move(frame_and_desc));
 }
 
-}
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/python_output_frame.cpp
+++ b/cpp/arcticdb/pipeline/python_output_frame.cpp
@@ -12,28 +12,31 @@
 
 namespace arcticdb::pipelines {
 
-PythonOutputFrame::PythonOutputFrame(const SegmentInMemory &frame, std::shared_ptr<BufferHolder> buffers) :
-        module_data_(ModuleData::instance()),
-        frame_(frame),
-        names_(frame.fields().size() - frame.descriptor().index().field_count()),
-        index_columns_(frame.descriptor().index().field_count()),
-        buffers_(std::move(buffers)) {
+PythonOutputFrame::PythonOutputFrame(const SegmentInMemory& frame, std::shared_ptr<BufferHolder> buffers)
+    : module_data_(ModuleData::instance()),
+      frame_(frame),
+      names_(frame.fields().size() - frame.descriptor().index().field_count()),
+      index_columns_(frame.descriptor().index().field_count()),
+      buffers_(std::move(buffers))
+{
     ARCTICDB_SAMPLE_DEFAULT(PythonOutputFrameCtor)
     const auto field_count = frame.descriptor().index().field_count();
     // works because we ensure that the index must be fetched
     for (std::size_t c = 0; c < field_count; ++c) {
         index_columns_[c] = frame.field(c).name();
     }
-    for (std::size_t c = frame.descriptor().index().field_count(); c < static_cast<size_t>(frame.fields().size()); ++c) {
+    for (std::size_t c = frame.descriptor().index().field_count(); c < static_cast<size_t>(frame.fields().size()); ++c)
+    {
         names_[c - field_count] = frame.field(c).name();
     }
 }
 
-PythonOutputFrame::~PythonOutputFrame() {
-    if(frame_.is_null())
+PythonOutputFrame::~PythonOutputFrame()
+{
+    if (frame_.is_null())
         return;
 
-    for (auto &column : frame_.columns()) {
+    for (auto& column : frame_.columns()) {
         auto dt = column->type().data_type();
         if (is_dynamic_string_type(dt) && column->is_inflated()) {
             auto column_data = column->data();
@@ -42,8 +45,8 @@ PythonOutputFrame::~PythonOutputFrame() {
                 if constexpr (is_dynamic_string_type(TDT::DataTypeTag::data_type)) {
                     while (auto block = column_data.next<TDT>()) {
                         for (auto item : block.value()) {
-                          util::check(reinterpret_cast<PyObject *>(item) != nullptr, "Can't delete null item");
-                          Py_DECREF(reinterpret_cast<PyObject *>(item));
+                            util::check(reinterpret_cast<PyObject*>(item) != nullptr, "Can't delete null item");
+                            Py_DECREF(reinterpret_cast<PyObject*>(item));
                         }
                     }
                 }
@@ -53,17 +56,19 @@ PythonOutputFrame::~PythonOutputFrame() {
     Allocator::instance()->trim();
 }
 
-std::shared_ptr<FrameDataWrapper> PythonOutputFrame::arrays(py::object &ref) {
-    if(auto cached = arrays_.lock())
+std::shared_ptr<FrameDataWrapper> PythonOutputFrame::arrays(py::object& ref)
+{
+    if (auto cached = arrays_.lock())
         return cached;
 
     auto generated = arcticdb::detail::initialize_array(frame_, ref);
-    arrays_  = generated;
+    arrays_ = generated;
     return generated;
 }
 
-py::array PythonOutputFrame::array_at(std::size_t col_pos, py::object &anchor) {
+py::array PythonOutputFrame::array_at(std::size_t col_pos, py::object& anchor)
+{
     return arcticdb::detail::array_at(frame_, col_pos, anchor);
 }
 
-}
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/python_output_frame.hpp
+++ b/cpp/arcticdb/pipeline/python_output_frame.hpp
@@ -22,17 +22,26 @@ struct ARCTICDB_VISIBILITY_HIDDEN PythonOutputFrame {
 
     ARCTICDB_MOVE_ONLY_DEFAULT(PythonOutputFrame)
 
-    std::shared_ptr<FrameDataWrapper> arrays(py::object &ref);
+    std::shared_ptr<FrameDataWrapper> arrays(py::object& ref);
 
-    std::vector<std::string> &names() { return names_; }
+    std::vector<std::string>& names()
+    {
+        return names_;
+    }
 
-    std::vector<std::string> &index_columns() { return index_columns_; }
+    std::vector<std::string>& index_columns()
+    {
+        return index_columns_;
+    }
 
-    SegmentInMemory frame() { return frame_; }
+    SegmentInMemory frame()
+    {
+        return frame_;
+    }
 
 private:
-    std::shared_ptr<FrameDataWrapper> initialize_array(py::object &ref);
-    py::array array_at(std::size_t col_pos, py::object &anchor);
+    std::shared_ptr<FrameDataWrapper> initialize_array(py::object& ref);
+    py::array array_at(std::size_t col_pos, py::object& anchor);
 
     std::shared_ptr<ModuleData> module_data_;
     SegmentInMemory frame_;
@@ -42,8 +51,9 @@ private:
     std::shared_ptr<BufferHolder> buffers_;
 };
 
-inline PythonOutputFrame output_frame_from_segment(const SegmentInMemory& frame) {
+inline PythonOutputFrame output_frame_from_segment(const SegmentInMemory& frame)
+{
     return PythonOutputFrame(frame, {});
 }
 
-}
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/query.cpp
+++ b/cpp/arcticdb/pipeline/query.cpp
@@ -16,37 +16,41 @@ namespace arcticdb::pipelines {
 using namespace arcticdb::stream;
 using namespace arcticdb::pipelines::index;
 
-IndexValue start_index(const std::vector<SliceAndKey> &sk, std::size_t row) {
+IndexValue start_index(const std::vector<SliceAndKey>& sk, std::size_t row)
+{
     return sk[row].key().start_index();
 }
 
-IndexValue start_index(const index::IndexSegmentReader &isr, std::size_t row) {
+IndexValue start_index(const index::IndexSegmentReader& isr, std::size_t row)
+{
     return index::index_value_from_segment(isr.seg(), row, index::Fields::start_index);
 }
 
-IndexValue end_index(const index::IndexSegmentReader &isr, std::size_t row) {
+IndexValue end_index(const index::IndexSegmentReader& isr, std::size_t row)
+{
     return index::index_value_from_segment(isr.seg(), row, index::Fields::end_index);
 }
 
-IndexValue end_index(const std::vector<SliceAndKey> &sk, std::size_t row) {
+IndexValue end_index(const std::vector<SliceAndKey>& sk, std::size_t row)
+{
     return sk[row].key().end_index();
 }
 
 template<typename ContainerType, typename IdxType>
-std::unique_ptr<util::BitSet> build_bitset_for_index(
-        const ContainerType& container,
-        IndexRange rg,
-        bool dynamic_schema,
-        bool column_groups,
-        std::unique_ptr<util::BitSet>&& input) {
+std::unique_ptr<util::BitSet> build_bitset_for_index(const ContainerType& container,
+    IndexRange rg,
+    bool dynamic_schema,
+    bool column_groups,
+    std::unique_ptr<util::BitSet>&& input)
+{
     auto res = std::make_unique<util::BitSet>(static_cast<util::BitSetSizeType>(container.size()));
     if (container.empty())
         return res;
 
     using IndexTagType = typename IdxType::TypeDescTag;
 
-    const auto &start_idx_col = container.seg().column(position_t(index::Fields::start_index));
-    const auto &end_idx_col = container.seg().column(position_t(index::Fields::end_index));
+    const auto& start_idx_col = container.seg().column(position_t(index::Fields::start_index));
+    const auto& end_idx_col = container.seg().column(position_t(index::Fields::end_index));
     ARCTICDB_DEBUG(log::version(), "Searching for match in index range {}", rg);
 
     auto end_index_col_begin = end_idx_col.template begin<IndexTagType>();
@@ -56,24 +60,18 @@ std::unique_ptr<util::BitSet> build_bitset_for_index(
         const auto range_start = std::get<timestamp>(rg.start_);
         const auto range_end = std::get<timestamp>(rg.end_);
 
-        auto start_pos = std::lower_bound(
-            end_index_col_begin,
-            end_index_col_end,
-            range_start
-        );
+        auto start_pos = std::lower_bound(end_index_col_begin, end_index_col_end, range_start);
 
-        if(start_pos == end_idx_col.template end<IndexTagType>()) {
+        if (start_pos == end_idx_col.template end<IndexTagType>()) {
             ARCTICDB_DEBUG(log::version(), "Returning as start pos is at end");
             return res;
         }
 
-        auto end_pos = std::upper_bound(
-            start_idx_col.template begin<IndexTagType>(),
+        auto end_pos = std::upper_bound(start_idx_col.template begin<IndexTagType>(),
             start_idx_col.template end<IndexTagType>(),
-            range_end
-        );
+            range_end);
 
-        if(end_pos == start_idx_col.template begin<IndexTagType >()) {
+        if (end_pos == start_idx_col.template begin<IndexTagType>()) {
             ARCTICDB_DEBUG(log::version(), "Returning as end pos is at beginning");
             return res;
         }
@@ -82,7 +80,7 @@ std::unique_ptr<util::BitSet> build_bitset_for_index(
         auto begin_offset = std::distance(end_index_col_begin, start_pos);
         ARCTICDB_DEBUG(log::version(), "start_pos at {} of {}", begin_offset, end_idx_col.row_count());
         auto end_offset = std::distance(start_idx_col.template begin<IndexTagType>(), end_pos);
-        if(end_offset == start_idx_col.row_count()) {
+        if (end_offset == start_idx_col.row_count()) {
             --end_pos;
             --end_offset;
         }
@@ -90,7 +88,9 @@ std::unique_ptr<util::BitSet> build_bitset_for_index(
 
         auto start_range_begin = start_idx_col.template begin<IndexTagType>();
         std::advance(start_range_begin, begin_offset);
-        while(begin_offset <= end_offset && !range_intersects<RawType>(range_start, range_end, *start_range_begin, *start_pos)) {
+        while (begin_offset <= end_offset &&
+               !range_intersects<RawType>(range_start, range_end, *start_range_begin, *start_pos))
+        {
             ARCTICDB_DEBUG(log::version(), "increasing start index");
             ++start_range_begin;
             ++start_pos;
@@ -99,14 +99,16 @@ std::unique_ptr<util::BitSet> build_bitset_for_index(
 
         auto end_range_last = end_idx_col.template begin<IndexTagType>();
         std::advance(end_range_last, end_offset);
-        while(!range_intersects<RawType>(range_start, range_end, *end_pos, *end_range_last) && begin_offset < end_offset) {
+        while (
+            !range_intersects<RawType>(range_start, range_end, *end_pos, *end_range_last) && begin_offset < end_offset)
+        {
             ARCTICDB_DEBUG(log::version(), "decreasing end index");
             --end_pos;
             --end_range_last;
             --end_offset;
         }
 
-        if(begin_offset > end_offset) {
+        if (begin_offset > end_offset) {
             ARCTICDB_DEBUG(log::version(), "Returning as start and end pos crossed, no intersecting ranges");
             return res;
         }
@@ -123,10 +125,10 @@ std::unique_ptr<util::BitSet> build_bitset_for_index(
         using RawType = typename IndexTagType::DataTypeTag::raw_type;
         const auto range_start = std::get<timestamp>(rg.start_);
         const auto range_end = std::get<timestamp>(rg.end_);
-        for(auto i = 0u; i < container.size(); ++i) {
+        for (auto i = 0u; i < container.size(); ++i) {
             const auto intersects = range_intersects<RawType>(range_start, range_end, *start_idx_pos, *end_idx_pos);
             (*res)[i] = intersects;
-            if(intersects)
+            if (intersects)
                 ARCTICDB_DEBUG(log::version(), "range intersects at {}", i);
 
             ++start_idx_pos;
@@ -136,14 +138,28 @@ std::unique_ptr<util::BitSet> build_bitset_for_index(
         ARCTICDB_DEBUG(log::version(), timer.display_all());
     }
 
-    if(input)
+    if (input)
         *res &= *input;
 
     ARCTICDB_DEBUG(log::version(), "Res count = {}", res->count());
     return res;
 }
 
-template std::unique_ptr<util::BitSet> build_bitset_for_index<IndexSegmentReader, TimeseriesIndex>(const index::IndexSegmentReader&,  IndexRange, bool, bool, std::unique_ptr<util::BitSet>&&);
-template std::unique_ptr<util::BitSet> build_bitset_for_index<IndexSegmentReader, TableIndex>(const index::IndexSegmentReader&,  IndexRange, bool, bool, std::unique_ptr<util::BitSet>&&);
-template std::unique_ptr<util::BitSet> build_bitset_for_index<TestContainer, TimeseriesIndex>(const TestContainer&,  IndexRange, bool, bool, std::unique_ptr<util::BitSet>&&);
-} //namespace arcticdb
+template std::unique_ptr<util::BitSet> build_bitset_for_index<IndexSegmentReader, TimeseriesIndex>(
+    const index::IndexSegmentReader&,
+    IndexRange,
+    bool,
+    bool,
+    std::unique_ptr<util::BitSet>&&);
+template std::unique_ptr<util::BitSet> build_bitset_for_index<IndexSegmentReader, TableIndex>(
+    const index::IndexSegmentReader&,
+    IndexRange,
+    bool,
+    bool,
+    std::unique_ptr<util::BitSet>&&);
+template std::unique_ptr<util::BitSet> build_bitset_for_index<TestContainer, TimeseriesIndex>(const TestContainer&,
+    IndexRange,
+    bool,
+    bool,
+    std::unique_ptr<util::BitSet>&&);
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -52,46 +52,49 @@ struct ReadQuery {
     FilterRange row_filter; // no filter by default
     std::shared_ptr<std::vector<Clause>> query_ = std::make_shared<std::vector<Clause>>();
 
-    void set_clause_builder(ClauseBuilder& builder) {
+    void set_clause_builder(ClauseBuilder& builder)
+    {
         ClauseBuilder b = std::move(builder);
-        for (auto&& c: b.get_clauses()) {
+        for (auto&& c : b.get_clauses()) {
             query_->emplace_back(std::move(c));
         }
     }
 
-    void calculate_row_filter(int64_t total_rows) {
-        util::variant_match(row_range,
-            [&](const HeadRange &head_range) {
-            if (head_range.num_rows_ >= 0) {
-                row_filter = RowRange(0, std::min(head_range.num_rows_, total_rows));
-            } else {
-                row_filter = RowRange(0, std::max(static_cast<int64_t>(0), total_rows + head_range.num_rows_));
-            }
-            if (query_->empty() && columns.empty() && head_range.num_rows_ > 0) {
-                // TODO: columns aren't supported due to AN-334
-                query_->emplace_back(RowNumberLimitClause{static_cast<size_t>(head_range.num_rows_)});
-            } else {
-                log::version().info("Arguments not compatible with head() memory usage optimisation");
-            }
+    void calculate_row_filter(int64_t total_rows)
+    {
+        util::variant_match(
+            row_range,
+            [&](const HeadRange& head_range) {
+                if (head_range.num_rows_ >= 0) {
+                    row_filter = RowRange(0, std::min(head_range.num_rows_, total_rows));
+                } else {
+                    row_filter = RowRange(0, std::max(static_cast<int64_t>(0), total_rows + head_range.num_rows_));
+                }
+                if (query_->empty() && columns.empty() && head_range.num_rows_ > 0) {
+                    // TODO: columns aren't supported due to AN-334
+                    query_->emplace_back(RowNumberLimitClause{static_cast<size_t>(head_range.num_rows_)});
+                } else {
+                    log::version().info("Arguments not compatible with head() memory usage optimisation");
+                }
             },
-            [&](const TailRange &tail_range) {
-            if (tail_range.num_rows_ >= 0) {
-                row_filter = RowRange(std::max(static_cast<int64_t>(0), total_rows - tail_range.num_rows_), total_rows);
-            } else {
-                row_filter = RowRange(std::min(-tail_range.num_rows_, total_rows), total_rows);
-            }
+            [&](const TailRange& tail_range) {
+                if (tail_range.num_rows_ >= 0) {
+                    row_filter =
+                        RowRange(std::max(static_cast<int64_t>(0), total_rows - tail_range.num_rows_), total_rows);
+                } else {
+                    row_filter = RowRange(std::min(-tail_range.num_rows_, total_rows), total_rows);
+                }
             },
-            [&](const SignedRowRange &signed_row_range) {
-            size_t start = signed_row_range.start_ >= 0 ?
-                    std::min(signed_row_range.start_, total_rows) :
-                    std::max(total_rows + signed_row_range.start_, static_cast<int64_t>(0));
-            size_t end = signed_row_range.end_ >= 0 ?
-                    std::min(signed_row_range.end_, total_rows) :
-                    std::max(total_rows + signed_row_range.end_, static_cast<int64_t>(0));
-            row_filter = RowRange(start, end);
+            [&](const SignedRowRange& signed_row_range) {
+                size_t start = signed_row_range.start_ >= 0
+                                   ? std::min(signed_row_range.start_, total_rows)
+                                   : std::max(total_rows + signed_row_range.start_, static_cast<int64_t>(0));
+                size_t end = signed_row_range.end_ >= 0
+                                 ? std::min(signed_row_range.end_, total_rows)
+                                 : std::max(total_rows + signed_row_range.end_, static_cast<int64_t>(0));
+                row_filter = RowRange(start, end);
             },
-            [](const auto &) {}
-            );
+            [](const auto&) {});
     }
 };
 
@@ -112,34 +115,41 @@ struct VersionQuery {
     std::optional<bool> skip_compat_;
     std::optional<bool> iterate_on_failure_;
 
-    void set_snap_name(const std::string& snap_name) {
+    void set_snap_name(const std::string& snap_name)
+    {
         content_ = SnapshotVersionQuery{snap_name};
     }
 
-    void set_timestamp(timestamp ts) {
+    void set_timestamp(timestamp ts)
+    {
         content_ = TimestampVersionQuery{ts};
     }
 
-    void set_version(VersionId version) {
+    void set_version(VersionId version)
+    {
         content_ = SpecificVersionQuery{version};
     }
 
-    void set_skip_compat(const std::optional<bool>& skip_compat) {
+    void set_skip_compat(const std::optional<bool>& skip_compat)
+    {
         skip_compat_ = skip_compat;
     }
 
-    void set_iterate_on_failure(const std::optional<bool>& iterate_on_failure) {
+    void set_iterate_on_failure(const std::optional<bool>& iterate_on_failure)
+    {
         iterate_on_failure_ = iterate_on_failure;
     }
 };
 
 template<typename ContainerType>
-using FilterQuery = folly::Function<std::unique_ptr<util::BitSet>(const ContainerType &, std::unique_ptr<util::BitSet>&&)>;
+using FilterQuery =
+    folly::Function<std::unique_ptr<util::BitSet>(const ContainerType&, std::unique_ptr<util::BitSet>&&)>;
 
 template<typename ContainerType>
 using CombinedQuery = folly::Function<std::unique_ptr<util::BitSet>(const ContainerType&)>;
 
-inline bool is_column_selected(size_t start_col, size_t end_col, const util::BitSet& sc) {
+inline bool is_column_selected(size_t start_col, size_t end_col, const util::BitSet& sc)
+{
     if (start_col == 0) {
         auto col = sc.get_first();
         return col < end_col;
@@ -149,8 +159,10 @@ inline bool is_column_selected(size_t start_col, size_t end_col, const util::Bit
     }
 }
 
-inline FilterQuery<index::IndexSegmentReader> create_static_col_filter(util::BitSet &&selected_columns) {
-    return [sc = std::move(selected_columns)](const index::IndexSegmentReader &isr, std::unique_ptr<util::BitSet>&& input) mutable {
+inline FilterQuery<index::IndexSegmentReader> create_static_col_filter(util::BitSet&& selected_columns)
+{
+    return [sc = std::move(selected_columns)](const index::IndexSegmentReader& isr,
+               std::unique_ptr<util::BitSet>&& input) mutable {
         auto res = std::make_unique<util::BitSet>(static_cast<util::BitSetSizeType>(isr.size()));
         auto start_col = isr.column(index::Fields::start_col).begin<stream::SliceTypeDescriptorTag>();
         auto end_col = isr.column(index::Fields::end_col).begin<stream::SliceTypeDescriptorTag>();
@@ -181,8 +193,11 @@ inline FilterQuery<index::IndexSegmentReader> create_static_col_filter(util::Bit
     };
 }
 
-inline FilterQuery<index::IndexSegmentReader> create_dynamic_col_filter(util::BitSet &&selected_columns, const std::shared_ptr<PipelineContext>& pipeline_context) {
-    return [sc = std::move(selected_columns), pipeline_context](const index::IndexSegmentReader &isr, std::unique_ptr<util::BitSet>&& input) mutable {
+inline FilterQuery<index::IndexSegmentReader> create_dynamic_col_filter(util::BitSet&& selected_columns,
+    const std::shared_ptr<PipelineContext>& pipeline_context)
+{
+    return [sc = std::move(selected_columns), pipeline_context](const index::IndexSegmentReader& isr,
+               std::unique_ptr<util::BitSet>&& input) mutable {
         auto res = std::make_unique<util::BitSet>(static_cast<util::BitSetSizeType>(sc.size()));
         util::check(isr.bucketize_dynamic(), "Expected column group in index segment reader dynamic column filter");
         auto hash_bucket = isr.column(index::Fields::hash_bucket).begin<stream::SliceTypeDescriptorTag>();
@@ -209,19 +224,19 @@ inline FilterQuery<index::IndexSegmentReader> create_dynamic_col_filter(util::Bi
                 pos = *en;
                 std::advance(hash_bucket, dist);
                 std::advance(num_buckets, dist);
-                (*res)[*en] = std::find_if(cols_hashes.begin(), cols_hashes.end(),
-                                        [&num_buckets, &hash_bucket](auto col_hash){
-                                            return (col_hash % *num_buckets) == (*hash_bucket);
-                                        }) != cols_hashes.end();
+                (*res)[*en] =
+                    std::find_if(cols_hashes.begin(), cols_hashes.end(), [&num_buckets, &hash_bucket](auto col_hash) {
+                        return (col_hash % *num_buckets) == (*hash_bucket);
+                    }) != cols_hashes.end();
                 ++en;
             }
 
         } else {
             for (std::size_t r = 0, end = isr.size(); r < end; ++r) {
-                (*res)[r] = std::find_if(cols_hashes.begin(), cols_hashes.end(),
-                                      [&num_buckets, &hash_bucket](auto col_hash){
-                                          return (col_hash % *num_buckets) == (*hash_bucket);
-                                      }) != cols_hashes.end();
+                (*res)[r] =
+                    std::find_if(cols_hashes.begin(), cols_hashes.end(), [&num_buckets, &hash_bucket](auto col_hash) {
+                        return (col_hash % *num_buckets) == (*hash_bucket);
+                    }) != cols_hashes.end();
                 ++hash_bucket;
                 ++num_buckets;
             }
@@ -231,25 +246,30 @@ inline FilterQuery<index::IndexSegmentReader> create_dynamic_col_filter(util::Bi
     };
 }
 
-inline std::size_t start_row(const index::IndexSegmentReader &isr, std::size_t row) {
+inline std::size_t start_row(const index::IndexSegmentReader& isr, std::size_t row)
+{
     return isr.column(index::Fields::start_row).scalar_at<std::size_t>(row).value();
 }
 
-inline std::size_t start_row(const std::vector<SliceAndKey> &sk, std::size_t row) {
+inline std::size_t start_row(const std::vector<SliceAndKey>& sk, std::size_t row)
+{
     return sk[row].slice_.row_range.first;
 }
 
-inline std::size_t end_row(const index::IndexSegmentReader &isr, std::size_t row) {
+inline std::size_t end_row(const index::IndexSegmentReader& isr, std::size_t row)
+{
     return isr.column(index::Fields::end_row).scalar_at<std::size_t>(row).value();
 }
 
-inline std::size_t end_row(const std::vector<SliceAndKey> &sk, std::size_t row) {
+inline std::size_t end_row(const std::vector<SliceAndKey>& sk, std::size_t row)
+{
     return sk[row].slice_.row_range.second;
 }
 
 template<typename ContainerType>
-inline FilterQuery<ContainerType> create_row_filter(RowRange &&range) {
-    return [rg = std::move(range)](const ContainerType &container, std::unique_ptr<util::BitSet>&& input) mutable {
+inline FilterQuery<ContainerType> create_row_filter(RowRange&& range)
+{
+    return [rg = std::move(range)](const ContainerType& container, std::unique_ptr<util::BitSet>&& input) mutable {
         auto res = std::make_unique<util::BitSet>(static_cast<util::BitSetSizeType>(container.size()));
         for (std::size_t r = 0, end = container.size(); r < end; ++r) {
             bool included = start_row(container, r) < rg.second && end_row(container, r) > rg.first;
@@ -257,7 +277,7 @@ inline FilterQuery<ContainerType> create_row_filter(RowRange &&range) {
             (*res)[r] = included;
         }
 
-        if(input)
+        if (input)
             *res &= *input;
 
         ARCTICDB_DEBUG(log::version(), "Row filter has {} bits set", res->count());
@@ -265,76 +285,82 @@ inline FilterQuery<ContainerType> create_row_filter(RowRange &&range) {
     };
 }
 
-IndexValue start_index(const std::vector<SliceAndKey> &sk, std::size_t row);
+IndexValue start_index(const std::vector<SliceAndKey>& sk, std::size_t row);
 
-IndexValue start_index(const index::IndexSegmentReader &isr, std::size_t row);
+IndexValue start_index(const index::IndexSegmentReader& isr, std::size_t row);
 
-IndexValue end_index(const index::IndexSegmentReader &isr, std::size_t row);
+IndexValue end_index(const index::IndexSegmentReader& isr, std::size_t row);
 
-IndexValue end_index(const std::vector<SliceAndKey> &sk, std::size_t row);
+IndexValue end_index(const std::vector<SliceAndKey>& sk, std::size_t row);
 
-template <typename RawType>
-bool range_intersects(RawType a_start, RawType a_end, RawType b_start, RawType b_end) {
+template<typename RawType>
+bool range_intersects(RawType a_start, RawType a_end, RawType b_start, RawType b_end)
+{
     return a_start <= b_end && a_end >= b_start;
 }
 
 template<typename ContainerType, typename IdxType>
-std::unique_ptr<util::BitSet> build_bitset_for_index(
-        const ContainerType& container,
-        IndexRange rg,
-        bool dynamic_schema,
-        bool column_groups,
-        std::unique_ptr<util::BitSet>&& input);
+std::unique_ptr<util::BitSet> build_bitset_for_index(const ContainerType& container,
+    IndexRange rg,
+    bool dynamic_schema,
+    bool column_groups,
+    std::unique_ptr<util::BitSet>&& input);
 
 template<typename ContainerType>
-inline FilterQuery<ContainerType> create_index_filter(const IndexRange &range, bool dynamic_schema, bool column_groups) {
+inline FilterQuery<ContainerType> create_index_filter(const IndexRange& range, bool dynamic_schema, bool column_groups)
+{
     static_assert(std::is_same_v<ContainerType, index::IndexSegmentReader>);
-    return [rg = range, dynamic_schema, column_groups](const ContainerType &container, std::unique_ptr<util::BitSet>&& input) mutable {
+    return [rg = range, dynamic_schema, column_groups](const ContainerType& container,
+               std::unique_ptr<util::BitSet>&& input) mutable {
         auto index_type = container.seg().template scalar_at<uint8_t>(0u, int(index::Fields::index_type));
 
         switch (index_type.value()) {
         case IndexDescriptor::TIMESTAMP: {
             return build_bitset_for_index<ContainerType, TimeseriesIndex>(container,
-                                                                          rg,
-                                                                          dynamic_schema,
-                                                                          column_groups,
-                                                                          std::move(input));
+                rg,
+                dynamic_schema,
+                column_groups,
+                std::move(input));
         }
         case IndexDescriptor::STRING: {
-            return build_bitset_for_index<ContainerType, TableIndex>(container, rg, dynamic_schema, column_groups, std::move(input));
+            return build_bitset_for_index<ContainerType, TableIndex>(container,
+                rg,
+                dynamic_schema,
+                column_groups,
+                std::move(input));
         }
-        default:util::raise_rte("Unknown index type {} in create_index_filter", uint32_t(index_type.value()));
+        default:
+            util::raise_rte("Unknown index type {} in create_index_filter", uint32_t(index_type.value()));
         }
     };
 }
 
 template<typename ContainerType>
-inline std::vector<FilterQuery<ContainerType>> build_read_query_filters(
-    std::optional<util::BitSet>& col_bitset,
+inline std::vector<FilterQuery<ContainerType>> build_read_query_filters(std::optional<util::BitSet>& col_bitset,
     const std::shared_ptr<PipelineContext>& pipeline_context,
-    const FilterRange &range,
+    const FilterRange& range,
     bool dynamic_schema,
-    bool column_groups) {
+    bool column_groups)
+{
     using namespace arcticdb::pipelines;
     std::vector<FilterQuery<ContainerType>> queries;
 
-    util::variant_match(range,
-                        [&](const RowRange &row_range) {
-                            queries.push_back(
-                                    create_row_filter<ContainerType>(RowRange{row_range.first, row_range.second}));
-                        },
-                        [&](const IndexRange &index_range) {
-                            if (index_range.specified_) {
-                                queries.push_back(create_index_filter<ContainerType>(index_range, dynamic_schema, column_groups));
-                            }
-                        },
-                        [](const auto &) {}
-    );
+    util::variant_match(
+        range,
+        [&](const RowRange& row_range) {
+            queries.push_back(create_row_filter<ContainerType>(RowRange{row_range.first, row_range.second}));
+        },
+        [&](const IndexRange& index_range) {
+            if (index_range.specified_) {
+                queries.push_back(create_index_filter<ContainerType>(index_range, dynamic_schema, column_groups));
+            }
+        },
+        [](const auto&) {});
 
-    if(col_bitset) {
+    if (col_bitset) {
         util::check(!dynamic_schema || column_groups, "Did not expect a column bitset with dynamic schema");
 
-        if(column_groups)
+        if (column_groups)
             queries.push_back(create_dynamic_col_filter(util::BitSet(col_bitset.value()), pipeline_context));
         else
             queries.push_back(create_static_col_filter(util::BitSet(col_bitset.value())));
@@ -348,91 +374,90 @@ struct UpdateQuery {
 };
 
 template<typename ContainerType>
-inline std::vector<FilterQuery<ContainerType>> build_update_query_filters(
-        const FilterRange &range,
-        const stream::Index& index,
-        const IndexRange& index_range,
-        bool dynamic_schema,
-        bool column_groups
-) {
+inline std::vector<FilterQuery<ContainerType>> build_update_query_filters(const FilterRange& range,
+    const stream::Index& index,
+    const IndexRange& index_range,
+    bool dynamic_schema,
+    bool column_groups)
+{
     // If a range was supplied, construct a query based on the type of the supplied range, otherwise create a query
     // based on the index type of the incoming update frame. All three types must match, i.e. the index type of the frame to
     // be appended to, the type of the frame being appended, and the specified range, if supplied.
     std::vector<FilterQuery<ContainerType>> queries;
-    util::variant_match(range,
-                        [&](const  RowRange &row_range) {
-                            util::check(std::holds_alternative<stream::RowCountIndex>(index), "Cannot partition by row count when a timeseries-indexed frame was supplied");
-                            queries.push_back(
-                                    create_row_filter<ContainerType>(RowRange{row_range.first, row_range.second}));
-                        },
-                        [&](const IndexRange &index_range) {
-                            util::check(std::holds_alternative<stream::TimeseriesIndex>(index), "Cannot partition by time when a rowcount-indexed frame was supplied");
-                            queries.push_back(create_index_filter<ContainerType>(IndexRange{index_range}, dynamic_schema, column_groups));
-                        },
-                        [&](const auto &) {
-                            util::variant_match(index,
-                                                [&](const stream::TimeseriesIndex &) {
-                                                    queries.push_back(create_index_filter<ContainerType>(IndexRange{index_range}, dynamic_schema, column_groups));
-                                                },
-                                                [&](const stream::RowCountIndex &) {
-                                                    RowRange row_range{std::get<NumericId>(index_range.start_), std::get<NumericIndex>(index_range.end_)};
-                                                    queries.push_back(create_row_filter<ContainerType>(std::move(row_range)));
-                                                },
-                                                [&](const auto &) {
-                                                });
-                        });
+    util::variant_match(
+        range,
+        [&](const RowRange& row_range) {
+            util::check(std::holds_alternative<stream::RowCountIndex>(index),
+                "Cannot partition by row count when a timeseries-indexed frame was supplied");
+            queries.push_back(create_row_filter<ContainerType>(RowRange{row_range.first, row_range.second}));
+        },
+        [&](const IndexRange& index_range) {
+            util::check(std::holds_alternative<stream::TimeseriesIndex>(index),
+                "Cannot partition by time when a rowcount-indexed frame was supplied");
+            queries.push_back(
+                create_index_filter<ContainerType>(IndexRange{index_range}, dynamic_schema, column_groups));
+        },
+        [&](const auto&) {
+            util::variant_match(
+                index,
+                [&](const stream::TimeseriesIndex&) {
+                    queries.push_back(
+                        create_index_filter<ContainerType>(IndexRange{index_range}, dynamic_schema, column_groups));
+                },
+                [&](const stream::RowCountIndex&) {
+                    RowRange row_range{std::get<NumericId>(index_range.start_),
+                        std::get<NumericIndex>(index_range.end_)};
+                    queries.push_back(create_row_filter<ContainerType>(std::move(row_range)));
+                },
+                [&](const auto&) {});
+        });
 
     return queries;
 }
 
-inline FilterRange get_query_index_range(
-        const stream::Index& index,
-        const IndexRange& index_range) {
-        if(std::holds_alternative<stream::TimeseriesIndex>(index))
-               return index_range;
-        else
-               return RowRange{std::get<NumericIndex>(index_range.start_), std::get<NumericIndex>(index_range.end_)};
+inline FilterRange get_query_index_range(const stream::Index& index, const IndexRange& index_range)
+{
+    if (std::holds_alternative<stream::TimeseriesIndex>(index))
+        return index_range;
+    else
+        return RowRange{std::get<NumericIndex>(index_range.start_), std::get<NumericIndex>(index_range.end_)};
 }
 
-inline std::vector<SliceAndKey> strictly_before(const FilterRange &range, const std::vector<SliceAndKey> &input) {
+inline std::vector<SliceAndKey> strictly_before(const FilterRange& range, const std::vector<SliceAndKey>& input)
+{
     std::vector<SliceAndKey> output;
-    util::variant_match(range,
-                        [&](const RowRange &row_range) {
-                            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output),
-                                         [&](const auto &sk) {
-                                             return sk.slice_.row_range.second < row_range.first;
-                                         });
-                        },
-                        [&](const IndexRange &index_range) {
-                            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output),
-                                         [&](const auto &sk) {
-                                             return sk.key().index_range().end_ < index_range.start_;
-                                         });
-                        },
-                        [&](const auto &) {
-                            util::raise_rte("Expected specified range ");
-                        });
+    util::variant_match(
+        range,
+        [&](const RowRange& row_range) {
+            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output), [&](const auto& sk) {
+                return sk.slice_.row_range.second < row_range.first;
+            });
+        },
+        [&](const IndexRange& index_range) {
+            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output), [&](const auto& sk) {
+                return sk.key().index_range().end_ < index_range.start_;
+            });
+        },
+        [&](const auto&) { util::raise_rte("Expected specified range "); });
     return output;
 }
 
-inline std::vector<SliceAndKey> strictly_after(const FilterRange &range, const std::vector<SliceAndKey> &input) {
+inline std::vector<SliceAndKey> strictly_after(const FilterRange& range, const std::vector<SliceAndKey>& input)
+{
     std::vector<SliceAndKey> output;
-    util::variant_match(range,
-                        [&input, &output](const RowRange &row_range) {
-                            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output),
-                                         [&](const auto &sk) {
-                                             return sk.slice_.row_range.first > row_range.second;
-                                         });
-                        },
-                        [&input, &output](const IndexRange &index_range) {
-                            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output),
-                                         [&](const auto &sk) {
-                                             return sk.key().index_range().start_ > index_range.end_;
-                                         });
-                        },
-                        [](const auto &) {
-                            util::raise_rte("Expected specified range ");
-                        });
+    util::variant_match(
+        range,
+        [&input, &output](const RowRange& row_range) {
+            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output), [&](const auto& sk) {
+                return sk.slice_.row_range.first > row_range.second;
+            });
+        },
+        [&input, &output](const IndexRange& index_range) {
+            std::copy_if(std::begin(input), std::end(input), std::back_inserter(output), [&](const auto& sk) {
+                return sk.key().index_range().start_ > index_range.end_;
+            });
+        },
+        [](const auto&) { util::raise_rte("Expected specified range "); });
     return output;
 }
 
@@ -444,15 +469,20 @@ using namespace arcticdb::pipelines;
 template<>
 struct formatter<VersionQuery> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const VersionQuery& q, FormatContext& ctx) const {
-        return arcticdb::util::variant_match(q.content_,
-                [&ctx](const SpecificVersionQuery& s) { return format_to(ctx.out(), "version {}", s.version_id_); },
-                [&ctx](const SnapshotVersionQuery& s) { return format_to(ctx.out(), "snapshot '{}'", s.name_); },
-                [&ctx](const TimestampVersionQuery& t) { return format_to(ctx.out(), "{}", t.timestamp_); },
-                [&ctx](const std::monostate&) { return format_to(ctx.out(), "latest"); });
+    auto format(const VersionQuery& q, FormatContext& ctx) const
+    {
+        return arcticdb::util::variant_match(
+            q.content_,
+            [&ctx](const SpecificVersionQuery& s) { return format_to(ctx.out(), "version {}", s.version_id_); },
+            [&ctx](const SnapshotVersionQuery& s) { return format_to(ctx.out(), "snapshot '{}'", s.name_); },
+            [&ctx](const TimestampVersionQuery& t) { return format_to(ctx.out(), "{}", t.timestamp_); },
+            [&ctx](const std::monostate&) { return format_to(ctx.out(), "latest"); });
     }
 };
-}
+} // namespace fmt

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -23,47 +23,51 @@ namespace arcticdb::pipelines {
 
 SegmentInMemory allocate_frame(const std::shared_ptr<PipelineContext>& context);
 
-template <typename KeySliceContainer>
-std::optional<util::BitSet> check_and_mark_slices(
-    const KeySliceContainer& slice_and_keys,
+template<typename KeySliceContainer>
+std::optional<util::BitSet> check_and_mark_slices(const KeySliceContainer& slice_and_keys,
     bool dynamic_schema,
     bool return_bitset,
     std::optional<size_t> incompletes_after,
-    bool has_column_groups) {
+    bool has_column_groups)
+{
     ARCTICDB_SAMPLE_DEFAULT(MarkIndexSlices)
     std::optional<util::BitSet> output = return_bitset ? std::make_optional<util::BitSet>(0u) : std::nullopt;
     if (slice_and_keys.empty())
         return output;
 
-    auto &index_slice = slice_and_keys.begin()->slice_;
+    auto& index_slice = slice_and_keys.begin()->slice_;
     ColRange col_range;
     bool is_first = true;
     size_t count = 0u;
     std::set<RowRange> row_ranges;
-    for (auto[opt_seg, slice, key] : slice_and_keys) {
-        if(has_column_groups) {
-          is_first = row_ranges.insert(slice.row_range).second;
+    for (auto [opt_seg, slice, key] : slice_and_keys) {
+        if (has_column_groups) {
+            is_first = row_ranges.insert(slice.row_range).second;
         } else if (slice.col_range != col_range) {
-            if(!dynamic_schema)
+            if (!dynamic_schema)
                 is_first = slice.col_range == index_slice.col_range;
-            
+
             col_range = slice.col_range;
         }
         row_ranges.insert(slice.row_range);
-        if(return_bitset)
-            output.value()[output.value().size()] = (dynamic_schema && !has_column_groups) || is_first || (incompletes_after && count >= incompletes_after.value());
+        if (return_bitset)
+            output.value()[output.value().size()] = (dynamic_schema && !has_column_groups) || is_first ||
+                                                    (incompletes_after && count >= incompletes_after.value());
 
         ++count;
     }
     util::check(!return_bitset || slice_and_keys.size() == output.value().size(),
-                "Index fetch vector size should match slice and key size");
+        "Index fetch vector size should match slice and key size");
 
-    if(!row_ranges.empty()) {
+    if (!row_ranges.empty()) {
         auto pos = row_ranges.begin();
         RowRange current = *pos;
         std::advance(pos, 1);
-        for(; pos != row_ranges.end(); ++pos){
-            sorting::check<ErrorCode::E_UNSORTED_DATA>(pos->start() == current.end(), "Non-contiguous rows, range search on unsorted data? {} {}", current, *pos);
+        for (; pos != row_ranges.end(); ++pos) {
+            sorting::check<ErrorCode::E_UNSORTED_DATA>(pos->start() == current.end(),
+                "Non-contiguous rows, range search on unsorted data? {} {}",
+                current,
+                *pos);
             current = *pos;
         }
     }
@@ -71,42 +75,30 @@ std::optional<util::BitSet> check_and_mark_slices(
     return output;
 }
 
-void mark_index_slices(
-    const std::shared_ptr<PipelineContext>& context,
-    bool dynamic_schema,
-    bool column_groups);
+void mark_index_slices(const std::shared_ptr<PipelineContext>& context, bool dynamic_schema, bool column_groups);
 
-folly::Future<std::vector<VariantKey>> fetch_data(
-    const SegmentInMemory& frame,
-    const std::shared_ptr<PipelineContext> &context,
+folly::Future<std::vector<VariantKey>> fetch_data(const SegmentInMemory& frame,
+    const std::shared_ptr<PipelineContext>& context,
     const std::shared_ptr<stream::StreamSource>& ssource,
     bool dynamic_schema,
-    std::shared_ptr<BufferHolder> buffers
-    );
+    std::shared_ptr<BufferHolder> buffers);
 
-void decode_into_frame_static(
-    SegmentInMemory &frame,
-    PipelineContextRow &context,
-    Segment &&seg,
-    const std::shared_ptr<BufferHolder>& buffers
-    );
+void decode_into_frame_static(SegmentInMemory& frame,
+    PipelineContextRow& context,
+    Segment&& seg,
+    const std::shared_ptr<BufferHolder>& buffers);
 
-void decode_into_frame_dynamic(
-        SegmentInMemory &frame,
-        PipelineContextRow &context,
-        Segment &&seg,
-        const std::shared_ptr<BufferHolder>& buffers
-);
+void decode_into_frame_dynamic(SegmentInMemory& frame,
+    PipelineContextRow& context,
+    Segment&& seg,
+    const std::shared_ptr<BufferHolder>& buffers);
 
-void reduce_and_fix_columns(
-        std::shared_ptr<PipelineContext> &context,
-        SegmentInMemory &frame,
-        const ReadOptions& read_options
-);
+void reduce_and_fix_columns(std::shared_ptr<PipelineContext>& context,
+    SegmentInMemory& frame,
+    const ReadOptions& read_options);
 
 size_t get_index_field_count(const SegmentInMemory& frame);
 
-StreamDescriptor get_filtered_descriptor(
-        const StreamDescriptor& desc,
-        const std::shared_ptr<std::vector<FieldDescriptor::Proto>>& filter_columns);
+StreamDescriptor get_filtered_descriptor(const StreamDescriptor& desc,
+    const std::shared_ptr<std::vector<FieldDescriptor::Proto>>& filter_columns);
 } // namespace  arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/read_options.hpp
+++ b/cpp/arcticdb/pipeline/read_options.hpp
@@ -20,35 +20,43 @@ struct ReadOptions {
     std::optional<bool> set_tz_;
     std::optional<bool> optimise_string_memory_;
 
-    void set_force_strings_to_fixed(const std::optional<bool>& force_strings_to_fixed) {
+    void set_force_strings_to_fixed(const std::optional<bool>& force_strings_to_fixed)
+    {
         force_strings_to_fixed_ = force_strings_to_fixed;
     }
 
-    void set_force_strings_to_object(const std::optional<bool>& force_strings_to_object) {
+    void set_force_strings_to_object(const std::optional<bool>& force_strings_to_object)
+    {
         force_strings_to_object_ = force_strings_to_object;
     }
 
-    void set_incompletes(const std::optional<bool>& incompletes) {
+    void set_incompletes(const std::optional<bool>& incompletes)
+    {
         incompletes_ = incompletes;
     }
 
-    bool get_incompletes() const {
+    bool get_incompletes() const
+    {
         return opt_false(incompletes_);
     }
 
-    void set_dynamic_schema(const std::optional<bool>& dynamic_schema) {
+    void set_dynamic_schema(const std::optional<bool>& dynamic_schema)
+    {
         dynamic_schema_ = dynamic_schema;
     }
 
-    void set_allow_sparse(const std::optional<bool>& allow_sparse) {
+    void set_allow_sparse(const std::optional<bool>& allow_sparse)
+    {
         allow_sparse_ = allow_sparse;
     }
 
-    void set_set_tz(const std::optional<bool>& set_tz) {
+    void set_set_tz(const std::optional<bool>& set_tz)
+    {
         set_tz_ = set_tz;
     }
 
-    void set_optimise_string_memory(const std::optional<bool>& optimise_string_memory) {
+    void set_optimise_string_memory(const std::optional<bool>& optimise_string_memory)
+    {
         optimise_string_memory_ = optimise_string_memory;
     }
 };

--- a/cpp/arcticdb/pipeline/read_pipeline.hpp
+++ b/cpp/arcticdb/pipeline/read_pipeline.hpp
@@ -37,47 +37,50 @@
 namespace arcticdb::pipelines {
 
 template<class ContainerType>
-std::optional<CombinedQuery<ContainerType>> combine_filter_functions(std::vector<FilterQuery<ContainerType>>& filters) {
-    if(filters.empty())
+std::optional<CombinedQuery<ContainerType>> combine_filter_functions(std::vector<FilterQuery<ContainerType>>& filters)
+{
+    if (filters.empty())
         return std::nullopt;
 
-    return [&](const ContainerType &container) mutable {
+    return [&](const ContainerType& container) mutable {
         auto filter = filters.begin();
         std::unique_ptr<util::BitSet> orig;
         auto bitset = (*filter)(container, std::move(orig));
-        for(++filter; filter!=filters.end(); ++filter) {
+        for (++filter; filter != filters.end(); ++filter) {
             bitset = (*filter)(container, std::move(bitset));
         }
         return bitset;
     };
 }
 
-inline SliceAndKey get_row(const index::IndexSegmentReader& isr, size_t row) {
+inline SliceAndKey get_row(const index::IndexSegmentReader& isr, size_t row)
+{
     return isr.row(row);
 }
 
 template<class C>
-void foreach_active_bit(const util::BitSet &bs, C &&visitor) {
+void foreach_active_bit(const util::BitSet& bs, C&& visitor)
+{
     for (auto r = bs.first(); r != bs.end(); r++) {
         visitor(*r);
     }
 }
 
 template<typename ContainerType>
-std::vector<SliceAndKey> filter_index(const ContainerType &container, std::optional<CombinedQuery<ContainerType>> &&query) {
+std::vector<SliceAndKey> filter_index(const ContainerType& container,
+    std::optional<CombinedQuery<ContainerType>>&& query)
+{
     ARCTICDB_SAMPLE_DEFAULT(FilterIndex)
     std::vector<SliceAndKey> output{};
-    if (container.size()> 0) {
-        if(query) {
+    if (container.size() > 0) {
+        if (query) {
             auto row_bitset = (*query)(container);
             ARCTICDB_DEBUG(log::version(), "Row bitset has {} bits set of {}", row_bitset->count(), row_bitset->size());
             output.reserve(row_bitset->count());
-            foreach_active_bit(*row_bitset, [&](auto r) {
-                output.push_back(get_row(container, r));
-            });
+            foreach_active_bit(*row_bitset, [&](auto r) { output.push_back(get_row(container, r)); });
         } else {
             output.reserve(container.size());
-            for(auto i = 0u; i < container.size(); ++i) {
+            for (auto i = 0u; i < container.size(); ++i) {
                 output.push_back(get_row(container, i));
             }
         }
@@ -86,7 +89,9 @@ std::vector<SliceAndKey> filter_index(const ContainerType &container, std::optio
     return output;
 }
 
-inline util::BitSet build_column_bitset(const StreamDescriptor::Proto &desc, const folly::F14FastSet<std::string_view>& columns) {
+inline util::BitSet build_column_bitset(const StreamDescriptor::Proto& desc,
+    const folly::F14FastSet<std::string_view>& columns)
+{
     util::BitSet col_bitset(static_cast<util::BitSetSizeType>(desc.fields().size()));
     for (std::size_t c = 0; c < static_cast<std::size_t>(desc.fields().size()); ++c) {
         auto& f = desc.fields(static_cast<int>(c));
@@ -97,31 +102,34 @@ inline util::BitSet build_column_bitset(const StreamDescriptor::Proto &desc, con
     return col_bitset;
 }
 
-inline util::BitSet build_column_bitset(const StreamDescriptor::Proto&desc, const std::vector<std::string>& columns) {
+inline util::BitSet build_column_bitset(const StreamDescriptor::Proto& desc, const std::vector<std::string>& columns)
+{
     folly::F14FastSet<std::string_view> col_set{columns.begin(), columns.end()};
     return build_column_bitset(desc, col_set);
 }
 
-inline bool contains_index_column(const std::vector<std::string>& columns, const StreamDescriptor::Proto& desc) {
-    return desc.index().field_count() == 0
-        || std::find(std::begin(columns), std::end(columns), desc.fields(0).name())
-            != std::end(columns);
+inline bool contains_index_column(const std::vector<std::string>& columns, const StreamDescriptor::Proto& desc)
+{
+    return desc.index().field_count() == 0 ||
+           std::find(std::begin(columns), std::end(columns), desc.fields(0).name()) != std::end(columns);
 }
 
-inline auto add_index_column(const std::vector<std::string>& columns, const StreamDescriptor::Proto& desc) {
+inline auto add_index_column(const std::vector<std::string>& columns, const StreamDescriptor::Proto& desc)
+{
     std::vector<std::string> columns_with_index{columns};
     columns_with_index.push_back(desc.fields(0).name());
     return columns_with_index;
 }
 
-inline std::optional<util::BitSet> requested_column_bitset_including_index(const StreamDescriptor::Proto& desc, const std::vector<std::string>& columns) {
+inline std::optional<util::BitSet> requested_column_bitset_including_index(const StreamDescriptor::Proto& desc,
+    const std::vector<std::string>& columns)
+{
     // Add the index column if it's not there
     if (!columns.empty()) {
-        if(!contains_index_column(columns, desc)) {
+        if (!contains_index_column(columns, desc)) {
             ARCTICDB_DEBUG(log::version(), "Specified columns missing index column");
             return build_column_bitset(desc, add_index_column(columns, desc));
-        }
-        else
+        } else
             return build_column_bitset(desc, columns);
     }
     return std::nullopt;
@@ -130,17 +138,18 @@ inline std::optional<util::BitSet> requested_column_bitset_including_index(const
 // Returns std::nullopt if all columns are required, which is the case if requested_columns is std::nullopt
 // Otherwise augment the requested_columns bitset with columns that are required by any of the clauses
 inline std::optional<util::BitSet> overall_column_bitset(const StreamDescriptor::Proto& desc,
-                                                         const std::shared_ptr<std::vector<Clause>>& clauses,
-                                                         const std::optional<util::BitSet>& requested_columns) {
+    const std::shared_ptr<std::vector<Clause>>& clauses,
+    const std::optional<util::BitSet>& requested_columns)
+{
     std::optional<util::BitSet> overall_column_bitset;
     if (requested_columns) {
         overall_column_bitset = *requested_columns;
         folly::F14FastSet<std::string_view> column_set;
         if (clauses) {
-            for (const auto& clause: *clauses) {
+            for (const auto& clause : *clauses) {
                 std::shared_ptr<ExecutionContext> execution_context = clause.execution_context();
                 if (execution_context) {
-                    for (const auto& column: execution_context->columns_) {
+                    for (const auto& column : execution_context->columns_) {
                         column_set.insert(std::string_view(column));
                     }
                 }
@@ -151,44 +160,52 @@ inline std::optional<util::BitSet> overall_column_bitset(const StreamDescriptor:
     return overall_column_bitset;
 }
 
-inline void generate_filtered_field_descriptors(PipelineContext& context, const std::vector<std::string>& columns) {
+inline void generate_filtered_field_descriptors(PipelineContext& context, const std::vector<std::string>& columns)
+{
     if (!columns.empty()) {
         std::unordered_set<std::string_view> column_set{std::begin(columns), std::end(columns)};
-        
+
         context.filter_columns_ = std::make_shared<std::vector<FieldDescriptor::Proto>>();
         context.filter_columns_->reserve(columns.size());
         const auto& desc = context.descriptor();
         ARCTICDB_DEBUG(log::version(), "Context descriptor: {}", desc);
-        std::copy_if(desc.fields().begin(), desc.fields().end(),
-                     std::back_inserter(*context.filter_columns_),
-                     [&](auto &field) {
-                         return column_set.find(field.name()) != column_set.end();
-                     });
+        std::copy_if(desc.fields().begin(),
+            desc.fields().end(),
+            std::back_inserter(*context.filter_columns_),
+            [&](auto& field) { return column_set.find(field.name()) != column_set.end(); });
 
         context.filter_columns_set_ = std::unordered_set<std::string_view>{};
-        for(const auto& field : *context.filter_columns_)
+        for (const auto& field : *context.filter_columns_)
             context.filter_columns_set_->insert(field.name());
     }
 }
 
-inline void generate_filtered_field_descriptors(std::shared_ptr<PipelineContext>& context, const std::vector<std::string>& columns) {
+inline void generate_filtered_field_descriptors(std::shared_ptr<PipelineContext>& context,
+    const std::vector<std::string>& columns)
+{
     generate_filtered_field_descriptors(*context, columns);
 }
 
 template<class ContainerType>
-inline std::vector<FilterQuery<ContainerType>> get_column_bitset_and_query_functions(
-    const ReadQuery& query,
+inline std::vector<FilterQuery<ContainerType>> get_column_bitset_and_query_functions(const ReadQuery& query,
     const std::shared_ptr<PipelineContext>& pipeline_context,
     bool dynamic_schema,
-    bool column_groups) {
+    bool column_groups)
+{
     using namespace arcticdb::pipelines::index;
 
-    if(!(dynamic_schema && !column_groups))
+    if (!(dynamic_schema && !column_groups))
         pipeline_context->set_selected_columns(query.columns);
 
-    pipeline_context->overall_column_bitset_ = overall_column_bitset(pipeline_context->descriptor().proto(), query.query_, pipeline_context->selected_columns_);
+    pipeline_context->overall_column_bitset_ = overall_column_bitset(pipeline_context->descriptor().proto(),
+        query.query_,
+        pipeline_context->selected_columns_);
 
-    return build_read_query_filters<ContainerType>(pipeline_context->overall_column_bitset_, pipeline_context, query.row_filter, dynamic_schema, column_groups);
+    return build_read_query_filters<ContainerType>(pipeline_context->overall_column_bitset_,
+        pipeline_context,
+        query.row_filter,
+        dynamic_schema,
+        column_groups);
 }
 
-} // arcticdb::pipelines
+} // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/slicing.cpp
+++ b/cpp/arcticdb/pipeline/slicing.cpp
@@ -12,47 +12,52 @@
 
 namespace arcticdb::pipelines {
 
-std::pair<int64_t, int64_t> get_index_and_field_count(const arcticdb::pipelines::InputTensorFrame& frame) {
+std::pair<int64_t, int64_t> get_index_and_field_count(const arcticdb::pipelines::InputTensorFrame& frame)
+{
     return {frame.desc.index().field_count(), frame.desc.fields().size()};
 }
 
-SlicingPolicy get_slicing_policy(
-    const WriteOptions& options,
-    const arcticdb::pipelines::InputTensorFrame& frame) {
-    if(frame.bucketize_dynamic) {
+SlicingPolicy get_slicing_policy(const WriteOptions& options, const arcticdb::pipelines::InputTensorFrame& frame)
+{
+    if (frame.bucketize_dynamic) {
         const auto [index_count, field_count] = get_index_and_field_count(frame);
         const auto col_count = field_count - index_count;
-        const auto num_buckets = std::min(static_cast<size_t>(std::ceil(double(col_count) / options.column_group_size)), options.max_num_buckets);
+        const auto num_buckets = std::min(static_cast<size_t>(std::ceil(double(col_count) / options.column_group_size)),
+            options.max_num_buckets);
         return HashedSlicer(num_buckets, options.segment_row_size);
     }
 
     return FixedSlicer{options.column_group_size, options.segment_row_size};
 }
 
-std::vector<FrameSlice> slice(InputTensorFrame& frame, const SlicingPolicy& arg) {
-    return util::variant_match(arg,
-            [&frame](NoSlicing) -> std::vector<FrameSlice> {
-                return {FrameSlice{std::make_shared<StreamDescriptor>(frame.desc),
-                                   ColRange{frame.desc.index().field_count(), frame.desc.fields().size()},
-                                   RowRange{0, frame.num_rows}}};
-            },
-            [&frame](const auto& slicer) {
-                return slicer(frame);
-            });
+std::vector<FrameSlice> slice(InputTensorFrame& frame, const SlicingPolicy& arg)
+{
+    return util::variant_match(
+        arg,
+        [&frame](NoSlicing) -> std::vector<FrameSlice> {
+            return {FrameSlice{std::make_shared<StreamDescriptor>(frame.desc),
+                ColRange{frame.desc.index().field_count(), frame.desc.fields().size()},
+                RowRange{0, frame.num_rows}}};
+        },
+        [&frame](const auto& slicer) { return slicer(frame); });
 }
 
-void add_index_fields(const arcticdb::pipelines::InputTensorFrame& frame, StreamDescriptor::FieldsCollection& current_fields) {
+void add_index_fields(const arcticdb::pipelines::InputTensorFrame& frame,
+    StreamDescriptor::FieldsCollection& current_fields)
+{
     for (auto i = 0u; i < frame.desc.index().field_count(); ++i) {
         auto ptr = current_fields.Add();
         ptr->CopyFrom(frame.desc.fields(0));
     }
 }
 
-std::pair<size_t, size_t> get_first_and_last_row(const arcticdb::pipelines::InputTensorFrame& frame) {
+std::pair<size_t, size_t> get_first_and_last_row(const arcticdb::pipelines::InputTensorFrame& frame)
+{
     return {frame.offset, frame.num_rows + frame.offset};
 }
 
-std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::InputTensorFrame& frame) const {
+std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::InputTensorFrame& frame) const
+{
     const auto [index_count, total_field_count] = get_index_and_field_count(frame);
     auto field_count = total_field_count - index_count;
     auto tensor_pos = std::begin(frame.field_tensors);
@@ -81,36 +86,35 @@ std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::Input
         StreamDescriptor::FieldsCollection current_fields;
         add_index_fields(frame, current_fields);
 
-        for(auto field = fields_pos; field < fields_next; ++field) {
+        for (auto field = fields_pos; field < fields_next; ++field) {
             auto ptr = current_fields.Add();
             ptr->CopyFrom(*field);
         }
 
         auto desc = std::make_shared<StreamDescriptor>(id, index, std::move(current_fields));
         for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
-            auto rdist = std::min(last_row-r, row_per_slice_);
-            slices.push_back(FrameSlice(desc,
-                              ColRange{col, col+distance},
-                              RowRange{r, r+rdist}));
+            auto rdist = std::min(last_row - r, row_per_slice_);
+            slices.push_back(FrameSlice(desc, ColRange{col, col + distance}, RowRange{r, r + rdist}));
         }
 
         col += col_per_slice_;
         tensor_pos = tensor_next;
         fields_pos = fields_next;
-    } while (tensor_pos!=std::end(frame.field_tensors));
+    } while (tensor_pos != std::end(frame.field_tensors));
     return slices;
 }
 
-std::vector<FrameSlice> HashedSlicer::operator()(const arcticdb::pipelines::InputTensorFrame& frame) const {
+std::vector<FrameSlice> HashedSlicer::operator()(const arcticdb::pipelines::InputTensorFrame& frame) const
+{
     std::vector<uint32_t> buckets;
     const auto [index_count, field_count] = get_index_and_field_count(frame);
 
-    for(auto i = index_count; i < field_count; ++i)
+    for (auto i = index_count; i < field_count; ++i)
         buckets.push_back(bucketize(frame.desc.field(i).name(), num_buckets_));
 
     std::vector<size_t> indices(buckets.size());
     std::iota(std::begin(indices), std::end(indices), index_count);
-    std::sort(std::begin(indices), std::end(indices), [&buckets, index_count=index_count] (size_t left, size_t right) {
+    std::sort(std::begin(indices), std::end(indices), [&buckets, index_count = index_count](size_t left, size_t right) {
         return buckets[left - index_count] < buckets[right - index_count];
     });
 
@@ -119,36 +123,37 @@ std::vector<FrameSlice> HashedSlicer::operator()(const arcticdb::pipelines::Inpu
     std::vector<FrameSlice> slices;
     auto start_pos = std::cbegin(indices);
     auto col = index_count;
-    
+
     do {
         const auto current_bucket = buckets[*start_pos - index_count];
-        const auto end_pos = std::find_if(start_pos, std::cend(indices), [&buckets, current_bucket, index_count=index_count] (size_t idx){
-            return buckets[idx - index_count] != current_bucket;
-        });
+        const auto end_pos = std::find_if(start_pos,
+            std::cend(indices),
+            [&buckets, current_bucket, index_count = index_count](
+                size_t idx) { return buckets[idx - index_count] != current_bucket; });
         const auto distance = std::distance(start_pos, end_pos);
 
         StreamDescriptor::FieldsCollection current_fields;
         add_index_fields(frame, current_fields);
 
-        for(auto field = start_pos; field < end_pos; ++field) {
+        for (auto field = start_pos; field < end_pos; ++field) {
             auto ptr = current_fields.Add();
             ptr->CopyFrom(frame.desc.field(*field));
         }
         auto desc = std::make_shared<StreamDescriptor>(frame.desc.id(), frame.desc.index(), std::move(current_fields));
-        
+
         for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
-            auto rdist = std::min(last_row-r, row_per_slice_);
+            auto rdist = std::min(last_row - r, row_per_slice_);
             slices.push_back(FrameSlice(desc,
-                                        ColRange{col, col + distance},
-                                        RowRange{r, r+rdist},
-                                        current_bucket,
-                                        num_buckets_,
-                                        std::vector<size_t>(start_pos, end_pos)));
+                ColRange{col, col + distance},
+                RowRange{r, r + rdist},
+                current_bucket,
+                num_buckets_,
+                std::vector<size_t>(start_pos, end_pos)));
         }
 
         start_pos = end_pos;
         col += distance;
-    } while(start_pos != std::cend(indices));
+    } while (start_pos != std::cend(indices));
 
     return slices;
 }

--- a/cpp/arcticdb/pipeline/string_pool_utils.cpp
+++ b/cpp/arcticdb/pipeline/string_pool_utils.cpp
@@ -9,14 +9,18 @@
 #include <arcticdb/pipeline/pipeline_context.hpp>
 
 namespace arcticdb {
-size_t first_context_row(const pipelines::SliceAndKey& slice_and_key, size_t first_row_in_frame) {
+size_t first_context_row(const pipelines::SliceAndKey& slice_and_key, size_t first_row_in_frame)
+{
     return slice_and_key.slice_.row_range.first - first_row_in_frame;
 }
 
-position_t get_offset_string(const pipelines::PipelineContextRow& context_row, ChunkedBuffer &src, std::size_t first_row_in_frame) {
+position_t
+get_offset_string(const pipelines::PipelineContextRow& context_row, ChunkedBuffer& src, std::size_t first_row_in_frame)
+{
     auto offset = first_context_row(context_row.slice_and_key(), first_row_in_frame);
     auto offset_val = get_offset_string_at(offset, src);
-    util::check(offset_val != nan_placeholder() && offset_val != not_a_string(), "NaN or None placeholder in get_offset_string");
+    util::check(offset_val != nan_placeholder() && offset_val != not_a_string(),
+        "NaN or None placeholder in get_offset_string");
     return offset_val;
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/pipeline/string_pool_utils.hpp
+++ b/cpp/arcticdb/pipeline/string_pool_utils.hpp
@@ -16,27 +16,36 @@
 namespace arcticdb {
 
 namespace pipelines {
-    struct SliceAndKey;
-    struct PipelineContextRow;
+struct SliceAndKey;
+struct PipelineContextRow;
+} // namespace pipelines
+
+inline auto get_offset_string_at(size_t offset, const ChunkedBuffer& src)
+{
+    return *(src.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t),
+        sizeof(StringPool::offset_t)));
 }
 
-inline auto get_offset_string_at(size_t offset, const ChunkedBuffer& src) {
-    return *(src.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t), sizeof(StringPool::offset_t)));
+inline auto get_offset_ptr_at(size_t offset, const ChunkedBuffer& src)
+{
+    return src.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t),
+        sizeof(StringPool::offset_t));
 }
 
-inline auto get_offset_ptr_at(size_t offset, const ChunkedBuffer& src) {
-    return src.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t), sizeof(StringPool::offset_t));
+inline void set_offset_string_at(size_t offset, ChunkedBuffer& target, StringPool::offset_t str)
+{
+    *(target.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t),
+        sizeof(StringPool::offset_t))) = str;
 }
 
-inline void set_offset_string_at(size_t offset, ChunkedBuffer& target,  StringPool::offset_t str) {
-    *(target.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t), sizeof(StringPool::offset_t))) = str;
-}
-
-inline auto get_string_from_pool(StringPool::offset_t offset_val, const StringPool& string_pool) {
+inline auto get_string_from_pool(StringPool::offset_t offset_val, const StringPool& string_pool)
+{
     return string_pool.get_const_view(offset_val);
 }
 
-inline std::variant<std::string_view, StringPool::offset_t> get_string_from_buffer(size_t offset, const ChunkedBuffer& src, const StringPool& string_pool) {
+inline std::variant<std::string_view, StringPool::offset_t>
+get_string_from_buffer(size_t offset, const ChunkedBuffer& src, const StringPool& string_pool)
+{
     auto offset_val = get_offset_string_at(offset, src);
     if (offset_val == nan_placeholder() || offset_val == not_a_string())
         return offset_val;
@@ -46,12 +55,17 @@ inline std::variant<std::string_view, StringPool::offset_t> get_string_from_buff
 
 size_t first_context_row(const pipelines::SliceAndKey& slice_and_key, size_t first_row_in_frame);
 
-position_t get_offset_string(const pipelines::PipelineContextRow& context_row, ChunkedBuffer &src, std::size_t first_row_in_frame);
+position_t
+get_offset_string(const pipelines::PipelineContextRow& context_row, ChunkedBuffer& src, std::size_t first_row_in_frame);
 
-inline size_t get_first_string_size(size_t num_rows, ChunkedBuffer &src, std::size_t first_row_in_frame, const StringPool& string_pool) {
+inline size_t get_first_string_size(size_t num_rows,
+    ChunkedBuffer& src,
+    std::size_t first_row_in_frame,
+    const StringPool& string_pool)
+{
     StringPool::offset_t offset_val{0};
 
-    for(auto row = 0u; row < num_rows; ++row) {
+    for (auto row = 0u; row < num_rows; ++row) {
         offset_val = get_offset_string_at(first_row_in_frame + row, src);
         if (offset_val != nan_placeholder() && offset_val != not_a_string())
             return get_string_from_pool(offset_val, string_pool).size();

--- a/cpp/arcticdb/pipeline/test/test_container.hpp
+++ b/cpp/arcticdb/pipeline/test/test_container.hpp
@@ -14,27 +14,29 @@ using namespace arcticdb::stream;
 using namespace arcticdb::pipelines::index;
 
 struct TestSegment {
-    TestSegment() :
-        start_(TypeDescriptor{DataType::UINT64, Dimension::Dim0}, false),
-        end_(TypeDescriptor{DataType::UINT64, Dimension::Dim0}, false) {
-
+    TestSegment()
+        : start_(TypeDescriptor{DataType::UINT64, Dimension::Dim0}, false),
+          end_(TypeDescriptor{DataType::UINT64, Dimension::Dim0}, false)
+    {
     }
     Column start_;
     Column end_;
     position_t row_ = 0;
 
-    const Column& column(position_t pos) const {
-        switch(pos) {
+    const Column& column(position_t pos) const
+    {
+        switch (pos) {
         case int(pipelines::index::Fields::start_index):
             return start_;
-            case int(pipelines::index::Fields::end_index):
-                return end_;
-                default:
-                    util::raise_rte("Unknown index");
+        case int(pipelines::index::Fields::end_index):
+            return end_;
+        default:
+            util::raise_rte("Unknown index");
         }
     }
 
-    void set_range(uint64_t start, uint64_t end) {
+    void set_range(uint64_t start, uint64_t end)
+    {
         start_.set_scalar(row_, start);
         end_.set_scalar(row_, end);
         ++row_;
@@ -44,17 +46,19 @@ struct TestSegment {
 struct TestContainer {
     mutable TestSegment seg_;
 
-    TestSegment& seg() const {
+    TestSegment& seg() const
+    {
         return seg_;
     }
 
-    size_t size() const {
+    size_t size() const
+    {
         return seg_.end_.row_count();
     }
 
-    bool empty() const {
+    bool empty() const
+    {
         return seg_.end_.row_count() == 0;
     }
 };
 } //namespace arcticdb
-

--- a/cpp/arcticdb/pipeline/test/test_query.cpp
+++ b/cpp/arcticdb/pipeline/test/test_query.cpp
@@ -10,8 +10,8 @@
 
 #include <arcticdb/pipeline/test/test_container.hpp>
 
-
-TEST(BitsetForIndex, DynamicSchemaStrictlyBefore) {
+TEST(BitsetForIndex, DynamicSchemaStrictlyBefore)
+{
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
     TestContainer container;
@@ -23,7 +23,8 @@ TEST(BitsetForIndex, DynamicSchemaStrictlyBefore) {
     ASSERT_EQ(bitset->count(), 0);
 }
 
-TEST(BitsetForIndex, DynamicSchemaStrictlyAfter) {
+TEST(BitsetForIndex, DynamicSchemaStrictlyAfter)
+{
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
     TestContainer container;
@@ -35,19 +36,21 @@ TEST(BitsetForIndex, DynamicSchemaStrictlyAfter) {
     ASSERT_EQ(bitset->count(), 0);
 }
 
-TEST(BitsetForIndex, DynamicSchemaMiddle) {
-   using namespace arcticdb;
-   using namespace arcticdb::pipelines;
-   TestContainer container;
-   container.seg().set_range(0, 2);
-   container.seg().set_range(5, 7);
-   IndexRange rg(3, 4);
-   std::unique_ptr<util::BitSet> input;
-   auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::move(input));
-   ASSERT_EQ(bitset->count(), 0);
+TEST(BitsetForIndex, DynamicSchemaMiddle)
+{
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+    TestContainer container;
+    container.seg().set_range(0, 2);
+    container.seg().set_range(5, 7);
+    IndexRange rg(3, 4);
+    std::unique_ptr<util::BitSet> input;
+    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::move(input));
+    ASSERT_EQ(bitset->count(), 0);
 }
 
-TEST(BitsetForIndex, DynamicSchemaOverlapBegin) {
+TEST(BitsetForIndex, DynamicSchemaOverlapBegin)
+{
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
     TestContainer container;
@@ -60,7 +63,8 @@ TEST(BitsetForIndex, DynamicSchemaOverlapBegin) {
     ASSERT_EQ(bitset->count(), 1);
 }
 
-TEST(BitsetForIndex, DynamicSchemaOverlapEnd) {
+TEST(BitsetForIndex, DynamicSchemaOverlapEnd)
+{
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
     TestContainer container;

--- a/cpp/arcticdb/pipeline/value.hpp
+++ b/cpp/arcticdb/pipeline/value.hpp
@@ -14,19 +14,24 @@ namespace arcticdb {
 using namespace arcticdb::entity;
 
 struct ValueIterator {
-    ValueIterator(char* data) :
-        data_(data) {
+    ValueIterator(char* data)
+        : data_(data)
+    {
     }
 
-    bool finished() const {
+    bool finished() const
+    {
         return false;
     }
 
-    uint8_t* value() const {
-        return reinterpret_cast<uint8_t *>(data_);
+    uint8_t* value() const
+    {
+        return reinterpret_cast<uint8_t*>(data_);
     }
 
-    void next() {}
+    void next()
+    {
+    }
 
     char* data_;
 };
@@ -37,50 +42,60 @@ struct Value {
     char data_[8];
     size_t len_ = 0;
 
-    template <typename T>
-    Value(T t) {
+    template<typename T>
+    Value(T t)
+    {
         *reinterpret_cast<T*>(&data_) = t;
     }
 
-    Value(const Value& other) :
-        data_type_(other.data_type_){
-        if(is_sequence_type(other.data_type_))
+    Value(const Value& other)
+        : data_type_(other.data_type_)
+    {
+        if (is_sequence_type(other.data_type_))
             assign_string(*other.str_data(), other.len_);
         else
             memcpy(data_, other.data_, 8);
     }
 
-    ValueIterator get_iterator() {
+    ValueIterator get_iterator()
+    {
         return {data_};
     }
 
-    template <typename T>
-    T get() const {
+    template<typename T>
+    T get() const
+    {
         return *reinterpret_cast<const T*>(&data_);
     }
 
-    template <typename T>
-    void set(T t) {
+    template<typename T>
+    void set(T t)
+    {
         *reinterpret_cast<T*>(data_) = t;
     }
 
-    TypeDescriptor type() const {
+    TypeDescriptor type() const
+    {
         return make_scalar_type(data_type_);
     }
 
-    char** str_data() {
+    char** str_data()
+    {
         return reinterpret_cast<char**>(data_);
     }
 
-    const char* const* str_data() const {
-        return reinterpret_cast<const char* const *>(data_);
+    const char* const* str_data() const
+    {
+        return reinterpret_cast<const char* const*>(data_);
     }
 
-    size_t len() const {
+    size_t len() const
+    {
         return len_;
     }
 
-    void assign_string(const char* c, size_t len) {
+    void assign_string(const char* c, size_t len)
+    {
         auto data = new char[len + 1];
         memcpy(data, c, len);
         data[len] = 0;
@@ -88,16 +103,18 @@ struct Value {
         len_ = len;
     }
 
-    void assign_string(const std::string& str) {
+    void assign_string(const std::string& str)
+    {
         len_ = str.size();
         auto data = new char[len_ + 1];
         memset(data, 0, len_ + 1);
-        memcpy(data, str.data(), str.size()) ;
+        memcpy(data, str.data(), str.size());
 
         *str_data() = data;
     }
 
-    void assign_utf32_string(const char* chr, size_t len) {
+    void assign_utf32_string(const char* chr, size_t len)
+    {
         len_ = len * UNICODE_WIDTH;
         auto data = new char[len_ + 1];
         memset(data, 0, len_ + 1);
@@ -109,7 +126,8 @@ struct Value {
         *str_data() = data;
     }
 
-    void assign_padded_utf32_string(const char* chr, size_t len, size_t buffer_len) {
+    void assign_padded_utf32_string(const char* chr, size_t len, size_t buffer_len)
+    {
         len_ = std::max(len * UNICODE_WIDTH, buffer_len);
         auto data = new char[len_ + 1];
         memset(data, 0, len_);
@@ -121,21 +139,25 @@ struct Value {
         *str_data() = data;
     }
 
-    ~Value() {
-        if(has_sequence_type())
+    ~Value()
+    {
+        if (has_sequence_type())
             delete[] *str_data();
     }
 
-    bool has_sequence_type() const {
+    bool has_sequence_type() const
+    {
         return is_sequence_type(data_type_);
     }
 
-    auto descriptor() {
-        return TypeDescriptor {data_type_, Dimension::Dim0};
+    auto descriptor()
+    {
+        return TypeDescriptor{data_type_, Dimension::Dim0};
     }
 };
 
-inline Value convert_to_utf32(const Value& other) {
+inline Value convert_to_utf32(const Value& other)
+{
     Value output;
     util::check(other.has_sequence_type(), "Can't convert value of non-sequence type to utf32");
     output.assign_utf32_string(*other.str_data(), other.len());
@@ -144,18 +166,20 @@ inline Value convert_to_utf32(const Value& other) {
 }
 
 template<typename T>
-Value construct_value(T val) {
+Value construct_value(T val)
+{
     util::raise_rte("Unrecognized value {}", val);
     return Value{};
 }
 
-#define VALUE_CONSTRUCT(__T__, __DT__)  \
-   template<> \
-    inline Value construct_value(__T__ val) { \
-        Value value; \
-        value.data_type_ = DataType::__DT__; \
-        *(reinterpret_cast<__T__ *>(&(value.data_))) = val; \
-        return value; \
+#define VALUE_CONSTRUCT(__T__, __DT__)                                                                                 \
+    template<>                                                                                                         \
+    inline Value construct_value(__T__ val)                                                                            \
+    {                                                                                                                  \
+        Value value;                                                                                                   \
+        value.data_type_ = DataType::__DT__;                                                                           \
+        *(reinterpret_cast<__T__*>(&(value.data_))) = val;                                                             \
+        return value;                                                                                                  \
     }
 
 VALUE_CONSTRUCT(bool, BOOL8)
@@ -170,27 +194,30 @@ VALUE_CONSTRUCT(int64_t, INT64)
 VALUE_CONSTRUCT(float, FLOAT32)
 VALUE_CONSTRUCT(double, FLOAT64)
 
-inline Value construct_string_value(const std::string& str) {
+inline Value construct_string_value(const std::string& str)
+{
     Value value;
     value.data_type_ = DataType::UTF_DYNAMIC64;
     value.assign_string(str);
     return value;
 }
 
-inline Value construct_string_value_from_char(const char* c, size_t len, DataType data_type) {
+inline Value construct_string_value_from_char(const char* c, size_t len, DataType data_type)
+{
     Value value;
     value.data_type_ = data_type;
     value.assign_string(c, len);
     return value;
 }
 
-inline std::optional<std::string> ascii_to_padded_utf32(std::string_view str, size_t width) {
+inline std::optional<std::string> ascii_to_padded_utf32(std::string_view str, size_t width)
+{
     if (str.size() * arcticdb::entity::UNICODE_WIDTH > width)
         return std::nullopt;
     std::string rv(width, '\0');
     auto input = str.data();
     auto output = rv.data();
-    for ([[maybe_unused]] const auto& c: str) {
+    for ([[maybe_unused]] const auto& c : str) {
         *output = *input++;
         output += arcticdb::entity::UNICODE_WIDTH;
     }

--- a/cpp/arcticdb/pipeline/value_set.cpp
+++ b/cpp/arcticdb/pipeline/value_set.cpp
@@ -13,79 +13,81 @@
 
 namespace arcticdb {
 
-    ValueSet::ValueSet(std::vector<std::string>&& value_list) {
-        base_type_ = make_scalar_type(entity::DataType::UTF_DYNAMIC64);
-        typed_set_string_ = std::make_shared<std::unordered_set<std::string>>();
-        for (const auto& value: value_list) {
-            typed_set_string_->emplace(std::move(value));
+ValueSet::ValueSet(std::vector<std::string>&& value_list)
+{
+    base_type_ = make_scalar_type(entity::DataType::UTF_DYNAMIC64);
+    typed_set_string_ = std::make_shared<std::unordered_set<std::string>>();
+    for (const auto& value : value_list) {
+        typed_set_string_->emplace(std::move(value));
+    }
+    empty_ = value_list.empty();
+}
+
+// This currently assumes that the numpy array passed in is already of minimal type, and cannot be shrunk further
+// We could relax this assumption with additional checks involving numeric limits here
+ValueSet::ValueSet(py::array value_list)
+{
+    if (py::isinstance<py::array_t<uint8_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S8));
+        numeric_base_set_ = typed_set_uint8_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<uint16_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S16));
+        numeric_base_set_ = typed_set_uint16_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<uint32_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S32));
+        numeric_base_set_ = typed_set_uint32_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<uint64_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S64));
+        numeric_base_set_ = typed_set_uint64_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<int8_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S8));
+        numeric_base_set_ = typed_set_int8_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<int16_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S16));
+        numeric_base_set_ = typed_set_int16_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<int32_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S32));
+        numeric_base_set_ = typed_set_int32_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<int64_t>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S64));
+        numeric_base_set_ = typed_set_int64_t_.create(value_list);
+    } else if (py::isinstance<py::array_t<float>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::FLOAT, entity::SizeBits::S32));
+        numeric_base_set_ = typed_set_float_.create(value_list);
+    } else if (py::isinstance<py::array_t<double>>(value_list)) {
+        base_type_ = make_scalar_type(combine_data_type(entity::ValueType::FLOAT, entity::SizeBits::S64));
+        numeric_base_set_ = typed_set_double_.create(value_list);
+    } else {
+        util::raise_rte("Unexpected numpy array type passed to ValueSet constructor");
+    }
+    util::variant_match(numeric_base_set_, [&](const auto& numeric_base_set) { empty_ = numeric_base_set->empty(); });
+}
+
+bool ValueSet::empty() const
+{
+    return empty_;
+}
+
+const entity::TypeDescriptor& ValueSet::base_type() const
+{
+    return base_type_;
+}
+
+std::shared_ptr<std::unordered_set<std::string>> ValueSet::get_fixed_width_string_set(size_t width)
+{
+    std::lock_guard lock(*mutex_);
+    auto it = typed_set_fixed_width_strings_.find(width);
+    if (it != typed_set_fixed_width_strings_.end()) {
+        return it->second;
+    } else {
+        auto fixed_width_string_set = std::make_shared<std::unordered_set<std::string>>();
+        for (const auto& str : *typed_set_string_) {
+            auto maybe_padded_str = ascii_to_padded_utf32(str, width);
+            if (maybe_padded_str.has_value())
+                fixed_width_string_set->insert(*maybe_padded_str);
         }
-        empty_ = value_list.empty();
-    }
-
-    // This currently assumes that the numpy array passed in is already of minimal type, and cannot be shrunk further
-    // We could relax this assumption with additional checks involving numeric limits here
-    ValueSet::ValueSet(py::array value_list) {
-        if (py::isinstance<py::array_t<uint8_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S8));
-            numeric_base_set_ = typed_set_uint8_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<uint16_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S16));
-            numeric_base_set_ = typed_set_uint16_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<uint32_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S32));
-            numeric_base_set_ = typed_set_uint32_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<uint64_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S64));
-            numeric_base_set_ = typed_set_uint64_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<int8_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S8));
-            numeric_base_set_ = typed_set_int8_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<int16_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S16));
-            numeric_base_set_ = typed_set_int16_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<int32_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S32));
-            numeric_base_set_ = typed_set_int32_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<int64_t>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S64));
-            numeric_base_set_ = typed_set_int64_t_.create(value_list);
-        } else if (py::isinstance<py::array_t<float>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::FLOAT, entity::SizeBits::S32));
-            numeric_base_set_ = typed_set_float_.create(value_list);
-        } else if (py::isinstance<py::array_t<double>>(value_list)) {
-            base_type_ = make_scalar_type(combine_data_type(entity::ValueType::FLOAT, entity::SizeBits::S64));
-            numeric_base_set_ = typed_set_double_.create(value_list);
-        } else {
-            util::raise_rte("Unexpected numpy array type passed to ValueSet constructor");
-        }
-        util::variant_match(numeric_base_set_,
-        [&](const auto& numeric_base_set) {
-            empty_ = numeric_base_set->empty();
-        });
-    }
-
-    bool ValueSet::empty() const {
-        return empty_;
-    }
-
-    const entity::TypeDescriptor& ValueSet::base_type() const {
-        return base_type_;
-    }
-
-    std::shared_ptr<std::unordered_set<std::string>> ValueSet::get_fixed_width_string_set(size_t width) {
-        std::lock_guard lock(*mutex_);
-        auto it = typed_set_fixed_width_strings_.find(width);
-        if (it != typed_set_fixed_width_strings_.end()) {
-            return it->second;
-        } else {
-            auto fixed_width_string_set = std::make_shared<std::unordered_set<std::string>>();
-            for (const auto& str: *typed_set_string_) {
-                auto maybe_padded_str = ascii_to_padded_utf32(str, width);
-                if (maybe_padded_str.has_value())
-                    fixed_width_string_set->insert(*maybe_padded_str);
-            }
-            typed_set_fixed_width_strings_.insert(std::make_pair(width, std::move(fixed_width_string_set)));
-            return typed_set_fixed_width_strings_.at(width);
-        }
+        typed_set_fixed_width_strings_.insert(std::make_pair(width, std::move(fixed_width_string_set)));
+        return typed_set_fixed_width_strings_.at(width);
     }
 }
+} // namespace arcticdb

--- a/cpp/arcticdb/pipeline/value_set.hpp
+++ b/cpp/arcticdb/pipeline/value_set.hpp
@@ -35,24 +35,24 @@ public:
     const entity::TypeDescriptor& base_type() const;
 
     template<typename T>
-    std::shared_ptr<std::unordered_set<T>> get_set() {
+    std::shared_ptr<std::unordered_set<T>> get_set()
+    {
         util::raise_rte("ValueSet::get_set called with unexpected template type");
     }
 
     std::shared_ptr<std::unordered_set<std::string>> get_fixed_width_string_set(size_t width);
 
 private:
-    using NumericSetType = std::variant<
-            std::shared_ptr<std::unordered_set<uint8_t>>,
-            std::shared_ptr<std::unordered_set<uint16_t>>,
-            std::shared_ptr<std::unordered_set<uint32_t>>,
-            std::shared_ptr<std::unordered_set<uint64_t>>,
-            std::shared_ptr<std::unordered_set<int8_t>>,
-            std::shared_ptr<std::unordered_set<int16_t>>,
-            std::shared_ptr<std::unordered_set<int32_t>>,
-            std::shared_ptr<std::unordered_set<int64_t>>,
-            std::shared_ptr<std::unordered_set<float>>,
-            std::shared_ptr<std::unordered_set<double>>>;
+    using NumericSetType = std::variant<std::shared_ptr<std::unordered_set<uint8_t>>,
+        std::shared_ptr<std::unordered_set<uint16_t>>,
+        std::shared_ptr<std::unordered_set<uint32_t>>,
+        std::shared_ptr<std::unordered_set<uint64_t>>,
+        std::shared_ptr<std::unordered_set<int8_t>>,
+        std::shared_ptr<std::unordered_set<int16_t>>,
+        std::shared_ptr<std::unordered_set<int32_t>>,
+        std::shared_ptr<std::unordered_set<int64_t>>,
+        std::shared_ptr<std::unordered_set<float>>,
+        std::shared_ptr<std::unordered_set<double>>>;
 
     bool empty_;
     entity::TypeDescriptor base_type_;
@@ -61,13 +61,15 @@ private:
     template<typename T>
     class typed_set {
     public:
-        ARCTICDB_VISIBILITY_HIDDEN std::shared_ptr<std::unordered_set<T>> create(py::array value_list) {
-            std::call_once(flag_, [&]{set_ = create_internal(value_list);});
+        ARCTICDB_VISIBILITY_HIDDEN std::shared_ptr<std::unordered_set<T>> create(py::array value_list)
+        {
+            std::call_once(flag_, [&] { set_ = create_internal(value_list); });
             return set_;
         }
 
-        std::shared_ptr<std::unordered_set<T>> transform(const NumericSetType& numeric_base_set) {
-            std::call_once(flag_, [&]{set_ = transform_internal(numeric_base_set);});
+        std::shared_ptr<std::unordered_set<T>> transform(const NumericSetType& numeric_base_set)
+        {
+            std::call_once(flag_, [&] { set_ = transform_internal(numeric_base_set); });
             return set_;
         }
 
@@ -75,7 +77,8 @@ private:
         std::shared_ptr<std::unordered_set<T>> set_;
         std::once_flag flag_;
 
-        std::shared_ptr<std::unordered_set<T>> create_internal(py::array value_list) {
+        std::shared_ptr<std::unordered_set<T>> create_internal(py::array value_list)
+        {
             auto arr = value_list.unchecked<T, 1>();
             auto set = std::make_shared<std::unordered_set<T>>();
             for (py::ssize_t i = 0; i < arr.shape(0); i++) {
@@ -84,11 +87,11 @@ private:
             return set;
         }
 
-        std::shared_ptr<std::unordered_set<T>> transform_internal(const NumericSetType& numeric_base_set) {
+        std::shared_ptr<std::unordered_set<T>> transform_internal(const NumericSetType& numeric_base_set)
+        {
             auto target_set = std::make_shared<std::unordered_set<T>>();
-            util::variant_match(numeric_base_set,
-            [&](const auto& source_set) {
-                for (const auto& member: *source_set) {
+            util::variant_match(numeric_base_set, [&](const auto& source_set) {
+                for (const auto& member : *source_set) {
                     target_set->insert(static_cast<T>(member));
                 }
             });
@@ -110,62 +113,72 @@ private:
     typed_set<float> typed_set_float_;
     typed_set<double> typed_set_double_;
     std::unique_ptr<std::mutex> mutex_ = std::make_unique<std::mutex>();
-
 };
 
 template<>
-inline std::shared_ptr<std::unordered_set<std::string>> ValueSet::get_set<std::string>() {
+inline std::shared_ptr<std::unordered_set<std::string>> ValueSet::get_set<std::string>()
+{
     return typed_set_string_;
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<uint8_t>> ValueSet::get_set<uint8_t>() {
+inline std::shared_ptr<std::unordered_set<uint8_t>> ValueSet::get_set<uint8_t>()
+{
     return typed_set_uint8_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<uint16_t>> ValueSet::get_set<uint16_t>() {
+inline std::shared_ptr<std::unordered_set<uint16_t>> ValueSet::get_set<uint16_t>()
+{
     return typed_set_uint16_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<uint32_t>> ValueSet::get_set<uint32_t>() {
+inline std::shared_ptr<std::unordered_set<uint32_t>> ValueSet::get_set<uint32_t>()
+{
     return typed_set_uint32_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<uint64_t>> ValueSet::get_set<uint64_t>() {
+inline std::shared_ptr<std::unordered_set<uint64_t>> ValueSet::get_set<uint64_t>()
+{
     return typed_set_uint64_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<int8_t>> ValueSet::get_set<int8_t>() {
+inline std::shared_ptr<std::unordered_set<int8_t>> ValueSet::get_set<int8_t>()
+{
     return typed_set_int8_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<int16_t>> ValueSet::get_set<int16_t>() {
+inline std::shared_ptr<std::unordered_set<int16_t>> ValueSet::get_set<int16_t>()
+{
     return typed_set_int16_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<int32_t>> ValueSet::get_set<int32_t>() {
+inline std::shared_ptr<std::unordered_set<int32_t>> ValueSet::get_set<int32_t>()
+{
     return typed_set_int32_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<int64_t>> ValueSet::get_set<int64_t>() {
+inline std::shared_ptr<std::unordered_set<int64_t>> ValueSet::get_set<int64_t>()
+{
     return typed_set_int64_t_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<float>> ValueSet::get_set<float>() {
+inline std::shared_ptr<std::unordered_set<float>> ValueSet::get_set<float>()
+{
     return typed_set_float_.transform(numeric_base_set_);
 }
 
 template<>
-inline std::shared_ptr<std::unordered_set<double>> ValueSet::get_set<double>() {
+inline std::shared_ptr<std::unordered_set<double>> ValueSet::get_set<double>()
+{
     return typed_set_double_.transform(numeric_base_set_);
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -30,14 +30,14 @@ namespace arcticdb::pipelines {
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;
 
-std::vector<folly::Future<SliceAndKey>> write_slices(
-        const InputTensorFrame &frame,
-        const std::vector<FrameSlice> &slices,
-        const SlicingPolicy &slicing,
-        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
-        const std::shared_ptr<stream::StreamSink>& sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map,
-        bool sparsify_floats) {
+std::vector<folly::Future<SliceAndKey>> write_slices(const InputTensorFrame& frame,
+    const std::vector<FrameSlice>& slices,
+    const SlicingPolicy& slicing,
+    folly::Function<stream::StreamSink::PartialKey(const FrameSlice&)>&& partial_key_gen,
+    const std::shared_ptr<stream::StreamSink>& sink,
+    const std::shared_ptr<DeDupMap>& de_dup_map,
+    bool sparsify_floats)
+{
     ARCTICDB_SAMPLE(WriteSlices, 0)
     std::vector<std::pair<stream::StreamSink::PartialKey, SegmentInMemory>> key_segs;
     key_segs.reserve(slices.size());
@@ -45,34 +45,32 @@ std::vector<folly::Future<SliceAndKey>> write_slices(
     std::vector<std::vector<folly::Future<VariantKey>>> key_groups;
 
     // construct batch
-    util::variant_match(frame.index, [&](auto &idx) {
+    util::variant_match(frame.index, [&](auto& idx) {
         using IdxType = std::decay_t<decltype(idx)>;
         using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
 
         size_t slice_num_for_column = 0;
         std::optional<size_t> first_row;
-        for (const FrameSlice &slice : slices) {
+        for (const FrameSlice& slice : slices) {
             // Build in mem segment
             ARCTICDB_SUBSAMPLE_AGG(WriteSliceCopyToSegment)
-            if(!first_row)
+            if (!first_row)
                 first_row = slice.row_range.first;
 
-            if(slice.row_range.first == first_row.value())
+            if (slice.row_range.first == first_row.value())
                 slice_num_for_column = 0;
 
-            SingleSegmentAggregator agg{FixedSchema{*slice.desc(), frame.index}, [&](auto &&segment) {
-                auto key = partial_key_gen(slice);
-                key_segs.emplace_back(partial_key_gen(slice), std::forward<SegmentInMemory>(segment));
-            }};
+            SingleSegmentAggregator agg{FixedSchema{*slice.desc(), frame.index}, [&](auto&& segment) {
+                                            auto key = partial_key_gen(slice);
+                                            key_segs.emplace_back(partial_key_gen(slice),
+                                                std::forward<SegmentInMemory>(segment));
+                                        }};
 
-            auto regular_slice_size = util::variant_match(slicing,
+            auto regular_slice_size = util::variant_match(
+                slicing,
 
-              [&](const NoSlicing &) {
-                  return slice.row_range.second - slice.row_range.first;
-              },
-              [&](const auto &slicer) {
-                return slicer.row_per_slice();
-              });
+                [&](const NoSlicing&) { return slice.row_range.second - slice.row_range.first; },
+                [&](const auto& slicer) { return slicer.row_per_slice(); });
 
             auto offset_in_frame = slice_begin_pos(slice, frame);
             // Offset is used for index value in row-count index
@@ -80,20 +78,30 @@ std::vector<folly::Future<SliceAndKey>> write_slices(
             auto rows_to_write = slice.row_range.second - slice.row_range.first;
             if (frame.desc.index().field_count() > 0) {
                 util::check(static_cast<bool>(frame.index_tensor), "Got null index tensor in write_slices");
-                aggregator_set_data(
-                    type_desc_from_proto(frame.desc.fields(0).type_desc()),
+                aggregator_set_data(type_desc_from_proto(frame.desc.fields(0).type_desc()),
                     frame.index_tensor.value(),
-                    agg, 0, rows_to_write, offset_in_frame, slice_num_for_column, regular_slice_size, false);
+                    agg,
+                    0,
+                    rows_to_write,
+                    offset_in_frame,
+                    slice_num_for_column,
+                    regular_slice_size,
+                    false);
             }
 
             for (size_t col = 0, end = slice.col_range.diff(); col < end; ++col) {
                 auto abs_col = col + frame.desc.index().field_count();
-                auto &fd = slice.non_index_field(col);
-                auto &tensor = frame.field_tensors[slice.absolute_field_col(col)];
-                aggregator_set_data(
-                    type_desc_from_proto(fd.type_desc()),
-                    tensor, agg, abs_col, rows_to_write, offset_in_frame, slice_num_for_column,
-                    regular_slice_size, sparsify_floats);
+                auto& fd = slice.non_index_field(col);
+                auto& tensor = frame.field_tensors[slice.absolute_field_col(col)];
+                aggregator_set_data(type_desc_from_proto(fd.type_desc()),
+                    tensor,
+                    agg,
+                    abs_col,
+                    rows_to_write,
+                    offset_in_frame,
+                    slice_num_for_column,
+                    regular_slice_size,
+                    sparsify_floats);
             }
 
             ++slice_num_for_column;
@@ -105,125 +113,130 @@ std::vector<folly::Future<SliceAndKey>> write_slices(
     auto fut_writes = sink->batch_write(std::move(key_segs), de_dup_map);
 
     ARCTICDB_SUBSAMPLE_DEFAULT(WriteSlicesWait)
-    return std::move(fut_writes).thenValue([&](auto &&keys) {
-        std::vector<folly::Future<SliceAndKey>> res;
-        res.reserve(keys.size());
-        for (std::size_t i = 0; i < res.capacity(); ++i) {
-            res.emplace_back(SliceAndKey{slices[i], std::move(to_atom(keys[i]))});
-        }
-        return res;
-    }).get();
+    return std::move(fut_writes)
+        .thenValue([&](auto&& keys) {
+            std::vector<folly::Future<SliceAndKey>> res;
+            res.reserve(keys.size());
+            for (std::size_t i = 0; i < res.capacity(); ++i) {
+                res.emplace_back(SliceAndKey{slices[i], std::move(to_atom(keys[i]))});
+            }
+            return res;
+        })
+        .get();
 }
 
-folly::Future<entity::VariantKey> write_multi_index(
-        InputTensorFrame&& frame,
-        std::vector<SliceAndKey>&& slice_and_keys,
-        const IndexPartialKey& partial_key,
-        const std::shared_ptr<stream::StreamSink>& sink
-) {
+folly::Future<entity::VariantKey> write_multi_index(InputTensorFrame&& frame,
+    std::vector<SliceAndKey>&& slice_and_keys,
+    const IndexPartialKey& partial_key,
+    const std::shared_ptr<stream::StreamSink>& sink)
+{
     auto metadata = descriptor_from_frame(std::move(frame), frame.offset);
     index::IndexWriter<stream::RowCountIndex> writer(sink, partial_key, std::move(metadata));
-    for (auto &slice_and_key : slice_and_keys) {
+    for (auto& slice_and_key : slice_and_keys) {
         writer.add(slice_and_key.key(), slice_and_key.slice_);
     }
     return writer.commit();
 }
 
-std::vector<folly::Future<SliceAndKey>> slice_and_write(
-        InputTensorFrame &frame,
-        const SlicingPolicy &slicing,
-        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
-        const std::shared_ptr<stream::StreamSink>& sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map,
-        bool sparsify_floats) {
+std::vector<folly::Future<SliceAndKey>> slice_and_write(InputTensorFrame& frame,
+    const SlicingPolicy& slicing,
+    folly::Function<stream::StreamSink::PartialKey(const FrameSlice&)>&& partial_key_gen,
+    const std::shared_ptr<stream::StreamSink>& sink,
+    const std::shared_ptr<DeDupMap>& de_dup_map,
+    bool sparsify_floats)
+{
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceFrame)
     auto slices = slice(frame, slicing);
 
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
-    auto fut_slice_keys = write_slices(frame, slices, slicing, std::move(partial_key_gen), sink, de_dup_map, sparsify_floats);
+    auto fut_slice_keys =
+        write_slices(frame, slices, slicing, std::move(partial_key_gen), sink, de_dup_map, sparsify_floats);
     return fut_slice_keys;
 }
 
-folly::Future<entity::AtomKey>
-write_frame(
-        const IndexPartialKey& key,
-        InputTensorFrame&& frame,
-        const SlicingPolicy &slicing,
-        const std::shared_ptr<Store>& store,
-        const std::shared_ptr<DeDupMap>& de_dup_map,
-        bool sparsify_floats) {
+folly::Future<entity::AtomKey> write_frame(const IndexPartialKey& key,
+    InputTensorFrame&& frame,
+    const SlicingPolicy& slicing,
+    const std::shared_ptr<Store>& store,
+    const std::shared_ptr<DeDupMap>& de_dup_map,
+    bool sparsify_floats)
+{
     ARCTICDB_SAMPLE_DEFAULT(WriteFrame)
-    auto fut_slice_keys = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store, de_dup_map, sparsify_floats);
+    auto fut_slice_keys =
+        slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store, de_dup_map, sparsify_floats);
     // Write the keys of the slices into an index segment
     ARCTICDB_SUBSAMPLE_DEFAULT(WriteIndex)
     return index::write_index(std::move(frame), std::move(fut_slice_keys), key, store);
 }
 
-arcticdb::entity::SortedValue deduce_sorted(arcticdb::proto::descriptors::SortedValue existing_sorted, arcticdb::proto::descriptors::SortedValue new_sorted){
+arcticdb::entity::SortedValue deduce_sorted(arcticdb::proto::descriptors::SortedValue existing_sorted,
+    arcticdb::proto::descriptors::SortedValue new_sorted)
+{
     auto final_sorted = arcticdb::entity::SortedValue::UNSORTED;
-    switch(existing_sorted){
-        case arcticdb::proto::descriptors::SortedValue::UNKNOWN:
-            if(new_sorted != arcticdb::proto::descriptors::SortedValue::UNSORTED){
-                final_sorted = arcticdb::entity::SortedValue::UNKNOWN;
-            }else{
-                final_sorted = arcticdb::entity::SortedValue::UNSORTED;
-            }
-            break;
-        case arcticdb::proto::descriptors::SortedValue::ASCENDING:
-            if(new_sorted  == arcticdb::proto::descriptors::SortedValue::UNKNOWN){
-                final_sorted = arcticdb::entity::SortedValue::UNKNOWN;
-            }else if (new_sorted  != arcticdb::proto::descriptors::SortedValue::ASCENDING){
-                final_sorted = arcticdb::entity::SortedValue::UNSORTED;
-            }else{
-                final_sorted = arcticdb::entity::SortedValue::ASCENDING;
-            }
-            break;
-        case arcticdb::proto::descriptors::SortedValue::DESCENDING:
-            if(new_sorted  == arcticdb::proto::descriptors::SortedValue::UNKNOWN){
-                final_sorted = arcticdb::entity::SortedValue::UNKNOWN;
-            }else if (new_sorted  != arcticdb::proto::descriptors::SortedValue::DESCENDING){
-                final_sorted = arcticdb::entity::SortedValue::UNSORTED;
-            }else{
-                final_sorted = arcticdb::entity::SortedValue::DESCENDING;
-            }
-            break;
-        default:
+    switch (existing_sorted) {
+    case arcticdb::proto::descriptors::SortedValue::UNKNOWN:
+        if (new_sorted != arcticdb::proto::descriptors::SortedValue::UNSORTED) {
+            final_sorted = arcticdb::entity::SortedValue::UNKNOWN;
+        } else {
             final_sorted = arcticdb::entity::SortedValue::UNSORTED;
-            break;
+        }
+        break;
+    case arcticdb::proto::descriptors::SortedValue::ASCENDING:
+        if (new_sorted == arcticdb::proto::descriptors::SortedValue::UNKNOWN) {
+            final_sorted = arcticdb::entity::SortedValue::UNKNOWN;
+        } else if (new_sorted != arcticdb::proto::descriptors::SortedValue::ASCENDING) {
+            final_sorted = arcticdb::entity::SortedValue::UNSORTED;
+        } else {
+            final_sorted = arcticdb::entity::SortedValue::ASCENDING;
+        }
+        break;
+    case arcticdb::proto::descriptors::SortedValue::DESCENDING:
+        if (new_sorted == arcticdb::proto::descriptors::SortedValue::UNKNOWN) {
+            final_sorted = arcticdb::entity::SortedValue::UNKNOWN;
+        } else if (new_sorted != arcticdb::proto::descriptors::SortedValue::DESCENDING) {
+            final_sorted = arcticdb::entity::SortedValue::UNSORTED;
+        } else {
+            final_sorted = arcticdb::entity::SortedValue::DESCENDING;
+        }
+        break;
+    default:
+        final_sorted = arcticdb::entity::SortedValue::UNSORTED;
+        break;
     }
     return final_sorted;
 }
 
-folly::Future<entity::AtomKey> append_frame(
-        const IndexPartialKey& key,
-        InputTensorFrame&& frame,
-        const SlicingPolicy& slicing,
-        index::IndexSegmentReader& index_segment_reader,
-        const std::shared_ptr<Store>& store,
-        bool dynamic_schema,
-        bool ignore_sort_order)
+folly::Future<entity::AtomKey> append_frame(const IndexPartialKey& key,
+    InputTensorFrame&& frame,
+    const SlicingPolicy& slicing,
+    index::IndexSegmentReader& index_segment_reader,
+    const std::shared_ptr<Store>& store,
+    bool dynamic_schema,
+    bool ignore_sort_order)
 {
     ARCTICDB_SAMPLE_DEFAULT(AppendFrame)
-    util::variant_match(frame.index,
-                        [&index_segment_reader, &frame, ignore_sort_order](const TimeseriesIndex &) {
-                            util::check(frame.has_index(), "Cannot append timeseries without index");
-                            util::check(static_cast<bool>(frame.index_tensor), "Got null index tensor in append_frame");
-                            auto& frame_index = frame.index_tensor.value();
-                            util::check(frame_index.size() > 0, "Cannot append empty frame");
-                            util::check(frame_index.data_type() == DataType::MICROS_UTC64,
-                                        "Expected timestamp index in append, got type {}", frame_index.data_type());
-                            if (index_segment_reader.tsd().total_rows() != 0) {
-                                auto first_index = NumericIndex{*frame_index.ptr_cast<timestamp>(0)};
-                                auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
-                                util::check(ignore_sort_order || prev - 1 <= first_index,
-                                            "Can't append dataframe with start index {} to existing sequence ending at {}",
-                                            util::format_timestamp(first_index), util::format_timestamp(prev));
-                            }
-                        },
-                        [](const auto &) {
-                            //Do whatever, but you can't range search it
-                        }
-    );
+    util::variant_match(
+        frame.index,
+        [&index_segment_reader, &frame, ignore_sort_order](const TimeseriesIndex&) {
+            util::check(frame.has_index(), "Cannot append timeseries without index");
+            util::check(static_cast<bool>(frame.index_tensor), "Got null index tensor in append_frame");
+            auto& frame_index = frame.index_tensor.value();
+            util::check(frame_index.size() > 0, "Cannot append empty frame");
+            util::check(frame_index.data_type() == DataType::MICROS_UTC64,
+                "Expected timestamp index in append, got type {}",
+                frame_index.data_type());
+            if (index_segment_reader.tsd().total_rows() != 0) {
+                auto first_index = NumericIndex{*frame_index.ptr_cast<timestamp>(0)};
+                auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
+                util::check(ignore_sort_order || prev - 1 <= first_index,
+                    "Can't append dataframe with start index {} to existing sequence ending at {}",
+                    util::format_timestamp(first_index),
+                    util::format_timestamp(prev));
+            }
+        },
+        [](const auto&) {
+            //Do whatever, but you can't range search it
+        });
 
     auto existing_slices = unfiltered_index(index_segment_reader);
     auto fut_slice_keys = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store);
@@ -232,116 +245,144 @@ folly::Future<entity::AtomKey> append_frame(
     auto slice_and_keys_to_append = keys_fut.wait().value();
 
     auto slices_to_write = std::move(existing_slices);
-    slices_to_write.insert(std::end(slices_to_write), std::begin(slice_and_keys_to_append), std::end(slice_and_keys_to_append));
+    slices_to_write.insert(std::end(slices_to_write),
+        std::begin(slice_and_keys_to_append),
+        std::end(slice_and_keys_to_append));
     std::sort(std::begin(slices_to_write), std::end(slices_to_write));
-    if(dynamic_schema) {
+    if (dynamic_schema) {
         auto merged_descriptor =
             merge_descriptors(frame.desc, {index_segment_reader.tsd().stream_descriptor().fields()}, {});
-        merged_descriptor.set_sorted(deduce_sorted(index_segment_reader.mutable_tsd().stream_descriptor().sorted(), frame.desc.get_sorted()));
-        auto pb_desc =
-            make_descriptor(frame.num_rows + frame.offset, std::move(merged_descriptor), frame.norm_meta, std::move(frame.user_meta), std::nullopt, frame.bucketize_dynamic);
-        return index::write_index(stream::index_type_from_descriptor(frame.desc), std::move(pb_desc), std::move(slices_to_write), key, store);
+        merged_descriptor.set_sorted(
+            deduce_sorted(index_segment_reader.mutable_tsd().stream_descriptor().sorted(), frame.desc.get_sorted()));
+        auto pb_desc = make_descriptor(frame.num_rows + frame.offset,
+            std::move(merged_descriptor),
+            frame.norm_meta,
+            std::move(frame.user_meta),
+            std::nullopt,
+            frame.bucketize_dynamic);
+        return index::write_index(stream::index_type_from_descriptor(frame.desc),
+            std::move(pb_desc),
+            std::move(slices_to_write),
+            key,
+            store);
     } else {
-        frame.desc.set_sorted(deduce_sorted(index_segment_reader.mutable_tsd().stream_descriptor().sorted(), frame.desc.get_sorted()));
+        frame.desc.set_sorted(
+            deduce_sorted(index_segment_reader.mutable_tsd().stream_descriptor().sorted(), frame.desc.get_sorted()));
         return index::write_index(std::move(frame), std::move(slices_to_write), key, store);
     }
 }
 
-void update_string_columns(const SegmentInMemory& original, SegmentInMemory output) {
-    util::check(original.descriptor() == output.descriptor(), "Update string column handling expects identical descriptors");
+void update_string_columns(const SegmentInMemory& original, SegmentInMemory output)
+{
+    util::check(original.descriptor() == output.descriptor(),
+        "Update string column handling expects identical descriptors");
     for (size_t column = 0; column < static_cast<size_t>(original.descriptor().fields().size()); ++column) {
-        auto &frame_field = original.field(column);
+        auto& frame_field = original.field(column);
         auto field_type = data_type_from_proto(frame_field.type_desc());
 
         if (is_sequence_type(field_type)) {
-            auto &target = output.column(static_cast<position_t>(column)).data().buffer();
+            auto& target = output.column(static_cast<position_t>(column)).data().buffer();
             size_t end = output.row_count();
-            for(auto row = 0u; row < end; ++row) {
+            for (auto row = 0u; row < end; ++row) {
                 auto val = get_string_from_buffer(row, target, original.const_string_pool());
-                util::variant_match(val,
-                                    [&] (std::string_view sv) {
-                                        auto off_str = output.string_pool().get(sv);
-                                        set_offset_string_at(row, target, off_str.offset());
-                                    },
-                                    [&] (StringPool::offset_t offset) {
-                                        set_offset_string_at(row, target, offset);
-                                    });
-
+                util::variant_match(
+                    val,
+                    [&](std::string_view sv) {
+                        auto off_str = output.string_pool().get(sv);
+                        set_offset_string_at(row, target, off_str.offset());
+                    },
+                    [&](StringPool::offset_t offset) { set_offset_string_at(row, target, offset); });
             }
         }
     }
 }
 
-std::optional<SliceAndKey> rewrite_partial_segment(
-        const SliceAndKey& existing,
-        IndexRange index_range,
-         VersionId version_id,
-         bool before,
-         const std::shared_ptr<Store>& store) {
-    const auto& key =  existing.key();
-    const auto& existing_range =key.index_range();
+std::optional<SliceAndKey> rewrite_partial_segment(const SliceAndKey& existing,
+    IndexRange index_range,
+    VersionId version_id,
+    bool before,
+    const std::shared_ptr<Store>& store)
+{
+    const auto& key = existing.key();
+    const auto& existing_range = key.index_range();
     auto kv = store->read(key).get();
-    auto &segment = kv.second;
+    auto& segment = kv.second;
 
     auto start = std::get<timestamp>(index_range.start_);
     auto end = std::get<timestamp>(index_range.end_);
 
-    if(!before) {
-        util::check(existing_range.start_ < index_range.start_, "Unexpected index range in after: {} !< {}", existing_range.start_, index_range.start_);
-        auto bound = std::lower_bound(std::begin(segment), std::end(segment), start, [] ( auto& row, timestamp t) {return row.template index<TimeseriesIndex>() < t; });
+    if (!before) {
+        util::check(existing_range.start_ < index_range.start_,
+            "Unexpected index range in after: {} !< {}",
+            existing_range.start_,
+            index_range.start_);
+        auto bound = std::lower_bound(std::begin(segment), std::end(segment), start, [](auto& row, timestamp t) {
+            return row.template index<TimeseriesIndex>() < t;
+        });
         size_t num_rows = std::distance(std::begin(segment), bound);
-        if(num_rows == 0)
+        if (num_rows == 0)
             return std::nullopt;
 
         auto output = SegmentInMemory{segment.descriptor(), num_rows};
         std::copy(std::begin(segment), bound, std::back_inserter(output));
         update_string_columns(segment, output);
-        FrameSlice new_slice{
-            std::make_shared<StreamDescriptor>(output.descriptor()),
+        FrameSlice new_slice{std::make_shared<StreamDescriptor>(output.descriptor()),
             existing.slice_.col_range,
             RowRange{0, num_rows},
             existing.slice_.hash_bucket(),
             existing.slice_.num_buckets()};
-        auto fut_key = store->write(key.type(), version_id, key.id(), existing_range.start_, index_range.start_, std::move(output));
+        auto fut_key = store->write(key.type(),
+            version_id,
+            key.id(),
+            existing_range.start_,
+            index_range.start_,
+            std::move(output));
         return SliceAndKey{std::move(new_slice), std::get<AtomKey>(std::move(fut_key).get())};
-    }
-    else {
-        util::check(existing_range.end_ > index_range.end_, "Unexpected non-intersection of update indices: {} !> {}", existing_range.end_ , index_range.end_);
+    } else {
+        util::check(existing_range.end_ > index_range.end_,
+            "Unexpected non-intersection of update indices: {} !> {}",
+            existing_range.end_,
+            index_range.end_);
 
-        auto bound = std::upper_bound(std::begin(segment), std::end(segment), end, [] ( timestamp t, auto& row) {
+        auto bound = std::upper_bound(std::begin(segment), std::end(segment), end, [](timestamp t, auto& row) {
             return t < row.template index<TimeseriesIndex>();
         });
         size_t num_rows = std::distance(bound, std::end(segment));
-        if(num_rows == 0)
+        if (num_rows == 0)
             return std::nullopt;
 
         auto output = SegmentInMemory{segment.descriptor(), num_rows};
         std::copy(bound, std::end(segment), std::back_inserter(output));
         update_string_columns(segment, output);
-        FrameSlice new_slice{
-            std::make_shared<StreamDescriptor>(output.descriptor()),
-                    existing.slice_.col_range,
-                    RowRange{0, num_rows},
-                    existing.slice_.hash_bucket(),
-                    existing.slice_.num_buckets()};
-        auto fut_key = store->write(key.type(), version_id, key.id(), index_range.end_, existing_range.end_, std::move(output));
+        FrameSlice new_slice{std::make_shared<StreamDescriptor>(output.descriptor()),
+            existing.slice_.col_range,
+            RowRange{0, num_rows},
+            existing.slice_.hash_bucket(),
+            existing.slice_.num_buckets()};
+        auto fut_key =
+            store->write(key.type(), version_id, key.id(), index_range.end_, existing_range.end_, std::move(output));
         return SliceAndKey{std::move(new_slice), std::get<AtomKey>(std::move(fut_key).get())};
     }
 }
 
-std::vector<SliceAndKey> flatten_and_fix_rows(const std::vector<std::vector<SliceAndKey>>& groups, size_t& global_count) {
+std::vector<SliceAndKey> flatten_and_fix_rows(const std::vector<std::vector<SliceAndKey>>& groups, size_t& global_count)
+{
     std::vector<SliceAndKey> output;
     global_count = 0;
-    for(auto group : groups) {
-        if(group.empty()) continue;
+    for (auto group : groups) {
+        if (group.empty())
+            continue;
         auto group_start = group.begin()->slice_.row_range.first;
-        auto group_end = std::accumulate(std::begin(group), std::end(group), 0ULL, [](size_t a, const SliceAndKey& sk) { return std::max(a, sk.slice_.row_range.second); });
-        std::transform(std::begin(group), std::end(group), std::back_inserter(output), [&] (auto& sk) {
+        auto group_end = std::accumulate(std::begin(group), std::end(group), 0ULL, [](size_t a, const SliceAndKey& sk) {
+            return std::max(a, sk.slice_.row_range.second);
+        });
+        std::transform(std::begin(group), std::end(group), std::back_inserter(output), [&](auto& sk) {
             auto range_start = global_count + (sk.slice_.row_range.first - group_start);
             auto new_range = RowRange{range_start, range_start + (sk.slice_.row_range.diff())};
             sk.slice_.row_range = new_range;
-            return sk; });
-        global_count += (group_end - group_start) ;
+            return sk;
+        });
+        global_count += (group_end - group_start);
     }
     return output;
 }

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -26,44 +26,35 @@ namespace arcticdb::pipelines {
 
 using namespace arcticdb::stream;
 
-std::vector<folly::Future<SliceAndKey>> slice_and_write(
-        InputTensorFrame &frame,
-        const SlicingPolicy &slicing,
-        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)> &&partial_key_gen,
-        const std::shared_ptr<stream::StreamSink> &sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
-        bool allow_sparse = false
-);
-
-
-folly::Future<entity::AtomKey> write_frame(
-    const IndexPartialKey &key,
-    InputTensorFrame&& frame,
-    const SlicingPolicy &slicing,
-    const std::shared_ptr<Store> &store,
+std::vector<folly::Future<SliceAndKey>> slice_and_write(InputTensorFrame& frame,
+    const SlicingPolicy& slicing,
+    folly::Function<stream::StreamSink::PartialKey(const FrameSlice&)>&& partial_key_gen,
+    const std::shared_ptr<stream::StreamSink>& sink,
     const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
-    bool allow_sparse = false
-);
+    bool allow_sparse = false);
 
-folly::Future<entity::AtomKey> append_frame(
-        const IndexPartialKey& key,
-        InputTensorFrame&& frame,
-        const SlicingPolicy& slicing,
-        index::IndexSegmentReader &index_segment_reader,
-        const std::shared_ptr<Store>& store,
-        bool dynamic_schema,
-        bool ignore_sort_order
-);
+folly::Future<entity::AtomKey> write_frame(const IndexPartialKey& key,
+    InputTensorFrame&& frame,
+    const SlicingPolicy& slicing,
+    const std::shared_ptr<Store>& store,
+    const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
+    bool allow_sparse = false);
 
-std::optional<SliceAndKey> rewrite_partial_segment(
-        const SliceAndKey& existing,
-        IndexRange index_range,
-        VersionId version_id,
-        bool before,
-        const std::shared_ptr<Store>& store);
+folly::Future<entity::AtomKey> append_frame(const IndexPartialKey& key,
+    InputTensorFrame&& frame,
+    const SlicingPolicy& slicing,
+    index::IndexSegmentReader& index_segment_reader,
+    const std::shared_ptr<Store>& store,
+    bool dynamic_schema,
+    bool ignore_sort_order);
 
-std::vector<SliceAndKey> flatten_and_fix_rows(
-        const std::vector<std::vector<SliceAndKey>>& groups,
-        size_t& global_count);
+std::optional<SliceAndKey> rewrite_partial_segment(const SliceAndKey& existing,
+    IndexRange index_range,
+    VersionId version_id,
+    bool before,
+    const std::shared_ptr<Store>& store);
+
+std::vector<SliceAndKey> flatten_and_fix_rows(const std::vector<std::vector<SliceAndKey>>& groups,
+    size_t& global_count);
 
 } //namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/write_options.hpp
+++ b/cpp/arcticdb/pipeline/write_options.hpp
@@ -11,20 +11,20 @@
 
 namespace arcticdb {
 struct WriteOptions {
-    static WriteOptions from_proto(const arcticdb::proto::storage::VersionStoreConfig::WriteOptions & opt){
+    static WriteOptions from_proto(const arcticdb::proto::storage::VersionStoreConfig::WriteOptions& opt)
+    {
         WriteOptions def;
-        return {
-                opt.dynamic_schema() && !opt.bucketize_dynamic() ? std::numeric_limits<size_t>::max() :
-                    (opt.column_group_size() > 0 ? size_t(opt.column_group_size()) : def.column_group_size),
-                opt.segment_row_size() > 0 ? size_t(opt.segment_row_size()): def.segment_row_size,
-                opt.prune_previous_version(),
-                opt.de_duplication(),
-                opt.snapshot_dedup(),
-                opt.dynamic_schema(),
-                opt.ignore_sort_order(),
-                opt.bucketize_dynamic(),
-                opt.max_num_buckets() > 0 ? size_t(opt.max_num_buckets()) : def.max_num_buckets
-        };
+        return {opt.dynamic_schema() && !opt.bucketize_dynamic()
+                    ? std::numeric_limits<size_t>::max()
+                    : (opt.column_group_size() > 0 ? size_t(opt.column_group_size()) : def.column_group_size),
+            opt.segment_row_size() > 0 ? size_t(opt.segment_row_size()) : def.segment_row_size,
+            opt.prune_previous_version(),
+            opt.de_duplication(),
+            opt.snapshot_dedup(),
+            opt.dynamic_schema(),
+            opt.ignore_sort_order(),
+            opt.bucketize_dynamic(),
+            opt.max_num_buckets() > 0 ? size_t(opt.max_num_buckets()) : def.max_num_buckets};
     }
 
     size_t column_group_size = 127;

--- a/cpp/arcticdb/processing/aggregation.cpp
+++ b/cpp/arcticdb/processing/aggregation.cpp
@@ -9,42 +9,48 @@
 #include <cmath>
 
 namespace arcticdb {
-void Sum::aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values) {
-    entity::details::visit_type(data_type_, [&input_column, unique_values, &groups, that=this] (auto global_type_desc_tag) {
-        using GlobalInputType = decltype(global_type_desc_tag);
-        if constexpr(!is_sequence_type(GlobalInputType::DataTypeTag::data_type)) {
-            using GlobalTypeDescriptorTag =  typename OutputType<GlobalInputType>::type;
-            using GlobalRawType = typename GlobalTypeDescriptorTag::DataTypeTag::raw_type;
-            that->aggregated_.resize(sizeof(GlobalRawType)* unique_values);
-            auto out_ptr = reinterpret_cast<GlobalRawType*>(that->aggregated_.data());
-            if(input_column.has_value()) {
-                entity::details::visit_type(input_column->column_->type().data_type(), [&input_column, &groups, &out_ptr] (auto type_desc_tag) {
-                    using InputType = decltype(type_desc_tag);
-                    if constexpr(!is_sequence_type(InputType::DataTypeTag::data_type)) {
-                        using TypeDescriptorTag =  typename OutputType<InputType>::type;
-                        using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
-                        auto col_data = input_column->column_->data();
-                        auto groups_pos = 0;
-                        while (auto block = col_data.next<TypeDescriptorTag>()) {
-                            auto ptr = reinterpret_cast<const RawType *>(block.value().data());
-                            for (auto i = 0u; i < block.value().row_count(); ++i, ++ptr) {
-                                out_ptr[groups[groups_pos++]] += GlobalRawType(*ptr);
+void Sum::aggregate(const std::optional<ColumnWithStrings>& input_column,
+    const std::vector<size_t>& groups,
+    size_t unique_values)
+{
+    entity::details::visit_type(data_type_,
+        [&input_column, unique_values, &groups, that = this](auto global_type_desc_tag) {
+            using GlobalInputType = decltype(global_type_desc_tag);
+            if constexpr (!is_sequence_type(GlobalInputType::DataTypeTag::data_type)) {
+                using GlobalTypeDescriptorTag = typename OutputType<GlobalInputType>::type;
+                using GlobalRawType = typename GlobalTypeDescriptorTag::DataTypeTag::raw_type;
+                that->aggregated_.resize(sizeof(GlobalRawType) * unique_values);
+                auto out_ptr = reinterpret_cast<GlobalRawType*>(that->aggregated_.data());
+                if (input_column.has_value()) {
+                    entity::details::visit_type(input_column->column_->type().data_type(),
+                        [&input_column, &groups, &out_ptr](auto type_desc_tag) {
+                            using InputType = decltype(type_desc_tag);
+                            if constexpr (!is_sequence_type(InputType::DataTypeTag::data_type)) {
+                                using TypeDescriptorTag = typename OutputType<InputType>::type;
+                                using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
+                                auto col_data = input_column->column_->data();
+                                auto groups_pos = 0;
+                                while (auto block = col_data.next<TypeDescriptorTag>()) {
+                                    auto ptr = reinterpret_cast<const RawType*>(block.value().data());
+                                    for (auto i = 0u; i < block.value().row_count(); ++i, ++ptr) {
+                                        out_ptr[groups[groups_pos++]] += GlobalRawType(*ptr);
+                                    }
+                                }
+                            } else {
+                                util::raise_rte("String aggregations not currently supported");
                             }
-                        }
-                    } else {
-                        util::raise_rte("String aggregations not currently supported");
-                    }
-                });
+                        });
+                }
             }
-        }
-    });
+        });
 }
 
-std::optional<DataType> Sum::finalize(SegmentInMemory& seg, bool, size_t unique_values) {
-    if(!aggregated_.empty()) {
-        entity::details::visit_type(data_type_, [that=this, &seg, unique_values] (auto type_desc_tag) {
+std::optional<DataType> Sum::finalize(SegmentInMemory& seg, bool, size_t unique_values)
+{
+    if (!aggregated_.empty()) {
+        entity::details::visit_type(data_type_, [that = this, &seg, unique_values](auto type_desc_tag) {
             using RawType = typename decltype(type_desc_tag)::DataTypeTag::raw_type;
-            that->aggregated_.resize(sizeof(RawType)* unique_values);
+            that->aggregated_.resize(sizeof(RawType) * unique_values);
             auto col = std::make_shared<Column>(make_scalar_type(that->data_type_), unique_values, true, false);
             memcpy(col->ptr(), that->aggregated_.data(), that->aggregated_.size());
             seg.add_column(scalar_field_proto(that->data_type_, that->get_output_column_name().value), col);
@@ -56,88 +62,97 @@ std::optional<DataType> Sum::finalize(SegmentInMemory& seg, bool, size_t unique_
     }
 }
 
-void MaxOrMin::aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values) {
-    if(input_column.has_value()) {
-        entity::details::visit_type(data_type_, [&input_column, unique_values, &groups, that=this] (auto global_type_desc_tag) {
-            using GlobalInputType = decltype(global_type_desc_tag);
-            if constexpr(!is_sequence_type(GlobalInputType::DataTypeTag::data_type)) {
-                using GlobalTypeDescriptorTag =  typename OutputType<GlobalInputType>::type;
-                using GlobalRawType = typename GlobalTypeDescriptorTag::DataTypeTag::raw_type;
-                auto prev_size = that->aggregated_.size() / sizeof(MaybeValue<GlobalRawType>);
-                that->aggregated_.resize(sizeof(MaybeValue<GlobalRawType>) * unique_values);
-                auto col_data = input_column->column_->data();
-                auto out_ptr = reinterpret_cast<MaybeValue<GlobalRawType>*>(that->aggregated_.data());
-                std::fill(out_ptr + prev_size, out_ptr + unique_values, MaybeValue<GlobalRawType>{});
-                entity::details::visit_type(input_column->column_->type().data_type(), [&groups, &out_ptr, &col_data, that=that] (auto type_desc_tag) {
-                    using InputType = decltype(type_desc_tag);
-                    if constexpr(!is_sequence_type(InputType::DataTypeTag::data_type)) {
-                        using TypeDescriptorTag =  typename OutputType<InputType>::type;
-                        using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
-                        auto groups_pos = 0;
-                        while (auto block = col_data.next<TypeDescriptorTag>()) {
-                            auto ptr = reinterpret_cast<const RawType *>(block.value().data());
-                            for (auto i = 0u; i < block.value().row_count(); ++i, ++ptr) {
-                                auto& val = out_ptr[groups[groups_pos]];
-                                if constexpr(std::is_floating_point_v<RawType>) {
-                                    const auto& curr = GlobalRawType(*ptr);
-                                    if (!val.written_ || std::isnan(static_cast<RawType>(val.value_))) {
-                                        val.value_ = curr;
-                                        val.written_ = true;
-                                    } else if (!std::isnan(static_cast<RawType>(curr))) {
-                                        if (that->extremum_ == Extremum::max) {
-                                            val.value_ = std::max(val.value_, curr);
+void MaxOrMin::aggregate(const std::optional<ColumnWithStrings>& input_column,
+    const std::vector<size_t>& groups,
+    size_t unique_values)
+{
+    if (input_column.has_value()) {
+        entity::details::visit_type(data_type_,
+            [&input_column, unique_values, &groups, that = this](auto global_type_desc_tag) {
+                using GlobalInputType = decltype(global_type_desc_tag);
+                if constexpr (!is_sequence_type(GlobalInputType::DataTypeTag::data_type)) {
+                    using GlobalTypeDescriptorTag = typename OutputType<GlobalInputType>::type;
+                    using GlobalRawType = typename GlobalTypeDescriptorTag::DataTypeTag::raw_type;
+                    auto prev_size = that->aggregated_.size() / sizeof(MaybeValue<GlobalRawType>);
+                    that->aggregated_.resize(sizeof(MaybeValue<GlobalRawType>) * unique_values);
+                    auto col_data = input_column->column_->data();
+                    auto out_ptr = reinterpret_cast<MaybeValue<GlobalRawType>*>(that->aggregated_.data());
+                    std::fill(out_ptr + prev_size, out_ptr + unique_values, MaybeValue<GlobalRawType>{});
+                    entity::details::visit_type(input_column->column_->type().data_type(),
+                        [&groups, &out_ptr, &col_data, that = that](auto type_desc_tag) {
+                            using InputType = decltype(type_desc_tag);
+                            if constexpr (!is_sequence_type(InputType::DataTypeTag::data_type)) {
+                                using TypeDescriptorTag = typename OutputType<InputType>::type;
+                                using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
+                                auto groups_pos = 0;
+                                while (auto block = col_data.next<TypeDescriptorTag>()) {
+                                    auto ptr = reinterpret_cast<const RawType*>(block.value().data());
+                                    for (auto i = 0u; i < block.value().row_count(); ++i, ++ptr) {
+                                        auto& val = out_ptr[groups[groups_pos]];
+                                        if constexpr (std::is_floating_point_v<RawType>) {
+                                            const auto& curr = GlobalRawType(*ptr);
+                                            if (!val.written_ || std::isnan(static_cast<RawType>(val.value_))) {
+                                                val.value_ = curr;
+                                                val.written_ = true;
+                                            } else if (!std::isnan(static_cast<RawType>(curr))) {
+                                                if (that->extremum_ == Extremum::max) {
+                                                    val.value_ = std::max(val.value_, curr);
+                                                } else {
+                                                    val.value_ = std::min(val.value_, curr);
+                                                }
+                                            }
                                         } else {
-                                            val.value_ = std::min(val.value_, curr);
+                                            if (that->extremum_ == Extremum::max) {
+                                                val.value_ = std::max(val.value_, GlobalRawType(*ptr));
+                                            } else {
+                                                // If unwritten, MaybeValue begins life with MIN_INT. That's always going to "win" when
+                                                // passed into `std::min`!
+                                                val.value_ = !val.written_ ? GlobalRawType(*ptr)
+                                                                           : std::min(val.value_, GlobalRawType(*ptr));
+                                            }
+                                            val.written_ = true;
                                         }
+                                        ++groups_pos;
                                     }
-                                } else {
-                                    if (that->extremum_ == Extremum::max) {
-                                        val.value_ = std::max(val.value_, GlobalRawType(*ptr));
-                                    } else {
-                                        // If unwritten, MaybeValue begins life with MIN_INT. That's always going to "win" when
-                                        // passed into `std::min`!
-                                        val.value_ = !val.written_ ? GlobalRawType(*ptr) : std::min(val.value_, GlobalRawType(*ptr));
-                                    }
-                                    val.written_ = true;
                                 }
-                                ++groups_pos;
+                            } else {
+                                util::raise_rte("String aggregations not currently supported");
                             }
-                        }
-                    } else {
-                        util::raise_rte("String aggregations not currently supported");
-                    }
-                });
-            }
-        });
+                        });
+                }
+            });
     }
 }
 
-std::optional<DataType> MaxOrMin::finalize(SegmentInMemory& seg, bool dynamic_schema, size_t unique_values) {
-    if(!aggregated_.empty()) {
-        if(dynamic_schema) {
-            entity::details::visit_type(data_type_, [that=this, &seg, unique_values] (auto type_desc_tag) {
+std::optional<DataType> MaxOrMin::finalize(SegmentInMemory& seg, bool dynamic_schema, size_t unique_values)
+{
+    if (!aggregated_.empty()) {
+        if (dynamic_schema) {
+            entity::details::visit_type(data_type_, [that = this, &seg, unique_values](auto type_desc_tag) {
                 using RawType = typename decltype(type_desc_tag)::DataTypeTag::raw_type;
                 auto prev_size = that->aggregated_.size() / sizeof(MaybeValue<RawType>);
                 auto new_size = sizeof(MaybeValue<RawType>) * unique_values;
                 that->aggregated_.resize(new_size);
-                auto in_ptr =  reinterpret_cast<MaybeValue<RawType>*>(that->aggregated_.data());
+                auto in_ptr = reinterpret_cast<MaybeValue<RawType>*>(that->aggregated_.data());
                 std::fill(in_ptr + prev_size, in_ptr + unique_values, MaybeValue<RawType>{});
                 auto col = std::make_shared<Column>(make_scalar_type(DataType::FLOAT64), unique_values, true, false);
                 auto out_ptr = reinterpret_cast<double*>(col->ptr());
-                for(auto i = 0u; i < unique_values; ++i, ++in_ptr, ++out_ptr) {
-                    *out_ptr = in_ptr->written_ ? static_cast<double>(in_ptr->value_) : std::numeric_limits<double>::quiet_NaN();                }
+                for (auto i = 0u; i < unique_values; ++i, ++in_ptr, ++out_ptr) {
+                    *out_ptr = in_ptr->written_ ? static_cast<double>(in_ptr->value_)
+                                                : std::numeric_limits<double>::quiet_NaN();
+                }
 
                 col->set_row_data(unique_values);
                 seg.add_column(scalar_field_proto(DataType::FLOAT64, that->get_output_column_name().value), col);
             });
             return DataType::FLOAT64;
         } else {
-            entity::details::visit_type(data_type_, [that=this, &seg, unique_values] (auto type_desc_tag) {
+            entity::details::visit_type(data_type_, [that = this, &seg, unique_values](auto type_desc_tag) {
                 using RawType = typename decltype(type_desc_tag)::DataTypeTag::raw_type;
                 auto col = std::make_shared<Column>(make_scalar_type(that->data_type_), unique_values, true, false);
-                const auto* in_ptr =  reinterpret_cast<const MaybeValue<RawType>*>(that->aggregated_.data());
+                const auto* in_ptr = reinterpret_cast<const MaybeValue<RawType>*>(that->aggregated_.data());
                 auto out_ptr = reinterpret_cast<RawType*>(col->ptr());
-                for(auto i = 0u; i < unique_values; ++i, ++in_ptr, ++out_ptr) {
+                for (auto i = 0u; i < unique_values; ++i, ++in_ptr, ++out_ptr) {
                     *out_ptr = in_ptr->value_;
                 }
                 col->set_row_data(unique_values);
@@ -150,17 +165,20 @@ std::optional<DataType> MaxOrMin::finalize(SegmentInMemory& seg, bool dynamic_sc
     }
 }
 
-void Mean::aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values) {
-    if(input_column.has_value()) {
-        input_column->column_->type().visit_tag([&] (auto type_desc_tag) {
-            using TypeDescriptorTag =  decltype(type_desc_tag);
+void Mean::aggregate(const std::optional<ColumnWithStrings>& input_column,
+    const std::vector<size_t>& groups,
+    size_t unique_values)
+{
+    if (input_column.has_value()) {
+        input_column->column_->type().visit_tag([&](auto type_desc_tag) {
+            using TypeDescriptorTag = decltype(type_desc_tag);
             using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
 
             data_.fractions_.resize(unique_values);
 
             auto col_data = input_column->column_->data();
             while (auto block = col_data.next<TypeDescriptorTag>()) {
-                auto ptr = reinterpret_cast<const RawType *>(block.value().data());
+                auto ptr = reinterpret_cast<const RawType*>(block.value().data());
                 for (auto i = 0u; i < block.value().row_count(); ++i) {
                     auto group = groups[i];
                     auto& fraction = data_.fractions_[group];
@@ -172,8 +190,9 @@ void Mean::aggregate(const std::optional<ColumnWithStrings>& input_column, const
     }
 }
 
-std::optional<DataType> Mean::finalize(SegmentInMemory& seg, bool, size_t unique_values) {
-    if(!data_.fractions_.empty()) {
+std::optional<DataType> Mean::finalize(SegmentInMemory& seg, bool, size_t unique_values)
+{
+    if (!data_.fractions_.empty()) {
         data_.fractions_.resize(unique_values);
         auto grouping_desc = scalar_field_proto(arcticdb::entity::DataType::FLOAT64, get_output_column_name().value);
         auto pos = seg.add_column(grouping_desc, data_.fractions_.size(), true);

--- a/cpp/arcticdb/processing/aggregation.hpp
+++ b/cpp/arcticdb/processing/aggregation.hpp
@@ -18,21 +18,23 @@
 
 namespace arcticdb {
 
-template<typename T, typename T2=void>
+template<typename T, typename T2 = void>
 struct OutputType;
 
-template <typename InputType>
-struct OutputType <InputType, typename std::enable_if_t<is_floating_point_type(InputType::DataTypeTag::data_type)>> {
+template<typename InputType>
+struct OutputType<InputType, typename std::enable_if_t<is_floating_point_type(InputType::DataTypeTag::data_type)>> {
     using type = ScalarTagType<DataTypeTag<DataType::FLOAT64>>;
 };
 
-template <typename InputType>
-struct OutputType <InputType, typename std::enable_if_t<is_unsigned_type(InputType::DataTypeTag::data_type)>> {
+template<typename InputType>
+struct OutputType<InputType, typename std::enable_if_t<is_unsigned_type(InputType::DataTypeTag::data_type)>> {
     using type = ScalarTagType<DataTypeTag<DataType::UINT64>>;
 };
 
-template <typename InputType>
-struct OutputType<InputType, typename std::enable_if_t<is_signed_type(InputType::DataTypeTag::data_type) && is_integer_type(InputType::DataTypeTag::data_type)>> {
+template<typename InputType>
+struct OutputType<InputType,
+    typename std::enable_if_t<is_signed_type(InputType::DataTypeTag::data_type) &&
+                              is_integer_type(InputType::DataTypeTag::data_type)>> {
     using type = ScalarTagType<DataTypeTag<DataType::INT64>>;
 };
 
@@ -52,33 +54,48 @@ struct Sum {
     ColumnName output_column_name_;
     DataType data_type_ = {};
 
-    Sum(ColumnName input_column_name, ColumnName output_column_name) :
-        input_column_name_(std::move(input_column_name)),
-        output_column_name_(std::move(output_column_name)) {
+    Sum(ColumnName input_column_name, ColumnName output_column_name)
+        : input_column_name_(std::move(input_column_name)),
+          output_column_name_(std::move(output_column_name))
+    {
     }
 
-    void aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values);
+    void aggregate(const std::optional<ColumnWithStrings>& input_column,
+        const std::vector<size_t>& groups,
+        size_t unique_values);
 
     std::optional<DataType> finalize(SegmentInMemory& seg, bool dynamic_schema, size_t unique_values);
 
-    [[nodiscard]] ColumnName get_input_column_name() const { return input_column_name_; }
+    [[nodiscard]] ColumnName get_input_column_name() const
+    {
+        return input_column_name_;
+    }
 
-    [[nodiscard]] ColumnName get_output_column_name() const { return output_column_name_; }
+    [[nodiscard]] ColumnName get_output_column_name() const
+    {
+        return output_column_name_;
+    }
 
-    [[nodiscard]] Sum construct() const { return {input_column_name_, output_column_name_}; }
+    [[nodiscard]] Sum construct() const
+    {
+        return {input_column_name_, output_column_name_};
+    }
 
-    void set_data_type(DataType data_type) { data_type_ = data_type; }
-
+    void set_data_type(DataType data_type)
+    {
+        data_type_ = data_type;
+    }
 };
 
-template <typename T>
+template<typename T>
 struct MaybeValue {
     bool written_ = false;
     T value_ = std::numeric_limits<T>::lowest();
 };
 
 enum class Extremum {
-    max, min
+    max,
+    min
 };
 
 struct MaxOrMin {
@@ -88,24 +105,38 @@ struct MaxOrMin {
     DataType data_type_ = {};
     Extremum extremum_;
 
-    MaxOrMin(ColumnName input_column_name, ColumnName output_column_name, Extremum extremum) :
-        input_column_name_(std::move(input_column_name)),
-        output_column_name_(std::move(output_column_name)),
-        extremum_(extremum){
+    MaxOrMin(ColumnName input_column_name, ColumnName output_column_name, Extremum extremum)
+        : input_column_name_(std::move(input_column_name)),
+          output_column_name_(std::move(output_column_name)),
+          extremum_(extremum)
+    {
     }
 
-    void aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values);
+    void aggregate(const std::optional<ColumnWithStrings>& input_column,
+        const std::vector<size_t>& groups,
+        size_t unique_values);
 
     std::optional<DataType> finalize(SegmentInMemory& seg, bool dynamic_schema, size_t unique_values);
 
-    [[nodiscard]] ColumnName get_input_column_name() const { return input_column_name_; }
+    [[nodiscard]] ColumnName get_input_column_name() const
+    {
+        return input_column_name_;
+    }
 
-    [[nodiscard]] ColumnName get_output_column_name() const { return output_column_name_; }
+    [[nodiscard]] ColumnName get_output_column_name() const
+    {
+        return output_column_name_;
+    }
 
-    [[nodiscard]] MaxOrMin construct() const { return {input_column_name_, output_column_name_, extremum_}; }
+    [[nodiscard]] MaxOrMin construct() const
+    {
+        return {input_column_name_, output_column_name_, extremum_};
+    }
 
-    void set_data_type(DataType data_type) { data_type_ = data_type; }
-
+    void set_data_type(DataType data_type)
+    {
+        data_type_ = data_type;
+    }
 };
 
 struct Mean {
@@ -115,23 +146,37 @@ struct Mean {
     ColumnName output_column_name_;
     DataType data_type_ = {};
 
-    explicit Mean(ColumnName input_column_name, ColumnName output_column_name) :
-        input_column_name_(std::move(input_column_name)),
-        output_column_name_(std::move(output_column_name)) {
+    explicit Mean(ColumnName input_column_name, ColumnName output_column_name)
+        : input_column_name_(std::move(input_column_name)),
+          output_column_name_(std::move(output_column_name))
+    {
     }
 
-    void aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values);
+    void aggregate(const std::optional<ColumnWithStrings>& input_column,
+        const std::vector<size_t>& groups,
+        size_t unique_values);
 
     std::optional<DataType> finalize(SegmentInMemory& seg, bool dynamic_schema, size_t unique_values);
 
-    [[nodiscard]] ColumnName get_input_column_name() const { return input_column_name_; }
+    [[nodiscard]] ColumnName get_input_column_name() const
+    {
+        return input_column_name_;
+    }
 
-    [[nodiscard]] ColumnName get_output_column_name() const { return output_column_name_; }
+    [[nodiscard]] ColumnName get_output_column_name() const
+    {
+        return output_column_name_;
+    }
 
-    [[nodiscard]] Mean construct() const { return Mean(input_column_name_, output_column_name_); }
+    [[nodiscard]] Mean construct() const
+    {
+        return Mean(input_column_name_, output_column_name_);
+    }
 
-    void set_data_type(DataType data_type) { data_type_ = data_type; }
-
+    void set_data_type(DataType data_type)
+    {
+        data_type_ = data_type;
+    }
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/processing/aggregation_interface.hpp
+++ b/cpp/arcticdb/processing/aggregation_interface.hpp
@@ -9,14 +9,16 @@
 
 #include <folly/Poly.h>
 
-namespace arcticdb{
+namespace arcticdb {
 
 struct Fraction {
     double numerator_{0.0};
     uint64_t denominator_{0};
 
-    double to_double() const {
-        return denominator_ == 0 ? std::numeric_limits<double>::quiet_NaN(): numerator_ / static_cast<double>(denominator_);
+    double to_double() const
+    {
+        return denominator_ == 0 ? std::numeric_limits<double>::quiet_NaN()
+                                 : numerator_ / static_cast<double>(denominator_);
     }
 };
 
@@ -27,19 +29,40 @@ struct CountAndTotals {
 struct IAggregation {
     template<class Base>
     struct Interface : Base {
-        void aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values) { folly::poly_call<0>(*this, input_column, groups, unique_values); }
+        void aggregate(const std::optional<ColumnWithStrings>& input_column,
+            const std::vector<size_t>& groups,
+            size_t unique_values)
+        {
+            folly::poly_call<0>(*this, input_column, groups, unique_values);
+        }
 
-        std::optional<DataType> finalize(SegmentInMemory& seg, bool dynamic_schema, size_t unique_values) { return folly::poly_call<1>(*this, seg, dynamic_schema, unique_values); }
+        std::optional<DataType> finalize(SegmentInMemory& seg, bool dynamic_schema, size_t unique_values)
+        {
+            return folly::poly_call<1>(*this, seg, dynamic_schema, unique_values);
+        }
 
-        [[nodiscard]] ColumnName get_input_column_name() const { return folly::poly_call<2>(*this); };
+        [[nodiscard]] ColumnName get_input_column_name() const
+        {
+            return folly::poly_call<2>(*this);
+        };
 
-        [[nodiscard]] ColumnName get_output_column_name() const { return folly::poly_call<3>(*this); };
+        [[nodiscard]] ColumnName get_output_column_name() const
+        {
+            return folly::poly_call<3>(*this);
+        };
 
-        void set_data_type(DataType data_type_) { folly::poly_call<4>(*this, data_type_); }
+        void set_data_type(DataType data_type_)
+        {
+            folly::poly_call<4>(*this, data_type_);
+        }
     };
 
     template<class T>
-    using Members = folly::PolyMembers<&T::aggregate, &T::finalize, &T::get_input_column_name, &T::get_output_column_name, &T::set_data_type>;
+    using Members = folly::PolyMembers<&T::aggregate,
+        &T::finalize,
+        &T::get_input_column_name,
+        &T::get_output_column_name,
+        &T::set_data_type>;
 };
 
 using Aggregation = folly::Poly<IAggregation>;
@@ -48,8 +71,10 @@ struct IAggregationFactory {
     template<class Base>
     struct Interface : Base {
 
-        [[nodiscard]] Aggregation construct() const { return folly::poly_call<0>(*this); }
-
+        [[nodiscard]] Aggregation construct() const
+        {
+            return folly::poly_call<0>(*this);
+        }
     };
 
     template<class T>

--- a/cpp/arcticdb/processing/bucketizer.hpp
+++ b/cpp/arcticdb/processing/bucketizer.hpp
@@ -15,16 +15,19 @@ struct VectorBucketizer {
     std::vector<size_t> vec_;
     size_t num_buckets_;
 
-    VectorBucketizer(std::vector<size_t> &&vec, size_t num_buckets) :
-        vec_(vec),
-        num_buckets_(num_buckets) {
+    VectorBucketizer(std::vector<size_t>&& vec, size_t num_buckets)
+        : vec_(vec),
+          num_buckets_(num_buckets)
+    {
     }
 
-    [[nodiscard]] size_t get_bucket(size_t row) const {
+    [[nodiscard]] size_t get_bucket(size_t row) const
+    {
         return vec_[row];
     }
 
-    [[nodiscard]] size_t num_buckets() const {
+    [[nodiscard]] size_t num_buckets() const
+    {
         return num_buckets_;
     }
 };

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -17,70 +17,64 @@
 
 namespace arcticdb {
 
-[[nodiscard]] Composite<ProcessingSegment>
-FilterClause::process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const {
+[[nodiscard]] Composite<ProcessingSegment> FilterClause::process(std::shared_ptr<Store> store,
+    Composite<ProcessingSegment>&& p) const
+{
     auto procs = std::move(p);
     Composite<ProcessingSegment> output;
-    procs.broadcast([&store, &execution_context = execution_context_, &output](auto &proc) {
+    procs.broadcast([&store, &execution_context = execution_context_, &output](auto& proc) {
         proc.set_execution_context(execution_context);
         auto variant_data = proc.get(execution_context->root_node_name_, store);
-        util::variant_match(variant_data,
-                            [&proc, &output, &store](const std::shared_ptr<util::BitSet> &bitset) {
-                                proc.apply_filter(*bitset, store);
-                                output.push_back(std::move(proc));
-                            },
-                            [](EmptyResult) {
-                               log::version().debug("Filter returned empty result");
-                            },
-                            [&output, &proc](FullResult) {
-                                output.push_back(std::move(proc));
-                            },
-                            [](const auto &) {
-                                util::raise_rte("Expected bitset from filter clause");
-                            });
+        util::variant_match(
+            variant_data,
+            [&proc, &output, &store](const std::shared_ptr<util::BitSet>& bitset) {
+                proc.apply_filter(*bitset, store);
+                output.push_back(std::move(proc));
+            },
+            [](EmptyResult) { log::version().debug("Filter returned empty result"); },
+            [&output, &proc](FullResult) { output.push_back(std::move(proc)); },
+            [](const auto&) { util::raise_rte("Expected bitset from filter clause"); });
     });
     return output;
 }
 
 [[nodiscard]] Composite<ProcessingSegment> ProjectClause::process(std::shared_ptr<Store> store,
-                                                                  Composite<ProcessingSegment> &&p) const {
+    Composite<ProcessingSegment>&& p) const
+{
     auto procs = std::move(p);
     Composite<ProcessingSegment> output;
-    procs.broadcast([&store, &execution_context = execution_context_, &output, that = this](auto &proc) {
+    procs.broadcast([&store, &execution_context = execution_context_, &output, that = this](auto& proc) {
         proc.set_execution_context(execution_context);
         auto variant_data = proc.get(execution_context->root_node_name_, store);
-        util::variant_match(variant_data,
-                            [&proc, &output, &store, &execution_context, &that](ColumnWithStrings &col) {
+        util::variant_match(
+            variant_data,
+            [&proc, &output, &store, &execution_context, &that](ColumnWithStrings& col) {
+                const auto data_type = col.column_->type().data_type();
+                const std::string_view name = that->column_name_;
 
-                                const auto data_type = col.column_->type().data_type();
-                                const std::string_view name = that->column_name_;
-
-                                std::call_once(*that->add_column_, [context = execution_context, &data_type, &name]() {
-                                    std::scoped_lock lock{*context->column_mutex_};
-                                    context->output_descriptor_->add_scalar_field(data_type, name);
-                                });
-                                auto &slice_and_keys = proc.data();
-                                auto &last = *slice_and_keys.rbegin();
-                                last.segment(store).add_column(scalar_field_proto(data_type, name), col.column_);
-                                ++last.slice().col_range.second;
-                                output.push_back(std::move(proc));
-                            },
-                            [&proc, &output, &execution_context](const EmptyResult&) {
-                                if(execution_context->dynamic_schema())
-                                    output.push_back(std::move(proc));
-                                else
-                                    util::raise_rte("Cannot project from empty column with static schema");
-                            },
-                            [](const auto &) {
-                                util::raise_rte("Expected bitset from filter clause");
-                            });
+                std::call_once(*that->add_column_, [context = execution_context, &data_type, &name]() {
+                    std::scoped_lock lock{*context->column_mutex_};
+                    context->output_descriptor_->add_scalar_field(data_type, name);
+                });
+                auto& slice_and_keys = proc.data();
+                auto& last = *slice_and_keys.rbegin();
+                last.segment(store).add_column(scalar_field_proto(data_type, name), col.column_);
+                ++last.slice().col_range.second;
+                output.push_back(std::move(proc));
+            },
+            [&proc, &output, &execution_context](const EmptyResult&) {
+                if (execution_context->dynamic_schema())
+                    output.push_back(std::move(proc));
+                else
+                    util::raise_rte("Cannot project from empty column with static schema");
+            },
+            [](const auto&) { util::raise_rte("Expected bitset from filter clause"); });
     });
     return output;
 }
 
 class GroupingMap {
-    using NumericMapType = std::variant<
-        std::monostate,
+    using NumericMapType = std::variant<std::monostate,
         std::shared_ptr<std::unordered_map<bool, size_t>>,
         std::shared_ptr<std::unordered_map<uint8_t, size_t>>,
         std::shared_ptr<std::unordered_map<uint16_t, size_t>>,
@@ -96,40 +90,40 @@ class GroupingMap {
     NumericMapType map_;
 
 public:
-    size_t size() const {
-        return util::variant_match(map_,
-                                   [](const std::monostate &) {
-                                       return size_t(0);
-                                   },
-                                   [](const auto &other) {
-                                       return other->size();
-                                   });
+    size_t size() const
+    {
+        return util::variant_match(
+            map_,
+            [](const std::monostate&) { return size_t(0); },
+            [](const auto& other) { return other->size(); });
     }
 
     template<typename T>
-    std::shared_ptr<std::unordered_map<T, size_t>> get() {
-        return util::variant_match(map_,
-                                   [that = this](const std::monostate &) {
-                                       that->map_ = std::make_shared<std::unordered_map<T, size_t>>();
-                                       return std::get<std::shared_ptr<std::unordered_map<T, size_t>>>(that->map_);
-                                   },
-                                   [](const std::shared_ptr<std::unordered_map<T, size_t>> &ptr) {
-                                       return ptr;
-                                   },
-                                   [](const auto &) -> std::shared_ptr<std::unordered_map<T, size_t>> {
-                                       util::raise_rte("Grouping column type change");
-                                   });
+    std::shared_ptr<std::unordered_map<T, size_t>> get()
+    {
+        return util::variant_match(
+            map_,
+            [that = this](const std::monostate&) {
+                that->map_ = std::make_shared<std::unordered_map<T, size_t>>();
+                return std::get<std::shared_ptr<std::unordered_map<T, size_t>>>(that->map_);
+            },
+            [](const std::shared_ptr<std::unordered_map<T, size_t>>& ptr) { return ptr; },
+            [](const auto&) -> std::shared_ptr<std::unordered_map<T, size_t>> {
+                util::raise_rte("Grouping column type change");
+            });
     }
 };
 
-std::vector<Composite<ProcessingSegment>> single_partition(std::vector<Composite<ProcessingSegment>> &&comps) {
+std::vector<Composite<ProcessingSegment>> single_partition(std::vector<Composite<ProcessingSegment>>&& comps)
+{
     std::vector<Composite<ProcessingSegment>> v;
     v.push_back(merge_composites_shallow(std::move(comps)));
     return v;
 }
 
-[[nodiscard]] Composite<ProcessingSegment>
-AggregationClause::process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const {
+[[nodiscard]] Composite<ProcessingSegment> AggregationClause::process(std::shared_ptr<Store> store,
+    Composite<ProcessingSegment>&& p) const
+{
     std::call_once(*reset_descriptor_, [context = execution_context_]() {
         std::scoped_lock lock{*context->column_mutex_};
         context->orig_output_descriptor_ = context->output_descriptor_;
@@ -140,10 +134,12 @@ AggregationClause::process(std::shared_ptr<Store> store, Composite<ProcessingSeg
     size_t num_unique = 0;
     std::vector<Aggregation> aggregators;
     auto desc = execution_context_->orig_output_descriptor_;
-    for (const auto &agg : aggregation_operators_){
+    for (const auto& agg : aggregation_operators_) {
         auto agg_construct = agg.construct();
         const auto& agg_field_pos = desc->find_field(agg_construct.get_input_column_name().value);
-        util::check(agg_field_pos.has_value(), "Field {} not found in aggregation", agg_construct.get_input_column_name().value);
+        util::check(agg_field_pos.has_value(),
+            "Field {} not found in aggregation",
+            agg_construct.get_input_column_name().value);
         auto agg_field = desc->field(agg_field_pos.value());
         agg_construct.set_data_type(data_type_from_proto(agg_field.type_desc()));
         aggregators.emplace_back(agg_construct);
@@ -154,70 +150,77 @@ AggregationClause::process(std::shared_ptr<Store> store, Composite<ProcessingSeg
     auto string_pool = std::make_shared<StringPool>();
     DataType grouping_data_type;
     GroupingMap grouping_map;
-    procs.broadcast(
-        [&store, &num_unique, &execution_context =
-        execution_context_, &grouping_data_type, &grouping_map, &offset, &aggregators, &string_pool, &grouping_column_name](
-            auto &proc) {
-            proc.set_execution_context(execution_context);
-            //TODO this is a hack, ideally the grouping should be able to be an expression
-            auto partitioning_column = proc.get(ColumnName(grouping_column_name), store);
-            if (std::holds_alternative<ColumnWithStrings>(partitioning_column)) {
-                ColumnWithStrings col = std::get<ColumnWithStrings>(partitioning_column);
-                entity::details::visit_type(col.column_->type().data_type(),
-                                            [&proc_ =
-                                            proc, &grouping_map, &offset, &aggregators, &string_pool, &col, &num_unique, &store, &grouping_data_type](
-                                                auto data_type_tag) {
-                                                using DataTypeTagType = decltype(data_type_tag);
-                                                using RawType = typename DataTypeTagType::raw_type;
-                                                constexpr auto data_type = DataTypeTagType::data_type;
-                                                grouping_data_type = data_type;
-                                                std::vector<size_t> row_to_group;
-                                                row_to_group.reserve(col.column_->row_count());
-                                                auto input_data = col.column_->data();
-                                                while (auto block = input_data.next<ScalarTagType<DataTypeTagType>>()) {
-                                                    const auto row_count = block->row_count();
-                                                    auto ptr = block->data();
-                                                    for (size_t i = 0; i < row_count; ++i, ++ptr) {
-                                                        RawType val;
-                                                        if constexpr(is_sequence_type(data_type)) {
-                                                            std::optional<std::string_view> str = col.string_at_offset(*ptr);
-                                                            if (str.has_value()) {
-                                                                val = string_pool->get(*str, true).offset();
-                                                            } else {
-                                                                val = *ptr;
-                                                            }
-                                                        } else {
-                                                            val = *ptr;
-                                                        }
-                                                        auto hashes = grouping_map.get<RawType>();
-                                                        if (auto it = hashes->find(val); it == hashes->end()) {
-                                                            row_to_group.push_back(offset);
-                                                            hashes->try_emplace(val, offset++);
-                                                        } else {
-                                                            row_to_group.push_back(it->second);
-                                                        }
-                                                    }
-                                                }
+    procs.broadcast([&store,
+                        &num_unique,
+                        &execution_context = execution_context_,
+                        &grouping_data_type,
+                        &grouping_map,
+                        &offset,
+                        &aggregators,
+                        &string_pool,
+                        &grouping_column_name](auto& proc) {
+        proc.set_execution_context(execution_context);
+        //TODO this is a hack, ideally the grouping should be able to be an expression
+        auto partitioning_column = proc.get(ColumnName(grouping_column_name), store);
+        if (std::holds_alternative<ColumnWithStrings>(partitioning_column)) {
+            ColumnWithStrings col = std::get<ColumnWithStrings>(partitioning_column);
+            entity::details::visit_type(col.column_->type().data_type(),
+                [&proc_ = proc,
+                    &grouping_map,
+                    &offset,
+                    &aggregators,
+                    &string_pool,
+                    &col,
+                    &num_unique,
+                    &store,
+                    &grouping_data_type](auto data_type_tag) {
+                    using DataTypeTagType = decltype(data_type_tag);
+                    using RawType = typename DataTypeTagType::raw_type;
+                    constexpr auto data_type = DataTypeTagType::data_type;
+                    grouping_data_type = data_type;
+                    std::vector<size_t> row_to_group;
+                    row_to_group.reserve(col.column_->row_count());
+                    auto input_data = col.column_->data();
+                    while (auto block = input_data.next<ScalarTagType<DataTypeTagType>>()) {
+                        const auto row_count = block->row_count();
+                        auto ptr = block->data();
+                        for (size_t i = 0; i < row_count; ++i, ++ptr) {
+                            RawType val;
+                            if constexpr (is_sequence_type(data_type)) {
+                                std::optional<std::string_view> str = col.string_at_offset(*ptr);
+                                if (str.has_value()) {
+                                    val = string_pool->get(*str, true).offset();
+                                } else {
+                                    val = *ptr;
+                                }
+                            } else {
+                                val = *ptr;
+                            }
+                            auto hashes = grouping_map.get<RawType>();
+                            if (auto it = hashes->find(val); it == hashes->end()) {
+                                row_to_group.push_back(offset);
+                                hashes->try_emplace(val, offset++);
+                            } else {
+                                row_to_group.push_back(it->second);
+                            }
+                        }
+                    }
 
-                                                num_unique = offset;
-                                                util::check(num_unique != 0, "Got zero unique values");
-                                                for (Aggregation &agg : aggregators) {
-                                                    auto input_column = proc_.get(agg.get_input_column_name(), store);
-                                                    std::optional<ColumnWithStrings> opt_input_column;
-                                                    if (std::holds_alternative<ColumnWithStrings>(input_column)) {
-                                                        opt_input_column.emplace(std::get<ColumnWithStrings>(input_column));
-                                                    }
-                                                    agg.aggregate(opt_input_column,
-                                                                    row_to_group,
-                                                                    num_unique);
-
-
-                                                }
-                                            });
-            } else {
-                util::raise_rte("Expected single column from expression");
-            }
-        });
+                    num_unique = offset;
+                    util::check(num_unique != 0, "Got zero unique values");
+                    for (Aggregation& agg : aggregators) {
+                        auto input_column = proc_.get(agg.get_input_column_name(), store);
+                        std::optional<ColumnWithStrings> opt_input_column;
+                        if (std::holds_alternative<ColumnWithStrings>(input_column)) {
+                            opt_input_column.emplace(std::get<ColumnWithStrings>(input_column));
+                        }
+                        agg.aggregate(opt_input_column, row_to_group, num_unique);
+                    }
+                });
+        } else {
+            util::raise_rte("Expected single column from expression");
+        }
+    });
 
     auto index_pos =
         seg.add_column(scalar_field_proto(grouping_data_type, grouping_column_name), grouping_map.size(), true);
@@ -226,24 +229,24 @@ AggregationClause::process(std::shared_ptr<Store> store, Composite<ProcessingSeg
         using DataTypeTagType = decltype(data_type_tag);
         using RawType = typename DataTypeTagType::raw_type;
         auto hashes = grouping_map.get<RawType>();
-        auto index_ptr = reinterpret_cast<RawType *>(seg.column(index_pos).ptr());
+        auto index_ptr = reinterpret_cast<RawType*>(seg.column(index_pos).ptr());
         std::vector<std::pair<RawType, size_t>> elements;
-        for (const auto &hash : *hashes)
+        for (const auto& hash : *hashes)
             elements.push_back(hash);
 
         std::sort(std::begin(elements),
-                  std::end(elements),
-                  [](const std::pair<RawType, size_t> &l, const std::pair<RawType, size_t> &r) {
-                      return l.second < r.second;
-                  });
+            std::end(elements),
+            [](const std::pair<RawType, size_t>& l, const std::pair<RawType, size_t>& r) {
+                return l.second < r.second;
+            });
 
-        for (const auto &element : elements)
+        for (const auto& element : elements)
             *index_ptr++ = element.first;
     });
 
-    for (auto &agg : aggregators) {
+    for (auto& agg : aggregators) {
         auto data_type = agg.finalize(seg, execution_context_->dynamic_schema(), num_unique);
-        if(data_type)
+        if (data_type)
             execution_context_->check_output_column(agg.get_output_column_name().value, data_type.value());
     }
 
@@ -260,25 +263,24 @@ AggregationClause::process(std::shared_ptr<Store> store, Composite<ProcessingSeg
 }
 
 template<typename IndexType, typename DensityPolicy, typename QueueType, typename Comparator, typename StreamId>
-void merge_impl(
-        Composite<ProcessingSegment> &ret,
-        QueueType &input_streams,
-        bool add_symbol_column,
-        StreamId stream_id,
-        const arcticdb::pipelines::RowRange row_range,
-        const arcticdb::pipelines::ColRange col_range,
-        IndexType index,
-        std::shared_ptr<ExecutionContext> execution_context
-) {
+void merge_impl(Composite<ProcessingSegment>& ret,
+    QueueType& input_streams,
+    bool add_symbol_column,
+    StreamId stream_id,
+    const arcticdb::pipelines::RowRange row_range,
+    const arcticdb::pipelines::ColRange col_range,
+    IndexType index,
+    std::shared_ptr<ExecutionContext> execution_context)
+{
     using namespace arcticdb::pipelines;
     auto num_segment_rows = ConfigsMap::instance()->get_int("Merge.SegmentSize", 100000);
     using SegmentationPolicy = stream::RowCountSegmentPolicy;
     SegmentationPolicy segmentation_policy{static_cast<size_t>(num_segment_rows)};
 
-    auto func = [&ret, &row_range, &col_range](auto &&segment) {
+    auto func = [&ret, &row_range, &col_range](auto&& segment) {
         ret.push_back(ProcessingSegment{std::forward<SegmentInMemory>(segment), FrameSlice{col_range, row_range}});
     };
-    
+
     using AggregatorType = stream::Aggregator<IndexType, stream::DynamicSchema, SegmentationPolicy, DensityPolicy>;
     auto fields = execution_context->output_descriptor_->fields();
     StreamDescriptor::FieldsCollection new_fields{};
@@ -286,96 +288,107 @@ void merge_impl(
     auto new_field = new_fields.Add();
     new_field->set_name(field_name.data(), field_name.size());
     new_field->CopyFrom(fields[0]);
-    
+
     auto index_desc = index_descriptor(stream_id, index, new_fields);
     auto desc = StreamDescriptor{index_desc};
 
-    AggregatorType agg{
-            stream::DynamicSchema{desc, index},
-            std::move(func), std::move(segmentation_policy), desc, std::nullopt
-    };
+    AggregatorType agg{stream::DynamicSchema{desc, index},
+        std::move(func),
+        std::move(segmentation_policy),
+        desc,
+        std::nullopt};
 
-
-    stream::do_merge<IndexType, SliceAndKeyWrapper, AggregatorType, decltype(input_streams)>(
-        input_streams, agg, add_symbol_column);
+    stream::do_merge<IndexType, SliceAndKeyWrapper, AggregatorType, decltype(input_streams)>(input_streams,
+        agg,
+        add_symbol_column);
 }
 
-// MergeClause receives a list of DataFrames as input and merge them into a single one where all 
+// MergeClause receives a list of DataFrames as input and merge them into a single one where all
 // the rows are sorted by time stamp
-[[nodiscard]] Composite<ProcessingSegment>
-MergeClause::process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const {
-        using namespace arcticdb::pipelines;
-        auto procs = std::move(p);
+[[nodiscard]] Composite<ProcessingSegment> MergeClause::process(std::shared_ptr<Store> store,
+    Composite<ProcessingSegment>&& p) const
+{
+    using namespace arcticdb::pipelines;
+    auto procs = std::move(p);
 
-        auto compare =
-                [](const std::unique_ptr<SliceAndKeyWrapper> &left,
-                   const std::unique_ptr<SliceAndKeyWrapper> &right) {
-                    const auto left_index = pipelines::index::index_value_from_row(left->row(),
-                                                                                   IndexDescriptor::TIMESTAMP, 0);
-                    const auto right_index = pipelines::index::index_value_from_row(right->row(),
-                                                                                    IndexDescriptor::TIMESTAMP, 0);
-                    return left_index > right_index;
-                };
+    auto compare = [](const std::unique_ptr<SliceAndKeyWrapper>& left,
+                       const std::unique_ptr<SliceAndKeyWrapper>& right) {
+        const auto left_index = pipelines::index::index_value_from_row(left->row(), IndexDescriptor::TIMESTAMP, 0);
+        const auto right_index = pipelines::index::index_value_from_row(right->row(), IndexDescriptor::TIMESTAMP, 0);
+        return left_index > right_index;
+    };
 
-        movable_priority_queue<std::unique_ptr<SliceAndKeyWrapper>, std::vector<std::unique_ptr<SliceAndKeyWrapper>>, decltype(compare)> input_streams{
-                compare};
+    movable_priority_queue<std::unique_ptr<SliceAndKeyWrapper>,
+        std::vector<std::unique_ptr<SliceAndKeyWrapper>>,
+        decltype(compare)>
+        input_streams{compare};
 
-        size_t min_start_row = std::numeric_limits<size_t>::max();
-        size_t max_end_row = 0;
-        size_t min_start_col = std::numeric_limits<size_t>::max();
-        size_t max_end_col = 0;
-        procs.broadcast([&input_streams, &store, &min_start_row, &max_end_row, &min_start_col, &max_end_col](auto &&proc) {
-            auto slice_and_keys = proc.release_data();
-            for (auto &&slice_and_key: slice_and_keys) {
-                size_t start_row = slice_and_key.slice().row_range.start();
-                min_start_row = start_row < min_start_row ? start_row : min_start_row;
-                size_t end_row = slice_and_key.slice().row_range.end();
-                max_end_row = end_row > max_end_row ? end_row : max_end_row;
-                size_t start_col = slice_and_key.slice().col_range.start();
-                min_start_col = start_col < min_start_col ? start_col : min_start_col;
-                size_t end_col = slice_and_key.slice().col_range.end();
-                max_end_col = end_col > max_end_col ? end_col : max_end_col;
-                input_streams.push(
-                        std::make_unique<SliceAndKeyWrapper>(std::forward<pipelines::SliceAndKey>(slice_and_key),
-                                                             store));
-            }
-        });
-        const RowRange row_range{min_start_row, max_end_row};
-        const ColRange col_range{min_start_col, max_end_col};
-        Composite<ProcessingSegment> ret;
-        std::visit(
-                [&ret, &input_streams, add_symbol_column = add_symbol_column_, &comp = compare, stream_id = stream_id_, &row_range, &col_range, execution_context = execution_context_](auto idx,
-                                                                                                auto density) {
-                    merge_impl<decltype(idx), decltype(density), decltype(input_streams), decltype(comp), decltype(stream_id)>(ret,
-                                                                                                          input_streams,
-                                                                                                          add_symbol_column,
-                                                                                                          stream_id,
-                                                                                                          row_range,
-                                                                                                          col_range,
-                                                                                                          idx,
-                                                                                                          execution_context);
-                }, index_, density_policy_);
+    size_t min_start_row = std::numeric_limits<size_t>::max();
+    size_t max_end_row = 0;
+    size_t min_start_col = std::numeric_limits<size_t>::max();
+    size_t max_end_col = 0;
+    procs.broadcast([&input_streams, &store, &min_start_row, &max_end_row, &min_start_col, &max_end_col](auto&& proc) {
+        auto slice_and_keys = proc.release_data();
+        for (auto&& slice_and_key : slice_and_keys) {
+            size_t start_row = slice_and_key.slice().row_range.start();
+            min_start_row = start_row < min_start_row ? start_row : min_start_row;
+            size_t end_row = slice_and_key.slice().row_range.end();
+            max_end_row = end_row > max_end_row ? end_row : max_end_row;
+            size_t start_col = slice_and_key.slice().col_range.start();
+            min_start_col = start_col < min_start_col ? start_col : min_start_col;
+            size_t end_col = slice_and_key.slice().col_range.end();
+            max_end_col = end_col > max_end_col ? end_col : max_end_col;
+            input_streams.push(
+                std::make_unique<SliceAndKeyWrapper>(std::forward<pipelines::SliceAndKey>(slice_and_key), store));
+        }
+    });
+    const RowRange row_range{min_start_row, max_end_row};
+    const ColRange col_range{min_start_col, max_end_col};
+    Composite<ProcessingSegment> ret;
+    std::visit(
+        [&ret,
+            &input_streams,
+            add_symbol_column = add_symbol_column_,
+            &comp = compare,
+            stream_id = stream_id_,
+            &row_range,
+            &col_range,
+            execution_context = execution_context_](auto idx, auto density) {
+            merge_impl<decltype(idx), decltype(density), decltype(input_streams), decltype(comp), decltype(stream_id)>(
+                ret,
+                input_streams,
+                add_symbol_column,
+                stream_id,
+                row_range,
+                col_range,
+                idx,
+                execution_context);
+        },
+        index_,
+        density_policy_);
 
-        return ret;
-    }
+    return ret;
+}
 
-[[nodiscard]] Composite<ProcessingSegment>
-RemoveColumnPartitioningClause::process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const {
-        using namespace arcticdb::pipelines;
-        auto procs = std::move(p);
-        Composite<ProcessingSegment> output;
-        auto index = stream::index_type_from_descriptor(execution_context_->output_descriptor_.value());
-        util::variant_match(index,
-        [&](const stream::TimeseriesIndex &) {
+[[nodiscard]] Composite<ProcessingSegment> RemoveColumnPartitioningClause::process(std::shared_ptr<Store> store,
+    Composite<ProcessingSegment>&& p) const
+{
+    using namespace arcticdb::pipelines;
+    auto procs = std::move(p);
+    Composite<ProcessingSegment> output;
+    auto index = stream::index_type_from_descriptor(execution_context_->output_descriptor_.value());
+    util::variant_match(
+        index,
+        [&](const stream::TimeseriesIndex&) {
             size_t num_index_columns = stream::TimeseriesIndex::field_count();
-            procs.broadcast([&store, &output, &num_index_columns](ProcessingSegment &proc) {
+            procs.broadcast([&store, &output, &num_index_columns](ProcessingSegment& proc) {
                 SegmentInMemory new_segment{empty_descriptor()};
                 new_segment.set_row_id(proc.data()[0].segment_->get_row_id());
                 size_t min_start_row = std::numeric_limits<size_t>::max();
                 size_t max_end_row = 0;
                 size_t min_start_col = std::numeric_limits<size_t>::max();
                 size_t max_end_col = 0;
-                for (auto &slice_and_key: proc.data()) {
+                for (auto& slice_and_key : proc.data()) {
                     size_t start_row = slice_and_key.slice().row_range.start();
                     min_start_row = start_row < min_start_row ? start_row : min_start_row;
                     size_t end_row = slice_and_key.slice().row_range.end();
@@ -385,16 +398,17 @@ RemoveColumnPartitioningClause::process(std::shared_ptr<Store> store, Composite<
                     size_t end_col = slice_and_key.slice().col_range.end();
                     max_end_col = end_col > max_end_col ? end_col : max_end_col;
                     size_t column_idx = 0;
-                    for(auto field : folly::enumerate(slice_and_key.segment(store).descriptor().fields())) {
+                    for (auto field : folly::enumerate(slice_and_key.segment(store).descriptor().fields())) {
                         const auto column_name = field->name();
                         auto column = proc.get(ColumnName(column_name), store);
                         if (std::holds_alternative<ColumnWithStrings>(column)) {
                             ColumnWithStrings column_strings = std::get<ColumnWithStrings>(column);
                             const auto data_type = column_strings.column_->type().data_type();
-                            if(((start_col - num_index_columns) == 0) || column_idx >= num_index_columns){
-                                new_segment.add_column(scalar_field_proto(data_type, column_name),  slice_and_key.segment(store).column_ptr(field.index));
+                            if (((start_col - num_index_columns) == 0) || column_idx >= num_index_columns) {
+                                new_segment.add_column(scalar_field_proto(data_type, column_name),
+                                    slice_and_key.segment(store).column_ptr(field.index));
                             }
-                        }else {
+                        } else {
                             util::raise_rte("Expected single column from expression");
                         }
                         column_idx++;
@@ -405,12 +419,8 @@ RemoveColumnPartitioningClause::process(std::shared_ptr<Store> store, Composite<
                 output.push_back(ProcessingSegment{std::move(new_segment), FrameSlice{col_range, row_range}});
             });
         },
-        [&](const auto &) {
-            util::raise_rte("Not supported index type for sort merge implementation");
-        }
-        );
-        return output;
+        [&](const auto&) { util::raise_rte("Not supported index type for sort merge implementation"); });
+    return output;
 }
-    
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -37,19 +37,27 @@ namespace arcticdb {
 struct IClause {
     template<class Base>
     struct Interface : Base {
-        [[nodiscard]] Composite<ProcessingSegment>
-        process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&segs) const {
+        [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+            Composite<ProcessingSegment>&& segs) const
+        {
             return std::move(folly::poly_call<0>(*this, store, std::move(segs)));
         }
 
         [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
-                [[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&comps) const {
+            [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& comps) const
+        {
             return folly::poly_call<1>(*this, std::move(comps));
         }
 
-        [[nodiscard]] bool requires_repartition() const { return folly::poly_call<2>(*this); }
+        [[nodiscard]] bool requires_repartition() const
+        {
+            return folly::poly_call<2>(*this);
+        }
 
-        [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return folly::poly_call<3>(*this); }
+        [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+        {
+            return folly::poly_call<3>(*this);
+        }
     };
 
     template<class T>
@@ -58,24 +66,34 @@ struct IClause {
 
 using Clause = folly::Poly<IClause>;
 
-std::vector<Composite<ProcessingSegment>> single_partition(std::vector<Composite<ProcessingSegment>> &&segs);
+std::vector<Composite<ProcessingSegment>> single_partition(std::vector<Composite<ProcessingSegment>>&& segs);
 
 struct FilterClause {
     std::shared_ptr<ExecutionContext> execution_context_;
 
-    explicit FilterClause(std::shared_ptr<ExecutionContext> execution_context) :
-        execution_context_(std::move(execution_context)) {
+    explicit FilterClause(std::shared_ptr<ExecutionContext> execution_context)
+        : execution_context_(std::move(execution_context))
+    {
     }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const;
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const;
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return execution_context_; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return execution_context_;
+    }
 
-    [[nodiscard]] bool requires_repartition() const { return false; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&&) const
+    {
+        return std::nullopt;
+    }
 };
 
 /**
@@ -88,12 +106,16 @@ struct FilterClause {
 struct RowNumberLimitClause {
     size_t n;
 
-    explicit RowNumberLimitClause(size_t n) : n(n) {}
+    explicit RowNumberLimitClause(size_t n)
+        : n(n)
+    {
+    }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const {
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const
+    {
         auto procs = std::move(p);
-        procs.broadcast([&store, this](ProcessingSegment &proc) {
+        procs.broadcast([&store, this](ProcessingSegment& proc) {
             auto row_range = proc.data()[0].slice_.row_range;
             if (row_range.start() == 0ULL && row_range.end() > n) {
                 util::BitSet bv(static_cast<util::BitSet::size_type>(row_range.diff()));
@@ -107,29 +129,40 @@ struct RowNumberLimitClause {
         return procs;
     }
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return nullptr; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return nullptr;
+    }
 
     mutable bool warning_shown = false; // folly::Poly can't deal with atomic_bool
-    [[nodiscard]] bool requires_repartition() const { return false; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&&) const
+    {
+        return std::nullopt;
+    }
 };
 
 template<typename GrouperType, typename BucketizerType>
 struct PartitionClause {
     std::shared_ptr<ExecutionContext> execution_context_;
 
-    explicit PartitionClause(std::shared_ptr<ExecutionContext> execution_context) :
-            execution_context_(std::move(execution_context)) {
+    explicit PartitionClause(std::shared_ptr<ExecutionContext> execution_context)
+        : execution_context_(std::move(execution_context))
+    {
     }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const {
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const
+    {
         Composite<ProcessingSegment> output;
 
         auto procs = std::move(p);
-        procs.broadcast([&output, &store, &execution_context = execution_context_](auto &proc) {
+        procs.broadcast([&output, &store, &execution_context = execution_context_](auto& proc) {
             proc.set_execution_context(execution_context);
             // TODO (AN-469): I would push all of the logic between here and calling partition_processing_segment down
             // into partition_processing_segment, just passing the column name to group on, processing segment, and
@@ -145,12 +178,16 @@ struct PartitionClause {
 
                     auto grouper = std::make_shared<ResolvedGrouperType>(ResolvedGrouperType());
                     // TODO (AN-469): We should put some thought into how to pick an appropriate value for num_buckets
-                    auto num_cores = std::thread::hardware_concurrency() == 0 ? 16 : std::thread::hardware_concurrency();
+                    auto num_cores =
+                        std::thread::hardware_concurrency() == 0 ? 16 : std::thread::hardware_concurrency();
                     auto num_buckets = ConfigsMap::instance()->get_int("Partition.NumBuckets", num_cores);
                     auto bucketizer = std::make_shared<BucketizerType>(num_buckets);
 
-                    output.push_back(
-                            partition_processing_segment<ResolvedGrouperType, BucketizerType>(proc, col, store, grouper, bucketizer));
+                    output.push_back(partition_processing_segment<ResolvedGrouperType, BucketizerType>(proc,
+                        col,
+                        store,
+                        grouper,
+                        bucketizer));
                 });
             } else {
                 util::raise_rte("Expected single column from expression");
@@ -160,17 +197,24 @@ struct PartitionClause {
         return output;
     }
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return execution_context_; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return execution_context_;
+    }
 
-    [[nodiscard]] bool requires_repartition() const { return true; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return true;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&c) const {
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& c) const
+    {
         auto comps = std::move(c);
         std::unordered_map<size_t, Composite<ProcessingSegment>> partition_map;
 
-        for (auto &comp : comps) {
-            comp.broadcast([&partition_map](auto &proc) {
+        for (auto& comp : comps) {
+            comp.broadcast([&partition_map](auto& proc) {
                 auto bucket_id = proc.get_bucket();
 
                 if (partition_map.find(bucket_id) == partition_map.end()) {
@@ -182,7 +226,7 @@ struct PartitionClause {
         }
 
         std::vector<Composite<ProcessingSegment>> ret;
-        for (auto &[key, value] : partition_map) {
+        for (auto& [key, value] : partition_map) {
             ret.push_back(std::move(value));
         }
 
@@ -190,7 +234,8 @@ struct PartitionClause {
     }
 };
 
-inline StreamDescriptor empty_descriptor() {
+inline StreamDescriptor empty_descriptor()
+{
     return StreamDescriptor{StreamId{"merged"}, IndexDescriptor{0, IndexDescriptor::ROWCOUNT}, {}};
 }
 
@@ -204,36 +249,55 @@ struct AggregationClause {
     ARCTICDB_MOVE_COPY_DEFAULT(AggregationClause)
 
     AggregationClause(std::shared_ptr<ExecutionContext> execution_context,
-                               std::vector<AggregationFactory> &&aggregation_operators) :
-            execution_context_(std::move(execution_context)),
-            aggregation_operators_(std::forward<std::vector<AggregationFactory>>(aggregation_operators)) {
+        std::vector<AggregationFactory>&& aggregation_operators)
+        : execution_context_(std::move(execution_context)),
+          aggregation_operators_(std::forward<std::vector<AggregationFactory>>(aggregation_operators))
+    {
     }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const;
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const;
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return execution_context_; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return execution_context_;
+    }
 
-    [[nodiscard]] bool requires_repartition() const { return false; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&comps) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& comps) const
+    {
+        return std::nullopt;
+    }
 };
 
 struct PassthroughClause {
-    [[nodiscard]] Composite<ProcessingSegment>
-    process([[maybe_unused]] const std::shared_ptr<Store> &store, Composite<ProcessingSegment> &&p) const {
+    [[nodiscard]] Composite<ProcessingSegment> process([[maybe_unused]] const std::shared_ptr<Store>& store,
+        Composite<ProcessingSegment>&& p) const
+    {
         auto procs = std::move(p);
         return procs;
     }
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return nullptr; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return nullptr;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&comps) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& comps) const
+    {
+        return std::nullopt;
+    }
 
-    [[nodiscard]] bool requires_repartition() const { return false; }
-
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 };
 
 struct SliceAndKeyWrapper {
@@ -242,22 +306,26 @@ struct SliceAndKeyWrapper {
     SegmentInMemory::iterator it_;
     const StreamId id_;
 
-    explicit SliceAndKeyWrapper(pipelines::SliceAndKey &&seg, std::shared_ptr<Store> store) :
-            seg_(std::move(seg)),
-            store_(std::move(store)),
-            it_(seg_.segment(store_).begin()),
-            id_(seg_.segment(store_).descriptor().id()) {
+    explicit SliceAndKeyWrapper(pipelines::SliceAndKey&& seg, std::shared_ptr<Store> store)
+        : seg_(std::move(seg)),
+          store_(std::move(store)),
+          it_(seg_.segment(store_).begin()),
+          id_(seg_.segment(store_).descriptor().id())
+    {
     }
 
-    bool advance() {
+    bool advance()
+    {
         return ++it_ != seg_.segment(store_).end();
     }
 
-    SegmentInMemory::Row &row() {
+    SegmentInMemory::Row& row()
+    {
         return *it_;
     }
 
-    const StreamId &id() const {
+    const StreamId& id() const
+    {
         return id_;
     }
 };
@@ -270,53 +338,62 @@ struct MergeClause {
     StreamId target_id_;
     const std::shared_ptr<ExecutionContext> execution_context_;
 
-    MergeClause(
-            stream::Index index,
-            const stream::VariantColumnPolicy &density_policy,
-            const StreamId& stream_id,
-            std::shared_ptr<ExecutionContext> execution_context ) :
-            index_(std::move(index)),
-            density_policy_(density_policy),
-            stream_id_(stream_id),
-            execution_context_(std::move(execution_context)) {
+    MergeClause(stream::Index index,
+        const stream::VariantColumnPolicy& density_policy,
+        const StreamId& stream_id,
+        std::shared_ptr<ExecutionContext> execution_context)
+        : index_(std::move(index)),
+          density_policy_(density_policy),
+          stream_id_(stream_id),
+          execution_context_(std::move(execution_context))
+    {
     }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const;
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const;
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return nullptr; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return nullptr;
+    }
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
 
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&comps) const {
+    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& comps) const
+    {
         return single_partition(std::move(comps));
     }
 
-    [[nodiscard]] bool requires_repartition() const { return true; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return true;
+    }
 };
 
 struct SplitClause {
     const size_t rows_;
 
-    explicit SplitClause(size_t rows) :
-            rows_(rows) {
+    explicit SplitClause(size_t rows)
+        : rows_(rows)
+    {
     }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&procs) const {
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& procs) const
+    {
         using namespace arcticdb::pipelines;
 
         auto proc_composite = std::move(procs);
         Composite<ProcessingSegment> ret;
-        proc_composite.broadcast([&store, rows = rows_, &ret](auto &&p) {
+        proc_composite.broadcast([&store, rows = rows_, &ret](auto&& p) {
             auto proc = std::forward<decltype(p)>(p);
             auto slice_and_keys = proc.data();
-            for (auto &slice_and_key: slice_and_keys) {
+            for (auto& slice_and_key : slice_and_keys) {
                 auto split_segs = slice_and_key.segment(store).split(rows);
                 const ColRange col_range{slice_and_key.slice().col_range};
                 size_t start_row = slice_and_key.slice().row_range.start();
                 size_t end_row = 0;
-                for (auto &item : split_segs) {
+                for (auto& item : split_segs) {
                     end_row = start_row + item.row_count();
                     const RowRange row_range{start_row, end_row};
                     ret.push_back(ProcessingSegment{std::move(item), FrameSlice{col_range, row_range}});
@@ -327,39 +404,59 @@ struct SplitClause {
         return ret;
     }
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return nullptr; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return nullptr;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&comps) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& comps) const
+    {
+        return std::nullopt;
+    }
 
-    [[nodiscard]] bool requires_repartition() const { return false; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 };
 
 struct SortClause {
     const std::string column_;
 
-    explicit SortClause(std::string column) :
-            column_(std::move(column)) {
+    explicit SortClause(std::string column)
+        : column_(std::move(column))
+    {
     }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const {
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const
+    {
         auto procs = std::move(p);
-        procs.broadcast([&store, &column = column_](auto &proc) {
+        procs.broadcast([&store, &column = column_](auto& proc) {
             auto slice_and_keys = proc.data();
-            for (auto &slice_and_key: slice_and_keys) {
+            for (auto& slice_and_key : slice_and_keys) {
                 slice_and_key.segment(store).sort(column);
             }
         });
         return procs;
     }
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return nullptr; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return nullptr;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&comps) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& comps) const
+    {
+        return std::nullopt;
+    }
 
-    [[nodiscard]] bool requires_repartition() const { return false; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 };
 
 struct ProjectClause {
@@ -371,20 +468,30 @@ struct ProjectClause {
 
     //TODO support multiple projections
     //explicit ProjectClause(std::shared_ptr<std::map<std::string, std::string>> projections) :
-    explicit ProjectClause(const std::string& column_name, std::shared_ptr<ExecutionContext> execution_context) :
-        column_name_(column_name),
-        execution_context_(std::move(execution_context)) {
+    explicit ProjectClause(const std::string& column_name, std::shared_ptr<ExecutionContext> execution_context)
+        : column_name_(column_name),
+          execution_context_(std::move(execution_context))
+    {
     }
 
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const;
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const;
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return execution_context_; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return execution_context_;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&comps) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&& comps) const
+    {
+        return std::nullopt;
+    }
 
-    [[nodiscard]] bool requires_repartition() const { return false; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 };
 
 class ClauseBuilder {
@@ -394,15 +501,18 @@ private:
     std::vector<AggregationFactory> operators_;
 
 public:
-    void add_ProjectClause(const std::string& column_name, const std::shared_ptr<ExecutionContext>& ec) {
+    void add_ProjectClause(const std::string& column_name, const std::shared_ptr<ExecutionContext>& ec)
+    {
         clauses_.emplace_back(ProjectClause(column_name, ec));
     }
 
-    void add_FilterClause(const std::shared_ptr<ExecutionContext>& ec) {
+    void add_FilterClause(const std::shared_ptr<ExecutionContext>& ec)
+    {
         clauses_.emplace_back(FilterClause(ec));
     }
 
-    void prepare_AggregationClause(const std::shared_ptr<ExecutionContext>& ec) {
+    void prepare_AggregationClause(const std::shared_ptr<ExecutionContext>& ec)
+    {
         execution_context_ = ec;
         if (!operators_.empty()) {
             util::raise_rte("Prior aggregation clause not finalised before adding new aggregation clause!");
@@ -411,31 +521,38 @@ public:
         operators_ = std::vector<AggregationFactory>{};
     }
 
-    void add_SumAggregationOperator(ColumnName &&input, ColumnName &&output) {
+    void add_SumAggregationOperator(ColumnName&& input, ColumnName&& output)
+    {
         operators_.emplace_back(Sum{std::move(input), std::move(output)});
     }
 
-    void add_MeanAggregationOperator(ColumnName &&input, ColumnName &&output) {
+    void add_MeanAggregationOperator(ColumnName&& input, ColumnName&& output)
+    {
         operators_.emplace_back(Mean{std::move(input), std::move(output)});
     }
 
-    void add_MaxAggregationOperator(ColumnName &&input, ColumnName &&output) {
+    void add_MaxAggregationOperator(ColumnName&& input, ColumnName&& output)
+    {
         operators_.emplace_back(MaxOrMin{std::move(input), std::move(output), Extremum::max});
     }
 
-    void add_MinAggregationOperator(ColumnName &&input, ColumnName &&output) {
+    void add_MinAggregationOperator(ColumnName&& input, ColumnName&& output)
+    {
         operators_.emplace_back(MaxOrMin{std::move(input), std::move(output), Extremum::min});
     }
 
-    void finalize_AggregationClause() {
+    void finalize_AggregationClause()
+    {
         // TODO: Complete hack. Two clauses shouldn't share an EC.
         clauses_.emplace_back(
-                 PartitionClause<arcticdb::grouping::HashingGroupers, arcticdb::grouping::ModuloBucketizer>{execution_context_});
+            PartitionClause<arcticdb::grouping::HashingGroupers, arcticdb::grouping::ModuloBucketizer>{
+                execution_context_});
         clauses_.emplace_back(AggregationClause{execution_context_, std::move(operators_)});
         execution_context_.reset();
     }
 
-    [[nodiscard]] std::vector<Clause> get_clauses() const {
+    [[nodiscard]] std::vector<Clause> get_clauses() const
+    {
         return clauses_;
     }
 };
@@ -443,20 +560,29 @@ public:
 struct RemoveColumnPartitioningClause {
     std::shared_ptr<ExecutionContext> execution_context_;
 
-    RemoveColumnPartitioningClause(
-            std::shared_ptr<ExecutionContext> execution_context ) :
-            execution_context_(std::move(execution_context)) {
+    RemoveColumnPartitioningClause(std::shared_ptr<ExecutionContext> execution_context)
+        : execution_context_(std::move(execution_context))
+    {
     }
-    [[nodiscard]] Composite<ProcessingSegment>
-    process(std::shared_ptr<Store> store, Composite<ProcessingSegment> &&p) const;
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+        Composite<ProcessingSegment>&& p) const;
 
-    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const { return nullptr; }
+    [[nodiscard]] std::shared_ptr<ExecutionContext> execution_context() const
+    {
+        return nullptr;
+    }
 
     mutable bool warning_shown = false; // folly::Poly can't deal with atomic_bool
-    [[nodiscard]] bool requires_repartition() const { return false; }
+    [[nodiscard]] bool requires_repartition() const
+    {
+        return false;
+    }
 
-    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>>
-    repartition([[maybe_unused]] std::vector<Composite<ProcessingSegment>> &&) const { return std::nullopt; }
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+        [[maybe_unused]] std::vector<Composite<ProcessingSegment>>&&) const
+    {
+        return std::nullopt;
+    }
 };
 
-}//namespace arcticdb
+} //namespace arcticdb

--- a/cpp/arcticdb/processing/execution_context.hpp
+++ b/cpp/arcticdb/processing/execution_context.hpp
@@ -33,14 +33,17 @@ struct ExecutionContext {
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ExecutionContext)
 
-    template <class T>
+    template<class T>
     class ConstantMap {
         std::unordered_map<std::string, std::shared_ptr<T>> map_;
+
     public:
-        void set_value(std::string name, std::shared_ptr<T> val) {
+        void set_value(std::string name, std::shared_ptr<T> val)
+        {
             map_.try_emplace(name, val);
         }
-        std::shared_ptr<T> get_value(std::string name) {
+        std::shared_ptr<T> get_value(std::string name)
+        {
             return map_.at(name);
         }
     };
@@ -48,49 +51,59 @@ struct ExecutionContext {
         SPEED,
         MEMORY
     };
-    void add_column(const std::string& column_name) {
+    void add_column(const std::string& column_name)
+    {
         columns_.emplace(column_name);
     }
 
-    void add_expression_node(const std::string& name, std::shared_ptr<ExpressionNode> expression_node) {
+    void add_expression_node(const std::string& name, std::shared_ptr<ExpressionNode> expression_node)
+    {
         expression_nodes_.set_value(name, std::move(expression_node));
     }
 
-    void set_descriptor(const StreamDescriptor& desc) {
+    void set_descriptor(const StreamDescriptor& desc)
+    {
         output_descriptor_ = desc;
     }
 
-    void set_norm_meta_descriptor(NormMetaDescriptor& desc) {
+    void set_norm_meta_descriptor(NormMetaDescriptor& desc)
+    {
         norm_meta_ = desc;
     }
 
-    NormMetaDescriptor get_norm_meta_descriptor() {
+    NormMetaDescriptor get_norm_meta_descriptor()
+    {
         return norm_meta_;
     }
 
-    void add_value(const std::string& name, std::shared_ptr<Value> value) {
+    void add_value(const std::string& name, std::shared_ptr<Value> value)
+    {
         values_.set_value(name, std::move(value));
     }
 
-    void add_value_set(const std::string& name, std::shared_ptr<ValueSet> value_set) {
+    void add_value_set(const std::string& name, std::shared_ptr<ValueSet> value_set)
+    {
         value_sets_.set_value(name, std::move(value_set));
     }
 
-    void check_output_column(const std::string& name, DataType type) {
+    void check_output_column(const std::string& name, DataType type)
+    {
         std::scoped_lock lock{*column_mutex_};
         auto it = output_columns_.find(name);
-        if(it == std::end(output_columns_)) {
+        if (it == std::end(output_columns_)) {
             output_columns_.try_emplace(name, type);
             output_descriptor_->add_field(scalar_field_proto(type, name));
             //TODO check type compatibility in dynamic schema
         }
     }
 
-    bool dynamic_schema() const {
+    bool dynamic_schema() const
+    {
         return dynamic_schema_;
     }
 
-    void set_dynamic_schema(bool dynamic_schema) {
+    void set_dynamic_schema(bool dynamic_schema)
+    {
         dynamic_schema_ = dynamic_schema;
     }
 
@@ -112,4 +125,4 @@ struct ExecutionContext {
     bool dynamic_schema_ = false;
 };
 
-}//namespace arcticdb
+} //namespace arcticdb

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -13,20 +13,23 @@
 
 namespace arcticdb {
 
-ExpressionNode::ExpressionNode(VariantNode left, VariantNode right, OperationType op) :
-    left_(std::move(left)),
-    right_(std::move(right)),
-    operation_type_(op) {
+ExpressionNode::ExpressionNode(VariantNode left, VariantNode right, OperationType op)
+    : left_(std::move(left)),
+      right_(std::move(right)),
+      operation_type_(op)
+{
     util::check(is_binary_operation(op), "Left and right expressions supplied to non-binary operator");
 }
 
-ExpressionNode::ExpressionNode(VariantNode left, OperationType op) :
-    left_(std::move(left)),
-    operation_type_(op) {
+ExpressionNode::ExpressionNode(VariantNode left, OperationType op)
+    : left_(std::move(left)),
+      operation_type_(op)
+{
     util::check(!is_binary_operation(op), "Binary expression expects both left and right children");
 }
 
-VariantData ExpressionNode::compute(ProcessingSegment& seg, const std::shared_ptr<Store>& store) const {
+VariantData ExpressionNode::compute(ProcessingSegment& seg, const std::shared_ptr<Store>& store) const
+{
     if (is_binary_operation(operation_type_)) {
         return dispatch_binary(seg.get(left_, store), seg.get(right_, store), operation_type_);
     } else {

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -20,16 +20,16 @@
 
 namespace arcticdb {
 
-struct ColumnNameTag{};
+struct ColumnNameTag {};
 using ColumnName = util::StringWrappingValue<ColumnNameTag>;
 
-struct ValueNameTag{};
+struct ValueNameTag {};
 using ValueName = util::StringWrappingValue<ValueNameTag>;
 
-struct ValueSetNameTag{};
+struct ValueSetNameTag {};
 using ValueSetName = util::StringWrappingValue<ValueSetNameTag>;
 
-struct ExpressionNameTag{};
+struct ExpressionNameTag {};
 using ExpressionName = util::StringWrappingValue<ExpressionNameTag>;
 
 using VariantNode = std::variant<std::monostate, ColumnName, ValueName, ValueSetName, ExpressionName>;
@@ -46,21 +46,26 @@ struct ColumnWithStrings {
 
     ARCTICDB_MOVE_COPY_DEFAULT(ColumnWithStrings)
 
-    explicit ColumnWithStrings(std::unique_ptr<Column>&& col) :
-        column_(std::move(col)) {
+    explicit ColumnWithStrings(std::unique_ptr<Column>&& col)
+        : column_(std::move(col))
+    {
     }
 
-    ColumnWithStrings(Column&& col, std::shared_ptr<StringPool> string_pool) :
-        column_(std::make_shared<Column>(std::move(col))),
-        string_pool_(std::move(string_pool)) {
+    ColumnWithStrings(Column&& col, std::shared_ptr<StringPool> string_pool)
+        : column_(std::make_shared<Column>(std::move(col))),
+          string_pool_(std::move(string_pool))
+    {
     }
 
-    ColumnWithStrings(std::shared_ptr<Column> column, const std::shared_ptr<StringPool>& string_pool) :
-        column_(std::move(column)),
-        string_pool_(string_pool) {
+    ColumnWithStrings(std::shared_ptr<Column> column, const std::shared_ptr<StringPool>& string_pool)
+        : column_(std::move(column)),
+          string_pool_(string_pool)
+    {
     }
 
-    [[nodiscard]] std::optional<std::string_view> string_at_offset(StringPool::offset_t offset, bool strip_fixed_width_trailing_nulls=false) const {
+    [[nodiscard]] std::optional<std::string_view> string_at_offset(StringPool::offset_t offset,
+        bool strip_fixed_width_trailing_nulls = false) const
+    {
         if (UNLIKELY(!column_ || !string_pool_))
             return std::nullopt;
         util::check(!column_->is_inflated(), "Unexpected inflated column in filtering");
@@ -71,19 +76,20 @@ struct ColumnWithStrings {
         if (strip_fixed_width_trailing_nulls && is_fixed_string_type(column_->type().data_type())) {
             auto char_width = is_utf_type(slice_value_type(column_->type().data_type())) ? UNICODE_WIDTH : ASCII_WIDTH;
             const std::string_view null_char_view("\0\0\0\0", char_width);
-            while(!raw.empty() && raw.substr(raw.size() - char_width) == null_char_view) {
+            while (!raw.empty() && raw.substr(raw.size() - char_width) == null_char_view) {
                 raw.remove_suffix(char_width);
             }
         }
         return raw;
     }
 
-    [[nodiscard]] std::optional<size_t> get_fixed_width_string_size() const {
+    [[nodiscard]] std::optional<size_t> get_fixed_width_string_size() const
+    {
         if (!column_ || !string_pool_)
             return std::nullopt;
 
         util::check(!column_->is_inflated(), "Unexpected inflated column in filtering");
-        for(position_t i = 0; i < column_->row_count(); ++i) {
+        for (position_t i = 0; i < column_->row_count(); ++i) {
             auto offset = column_->scalar_at<StringPool::offset_t>(i);
             if (offset != std::nullopt) {
                 std::string_view raw = string_pool_->get_view(offset.value());
@@ -98,7 +104,12 @@ struct FullResult {};
 
 struct EmptyResult {};
 
-using VariantData = std::variant<FullResult, EmptyResult, std::shared_ptr<Value>, std::shared_ptr<ValueSet>, ColumnWithStrings, std::shared_ptr<util::BitSet>>;
+using VariantData = std::variant<FullResult,
+    EmptyResult,
+    std::shared_ptr<Value>,
+    std::shared_ptr<ValueSet>,
+    ColumnWithStrings,
+    std::shared_ptr<util::BitSet>>;
 
 /*
  * Basic AST node.

--- a/cpp/arcticdb/processing/grouper.hpp
+++ b/cpp/arcticdb/processing/grouper.hpp
@@ -35,10 +35,13 @@ public:
         using DataTypeTag = typename GrouperDescriptor::DataTypeTag;
         using RawType = typename DataTypeTag::raw_type;
 
-        size_t group(RawType key, std::shared_ptr<StringPool> sp) const {
+        size_t group(RawType key, std::shared_ptr<StringPool> sp) const
+        {
             constexpr DataType dt = DataTypeTag::data_type;
             HashedValue hash_result;
-            if constexpr(dt == DataType::ASCII_FIXED64 || dt == DataType::ASCII_DYNAMIC64 || dt == DataType::UTF_FIXED64 || dt == DataType::UTF_DYNAMIC64) {
+            if constexpr (dt == DataType::ASCII_FIXED64 || dt == DataType::ASCII_DYNAMIC64 ||
+                          dt == DataType::UTF_FIXED64 || dt == DataType::UTF_DYNAMIC64)
+            {
                 // TODO (AN-468): This will throw on Nones/NaNs
                 hash_result = hash(sp->get_view(key));
             } else {
@@ -51,28 +54,32 @@ public:
 };
 
 class Bucketizer {
-    public:
+public:
     virtual size_t bucket(size_t group) const = 0;
 
     virtual size_t num_buckets() const = 0;
 
-    virtual ~Bucketizer() {};
+    virtual ~Bucketizer(){};
 };
 
 class ModuloBucketizer : Bucketizer {
     size_t mod_;
+
 public:
-    ModuloBucketizer(size_t mod) :
-        mod_(mod) {
+    ModuloBucketizer(size_t mod)
+        : mod_(mod)
+    {
     }
 
     ARCTICDB_MOVE_COPY_DEFAULT(ModuloBucketizer)
 
-    size_t bucket(size_t group) const {
+    size_t bucket(size_t group) const
+    {
         return group % mod_;
     }
 
-    virtual size_t num_buckets() const {
+    virtual size_t num_buckets() const
+    {
         return mod_;
     }
 
@@ -81,12 +88,14 @@ public:
 
 class IdentityBucketizer : Bucketizer {
 public:
-    size_t bucket(size_t group) const {
+    size_t bucket(size_t group) const
+    {
         return group;
     }
 
-    virtual size_t num_buckets() const {
+    virtual size_t num_buckets() const
+    {
         return 0;
     }
 };
-}
+} // namespace arcticdb::grouping

--- a/cpp/arcticdb/processing/operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch.cpp
@@ -10,24 +10,23 @@
 
 namespace arcticdb {
 
-VariantData transform_to_placeholder(VariantData data) {
+VariantData transform_to_placeholder(VariantData data)
+{
     // There is a further optimization we can do here which is to return FullResult
     // when the number of set bits is the same as the processing segments row-count,
     // however that would need to be maintained by the processing segment and
     // modified with each transformation. It would be worth it in the scenario
     // where a true result is very common, but is a premature change to make at this point.
-    return util::variant_match(data,
-                               [](std::shared_ptr<util::BitSet> bitset) -> VariantData {
-                                   if (bitset->count() == 0) {
-                                       return VariantData{EmptyResult{}};
-                                   } else {
-                                       return VariantData{bitset};
-                                   }
-                               },
-                               [](auto v) -> VariantData {
-                                   return VariantData{v};
-                               }
-    );
+    return util::variant_match(
+        data,
+        [](std::shared_ptr<util::BitSet> bitset) -> VariantData {
+            if (bitset->count() == 0) {
+                return VariantData{EmptyResult{}};
+            } else {
+                return VariantData{bitset};
+            }
+        },
+        [](auto v) -> VariantData { return VariantData{v}; });
 }
 
 // Unary and binary boolean operations work on bitsets, full results and empty results
@@ -37,45 +36,47 @@ VariantData transform_to_placeholder(VariantData data) {
 //  - returns util::Bitset, FullResult, and EmptyResult as provided
 //  - throws if the input VariantData is a Value, a ValueSet, or a non-bool column
 //  - returns a util::BitSet if the input is a bool column
-VariantData transform_to_bitset(const VariantData& data) {
-    return std::visit(util::overload{
-            [&] (const std::shared_ptr<Value>&) -> VariantData {
-                util::raise_rte("Value inputs cannot be input to boolean operations");
-            },
-            [&] (const std::shared_ptr<ValueSet>&) -> VariantData {
-                util::raise_rte("ValueSet inputs cannot be input to boolean operations");
-            },
-            [&] (const ColumnWithStrings& column_with_strings) -> VariantData {
-                auto output = std::make_shared<util::BitSet>(static_cast<util::BitSetSizeType>(column_with_strings.column_->row_count()));
-                column_with_strings.column_->type().visit_tag([&column_with_strings, &output] (auto column_desc_tag) {
-                    using ColumnDescriptorType = std::decay_t<decltype(column_desc_tag)>;
-                    using ColumnTagType =  typename ColumnDescriptorType::DataTypeTag;
-                    using ColumnType =  typename ColumnTagType::raw_type;
-                    if constexpr (is_bool_type(ColumnTagType::data_type)) {
-                        auto column_data = column_with_strings.column_->data();
-                        util::BitSet::bulk_insert_iterator inserter(*output);
-                        auto pos = 0u;
-                        while (auto block = column_data.next<ColumnDescriptorType>()) {
-                            auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
-                            const auto row_count = block.value().row_count();
-                            for (auto i = 0u; i < row_count; ++i, ++pos) {
-                                if(*ptr++)
-                                    inserter = pos;
-                            }
-                        }
-                        inserter.flush();
-                    } else {
-                        util::raise_rte("Cannot convert column of type {} to a bitset", column_with_strings.column_->type());
-                    }
-                });
-                return output;
-            },
-            [](const auto& d) -> VariantData {
-                // util::BitSet, FullResult, or EmptyResult
-                return d;
-            }
-    }, data);
+VariantData transform_to_bitset(const VariantData& data)
+{
+    return std::visit(util::overload{[&](const std::shared_ptr<Value>&) -> VariantData {
+                                         util::raise_rte("Value inputs cannot be input to boolean operations");
+                                     },
+                          [&](const std::shared_ptr<ValueSet>&) -> VariantData {
+                              util::raise_rte("ValueSet inputs cannot be input to boolean operations");
+                          },
+                          [&](const ColumnWithStrings& column_with_strings) -> VariantData {
+                              auto output = std::make_shared<util::BitSet>(
+                                  static_cast<util::BitSetSizeType>(column_with_strings.column_->row_count()));
+                              column_with_strings.column_->type().visit_tag(
+                                  [&column_with_strings, &output](auto column_desc_tag) {
+                                      using ColumnDescriptorType = std::decay_t<decltype(column_desc_tag)>;
+                                      using ColumnTagType = typename ColumnDescriptorType::DataTypeTag;
+                                      using ColumnType = typename ColumnTagType::raw_type;
+                                      if constexpr (is_bool_type(ColumnTagType::data_type)) {
+                                          auto column_data = column_with_strings.column_->data();
+                                          util::BitSet::bulk_insert_iterator inserter(*output);
+                                          auto pos = 0u;
+                                          while (auto block = column_data.next<ColumnDescriptorType>()) {
+                                              auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
+                                              const auto row_count = block.value().row_count();
+                                              for (auto i = 0u; i < row_count; ++i, ++pos) {
+                                                  if (*ptr++)
+                                                      inserter = pos;
+                                              }
+                                          }
+                                          inserter.flush();
+                                      } else {
+                                          util::raise_rte("Cannot convert column of type {} to a bitset",
+                                              column_with_strings.column_->type());
+                                      }
+                                  });
+                              return output;
+                          },
+                          [](const auto& d) -> VariantData {
+                              // util::BitSet, FullResult, or EmptyResult
+                              return d;
+                          }},
+        data);
 }
 
-
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch.hpp
@@ -30,4 +30,4 @@ namespace arcticdb {
 VariantData transform_to_placeholder(VariantData data);
 
 VariantData transform_to_bitset(const VariantData& data);
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.cpp
@@ -10,153 +10,159 @@
 
 namespace arcticdb {
 
-VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, const std::shared_ptr<util::BitSet>& right, OperationType operation) {
-    util::check(left->size() == right->size(), "BitSets of different lengths ({} and {}) in binary comparator", left->size(), right->size());
-    switch(operation) {
-        case OperationType::AND:
-            return std::make_shared<util::BitSet>(*left & *right);
-        case OperationType::OR:
-            return std::make_shared<util::BitSet>(*left | *right);
-        case OperationType::XOR:
-            return std::make_shared<util::BitSet>(*left ^ *right);
-        default:
-            util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
+VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left,
+    const std::shared_ptr<util::BitSet>& right,
+    OperationType operation)
+{
+    util::check(left->size() == right->size(),
+        "BitSets of different lengths ({} and {}) in binary comparator",
+        left->size(),
+        right->size());
+    switch (operation) {
+    case OperationType::AND:
+        return std::make_shared<util::BitSet>(*left & *right);
+    case OperationType::OR:
+        return std::make_shared<util::BitSet>(*left | *right);
+    case OperationType::XOR:
+        return std::make_shared<util::BitSet>(*left ^ *right);
+    default:
+        util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
     }
 }
 
-VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, EmptyResult, OperationType operation) {
-    switch(operation) {
-        case OperationType::AND:
-            return EmptyResult{};
-        case OperationType::OR:
-        case OperationType::XOR:
-            return left;
-        default:
-            util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
+VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, EmptyResult, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::AND:
+        return EmptyResult{};
+    case OperationType::OR:
+    case OperationType::XOR:
+        return left;
+    default:
+        util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
     }
 }
 
-VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, FullResult, OperationType operation) {
-    switch(operation) {
-        case OperationType::AND:
-            return left;
-        case OperationType::OR:
-            return FullResult{};
-        case OperationType::XOR: {
-            return std::make_shared<util::BitSet>(~(*left));
-        }
-        default:
-            util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
+VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, FullResult, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::AND:
+        return left;
+    case OperationType::OR:
+        return FullResult{};
+    case OperationType::XOR: {
+        return std::make_shared<util::BitSet>(~(*left));
+    }
+    default:
+        util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
     }
 }
 
-VariantData binary_boolean(EmptyResult, FullResult, OperationType operation) {
-    switch(operation) {
-        case OperationType::AND:
-            return EmptyResult{};
-        case OperationType::OR:
-        case OperationType::XOR:
-            return FullResult{};
-        default:
-            util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
+VariantData binary_boolean(EmptyResult, FullResult, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::AND:
+        return EmptyResult{};
+    case OperationType::OR:
+    case OperationType::XOR:
+        return FullResult{};
+    default:
+        util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
     }
 }
 
-VariantData binary_boolean(FullResult, FullResult, OperationType operation) {
-    switch(operation) {
-        case OperationType::AND:
-        case OperationType::OR:
-            return FullResult{};
-        case OperationType::XOR:
-            return EmptyResult{};
-        default:
-            util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
+VariantData binary_boolean(FullResult, FullResult, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::AND:
+    case OperationType::OR:
+        return FullResult{};
+    case OperationType::XOR:
+        return EmptyResult{};
+    default:
+        util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
     }
 }
 
-VariantData binary_boolean(EmptyResult, EmptyResult, OperationType operation) {
-    switch(operation) {
-        case OperationType::AND:
-        case OperationType::OR:
-        case OperationType::XOR:
-            return EmptyResult{};
-        default:
-            util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
+VariantData binary_boolean(EmptyResult, EmptyResult, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::AND:
+    case OperationType::OR:
+    case OperationType::XOR:
+        return EmptyResult{};
+    default:
+        util::raise_rte("Unexpected operator in binary_boolean {}", int(operation));
     }
 }
 
 // Note that we can have fewer of these and reverse the parameters because all the operations are
 // commutative, however if that were to change we would need the full set
-VariantData visit_binary_boolean(const VariantData& left, const VariantData& right, OperationType operation) {
+VariantData visit_binary_boolean(const VariantData& left, const VariantData& right, OperationType operation)
+{
     auto left_transformed = transform_to_bitset(left);
     auto right_transformed = transform_to_bitset(right);
-    return std::visit(util::overload {
-            [&operation] (const std::shared_ptr<util::BitSet>& l, const std::shared_ptr<util::BitSet>& r) {
+    return std::visit(
+        util::overload{[&operation](const std::shared_ptr<util::BitSet>& l, const std::shared_ptr<util::BitSet>& r) {
+                           return transform_to_placeholder(binary_boolean(l, r, operation));
+                       },
+            [&operation](const std::shared_ptr<util::BitSet>& l, EmptyResult r) {
                 return transform_to_placeholder(binary_boolean(l, r, operation));
             },
-            [&operation] (const std::shared_ptr<util::BitSet>& l, EmptyResult r) {
+            [&operation](const std::shared_ptr<util::BitSet>& l, FullResult r) {
                 return transform_to_placeholder(binary_boolean(l, r, operation));
             },
-            [&operation] (const std::shared_ptr<util::BitSet>& l, FullResult r) {
-                return transform_to_placeholder(binary_boolean(l, r, operation));
-            },
-            [&operation] (EmptyResult l, const std::shared_ptr<util::BitSet>& r) {
+            [&operation](EmptyResult l, const std::shared_ptr<util::BitSet>& r) {
                 return binary_boolean(r, l, operation);
             },
-            [&operation] (FullResult l, const std::shared_ptr<util::BitSet>& r) {
+            [&operation](FullResult l, const std::shared_ptr<util::BitSet>& r) {
                 return transform_to_placeholder(binary_boolean(r, l, operation));
             },
-            [&operation] (FullResult l, EmptyResult r) {
-                return binary_boolean(r, l, operation);
-            },
-            [&operation] (EmptyResult l, FullResult r) {
-                return binary_boolean(l, r, operation);
-            },
-            [&operation] (FullResult l, FullResult r) {
-                return binary_boolean(l, r, operation);
-            },
-            [&operation] (EmptyResult l, EmptyResult r) {
-                return binary_boolean(r, l, operation);
-            },
-            [](const auto &, const auto&) -> VariantData {
+            [&operation](FullResult l, EmptyResult r) { return binary_boolean(r, l, operation); },
+            [&operation](EmptyResult l, FullResult r) { return binary_boolean(l, r, operation); },
+            [&operation](FullResult l, FullResult r) { return binary_boolean(l, r, operation); },
+            [&operation](EmptyResult l, EmptyResult r) { return binary_boolean(r, l, operation); },
+            [](const auto&, const auto&) -> VariantData {
                 util::raise_rte("Value/ValueSet/non-bool column inputs not accepted to binary boolean");
-            }
-    }, left_transformed, right_transformed);
+            }},
+        left_transformed,
+        right_transformed);
 }
 
-VariantData dispatch_binary(const VariantData& left, const VariantData& right, OperationType operation) {
-    switch(operation) {
-        case OperationType::ADD:
-            return visit_binary_operator(left, right, PlusOperator{});
-        case OperationType::SUB:
-            return visit_binary_operator(left, right, MinusOperator{});
-        case OperationType::MUL:
-            return visit_binary_operator(left, right, TimesOperator{});
-        case OperationType::DIV:
-            return visit_binary_operator(left, right, DivideOperator{});
-        case OperationType::EQ:
-            return visit_binary_comparator(left, right, EqualsOperator{});
-        case OperationType::NE:
-            return visit_binary_comparator(left, right, NotEqualsOperator{});
-        case OperationType::LT:
-            return visit_binary_comparator(left, right, LessThanOperator{});
-        case OperationType::LE:
-            return visit_binary_comparator(left, right, LessThanEqualsOperator{});
-        case OperationType::GT:
-            return visit_binary_comparator(left, right, GreaterThanOperator{});
-        case OperationType::GE:
-            return visit_binary_comparator(left, right, GreaterThanEqualsOperator{});
-        case OperationType::ISIN:
-            return visit_binary_membership(left, right, IsInOperator{});
-        case OperationType::ISNOTIN:
-            return visit_binary_membership(left, right, IsNotInOperator{});
-        case OperationType::AND:
-        case OperationType::OR:
-        case OperationType::XOR:
-            return visit_binary_boolean(left, right, operation);
-        default:
-            util::raise_rte("Unknown operation {}", int(operation));
+VariantData dispatch_binary(const VariantData& left, const VariantData& right, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::ADD:
+        return visit_binary_operator(left, right, PlusOperator{});
+    case OperationType::SUB:
+        return visit_binary_operator(left, right, MinusOperator{});
+    case OperationType::MUL:
+        return visit_binary_operator(left, right, TimesOperator{});
+    case OperationType::DIV:
+        return visit_binary_operator(left, right, DivideOperator{});
+    case OperationType::EQ:
+        return visit_binary_comparator(left, right, EqualsOperator{});
+    case OperationType::NE:
+        return visit_binary_comparator(left, right, NotEqualsOperator{});
+    case OperationType::LT:
+        return visit_binary_comparator(left, right, LessThanOperator{});
+    case OperationType::LE:
+        return visit_binary_comparator(left, right, LessThanEqualsOperator{});
+    case OperationType::GT:
+        return visit_binary_comparator(left, right, GreaterThanOperator{});
+    case OperationType::GE:
+        return visit_binary_comparator(left, right, GreaterThanEqualsOperator{});
+    case OperationType::ISIN:
+        return visit_binary_membership(left, right, IsInOperator{});
+    case OperationType::ISNOTIN:
+        return visit_binary_membership(left, right, IsNotInOperator{});
+    case OperationType::AND:
+    case OperationType::OR:
+    case OperationType::XOR:
+        return visit_binary_boolean(left, right, operation);
+    default:
+        util::raise_rte("Unknown operation {}", int(operation));
     }
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -28,7 +28,9 @@
 
 namespace arcticdb {
 
-VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, const std::shared_ptr<util::BitSet>& right, OperationType operation);
+VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left,
+    const std::shared_ptr<util::BitSet>& right,
+    OperationType operation);
 
 VariantData binary_boolean(const std::shared_ptr<util::BitSet>& left, EmptyResult, OperationType operation);
 
@@ -44,85 +46,101 @@ VariantData binary_boolean(EmptyResult, EmptyResult, OperationType operation);
 // commutative, however if that were to change we would need the full set
 VariantData visit_binary_boolean(const VariantData& left, const VariantData& right, OperationType operation);
 
-template <typename Func>
-VariantData binary_membership(const ColumnWithStrings& column_with_strings, ValueSet& value_set, Func&& func) {
+template<typename Func>
+VariantData binary_membership(const ColumnWithStrings& column_with_strings, ValueSet& value_set, Func&& func)
+{
     auto output = std::make_shared<util::BitSet>(column_with_strings.column_->row_count());
     // If the value set is empty, then for IsInOperator, we are done
     // For the IsNotInOperator, set all bits to 1
     if (value_set.empty()) {
-        if constexpr(std::is_same_v<Func, IsNotInOperator&&>)
+        if constexpr (std::is_same_v<Func, IsNotInOperator&&>)
             output->set();
     } else {
-        entity::details::visit_type(column_with_strings.column_->type().data_type(),[&column_with_strings, &value_set, &func, &output] (auto column_desc_tag) {
-            using ColumnTagType = std::decay_t<decltype(column_desc_tag)>;
-            using ColumnType =  typename ColumnTagType::raw_type;
+        entity::details::visit_type(column_with_strings.column_->type().data_type(),
+            [&column_with_strings, &value_set, &func, &output](auto column_desc_tag) {
+                using ColumnTagType = std::decay_t<decltype(column_desc_tag)>;
+                using ColumnType = typename ColumnTagType::raw_type;
 
-            entity::details::visit_type(value_set.base_type().data_type(),[&column_with_strings, &value_set, &func, &output, &column_desc_tag] (auto value_set_desc_tag) {
-                using ValueSetBaseTypeTag = decltype(value_set_desc_tag);
+                entity::details::visit_type(value_set.base_type().data_type(),
+                    [&column_with_strings, &value_set, &func, &output, &column_desc_tag](auto value_set_desc_tag) {
+                        using ValueSetBaseTypeTag = decltype(value_set_desc_tag);
 
-                if constexpr(is_sequence_type(ColumnTagType::data_type) && is_sequence_type(ValueSetBaseTypeTag::data_type)) {
-                    std::shared_ptr<std::unordered_set<std::string>> typed_value_set;
-                    if constexpr(is_fixed_string_type(ColumnTagType::data_type)) {
-                        auto width = column_with_strings.get_fixed_width_string_size();
-                        if (width.has_value()) {
-                            typed_value_set = value_set.get_fixed_width_string_set(*width);
+                        if constexpr (is_sequence_type(ColumnTagType::data_type) &&
+                                      is_sequence_type(ValueSetBaseTypeTag::data_type))
+                        {
+                            std::shared_ptr<std::unordered_set<std::string>> typed_value_set;
+                            if constexpr (is_fixed_string_type(ColumnTagType::data_type)) {
+                                auto width = column_with_strings.get_fixed_width_string_size();
+                                if (width.has_value()) {
+                                    typed_value_set = value_set.get_fixed_width_string_set(*width);
+                                }
+                            } else {
+                                typed_value_set = value_set.get_set<std::string>();
+                            }
+                            auto offset_set = column_with_strings.string_pool_->get_offsets_for_column(typed_value_set,
+                                *column_with_strings.column_);
+                            auto column_data = column_with_strings.column_->data();
+
+                            util::BitSet::bulk_insert_iterator inserter(*output);
+                            auto pos = 0u;
+                            while (
+                                auto block = column_data.next<
+                                             TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>())
+                            {
+                                auto ptr = reinterpret_cast<const StringPool::offset_t*>(block.value().data());
+                                const auto row_count = block.value().row_count();
+                                for (auto i = 0u; i < row_count; ++i, ++pos) {
+                                    auto offset = *ptr++;
+                                    if (func(offset, offset_set))
+                                        inserter = pos;
+                                }
+                            }
+                            inserter.flush();
+                        } else if constexpr (is_bool_type(ColumnTagType::data_type) &&
+                                             is_bool_type(ValueSetBaseTypeTag::data_type))
+                        {
+                            util::raise_rte("Binary membership not implemented for bools");
+                        } else if constexpr (is_numeric_type(ColumnTagType::data_type) &&
+                                             is_numeric_type(ValueSetBaseTypeTag::data_type))
+                        {
+                            using ValueSetBaseType = typename decltype(value_set_desc_tag)::DataTypeTag::raw_type;
+
+                            using WideType = typename type_arithmetic_promoted_type<ColumnType,
+                                ValueSetBaseType,
+                                std::remove_reference_t<Func>>::type;
+                            auto typed_value_set = value_set.get_set<WideType>();
+                            auto column_data = column_with_strings.column_->data();
+
+                            util::BitSet::bulk_insert_iterator inserter(*output);
+                            auto pos = 0u;
+                            while (auto block = column_data.next<ScalarTagType<ColumnTagType>>()) {
+                                auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
+                                const auto row_count = block.value().row_count();
+                                for (auto i = 0u; i < row_count; ++i, ++pos) {
+                                    if (func(static_cast<WideType>(*ptr++), *typed_value_set))
+                                        inserter = pos;
+                                }
+                            }
+                            inserter.flush();
+                        } else {
+                            util::raise_rte("Cannot check membership of {} in set of {} (possible categorical?)",
+                                column_with_strings.column_->type(),
+                                value_set.base_type());
                         }
-                    } else {
-                        typed_value_set = value_set.get_set<std::string>();
-                    }
-                    auto offset_set = column_with_strings.string_pool_->get_offsets_for_column(typed_value_set, *column_with_strings.column_);
-                    auto column_data = column_with_strings.column_->data();
-
-                    util::BitSet::bulk_insert_iterator inserter(*output);
-                    auto pos = 0u;
-                    while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
-                        auto ptr = reinterpret_cast<const StringPool::offset_t*>(block.value().data());
-                        const auto row_count = block.value().row_count();
-                        for (auto i = 0u; i < row_count; ++i, ++pos) {
-                            auto offset = *ptr++;
-                            if(func(offset, offset_set))
-                                inserter = pos;
-                        }
-                    }
-                    inserter.flush();
-                } else if constexpr (is_bool_type(ColumnTagType::data_type) && is_bool_type(ValueSetBaseTypeTag::data_type)) {
-                    util::raise_rte("Binary membership not implemented for bools");
-                } else if constexpr (is_numeric_type(ColumnTagType::data_type) && is_numeric_type(ValueSetBaseTypeTag::data_type)) {
-                    using ValueSetBaseType =  typename decltype(value_set_desc_tag)::DataTypeTag::raw_type;
-
-                    using WideType = typename type_arithmetic_promoted_type<ColumnType, ValueSetBaseType, std::remove_reference_t<Func>>::type;
-                    auto typed_value_set = value_set.get_set<WideType>();
-                    auto column_data = column_with_strings.column_->data();
-
-                    util::BitSet::bulk_insert_iterator inserter(*output);
-                    auto pos = 0u;
-                    while (auto block = column_data.next<ScalarTagType<ColumnTagType>>()) {
-                        auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
-                        const auto row_count = block.value().row_count();
-                        for (auto i = 0u; i < row_count; ++i, ++pos) {
-                            if(func(static_cast<WideType>(*ptr++), *typed_value_set))
-                                inserter = pos;
-                        }
-                    }
-                    inserter.flush();
-                } else {
-                    util::raise_rte("Cannot check membership of {} in set of {} (possible categorical?)",
-                                    column_with_strings.column_->type(), value_set.base_type());
-                }
+                    });
             });
-        });
     }
 
     output->optimize();
     auto pos = 0;
 
-    if(column_with_strings.column_->is_sparse()) {
+    if (column_with_strings.column_->is_sparse()) {
         const auto& sparse_map = column_with_strings.column_->opt_sparse_map().value();
         util::BitSet replace(sparse_map.size());
         auto it = sparse_map.first();
         auto it_end = sparse_map.end();
-        while(it < it_end) {
-           replace.set(*it, output->test(pos++));
+        while (it < it_end) {
+            replace.set(*it, output->test(pos++));
             ++it;
         }
     }
@@ -133,35 +151,40 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
 }
 
 template<typename Func>
-VariantData visit_binary_membership(const VariantData &left, const VariantData &right, Func &&func) {
+VariantData visit_binary_membership(const VariantData& left, const VariantData& right, Func&& func)
+{
     if (std::holds_alternative<EmptyResult>(left))
         return EmptyResult{};
 
-    return std::visit(util::overload {
-        [&] (const ColumnWithStrings& l, const std::shared_ptr<ValueSet>& r) ->VariantData  {
-            return transform_to_placeholder(binary_membership<decltype(func)>(l, *r, std::forward<Func>(func)));
-            },
-            [](const auto &, const auto&) -> VariantData {
-            util::raise_rte("Binary membership operations must be Column/ValueSet");
-        }
-        }, left, right);
+    return std::visit(
+        util::overload{[&](const ColumnWithStrings& l, const std::shared_ptr<ValueSet>& r) -> VariantData {
+                           return transform_to_placeholder(
+                               binary_membership<decltype(func)>(l, *r, std::forward<Func>(func)));
+                       },
+            [](const auto&, const auto&) -> VariantData {
+                util::raise_rte("Binary membership operations must be Column/ValueSet");
+            }},
+        left,
+        right);
 }
 
-template <typename Func>
-VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_with_strings, Func&& func) {
-    auto output = std::make_shared<util::BitSet>(static_cast<util::BitSetSizeType>(column_with_strings.column_->row_count()));
+template<typename Func>
+VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_with_strings, Func&& func)
+{
+    auto output =
+        std::make_shared<util::BitSet>(static_cast<util::BitSetSizeType>(column_with_strings.column_->row_count()));
 
-    column_with_strings.column_->type().visit_tag([&val, &column_with_strings, &func, &output] (auto column_desc_tag) {
+    column_with_strings.column_->type().visit_tag([&val, &column_with_strings, &func, &output](auto column_desc_tag) {
         using ColumnDescriptorType = std::decay_t<decltype(column_desc_tag)>;
-        using ColumnTagType =  typename ColumnDescriptorType::DataTypeTag;
-        using ColumnType =  typename ColumnTagType::raw_type;
+        using ColumnTagType = typename ColumnDescriptorType::DataTypeTag;
+        using ColumnType = typename ColumnTagType::raw_type;
         TypeDescriptor value_type{val.data_type_, Dimension::Dim0};
-        value_type.visit_tag([&] (auto value_desc_tag ) {
-            using DataTypeTag =  typename decltype(value_desc_tag)::DataTypeTag;
-            if constexpr(is_sequence_type(ColumnTagType::data_type) && is_sequence_type(DataTypeTag::data_type)) {
+        value_type.visit_tag([&](auto value_desc_tag) {
+            using DataTypeTag = typename decltype(value_desc_tag)::DataTypeTag;
+            if constexpr (is_sequence_type(ColumnTagType::data_type) && is_sequence_type(DataTypeTag::data_type)) {
                 std::optional<std::string> utf32_string;
                 std::optional<std::string_view> value_string;
-                if constexpr(is_fixed_string_type(ColumnTagType::data_type)) {
+                if constexpr (is_fixed_string_type(ColumnTagType::data_type)) {
                     auto width = column_with_strings.get_fixed_width_string_size();
                     if (width.has_value()) {
                         utf32_string = ascii_to_padded_utf32(std::string_view(*val.str_data(), val.len()), *width);
@@ -172,23 +195,26 @@ VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_
                 } else {
                     value_string = std::string_view(*val.str_data(), val.len());
                 }
-                auto value_offset = column_with_strings.string_pool_->get_offset_for_column(*value_string, *column_with_strings.column_);
+                auto value_offset = column_with_strings.string_pool_->get_offset_for_column(*value_string,
+                    *column_with_strings.column_);
                 auto column_data = column_with_strings.column_->data();
 
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
-                while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
+                while (auto block =
+                           column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>())
+                {
                     auto ptr = reinterpret_cast<const StringPool::offset_t*>(block.value().data());
                     const auto row_count = block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         auto offset = *ptr++;
-                        if(func(offset, value_offset))
+                        if (func(offset, value_offset))
                             inserter = pos;
                     }
                 }
                 inserter.flush();
             } else if constexpr (is_numeric_type(ColumnTagType::data_type) && is_numeric_type(DataTypeTag::data_type)) {
-                using RawType =  typename decltype(value_desc_tag)::DataTypeTag::raw_type;
+                using RawType = typename decltype(value_desc_tag)::DataTypeTag::raw_type;
                 using comp = typename arcticdb::Comparable<RawType, ColumnType>;
                 auto value = static_cast<typename comp::left_type>(*reinterpret_cast<const RawType*>(val.data_));
                 auto column_data = column_with_strings.column_->data();
@@ -199,13 +225,15 @@ VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_
                     auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
                     const auto row_count = block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
-                        if(func(value, static_cast<typename comp::right_type>(*ptr++)))
+                        if (func(value, static_cast<typename comp::right_type>(*ptr++)))
                             inserter = pos;
                     }
                 }
                 inserter.flush();
             } else {
-                util::raise_rte("Cannot compare {} to {} (possible categorical?)", val.type(), column_with_strings.column_->type());
+                util::raise_rte("Cannot compare {} to {} (possible categorical?)",
+                    val.type(),
+                    column_with_strings.column_->type());
             }
         });
     });
@@ -214,23 +242,28 @@ VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_
     return VariantData{std::move(output)};
 }
 
-template <typename Func>
-VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStrings& right, Func&& func) {
-    util::check(left.column_->row_count() == right.column_->row_count(), "Columns with different row counts ({} and {}) in binary comparator", left.column_->row_count(), right.column_->row_count());
+template<typename Func>
+VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStrings& right, Func&& func)
+{
+    util::check(left.column_->row_count() == right.column_->row_count(),
+        "Columns with different row counts ({} and {}) in binary comparator",
+        left.column_->row_count(),
+        right.column_->row_count());
     auto output = std::make_shared<util::BitSet>(static_cast<util::BitSetSizeType>(left.column_->row_count()));
 
-    left.column_->type().visit_tag([&] (auto left_desc_tag) {
+    left.column_->type().visit_tag([&](auto left_desc_tag) {
         using LeftDescriptorType = std::decay_t<decltype(left_desc_tag)>;
-        using LeftTagType =  typename decltype(left_desc_tag)::DataTypeTag;
-        using LeftType =  typename LeftTagType::raw_type;
-        right.column_->type().visit_tag([&] (auto right_desc_tag ) {
+        using LeftTagType = typename decltype(left_desc_tag)::DataTypeTag;
+        using LeftType = typename LeftTagType::raw_type;
+        right.column_->type().visit_tag([&](auto right_desc_tag) {
             using RightDescriptorType = std::decay_t<decltype(right_desc_tag)>;
-            using RightTagType =  typename decltype(right_desc_tag)::DataTypeTag;
-            using RightType =  typename RightTagType::raw_type;
-            if constexpr(is_sequence_type(LeftTagType::data_type) && is_sequence_type(RightTagType::data_type)) {
+            using RightTagType = typename decltype(right_desc_tag)::DataTypeTag;
+            using RightType = typename RightTagType::raw_type;
+            if constexpr (is_sequence_type(LeftTagType::data_type) && is_sequence_type(RightTagType::data_type)) {
                 bool strip_fixed_width_trailing_nulls{false};
                 // If one or both columns are fixed width strings, we need to strip trailing null characters to get intuitive results
-                if constexpr (is_fixed_string_type(LeftTagType::data_type) || is_fixed_string_type(RightTagType::data_type))
+                if constexpr (is_fixed_string_type(LeftTagType::data_type) ||
+                              is_fixed_string_type(RightTagType::data_type))
                     strip_fixed_width_trailing_nulls = true;
 
                 auto left_column_data = left.column_->data();
@@ -244,7 +277,8 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
                     auto right_ptr = reinterpret_cast<const RightType*>(right_block.value().data());
                     const auto row_count = left_block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
-                        if(func(left.string_at_offset(*left_ptr++, strip_fixed_width_trailing_nulls), right.string_at_offset(*right_ptr++, strip_fixed_width_trailing_nulls)))
+                        if (func(left.string_at_offset(*left_ptr++, strip_fixed_width_trailing_nulls),
+                                right.string_at_offset(*right_ptr++, strip_fixed_width_trailing_nulls)))
                             inserter = pos;
                     }
                 }
@@ -263,13 +297,16 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
                     auto right_ptr = reinterpret_cast<const RightType*>(right_block.value().data());
                     const auto row_count = left_block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
-                        if(func(static_cast<typename comp::left_type>(*left_ptr++), static_cast<typename comp::right_type>(*right_ptr++)))
+                        if (func(static_cast<typename comp::left_type>(*left_ptr++),
+                                static_cast<typename comp::right_type>(*right_ptr++)))
                             inserter = pos;
                     }
                 }
                 inserter.flush();
             } else {
-                util::raise_rte("Cannot compare {} to {} (possible categorical?)", left.column_->type(), right.column_->type());
+                util::raise_rte("Cannot compare {} to {} (possible categorical?)",
+                    left.column_->type(),
+                    right.column_->type());
             }
         });
     });
@@ -278,21 +315,23 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
     return VariantData{std::move(output)};
 }
 
-template <typename Func>
-VariantData binary_comparator(const ColumnWithStrings& column_with_strings, const Value& val, Func&& func) {
-    auto output = std::make_shared<util::BitSet>(static_cast<util::BitSetSizeType>(column_with_strings.column_->row_count()));
+template<typename Func>
+VariantData binary_comparator(const ColumnWithStrings& column_with_strings, const Value& val, Func&& func)
+{
+    auto output =
+        std::make_shared<util::BitSet>(static_cast<util::BitSetSizeType>(column_with_strings.column_->row_count()));
 
-    column_with_strings.column_->type().visit_tag([&val, &column_with_strings, &func, &output] (auto column_desc_tag) {
+    column_with_strings.column_->type().visit_tag([&val, &column_with_strings, &func, &output](auto column_desc_tag) {
         using ColumnDescriptorType = std::decay_t<decltype(column_desc_tag)>;
-        using ColumnTagType =  typename ColumnDescriptorType::DataTypeTag;
-        using ColumnType =  typename ColumnTagType::raw_type;
+        using ColumnTagType = typename ColumnDescriptorType::DataTypeTag;
+        using ColumnType = typename ColumnTagType::raw_type;
         TypeDescriptor value_type{val.data_type_, Dimension::Dim0};
-        value_type.visit_tag([&] (auto value_desc_tag ) {
-            using DataTypeTag =  typename decltype(value_desc_tag)::DataTypeTag;
-            if constexpr(is_sequence_type(ColumnTagType::data_type) && is_sequence_type(DataTypeTag::data_type)) {
+        value_type.visit_tag([&](auto value_desc_tag) {
+            using DataTypeTag = typename decltype(value_desc_tag)::DataTypeTag;
+            if constexpr (is_sequence_type(ColumnTagType::data_type) && is_sequence_type(DataTypeTag::data_type)) {
                 std::optional<std::string> utf32_string;
                 std::optional<std::string_view> value_string;
-                if constexpr(is_fixed_string_type(ColumnTagType::data_type)) {
+                if constexpr (is_fixed_string_type(ColumnTagType::data_type)) {
                     auto width = column_with_strings.get_fixed_width_string_size();
                     if (width.has_value()) {
                         utf32_string = ascii_to_padded_utf32(std::string_view(*val.str_data(), val.len()), *width);
@@ -303,24 +342,29 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                 } else {
                     value_string = std::string_view(*val.str_data(), val.len());
                 }
-                auto value_offset = column_with_strings.string_pool_->get_offset_for_column(*value_string, *column_with_strings.column_);
+                auto value_offset = column_with_strings.string_pool_->get_offset_for_column(*value_string,
+                    *column_with_strings.column_);
                 auto column_data = column_with_strings.column_->data();
 
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
-                while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
+                while (auto block =
+                           column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>())
+                {
                     auto ptr = reinterpret_cast<const StringPool::offset_t*>(block.value().data());
                     const auto row_count = block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         auto offset = *ptr++;
-                        if(func(value_offset, offset))
+                        if (func(value_offset, offset))
                             inserter = pos;
                     }
                 }
                 inserter.flush();
-            } else if constexpr ((is_numeric_type(ColumnTagType::data_type) && is_numeric_type(DataTypeTag::data_type)) ||
-                                 (is_bool_type(ColumnTagType::data_type) && is_bool_type(DataTypeTag::data_type))) {
-                using RawType =  typename decltype(value_desc_tag)::DataTypeTag::raw_type;
+            } else if constexpr ((is_numeric_type(ColumnTagType::data_type) &&
+                                     is_numeric_type(DataTypeTag::data_type)) ||
+                                 (is_bool_type(ColumnTagType::data_type) && is_bool_type(DataTypeTag::data_type)))
+            {
+                using RawType = typename decltype(value_desc_tag)::DataTypeTag::raw_type;
                 using comp = typename arcticdb::Comparable<RawType, ColumnType>;
                 auto value = static_cast<typename comp::left_type>(*reinterpret_cast<const RawType*>(val.data_));
                 auto column_data = column_with_strings.column_->data();
@@ -331,13 +375,15 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                     auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
                     const auto row_count = block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
-                        if(func(static_cast<typename comp::right_type>(*ptr++), value))
+                        if (func(static_cast<typename comp::right_type>(*ptr++), value))
                             inserter = pos;
                     }
                 }
                 inserter.flush();
             } else {
-                util::raise_rte("Cannot compare {} to {} (possible categorical?)", column_with_strings.column_->type(), val.type());
+                util::raise_rte("Cannot compare {} to {} (possible categorical?)",
+                    column_with_strings.column_->type(),
+                    val.type());
             }
         });
     });
@@ -347,40 +393,42 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
 }
 
 template<typename Func>
-VariantData visit_binary_comparator(const VariantData& left, const VariantData& right, Func&& func) {
-    if(std::holds_alternative<EmptyResult>(left) || std::holds_alternative<EmptyResult>(right))
+VariantData visit_binary_comparator(const VariantData& left, const VariantData& right, Func&& func)
+{
+    if (std::holds_alternative<EmptyResult>(left) || std::holds_alternative<EmptyResult>(right))
         return EmptyResult{};
 
-    return std::visit(util::overload {
-     [&func] (const ColumnWithStrings& l, const std::shared_ptr<Value>& r) ->VariantData  {
-        auto result = binary_comparator<decltype(func)>(l, *r, std::forward<Func>(func));
-         return transform_to_placeholder(result);
-        },
-        [&] (const ColumnWithStrings& l, const ColumnWithStrings& r)  ->VariantData {
-        auto result = binary_comparator<decltype(func)>(l, r, std::forward<Func>(func));
-        return transform_to_placeholder(result);
-        },
-        [&](const std::shared_ptr<Value>& l, const ColumnWithStrings& r) ->VariantData {
-        auto result = binary_comparator<decltype(func)>(*l, r, std::forward<Func>(func));
-            return transform_to_placeholder(result);
-        },
-        [&] ([[maybe_unused]] const std::shared_ptr<Value>& l, [[maybe_unused]] const std::shared_ptr<Value>& r) ->VariantData  {
-        util::raise_rte("Two value inputs not accepted to binary comparators");
-        },
-        [](const auto &, const auto&) -> VariantData {
-        util::raise_rte("Bitset/ValueSet inputs not accepted to binary comparators");
-    }
-    }, left, right);
+    return std::visit(
+        util::overload{[&func](const ColumnWithStrings& l, const std::shared_ptr<Value>& r) -> VariantData {
+                           auto result = binary_comparator<decltype(func)>(l, *r, std::forward<Func>(func));
+                           return transform_to_placeholder(result);
+                       },
+            [&](const ColumnWithStrings& l, const ColumnWithStrings& r) -> VariantData {
+                auto result = binary_comparator<decltype(func)>(l, r, std::forward<Func>(func));
+                return transform_to_placeholder(result);
+            },
+            [&](const std::shared_ptr<Value>& l, const ColumnWithStrings& r) -> VariantData {
+                auto result = binary_comparator<decltype(func)>(*l, r, std::forward<Func>(func));
+                return transform_to_placeholder(result);
+            },
+            [&]([[maybe_unused]] const std::shared_ptr<Value>& l, [[maybe_unused]] const std::shared_ptr<Value>& r)
+                -> VariantData { util::raise_rte("Two value inputs not accepted to binary comparators"); },
+            [](const auto&, const auto&) -> VariantData {
+                util::raise_rte("Bitset/ValueSet inputs not accepted to binary comparators");
+            }},
+        left,
+        right);
 }
 
-template <typename Func>
-VariantData binary_operator(const Value& left, const Value& right, Func&& func) {
+template<typename Func>
+VariantData binary_operator(const Value& left, const Value& right, Func&& func)
+{
     auto output = std::make_unique<Value>();
 
     details::visit_type(left.type().data_type(), [&](auto left_desc_tag) {
         using LTDT = TypeDescriptorTag<decltype(left_desc_tag), DimensionTag<Dimension::Dim0>>;
         using LeftRawType = typename LTDT::DataTypeTag::raw_type;
-        if constexpr(!is_numeric_type(LTDT::DataTypeTag::data_type)) {
+        if constexpr (!is_numeric_type(LTDT::DataTypeTag::data_type)) {
             util::raise_rte("Non-numeric type provided to binary operation: {}", left.type());
         }
         auto left_value = *reinterpret_cast<const LeftRawType*>(left.data_);
@@ -388,11 +436,12 @@ VariantData binary_operator(const Value& left, const Value& right, Func&& func) 
         details::visit_type(right.type().data_type(), [&](auto right_desc_tag) {
             using RTDT = TypeDescriptorTag<decltype(right_desc_tag), DimensionTag<Dimension::Dim0>>;
             using RightRawType = typename RTDT::DataTypeTag::raw_type;
-            if constexpr(!is_numeric_type(RTDT::DataTypeTag::data_type)) {
+            if constexpr (!is_numeric_type(RTDT::DataTypeTag::data_type)) {
                 util::raise_rte("Non-numeric type provided to binary operation: {}", right.type());
             }
             auto right_value = *reinterpret_cast<const RightRawType*>(right.data_);
-            using TargetType = typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
+            using TargetType =
+                typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
             output->data_type_ = data_type_from_raw_type<TargetType>();
             *reinterpret_cast<TargetType*>(output->data_) = func.apply(left_value, right_value);
         });
@@ -401,14 +450,15 @@ VariantData binary_operator(const Value& left, const Value& right, Func&& func) 
     return VariantData(std::move(output));
 }
 
-template <typename Func>
-VariantData binary_operator(const Value& val, const Column& col, Func&& func) {
+template<typename Func>
+VariantData binary_operator(const Value& val, const Column& col, Func&& func)
+{
     std::unique_ptr<Column> output;
 
     details::visit_type(col.type().data_type(), [&](auto right_desc_tag) {
         using RTDT = TypeDescriptorTag<decltype(right_desc_tag), DimensionTag<Dimension::Dim0>>;
         using RightRawType = typename RTDT::DataTypeTag::raw_type;
-        if constexpr(!is_numeric_type(RTDT::DataTypeTag::data_type)) {
+        if constexpr (!is_numeric_type(RTDT::DataTypeTag::data_type)) {
             util::raise_rte("Non-numeric type provided to binary operation: {}", col.type());
         }
         auto right_data = col.data();
@@ -416,20 +466,21 @@ VariantData binary_operator(const Value& val, const Column& col, Func&& func) {
         details::visit_type(val.type().data_type(), [&](auto left_desc_tag) {
             using LTDT = TypeDescriptorTag<decltype(left_desc_tag), DimensionTag<Dimension::Dim0>>;
             using LeftRawType = typename LTDT::DataTypeTag::raw_type;
-            if constexpr(!is_numeric_type(LTDT::DataTypeTag::data_type)) {
+            if constexpr (!is_numeric_type(LTDT::DataTypeTag::data_type)) {
                 util::raise_rte("Non-numeric type provided to binary operation: {}", val.type());
             }
             auto left_value = *reinterpret_cast<const LeftRawType*>(val.data_);
-            using TargetType = typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
+            using TargetType =
+                typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
             auto output_data_type = data_type_from_raw_type<TargetType>();
             output = std::make_unique<Column>(make_scalar_type(output_data_type), col.is_sparse());
 
-            while(auto opt_right_block = right_data.next<RTDT>()) {
+            while (auto opt_right_block = right_data.next<RTDT>()) {
                 auto right_block = opt_right_block.value();
                 const auto nbytes = sizeof(TargetType) * right_block.row_count();
                 auto ptr = reinterpret_cast<TargetType*>(output->allocate_data(nbytes));
 
-                for(auto i = 0u; i < right_block.row_count(); ++i)
+                for (auto i = 0u; i < right_block.row_count(); ++i)
                     *ptr++ = func.apply(left_value, right_block[i]);
 
                 output->advance_data(nbytes);
@@ -442,44 +493,53 @@ VariantData binary_operator(const Value& val, const Column& col, Func&& func) {
     return VariantData(ColumnWithStrings(std::move(output)));
 }
 
-template <typename Func>
-VariantData binary_operator(const Column& left, const Column& right, Func&& func) {
-    util::check(left.row_count() == right.row_count(), "Columns with different row counts ({} and {}) in binary operator", left.row_count(), right.row_count());
+template<typename Func>
+VariantData binary_operator(const Column& left, const Column& right, Func&& func)
+{
+    util::check(left.row_count() == right.row_count(),
+        "Columns with different row counts ({} and {}) in binary operator",
+        left.row_count(),
+        right.row_count());
     std::unique_ptr<Column> output;
 
     details::visit_type(left.type().data_type(), [&](auto left_desc_tag) {
         using LTDT = TypeDescriptorTag<decltype(left_desc_tag), DimensionTag<Dimension::Dim0>>;
         using LeftRawType = typename LTDT::DataTypeTag::raw_type;
-        if constexpr(!is_numeric_type(LTDT::DataTypeTag::data_type)) {
+        if constexpr (!is_numeric_type(LTDT::DataTypeTag::data_type)) {
             util::raise_rte("Non-numeric type provided to binary operation: {}", left.type());
         }
         auto left_data = left.data();
-        auto opt_left_block =  left_data.next<LTDT>();
+        auto opt_left_block = left_data.next<LTDT>();
 
         details::visit_type(right.type().data_type(), [&](auto right_desc_tag) {
             using RTDT = TypeDescriptorTag<decltype(right_desc_tag), DimensionTag<Dimension::Dim0>>;
             using RightRawType = typename RTDT::DataTypeTag::raw_type;
-            if constexpr(!is_numeric_type(RTDT::DataTypeTag::data_type)) {
+            if constexpr (!is_numeric_type(RTDT::DataTypeTag::data_type)) {
                 util::raise_rte("Non-numeric type provided to binary operation: {}", right.type());
             }
-            using TargetType = typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
+            using TargetType =
+                typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
             auto output_data_type = data_type_from_raw_type<TargetType>();
-            output = std::make_unique<Column>(make_scalar_type(output_data_type), left.is_sparse() || right.is_sparse());
+            output =
+                std::make_unique<Column>(make_scalar_type(output_data_type), left.is_sparse() || right.is_sparse());
             auto right_data = right.data();
             auto opt_right_block = right_data.next<RTDT>();
             while (opt_left_block && opt_right_block) {
                 auto& left_block = opt_left_block.value();
                 auto& right_block = opt_right_block.value();
-                util::check(left_block.row_count() == right_block.row_count(), "Non-matching row counts in dense blocks: {} != {}", left_block.row_count(), right_block.row_count());
+                util::check(left_block.row_count() == right_block.row_count(),
+                    "Non-matching row counts in dense blocks: {} != {}",
+                    left_block.row_count(),
+                    right_block.row_count());
                 const auto nbytes = sizeof(TargetType) * right_block.row_count();
                 auto ptr = reinterpret_cast<TargetType*>(output->allocate_data(nbytes));
 
-                for(auto i = 0u; i < right_block.row_count(); ++i)
+                for (auto i = 0u; i < right_block.row_count(); ++i)
                     *ptr++ = func.apply(left_block[i], right_block[i]);
 
                 output->advance_data(nbytes);
 
-                opt_left_block =  left_data.next<LTDT>();
+                opt_left_block = left_data.next<LTDT>();
                 opt_right_block = right_data.next<RTDT>();
             }
             output->set_row_data(left.row_count() - 1);
@@ -488,14 +548,15 @@ VariantData binary_operator(const Column& left, const Column& right, Func&& func
     return VariantData(ColumnWithStrings(std::move(output)));
 }
 
-template <typename Func>
-VariantData binary_operator(const Column& col, const Value& val, Func&& func) {
+template<typename Func>
+VariantData binary_operator(const Column& col, const Value& val, Func&& func)
+{
     std::unique_ptr<Column> output;
 
     details::visit_type(col.type().data_type(), [&](auto left_desc_tag) {
         using LTDT = TypeDescriptorTag<decltype(left_desc_tag), DimensionTag<Dimension::Dim0>>;
         using LeftRawType = typename LTDT::DataTypeTag::raw_type;
-        if constexpr(!is_numeric_type(LTDT::DataTypeTag::data_type)) {
+        if constexpr (!is_numeric_type(LTDT::DataTypeTag::data_type)) {
             util::raise_rte("Non-numeric type provided to binary operation: {}", col.type());
         }
         auto left_data = col.data();
@@ -503,20 +564,21 @@ VariantData binary_operator(const Column& col, const Value& val, Func&& func) {
         details::visit_type(val.type().data_type(), [&](auto right_desc_tag) {
             using RTDT = TypeDescriptorTag<decltype(right_desc_tag), DimensionTag<Dimension::Dim0>>;
             using RightRawType = typename RTDT::DataTypeTag::raw_type;
-            if constexpr(!is_numeric_type(RTDT::DataTypeTag::data_type)) {
+            if constexpr (!is_numeric_type(RTDT::DataTypeTag::data_type)) {
                 util::raise_rte("Non-numeric type provided to binary operation: {}", val.type());
             }
             auto right_value = *reinterpret_cast<const RightRawType*>(val.data_);
-            using TargetType = typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
+            using TargetType =
+                typename type_arithmetic_promoted_type<LeftRawType, RightRawType, std::remove_reference_t<Func>>::type;
             auto output_data_type = data_type_from_raw_type<TargetType>();
             output = std::make_unique<Column>(make_scalar_type(output_data_type), col.is_sparse());
 
-            while(auto opt_left_block = left_data.next<LTDT>()) {
+            while (auto opt_left_block = left_data.next<LTDT>()) {
                 auto left_block = opt_left_block.value();
                 const auto nbytes = sizeof(TargetType) * left_block.row_count();
                 auto ptr = reinterpret_cast<TargetType*>(output->allocate_data(nbytes));
 
-                for(auto i = 0u; i < left_block.row_count(); ++i)
+                for (auto i = 0u; i < left_block.row_count(); ++i)
                     *ptr++ = func.apply(left_block[i], right_value);
 
                 output->advance_data(nbytes);
@@ -526,57 +588,59 @@ VariantData binary_operator(const Column& col, const Value& val, Func&& func) {
         });
     });
 
-    return { ColumnWithStrings(std::move(output))};
+    return {ColumnWithStrings(std::move(output))};
 }
 
 template<typename Func>
-VariantData visit_binary_operator(const VariantData& left, const VariantData& right, Func&& func) {
-    if(std::holds_alternative<EmptyResult>(left) || std::holds_alternative<EmptyResult>(right))
+VariantData visit_binary_operator(const VariantData& left, const VariantData& right, Func&& func)
+{
+    if (std::holds_alternative<EmptyResult>(left) || std::holds_alternative<EmptyResult>(right))
         return EmptyResult{};
 
-    return std::visit(util::overload {
-        [&] (const ColumnWithStrings& l, const std::shared_ptr<Value>& r) ->VariantData  {
-            return binary_operator<decltype(func)>(*(l.column_), *r, std::forward<Func>(func));
+    return std::visit(
+        util::overload{[&](const ColumnWithStrings& l, const std::shared_ptr<Value>& r) -> VariantData {
+                           return binary_operator<decltype(func)>(*(l.column_), *r, std::forward<Func>(func));
+                       },
+            [&](const ColumnWithStrings& l, const ColumnWithStrings& r) -> VariantData {
+                return binary_operator<decltype(func)>(*(l.column_), *(r.column_), std::forward<Func>(func));
             },
-            [&] (const ColumnWithStrings& l, const ColumnWithStrings& r)  ->VariantData {
-            return binary_operator<decltype(func)>(*(l.column_), *(r.column_), std::forward<Func>(func));
+            [&](const std::shared_ptr<Value>& l, const ColumnWithStrings& r) -> VariantData {
+                return binary_operator<decltype(func)>(*l, *(r.column_), std::forward<Func>(func));
             },
-            [&](const std::shared_ptr<Value>& l, const ColumnWithStrings& r) ->VariantData {
-            return binary_operator<decltype(func)>(*l, *(r.column_), std::forward<Func>(func));
+            [&](const std::shared_ptr<Value>& l, const std::shared_ptr<Value>& r) -> VariantData {
+                return binary_operator<decltype(func)>(*l, *r, std::forward<Func>(func));
             },
-            [&] (const std::shared_ptr<Value>& l, const std::shared_ptr<Value>& r) -> VariantData {
-            return binary_operator<decltype(func)>(*l, *r, std::forward<Func>(func));
-            },
-            [](const auto &, const auto&) -> VariantData {
-            util::raise_rte("Bitset/ValueSet inputs not accepted to binary operators");
-        }
-        }, left, right);
+            [](const auto&, const auto&) -> VariantData {
+                util::raise_rte("Bitset/ValueSet inputs not accepted to binary operators");
+            }},
+        left,
+        right);
 }
 
 VariantData dispatch_binary(const VariantData& left, const VariantData& right, OperationType operation);
 
 // instantiated in operation_dispatch_binary_operator.cpp to reduce compilation memory use
-extern template
-VariantData visit_binary_operator<arcticdb::PlusOperator>(const VariantData&, const VariantData&, PlusOperator&&);
-extern template
-VariantData visit_binary_operator<arcticdb::MinusOperator>(const VariantData&, const VariantData&, MinusOperator&&);
-extern template
-VariantData visit_binary_operator<arcticdb::TimesOperator>(const VariantData&, const VariantData&, TimesOperator&&);
-extern template
-VariantData visit_binary_operator<arcticdb::DivideOperator>(const VariantData&, const VariantData&, DivideOperator&&);
+extern template VariantData
+visit_binary_operator<arcticdb::PlusOperator>(const VariantData&, const VariantData&, PlusOperator&&);
+extern template VariantData
+visit_binary_operator<arcticdb::MinusOperator>(const VariantData&, const VariantData&, MinusOperator&&);
+extern template VariantData
+visit_binary_operator<arcticdb::TimesOperator>(const VariantData&, const VariantData&, TimesOperator&&);
+extern template VariantData
+visit_binary_operator<arcticdb::DivideOperator>(const VariantData&, const VariantData&, DivideOperator&&);
 
 // instantiated in operation_dispatch_binary_comparator.cpp to reduce compilation memory use
-extern template
-VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
-extern template
-VariantData visit_binary_comparator<NotEqualsOperator>(const VariantData&, const VariantData&, NotEqualsOperator&&);
-extern template
-VariantData visit_binary_comparator<LessThanOperator>(const VariantData&, const VariantData&, LessThanOperator&&);
-extern template
-VariantData visit_binary_comparator<LessThanEqualsOperator>(const VariantData&, const VariantData&, LessThanEqualsOperator&&);
-extern template
-VariantData visit_binary_comparator<GreaterThanOperator>(const VariantData&, const VariantData&, GreaterThanOperator&&);
-extern template
-VariantData visit_binary_comparator<GreaterThanEqualsOperator>(const VariantData&, const VariantData&, GreaterThanEqualsOperator&&);
+extern template VariantData
+visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
+extern template VariantData
+visit_binary_comparator<NotEqualsOperator>(const VariantData&, const VariantData&, NotEqualsOperator&&);
+extern template VariantData
+visit_binary_comparator<LessThanOperator>(const VariantData&, const VariantData&, LessThanOperator&&);
+extern template VariantData
+visit_binary_comparator<LessThanEqualsOperator>(const VariantData&, const VariantData&, LessThanEqualsOperator&&);
+extern template VariantData
+visit_binary_comparator<GreaterThanOperator>(const VariantData&, const VariantData&, GreaterThanOperator&&);
+extern template VariantData
+visit_binary_comparator<GreaterThanEqualsOperator>(const VariantData&, const VariantData&, GreaterThanEqualsOperator&&);
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary_eq.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_eq.cpp
@@ -11,6 +11,7 @@
 namespace arcticdb {
 
 template VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
-template VariantData visit_binary_comparator<NotEqualsOperator>(const VariantData&, const VariantData&, NotEqualsOperator&&);
+template VariantData
+visit_binary_comparator<NotEqualsOperator>(const VariantData&, const VariantData&, NotEqualsOperator&&);
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
@@ -10,7 +10,9 @@
 
 namespace arcticdb {
 
-template VariantData visit_binary_comparator<GreaterThanOperator>(const VariantData&, const VariantData&, GreaterThanOperator&&);
-template VariantData visit_binary_comparator<GreaterThanEqualsOperator>(const VariantData&, const VariantData&, GreaterThanEqualsOperator&&);
+template VariantData
+visit_binary_comparator<GreaterThanOperator>(const VariantData&, const VariantData&, GreaterThanOperator&&);
+template VariantData
+visit_binary_comparator<GreaterThanEqualsOperator>(const VariantData&, const VariantData&, GreaterThanEqualsOperator&&);
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
@@ -10,7 +10,9 @@
 
 namespace arcticdb {
 
-template VariantData visit_binary_comparator<LessThanOperator>(const VariantData&, const VariantData&, LessThanOperator&&);
-template VariantData visit_binary_comparator<LessThanEqualsOperator>(const VariantData&, const VariantData&, LessThanEqualsOperator&&);
+template VariantData
+visit_binary_comparator<LessThanOperator>(const VariantData&, const VariantData&, LessThanOperator&&);
+template VariantData
+visit_binary_comparator<LessThanEqualsOperator>(const VariantData&, const VariantData&, LessThanEqualsOperator&&);
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator.cpp
@@ -15,4 +15,4 @@ template VariantData visit_binary_operator<MinusOperator>(const VariantData&, co
 template VariantData visit_binary_operator<TimesOperator>(const VariantData&, const VariantData&, TimesOperator&&);
 template VariantData visit_binary_operator<DivideOperator>(const VariantData&, const VariantData&, DivideOperator&&);
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_unary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.cpp
@@ -10,69 +10,69 @@
 
 namespace arcticdb {
 
-VariantData unary_boolean(const std::shared_ptr<util::BitSet>& bitset, OperationType operation) {
-    switch(operation) {
-        case OperationType::IDENTITY:
-            return bitset;
-        case OperationType::NOT:
-            return std::make_shared<util::BitSet>(~(*bitset));
-        default:
-            util::raise_rte("Unexpected operator in unary_boolean {}", int(operation));
+VariantData unary_boolean(const std::shared_ptr<util::BitSet>& bitset, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::IDENTITY:
+        return bitset;
+    case OperationType::NOT:
+        return std::make_shared<util::BitSet>(~(*bitset));
+    default:
+        util::raise_rte("Unexpected operator in unary_boolean {}", int(operation));
     }
 }
 
-VariantData unary_boolean(EmptyResult, OperationType operation) {
-    switch(operation) {
-        case OperationType::IDENTITY:
-            return EmptyResult{};
-        case OperationType::NOT:
-            return FullResult{};
-        default:
-            util::raise_rte("Unexpected operator in unary_boolean {}", int(operation));
+VariantData unary_boolean(EmptyResult, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::IDENTITY:
+        return EmptyResult{};
+    case OperationType::NOT:
+        return FullResult{};
+    default:
+        util::raise_rte("Unexpected operator in unary_boolean {}", int(operation));
     }
 }
 
-VariantData unary_boolean(FullResult, OperationType operation) {
-    switch(operation) {
-        case OperationType::IDENTITY:
-            return FullResult{};
-        case OperationType::NOT:
-            return EmptyResult{};
-        default:
-            util::raise_rte("Unexpected operator in unary_boolean {}", int(operation));
+VariantData unary_boolean(FullResult, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::IDENTITY:
+        return FullResult{};
+    case OperationType::NOT:
+        return EmptyResult{};
+    default:
+        util::raise_rte("Unexpected operator in unary_boolean {}", int(operation));
     }
 }
 
-VariantData visit_unary_boolean(const VariantData& left, OperationType operation) {
+VariantData visit_unary_boolean(const VariantData& left, OperationType operation)
+{
     auto data = transform_to_bitset(left);
-    return std::visit(util::overload{
-            [operation] (const std::shared_ptr<util::BitSet>& d) -> VariantData {
-                return transform_to_placeholder(unary_boolean(d, operation));
-            },
-            [operation](EmptyResult d) {
-                return transform_to_placeholder(unary_boolean(d, operation));
-            },
-            [operation](FullResult d) {
-                return transform_to_placeholder(unary_boolean(d, operation));
-            },
-            [](const auto &) -> VariantData {
-                util::raise_rte("Value/ValueSet/non-bool column inputs not accepted to unary boolean");
-            }
-    }, data);
+    return std::visit(util::overload{[operation](const std::shared_ptr<util::BitSet>& d) -> VariantData {
+                                         return transform_to_placeholder(unary_boolean(d, operation));
+                                     },
+                          [operation](EmptyResult d) { return transform_to_placeholder(unary_boolean(d, operation)); },
+                          [operation](FullResult d) { return transform_to_placeholder(unary_boolean(d, operation)); },
+                          [](const auto&) -> VariantData {
+                              util::raise_rte("Value/ValueSet/non-bool column inputs not accepted to unary boolean");
+                          }},
+        data);
 }
 
-VariantData dispatch_unary(const VariantData& left, OperationType operation) {
-    switch(operation) {
-        case OperationType::ABS:
-            return visit_unary_operator(left, AbsOperator());
-        case OperationType::NEG:
-            return visit_unary_operator(left, NegOperator());
-        case OperationType::IDENTITY:
-        case OperationType::NOT:
-            return visit_unary_boolean(left, operation);
-        default:
-            util::raise_rte("Unknown operation {}", int(operation));
+VariantData dispatch_unary(const VariantData& left, OperationType operation)
+{
+    switch (operation) {
+    case OperationType::ABS:
+        return visit_unary_operator(left, AbsOperator());
+    case OperationType::NEG:
+        return visit_unary_operator(left, NegOperator());
+    case OperationType::IDENTITY:
+    case OperationType::NOT:
+        return visit_unary_boolean(left, operation);
+    default:
+        util::raise_rte("Unknown operation {}", int(operation));
     }
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -45,7 +45,8 @@ enum class OperationType : uint8_t {
     XOR
 };
 
-constexpr bool is_binary_operation(OperationType o) {
+constexpr bool is_binary_operation(OperationType o)
+{
     return uint8_t(o) >= uint8_t(OperationType::ADD);
 }
 
@@ -57,56 +58,40 @@ struct TimesOperator;
 struct DivideOperator;
 
 namespace arithmetic_promoted_type::details {
-    template <class VAL>
-    struct width {
-        static constexpr size_t value = sizeof(VAL);
-    };
-    template <class LHS, class RHS>
-    struct max_width {
-        static constexpr size_t value = std::max(sizeof(LHS), sizeof(RHS));
-    };
-    // Has member type naming an unsigned integer of WIDTH 1, 2, 4, or 8 bytes (the default)
-    template<size_t WIDTH>
-    struct unsigned_width {
-        using type = typename
-            std::conditional_t<WIDTH == 1,
-                uint8_t,
-                std::conditional_t<WIDTH == 2,
-                    uint16_t,
-                    std::conditional_t<WIDTH == 4,
-                        uint32_t,
-                        uint64_t
-                    >
-                >
-            >;
-    };
-    // Has member type naming a signed integer of WIDTH 1, 2, 4, or 8 bytes (the default)
-    template<size_t WIDTH>
-    struct signed_width {
-        using type = typename
-            std::conditional_t<WIDTH == 1,
-                int8_t,
-                std::conditional_t<WIDTH == 2,
-                    int16_t,
-                    std::conditional_t<WIDTH == 4,
-                        int32_t,
-                        int64_t
-                    >
-                >
-            >;
-    };
+template<class VAL>
+struct width {
+    static constexpr size_t value = sizeof(VAL);
+};
+template<class LHS, class RHS>
+struct max_width {
+    static constexpr size_t value = std::max(sizeof(LHS), sizeof(RHS));
+};
+// Has member type naming an unsigned integer of WIDTH 1, 2, 4, or 8 bytes (the default)
+template<size_t WIDTH>
+struct unsigned_width {
+    using type = typename std::conditional_t<WIDTH == 1,
+        uint8_t,
+        std::conditional_t<WIDTH == 2, uint16_t, std::conditional_t<WIDTH == 4, uint32_t, uint64_t>>>;
+};
+// Has member type naming a signed integer of WIDTH 1, 2, 4, or 8 bytes (the default)
+template<size_t WIDTH>
+struct signed_width {
+    using type = typename std::conditional_t<WIDTH == 1,
+        int8_t,
+        std::conditional_t<WIDTH == 2, int16_t, std::conditional_t<WIDTH == 4, int32_t, int64_t>>>;
+};
 
-    template <class VAL>
-    inline constexpr size_t width_v = width<VAL>::value;
-    template <class LHS, class RHS>
-    inline constexpr size_t max_width_v = max_width<LHS, RHS>::value;
-    template <size_t WIDTH>
-    using unsigned_width_t = typename unsigned_width<WIDTH>::type;
-    template <size_t WIDTH>
-    using signed_width_t = typename signed_width<WIDTH>::type;
-}
+template<class VAL>
+inline constexpr size_t width_v = width<VAL>::value;
+template<class LHS, class RHS>
+inline constexpr size_t max_width_v = max_width<LHS, RHS>::value;
+template<size_t WIDTH>
+using unsigned_width_t = typename unsigned_width<WIDTH>::type;
+template<size_t WIDTH>
+using signed_width_t = typename signed_width<WIDTH>::type;
+} // namespace arithmetic_promoted_type::details
 
-template <class VAL, class Func>
+template<class VAL, class Func>
 struct unary_arithmetic_promoted_type {
     static constexpr size_t val_width = arithmetic_promoted_type::details::width_v<VAL>;
     using type = typename
@@ -115,41 +100,32 @@ struct unary_arithmetic_promoted_type {
         std::conditional_t<std::is_same_v<Func, AbsOperator> || std::is_signed_v<VAL>,
             VAL,
             // Unsigned integer types promote to a signed type of double the width with the NegOperator
-            typename arithmetic_promoted_type::details::signed_width_t<2 * val_width>
-        >;
+            typename arithmetic_promoted_type::details::signed_width_t<2 * val_width>>;
 };
 
-template <class LHS, class RHS, class Func>
+template<class LHS, class RHS, class Func>
 struct type_arithmetic_promoted_type {
     static constexpr size_t max_width = arithmetic_promoted_type::details::max_width_v<LHS, RHS>;
-    using type = typename
-        std::conditional_t<std::is_floating_point_v<LHS> || std::is_floating_point_v<RHS>,
-            // At least one of the types is floating point
-            std::conditional_t<std::is_floating_point_v<LHS> && std::is_floating_point_v<RHS>,
-                // If both types are floating point, promote to the type of the widest one
-                std::conditional_t<max_width == 8,
-                    double,
-                    float
-                >,
-                // Otherwise, if only one type is floating point, promote to this type
-                std::conditional_t<std::is_floating_point_v<LHS>,
-                    LHS,
-                    RHS
-                >
-            >,
-            // Otherwise, both types are integers
-            std::conditional_t<std::is_unsigned_v<LHS> && std::is_unsigned_v<RHS>,
-                // Both types are unsigned
-                std::conditional_t<std::is_same_v<Func, PlusOperator> || std::is_same_v<Func, TimesOperator>,
-                    /* Plus and Times operators can overflow if using max_width, so promote to a wider unsigned type
+    using type = typename std::conditional_t<std::is_floating_point_v<LHS> || std::is_floating_point_v<RHS>,
+        // At least one of the types is floating point
+        std::conditional_t<std::is_floating_point_v<LHS> && std::is_floating_point_v<RHS>,
+            // If both types are floating point, promote to the type of the widest one
+            std::conditional_t<max_width == 8, double, float>,
+            // Otherwise, if only one type is floating point, promote to this type
+            std::conditional_t<std::is_floating_point_v<LHS>, LHS, RHS>>,
+        // Otherwise, both types are integers
+        std::conditional_t<std::is_unsigned_v<LHS> && std::is_unsigned_v<RHS>,
+            // Both types are unsigned
+            std::conditional_t<std::is_same_v<Func, PlusOperator> || std::is_same_v<Func, TimesOperator>,
+                /* Plus and Times operators can overflow if using max_width, so promote to a wider unsigned type
                      * e.g. 255*255 (both uint8_t's) = 65025, requiring uint16_t to hold the result */
-                    typename arithmetic_promoted_type::details::unsigned_width_t<2 * max_width>,
-                    std::conditional_t<std::is_same_v<Func, MinusOperator>,
-                        /* The result of Minus with two unsigned types can be negative
+                typename arithmetic_promoted_type::details::unsigned_width_t<2 * max_width>,
+                std::conditional_t<std::is_same_v<Func, MinusOperator>,
+                    /* The result of Minus with two unsigned types can be negative
                          * Can also underflow if using max_width, so promote to a wider signed type
                          * e.g. 0 - 255 (both uint8_t's) = -255, requiring int16_t to hold the result */
-                        typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>,
-                        /* The result of integer division with two unsigned types COULD always be represented by an
+                    typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>,
+                    /* The result of integer division with two unsigned types COULD always be represented by an
                          * unsigned type of the width of the numerator (as the result is <= the numerator)
                          * However, this would require extra logic in the DivideOperator::apply method, which we would
                          * like to avoid.
@@ -158,266 +134,303 @@ struct type_arithmetic_promoted_type {
                          * We cannot safely static_cast the uint16_t to uint8_t without a runtime check if it is >255
                          * We could also static_cast to the larger type, perform the division, and then static_cast back
                          * To avoid all this complexity, we just promote to the type of the widest input */
-                        typename arithmetic_promoted_type::details::unsigned_width_t<max_width>
-                    >
-                >,
-                std::conditional_t<std::is_signed_v<LHS> && std::is_signed_v<RHS>,
-                    // Both types are signed integers (as we are in the "else" of the floating point checks)
-                    std::conditional_t<std::is_same_v<Func, PlusOperator> || std::is_same_v<Func, MinusOperator> || std::is_same_v<Func, TimesOperator>,
-                        /* Plus, Minus, and Times operators can overflow if using max_width, so promote to a wider signed type
+                    typename arithmetic_promoted_type::details::unsigned_width_t<max_width>>>,
+            std::conditional_t<std::is_signed_v<LHS> && std::is_signed_v<RHS>,
+                // Both types are signed integers (as we are in the "else" of the floating point checks)
+                std::conditional_t<std::is_same_v<Func, PlusOperator> || std::is_same_v<Func, MinusOperator> ||
+                                       std::is_same_v<Func, TimesOperator>,
+                    /* Plus, Minus, and Times operators can overflow if using max_width, so promote to a wider signed type
                         * e.g. -100*100 (both int8_t's) = -10000, requiring int16_t to hold the result */
-                        typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>,
-                        // See above comment on division of two unsigned types
-                        typename arithmetic_promoted_type::details::signed_width_t<max_width>
-                    >,
-                    // We have one signed and one unsigned type
-                    std::conditional_t<std::is_same_v<Func, PlusOperator> || std::is_same_v<Func, MinusOperator> || std::is_same_v<Func, TimesOperator>,
-                        // Plus, Minus, and Times operators can overflow if using max_width, so promote to a wider signed type
-                        typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>,
-                        // Divide/IsIn/IsNotIn Operator
-                        std::conditional_t<(std::is_signed_v<LHS> && sizeof(LHS) > sizeof(RHS)) || (std::is_signed_v<RHS> && sizeof(RHS) > sizeof(LHS)),
-                            // If the signed type is strictly larger than the unsigned type, then promote to the signed type
-                            typename arithmetic_promoted_type::details::signed_width_t<max_width>,
-                            // Otherwise, promote to a signed type wider than the unsigned type, so that it can be exactly represented
-                            typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>
-                        >
-                    >
-                >
-            >
-        >;
+                    typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>,
+                    // See above comment on division of two unsigned types
+                    typename arithmetic_promoted_type::details::signed_width_t<max_width>>,
+                // We have one signed and one unsigned type
+                std::conditional_t<std::is_same_v<Func, PlusOperator> || std::is_same_v<Func, MinusOperator> ||
+                                       std::is_same_v<Func, TimesOperator>,
+                    // Plus, Minus, and Times operators can overflow if using max_width, so promote to a wider signed type
+                    typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>,
+                    // Divide/IsIn/IsNotIn Operator
+                    std::conditional_t<(std::is_signed_v<LHS> && sizeof(LHS) > sizeof(RHS)) ||
+                                           (std::is_signed_v<RHS> && sizeof(RHS) > sizeof(LHS)),
+                        // If the signed type is strictly larger than the unsigned type, then promote to the signed type
+                        typename arithmetic_promoted_type::details::signed_width_t<max_width>,
+                        // Otherwise, promote to a signed type wider than the unsigned type, so that it can be exactly represented
+                        typename arithmetic_promoted_type::details::signed_width_t<2 * max_width>>>>>>;
 };
 
 struct AbsOperator {
-template<typename T, typename V = typename unary_arithmetic_promoted_type<T, AbsOperator>::type>
-V apply(T t) {
-    if constexpr(std::is_unsigned_v<T>)
-        return t;
-    else
-        return std::abs(static_cast<V>(t));
-}
+    template<typename T, typename V = typename unary_arithmetic_promoted_type<T, AbsOperator>::type>
+    V apply(T t)
+    {
+        if constexpr (std::is_unsigned_v<T>)
+            return t;
+        else
+            return std::abs(static_cast<V>(t));
+    }
 };
 
 struct NegOperator {
-template<typename T, typename V = typename unary_arithmetic_promoted_type<T, NegOperator>::type>
-V apply(T t) {
-    return -static_cast<V>(t);
-}
+    template<typename T, typename V = typename unary_arithmetic_promoted_type<T, NegOperator>::type>
+    V apply(T t)
+    {
+        return -static_cast<V>(t);
+    }
 };
 
 struct PlusOperator {
-template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, PlusOperator>::type>
-V apply(T t, U u) {
-    return static_cast<V>(t) + static_cast<V>(u);
-}
+    template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, PlusOperator>::type>
+    V apply(T t, U u)
+    {
+        return static_cast<V>(t) + static_cast<V>(u);
+    }
 };
 
 struct MinusOperator {
-template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, MinusOperator>::type>
-V apply(T t, U u) {
-    return static_cast<V>(t) - static_cast<V>(u);
-}
+    template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, MinusOperator>::type>
+    V apply(T t, U u)
+    {
+        return static_cast<V>(t) - static_cast<V>(u);
+    }
 };
 
 struct TimesOperator {
-template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, TimesOperator>::type>
-V apply(T t, U u) {
-    return static_cast<V>(t) * static_cast<V>(u);
-}
+    template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, TimesOperator>::type>
+    V apply(T t, U u)
+    {
+        return static_cast<V>(t) * static_cast<V>(u);
+    }
 };
 
 struct DivideOperator {
-template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, DivideOperator>::type>
-V apply(T t, U u) {
-    return static_cast<V>(t) / static_cast<V>(u);
-}
+    template<typename T, typename U, typename V = typename type_arithmetic_promoted_type<T, U, DivideOperator>::type>
+    V apply(T t, U u)
+    {
+        return static_cast<V>(t) / static_cast<V>(u);
+    }
 };
 
 struct EqualsOperator {
-template<typename T, typename U>
-bool operator()(T t, U u) const {
-    return t == T(u);
-}
-template<typename T>
-bool operator()(T t, std::optional<T> u) const {
-    if (u.has_value())
-        return t == *u;
-    else
-        return false;
-}
-template<typename T>
-bool operator()(std::optional<T> t, T u) const {
-    if (t.has_value())
-        return *t == u;
-    else
-        return false;
-}
-template<typename T>
-bool operator()(std::optional<T> t, std::optional<T> u) const {
-    if (t.has_value() && u.has_value())
-        return *t == *u;
-    else
-        return false;
-}
+    template<typename T, typename U>
+    bool operator()(T t, U u) const
+    {
+        return t == T(u);
+    }
+    template<typename T>
+    bool operator()(T t, std::optional<T> u) const
+    {
+        if (u.has_value())
+            return t == *u;
+        else
+            return false;
+    }
+    template<typename T>
+    bool operator()(std::optional<T> t, T u) const
+    {
+        if (t.has_value())
+            return *t == u;
+        else
+            return false;
+    }
+    template<typename T>
+    bool operator()(std::optional<T> t, std::optional<T> u) const
+    {
+        if (t.has_value() && u.has_value())
+            return *t == *u;
+        else
+            return false;
+    }
 };
 
 struct NotEqualsOperator {
-template<typename T, typename U>
-bool operator()(T t, U u) const {
-    return t != T(u);
-}
-template<typename T>
-bool operator()(T t, std::optional<T> u) const {
-    if (u.has_value())
-        return t != *u;
-    else
-        return true;
-}
-template<typename T>
-bool operator()(std::optional<T> t, T u) const {
-    if (t.has_value())
-        return *t != u;
-    else
-        return true;
-}
-template<typename T>
-bool operator()(std::optional<T> t, std::optional<T> u) const {
-    if (t.has_value() && u.has_value())
-        return *t != *u;
-    else
-        return true;
-}
+    template<typename T, typename U>
+    bool operator()(T t, U u) const
+    {
+        return t != T(u);
+    }
+    template<typename T>
+    bool operator()(T t, std::optional<T> u) const
+    {
+        if (u.has_value())
+            return t != *u;
+        else
+            return true;
+    }
+    template<typename T>
+    bool operator()(std::optional<T> t, T u) const
+    {
+        if (t.has_value())
+            return *t != u;
+        else
+            return true;
+    }
+    template<typename T>
+    bool operator()(std::optional<T> t, std::optional<T> u) const
+    {
+        if (t.has_value() && u.has_value())
+            return *t != *u;
+        else
+            return true;
+    }
 };
 
 struct LessThanOperator {
-template<typename T, typename U>
-bool operator()(T t, U u) const {
-    return t < T(u);
-}
-template<typename T>
-bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const {
-    util::raise_rte("Less than operator not supported with strings");
-}
-template<typename T>
-bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const {
-    util::raise_rte("Less than operator not supported with strings");
-}
-bool operator()(uint64_t t, int64_t u) const {
-    return comparison::less_than(t, u);
-}
-bool operator()(int64_t t, uint64_t u) const {
-    return comparison::less_than(t, u);
-}
+    template<typename T, typename U>
+    bool operator()(T t, U u) const
+    {
+        return t < T(u);
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const
+    {
+        util::raise_rte("Less than operator not supported with strings");
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const
+    {
+        util::raise_rte("Less than operator not supported with strings");
+    }
+    bool operator()(uint64_t t, int64_t u) const
+    {
+        return comparison::less_than(t, u);
+    }
+    bool operator()(int64_t t, uint64_t u) const
+    {
+        return comparison::less_than(t, u);
+    }
 };
 
 struct LessThanEqualsOperator {
-template<typename T, typename U>
-bool operator()(T t, U u) const {
-    return t <= T(u);
-}
-template<typename T>
-bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const {
-    util::raise_rte("Less than equals operator not supported with strings");
-}
-template<typename T>
-bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const {
-    util::raise_rte("Less than equals operator not supported with strings");
-}
-bool operator()(uint64_t t, int64_t u) const {
-    return comparison::less_than_equals(t, u);
-}
-bool operator()(int64_t t, uint64_t u) const {
-    return comparison::less_than_equals(t, u);
-}
+    template<typename T, typename U>
+    bool operator()(T t, U u) const
+    {
+        return t <= T(u);
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const
+    {
+        util::raise_rte("Less than equals operator not supported with strings");
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const
+    {
+        util::raise_rte("Less than equals operator not supported with strings");
+    }
+    bool operator()(uint64_t t, int64_t u) const
+    {
+        return comparison::less_than_equals(t, u);
+    }
+    bool operator()(int64_t t, uint64_t u) const
+    {
+        return comparison::less_than_equals(t, u);
+    }
 };
 
 struct GreaterThanOperator {
-template<typename T, typename U>
-bool operator()(T t, U u) const {
-    return t > T(u);
-}
-template<typename T>
-bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const {
-    util::raise_rte("Greater than operator not supported with strings");
-}
-template<typename T>
-bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const {
-    util::raise_rte("Greater than operator not supported with strings");
-}
-bool operator()(uint64_t t, int64_t u) const {
-    return comparison::greater_than(t, u);
-}
-bool operator()(int64_t t, uint64_t u) const {
-    return comparison::greater_than(t, u);
-}
+    template<typename T, typename U>
+    bool operator()(T t, U u) const
+    {
+        return t > T(u);
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const
+    {
+        util::raise_rte("Greater than operator not supported with strings");
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const
+    {
+        util::raise_rte("Greater than operator not supported with strings");
+    }
+    bool operator()(uint64_t t, int64_t u) const
+    {
+        return comparison::greater_than(t, u);
+    }
+    bool operator()(int64_t t, uint64_t u) const
+    {
+        return comparison::greater_than(t, u);
+    }
 };
 
 struct GreaterThanEqualsOperator {
-template<typename T, typename U>
-bool operator()(T t, U u) const {
-    return t >= T(u);
-}
-template<typename T>
-bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const {
-    util::raise_rte("Greater than equals operator not supported with strings");
-}
-template<typename T>
-bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const {
-    util::raise_rte("Greater than equals operator not supported with strings");
-}
-bool operator()(uint64_t t, int64_t u) const {
-    return comparison::greater_than_equals(t, u);
-}
-bool operator()(int64_t t, uint64_t u) const {
-    return comparison::greater_than_equals(t, u);
-}
+    template<typename T, typename U>
+    bool operator()(T t, U u) const
+    {
+        return t >= T(u);
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] std::optional<T> t, [[maybe_unused]] T u) const
+    {
+        util::raise_rte("Greater than equals operator not supported with strings");
+    }
+    template<typename T>
+    bool operator()([[maybe_unused]] T t, [[maybe_unused]] std::optional<T> u) const
+    {
+        util::raise_rte("Greater than equals operator not supported with strings");
+    }
+    bool operator()(uint64_t t, int64_t u) const
+    {
+        return comparison::greater_than_equals(t, u);
+    }
+    bool operator()(int64_t t, uint64_t u) const
+    {
+        return comparison::greater_than_equals(t, u);
+    }
 };
 
 struct IsInOperator {
-template<typename T, typename U>
-bool operator()(T t, const std::unordered_set<U>& u) const {
-    return u.count(t) > 0;
-}
-bool operator()(uint64_t t, const std::unordered_set<int64_t>& u) const {
-    if (comparison::msb_set(t))
-        return false;
-    else
+    template<typename T, typename U>
+    bool operator()(T t, const std::unordered_set<U>& u) const
+    {
         return u.count(t) > 0;
-}
-bool operator()(int64_t t, const std::unordered_set<uint64_t>& u) const {
-    if (t < 0)
-        return false;
-    else
-        return u.count(t) > 0;
-}
-// This is the version called when checking string set membership with T = uint64_t and U = int64_t
-template<typename T, typename U>
-bool operator()(T t, const emilib::HashSet<U>& u) const {
-    return u.contains(t);
-} 
+    }
+    bool operator()(uint64_t t, const std::unordered_set<int64_t>& u) const
+    {
+        if (comparison::msb_set(t))
+            return false;
+        else
+            return u.count(t) > 0;
+    }
+    bool operator()(int64_t t, const std::unordered_set<uint64_t>& u) const
+    {
+        if (t < 0)
+            return false;
+        else
+            return u.count(t) > 0;
+    }
+    // This is the version called when checking string set membership with T = uint64_t and U = int64_t
+    template<typename T, typename U>
+    bool operator()(T t, const emilib::HashSet<U>& u) const
+    {
+        return u.contains(t);
+    }
 };
 
 struct IsNotInOperator {
-template<typename T, typename U>
-bool operator()(T t, const std::unordered_set<U>& u) const {
-    return u.count(t) == 0;
-}
-bool operator()(uint64_t t, const std::unordered_set<int64_t>& u) const {
-    if (comparison::msb_set(t))
-        return true;
-    else
+    template<typename T, typename U>
+    bool operator()(T t, const std::unordered_set<U>& u) const
+    {
         return u.count(t) == 0;
-}
-bool operator()(int64_t t, const std::unordered_set<uint64_t>& u) const {
-    if (t < 0)
-        return true;
-    else
-        return u.count(t) == 0;
-}
-// This is the version called when checking string set membership with T = uint64_t and U = int64_t
-template<typename T, typename U>
-bool operator()(T t, const emilib::HashSet<U>& u) const {
-    return !u.contains(t);
-}
+    }
+    bool operator()(uint64_t t, const std::unordered_set<int64_t>& u) const
+    {
+        if (comparison::msb_set(t))
+            return true;
+        else
+            return u.count(t) == 0;
+    }
+    bool operator()(int64_t t, const std::unordered_set<uint64_t>& u) const
+    {
+        if (t < 0)
+            return true;
+        else
+            return u.count(t) == 0;
+    }
+    // This is the version called when checking string set membership with T = uint64_t and U = int64_t
+    template<typename T, typename U>
+    bool operator()(T t, const emilib::HashSet<U>& u) const
+    {
+        return !u.contains(t);
+    }
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/processing/processing_segment.hpp
+++ b/cpp/arcticdb/processing/processing_segment.hpp
@@ -22,7 +22,7 @@
 #include <arcticdb/util/variant.hpp>
 
 namespace arcticdb {
-    /*
+/*
      * A processing segment is designed to be used in conjunction with the clause processing framework.
      * Each clause will execute in turn and will be passed the same mutable ProcessingSegment which it will have free
      * rein to modify prior to passing off to the next clause. In contract, clauses and the expression trees contained
@@ -39,151 +39,170 @@ namespace arcticdb {
      * df['col1'] + 1 appear multiple times in the tree this allows us to only perform the computation once and spill
      * the result to disk.
      */
-    struct ProcessingSegment {
-        // We want a collection of SliceAndKeys here so that we have all of the columns for a given row present in a single
-        // ProcessingSegment, for 2 reasons:
-        // 1: For binary operations in ExpressionNode involving 2 columns, we need both available in a single processing
-        //    segment in order for "get" calls to make sense
-        // 2: As "get" uses cached results where possible, it is not obvious which processing segment should hold the
-        //    cached result for operations involving 2 columns (probably both). By moving these cached results up a level
-        //    to contain all of the information for a given row, this becomes unambiguous.
-        std::vector<pipelines::SliceAndKey> data_;
-        std::shared_ptr<ExecutionContext> execution_context_;
-        std::unordered_map<std::string, VariantData> computed_data_;
+struct ProcessingSegment {
+    // We want a collection of SliceAndKeys here so that we have all of the columns for a given row present in a single
+    // ProcessingSegment, for 2 reasons:
+    // 1: For binary operations in ExpressionNode involving 2 columns, we need both available in a single processing
+    //    segment in order for "get" calls to make sense
+    // 2: As "get" uses cached results where possible, it is not obvious which processing segment should hold the
+    //    cached result for operations involving 2 columns (probably both). By moving these cached results up a level
+    //    to contain all of the information for a given row, this becomes unambiguous.
+    std::vector<pipelines::SliceAndKey> data_;
+    std::shared_ptr<ExecutionContext> execution_context_;
+    std::unordered_map<std::string, VariantData> computed_data_;
 
-        // Set by PartitioningClause
-        std::optional<size_t> bucket_;
+    // Set by PartitioningClause
+    std::optional<size_t> bucket_;
 
-        ProcessingSegment() = default;
+    ProcessingSegment() = default;
 
-        ProcessingSegment(SegmentInMemory &&seg, pipelines::FrameSlice&& slice, std::optional<size_t> bucket = std::nullopt) :
-                bucket_(bucket) {
-            data_.emplace_back(pipelines::SliceAndKey{std::move(seg), std::move(slice)});
-        }
-
-        explicit ProcessingSegment(pipelines::SliceAndKey &&sk, std::optional<size_t> bucket = std::nullopt) :
-                bucket_(bucket) {
-            data_.emplace_back(pipelines::SliceAndKey{std::move(sk)});
-        }
-
-        explicit ProcessingSegment(std::vector<pipelines::SliceAndKey> &&sk, std::optional<size_t> bucket = std::nullopt) :
-                bucket_(bucket) {
-            data_ = std::move(sk);
-        }
-
-        explicit ProcessingSegment(SegmentInMemory &&seg, std::optional<size_t> bucket = std::nullopt) :
-                bucket_(bucket) {
-            data_.emplace_back(pipelines::SliceAndKey{std::move(seg)});
-        }
-
-        std::vector<pipelines::SliceAndKey>&& release_data() {
-            return std::move(data_);
-        }
-
-        std::vector<pipelines::SliceAndKey>& data() {
-            return data_;
-        }
-
-        const std::vector<pipelines::SliceAndKey>& data() const {
-            return data_;
-        }
-
-        ProcessingSegment &self() {
-            return *this;
-        }
-
-        size_t get_bucket(){
-            return bucket_.value();
-        }
-
-        void set_bucket(size_t bucket) {
-            bucket_ = bucket;
-        }
-
-        void apply_filter(const util::BitSet& bitset, const std::shared_ptr<Store>& store);
-
-        void set_execution_context(const std::shared_ptr<ExecutionContext>& execution_context) {
-            execution_context_ = execution_context;
-        }
-
-        // The name argument to this function is either a column/value name, or uniquely identifies an ExpressionNode object.
-        // If this function has been called before with the same ExpressionNode name, then we cache the result in the
-        // computed_data_ map to avoid duplicating work.
-        VariantData get(const VariantNode &name, const std::shared_ptr<Store> &store);
-    };
-
-    inline std::vector<pipelines::SliceAndKey> collect_segments(Composite<ProcessingSegment>&& p) {
-        auto procs = std::move(p);
-        std::vector<pipelines::SliceAndKey> output;
-
-        procs.broadcast([&output] (auto&& p) {
-            auto proc = std::forward<ProcessingSegment>(p);
-            auto slice_and_keys = proc.release_data();
-            std::move(std::begin(slice_and_keys), std::end(slice_and_keys), std::back_inserter(output));
-        });
-
-        return output;
+    ProcessingSegment(SegmentInMemory&& seg, pipelines::FrameSlice&& slice, std::optional<size_t> bucket = std::nullopt)
+        : bucket_(bucket)
+    {
+        data_.emplace_back(pipelines::SliceAndKey{std::move(seg), std::move(slice)});
     }
 
-    using BucketVectorType = std::vector<size_t>;
+    explicit ProcessingSegment(pipelines::SliceAndKey&& sk, std::optional<size_t> bucket = std::nullopt)
+        : bucket_(bucket)
+    {
+        data_.emplace_back(pipelines::SliceAndKey{std::move(sk)});
+    }
 
-    template<typename Grouper, typename Bucketizer>
-    BucketVectorType get_buckets(const ColumnWithStrings& col, std::shared_ptr<Grouper> grouper, std::shared_ptr<Bucketizer> bucketizer) {
-        auto input_data = col.column_->data();
+    explicit ProcessingSegment(std::vector<pipelines::SliceAndKey>&& sk, std::optional<size_t> bucket = std::nullopt)
+        : bucket_(bucket)
+    {
+        data_ = std::move(sk);
+    }
 
-        BucketVectorType output;
-        output.reserve(col.column_->row_count());
-        col.column_->type().visit_tag([&input_data, &grouper, &bucketizer, &col, &output] (auto type_desc_tag) {
-            using TypeDescriptorTag =  decltype(type_desc_tag);
-            using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
+    explicit ProcessingSegment(SegmentInMemory&& seg, std::optional<size_t> bucket = std::nullopt)
+        : bucket_(bucket)
+    {
+        data_.emplace_back(pipelines::SliceAndKey{std::move(seg)});
+    }
 
-            while (auto block = input_data.next<TypeDescriptorTag>()) {
-                const auto row_count = block->row_count();
-                auto ptr = reinterpret_cast<const RawType*>(block->data());
-                for(auto i = 0u; i < row_count; ++i, ++ptr){
-                    if constexpr(std::is_same_v<typename Grouper::GrouperDescriptor, TypeDescriptorTag>) {
-                        auto group = grouper->group(*ptr, col.string_pool_);
-                        output.emplace_back(bucketizer->bucket(group));
-                    }
+    std::vector<pipelines::SliceAndKey>&& release_data()
+    {
+        return std::move(data_);
+    }
+
+    std::vector<pipelines::SliceAndKey>& data()
+    {
+        return data_;
+    }
+
+    const std::vector<pipelines::SliceAndKey>& data() const
+    {
+        return data_;
+    }
+
+    ProcessingSegment& self()
+    {
+        return *this;
+    }
+
+    size_t get_bucket()
+    {
+        return bucket_.value();
+    }
+
+    void set_bucket(size_t bucket)
+    {
+        bucket_ = bucket;
+    }
+
+    void apply_filter(const util::BitSet& bitset, const std::shared_ptr<Store>& store);
+
+    void set_execution_context(const std::shared_ptr<ExecutionContext>& execution_context)
+    {
+        execution_context_ = execution_context;
+    }
+
+    // The name argument to this function is either a column/value name, or uniquely identifies an ExpressionNode object.
+    // If this function has been called before with the same ExpressionNode name, then we cache the result in the
+    // computed_data_ map to avoid duplicating work.
+    VariantData get(const VariantNode& name, const std::shared_ptr<Store>& store);
+};
+
+inline std::vector<pipelines::SliceAndKey> collect_segments(Composite<ProcessingSegment>&& p)
+{
+    auto procs = std::move(p);
+    std::vector<pipelines::SliceAndKey> output;
+
+    procs.broadcast([&output](auto&& p) {
+        auto proc = std::forward<ProcessingSegment>(p);
+        auto slice_and_keys = proc.release_data();
+        std::move(std::begin(slice_and_keys), std::end(slice_and_keys), std::back_inserter(output));
+    });
+
+    return output;
+}
+
+using BucketVectorType = std::vector<size_t>;
+
+template<typename Grouper, typename Bucketizer>
+BucketVectorType
+get_buckets(const ColumnWithStrings& col, std::shared_ptr<Grouper> grouper, std::shared_ptr<Bucketizer> bucketizer)
+{
+    auto input_data = col.column_->data();
+
+    BucketVectorType output;
+    output.reserve(col.column_->row_count());
+    col.column_->type().visit_tag([&input_data, &grouper, &bucketizer, &col, &output](auto type_desc_tag) {
+        using TypeDescriptorTag = decltype(type_desc_tag);
+        using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
+
+        while (auto block = input_data.next<TypeDescriptorTag>()) {
+            const auto row_count = block->row_count();
+            auto ptr = reinterpret_cast<const RawType*>(block->data());
+            for (auto i = 0u; i < row_count; ++i, ++ptr) {
+                if constexpr (std::is_same_v<typename Grouper::GrouperDescriptor, TypeDescriptorTag>) {
+                    auto group = grouper->group(*ptr, col.string_pool_);
+                    output.emplace_back(bucketizer->bucket(group));
                 }
             }
-        });
-        return output;
-    }
-
-    template<typename Grouper, typename Bucketizer>
-    Composite<ProcessingSegment> partition_processing_segment(const ProcessingSegment& input, const ColumnWithStrings& col, const std::shared_ptr<Store>& store, std::shared_ptr<Grouper> grouper, std::shared_ptr<Bucketizer> bucketizer) {
-        Composite<ProcessingSegment> output;
-        auto bucket_vec = get_buckets(col, grouper, bucketizer);
-        std::vector<util::BitSet> bitsets;
-        bitsets.resize(bucketizer->num_buckets());
-        std::vector<util::BitSet::bulk_insert_iterator> iterators;
-        for(auto& bitset : bitsets)
-            iterators.emplace_back(util::BitSet::bulk_insert_iterator(bitset));
-
-        for(auto val : folly::enumerate(bucket_vec))
-            iterators[*val] = val.index;
-
-        for(auto& iterator : iterators)
-            iterator.flush();
-
-        for(auto bitset : folly::enumerate(bitsets)) {
-            if(bitset->count() != 0) {
-                ProcessingSegment proc;
-                proc.set_bucket(bitset.index);
-                for (auto& seg_slice_and_key : input.data()) {
-                    const SegmentInMemory& seg = seg_slice_and_key.segment(store);
-                    bitset->resize(seg.row_count());
-                    auto new_seg = filter_segment(seg, *bitset);
-                    pipelines::FrameSlice new_slice{seg_slice_and_key.slice()};
-                    new_slice.adjust_rows(new_seg.row_count());
-
-                    proc.data().emplace_back(pipelines::SliceAndKey{std::move(new_seg), std::move(new_slice)});
-                }
-                output.push_back(std::move(proc));
-            }
         }
-        return output;
+    });
+    return output;
+}
+
+template<typename Grouper, typename Bucketizer>
+Composite<ProcessingSegment> partition_processing_segment(const ProcessingSegment& input,
+    const ColumnWithStrings& col,
+    const std::shared_ptr<Store>& store,
+    std::shared_ptr<Grouper> grouper,
+    std::shared_ptr<Bucketizer> bucketizer)
+{
+    Composite<ProcessingSegment> output;
+    auto bucket_vec = get_buckets(col, grouper, bucketizer);
+    std::vector<util::BitSet> bitsets;
+    bitsets.resize(bucketizer->num_buckets());
+    std::vector<util::BitSet::bulk_insert_iterator> iterators;
+    for (auto& bitset : bitsets)
+        iterators.emplace_back(util::BitSet::bulk_insert_iterator(bitset));
+
+    for (auto val : folly::enumerate(bucket_vec))
+        iterators[*val] = val.index;
+
+    for (auto& iterator : iterators)
+        iterator.flush();
+
+    for (auto bitset : folly::enumerate(bitsets)) {
+        if (bitset->count() != 0) {
+            ProcessingSegment proc;
+            proc.set_bucket(bitset.index);
+            for (auto& seg_slice_and_key : input.data()) {
+                const SegmentInMemory& seg = seg_slice_and_key.segment(store);
+                bitset->resize(seg.row_count());
+                auto new_seg = filter_segment(seg, *bitset);
+                pipelines::FrameSlice new_slice{seg_slice_and_key.slice()};
+                new_slice.adjust_rows(new_seg.row_count());
+
+                proc.data().emplace_back(pipelines::SliceAndKey{std::move(new_seg), std::move(new_slice)});
+            }
+            output.push_back(std::move(proc));
+        }
     }
+    return output;
+}
 
 } //namespace arcticdb

--- a/cpp/arcticdb/processing/signed_unsigned_comparison.hpp
+++ b/cpp/arcticdb/processing/signed_unsigned_comparison.hpp
@@ -11,45 +11,55 @@
 
 namespace arcticdb::comparison {
 
-    constexpr uint64_t msb = uint64_t{1} << 63;
+constexpr uint64_t msb = uint64_t{1} << 63;
 
-    inline bool msb_set(uint64_t val) {
-        return static_cast<bool>(val & msb);
-    }
-
-    inline int64_t to_signed(uint64_t val) {
-        return static_cast<int64_t>(val);
-    }
-
-    inline bool less_than(uint64_t left, int64_t right) {
-        return !msb_set(left) && to_signed(left) < right;
-    }
-
-    inline bool less_than(int64_t left, uint64_t right) {
-        return msb_set(right) || left < to_signed(right);
-    }
-
-    inline bool less_than_equals(uint64_t left, int64_t right) {
-        return !msb_set(left) && to_signed(left) <= right;
-    }
-
-    inline bool less_than_equals(int64_t left, uint64_t right) {
-        return msb_set(right) || left <= to_signed(right);
-    }
-
-    inline bool greater_than(uint64_t left, int64_t right) {
-        return msb_set(left) || to_signed(left) > right;
-    }
-
-    inline bool greater_than(int64_t left, uint64_t right) {
-        return !msb_set(right) && left > to_signed(right);
-    }
-
-    inline bool greater_than_equals(uint64_t left, int64_t right) {
-        return msb_set(left) || to_signed(left) >= right;
-    }
-
-    inline bool greater_than_equals(int64_t left, uint64_t right) {
-        return !msb_set(right) && left >= to_signed(right);
-    }
+inline bool msb_set(uint64_t val)
+{
+    return static_cast<bool>(val & msb);
 }
+
+inline int64_t to_signed(uint64_t val)
+{
+    return static_cast<int64_t>(val);
+}
+
+inline bool less_than(uint64_t left, int64_t right)
+{
+    return !msb_set(left) && to_signed(left) < right;
+}
+
+inline bool less_than(int64_t left, uint64_t right)
+{
+    return msb_set(right) || left < to_signed(right);
+}
+
+inline bool less_than_equals(uint64_t left, int64_t right)
+{
+    return !msb_set(left) && to_signed(left) <= right;
+}
+
+inline bool less_than_equals(int64_t left, uint64_t right)
+{
+    return msb_set(right) || left <= to_signed(right);
+}
+
+inline bool greater_than(uint64_t left, int64_t right)
+{
+    return msb_set(left) || to_signed(left) > right;
+}
+
+inline bool greater_than(int64_t left, uint64_t right)
+{
+    return !msb_set(right) && left > to_signed(right);
+}
+
+inline bool greater_than_equals(uint64_t left, int64_t right)
+{
+    return msb_set(left) || to_signed(left) >= right;
+}
+
+inline bool greater_than_equals(int64_t left, uint64_t right)
+{
+    return !msb_set(right) && left >= to_signed(right);
+}
+} // namespace arcticdb::comparison

--- a/cpp/arcticdb/processing/test/test_arithmetic_type_promotion.cpp
+++ b/cpp/arcticdb/processing/test/test_arithmetic_type_promotion.cpp
@@ -8,548 +8,554 @@
 #include <gtest/gtest.h>
 #include <arcticdb/processing/operation_types.hpp>
 
-TEST(ArithmeticTypePromotion, Abs) {
+TEST(ArithmeticTypePromotion, Abs)
+{
     using namespace arcticdb;
     // All types should promote to themselves
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<float,     AbsOperator>::type, float>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<double,    AbsOperator>::type, double>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint8_t,   AbsOperator>::type, uint8_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint16_t,  AbsOperator>::type, uint16_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint32_t,  AbsOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint64_t,  AbsOperator>::type, uint64_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int8_t,    AbsOperator>::type, int8_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int16_t,   AbsOperator>::type, int16_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int32_t,   AbsOperator>::type, int32_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int64_t,   AbsOperator>::type, int64_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<float, AbsOperator>::type, float>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<double, AbsOperator>::type, double>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint8_t, AbsOperator>::type, uint8_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint16_t, AbsOperator>::type, uint16_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint32_t, AbsOperator>::type, uint32_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint64_t, AbsOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int8_t, AbsOperator>::type, int8_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int16_t, AbsOperator>::type, int16_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int32_t, AbsOperator>::type, int32_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int64_t, AbsOperator>::type, int64_t>);
 }
 
-TEST(ArithmeticTypePromotion, Neg) {
+TEST(ArithmeticTypePromotion, Neg)
+{
     using namespace arcticdb;
     // Floating point and signed integer types should promote to themselves
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<float,     NegOperator>::type, float>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<double,    NegOperator>::type, double>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int8_t,    NegOperator>::type, int8_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int16_t,   NegOperator>::type, int16_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int32_t,   NegOperator>::type, int32_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int64_t,   NegOperator>::type, int64_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<float, NegOperator>::type, float>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<double, NegOperator>::type, double>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int8_t, NegOperator>::type, int8_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int16_t, NegOperator>::type, int16_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int32_t, NegOperator>::type, int32_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<int64_t, NegOperator>::type, int64_t>);
     // Unsigned integer types should promote to a signed type of double the width, capped at int64_t
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint8_t,   NegOperator>::type, int16_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint16_t,  NegOperator>::type, int32_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint32_t,  NegOperator>::type, int64_t>);
-    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint64_t,  NegOperator>::type, int64_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint8_t, NegOperator>::type, int16_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint16_t, NegOperator>::type, int32_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint32_t, NegOperator>::type, int64_t>);
+    static_assert(std::is_same_v<unary_arithmetic_promoted_type<uint64_t, NegOperator>::type, int64_t>);
 }
 
-TEST(ArithmeticTypePromotion, Plus) {
+TEST(ArithmeticTypePromotion, Plus)
+{
     using namespace arcticdb;
     // Floating point types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  float,  PlusOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  double, PlusOperator>::type, double>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float,  PlusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, float, PlusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, double, PlusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, double, PlusOperator>::type, double>);
     // Unsigned types should promote to an unsigned type one size larger than the biggest provided, capped at uint64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint8_t,  PlusOperator>::type, uint16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint16_t, PlusOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint32_t, PlusOperator>::type, uint64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint64_t, PlusOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint8_t, PlusOperator>::type, uint16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint16_t, PlusOperator>::type, uint32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint32_t, PlusOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint64_t, PlusOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t,  PlusOperator>::type, uint32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t, PlusOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint16_t, PlusOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint32_t, PlusOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint64_t, PlusOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t,  PlusOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t, PlusOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint16_t, PlusOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint32_t, PlusOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint64_t, PlusOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t,  PlusOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t, PlusOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint16_t, PlusOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint32_t, PlusOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint64_t, PlusOperator>::type, uint64_t>);
     // Signed types should promote to a signed type one size larger than the biggest provided, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int8_t,  PlusOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int16_t, PlusOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int32_t, PlusOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int64_t, PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int8_t, PlusOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int16_t, PlusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int32_t, PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t,  PlusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t, PlusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int16_t, PlusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t,  PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int16_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t,  PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int16_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int64_t, PlusOperator>::type, int64_t>);
     // Mixed signed and unsigned types should promote to a signed type one size larger than the biggest provided, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int8_t,  PlusOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int16_t, PlusOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int32_t, PlusOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int64_t, PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int8_t, PlusOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int16_t, PlusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int32_t, PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t,  PlusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t, PlusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int16_t, PlusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t,  PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int16_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t,  PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int16_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint8_t,  PlusOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint16_t, PlusOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint32_t, PlusOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint64_t, PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint8_t, PlusOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint16_t, PlusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint32_t, PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t,  PlusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t, PlusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint16_t, PlusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t,  PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint16_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint64_t, PlusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t,  PlusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint16_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint32_t, PlusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint64_t, PlusOperator>::type, int64_t>);
     // Mixed integral and floating point types should promote to the floating point type
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  float, PlusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, float, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, float, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, float, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, float, PlusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t,  PlusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint16_t, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint32_t, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint64_t, PlusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  float, PlusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, float, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, float, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, float, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, float, PlusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t,  PlusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int16_t, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int32_t, PlusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int64_t, PlusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  double, PlusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, double, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, double, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, double, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, double, PlusOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t,  PlusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint16_t, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint32_t, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint64_t, PlusOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  double, PlusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, double, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, double, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, double, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, double, PlusOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t,  PlusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int16_t, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int32_t, PlusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int64_t, PlusOperator>::type, double>);
 }
 
-TEST(ArithmeticTypePromotion, Minus) {
+TEST(ArithmeticTypePromotion, Minus)
+{
     using namespace arcticdb;
     // Floating point types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  float,  MinusOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  double, MinusOperator>::type, double>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float,  MinusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, float, MinusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, double, MinusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, double, MinusOperator>::type, double>);
     // Unsigned types should promote to a signed type one size larger than the biggest provided, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint8_t,  MinusOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint16_t, MinusOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint32_t, MinusOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint64_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint8_t, MinusOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint16_t, MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint32_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t,  MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint16_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint64_t, MinusOperator>::type, int64_t>);
     // Signed types should promote to a signed type one size larger than the biggest provided, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int8_t,  MinusOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int16_t, MinusOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int32_t, MinusOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int64_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int8_t, MinusOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int16_t, MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int32_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t,  MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int16_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int64_t, MinusOperator>::type, int64_t>);
     // Mixed signed and unsigned types should promote to a signed type one size larger than the biggest provided, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int8_t,  MinusOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int16_t, MinusOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int32_t, MinusOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int64_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int8_t, MinusOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int16_t, MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int32_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t,  MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int16_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint8_t,  MinusOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint16_t, MinusOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint32_t, MinusOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint64_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint8_t, MinusOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint16_t, MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint32_t, MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t,  MinusOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint16_t, MinusOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint64_t, MinusOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t,  MinusOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint16_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint32_t, MinusOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint64_t, MinusOperator>::type, int64_t>);
     // Mixed integral and floating point types should promote to the floating point type
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  float, MinusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, float, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, float, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, float, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, float, MinusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t,  MinusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint16_t, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint32_t, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint64_t, MinusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  float, MinusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, float, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, float, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, float, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, float, MinusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t,  MinusOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int16_t, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int32_t, MinusOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int64_t, MinusOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  double, MinusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, double, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, double, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, double, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, double, MinusOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t,  MinusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint16_t, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint32_t, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint64_t, MinusOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  double, MinusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, double, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, double, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, double, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, double, MinusOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t,  MinusOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int16_t, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int32_t, MinusOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int64_t, MinusOperator>::type, double>);
 }
 
-TEST(ArithmeticTypePromotion, Times) {
+TEST(ArithmeticTypePromotion, Times)
+{
     using namespace arcticdb;
     // Floating point types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  float,  TimesOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  double, TimesOperator>::type, double>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float,  TimesOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, float, TimesOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, double, TimesOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, double, TimesOperator>::type, double>);
     // Unsigned types should promote to an unsigned type one size larger than the biggest provided, capped at uint64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint8_t,  TimesOperator>::type, uint16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint16_t, TimesOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint32_t, TimesOperator>::type, uint64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint64_t, TimesOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint8_t, TimesOperator>::type, uint16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint16_t, TimesOperator>::type, uint32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint32_t, TimesOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint64_t, TimesOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t,  TimesOperator>::type, uint32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t, TimesOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint16_t, TimesOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint32_t, TimesOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint64_t, TimesOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t,  TimesOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t, TimesOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint16_t, TimesOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint32_t, TimesOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint64_t, TimesOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t,  TimesOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t, TimesOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint16_t, TimesOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint32_t, TimesOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint64_t, TimesOperator>::type, uint64_t>);
     // Signed types should promote to a signed type one size larger than the biggest provided, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int8_t,  TimesOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int16_t, TimesOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int32_t, TimesOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int64_t, TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int8_t, TimesOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int16_t, TimesOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int32_t, TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t,  TimesOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t, TimesOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int16_t, TimesOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t,  TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int16_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t,  TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int16_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int64_t, TimesOperator>::type, int64_t>);
     // Mixed signed and unsigned types should promote to a signed type one size larger than the biggest provided, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int8_t,  TimesOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int16_t, TimesOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int32_t, TimesOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int64_t, TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int8_t, TimesOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int16_t, TimesOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int32_t, TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t,  TimesOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t, TimesOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int16_t, TimesOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t,  TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int16_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t,  TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int16_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint8_t,  TimesOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint16_t, TimesOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint32_t, TimesOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint64_t, TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint8_t, TimesOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint16_t, TimesOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint32_t, TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t,  TimesOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t, TimesOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint16_t, TimesOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t,  TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint16_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint64_t, TimesOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t,  TimesOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint16_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint32_t, TimesOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint64_t, TimesOperator>::type, int64_t>);
     // Mixed integral and floating point types should promote to the floating point type
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  float, TimesOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, float, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, float, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, float, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, float, TimesOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t,  TimesOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint16_t, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint32_t, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint64_t, TimesOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  float, TimesOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, float, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, float, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, float, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, float, TimesOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t,  TimesOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int16_t, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int32_t, TimesOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int64_t, TimesOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  double, TimesOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, double, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, double, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, double, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, double, TimesOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t,  TimesOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint16_t, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint32_t, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint64_t, TimesOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  double, TimesOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, double, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, double, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, double, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, double, TimesOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t,  TimesOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int16_t, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int32_t, TimesOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int64_t, TimesOperator>::type, double>);
 }
 
-TEST(ArithmeticTypePromotion, Divide) {
+TEST(ArithmeticTypePromotion, Divide)
+{
     using namespace arcticdb;
     // Floating point types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  float,  DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  double, DivideOperator>::type, double>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, float, DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, double, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, double, DivideOperator>::type, double>);
     // Unsigned types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint8_t,  DivideOperator>::type, uint8_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint16_t, DivideOperator>::type, uint16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint32_t, DivideOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint64_t, DivideOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint8_t, DivideOperator>::type, uint8_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint16_t, DivideOperator>::type, uint16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint32_t, DivideOperator>::type, uint32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, uint64_t, DivideOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t,  DivideOperator>::type, uint16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t, DivideOperator>::type, uint16_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint16_t, DivideOperator>::type, uint16_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint32_t, DivideOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint64_t, DivideOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t,  DivideOperator>::type, uint32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t, DivideOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint16_t, DivideOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint32_t, DivideOperator>::type, uint32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint64_t, DivideOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t,  DivideOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t, DivideOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint16_t, DivideOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint32_t, DivideOperator>::type, uint64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint64_t, DivideOperator>::type, uint64_t>);
     // Signed types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int8_t,  DivideOperator>::type, int8_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int16_t, DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int32_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int8_t, DivideOperator>::type, int8_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int16_t, DivideOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int32_t, DivideOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, int64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t,  DivideOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t, DivideOperator>::type, int16_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int16_t, DivideOperator>::type, int16_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int32_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t,  DivideOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int16_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int32_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t,  DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int16_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int32_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int64_t, DivideOperator>::type, int64_t>);
     // Mixed signed and unsigned types should promote to a signed type capable of exactly representing both types, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int8_t,  DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int16_t, DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int32_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int8_t, DivideOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int16_t, DivideOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int32_t, DivideOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, int64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t,  DivideOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int16_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int32_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t,  DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int16_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int32_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t,  DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int16_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int32_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint8_t,  DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint16_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint8_t, DivideOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint16_t, DivideOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint32_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, uint64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t,  DivideOperator>::type, int16_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t, DivideOperator>::type, int16_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint16_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint32_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t,  DivideOperator>::type, int32_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint16_t, DivideOperator>::type, int32_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint32_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint64_t, DivideOperator>::type, int64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t,  DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint16_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint32_t, DivideOperator>::type, int64_t>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint64_t, DivideOperator>::type, int64_t>);
     // Mixed integral and floating point types should promote to the floating point type
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  float, DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, float, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, float, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, float, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, float, DivideOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t,  DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint16_t, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint32_t, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint64_t, DivideOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  float, DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, float, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, float, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, float, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, float, DivideOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t,  DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int16_t, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int32_t, DivideOperator>::type, float>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int64_t, DivideOperator>::type, float>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  double, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t, double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, double, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint8_t, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint16_t, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint32_t, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  double, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t, double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, double, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int8_t, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int16_t, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int32_t, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, int64_t, DivideOperator>::type, double>);

--- a/cpp/arcticdb/processing/test/test_clause.cpp
+++ b/cpp/arcticdb/processing/test/test_clause.cpp
@@ -12,7 +12,11 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 
 template<typename T>
-void segment_scalar_assert_all_values_equal(const arcticdb::ProcessingSegment& segment, const arcticdb::ColumnName& name, const std::unordered_set<T>& expected, size_t expected_row_count) {
+void segment_scalar_assert_all_values_equal(const arcticdb::ProcessingSegment& segment,
+    const arcticdb::ColumnName& name,
+    const std::unordered_set<T>& expected,
+    size_t expected_row_count)
+{
     const arcticdb::pipelines::SliceAndKey& slice_and_key = segment.data().front();
     std::shared_ptr<arcticdb::Store> empty;
     slice_and_key.ensure_segment(empty);
@@ -21,10 +25,9 @@ void segment_scalar_assert_all_values_equal(const arcticdb::ProcessingSegment& s
     size_t row_counter = 0;
     for (auto row : segment_memory) {
         auto column_index = segment_memory.column_index(name.value).value();
-        if (row.scalar_at<T>(column_index)){
-            row.visit_scalar(size_t{ column_index }, [&expected](auto val) {
-                ASSERT_NE(expected.find(val.value()), expected.end());
-            });
+        if (row.scalar_at<T>(column_index)) {
+            row.visit_scalar(size_t{column_index},
+                [&expected](auto val) { ASSERT_NE(expected.find(val.value()), expected.end()); });
 
             row_counter++;
         }
@@ -33,7 +36,11 @@ void segment_scalar_assert_all_values_equal(const arcticdb::ProcessingSegment& s
     ASSERT_EQ(expected_row_count, row_counter);
 }
 
-void segment_string_assert_all_values_equal(const arcticdb::ProcessingSegment& segment, const arcticdb::ColumnName& name, std::string_view expected, size_t expected_row_count) {
+void segment_string_assert_all_values_equal(const arcticdb::ProcessingSegment& segment,
+    const arcticdb::ColumnName& name,
+    std::string_view expected,
+    size_t expected_row_count)
+{
     const arcticdb::pipelines::SliceAndKey& slice_and_key = segment.data().front();
     std::shared_ptr<arcticdb::Store> empty;
     slice_and_key.ensure_segment(empty);
@@ -42,22 +49,20 @@ void segment_string_assert_all_values_equal(const arcticdb::ProcessingSegment& s
     size_t row_counter = 0;
     for (auto row : segment_memory) {
         auto column_index = segment_memory.column_index(name.value).value();
-        if (row.string_at(column_index)){
-            row.visit_string(size_t{column_index}, [&expected](auto val) {
-                ASSERT_EQ(val.value(), expected);
-            });
+        if (row.string_at(column_index)) {
+            row.visit_string(size_t{column_index}, [&expected](auto val) { ASSERT_EQ(val.value(), expected); });
 
             row_counter++;
         }
     }
 
     ASSERT_EQ(expected_row_count, row_counter);
-
 }
 
-TEST(Clause, Partition) {
+TEST(Clause, Partition)
+{
     using namespace arcticdb;
-    auto seg = get_groupable_timeseries_segment("groupable", 30, {1,2,3,1,2,3,1,2,3});
+    auto seg = get_groupable_timeseries_segment("groupable", 30, {1, 2, 3, 1, 2, 3, 1, 2, 3});
 
     ScopedConfig num_buckets("Partition.NumBuckets", 16);
     std::shared_ptr<Store> empty;
@@ -69,7 +74,8 @@ TEST(Clause, Partition) {
 
     ExecutionContext context{};
     context.root_node_name_ = ExpressionName("int8");
-    PartitionClause<arcticdb::grouping::HashingGroupers, arcticdb::grouping::ModuloBucketizer> partition{std::make_shared<ExecutionContext>(std::move(context))};
+    PartitionClause<arcticdb::grouping::HashingGroupers, arcticdb::grouping::ModuloBucketizer> partition{
+        std::make_shared<ExecutionContext>(std::move(context))};
 
     auto partitioned = partition.process(empty, std::move(comp));
 
@@ -77,14 +83,18 @@ TEST(Clause, Partition) {
 
     std::vector<std::unordered_set<int8_t>> tags = {{1, 3}, {2}};
     std::vector<size_t> sizes = {180, 90};
-    for (auto inner_seg : folly::enumerate(partitioned.as_range())){
-        segment_scalar_assert_all_values_equal<int8_t>(*inner_seg, ColumnName("int8"), tags[inner_seg.index], sizes[inner_seg.index]);
+    for (auto inner_seg : folly::enumerate(partitioned.as_range())) {
+        segment_scalar_assert_all_values_equal<int8_t>(*inner_seg,
+            ColumnName("int8"),
+            tags[inner_seg.index],
+            sizes[inner_seg.index]);
     }
 }
 
-TEST(Clause, PartitionString) {
+TEST(Clause, PartitionString)
+{
     using namespace arcticdb;
-    auto seg = get_groupable_timeseries_segment("groupable", 30, {1,1,3,3,1,1});
+    auto seg = get_groupable_timeseries_segment("groupable", 30, {1, 1, 3, 3, 1, 1});
     ScopedConfig num_buckets("Partition.NumBuckets", 16);
     std::shared_ptr<Store> empty;
     auto proc_seg = ProcessingSegment{std::move(seg), pipelines::FrameSlice{}};
@@ -95,7 +105,8 @@ TEST(Clause, PartitionString) {
 
     ExecutionContext context{};
     context.root_node_name_ = ExpressionName("strings");
-    PartitionClause<arcticdb::grouping::HashingGroupers, arcticdb::grouping::ModuloBucketizer> partition{std::make_shared<ExecutionContext>(std::move(context))};
+    PartitionClause<arcticdb::grouping::HashingGroupers, arcticdb::grouping::ModuloBucketizer> partition{
+        std::make_shared<ExecutionContext>(std::move(context))};
 
     auto partitioned = partition.process(empty, std::move(comp));
 
@@ -103,12 +114,16 @@ TEST(Clause, PartitionString) {
 
     std::vector<size_t> tags = {1, 3};
     std::vector<size_t> sizes = {120, 60};
-    for (auto inner_seg : folly::enumerate(partitioned.as_range())){
-        segment_string_assert_all_values_equal(*inner_seg, ColumnName("strings"), fmt::format("string_{}", tags[inner_seg.index]), sizes[inner_seg.index]);
+    for (auto inner_seg : folly::enumerate(partitioned.as_range())) {
+        segment_string_assert_all_values_equal(*inner_seg,
+            ColumnName("strings"),
+            fmt::format("string_{}", tags[inner_seg.index]),
+            sizes[inner_seg.index]);
     }
 }
 
-TEST(Clause, Passthrough) {
+TEST(Clause, Passthrough)
+{
     using namespace arcticdb;
     auto seg = get_standard_timeseries_segment("passthrough");
 
@@ -120,7 +135,8 @@ TEST(Clause, Passthrough) {
     auto ret = passthrough.process(empty, std::move(comp));
 }
 
-TEST(Clause, Sort) {
+TEST(Clause, Sort)
+{
     using namespace arcticdb;
     auto seg = get_standard_timeseries_segment("sort");
     std::random_device rng;
@@ -138,7 +154,8 @@ TEST(Clause, Sort) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(Clause, Split) {
+TEST(Clause, Split)
+{
     using namespace arcticdb;
     std::string symbol{"split"};
     auto seg = get_standard_timeseries_segment(symbol, 100);
@@ -155,7 +172,7 @@ TEST(Clause, Split) {
     const auto& fields = copied.descriptor().fields();
     auto beg = std::begin(fields);
     std::advance(beg, 1);
-    for(auto field = beg; field != std::end(fields); ++field) {
+    for (auto field = beg; field != std::end(fields); ++field) {
         FieldDescriptor::Proto proto;
         proto.CopyFrom(*field);
         desc.emplace_back(std::move(proto));
@@ -163,8 +180,8 @@ TEST(Clause, Split) {
 
     SegmentSinkWrapper seg_wrapper(symbol, TimeseriesIndex::default_index(), std::move(desc));
 
-    for(auto i = 0u; i < res.level_1_size(); ++i ) {
-        auto item =  std::move(std::get<ProcessingSegment>(res[i]));
+    for (auto i = 0u; i < res.level_1_size(); ++i) {
+        auto item = std::move(std::get<ProcessingSegment>(res[i]));
         pipelines::FrameSlice slice(item.data_[0].segment(empty));
         seg_wrapper.aggregator_.add_segment(std::move(item.data_[0].segment(empty)), slice, false);
     }
@@ -176,7 +193,8 @@ TEST(Clause, Split) {
     ASSERT_EQ(equal, true);
 }
 
-TEST(Clause, Merge) {
+TEST(Clause, Merge)
+{
     using namespace arcticdb;
     const auto seg_size = 5;
     ScopedConfig max_blocks("Merge.SegmentSize", seg_size);
@@ -184,7 +202,7 @@ TEST(Clause, Merge) {
     std::vector<SegmentInMemory> copies;
     const auto num_segs = 2;
     const auto num_rows = 5;
-    for(auto x = 0u; x < num_segs; ++x) {
+    for (auto x = 0u; x < num_segs; ++x) {
         auto symbol = fmt::format("merge_{}", x);
         auto seg = get_standard_timeseries_segment(symbol, 10);
         copies.emplace_back(seg.clone());
@@ -197,22 +215,25 @@ TEST(Clause, Merge) {
     ExecutionContext merge_clause_context{};
     merge_clause_context.set_descriptor(descriptor);
     auto stream_id = StreamId("Merge");
-    MergeClause merge_clause{TimeseriesIndex{"time"}, DenseColumnPolicy{}, stream_id, std::make_shared<ExecutionContext>(std::move(merge_clause_context))};
+    MergeClause merge_clause{TimeseriesIndex{"time"},
+        DenseColumnPolicy{},
+        stream_id,
+        std::make_shared<ExecutionContext>(std::move(merge_clause_context))};
     std::shared_ptr<Store> empty;
     auto res = merge_clause.process(empty, std::move(comp));
     ASSERT_EQ(res.size(), 4u);
-    for(auto i = 0; i < num_rows * num_segs; ++i) {
+    for (auto i = 0; i < num_rows * num_segs; ++i) {
         auto& output_seg = std::get<ProcessingSegment>(res[i / seg_size]).data_[0].segment(empty);
         auto output_row = i % seg_size;
         const auto& expected_seg = copies[i % num_segs];
         auto expected_row = i / num_segs;
-        for(auto field : folly::enumerate(output_seg.descriptor().fields())) {
-            if(field.index == 1)
+        for (auto field : folly::enumerate(output_seg.descriptor().fields())) {
+            if (field.index == 1)
                 continue;
 
-            visit_field(*field, [&output_seg, &expected_seg, output_row, expected_row, &field] (auto tdt) {
+            visit_field(*field, [&output_seg, &expected_seg, output_row, expected_row, &field](auto tdt) {
                 using DataTypeTag = typename decltype(tdt)::DataTypeTag;
-                if constexpr(is_sequence_type(DataTypeTag::data_type)) {
+                if constexpr (is_sequence_type(DataTypeTag::data_type)) {
                     const auto val1 = output_seg.string_at(output_row, position_t(field.index));
                     const auto val2 = expected_seg.string_at(expected_row, position_t(field.index));
                     ASSERT_EQ(val1, val2);

--- a/cpp/arcticdb/processing/test/test_expression.cpp
+++ b/cpp/arcticdb/processing/test/test_expression.cpp
@@ -11,16 +11,15 @@
 #include <arcticdb/processing/processing_segment.hpp>
 #include <arcticdb/util/test/generators.hpp>
 
-TEST(ExpressionNode, AddBasic) {
+TEST(ExpressionNode, AddBasic)
+{
     using namespace arcticdb;
     StreamId symbol("test_add");
-    auto wrapper = SinkWrapper(symbol, {
-            scalar_field_proto(DataType::UINT64, "thing1"),
-            scalar_field_proto(DataType::UINT64, "thing2")
-    });
+    auto wrapper = SinkWrapper(symbol,
+        {scalar_field_proto(DataType::UINT64, "thing1"), scalar_field_proto(DataType::UINT64, "thing2")});
 
-    for(auto j = 0; j < 20; ++j ) {
-        wrapper.aggregator_.start_row(timestamp(j))([&](auto &&rb) {
+    for (auto j = 0; j < 20; ++j) {
+        wrapper.aggregator_.start_row(timestamp(j))([&](auto&& rb) {
             rb.set_scalar(1, j);
             rb.set_scalar(2, j + 1);
         });
@@ -38,8 +37,8 @@ TEST(ExpressionNode, AddBasic) {
     auto ret = proc.get(ExpressionName("new_thing"), empty);
     const auto& col = std::get<ColumnWithStrings>(ret).column_;
 
-    for(auto j = 0; j < 20; ++j ) {
-        auto v1 =proc.data_[0].segment(empty).scalar_at<uint64_t>(j, 1) ;
+    for (auto j = 0; j < 20; ++j) {
+        auto v1 = proc.data_[0].segment(empty).scalar_at<uint64_t>(j, 1);
         ASSERT_EQ(v1.value(), j);
         auto v2 = proc.data_[0].segment(empty).scalar_at<uint64_t>(j, 2);
         ASSERT_EQ(v2.value(), j + 1);

--- a/cpp/arcticdb/processing/test/test_has_valid_type_promotion.cpp
+++ b/cpp/arcticdb/processing/test/test_has_valid_type_promotion.cpp
@@ -9,7 +9,8 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 
-TEST(HasValidTypePromotion, DifferentDimensions) {
+TEST(HasValidTypePromotion, DifferentDimensions)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::UNKNOWN_VALUE_TYPE, SizeBits::UNKNOWN_SIZE_BITS, Dimension::Dim0);
@@ -18,7 +19,8 @@ TEST(HasValidTypePromotion, DifferentDimensions) {
     EXPECT_FALSE(result.has_value());
 }
 
-TEST(HasValidTypePromotion, NonNumericTypes) {
+TEST(HasValidTypePromotion, NonNumericTypes)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor non_numeric_source(ValueType::ASCII_FIXED, SizeBits::UNKNOWN_SIZE_BITS, Dimension::Dim0);
@@ -31,7 +33,8 @@ TEST(HasValidTypePromotion, NonNumericTypes) {
     EXPECT_FALSE(result.has_value());
 }
 
-TEST(HasValidTypePromotion, UintUint) {
+TEST(HasValidTypePromotion, UintUint)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::UINT, SizeBits::S16, Dimension::Dim0);
@@ -43,7 +46,8 @@ TEST(HasValidTypePromotion, UintUint) {
     ASSERT_EQ(has_valid_type_promotion(source, target_wider), target_wider);
 }
 
-TEST(HasValidTypePromotion, UintInt) {
+TEST(HasValidTypePromotion, UintInt)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::UINT, SizeBits::S16, Dimension::Dim0);
@@ -55,7 +59,8 @@ TEST(HasValidTypePromotion, UintInt) {
     ASSERT_EQ(has_valid_type_promotion(source, target_wider), target_wider);
 }
 
-TEST(HasValidTypePromotion, UintFloat) {
+TEST(HasValidTypePromotion, UintFloat)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::UINT, SizeBits::S64, Dimension::Dim0);
@@ -65,7 +70,8 @@ TEST(HasValidTypePromotion, UintFloat) {
     ASSERT_EQ(has_valid_type_promotion(source, float64), float64);
 }
 
-TEST(HasValidTypePromotion, IntUint) {
+TEST(HasValidTypePromotion, IntUint)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::INT, SizeBits::S8, Dimension::Dim0);
@@ -73,7 +79,8 @@ TEST(HasValidTypePromotion, IntUint) {
     EXPECT_FALSE(has_valid_type_promotion(source, target));
 }
 
-TEST(HasValidTypePromotion, IntInt) {
+TEST(HasValidTypePromotion, IntInt)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::INT, SizeBits::S16, Dimension::Dim0);
@@ -85,7 +92,8 @@ TEST(HasValidTypePromotion, IntInt) {
     ASSERT_EQ(has_valid_type_promotion(source, target_wider), target_wider);
 }
 
-TEST(HasValidTypePromotion, IntFloat) {
+TEST(HasValidTypePromotion, IntFloat)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::INT, SizeBits::S64, Dimension::Dim0);
@@ -95,7 +103,8 @@ TEST(HasValidTypePromotion, IntFloat) {
     ASSERT_EQ(has_valid_type_promotion(source, float64), float64);
 }
 
-TEST(HasValidTypePromotion, FloatUint) {
+TEST(HasValidTypePromotion, FloatUint)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::FLOAT, SizeBits::S32, Dimension::Dim0);
@@ -103,7 +112,8 @@ TEST(HasValidTypePromotion, FloatUint) {
     EXPECT_FALSE(has_valid_type_promotion(source, target));
 }
 
-TEST(HasValidTypePromotion, FloatInt) {
+TEST(HasValidTypePromotion, FloatInt)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor source(ValueType::FLOAT, SizeBits::S32, Dimension::Dim0);
@@ -111,7 +121,8 @@ TEST(HasValidTypePromotion, FloatInt) {
     EXPECT_FALSE(has_valid_type_promotion(source, target));
 }
 
-TEST(HasValidTypePromotion, FloatFloat) {
+TEST(HasValidTypePromotion, FloatFloat)
+{
     using namespace arcticdb;
     using namespace arcticdb::entity;
     TypeDescriptor float32(ValueType::FLOAT, SizeBits::S32, Dimension::Dim0);
@@ -120,4 +131,3 @@ TEST(HasValidTypePromotion, FloatFloat) {
     ASSERT_EQ(has_valid_type_promotion(float32, float32), float32);
     EXPECT_FALSE(has_valid_type_promotion(float64, float32));
 }
-

--- a/cpp/arcticdb/processing/test/test_set_membership.cpp
+++ b/cpp/arcticdb/processing/test/test_set_membership.cpp
@@ -13,7 +13,8 @@
 
 #include <arcticdb/processing/operation_types.hpp>
 
-TEST(SetMembership, uint64_isin_int64) {
+TEST(SetMembership, uint64_isin_int64)
+{
     using namespace arcticdb;
     uint64_t u = std::numeric_limits<uint64_t>::max();
     std::unordered_set<int64_t> iset{-1};
@@ -21,7 +22,8 @@ TEST(SetMembership, uint64_isin_int64) {
     ASSERT_FALSE(IsInOperator{}(u, iset));
 }
 
-TEST(SetMembership, int64_isin_uint64) {
+TEST(SetMembership, int64_isin_uint64)
+{
     using namespace arcticdb;
     int64_t i = -1;
     std::unordered_set<uint64_t> uset{std::numeric_limits<uint64_t>::max()};
@@ -29,7 +31,8 @@ TEST(SetMembership, int64_isin_uint64) {
     ASSERT_FALSE(IsInOperator{}(i, uset));
 }
 
-TEST(SetMembership, uint64_isnotin_int64) {
+TEST(SetMembership, uint64_isnotin_int64)
+{
     using namespace arcticdb;
     uint64_t u = std::numeric_limits<uint64_t>::max();
     std::unordered_set<int64_t> iset{-1};
@@ -37,7 +40,8 @@ TEST(SetMembership, uint64_isnotin_int64) {
     ASSERT_TRUE(IsNotInOperator{}(u, iset));
 }
 
-TEST(SetMembership, int64_isnotin_uint64) {
+TEST(SetMembership, int64_isnotin_uint64)
+{
     using namespace arcticdb;
     int64_t i = -1;
     std::unordered_set<uint64_t> uset{std::numeric_limits<uint64_t>::max()};

--- a/cpp/arcticdb/processing/test/test_signed_unsigned_comparison.cpp
+++ b/cpp/arcticdb/processing/test/test_signed_unsigned_comparison.cpp
@@ -9,7 +9,8 @@
 #include <arcticdb/processing/signed_unsigned_comparison.hpp>
 #include <limits>
 
-TEST(CompareSignedUnsigned, LessThan) {
+TEST(CompareSignedUnsigned, LessThan)
+{
     using namespace arcticdb::comparison;
 
     auto uint64_max = std::numeric_limits<uint64_t>::max();
@@ -25,7 +26,8 @@ TEST(CompareSignedUnsigned, LessThan) {
     ASSERT_EQ(less_than(int64_t{3}, uint64_t{3}), false);
 }
 
-TEST(CompareSignedUnsigned, GreaterThan) {
+TEST(CompareSignedUnsigned, GreaterThan)
+{
     using namespace arcticdb::comparison;
 
     auto uint64_max = std::numeric_limits<uint64_t>::max();
@@ -41,7 +43,8 @@ TEST(CompareSignedUnsigned, GreaterThan) {
     ASSERT_EQ(greater_than(int64_t{3}, uint64_t{3}), false);
 }
 
-TEST(CompareSignedUnsigned, LessthanEquals) {
+TEST(CompareSignedUnsigned, LessthanEquals)
+{
     using namespace arcticdb::comparison;
 
     auto uint64_max = std::numeric_limits<uint64_t>::max();
@@ -57,7 +60,8 @@ TEST(CompareSignedUnsigned, LessthanEquals) {
     ASSERT_EQ(less_than_equals(int64_t{3}, uint64_t{3}), true);
 }
 
-TEST(CompareSignedUnsigned, GreaterThanEquals) {
+TEST(CompareSignedUnsigned, GreaterThanEquals)
+{
     using namespace arcticdb::comparison;
 
     auto uint64_max = std::numeric_limits<uint64_t>::max();

--- a/cpp/arcticdb/processing/test/test_type_comparison.cpp
+++ b/cpp/arcticdb/processing/test/test_type_comparison.cpp
@@ -8,7 +8,8 @@
 #include <gtest/gtest.h>
 #include <arcticdb/entity/type_conversion.hpp>
 
-TEST(Comparisons, Simple) {
+TEST(Comparisons, Simple)
+{
     using namespace arcticdb;
 
     // double/T and T/double always become double/double

--- a/cpp/arcticdb/python/adapt_read_dataframe.hpp
+++ b/cpp/arcticdb/python/adapt_read_dataframe.hpp
@@ -12,7 +12,7 @@
 
 namespace arcticdb {
 
-inline auto adapt_read_df = [](ReadResult && ret) -> py::tuple{
+inline auto adapt_read_df = [](ReadResult&& ret) -> py::tuple {
     auto pynorm = python_util::pb_to_python(ret.norm_meta);
     auto pyuser_meta = python_util::pb_to_python(ret.user_meta);
     auto multi_key_meta = python_util::pb_to_python(ret.multi_key_meta);

--- a/cpp/arcticdb/python/arctic_version.cpp
+++ b/cpp/arcticdb/python/arctic_version.cpp
@@ -8,7 +8,8 @@
 #include <arcticdb/python/arctic_version.hpp>
 
 namespace arcticdb {
-std::string get_arcticdb_version_string() {
+std::string get_arcticdb_version_string()
+{
     return std::string("Arctic Native v0.999");
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/python/arctic_version.hpp
+++ b/cpp/arcticdb/python/arctic_version.hpp
@@ -10,5 +10,5 @@
 #include <string>
 
 namespace arcticdb {
-    std::string get_arcticdb_version_string();
+std::string get_arcticdb_version_string();
 }

--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -12,28 +12,33 @@
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
-#undef GetMessage  // defined as GetMessageA on Windows
+#undef GetMessage // defined as GetMessageA on Windows
 
 namespace arcticdb {
 
-template<typename NormalizationMetadata, typename InnerFunction, typename FieldType=google::protobuf::FieldDescriptor *>
-auto get_pandas_common_via_reflection(NormalizationMetadata norm_meta, InnerFunction &&inner_function)
--> decltype(inner_function(norm_meta, std::declval<FieldType>(), std::declval<FieldType>())) {
+template<typename NormalizationMetadata,
+    typename InnerFunction,
+    typename FieldType = google::protobuf::FieldDescriptor*>
+auto get_pandas_common_via_reflection(NormalizationMetadata norm_meta, InnerFunction&& inner_function)
+    -> decltype(inner_function(norm_meta, std::declval<FieldType>(), std::declval<FieldType>()))
+{
     try {
         if (norm_meta.input_type_case() != NormalizationMetadata::INPUT_TYPE_NOT_SET) {
             if (auto one_of = NormalizationMetadata::descriptor()->field(norm_meta.input_type_case()); one_of) {
                 log::storage().info("Inefficient NormalizationMetadata.input_type.{} access via reflection",
-                                    one_of->name());
+                    one_of->name());
                 if (auto msg_type = one_of->message_type(); msg_type) {
                     if (auto common_field = msg_type->FindFieldByName("common"); common_field) {
-                        normalization::check<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(common_field->message_type() == NormalizationMetadata::Pandas::descriptor(),
-                                    "{}.common must be Pandas", one_of->name());
+                        normalization::check<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(
+                            common_field->message_type() == NormalizationMetadata::Pandas::descriptor(),
+                            "{}.common must be Pandas",
+                            one_of->name());
                         return inner_function(norm_meta, one_of, common_field);
                     }
                 }
             }
         }
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         log::storage().info("get_common_pandas() reflection exception: {}", e.what());
     }
     log::storage().warn("New NormalizationMetadata.input_type access failure. Cannot check.");
@@ -42,118 +47,107 @@ auto get_pandas_common_via_reflection(NormalizationMetadata norm_meta, InnerFunc
 
 template<typename NormalizationMetadata>
 std::optional<std::decay_t<std::reference_wrapper<const arcticdb::proto::descriptors::NormalizationMetadata_Pandas>>>
-get_common_pandas(const NormalizationMetadata &norm_meta) {
+get_common_pandas(const NormalizationMetadata& norm_meta)
+{
     using Pandas = const arcticdb::proto::descriptors::NormalizationMetadata_Pandas;
     switch (norm_meta.input_type_case()) {
-    case NormalizationMetadata::kDf:return std::make_optional(std::reference_wrapper<Pandas>(norm_meta.df().common()));
+    case NormalizationMetadata::kDf:
+        return std::make_optional(std::reference_wrapper<Pandas>(norm_meta.df().common()));
     case NormalizationMetadata::kSeries:
-        return std::make_optional(
-            std::reference_wrapper<Pandas>(norm_meta.series().common()));
-    case NormalizationMetadata::kTs:return std::make_optional(std::reference_wrapper<Pandas>(norm_meta.ts().common()));
+        return std::make_optional(std::reference_wrapper<Pandas>(norm_meta.series().common()));
+    case NormalizationMetadata::kTs:
+        return std::make_optional(std::reference_wrapper<Pandas>(norm_meta.ts().common()));
 
     case NormalizationMetadata::kMsgPackFrame:
-    case NormalizationMetadata::kNp:return std::nullopt;
+    case NormalizationMetadata::kNp:
+        return std::nullopt;
 
     default:
-        return get_pandas_common_via_reflection(norm_meta, [](auto &norm_meta, auto one_of, auto common_field) {
-            auto &one_of_msg = norm_meta.GetReflection()->GetMessage(norm_meta, one_of);
-            auto &common_msg = one_of_msg.GetReflection()->GetMessage(one_of_msg, common_field);
+        return get_pandas_common_via_reflection(norm_meta, [](auto& norm_meta, auto one_of, auto common_field) {
+            auto& one_of_msg = norm_meta.GetReflection()->GetMessage(norm_meta, one_of);
+            auto& common_msg = one_of_msg.GetReflection()->GetMessage(one_of_msg, common_field);
             return std::make_optional(std::reference_wrapper<Pandas>(
-                *reinterpret_cast<Pandas *>(const_cast<::google::protobuf::Message *>(&common_msg))));
+                *reinterpret_cast<Pandas*>(const_cast<::google::protobuf::Message*>(&common_msg))));
         });
     }
 }
 
 template<typename NormalizationMetadata>
 std::optional<std::decay_t<std::reference_wrapper<arcticdb::proto::descriptors::NormalizationMetadata_Pandas>>>
-get_common_pandas(NormalizationMetadata
-                  &norm_meta) {
+get_common_pandas(NormalizationMetadata& norm_meta)
+{
     using Pandas = arcticdb::proto::descriptors::NormalizationMetadata_Pandas;
-    switch (norm_meta.
-        input_type_case()
-        ) {
+    switch (norm_meta.input_type_case()) {
     case NormalizationMetadata::kDf:
-        return
-            std::make_optional(std::reference_wrapper<Pandas>(*norm_meta.mutable_df()->mutable_common())
-            );
+        return std::make_optional(std::reference_wrapper<Pandas>(*norm_meta.mutable_df()->mutable_common()));
     case NormalizationMetadata::kSeries:
-        return
-            std::make_optional(std::reference_wrapper<Pandas>(*norm_meta.mutable_series()->mutable_common())
-            );
+        return std::make_optional(std::reference_wrapper<Pandas>(*norm_meta.mutable_series()->mutable_common()));
     case NormalizationMetadata::kTs:
-        return
-            std::make_optional(std::reference_wrapper<Pandas>(*norm_meta.mutable_ts()->mutable_common())
-            );
+        return std::make_optional(std::reference_wrapper<Pandas>(*norm_meta.mutable_ts()->mutable_common()));
 
     case NormalizationMetadata::kMsgPackFrame:
     case NormalizationMetadata::kNp:
-        return
-            std::nullopt;
+        return std::nullopt;
 
     default:
-        return
-            get_pandas_common_via_reflection(norm_meta,
-                 [](
-                     auto &norm_meta,
-                     auto one_of,
-                     auto common_field
-                 ) {
-                     auto &one_of_msg =
-                         norm_meta.GetReflection()->GetMessage(norm_meta, one_of);
-                     auto &common_msg =
-                         one_of_msg.GetReflection()->GetMessage(one_of_msg, common_field);
-                     return
-                         std::make_optional
-                             (std::reference_wrapper<Pandas>(*reinterpret_cast<Pandas *>(const_cast<::google::protobuf::Message *>(&common_msg)))
-                             );
-                 }
-            );
+        return get_pandas_common_via_reflection(norm_meta, [](auto& norm_meta, auto one_of, auto common_field) {
+            auto& one_of_msg = norm_meta.GetReflection()->GetMessage(norm_meta, one_of);
+            auto& common_msg = one_of_msg.GetReflection()->GetMessage(one_of_msg, common_field);
+            return std::make_optional(std::reference_wrapper<Pandas>(
+                *reinterpret_cast<Pandas*>(const_cast<::google::protobuf::Message*>(&common_msg))));
+        });
     }
 }
 
 template<class NormalizationMetadata>
 bool check_pandas_like(bool is_append,
-                       const NormalizationMetadata &old_norm,
-                       NormalizationMetadata &new_norm,
-                       size_t old_length) {
+    const NormalizationMetadata& old_norm,
+    NormalizationMetadata& new_norm,
+    size_t old_length)
+{
     auto old_pandas = get_common_pandas(old_norm);
     auto new_pandas = get_common_pandas(new_norm);
     if (old_pandas || new_pandas) {
         normalization::check<ErrorCode::E_UPDATE_NOT_SUPPORTED>(old_pandas && new_pandas,
-                        "Currently only supports modifying existing Pandas data with Pandas.\nexisting={}\nargument={}",
-                        util::newlines_to_spaces(old_norm),
-                        util::newlines_to_spaces(new_norm));
+            "Currently only supports modifying existing Pandas data with Pandas.\nexisting={}\nargument={}",
+            util::newlines_to_spaces(old_norm),
+            util::newlines_to_spaces(new_norm));
 
-        const auto *old_index = old_pandas->get().has_index() ? &old_pandas->get().index() : nullptr;
-        const auto *new_index = new_pandas->get().has_index() ? &new_pandas->get().index() : nullptr;
-        normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(static_cast<bool>(old_index) == static_cast<bool>(new_index),
-                        "The argument has an index type incompatible with the existing version:\nexisting={}\nargument={}",
-                        util::newlines_to_spaces(old_norm),
-                        util::newlines_to_spaces(new_norm));
+        const auto* old_index = old_pandas->get().has_index() ? &old_pandas->get().index() : nullptr;
+        const auto* new_index = new_pandas->get().has_index() ? &new_pandas->get().index() : nullptr;
+        normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(static_cast<bool>(old_index) ==
+                                                                  static_cast<bool>(new_index),
+            "The argument has an index type incompatible with the existing version:\nexisting={}\nargument={}",
+            util::newlines_to_spaces(old_norm),
+            util::newlines_to_spaces(new_norm));
 
         if (old_index) {
-            constexpr auto
-                error_suffix = " the existing version. Please convert both to use Int64Index if you need this to work.";
-            normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(old_index->is_not_range_index() == new_index->is_not_range_index(),
-                            "The argument uses a {} index which is incompatible with {}",
-                            new_index->is_not_range_index() ? "non-range" : "range-style", error_suffix);
+            constexpr auto error_suffix =
+                " the existing version. Please convert both to use Int64Index if you need this to work.";
+            normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(old_index->is_not_range_index() ==
+                                                                      new_index->is_not_range_index(),
+                "The argument uses a {} index which is incompatible with {}",
+                new_index->is_not_range_index() ? "non-range" : "range-style",
+                error_suffix);
 
             if (!old_index->is_not_range_index()) {
                 normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(old_index->step() == new_index->step(),
-                                "The new argument has a different RangeIndex step from {}", error_suffix);
+                    "The new argument has a different RangeIndex step from {}",
+                    error_suffix);
 
                 size_t new_start = new_index->start();
                 if (new_start != 0) {
                     auto stop = old_index->start() + old_length * old_index->step();
                     normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(new_start == stop,
-                                    "The appending data has a RangeIndex.start={} that is not contiguous with the {}"
-                                    "stop ({}) of",
-                                    error_suffix,
-                                    new_start,
-                                    stop);
+                        "The appending data has a RangeIndex.start={} that is not contiguous with the {}"
+                        "stop ({}) of",
+                        error_suffix,
+                        new_start,
+                        stop);
                 }
 
-                normalization::check<ErrorCode::E_UPDATE_NOT_SUPPORTED>(is_append, "update() on ROWCOUNT index is not implemented");
+                normalization::check<ErrorCode::E_UPDATE_NOT_SUPPORTED>(is_append,
+                    "update() on ROWCOUNT index is not implemented");
                 new_pandas->get().mutable_index()->set_start(old_index->start());
             }
         }
@@ -165,7 +159,8 @@ bool check_pandas_like(bool is_append,
     return false;
 }
 
-size_t product(const google::protobuf::RepeatedField<size_t> &shape) {
+size_t product(const google::protobuf::RepeatedField<size_t>& shape)
+{
     // FUTURE: use std::reduce when our libc++ implements it
     size_t out = 1;
     for (auto i : shape)
@@ -174,28 +169,31 @@ size_t product(const google::protobuf::RepeatedField<size_t> &shape) {
 }
 
 template<class NormalizationMetadata>
-bool check_ndarray_append(const NormalizationMetadata &old_norm, NormalizationMetadata &new_norm) {
+bool check_ndarray_append(const NormalizationMetadata& old_norm, NormalizationMetadata& new_norm)
+{
     if (old_norm.has_np() || new_norm.has_np()) {
         normalization::check<ErrorCode::E_INCOMPATIBLE_OBJECTS>(old_norm.has_np() && new_norm.has_np(),
-                        "Currently, can only append numpy.ndarray to each other.");
+            "Currently, can only append numpy.ndarray to each other.");
 
-        const auto &old_shape = old_norm.np().shape();
-        auto *new_shape = new_norm.mutable_np()->mutable_shape();
-        normalization::check<ErrorCode::E_WRONG_SHAPE>(!new_shape->empty(), "Append input has invalid normalization metadata (empty shape)");
-        normalization::check<ErrorCode::E_WRONG_SHAPE>(std::equal(old_shape.begin() + 1, old_shape.end(), new_shape->begin() + 1, new_shape->end()),
-                        "The appending NDArray must have the same shape as the existing (excl. the first dimension)");
+        const auto& old_shape = old_norm.np().shape();
+        auto* new_shape = new_norm.mutable_np()->mutable_shape();
+        normalization::check<ErrorCode::E_WRONG_SHAPE>(!new_shape->empty(),
+            "Append input has invalid normalization metadata (empty shape)");
+        normalization::check<ErrorCode::E_WRONG_SHAPE>(
+            std::equal(old_shape.begin() + 1, old_shape.end(), new_shape->begin() + 1, new_shape->end()),
+            "The appending NDArray must have the same shape as the existing (excl. the first dimension)");
         (*new_shape)[0] += old_shape[0];
         return true;
     }
     return false;
 }
 
-void fix_normalization_or_throw(
-    bool is_append,
-    const pipelines::index::IndexSegmentReader &existing_isr,
-    const pipelines::InputTensorFrame &new_frame) {
-    auto &old_norm = existing_isr.tsd().normalization();
-    auto &new_norm = new_frame.norm_meta;
+void fix_normalization_or_throw(bool is_append,
+    const pipelines::index::IndexSegmentReader& existing_isr,
+    const pipelines::InputTensorFrame& new_frame)
+{
+    auto& old_norm = existing_isr.tsd().normalization();
+    auto& new_norm = new_frame.norm_meta;
 
     if (check_pandas_like(is_append, old_norm, new_norm, existing_isr.tsd().total_rows()))
         return;
@@ -205,7 +203,7 @@ void fix_normalization_or_throw(
     } else {
         // ndarray normalizes to a ROWCOUNT frame and we don't support update on those
         normalization::check<ErrorCode::E_UPDATE_NOT_SUPPORTED>(!old_norm.has_np() && !new_norm.has_np(),
-                        "current normalization scheme doesn't allow update of ndarray");
+            "current normalization scheme doesn't allow update of ndarray");
     }
 }
 

--- a/cpp/arcticdb/python/normalization_checks.hpp
+++ b/cpp/arcticdb/python/normalization_checks.hpp
@@ -17,14 +17,13 @@ namespace pipelines {
 struct InputTensorFrame;
 namespace index {
 struct IndexSegmentReader;
-} //namespace pipelines::index
+} // namespace index
 } // namespace pipelines
 
 /**
  * The new frame for append/update is compatible with the existing index. Throws various exceptions if not.
  */
-void fix_normalization_or_throw(
-    bool is_append,
-    const pipelines::index::IndexSegmentReader &existing_isr,
-    const pipelines::InputTensorFrame &new_frame);
+void fix_normalization_or_throw(bool is_append,
+    const pipelines::index::IndexSegmentReader& existing_isr,
+    const pipelines::InputTensorFrame& new_frame);
 } // namespace arcticdb

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -5,7 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-
 #include <arcticdb/python/python_to_tensor_frame.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
@@ -19,12 +18,14 @@ namespace arcticdb::convert {
 
 using namespace arcticdb::pipelines;
 
-bool is_unicode(PyObject *obj) {
+bool is_unicode(PyObject* obj)
+{
     return PyUnicode_Check(obj);
 }
 
-PyStringWrapper pystring_to_buffer(PyObject *obj, py::handle handle) {
-    char *buffer;
+PyStringWrapper pystring_to_buffer(PyObject* obj, py::handle handle)
+{
+    char* buffer;
     ssize_t length;
     util::check(!is_unicode(obj), "Unexpected unicode object");
     if (PYBIND11_BYTES_AS_STRING_AND_SIZE(obj, &buffer, &length))
@@ -33,7 +34,8 @@ PyStringWrapper pystring_to_buffer(PyObject *obj, py::handle handle) {
     return {buffer, length, handle};
 }
 
-PyStringWrapper py_unicode_to_buffer(PyObject *obj) {
+PyStringWrapper py_unicode_to_buffer(PyObject* obj)
+{
     if (is_unicode(obj)) {
         py::handle handle{PyUnicode_AsUTF8String(obj)};
         if (!handle)
@@ -44,8 +46,9 @@ PyStringWrapper py_unicode_to_buffer(PyObject *obj) {
     }
 }
 
-NativeTensor obj_to_tensor(PyObject *ptr) {
-//    ARCTICDB_SAMPLE(ObjToTensor, RMTSF_Aggregate)
+NativeTensor obj_to_tensor(PyObject* ptr)
+{
+    //    ARCTICDB_SAMPLE(ObjToTensor, RMTSF_Aggregate)
     auto& api = pybind11::detail::npy_api::get();
     util::check(api.PyArray_Check_(ptr), "Expected Python array");
     auto arr = pybind11::detail::array_proxy(ptr);
@@ -65,9 +68,9 @@ NativeTensor obj_to_tensor(PyObject *ptr) {
         // otherwise try to work out whether it was a bytes (string) type or unicode
         if (!is_fixed_string_type(val_type) && size > 0) {
             auto none = py::none{};
-            auto obj = reinterpret_cast<PyObject **>(arr->data);
+            auto obj = reinterpret_cast<PyObject**>(arr->data);
             bool empty = false;
-            PyObject *sample = *obj;
+            PyObject* sample = *obj;
             if (sample == none.ptr() || is_py_nan(sample)) {
                 // Iterate till we find the first non null element, the frontend ensures there is at least one.
                 util::check(c_style, "Non contiguous columns with first element as None not supported yet.");
@@ -88,11 +91,11 @@ NativeTensor obj_to_tensor(PyObject *ptr) {
     return {nbytes, ndim, arr->strides, arr->dimensions, dt, descr->elsize, arr->data};
 }
 
-InputTensorFrame py_ndf_to_frame(
-    const StreamId& stream_name,
-    const py::tuple &item,
-    const py::object &norm_meta,
-    const py::object &user_meta) {
+InputTensorFrame py_ndf_to_frame(const StreamId& stream_name,
+    const py::tuple& item,
+    const py::object& norm_meta,
+    const py::object& user_meta)
+{
     ARCTICDB_SUBSAMPLE_DEFAULT(NormalizeFrame)
     InputTensorFrame res;
     res.desc.set_id(stream_name);
@@ -105,8 +108,9 @@ InputTensorFrame py_ndf_to_frame(
     auto idx_names = item[0].cast<std::vector<std::string>>();
     auto idx_vals = item[2].cast<std::vector<py::object>>();
     util::check(idx_names.size() == idx_vals.size(),
-                "Number idx names {} and values {} do not match",
-                idx_names.size(), idx_vals.size());
+        "Number idx names {} and values {} do not match",
+        idx_names.size(),
+        idx_vals.size());
 
     if (idx_names.empty()) {
         res.index = stream::RowCountIndex();

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -18,34 +18,33 @@ namespace py = pybind11;
 using namespace arcticdb::entity;
 
 struct ARCTICDB_VISIBILITY_HIDDEN PyStringWrapper {
-    char *buffer_;
+    char* buffer_;
     size_t length_;
     py::handle handle_;
 
-    PyStringWrapper(char *buf, ssize_t len, py::handle handle) :
-        buffer_(buf),
-        length_(size_t(len)),
-        handle_(handle) {}
+    PyStringWrapper(char* buf, ssize_t len, py::handle handle)
+        : buffer_(buf),
+          length_(size_t(len)),
+          handle_(handle)
+    {
+    }
 
-    ~PyStringWrapper() {
+    ~PyStringWrapper()
+    {
         if (handle_)
             handle_.dec_ref();
     }
 };
 
-PyStringWrapper pystring_to_buffer(
-    PyObject *obj,
-    py::handle handle = py::handle());
+PyStringWrapper pystring_to_buffer(PyObject* obj, py::handle handle = py::handle());
 
-PyStringWrapper py_unicode_to_buffer(
-    PyObject *obj);
+PyStringWrapper py_unicode_to_buffer(PyObject* obj);
 
-NativeTensor obj_to_tensor(PyObject *ptr);
+NativeTensor obj_to_tensor(PyObject* ptr);
 
-pipelines::InputTensorFrame py_ndf_to_frame(
-    const StreamId& stream_name,
-    const py::tuple &item,
-    const py::object &norm_meta,
-    const py::object &user_meta);
+pipelines::InputTensorFrame py_ndf_to_frame(const StreamId& stream_name,
+    const py::tuple& item,
+    const py::object& norm_meta,
+    const py::object& user_meta);
 
 } // namespace arcticdb::convert

--- a/cpp/arcticdb/python/python_types.hpp
+++ b/cpp/arcticdb/python/python_types.hpp
@@ -21,11 +21,13 @@ namespace arcticdb {
 using namespace arcticdb::entity;
 
 template<typename T>
-void print_iterable(std::string_view key, const T &vals) {
+void print_iterable(std::string_view key, const T& vals)
+{
     fmt::print("{}=[{}]\n", key, vals);
 }
 
-inline void print_buffer_info(py::buffer &buf) {
+inline void print_buffer_info(py::buffer& buf)
+{
     auto info{buf.request()};
     py::dtype dtype(info);
 
@@ -34,24 +36,27 @@ inline void print_buffer_info(py::buffer &buf) {
     print_iterable("strides", info.strides);
 }
 
-inline std::string get_format_specifier(DataType dt) {
+inline std::string get_format_specifier(DataType dt)
+{
     return details::visit_type(dt,
-                               [&](auto DTT) { return py::format_descriptor<typename decltype(DTT)::raw_type>::format(); });
+        [&](auto DTT) { return py::format_descriptor<typename decltype(DTT)::raw_type>::format(); });
 }
 
-
 // Python adaptor functions
-inline DataType get_buffer_type(py::dtype &dtype) {
+inline DataType get_buffer_type(py::dtype& dtype)
+{
     // enumerated sizes go 1,2,4,8 so the offset in sizebits is the binary log of itemsize + 1
     return get_data_type(dtype.kind(), SizeBits(static_cast<uint8_t>(log2(dtype.itemsize()) + 1.5)));
 };
 
-inline TypeDescriptor get_type_descriptor(py::buffer_info &info) {
+inline TypeDescriptor get_type_descriptor(py::buffer_info& info)
+{
     py::dtype dtype(info);
     return TypeDescriptor(get_buffer_type(dtype), as_dim_checked(uint8_t(info.ndim)));
 }
 
-inline bool is_py_nan(PyObject* obj) {
+inline bool is_py_nan(PyObject* obj)
+{
     if (PyFloat_Check(obj)) {
         auto val = PyFloat_AsDouble(obj);
         return std::isnan(val);
@@ -59,5 +64,4 @@ inline bool is_py_nan(PyObject* obj) {
     return false;
 }
 
-}
-
+} // namespace arcticdb

--- a/cpp/arcticdb/python/python_utils.hpp
+++ b/cpp/arcticdb/python/python_utils.hpp
@@ -23,28 +23,33 @@ namespace arcticdb::python_util {
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;
 
-template<class C, class...Args>
-auto shptr_class(Args...args) {
+template<class C, class... Args>
+auto shptr_class(Args... args)
+{
     return py::class_<C, std::shared_ptr<C>>(std::forward<Args>(args)...);
 }
 
 class ARCTICDB_VISIBILITY_HIDDEN PyRowRef : public py::tuple {
-  public:
-  PYBIND11_OBJECT_DEFAULT(PyRowRef, py::tuple, PyTuple_Check)
+public:
+    PYBIND11_OBJECT_DEFAULT(PyRowRef, py::tuple, PyTuple_Check)
 
-    PyRowRef(RowRef row_ref) : py::tuple(row_ref.col_count()), row_ref_(row_ref) {
+    PyRowRef(RowRef row_ref)
+        : py::tuple(row_ref.col_count()),
+          row_ref_(row_ref)
+    {
         // tuple is still mutable while ref count is 1
         py::list res;
-        auto &segment = row_ref_.segment();
+        auto& segment = row_ref_.segment();
         segment.check_magic();
         auto row_pos_ = row_ref_.row_pos();
         for (std::size_t col = 0; col < segment.num_columns(); ++col) {
-            visit_field(segment.column_descriptor(col), [&](auto &&impl) {
-                using T= std::decay_t<decltype(impl)>;
+            visit_field(segment.column_descriptor(col), [&](auto&& impl) {
+                using T = std::decay_t<decltype(impl)>;
                 using RawType = typename T::DataTypeTag::raw_type;
                 if constexpr (T::DimensionTag::value == Dimension::Dim0) {
-                    if constexpr (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64
-                        || T::DataTypeTag::data_type == DataType::ASCII_FIXED64) {
+                    if constexpr (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64 ||
+                                  T::DataTypeTag::data_type == DataType::ASCII_FIXED64)
+                    {
                         set_col(col, segment.string_at(row_pos_, col).value());
                     } else {
                         set_col(col, segment.scalar_at<RawType>(row_pos_, col).value()); // TODO handle sparse
@@ -63,7 +68,7 @@ class ARCTICDB_VISIBILITY_HIDDEN PyRowRef : public py::tuple {
                         set_col(col, output);
                     } else {
                         auto opt_tensor = segment.tensor_at<RawType>(row_pos_, col);
-                        if(opt_tensor.has_value()){
+                        if (opt_tensor.has_value()) {
                             set_col(col, to_py_array(opt_tensor.value()));
                         }
                     }
@@ -72,40 +77,41 @@ class ARCTICDB_VISIBILITY_HIDDEN PyRowRef : public py::tuple {
         }
     }
 
-  private:
-    std::string_view view_at(OffsetString::offset_t o) {
+private:
+    std::string_view view_at(OffsetString::offset_t o)
+    {
         return row_ref_.segment().string_pool().get_view(o);
     }
 
-    static py::buffer_info from_string_array(const Column::StringArrayData &data) {
+    static py::buffer_info from_string_array(const Column::StringArrayData& data)
+    {
         std::vector<ssize_t> shapes{data.num_strings_};
         std::vector<ssize_t> strides{data.string_size_};
 
-        return py::buffer_info{
-            (void *) data.data_,
+        return py::buffer_info{(void*)data.data_,
             data.string_size_,
             std::string(fmt::format("{}{}", data.string_size_, 's')),
             ssize_t(Dimension::Dim1),
             shapes,
-            strides
-        };
+            strides};
     }
     template<class O>
-    void set_col(std::size_t col, O &&o) {
+    void set_col(std::size_t col, O&& o)
+    {
         (*this)[col] = std::forward<O>(o);
     }
 
     RowRef row_ref_;
-
 };
 
 template<typename Msg>
-py::object pb_to_python(const Msg & out){
+py::object pb_to_python(const Msg& out)
+{
     std::string_view full_name = out.descriptor()->full_name();
-    auto & name = out.descriptor()->name();
+    auto& name = out.descriptor()->name();
     std::string_view pkg_name = full_name.substr(0, full_name.size() - name.size());
-    if(pkg_name[pkg_name.size()-1] == '.'){
-        pkg_name = pkg_name.substr(0, pkg_name.size()-1);
+    if (pkg_name[pkg_name.size() - 1] == '.') {
+        pkg_name = pkg_name.substr(0, pkg_name.size() - 1);
     }
 
     auto py_pkg_obj = py::module::import(std::string(pkg_name).data());
@@ -118,7 +124,8 @@ py::object pb_to_python(const Msg & out){
 }
 
 template<typename Msg>
-void pb_from_python(const py::object & py_msg, Msg & out){
+void pb_from_python(const py::object& py_msg, Msg& out)
+{
     std::string s = py_msg.attr("SerializeToString")().cast<std::string>();
     out.ParseFromString(s);
 }
@@ -130,19 +137,20 @@ void pb_from_python(const py::object & py_msg, Msg & out){
  * @return the reference passed in (to support fluent like api)
  */
 template<class PyClass>
-PyClass & add_repr(PyClass & py_class){
-    py_class.def("__repr__",[](const typename PyClass::type & a){
-        return fmt::format("{}", a);
-    });
+PyClass& add_repr(PyClass& py_class)
+{
+    py_class.def("__repr__", [](const typename PyClass::type& a) { return fmt::format("{}", a); });
     return py_class;
 }
 
-inline py::object &pd_Timestamp() {
+inline py::object& pd_Timestamp()
+{
     static py::object T = py::module::import("pandas").attr("Timestamp");
     return T;
 }
 
-inline bool from_pd_timestamp(const py::object &o, timestamp &ts) {
+inline bool from_pd_timestamp(const py::object& o, timestamp& ts)
+{
     if (py::isinstance(o, pd_Timestamp())) {
         ts = o.attr("value").cast<timestamp>();
         return true;
@@ -151,12 +159,14 @@ inline bool from_pd_timestamp(const py::object &o, timestamp &ts) {
     return false;
 }
 
-inline py::object &dt_datetime() {
+inline py::object& dt_datetime()
+{
     static py::object T = py::module::import("datetime").attr("datetime");
     return T;
 }
 
-inline bool from_datetime(const py::object &o, timestamp &ts) {
+inline bool from_datetime(const py::object& o, timestamp& ts)
+{
     if (py::isinstance(o, dt_datetime())) {
         auto pd_ts = pd_Timestamp()(o);
         return from_pd_timestamp(pd_ts, ts);
@@ -164,12 +174,14 @@ inline bool from_datetime(const py::object &o, timestamp &ts) {
     return false;
 }
 
-inline py::object &np_datetime64() {
+inline py::object& np_datetime64()
+{
     static py::object T = py::module::import("numpy").attr("datetime64");
     return T;
 }
 
-inline bool from_dt64(const py::object &o, timestamp &ts) {
+inline bool from_dt64(const py::object& o, timestamp& ts)
+{
     if (py::isinstance(o, np_datetime64())) {
         ts = o.attr("astype")("datetime64[ns]").attr("astype")("uint64").cast<timestamp>();
         return true;
@@ -177,29 +189,42 @@ inline bool from_dt64(const py::object &o, timestamp &ts) {
     return false;
 }
 
-inline timestamp py_convert_type(const py::object &convertible) {
+inline timestamp py_convert_type(const py::object& convertible)
+{
     timestamp ts = 0;
-    if (from_dt64(convertible, ts)) return ts;
-    if (from_pd_timestamp(convertible, ts)) return ts;
-    if (from_datetime(convertible, ts)) return ts;
+    if (from_dt64(convertible, ts))
+        return ts;
+    if (from_pd_timestamp(convertible, ts))
+        return ts;
+    if (from_datetime(convertible, ts))
+        return ts;
     return convertible.cast<timestamp>();
 }
 
 class PyTimestampRange {
-  public:
-    PyTimestampRange(const py::object &start, const py::object &end) :
-        start_(py_convert_type(start)), end_(py_convert_type(end)) {
+public:
+    PyTimestampRange(const py::object& start, const py::object& end)
+        : start_(py_convert_type(start)),
+          end_(py_convert_type(end))
+    {
         util::check_arg(start_ <= end_, "expected star <= end, actual {}, {}", start_, end_);
     }
 
-    operator entity::TimestampRange() const {
+    operator entity::TimestampRange() const
+    {
         return {start_, end_};
     }
 
-    timestamp start_nanos_utc() const { return start_; }
-    timestamp end_nanos_utc() const { return end_; }
+    timestamp start_nanos_utc() const
+    {
+        return start_;
+    }
+    timestamp end_nanos_utc() const
+    {
+        return end_;
+    }
 
-  private:
+private:
     timestamp start_;
     timestamp end_;
 };

--- a/cpp/arcticdb/python/reader.hpp
+++ b/cpp/arcticdb/python/reader.hpp
@@ -15,51 +15,53 @@
 //TODO this class is bogus and not part of the long-term plan. If it's only used for
 // testing and the toolbox then move it, otherwise get rid of it
 
-namespace  py = pybind11;
+namespace py = pybind11;
 
 namespace arcticdb {
 
 class TickReader {
 public:
-
     TickReader() = default;
 
-    void add_segment(SegmentInMemory &segment) {
+    void add_segment(SegmentInMemory& segment)
+    {
         segment_ = std::move(segment);
     }
 
-    [[nodiscard]] size_t row_count() const {
+    [[nodiscard]] size_t row_count() const
+    {
         return segment_.row_count();
     }
 
-    std::string_view view_at(OffsetString::offset_t o) {
+    std::string_view view_at(OffsetString::offset_t o)
+    {
         return segment_.string_pool().get_view(o);
     }
 
-    py::buffer_info from_string_array( const Column::StringArrayData& data) const
+    py::buffer_info from_string_array(const Column::StringArrayData& data) const
     {
-        std::vector<ssize_t> shapes { data.num_strings_};
-        std::vector<ssize_t> strides { data.string_size_ };
+        std::vector<ssize_t> shapes{data.num_strings_};
+        std::vector<ssize_t> strides{data.string_size_};
 
-        return py::buffer_info {
-                (void *) data.data_,
-                data.string_size_,
-                std::string(fmt::format("{}{}", data.string_size_, 's')),
-                ssize_t(Dimension::Dim1),
-                shapes,
-                strides
-        };
+        return py::buffer_info{(void*)data.data_,
+            data.string_size_,
+            std::string(fmt::format("{}{}", data.string_size_, 's')),
+            ssize_t(Dimension::Dim1),
+            shapes,
+            strides};
     }
 
-    py::tuple at(size_t row) {
+    py::tuple at(size_t row)
+    {
         py::list res;
-        for (std::size_t  col= 0; col < segment_.num_columns(); ++col) {
+        for (std::size_t col = 0; col < segment_.num_columns(); ++col) {
             auto type_desc = type_desc_from_proto(segment_.column_descriptor(col).type_desc());
-            type_desc.visit_tag([&](auto && impl){
-                using T= std::decay_t<decltype(impl)>;
+            type_desc.visit_tag([&](auto&& impl) {
+                using T = std::decay_t<decltype(impl)>;
                 using RawType = typename T::DataTypeTag::raw_type;
-                if constexpr (T::DimensionTag::value == Dimension::Dim0){
-                    if constexpr (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64 || T::DataTypeTag::data_type == DataType::ASCII_FIXED64)
+                if constexpr (T::DimensionTag::value == Dimension::Dim0) {
+                    if constexpr (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64 ||
+                                  T::DataTypeTag::data_type == DataType::ASCII_FIXED64)
                     {
                         auto str = segment_.string_at(row, col).value();
                         res.append(str);
@@ -68,21 +70,17 @@ public:
                         res.append(v);
                     }
                 } else {
-                    if (T::DataTypeTag::data_type == DataType::ASCII_FIXED64)
-                    {
+                    if (T::DataTypeTag::data_type == DataType::ASCII_FIXED64) {
                         auto str_arr = segment_.string_array_at(row, col).value();
                         res.append(py::array(from_string_array(str_arr)));
-                    }
-                    else if (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64)
-                    {
+                    } else if (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64) {
                         auto string_refs = segment_.tensor_at<OffsetString::offset_t>(row, col).value();
-                        std::vector<std::string_view > output;
-                        for(ssize_t i = 0; i < string_refs.size(); ++i )
+                        std::vector<std::string_view> output;
+                        for (ssize_t i = 0; i < string_refs.size(); ++i)
                             output.push_back(view_at(string_refs.at(i)));
 
                         res.append(output);
-                    }
-                    else
+                    } else
                         res.append(to_py_array(segment_.tensor_at<RawType>(row, col).value()));
                 }
             });
@@ -95,4 +93,4 @@ private:
     SegmentInMemory segment_;
 };
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -17,14 +17,13 @@
 
 namespace arcticdb::storage {
 
-
-struct EnvironmentNameTag{};
+struct EnvironmentNameTag {};
 using EnvironmentName = util::StringWrappingValue<EnvironmentNameTag>;
 
-struct StorageNameTag{};
+struct StorageNameTag {};
 using StorageName = util::StringWrappingValue<StorageNameTag>;
 
-struct InstanceUriTag{};
+struct InstanceUriTag {};
 using InstanceUri = util::StringWrappingValue<InstanceUriTag>;
 
 /*
@@ -38,26 +37,26 @@ struct LibraryDescriptor {
     std::string description_;
     std::vector<StorageName> storage_ids_;
 
-    using VariantStoreConfig = std::variant<
-            std::monostate, //  make variant default constructible and unconfigured
-            arcticdb::proto::storage::VersionStoreConfig
-     >;
+    using VariantStoreConfig = std::variant<std::monostate, //  make variant default constructible and unconfigured
+        arcticdb::proto::storage::VersionStoreConfig>;
 
-     VariantStoreConfig config_ = std::monostate{};
+    VariantStoreConfig config_ = std::monostate{};
 };
 
-inline std::vector<char> stream_to_vector(std::vector<char> &src) {
+inline std::vector<char> stream_to_vector(std::vector<char>& src)
+{
     return src;
 }
 
-inline size_t get_stream_length(std::iostream& src) {
+inline size_t get_stream_length(std::iostream& src)
+{
     src.seekg(0, std::ios::end);
     auto len = src.tellg();
     src.seekg(0, std::ios::beg);
     return static_cast<size_t>(len);
 }
 
-inline std::vector<char> stream_to_vector(std::iostream &src)
+inline std::vector<char> stream_to_vector(std::iostream& src)
 {
     ARCTICDB_SAMPLE(StreamToVector, 0)
     auto len = get_stream_length(src);
@@ -66,12 +65,13 @@ inline std::vector<char> stream_to_vector(std::iostream &src)
     return v;
 }
 
-inline void vector_to_stream(std::vector<char>& src, std::stringstream& output) {
+inline void vector_to_stream(std::vector<char>& src, std::stringstream& output)
+{
     output.write(src.data(), src.size());
 }
 
 template<typename T>
-struct is_key_type :  std::false_type {};
+struct is_key_type : std::false_type {};
 
 template<>
 struct is_key_type<entity::AtomKey> : std::true_type {};
@@ -82,8 +82,7 @@ struct is_key_type<entity::RefKey> : std::true_type {};
 template<>
 struct is_key_type<entity::VariantKey> : std::true_type {};
 
-template <typename T>
+template<typename T>
 inline constexpr bool is_key_type_v = is_key_type<T>::value;
 
-}  //namespace arcticdb::storage
-
+} //namespace arcticdb::storage

--- a/cpp/arcticdb/storage/config_cache.hpp
+++ b/cpp/arcticdb/storage/config_cache.hpp
@@ -21,13 +21,17 @@ namespace arcticdb::storage {
 
 //TODO cache invalidation
 class ConfigCache {
-  public:
-    ConfigCache(const EnvironmentName &environment_name, const std::shared_ptr<ConfigResolver> &resolver) :
-        environment_name_(environment_name), descriptor_map_(), config_resolver_(resolver) {
+public:
+    ConfigCache(const EnvironmentName& environment_name, const std::shared_ptr<ConfigResolver>& resolver)
+        : environment_name_(environment_name),
+          descriptor_map_(),
+          config_resolver_(resolver)
+    {
         refresh_config();
     }
 
-    std::optional<LibraryDescriptor> get_descriptor(const LibraryPath &path) {
+    std::optional<LibraryDescriptor> get_descriptor(const LibraryPath& path)
+    {
         std::lock_guard<std::mutex> lock{mutex_};
         auto descriptor = descriptor_map_.find(path);
         if (descriptor == descriptor_map_.end())
@@ -36,31 +40,36 @@ class ConfigCache {
         return descriptor->second;
     }
 
-    bool library_exists(const LibraryPath &path) const {
+    bool library_exists(const LibraryPath& path) const
+    {
         std::lock_guard<std::mutex> lock{mutex_};
         return descriptor_map_.find(path) != descriptor_map_.end();
     }
 
-    void add_library_config(const LibraryPath &path, const arcticdb::proto::storage::LibraryConfig lib_cfg) {
+    void add_library_config(const LibraryPath& path, const arcticdb::proto::storage::LibraryConfig lib_cfg)
+    {
         add_library(path, decode_library_descriptor(lib_cfg.lib_desc()));
-        for(const auto& storage: lib_cfg.storage_by_id())
+        for (const auto& storage : lib_cfg.storage_by_id())
             add_storage(StorageName{storage.first}, storage.second);
     }
 
-    void add_library(const LibraryPath &path, const LibraryDescriptor &desc) {
+    void add_library(const LibraryPath& path, const LibraryDescriptor& desc)
+    {
         config_resolver_->add_library(environment_name_, encode_library_descriptor(desc));
         std::lock_guard<std::mutex> lock{mutex_};
         descriptor_map_.emplace(path, desc);
     }
 
-    void add_storage(const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage storage) {
+    void add_storage(const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage storage)
+    {
         config_resolver_->add_storage(environment_name_, storage_name, storage);
     }
 
-    std::vector<LibraryPath> list_libraries(const std::string_view &prefix) {
+    std::vector<LibraryPath> list_libraries(const std::string_view& prefix)
+    {
         std::lock_guard<std::mutex> lock{mutex_};
         std::vector<LibraryPath> res;
-        for (auto &[lib, _] : descriptor_map_) {
+        for (auto& [lib, _] : descriptor_map_) {
             auto l = lib.to_delim_path();
             if (l.find(prefix) != std::string::npos) {
                 res.push_back(lib);
@@ -70,12 +79,13 @@ class ConfigCache {
         return res;
     }
 
-    std::shared_ptr<Storages> create_storages(const LibraryPath &path, OpenMode mode) {
+    std::shared_ptr<Storages> create_storages(const LibraryPath& path, OpenMode mode)
+    {
         auto maybe_descriptor = get_descriptor(path);
         if (!maybe_descriptor.has_value())
             throw std::runtime_error(fmt::format("Library {} not found", path));
 
-        auto &descriptor = maybe_descriptor.value();
+        auto& descriptor = maybe_descriptor.value();
 
         util::check(!descriptor.storage_ids_.empty(), "Can't configure library with no storage ids");
         std::vector<std::unique_ptr<VariantStorage>> variants;
@@ -86,8 +96,9 @@ class ConfigCache {
         return std::make_shared<Storages>(std::move(variants), mode);
     }
 
-  private:
-    void refresh_config() {
+private:
+    void refresh_config()
+    {
         std::lock_guard<std::mutex> lock{mutex_};
         descriptor_map_.clear();
         storage_configs_.clear();
@@ -97,11 +108,11 @@ class ConfigCache {
             descriptor_map_.emplace(library_path, decode_library_descriptor(descriptor));
         }
         auto storages = config_resolver_->get_storages(environment_name_);
-        for(auto& [storage_name, config] : storages) {
+        for (auto& [storage_name, config] : storages) {
             storage_configs_.emplace(StorageName(storage_name), config);
         }
         auto default_storages = config_resolver_->get_default_storages(environment_name_);
-        for(auto& [storage_name, config] : default_storages) {
+        for (auto& [storage_name, config] : default_storages) {
             if (storage_configs_.find(storage_name) == storage_configs_.end()) {
                 config_resolver_->add_storage(environment_name_, storage_name, config);
                 storage_configs_.emplace(StorageName(storage_name), config);
@@ -109,7 +120,8 @@ class ConfigCache {
         }
     }
 
-    std::shared_ptr<VariantStorageFactory> get_storage_factory_internal(const StorageName &storage_name) {
+    std::shared_ptr<VariantStorageFactory> get_storage_factory_internal(const StorageName& storage_name)
+    {
         //See if we have previously cached the factory
         auto factory_it = storage_factories_.find(storage_name);
         if (factory_it != storage_factories_.end())
@@ -117,26 +129,26 @@ class ConfigCache {
 
         //Otherwise see if we have the storage config
         auto storage_conf = storage_configs_.find(storage_name);
-        if(storage_conf != storage_configs_.end())
+        if (storage_conf != storage_configs_.end())
             return create_storage_factory(storage_conf->second);
-
 
         //As a last resort, get the whole environment config from the resolver
         refresh_config();
         storage_conf = storage_configs_.find(storage_name);
-        if(storage_conf != storage_configs_.end())
+        if (storage_conf != storage_configs_.end())
             return create_storage_factory(storage_conf->second);
         else
             return std::shared_ptr<VariantStorageFactory>();
     }
 
-
-    std::shared_ptr<VariantStorageFactory> get_storage_factory(const StorageName &storage_name) {
+    std::shared_ptr<VariantStorageFactory> get_storage_factory(const StorageName& storage_name)
+    {
         auto factory = get_storage_factory_internal(storage_name);
         util::check(factory != nullptr,
-                    "cannot create storage factory for environment_name={}, storage_name={}",
-                    environment_name_.value, storage_name.value);
-        if (auto[it, inserted] = storage_factories_.insert(std::make_pair(storage_name, factory)); !inserted) {
+            "cannot create storage factory for environment_name={}, storage_name={}",
+            environment_name_.value,
+            storage_name.value);
+        if (auto [it, inserted] = storage_factories_.insert(std::make_pair(storage_name, factory)); !inserted) {
             factory = it->second;
         }
 
@@ -151,4 +163,4 @@ class ConfigCache {
     mutable std::mutex mutex_;
 };
 
-}
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/config_resolvers.cpp
+++ b/cpp/arcticdb/storage/config_resolvers.cpp
@@ -19,55 +19,69 @@
 
 namespace arcticdb::storage::details {
 
-std::optional<InMemoryConfigResolver::MemoryConfig> InMemoryConfigResolver::get_environment(const EnvironmentName& environment_name) const {
+std::optional<InMemoryConfigResolver::MemoryConfig> InMemoryConfigResolver::get_environment(
+    const EnvironmentName& environment_name) const
+{
     auto env = environments_.find(environment_name);
-    if(env == environments_.end())
+    if (env == environments_.end())
         return std::nullopt;
 
     return env->second;
 }
 
-InMemoryConfigResolver::MemoryConfig& InMemoryConfigResolver::get_or_add_environment(const EnvironmentName& environment_name) {
+InMemoryConfigResolver::MemoryConfig& InMemoryConfigResolver::get_or_add_environment(
+    const EnvironmentName& environment_name)
+{
     auto env = environments_.find(environment_name);
-    if(env == environments_.end()) {
+    if (env == environments_.end()) {
         env = environments_.insert(std::make_pair(environment_name, MemoryConfig())).first;
     }
 
     return env->second;
 }
 
-std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> InMemoryConfigResolver::get_libraries(const EnvironmentName &environment_name) const {
+std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> InMemoryConfigResolver::get_libraries(
+    const EnvironmentName& environment_name) const
+{
     auto config = get_environment(environment_name);
     std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> output;
-    if(!config.has_value())
+    if (!config.has_value())
         return output;
 
-    for(auto& pair : config.value().libraries_)
+    for (auto& pair : config.value().libraries_)
         output.emplace_back(pair);
 
     return output;
 }
 
-std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> InMemoryConfigResolver::get_storages(const EnvironmentName &environment_name) const {
+std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> InMemoryConfigResolver::get_storages(
+    const EnvironmentName& environment_name) const
+{
     auto config = get_environment(environment_name);
     std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> output;
-    if(!config.has_value())
+    if (!config.has_value())
         return output;
 
-    for(auto& pair : config.value().storages_)
+    for (auto& pair : config.value().storages_)
         output.emplace_back(pair);
 
     return output;
 }
 
-void InMemoryConfigResolver::add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) {
+void InMemoryConfigResolver::add_library(const EnvironmentName& environment_name,
+    const arcticdb::proto::storage::LibraryDescriptor& library_descriptor)
+{
     auto& config = get_or_add_environment(environment_name);
-    config.libraries_.insert(std::make_pair(LibraryPath::from_delim_path(library_descriptor.name()), library_descriptor));
+    config.libraries_.insert(
+        std::make_pair(LibraryPath::from_delim_path(library_descriptor.name()), library_descriptor));
 }
 
-void InMemoryConfigResolver::add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) {
+void InMemoryConfigResolver::add_storage(const EnvironmentName& environment_name,
+    const StorageName& storage_name,
+    const arcticdb::proto::storage::VariantStorage& storage)
+{
     auto& config = get_or_add_environment(environment_name);
     config.storages_.insert(std::make_pair(StorageName(storage_name), storage));
 }
 
-}
+} // namespace arcticdb::storage::details

--- a/cpp/arcticdb/storage/config_resolvers.hpp
+++ b/cpp/arcticdb/storage/config_resolvers.hpp
@@ -17,28 +17,34 @@
 
 namespace arcticdb::storage {
 class ConfigResolver {
-  public:
+public:
     virtual ~ConfigResolver() = default;
 
     //TODO nothing especially wrong with this method but what's the expected use case?
     //virtual std::vector<EnvironmentName> list_environments() const = 0;
-    virtual std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> get_libraries(const EnvironmentName &environment_name) const = 0;
-    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_storages(const EnvironmentName &environment_name) const = 0;
-    virtual void add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) = 0;
-    virtual void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) = 0;
+    virtual std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> get_libraries(
+        const EnvironmentName& environment_name) const = 0;
+    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_storages(
+        const EnvironmentName& environment_name) const = 0;
+    virtual void add_library(const EnvironmentName& environment_name,
+        const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) = 0;
+    virtual void add_storage(const EnvironmentName& environment_name,
+        const StorageName& storage_name,
+        const arcticdb::proto::storage::VariantStorage& storage) = 0;
     virtual void initialize_environment(const EnvironmentName& environment_name) = 0;
-    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(const EnvironmentName& environment_name) const = 0;
+    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(
+        const EnvironmentName& environment_name) const = 0;
     virtual std::string_view resolver_type() const = 0;
 };
 
 template<class T>
-std::shared_ptr<ConfigResolver> create_in_memory_resolver(const T &id_and_env_pairs);
-}
+std::shared_ptr<ConfigResolver> create_in_memory_resolver(const T& id_and_env_pairs);
+} // namespace arcticdb::storage
 
 namespace arcticdb::storage::details {
 
 class InMemoryConfigResolver final : public ConfigResolver {
-  public:
+public:
     typedef std::unordered_map<StorageName, arcticdb::proto::storage::VariantStorage> StorageMap;
     typedef std::unordered_map<LibraryPath, arcticdb::proto::storage::LibraryDescriptor> LibraryMap;
 
@@ -50,39 +56,52 @@ class InMemoryConfigResolver final : public ConfigResolver {
     InMemoryConfigResolver() = default;
 
     template<class T>
-    explicit InMemoryConfigResolver(const T &environments) :
-        environments_() {
-        for (auto &&[environment_name, env_storages] : environments) {
+    explicit InMemoryConfigResolver(const T& environments)
+        : environments_()
+    {
+        for (auto&& [environment_name, env_storages] : environments) {
             environments_.emplace(environment_name, env_storages);
         }
     }
 
-    std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> get_libraries(const EnvironmentName &environment_name) const override;
-    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_storages(const EnvironmentName &environment_name) const override;
+    std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> get_libraries(
+        const EnvironmentName& environment_name) const override;
+    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_storages(
+        const EnvironmentName& environment_name) const override;
 
-    void add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) override;
-    void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) override;
-    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(const EnvironmentName&) const override {
+    void add_library(const EnvironmentName& environment_name,
+        const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) override;
+    void add_storage(const EnvironmentName& environment_name,
+        const StorageName& storage_name,
+        const arcticdb::proto::storage::VariantStorage& storage) override;
+    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(
+        const EnvironmentName&) const override
+    {
         return std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>>();
     }
 
-    void initialize_environment(const EnvironmentName&) override { }
-    std::string_view resolver_type()  const override { return "in_mem"; }
+    void initialize_environment(const EnvironmentName&) override
+    {
+    }
+    std::string_view resolver_type() const override
+    {
+        return "in_mem";
+    }
 
-  private:
-
+private:
     std::optional<MemoryConfig> get_environment(const EnvironmentName& environment_name) const;
     MemoryConfig& get_or_add_environment(const EnvironmentName& environment_name);
     std::unordered_map<EnvironmentName, MemoryConfig> environments_;
 };
 
-}
+} // namespace arcticdb::storage::details
 
 namespace arcticdb::storage {
 
 template<class T>
-std::shared_ptr<ConfigResolver> create_in_memory_resolver(const T &id_and_env_pairs) {
+std::shared_ptr<ConfigResolver> create_in_memory_resolver(const T& id_and_env_pairs)
+{
     return std::make_shared<details::InMemoryConfigResolver>(id_and_env_pairs);
 }
 
-}
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/failure_simulation.cpp
+++ b/cpp/arcticdb/storage/failure_simulation.cpp
@@ -8,11 +8,12 @@
 #include <arcticdb/storage/failure_simulation.hpp>
 
 namespace arcticdb {
-std::shared_ptr<StorageFailureSimulator> StorageFailureSimulator::instance(){
+std::shared_ptr<StorageFailureSimulator> StorageFailureSimulator::instance()
+{
     std::call_once(StorageFailureSimulator::init_flag_, &StorageFailureSimulator::init);
     return StorageFailureSimulator::instance_;
 }
 
 std::shared_ptr<StorageFailureSimulator> StorageFailureSimulator::instance_;
 std::once_flag StorageFailureSimulator::init_flag_;
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/storage/failure_simulation.hpp
+++ b/cpp/arcticdb/storage/failure_simulation.hpp
@@ -18,16 +18,17 @@ enum class FailureType : int {
     READ
 };
 
-static const char* failure_names[] = {
-        "WRITE",
-        "READ"
-};
+static const char* failure_names[] = {"WRITE", "READ"};
 
 struct FailureCategory {
     double prob_;
     bool thrown_;
 
-    explicit FailureCategory(double prob) :  prob_(prob), thrown_(false) {}
+    explicit FailureCategory(double prob)
+        : prob_(prob),
+          thrown_(false)
+    {
+    }
 };
 
 class StorageFailureSimulator {
@@ -35,37 +36,46 @@ public:
     static std::shared_ptr<StorageFailureSimulator> instance();
     static std::shared_ptr<StorageFailureSimulator> instance_;
     static std::once_flag init_flag_;
-    static void init(){
+    static void init()
+    {
         instance_ = std::make_shared<StorageFailureSimulator>();
     }
-    static void destroy_instance(){instance_.reset();}
-
-    StorageFailureSimulator() :
-        configured_(false) {
+    static void destroy_instance()
+    {
+        instance_.reset();
     }
 
-    void configure(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator& cfg)  {
+    StorageFailureSimulator()
+        : configured_(false)
+    {
+    }
+
+    void configure(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator& cfg)
+    {
         log::storage().info("Initializing storage failure simulator");
         configured_ = true;
         categories_.insert(std::make_pair(FailureType::WRITE, FailureCategory{cfg.write_failure_prob()}));
         categories_.insert(std::make_pair(FailureType::READ, FailureCategory{cfg.read_failure_prob()}));
     }
 
-    FailureCategory& find(FailureType failure_type) {
+    FailureCategory& find(FailureType failure_type)
+    {
         auto item = categories_.find(failure_type);
-        if(item == categories_.end())
+        if (item == categories_.end())
             util::raise_rte("Unknown failure type {}", failure_type);
 
         return item->second;
     }
 
-    bool configured() const {
+    bool configured() const
+    {
         return configured_;
     }
 
     ARCTICDB_NO_MOVE_OR_COPY(StorageFailureSimulator)
 
-    void go(FailureType failure_type) {
+    void go(FailureType failure_type)
+    {
         util::check(configured_, "Attempted failure simulation in unconfigured class");
         thread_local std::once_flag flag;
         std::atomic<uint64_t> counter{42};
@@ -75,7 +85,8 @@ public:
         throw std::runtime_error(fmt::format("Simulating storage failure {}", failure_type));
     }
 
-    bool was_thrown(FailureType failure_type)  {
+    bool was_thrown(FailureType failure_type)
+    {
         auto category = find(failure_type);
         return category.thrown_;
     }
@@ -91,11 +102,15 @@ namespace fmt {
 template<>
 struct formatter<arcticdb::FailureType> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(arcticdb::FailureType failure_type, FormatContext &ctx) const {
+    auto format(arcticdb::FailureType failure_type, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), arcticdb::failure_names[int(failure_type)]);
     }
 };
-}
+} // namespace fmt

--- a/cpp/arcticdb/storage/key_segment_pair.hpp
+++ b/cpp/arcticdb/storage/key_segment_pair.hpp
@@ -11,100 +11,133 @@
 #include <arcticdb/codec/segment.hpp>
 
 namespace arcticdb::storage {
-    using namespace entity;
+using namespace entity;
 
-    /*
+/*
      * KeySegmentPair contains compressed data as returned from storage. Unlike FrameSlice, this does
      * not contain any positioning information for the contained data.
      */
-    class KeySegmentPair {
+class KeySegmentPair {
 
-        struct KeySegmentData {
-            VariantKey key_;
-            Segment segment_;
-            size_t id_;
+    struct KeySegmentData {
+        VariantKey key_;
+        Segment segment_;
+        size_t id_;
 
-            KeySegmentData() = default;
-            explicit KeySegmentData(VariantKey &&key) : key_(std::move(key)), segment_(), id_(0) {}
-            KeySegmentData(VariantKey &&key, Segment &&segment, size_t id) : key_(std::move(key)), segment_(std::move(segment)), id_(id) {}
-
-            ARCTICDB_NO_MOVE_OR_COPY(KeySegmentData)
-        };
-
-    public:
-        KeySegmentPair() : data_(std::make_shared<KeySegmentData>()) {}
-        explicit KeySegmentPair(VariantKey &&key) : data_(std::make_shared<KeySegmentData>(std::move(key))) {}
-        KeySegmentPair(VariantKey &&key, Segment&& segment) :
-            data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment), 0)) {}
-        KeySegmentPair(VariantKey &&key, Segment&& segment, size_t id) :
-            data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment), id)) {}
-
-        ARCTICDB_MOVE_COPY_DEFAULT(KeySegmentPair)
-
-        Segment &segment() {
-            return data_->segment_;
+        KeySegmentData() = default;
+        explicit KeySegmentData(VariantKey&& key)
+            : key_(std::move(key)),
+              segment_(),
+              id_(0)
+        {
+        }
+        KeySegmentData(VariantKey&& key, Segment&& segment, size_t id)
+            : key_(std::move(key)),
+              segment_(std::move(segment)),
+              id_(id)
+        {
         }
 
-        Segment&& release_segment() {
-            return std::move(data_->segment_);
-        }
-
-        AtomKey &atom_key() {
-            util::check(std::holds_alternative<AtomKey>(variant_key()), "Expected atom key access");
-            return std::get<AtomKey >(variant_key());
-        }
-
-        const AtomKey &atom_key() const {
-            util::check(std::holds_alternative<AtomKey>(variant_key()), "Expected atom key access");
-            return std::get<AtomKey >(variant_key());
-        }
-
-        RefKey &ref_key() {
-            util::check(std::holds_alternative<RefKey>(variant_key()), "Expected ref key access");
-            return std::get<RefKey >(variant_key());
-        }
-
-        const RefKey &ref_key() const {
-            util::check(std::holds_alternative<RefKey>(variant_key()), "Expected ref key access");
-            return std::get<RefKey >(variant_key());
-        }
-
-        VariantKey& variant_key() {
-            return data_->key_;
-        }
-
-        const VariantKey& variant_key() const {
-            return data_->key_;
-        }
-
-        const Segment &segment() const {
-            return data_->segment_;
-        }
-
-        bool has_segment() const {
-            return !segment().is_empty();
-        }
-
-        std::string_view key_view() const {
-            return variant_key_view(variant_key());
-        }
-
-        KeyType key_type() const {
-            return variant_key_type(variant_key());
-        }
-
-        size_t id() {
-            return data_->id_;
-        }
-    private:
-        std::shared_ptr<KeySegmentData> data_;
+        ARCTICDB_NO_MOVE_OR_COPY(KeySegmentData)
     };
 
-    template<class T, std::enable_if_t<std::is_same_v<T, EnvironmentName> || std::is_same_v<T, StorageName>, int> = 0>
-    bool operator==(const T &l, const T &r) {
-        return l.value == r.value;
+public:
+    KeySegmentPair()
+        : data_(std::make_shared<KeySegmentData>())
+    {
+    }
+    explicit KeySegmentPair(VariantKey&& key)
+        : data_(std::make_shared<KeySegmentData>(std::move(key)))
+    {
+    }
+    KeySegmentPair(VariantKey&& key, Segment&& segment)
+        : data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment), 0))
+    {
+    }
+    KeySegmentPair(VariantKey&& key, Segment&& segment, size_t id)
+        : data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment), id))
+    {
     }
 
+    ARCTICDB_MOVE_COPY_DEFAULT(KeySegmentPair)
 
+    Segment& segment()
+    {
+        return data_->segment_;
+    }
 
-} //namespace arcticdb
+    Segment&& release_segment()
+    {
+        return std::move(data_->segment_);
+    }
+
+    AtomKey& atom_key()
+    {
+        util::check(std::holds_alternative<AtomKey>(variant_key()), "Expected atom key access");
+        return std::get<AtomKey>(variant_key());
+    }
+
+    const AtomKey& atom_key() const
+    {
+        util::check(std::holds_alternative<AtomKey>(variant_key()), "Expected atom key access");
+        return std::get<AtomKey>(variant_key());
+    }
+
+    RefKey& ref_key()
+    {
+        util::check(std::holds_alternative<RefKey>(variant_key()), "Expected ref key access");
+        return std::get<RefKey>(variant_key());
+    }
+
+    const RefKey& ref_key() const
+    {
+        util::check(std::holds_alternative<RefKey>(variant_key()), "Expected ref key access");
+        return std::get<RefKey>(variant_key());
+    }
+
+    VariantKey& variant_key()
+    {
+        return data_->key_;
+    }
+
+    const VariantKey& variant_key() const
+    {
+        return data_->key_;
+    }
+
+    const Segment& segment() const
+    {
+        return data_->segment_;
+    }
+
+    bool has_segment() const
+    {
+        return !segment().is_empty();
+    }
+
+    std::string_view key_view() const
+    {
+        return variant_key_view(variant_key());
+    }
+
+    KeyType key_type() const
+    {
+        return variant_key_type(variant_key());
+    }
+
+    size_t id()
+    {
+        return data_->id_;
+    }
+
+private:
+    std::shared_ptr<KeySegmentData> data_;
+};
+
+template<class T, std::enable_if_t<std::is_same_v<T, EnvironmentName> || std::is_same_v<T, StorageName>, int> = 0>
+bool operator==(const T& l, const T& r)
+{
+    return l.value == r.value;
+}
+
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -23,7 +23,6 @@
 #include <boost/core/noncopyable.hpp>
 #include <filesystem>
 
-
 #ifdef _WIN32
 //Windows #defines DELETE in winnt.h which clashes with OpenMode.DELETE
 #undef DELETE
@@ -32,25 +31,25 @@
 namespace arcticdb::storage {
 
 class Library {
-  public:
-    Library(
-        LibraryPath path,
-        std::shared_ptr<Storages> &&storages,
-        LibraryDescriptor::VariantStoreConfig cfg) :
-            library_path_(std::move(path)),
-            storages_(std::move(storages)),
-            config_(std::move(cfg)){
+public:
+    Library(LibraryPath path, std::shared_ptr<Storages>&& storages, LibraryDescriptor::VariantStoreConfig cfg)
+        : library_path_(std::move(path)),
+          storages_(std::move(storages)),
+          config_(std::move(cfg))
+    {
         ARCTICDB_DEBUG(log::storage(), fmt::format("Opened library {}", library_path()));
-        util::variant_match(config_,
-                            [that = this](const arcticdb::proto::storage::VersionStoreConfig &version_config) {
-            that->storage_fallthrough_ = version_config.storage_fallthrough();
+        util::variant_match(
+            config_,
+            [that = this](const arcticdb::proto::storage::VersionStoreConfig& version_config) {
+                that->storage_fallthrough_ = version_config.storage_fallthrough();
             },
-            [](std::monostate) {}
-            );
+            [](std::monostate) {});
     }
 
-    Library(LibraryPath path, std::shared_ptr<Storages> &&storages) :
-        Library(std::move(path), std::move(storages), std::monostate{}){}
+    Library(LibraryPath path, std::shared_ptr<Storages>&& storages)
+        : Library(std::move(path), std::move(storages), std::monostate{})
+    {
+    }
 
     Library(const Library&) = delete;
     Library(Library&&) = default;
@@ -63,40 +62,49 @@ class Library {
      * @param visitor Takes one VariantKey which should be moved in but no guarantees
      */
     template<class Visitor>
-    void iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix=std::string{}) {
+    void iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix = std::string{})
+    {
         ARCTICDB_SAMPLE(LibraryIterate, 0)
         storages_->iterate_type(key_type, std::forward<Visitor>(visitor), prefix);
     }
 
-    void write(Composite<KeySegmentPair>&& kvs) {
+    void write(Composite<KeySegmentPair>&& kvs)
+    {
         ARCTICDB_SAMPLE(LibraryWrite, 0)
         if (open_mode() < OpenMode::WRITE)
             throw PermissionException(library_path_, open_mode(), "write");
 
-        size_t ARCTICDB_UNUSED total_size = kvs.fold([] (size_t s, const KeySegmentPair& seg) { return s + seg.segment().total_segment_size(); }, size_t(0));
+        size_t ARCTICDB_UNUSED total_size =
+            kvs.fold([](size_t s, const KeySegmentPair& seg) { return s + seg.segment().total_segment_size(); },
+                size_t(0));
         auto kv_count ARCTICDB_UNUSED = kvs.size();
         storages_->write(std::move(kvs));
         ARCTICDB_TRACE(log::storage(), "{} kv written, {} bytes", kv_count, total_size);
     }
 
-    void update(Composite<KeySegmentPair>&& kvs, storage::UpdateOpts opts) {
+    void update(Composite<KeySegmentPair>&& kvs, storage::UpdateOpts opts)
+    {
         ARCTICDB_SAMPLE(LibraryUpdate, 0)
         if (open_mode() < OpenMode::WRITE)
             throw PermissionException(library_path_, open_mode(), "update");
 
-        size_t total_size ARCTICDB_UNUSED = kvs.fold([] (size_t s, const KeySegmentPair& seg) { return s + seg.segment().total_segment_size(); }, size_t(0));
+        size_t total_size ARCTICDB_UNUSED =
+            kvs.fold([](size_t s, const KeySegmentPair& seg) { return s + seg.segment().total_segment_size(); },
+                size_t(0));
         auto kv_count ARCTICDB_UNUSED = kvs.size();
         storages_->update(std::move(kvs), opts);
         ARCTICDB_TRACE(log::storage(), "{} kv updated, {} bytes", kv_count, total_size);
     }
 
     template<class Visitor>
-    void read(Composite<VariantKey>&& ks, Visitor &&visitor, ReadKeyOpts opts) {
+    void read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts)
+    {
         ARCTICDB_SAMPLE(LibraryRead, 0)
         storages_->read(std::move(ks), std::forward<Visitor>(visitor), opts, !storage_fallthrough_);
     }
 
-    void remove(Composite<VariantKey>&& ks, storage::RemoveOpts opts) {
+    void remove(Composite<VariantKey>&& ks, storage::RemoveOpts opts)
+    {
         if (open_mode() < arcticdb::storage::OpenMode::DELETE)
             throw PermissionException(library_path_, open_mode(), "delete");
 
@@ -104,59 +112,83 @@ class Library {
         storages_->remove(std::move(ks), opts);
     }
 
-    bool fast_delete() {
+    bool fast_delete()
+    {
         return storages_->fast_delete();
     }
 
-    bool key_exists(const VariantKey& key) {
+    bool key_exists(const VariantKey& key)
+    {
         return storages_->key_exists(key);
     }
 
-    KeySegmentPair read(VariantKey key, ReadKeyOpts opts = ReadKeyOpts{}) {
+    KeySegmentPair read(VariantKey key, ReadKeyOpts opts = ReadKeyOpts{})
+    {
         KeySegmentPair res{VariantKey{key}};
-        util::check(!std::holds_alternative<StringId>(variant_key_id(key)) || !std::get<StringId>(variant_key_id(key)).empty(), "Unexpected empty id");
-        read(Composite<VariantKey>(std::move(key)), [&res](auto &&, auto &&value) {
-            res.segment() = std::move(value);
-            }, opts);
+        util::check(!std::holds_alternative<StringId>(variant_key_id(key)) ||
+                        !std::get<StringId>(variant_key_id(key)).empty(),
+            "Unexpected empty id");
+        read(
+            Composite<VariantKey>(std::move(key)),
+            [&res](auto&&, auto&& value) { res.segment() = std::move(value); },
+            opts);
         return res;
     }
 
     /** Calls VariantStorage::do_storage_specific on the primary storage */
     template<class Visitor>
-    void storage_specific(Visitor&& visitor) {
+    void storage_specific(Visitor&& visitor)
+    {
         storages_->storage_specific(std::forward<Visitor>(visitor));
     }
 
-    void move_storage(KeyType key_type, timestamp horizon, size_t storage_index = 0) {
+    void move_storage(KeyType key_type, timestamp horizon, size_t storage_index = 0)
+    {
         storages_->move_storage(key_type, horizon, storage_index);
     }
 
-    bool supports_prefix_matching() { return storages_->supports_prefix_matching(); }
-
-    const LibraryPath &library_path() const { return library_path_; }
-
-    OpenMode open_mode() const { return storages_->open_mode(); }
-
-    const auto & config() const { return config_;}
-
-    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator& cfg) {
-       StorageFailureSimulator::instance()->configure(cfg);
+    bool supports_prefix_matching()
+    {
+        return storages_->supports_prefix_matching();
     }
 
-    std::string name() {
+    const LibraryPath& library_path() const
+    {
+        return library_path_;
+    }
+
+    OpenMode open_mode() const
+    {
+        return storages_->open_mode();
+    }
+
+    const auto& config() const
+    {
+        return config_;
+    }
+
+    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator& cfg)
+    {
+        StorageFailureSimulator::instance()->configure(cfg);
+    }
+
+    std::string name()
+    {
         return library_path_.to_delim_path();
     }
 
-  private:
+private:
     LibraryPath library_path_;
     std::shared_ptr<Storages> storages_;
     LibraryDescriptor::VariantStoreConfig config_;
     bool storage_fallthrough_ = false;
 };
 
-inline Library create_library(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::VariantStorage>& storage_configs) {
+inline Library create_library(const LibraryPath& library_path,
+    OpenMode mode,
+    const std::vector<arcticdb::proto::storage::VariantStorage>& storage_configs)
+{
     return Library{library_path, create_storages(library_path, mode, storage_configs)};
 }
 
-}
-
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -30,79 +30,81 @@
 #include <filesystem>
 
 namespace arcticdb::storage {
-    class LibraryManager {
-    public:
-        explicit LibraryManager(std::shared_ptr<storage::Library> library) :
-            store_(std::make_shared<async::AsyncStore<util::SysClock>>(library, codec::default_lz4_codec())){
+class LibraryManager {
+public:
+    explicit LibraryManager(std::shared_ptr<storage::Library> library)
+        : store_(std::make_shared<async::AsyncStore<util::SysClock>>(library, codec::default_lz4_codec()))
+    {
+    }
+
+    void write_library_config(const py::object& lib_cfg, const LibraryPath& path)
+    {
+        SegmentInMemory segment;
+
+        arcticdb::proto::storage::LibraryConfig lib_cfg_proto;
+        google::protobuf::Any output = {};
+        python_util::pb_from_python(lib_cfg, lib_cfg_proto);
+        output.PackFrom(lib_cfg_proto);
+        segment.set_metadata(std::move(output));
+
+        store_->write_sync(entity::KeyType::LIBRARY_CONFIG, StreamId(path.to_delim_path()), std::move(segment));
+    }
+
+    py::object get_library_config(const LibraryPath& path)
+    {
+        arcticdb::proto::storage::LibraryConfig config = get_config_internal(path);
+
+        return arcticdb::python_util::pb_to_python(config);
+    }
+
+    void remove_library_config(const LibraryPath& path)
+    {
+        store_->remove_key(RefKey{StreamId(path.to_delim_path()), entity::KeyType::LIBRARY_CONFIG}).wait();
+    }
+
+    std::shared_ptr<Library> get_library(const LibraryPath& path)
+    {
+        arcticdb::proto::storage::LibraryConfig config = get_config_internal(path);
+
+        std::vector<arcticdb::proto::storage::VariantStorage> st;
+        for (const auto& storage : config.storage_by_id()) {
+            st.emplace_back(storage.second);
         }
+        auto storages = create_storages(path, OpenMode::DELETE, st);
 
-        void write_library_config(const py::object& lib_cfg, const LibraryPath& path){
-            SegmentInMemory segment;
+        return std::make_shared<Library>(path, std::move(storages), config.lib_desc().version());
+    }
 
-            arcticdb::proto::storage::LibraryConfig lib_cfg_proto;
-            google::protobuf::Any output = {};
-            python_util::pb_from_python(lib_cfg, lib_cfg_proto);
-            output.PackFrom(lib_cfg_proto);
-            segment.set_metadata(std::move(output));
+    std::vector<LibraryPath> get_library_paths()
+    {
+        std::vector<LibraryPath> ids;
+        store_->iterate_type(entity::KeyType::LIBRARY_CONFIG, [&](const VariantKey&& key) {
+            auto k = std::get<entity::RefKey>(key);
+            auto lp = std::get<std::string>(k.id());
+            ids.emplace_back(LibraryPath{lp, '.'});
+        });
 
-            store_->write_sync(
-                    entity::KeyType::LIBRARY_CONFIG,
-                    StreamId(path.to_delim_path()),
-                    std::move(segment)
-            );
-        }
+        return ids;
+    }
 
-        py::object get_library_config(const LibraryPath& path) {
-            arcticdb::proto::storage::LibraryConfig config = get_config_internal(path);
+    bool has_library(const LibraryPath& path)
+    {
+        return store_->key_exists_sync(RefKey{StreamId(path.to_delim_path()), entity::KeyType::LIBRARY_CONFIG});
+    }
 
-            return arcticdb::python_util::pb_to_python(config);
-        }
+private:
+    arcticdb::proto::storage::LibraryConfig get_config_internal(const LibraryPath& path)
+    {
+        auto [key, segment_in_memory] =
+            store_->read_sync(RefKey{StreamId(path.to_delim_path()), entity::KeyType::LIBRARY_CONFIG});
 
-        void remove_library_config(const LibraryPath& path) {
-            store_->remove_key(RefKey{StreamId(path.to_delim_path()), entity::KeyType::LIBRARY_CONFIG}).wait();
-        }
+        auto any = segment_in_memory.metadata();
+        arcticdb::proto::storage::LibraryConfig lib_cfg_proto;
+        any->UnpackTo(&lib_cfg_proto);
 
-        std::shared_ptr<Library> get_library(const LibraryPath& path) {
-            arcticdb::proto::storage::LibraryConfig config = get_config_internal(path);
+        return lib_cfg_proto;
+    }
 
-            std::vector<arcticdb::proto::storage::VariantStorage> st;
-            for(const auto& storage: config.storage_by_id()){
-                st.emplace_back(storage.second);
-            }
-            auto storages = create_storages(path, OpenMode::DELETE, st);
-
-            return std::make_shared<Library>(path, std::move(storages), config.lib_desc().version());
-        }
-
-        std::vector<LibraryPath> get_library_paths() {
-            std::vector<LibraryPath> ids;
-            store_->iterate_type(entity::KeyType::LIBRARY_CONFIG, [&](const VariantKey &&key) {
-                                     auto k = std::get<entity::RefKey>(key);
-                                     auto lp = std::get<std::string>(k.id());
-                                     ids.emplace_back(LibraryPath{lp, '.'});
-                                 }
-            );
-
-            return ids;
-        }
-
-        bool has_library(const LibraryPath& path) {
-            return store_->key_exists_sync(RefKey{StreamId(path.to_delim_path()), entity::KeyType::LIBRARY_CONFIG});
-        }
-
-    private:
-        arcticdb::proto::storage::LibraryConfig get_config_internal(const LibraryPath& path) {
-            auto [key, segment_in_memory] = store_->read_sync(
-                    RefKey{StreamId(path.to_delim_path()), entity::KeyType::LIBRARY_CONFIG}
-            );
-
-            auto any = segment_in_memory.metadata();
-            arcticdb::proto::storage::LibraryConfig lib_cfg_proto;
-            any->UnpackTo(&lib_cfg_proto);
-
-            return lib_cfg_proto;
-        }
-
-        std::shared_ptr<Store> store_;
-    };
-}
+    std::shared_ptr<Store> store_;
+};
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -21,61 +21,75 @@ namespace arcticdb::storage {
 
 // Using StringViewable to make it easily pluggable with a custom internalized string class
 class DefaultStringViewable : public std::shared_ptr<std::string> {
-  public:
+public:
     using std::shared_ptr<std::string>::shared_ptr;
 
-    template<class ...Args>
-    DefaultStringViewable(Args &&...args) : std::shared_ptr<std::string>::shared_ptr(
-        std::make_shared<std::string>(args...)),
-                                            hash_(arcticdb::hash(std::string_view{*this})) {}
+    template<class... Args>
+    DefaultStringViewable(Args&&... args)
+        : std::shared_ptr<std::string>::shared_ptr(std::make_shared<std::string>(args...)),
+          hash_(arcticdb::hash(std::string_view{*this}))
+    {
+    }
 
-    DefaultStringViewable(const DefaultStringViewable &that) :
-        std::shared_ptr<std::string>::shared_ptr(that), hash_(that.hash_) {}
+    DefaultStringViewable(const DefaultStringViewable& that)
+        : std::shared_ptr<std::string>::shared_ptr(that),
+          hash_(that.hash_)
+    {
+    }
 
-    operator std::string_view() const {
+    operator std::string_view() const
+    {
         return *this->get();
     }
 
-    operator std::string() const {
+    operator std::string() const
+    {
         return *this->get();
     }
 
-    auto hash() const {
+    auto hash() const
+    {
         return hash_;
     }
 
-  private:
+private:
     HashedValue hash_;
 };
 
-inline bool operator==(const DefaultStringViewable &l, const DefaultStringViewable &r) {
-    return static_cast<std::shared_ptr<std::string>>(l) == static_cast<std::shared_ptr<std::string>>(r)
-        || (l.hash() == r.hash() && std::string_view{l} == std::string_view{r});
+inline bool operator==(const DefaultStringViewable& l, const DefaultStringViewable& r)
+{
+    return static_cast<std::shared_ptr<std::string>>(l) == static_cast<std::shared_ptr<std::string>>(r) ||
+           (l.hash() == r.hash() && std::string_view{l} == std::string_view{r});
 }
 
-template<class StringViewable=DefaultStringViewable>
+template<class StringViewable = DefaultStringViewable>
 class LibraryPathImpl {
     static constexpr std::uint8_t NUM_LIBRARY_PARTS = 3;
-  public:
+
+public:
     template<class S>
-    LibraryPathImpl(std::initializer_list<S> values):
-        parts_(values.begin(), values.end()),
-        hash_(compute_hash()) {
-        }
+    LibraryPathImpl(std::initializer_list<S> values)
+        : parts_(values.begin(), values.end()),
+          hash_(compute_hash())
+    {
+    }
 
     template<class StringViewableRange>
-    LibraryPathImpl(const StringViewableRange &parts) :
-        parts_(parts.begin(), parts.end()),
-        hash_(compute_hash()) {
-        }
+    LibraryPathImpl(const StringViewableRange& parts)
+        : parts_(parts.begin(), parts.end()),
+          hash_(compute_hash())
+    {
+    }
 
-        bool empty() const {
-            return parts_.empty();
-        }
+    bool empty() const
+    {
+        return parts_.empty();
+    }
 
-    LibraryPathImpl(const std::string_view &delim_path, char delim) :
-        parts_(),
-        hash_() {
+    LibraryPathImpl(const std::string_view& delim_path, char delim)
+        : parts_(),
+          hash_()
+    {
         folly::StringPiece p{delim_path};
         while (!p.empty()) {
             auto part = p.split_step(delim);
@@ -85,11 +99,13 @@ class LibraryPathImpl {
         hash_ = compute_hash();
     }
 
-    static LibraryPathImpl<StringViewable> from_delim_path(const std::string_view &delim_path, char delim = '.') {
+    static LibraryPathImpl<StringViewable> from_delim_path(const std::string_view& delim_path, char delim = '.')
+    {
         return LibraryPathImpl<StringViewable>{delim_path, delim};
     }
 
-    std::string to_delim_path(char delim = '.') const {
+    std::string to_delim_path(char delim = '.') const
+    {
         auto rg = as_range();
         auto delim_fold = [=](std::string a, DefaultStringViewable b) {
             return std::move(a) + delim + fmt::format("{}", b);
@@ -98,17 +114,22 @@ class LibraryPathImpl {
         return std::accumulate(std::next(rg.begin()), rg.end(), fmt::format("{}", rg[0]), delim_fold);
     }
 
-    auto as_range() const {
+    auto as_range() const
+    {
         return folly::range(parts_.cbegin(), parts_.cend());
     }
 
-    auto hash() const { return hash_; }
+    auto hash() const
+    {
+        return hash_;
+    }
 
-  private:
-    HashedValue compute_hash() {
+private:
+    HashedValue compute_hash()
+    {
         HashAccum accum;
         auto rg = as_range();
-        std::for_each(rg.begin(), rg.end(), [&accum](auto &part) {
+        std::for_each(rg.begin(), rg.end(), [&accum](auto& part) {
             auto h = part.hash();
             accum(&h);
         });
@@ -119,8 +140,9 @@ class LibraryPathImpl {
     HashedValue hash_;
 };
 
-template<class StringViewable=DefaultStringViewable>
-inline bool operator==(const LibraryPathImpl<StringViewable> &l, const LibraryPathImpl<StringViewable> &r) {
+template<class StringViewable = DefaultStringViewable>
+inline bool operator==(const LibraryPathImpl<StringViewable>& l, const LibraryPathImpl<StringViewable>& r)
+{
     auto l_rg = l.as_range();
     auto r_rg = r.as_range();
     return l.hash() == r.hash() && std::equal(l_rg.begin(), l_rg.end(), r_rg.begin());
@@ -137,10 +159,14 @@ using namespace arcticdb::storage;
 template<>
 struct formatter<DefaultStringViewable> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const DefaultStringViewable &dsv, FormatContext &ctx) const {
+    auto format(const DefaultStringViewable& dsv, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}", std::string_view{dsv});
     }
 };
@@ -148,12 +174,14 @@ struct formatter<DefaultStringViewable> {
 template<>
 struct formatter<LibraryPath> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) {
+    constexpr auto parse(ParseContext& ctx)
+    {
         return ctx.begin();
     }
 
     template<typename FormatContext>
-    auto format(const LibraryPath &lib, FormatContext &ctx) const {
+    auto format(const LibraryPath& lib, FormatContext& ctx) const
+    {
         auto out = ctx.out();
         format_to(out, "{}", lib.to_delim_path());
 
@@ -161,13 +189,14 @@ struct formatter<LibraryPath> {
     }
 };
 
-}
+} // namespace fmt
 
 namespace std {
 template<>
 struct hash<arcticdb::storage::DefaultStringViewable> {
 
-    inline arcticdb::HashedValue operator()(const arcticdb::storage::DefaultStringViewable &v) const noexcept {
+    inline arcticdb::HashedValue operator()(const arcticdb::storage::DefaultStringViewable& v) const noexcept
+    {
         return v.hash();
     }
 };
@@ -175,9 +204,10 @@ struct hash<arcticdb::storage::DefaultStringViewable> {
 template<class StringViewable>
 struct hash<arcticdb::storage::LibraryPathImpl<StringViewable>> {
 
-    inline arcticdb::HashedValue operator()(const arcticdb::storage::LibraryPathImpl<StringViewable> &v) const noexcept {
+    inline arcticdb::HashedValue operator()(const arcticdb::storage::LibraryPathImpl<StringViewable>& v) const noexcept
+    {
         return v.hash();
     }
 };
 
-}
+} // namespace std

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -18,22 +18,27 @@ namespace arcticdb::storage::lmdb {
 
 namespace {
 template<class T>
-T or_else(T val, T or_else_val, T def = T()) {
+T or_else(T val, T or_else_val, T def = T())
+{
     return val == def ? or_else_val : val;
 }
-} // anonymous
+} // namespace
 
-LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
-    Parent(library_path, mode),
-    write_mutex_(new std::mutex{}),
-    env_(std::make_unique<::lmdb::env>(::lmdb::env::create(conf.flags()))) {
+LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const Config& conf)
+    : Parent(library_path, mode),
+      write_mutex_(new std::mutex{}),
+      env_(std::make_unique<::lmdb::env>(::lmdb::env::create(conf.flags())))
+{
     fs::path root_path = conf.path().c_str();
     auto lib_path_str = library_path.to_delim_path(fs::path::preferred_separator);
 
     auto lib_dir = root_path / lib_path_str;
     if (!fs::exists(lib_dir)) {
-        util::check_arg(mode > OpenMode::READ, "Missing dir {} for lib={}. mode={}",
-                        lib_dir.generic_string(), lib_path_str, mode);
+        util::check_arg(mode > OpenMode::READ,
+            "Missing dir {} for lib={}. mode={}",
+            lib_dir.generic_string(),
+            lib_path_str,
+            mode);
 
         fs::create_directories(lib_dir);
     }
@@ -47,9 +52,9 @@ LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const C
 
     bool is_read_only = ((conf.flags() & MDB_RDONLY) != 0);
     util::check_arg(is_read_only || mode != OpenMode::READ,
-                    "Flags {} and operating mode {} are conflicting",
-                    conf.flags(), mode
-    );
+        "Flags {} and operating mode {} are conflicting",
+        conf.flags(),
+        mode);
     // Windows needs a sensible size as it allocates disk for the whole file even before any writes. Linux just gets an arbitrarily large size
     // that it probably won't ever reach.
 #ifdef _WIN32
@@ -63,8 +68,10 @@ LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const C
     env().set_max_readers(or_else(conf.max_readers(), 1024U));
     env().open(lib_dir.generic_string().c_str(), MDB_NOTLS);
 
-
-    ARCTICDB_DEBUG(log::storage(), "Opened lmdb storage at {} with map size {}", lib_dir.generic_string(), format_bytes(mapsize));
+    ARCTICDB_DEBUG(log::storage(),
+        "Opened lmdb storage at {} with map size {}",
+        lib_dir.generic_string(),
+        format_bytes(mapsize));
 }
 
 } // namespace arcticdb::storage::lmdb

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -28,33 +28,37 @@ class LmdbStorage final : public Storage<LmdbStorage> {
     using Parent = Storage<LmdbStorage>;
     friend Parent;
 
-  public:
+public:
     using Config = arcticdb::proto::lmdb_storage::Config;
 
-    LmdbStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
+    LmdbStorage(const LibraryPath& lib, OpenMode mode, const Config& conf);
 
-  protected:
+protected:
     void do_write(Composite<KeySegmentPair>&& kvs);
 
     void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts);
 
     template<class Visitor>
-    void do_read(Composite<VariantKey>&& ks, Visitor &&visitor, storage::ReadKeyOpts opts);
+    void do_read(Composite<VariantKey>&& ks, Visitor&& visitor, storage::ReadKeyOpts opts);
 
     void do_remove(Composite<VariantKey>&& ks, RemoveOpts opts);
 
-    bool do_supports_prefix_matching() {
+    bool do_supports_prefix_matching()
+    {
         return false;
     };
 
     inline bool do_fast_delete();
 
     template<class Visitor>
-    void do_iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix);
+    void do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix);
 
-    bool do_key_exists(const VariantKey & key);
+    bool do_key_exists(const VariantKey& key);
 
-    ::lmdb::env& env() { return *env_;  }
+    ::lmdb::env& env()
+    {
+        return *env_;
+    }
 
 private:
     // _internal methods assume the write mutex is already held
@@ -69,18 +73,22 @@ class LmdbStorageFactory final : public StorageFactory<LmdbStorageFactory> {
     using Parent = StorageFactory<LmdbStorageFactory>;
     friend Parent;
 
-  public:
+public:
     using Config = arcticdb::proto::lmdb_storage::Config;
     using StorageType = LmdbStorage;
 
-    explicit LmdbStorageFactory(const Config &conf) :
-            conf_(conf), root_path_(conf.path().c_str()) {
+    explicit LmdbStorageFactory(const Config& conf)
+        : conf_(conf),
+          root_path_(conf.path().c_str())
+    {
         if (!fs::exists(root_path_)) {
             fs::create_directories(root_path_);
         }
     }
-  private:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
+
+private:
+    auto do_create_storage(const LibraryPath& lib, OpenMode mode)
+    {
         return LmdbStorage(lib, mode, conf_);
     }
 
@@ -88,7 +96,8 @@ class LmdbStorageFactory final : public StorageFactory<LmdbStorageFactory> {
     fs::path root_path_;
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(const std::string& path) {
+inline arcticdb::proto::storage::VariantStorage pack_config(const std::string& path)
+{
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::lmdb_storage::Config cfg;
     cfg.set_path(path);
@@ -96,7 +105,7 @@ inline arcticdb::proto::storage::VariantStorage pack_config(const std::string& p
     return output;
 }
 
-}
+} // namespace arcticdb::storage::lmdb
 
 #define ARCTICDB_LMDB_STORAGE_H_
 #include <arcticdb/storage/lmdb/lmdb_storage-inl.hpp>

--- a/cpp/arcticdb/storage/memory/memory_storage-inl.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage-inl.hpp
@@ -16,119 +16,126 @@
 
 namespace arcticdb::storage::memory {
 
-    namespace fg = folly::gen;
+namespace fg = folly::gen;
 
-    inline void MemoryStorage::do_write(Composite<KeySegmentPair>&& kvs) {
-        ARCTICDB_SAMPLE(MemoryStorageWrite, 0)
-        std::lock_guard lock{*mutex_};
+inline void MemoryStorage::do_write(Composite<KeySegmentPair>&& kvs)
+{
+    ARCTICDB_SAMPLE(MemoryStorageWrite, 0)
+    std::lock_guard lock{*mutex_};
 
-        auto fmt_db = [](auto &&k) { return variant_key_type(k.variant_key()); };
+    auto fmt_db = [](auto&& k) { return variant_key_type(k.variant_key()); };
 
-        (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-            auto& key_vec = data_[group.key()];
+    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        auto& key_vec = data_[group.key()];
 
-            for (auto &kv : group.values()) {
-                util::variant_match(kv.variant_key(),
-                                    [&](const RefKey &key) {
-                                        key_vec[key] = kv.segment();
-                                    },
-                                    [&](const AtomKey &key) {
-                                        util::check(key_vec.find(key) == key_vec.end(),
-                                                    "Cannot replace atom key in in-memory storage");
+        for (auto& kv : group.values()) {
+            util::variant_match(
+                kv.variant_key(),
+                [&](const RefKey& key) { key_vec[key] = kv.segment(); },
+                [&](const AtomKey& key) {
+                    util::check(key_vec.find(key) == key_vec.end(), "Cannot replace atom key in in-memory storage");
 
-                                        key_vec[key] = kv.segment();
-                                    }
-                );
-            }
-        });
-    }
-
-    inline void MemoryStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts) {
-        ARCTICDB_SAMPLE(MemoryStorageUpdate, 0)
-        std::lock_guard lock{*mutex_};
-
-        auto fmt_db = [](auto &&k) { return variant_key_type(k.variant_key()); };
-
-        (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-            auto& key_vec = data_[group.key()];
-
-            for (auto &kv : group.values()) {
-                auto it = key_vec.find(kv.variant_key());
-
-                util::check_rte(opts.upsert_ || it != key_vec.end(), "update called with upsert=false but key does not exist");
-
-                if(it != key_vec.end()) {
-                    key_vec.erase(it);
-                }
-                key_vec.insert(std::make_pair(kv.variant_key(), kv.segment()));
-            }
-        });
-    }
-
-    template<class Visitor>
-    void MemoryStorage::do_read(Composite<VariantKey>&& ks, Visitor &&visitor, ReadKeyOpts) {
-        ARCTICDB_SAMPLE(MemoryStorageRead, 0)
-        std::lock_guard lock{*mutex_};
-        auto fmt_db = [](auto &&k) { return variant_key_type(k); };
-
-        (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-            auto& key_vec = data_[group.key()];
-            for (auto &k : group.values()) {
-                auto it = key_vec.find(k);
-
-                if(it != key_vec.end()) {
-                    ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(k), variant_key_view(k));
-                    auto seg = it->second;
-                    visitor(k, seg);
-                } else {
-                    throw KeyNotFoundException(std::move(ks));
-                }
-            }
-        });
-    }
-
-inline bool MemoryStorage::do_key_exists(const VariantKey& key) {
-        ARCTICDB_SAMPLE(MemoryStorageKeyExists, 0)
-        std::lock_guard lock{*mutex_};
-        auto& key_vec = data_[variant_key_type(key)];
-        auto it = key_vec.find(key);
-        return it != key_vec.end();
-    }
-
-    inline void MemoryStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts opts)
-    {
-        ARCTICDB_SAMPLE(MemoryStorageRemove, 0)
-        std::lock_guard lock{*mutex_};
-        auto fmt_db = [](auto &&k) { return variant_key_type(k); };
-
-        (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-            auto& key_vec = data_[group.key()];
-
-            for (auto &k : group.values()) {
-                auto it = key_vec.find(k);
-
-                if(it != key_vec.end()) {
-                    ARCTICDB_DEBUG(log::storage(), "Read key {}: {}, with {} bytes of data", variant_key_type(k), variant_key_view(k));
-                    key_vec.erase(it);
-                } else if (!opts.ignores_missing_key_) {
-                    util::raise_rte("Failed to find segment for key {}",variant_key_view(k));
-                }
-            }
-        });
-    }
-
-    bool MemoryStorage::do_fast_delete() {
-        return false;
-    }
-
-    template<class Visitor>
-    void MemoryStorage::do_iterate_type(KeyType key_type, Visitor &&visitor, const std::string &/*prefix*/) {
-        ARCTICDB_SAMPLE(MemoryStorageItType, 0)
-        std::lock_guard lock{*mutex_};
-        auto& key_vec = data_[key_type];
-        for(auto& key_value : key_vec) {
-            auto key = key_value.first;
-            visitor(std::move(key));
+                    key_vec[key] = kv.segment();
+                });
         }
+    });
+}
+
+inline void MemoryStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts)
+{
+    ARCTICDB_SAMPLE(MemoryStorageUpdate, 0)
+    std::lock_guard lock{*mutex_};
+
+    auto fmt_db = [](auto&& k) { return variant_key_type(k.variant_key()); };
+
+    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        auto& key_vec = data_[group.key()];
+
+        for (auto& kv : group.values()) {
+            auto it = key_vec.find(kv.variant_key());
+
+            util::check_rte(opts.upsert_ || it != key_vec.end(),
+                "update called with upsert=false but key does not exist");
+
+            if (it != key_vec.end()) {
+                key_vec.erase(it);
+            }
+            key_vec.insert(std::make_pair(kv.variant_key(), kv.segment()));
+        }
+    });
+}
+
+template<class Visitor>
+void MemoryStorage::do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts)
+{
+    ARCTICDB_SAMPLE(MemoryStorageRead, 0)
+    std::lock_guard lock{*mutex_};
+    auto fmt_db = [](auto&& k) { return variant_key_type(k); };
+
+    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        auto& key_vec = data_[group.key()];
+        for (auto& k : group.values()) {
+            auto it = key_vec.find(k);
+
+            if (it != key_vec.end()) {
+                ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(k), variant_key_view(k));
+                auto seg = it->second;
+                visitor(k, seg);
+            } else {
+                throw KeyNotFoundException(std::move(ks));
+            }
+        }
+    });
+}
+
+inline bool MemoryStorage::do_key_exists(const VariantKey& key)
+{
+    ARCTICDB_SAMPLE(MemoryStorageKeyExists, 0)
+    std::lock_guard lock{*mutex_};
+    auto& key_vec = data_[variant_key_type(key)];
+    auto it = key_vec.find(key);
+    return it != key_vec.end();
+}
+
+inline void MemoryStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts opts)
+{
+    ARCTICDB_SAMPLE(MemoryStorageRemove, 0)
+    std::lock_guard lock{*mutex_};
+    auto fmt_db = [](auto&& k) { return variant_key_type(k); };
+
+    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        auto& key_vec = data_[group.key()];
+
+        for (auto& k : group.values()) {
+            auto it = key_vec.find(k);
+
+            if (it != key_vec.end()) {
+                ARCTICDB_DEBUG(log::storage(),
+                    "Read key {}: {}, with {} bytes of data",
+                    variant_key_type(k),
+                    variant_key_view(k));
+                key_vec.erase(it);
+            } else if (!opts.ignores_missing_key_) {
+                util::raise_rte("Failed to find segment for key {}", variant_key_view(k));
+            }
+        }
+    });
+}
+
+bool MemoryStorage::do_fast_delete()
+{
+    return false;
+}
+
+template<class Visitor>
+void MemoryStorage::do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& /*prefix*/)
+{
+    ARCTICDB_SAMPLE(MemoryStorageItType, 0)
+    std::lock_guard lock{*mutex_};
+    auto& key_vec = data_[key_type];
+    for (auto& key_value : key_vec) {
+        auto key = key_value.first;
+        visitor(std::move(key));
     }
 }
+} // namespace arcticdb::storage::memory

--- a/cpp/arcticdb/storage/memory/memory_storage.cpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.cpp
@@ -8,8 +8,9 @@
 #include <arcticdb/storage/memory/memory_storage.hpp>
 
 namespace arcticdb::storage::memory {
-    MemoryStorage::MemoryStorage(const LibraryPath &library_path, OpenMode mode, const Config&) :
-        Parent(library_path, mode),
-        mutex_(std::make_unique<MutexType>()) {
-    }
-} // arcticdb::storage::memory
+MemoryStorage::MemoryStorage(const LibraryPath& library_path, OpenMode mode, const Config&)
+    : Parent(library_path, mode),
+      mutex_(std::make_unique<MutexType>())
+{
+}
+} // namespace arcticdb::storage::memory

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -16,75 +16,80 @@
 
 namespace arcticdb::storage::memory {
 
-    class MemoryStorage final : public Storage<MemoryStorage> {
+class MemoryStorage final : public Storage<MemoryStorage> {
 
-        using Parent = Storage<MemoryStorage>;
-        friend Parent;
+    using Parent = Storage<MemoryStorage>;
+    friend Parent;
 
-    public:
-        using Config = arcticdb::proto::memory_storage::Config;
+public:
+    using Config = arcticdb::proto::memory_storage::Config;
 
-        MemoryStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
+    MemoryStorage(const LibraryPath& lib, OpenMode mode, const Config& conf);
 
-    protected:
-        void do_write(Composite<KeySegmentPair>&& kvs);
+protected:
+    void do_write(Composite<KeySegmentPair>&& kvs);
 
-        void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts);
+    void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts);
 
-        template<class Visitor>
-        void do_read(Composite<VariantKey>&& ks, Visitor &&visitor, ReadKeyOpts opts);
+    template<class Visitor>
+    void do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts);
 
-        void do_remove(Composite<VariantKey>&& ks, RemoveOpts opts);
+    void do_remove(Composite<VariantKey>&& ks, RemoveOpts opts);
 
-        bool do_key_exists(const VariantKey& key);
+    bool do_key_exists(const VariantKey& key);
 
-        bool do_supports_prefix_matching() {
-            return false;
-        }
-
-        inline bool do_fast_delete();
-
-        template<class Visitor>
-        void do_iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix);
-
-    private:
-        using KeyMap = std::unordered_map<VariantKey, Segment>;
-        using TypeMap = std::unordered_map<KeyType, KeyMap>;
-        using MutexType = std::recursive_mutex;
-
-        TypeMap data_;
-        std::unique_ptr<MutexType> mutex_;  // Methods taking functions pointers may call back into the storage
-    };
-
-    class MemoryStorageFactory final : public StorageFactory<MemoryStorageFactory> {
-
-        using Parent = StorageFactory<MemoryStorageFactory>;
-        friend Parent;
-
-    public:
-        using Config = arcticdb::proto::memory_storage::Config;
-        using StorageType = MemoryStorage;
-
-        MemoryStorageFactory(Config conf) :
-                conf_(std::move(conf)) {}
-
-    private:
-        auto do_create_storage(LibraryPath lib, OpenMode mode) {
-            return MemoryStorage(std::move(lib), mode, conf_);
-        }
-
-        Config conf_;
-    };
-
-    inline arcticdb::proto::storage::VariantStorage pack_config(uint64_t cache_size) {
-        arcticdb::proto::storage::VariantStorage output;
-        arcticdb::proto::memory_storage::Config cfg;
-        cfg.set_cache_size(cache_size);
-        util::pack_to_any(cfg, *output.mutable_config());
-        return output;
+    bool do_supports_prefix_matching()
+    {
+        return false;
     }
 
-}//namespace arcticdbx::storage
+    inline bool do_fast_delete();
+
+    template<class Visitor>
+    void do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix);
+
+private:
+    using KeyMap = std::unordered_map<VariantKey, Segment>;
+    using TypeMap = std::unordered_map<KeyType, KeyMap>;
+    using MutexType = std::recursive_mutex;
+
+    TypeMap data_;
+    std::unique_ptr<MutexType> mutex_; // Methods taking functions pointers may call back into the storage
+};
+
+class MemoryStorageFactory final : public StorageFactory<MemoryStorageFactory> {
+
+    using Parent = StorageFactory<MemoryStorageFactory>;
+    friend Parent;
+
+public:
+    using Config = arcticdb::proto::memory_storage::Config;
+    using StorageType = MemoryStorage;
+
+    MemoryStorageFactory(Config conf)
+        : conf_(std::move(conf))
+    {
+    }
+
+private:
+    auto do_create_storage(LibraryPath lib, OpenMode mode)
+    {
+        return MemoryStorage(std::move(lib), mode, conf_);
+    }
+
+    Config conf_;
+};
+
+inline arcticdb::proto::storage::VariantStorage pack_config(uint64_t cache_size)
+{
+    arcticdb::proto::storage::VariantStorage output;
+    arcticdb::proto::memory_storage::Config cfg;
+    cfg.set_cache_size(cache_size);
+    util::pack_to_any(cfg, *output.mutable_config());
+    return output;
+}
+
+} // namespace arcticdb::storage::memory
 
 #define ARCTICDB_MEMORY_STORAGE_H_
 #include <arcticdb/storage/memory/memory_storage-inl.hpp>

--- a/cpp/arcticdb/storage/mongo/mongo_client.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.hpp
@@ -17,59 +17,45 @@ class MongoClientImpl;
 
 class MongoClient {
     using Config = arcticdb::proto::mongo_storage::Config;
-  public:
-    explicit MongoClient(
-        const Config& config,
+
+public:
+    explicit MongoClient(const Config& config,
         uint64_t min_pool_size,
         uint64_t max_pool_size,
         uint64_t selection_timeout_ms);
 
     ~MongoClient();
 
-    void write_segment(
-        const std::string &database_name,
-        const std::string &collection_name,
-        storage::KeySegmentPair&& kv);
+    void
+    write_segment(const std::string& database_name, const std::string& collection_name, storage::KeySegmentPair&& kv);
 
-    void update_segment(
-        const std::string &database_name,
-        const std::string &collection_name,
+    void update_segment(const std::string& database_name,
+        const std::string& collection_name,
         storage::KeySegmentPair&& kv,
         bool upsert);
 
-    storage::KeySegmentPair read_segment(
-        const std::string &database_name,
-        const std::string &collection_name,
-        const entity::VariantKey &key);
+    storage::KeySegmentPair
+    read_segment(const std::string& database_name, const std::string& collection_name, const entity::VariantKey& key);
 
-    void remove_keyvalue(
-        const std::string &database_name,
-        const std::string &collection_name,
-        const entity::VariantKey &key);
+    void remove_keyvalue(const std::string& database_name,
+        const std::string& collection_name,
+        const entity::VariantKey& key);
 
-    void iterate_type(
-        const std::string &database_name,
-        const std::string &collection_name,
+    void iterate_type(const std::string& database_name,
+        const std::string& collection_name,
         KeyType key_type,
-        folly::Function<void(entity::VariantKey &&)>&& visitor,
-        const std::optional<std::string> &prefix
-        );
+        folly::Function<void(entity::VariantKey&&)>&& visitor,
+        const std::optional<std::string>& prefix);
 
-    void ensure_collection(
-        std::string_view database_name,
-        std::string_view collection_name);
+    void ensure_collection(std::string_view database_name, std::string_view collection_name);
 
-    void drop_collection(
-            std::string database_name,
-            std::string collection_name);
+    void drop_collection(std::string database_name, std::string collection_name);
 
-    bool key_exists(
-        const std::string &database_name,
-        const std::string &collection_name,
-        const  entity::VariantKey &key);
+    bool
+    key_exists(const std::string& database_name, const std::string& collection_name, const entity::VariantKey& key);
 
 private:
     MongoClientImpl* client_;
 };
 
-}
+} // namespace arcticdb::storage::mongo

--- a/cpp/arcticdb/storage/mongo/mongo_instance.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_instance.cpp
@@ -11,20 +11,23 @@
 
 namespace arcticdb::storage::mongo {
 
-void MongoInstance::init() {
+void MongoInstance::init()
+{
     MongoInstance::instance_ = std::make_shared<MongoInstance>();
 }
 
-std::shared_ptr<MongoInstance> MongoInstance::instance() {
+std::shared_ptr<MongoInstance> MongoInstance::instance()
+{
     std::call_once(MongoInstance::init_flag_, &MongoInstance::init);
     return instance_;
 }
 
-void MongoInstance::destroy_instance() {
+void MongoInstance::destroy_instance()
+{
     MongoInstance::instance_.reset();
 }
 
 std::shared_ptr<MongoInstance> MongoInstance::instance_;
 std::once_flag MongoInstance::init_flag_;
 
-}
+} // namespace arcticdb::storage::mongo

--- a/cpp/arcticdb/storage/mongo/mongo_instance.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_instance.hpp
@@ -16,7 +16,8 @@ namespace arcticdb::storage::mongo {
 
 class MongoInstance {
     mongocxx::instance api_instance_;
-  public:
+
+public:
     static std::shared_ptr<MongoInstance> instance_;
     static std::once_flag init_flag_;
 
@@ -25,4 +26,4 @@ class MongoInstance {
     static void destroy_instance();
 };
 
-}
+} // namespace arcticdb::storage::mongo

--- a/cpp/arcticdb/storage/mongo/mongo_storage-inl.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage-inl.hpp
@@ -18,32 +18,35 @@
 
 namespace arcticdb::storage::mongo {
 
-inline std::string MongoStorage::collection_name(KeyType k) {
+inline std::string MongoStorage::collection_name(KeyType k)
+{
     return (fmt::format("{}{}", prefix_, k));
 }
 
-inline void MongoStorage::do_write(Composite<KeySegmentPair>&& kvs) {
+inline void MongoStorage::do_write(Composite<KeySegmentPair>&& kvs)
+{
     namespace fg = folly::gen;
-    auto fmt_db = [](auto &&kv) { return kv.key_type(); };
+    auto fmt_db = [](auto&& kv) { return kv.key_type(); };
 
     ARCTICDB_SAMPLE(MongoStorageWrite, 0)
 
-    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-        for (auto &kv : group.values()) {
+    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        for (auto& kv : group.values()) {
             auto collection = collection_name(kv.key_type());
             client_->write_segment(db_, collection, std::move(kv));
         }
     });
 }
 
-inline void MongoStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts) {
+inline void MongoStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts)
+{
     namespace fg = folly::gen;
-    auto fmt_db = [](auto &&kv) { return kv.key_type(); };
+    auto fmt_db = [](auto&& kv) { return kv.key_type(); };
 
     ARCTICDB_SAMPLE(MongoStorageWrite, 0)
 
-    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-        for (auto &kv : group.values()) {
+    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        for (auto& kv : group.values()) {
             auto collection = collection_name(kv.key_type());
             client_->update_segment(db_, collection, std::move(kv), opts.upsert_);
         }
@@ -51,42 +54,45 @@ inline void MongoStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts 
 }
 
 template<class Visitor>
-void MongoStorage::do_read(Composite<VariantKey>&& ks, Visitor &&visitor, ReadKeyOpts) {
+void MongoStorage::do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts)
+{
     namespace fg = folly::gen;
-    auto fmt_db = [](auto &&k) { return variant_key_type(k); };
+    auto fmt_db = [](auto&& k) { return variant_key_type(k); };
     ARCTICDB_SAMPLE(MongoStorageRead, 0)
     std::vector<VariantKey> failed_reads;
 
-    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-        for (auto &k : group.values()) {
-                auto collection = collection_name(variant_key_type(k));
-                auto kv = client_->read_segment(db_, collection, k);
-                if(kv.has_segment())
-                    visitor(k, kv.segment());
-                else
-                   failed_reads.push_back(k);
+    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        for (auto& k : group.values()) {
+            auto collection = collection_name(variant_key_type(k));
+            auto kv = client_->read_segment(db_, collection, k);
+            if (kv.has_segment())
+                visitor(k, kv.segment());
+            else
+                failed_reads.push_back(k);
         }
     });
 
-    if(!failed_reads.empty())
+    if (!failed_reads.empty())
         throw KeyNotFoundException(Composite<VariantKey>{std::move(failed_reads)});
 }
 
-bool MongoStorage::do_fast_delete() {
-    foreach_key_type([&] (KeyType key_type) {
+bool MongoStorage::do_fast_delete()
+{
+    foreach_key_type([&](KeyType key_type) {
         auto collection = collection_name(key_type);
         client_->drop_collection(db_, collection);
     });
     return true;
 }
 
-inline void MongoStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
+inline void MongoStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts)
+{
     namespace fg = folly::gen;
-    auto fmt_db = [](auto &&k) { return variant_key_type(k); };
+    auto fmt_db = [](auto&& k) { return variant_key_type(k); };
     ARCTICDB_SAMPLE(MongoStorageRemove, 0)
 
-    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-        for (auto &k : group.values()) {
+    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
+        for (auto& k : group.values()) {
             auto collection = collection_name(variant_key_type(k));
             client_->remove_keyvalue(db_, collection, k);
         }
@@ -94,14 +100,16 @@ inline void MongoStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
 }
 
 template<class Visitor>
-void MongoStorage::do_iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix) {
+void MongoStorage::do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix)
+{
     auto collection = collection_name(key_type);
     auto func = folly::Function<void(entity::VariantKey&&)>(std::move(visitor));
     ARCTICDB_SAMPLE(MongoStorageItType, 0)
     client_->iterate_type(db_, collection, key_type, std::move(func), prefix);
 }
 
-inline bool MongoStorage::do_key_exists(const VariantKey& key) {
+inline bool MongoStorage::do_key_exists(const VariantKey& key)
+{
     auto collection = collection_name(variant_key_type(key));
     return client_->key_exists(db_, collection, key);
 }

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -22,18 +22,14 @@ namespace arcticdb::storage::mongo {
 
 using Config = arcticdb::proto::mongo_storage::Config;
 
-MongoStorage::MongoStorage(
-    const LibraryPath &lib,
-    OpenMode mode,
-    const Config &config) :
-    Parent(lib, mode),
-    instance_(MongoInstance::instance()),
-    client_(std::make_unique<MongoClient>(
-        config,
-        ConfigsMap::instance()->get_int("MongoClient.MinPoolSize", 100),
-        ConfigsMap::instance()->get_int("MongoClient.MaxPoolSize", 1000),
-        ConfigsMap::instance()->get_int("MongoClient.SelectionTimeoutMs", 120000))
-        ) {
+MongoStorage::MongoStorage(const LibraryPath& lib, OpenMode mode, const Config& config)
+    : Parent(lib, mode),
+      instance_(MongoInstance::instance()),
+      client_(std::make_unique<MongoClient>(config,
+          ConfigsMap::instance()->get_int("MongoClient.MinPoolSize", 100),
+          ConfigsMap::instance()->get_int("MongoClient.MaxPoolSize", 1000),
+          ConfigsMap::instance()->get_int("MongoClient.SelectionTimeoutMs", 120000)))
+{
     instance_.reset(); //Just want to ensure singleton here, not hang onto it
     auto key_rg = lib.as_range();
     auto it = key_rg.begin();
@@ -45,4 +41,4 @@ MongoStorage::MongoStorage(
     prefix_ = strm.str();
 }
 
-}
+} // namespace arcticdb::storage::mongo

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -23,33 +23,34 @@ class MongoStorage final : public Storage<MongoStorage> {
     using Parent = Storage<MongoStorage>;
     friend Parent;
 
-  public:
+public:
     using Config = arcticdb::proto::mongo_storage::Config;
 
-    MongoStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
+    MongoStorage(const LibraryPath& lib, OpenMode mode, const Config& conf);
 
-  protected:
+protected:
     void do_write(Composite<KeySegmentPair>&& kvs);
 
     void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts);
 
     template<class Visitor>
-    void do_read(Composite<VariantKey>&& ks, Visitor &&visitor, ReadKeyOpts opts);
+    void do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts);
 
     void do_remove(Composite<VariantKey>&& ks, RemoveOpts opts);
 
     bool do_key_exists(const VariantKey& key);
 
-    bool do_supports_prefix_matching() {
+    bool do_supports_prefix_matching()
+    {
         return false;
     }
 
     inline bool do_fast_delete();
 
     template<class Visitor>
-    void do_iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix);
+    void do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix);
 
-  private:
+private:
     std::string collection_name(KeyType k);
 
     std::shared_ptr<MongoInstance> instance_;
@@ -64,22 +65,26 @@ class MongoStorageFactory final : public StorageFactory<MongoStorageFactory> {
     using Parent = StorageFactory<MongoStorageFactory>;
     friend Parent;
 
-  public:
+public:
     using Config = arcticdb::proto::mongo_storage::Config;
     using StorageType = MongoStorage;
 
-    MongoStorageFactory(Config conf) :
-        conf_(std::move(conf)) {}
+    MongoStorageFactory(Config conf)
+        : conf_(std::move(conf))
+    {
+    }
 
-  private:
-    auto do_create_storage(LibraryPath lib, OpenMode mode) {
+private:
+    auto do_create_storage(LibraryPath lib, OpenMode mode)
+    {
         return MongoStorage(std::move(lib), mode, conf_);
     }
 
     Config conf_;
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(InstanceUri uri) {
+inline arcticdb::proto::storage::VariantStorage pack_config(InstanceUri uri)
+{
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::mongo_storage::Config cfg;
     cfg.set_uri(uri.value);
@@ -87,7 +92,7 @@ inline arcticdb::proto::storage::VariantStorage pack_config(InstanceUri uri) {
     return output;
 }
 
-}
+} // namespace arcticdb::storage::mongo
 
 #define ARCTICDB_MONGO_STORAGE_H_
 #include <arcticdb/storage/mongo/mongo_storage-inl.hpp>

--- a/cpp/arcticdb/storage/open_mode.hpp
+++ b/cpp/arcticdb/storage/open_mode.hpp
@@ -23,48 +23,59 @@ enum class OpenMode : std::uint8_t {
     DELETE = 7 // implies READ + WRITE
 };
 
-inline bool operator<(const OpenMode l, const OpenMode r) {
+inline bool operator<(const OpenMode l, const OpenMode r)
+{
     return static_cast<std::uint8_t>(l) < static_cast<std::uint8_t>(r);
 }
-inline bool operator>(const OpenMode l, const OpenMode r) {
+inline bool operator>(const OpenMode l, const OpenMode r)
+{
     return static_cast<std::uint8_t>(l) > static_cast<std::uint8_t>(r);
 }
-inline bool operator==(const OpenMode l, const OpenMode r) {
+inline bool operator==(const OpenMode l, const OpenMode r)
+{
     return static_cast<std::uint8_t>(l) == static_cast<std::uint8_t>(r);
 }
-inline bool operator!=(const OpenMode l, const OpenMode r) {
+inline bool operator!=(const OpenMode l, const OpenMode r)
+{
     return static_cast<std::uint8_t>(l) != static_cast<std::uint8_t>(r);
 }
-inline bool operator<=(const OpenMode l, const OpenMode r) {
+inline bool operator<=(const OpenMode l, const OpenMode r)
+{
     return static_cast<std::uint8_t>(l) <= static_cast<std::uint8_t>(r);
 }
-inline bool operator>=(const OpenMode l, const OpenMode r) {
+inline bool operator>=(const OpenMode l, const OpenMode r)
+{
     return static_cast<std::uint8_t>(l) >= static_cast<std::uint8_t>(r);
 }
 
-}
+} // namespace arcticdb::storage
 
 namespace fmt {
 template<>
 struct formatter<arcticdb::storage::OpenMode> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(arcticdb::storage::OpenMode mode, FormatContext &ctx) const {
+    auto format(arcticdb::storage::OpenMode mode, FormatContext& ctx) const
+    {
         char c = 'X';
         switch (mode) {
-            case arcticdb::storage::OpenMode::READ:c = 'r';
-                break;
-            case arcticdb::storage::OpenMode::WRITE:c = 'w';
-                break;
-            case arcticdb::storage::OpenMode::DELETE:c = 'd';
-                break;
-
+        case arcticdb::storage::OpenMode::READ:
+            c = 'r';
+            break;
+        case arcticdb::storage::OpenMode::WRITE:
+            c = 'w';
+            break;
+        case arcticdb::storage::OpenMode::DELETE:
+            c = 'd';
+            break;
         }
         return format_to(ctx.out(), "{:c}", c);
     }
 };
 
-}
-
+} // namespace fmt

--- a/cpp/arcticdb/storage/protobuf_mappings.hpp
+++ b/cpp/arcticdb/storage/protobuf_mappings.hpp
@@ -24,15 +24,17 @@
 
 namespace arcticdb::storage {
 
-inline arcticdb::proto::storage::LibraryPath encode_library_path(const storage::LibraryPath& library_path) {
+inline arcticdb::proto::storage::LibraryPath encode_library_path(const storage::LibraryPath& library_path)
+{
     arcticdb::proto::storage::LibraryPath output;
-    for (auto &part : library_path.as_range()) {
+    for (auto& part : library_path.as_range()) {
         output.add_parts(std::string(part));
     }
     return output;
 }
 
-inline arcticdb::storage::LibraryPath decode_library_path(const arcticdb::proto::storage::LibraryPath& protobuf_path) {
+inline arcticdb::storage::LibraryPath decode_library_path(const arcticdb::proto::storage::LibraryPath& protobuf_path)
+{
     std::vector<std::string> parts;
     for (auto i = 0; i < protobuf_path.parts_size(); ++i)
         parts.push_back(protobuf_path.parts(i));
@@ -40,46 +42,53 @@ inline arcticdb::storage::LibraryPath decode_library_path(const arcticdb::proto:
     return storage::LibraryPath(parts);
 }
 
-inline arcticdb::proto::storage::LibraryDescriptor encode_library_descriptor(storage::LibraryDescriptor library_descriptor) {
+inline arcticdb::proto::storage::LibraryDescriptor encode_library_descriptor(
+    storage::LibraryDescriptor library_descriptor)
+{
     arcticdb::proto::storage::LibraryDescriptor output;
     output.set_name(library_descriptor.name_);
     output.set_description(library_descriptor.description_);
-    for(auto& id : library_descriptor.storage_ids_)
+    for (auto& id : library_descriptor.storage_ids_)
         output.add_storage_ids(id.value);
 
     return output;
 }
 
-inline storage::LibraryDescriptor decode_library_descriptor(const arcticdb::proto::storage::LibraryDescriptor & protobuf_descriptor) {
+inline storage::LibraryDescriptor decode_library_descriptor(
+    const arcticdb::proto::storage::LibraryDescriptor& protobuf_descriptor)
+{
     storage::LibraryDescriptor output;
     output.name_ = protobuf_descriptor.name();
     output.description_ = protobuf_descriptor.description();
-    for(int i = 0; i < protobuf_descriptor.storage_ids_size(); ++i)
+    for (int i = 0; i < protobuf_descriptor.storage_ids_size(); ++i)
         output.storage_ids_.push_back(StorageName(protobuf_descriptor.storage_ids(i)));
 
-    switch (protobuf_descriptor.store_type_case()){
-        case arcticdb::proto::storage::LibraryDescriptor::StoreTypeCase::kVersion:
-            output.config_ = protobuf_descriptor.version(); // copy
-            break;
-            case arcticdb::proto::storage::LibraryDescriptor::StoreTypeCase::STORE_TYPE_NOT_SET:
-            // nothing to do, the variant is a monostate (empty struct) by default
-            break;
-        default: util::raise_rte("Unsupported store config type {}", protobuf_descriptor.store_type_case());
+    switch (protobuf_descriptor.store_type_case()) {
+    case arcticdb::proto::storage::LibraryDescriptor::StoreTypeCase::kVersion:
+        output.config_ = protobuf_descriptor.version(); // copy
+        break;
+    case arcticdb::proto::storage::LibraryDescriptor::StoreTypeCase::STORE_TYPE_NOT_SET:
+        // nothing to do, the variant is a monostate (empty struct) by default
+        break;
+    default:
+        util::raise_rte("Unsupported store config type {}", protobuf_descriptor.store_type_case());
     }
 
     return output;
 }
 
-using MemConfig  = storage::details::InMemoryConfigResolver::MemoryConfig;
+using MemConfig = storage::details::InMemoryConfigResolver::MemoryConfig;
 
-inline std::vector<std::pair<std::string, MemConfig>> convert_environment_config(arcticdb::proto::storage::EnvironmentConfigsMap envs) {
+inline std::vector<std::pair<std::string, MemConfig>> convert_environment_config(
+    arcticdb::proto::storage::EnvironmentConfigsMap envs)
+{
     std::vector<std::pair<std::string, MemConfig>> env_by_id;
-    for (auto&[env_key, env_config] : envs.env_by_id()) {
+    for (auto& [env_key, env_config] : envs.env_by_id()) {
         MemConfig current;
-        for (auto &[storage_key, storage_value] : env_config.storage_by_id())
+        for (auto& [storage_key, storage_value] : env_config.storage_by_id())
             current.storages_.insert(std::make_pair(storage::StorageName(storage_key), storage_value));
 
-        for (auto &[library_key, library_value] : env_config.lib_by_path())
+        for (auto& [library_key, library_value] : env_config.lib_by_path())
             current.libraries_.insert(std::make_pair(LibraryPath::from_delim_path(library_key), library_value));
 
         env_by_id.push_back(std::make_pair(env_key, current));
@@ -87,7 +96,8 @@ inline std::vector<std::pair<std::string, MemConfig>> convert_environment_config
     return env_by_id;
 }
 
-inline proto::mongo_storage::Config create_mongo_config(InstanceUri uri, uint32_t flags = 0) {
+inline proto::mongo_storage::Config create_mongo_config(InstanceUri uri, uint32_t flags = 0)
+{
     proto::mongo_storage::Config output;
     output.set_uri(uri.value);
     output.set_flags(flags);

--- a/cpp/arcticdb/storage/python_bindings.hpp
+++ b/cpp/arcticdb/storage/python_bindings.hpp
@@ -18,6 +18,6 @@ namespace arcticdb::storage::apy {
 
 namespace py = pybind11;
 
-void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception);
+void register_bindings(py::module& m, py::exception<arcticdb::ArcticException>& base_exception);
 
-} // namespace arcticdb
+} // namespace arcticdb::storage::apy

--- a/cpp/arcticdb/storage/s3/aws_provider_chain.cpp
+++ b/cpp/arcticdb/storage/s3/aws_provider_chain.cpp
@@ -25,51 +25,53 @@ static const char DefaultCredentialsProviderChainTag[] = "DefaultAWSCredentialsP
 // NOTE: These classes are not currently in use and may only be required if we need the STSProfileCred provider.
 namespace arcticdb::storage::s3 {
 
-    using namespace Aws::Auth;
+using namespace Aws::Auth;
 
-    MyAWSCredentialsProviderChain::MyAWSCredentialsProviderChain() : Aws::Auth::AWSCredentialsProviderChain() {
-        AddProvider(Aws::MakeShared<EnvironmentAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
-        AddProvider(Aws::MakeShared<ProfileConfigFileAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
-        AddProvider(Aws::MakeShared<ProcessCredentialsProvider>(DefaultCredentialsProviderChainTag));
-        AddProvider(Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(DefaultCredentialsProviderChainTag));
-        AddProvider(Aws::MakeShared<SSOCredentialsProvider>(DefaultCredentialsProviderChainTag));
-        AddProvider(Aws::MakeShared<STSProfileCredentialsProvider>(DefaultCredentialsProviderChainTag));
+MyAWSCredentialsProviderChain::MyAWSCredentialsProviderChain()
+    : Aws::Auth::AWSCredentialsProviderChain()
+{
+    AddProvider(Aws::MakeShared<EnvironmentAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<ProfileConfigFileAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<ProcessCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<SSOCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<STSProfileCredentialsProvider>(DefaultCredentialsProviderChainTag));
 
-        //ECS TaskRole Credentials only available when ENVIRONMENT VARIABLE is set
-        const auto relativeUri = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI);
-        AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI
-                                                                                                  << " is " << relativeUri);
+    //ECS TaskRole Credentials only available when ENVIRONMENT VARIABLE is set
+    const auto relativeUri = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI);
+    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag,
+        "The environment variable value " << AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI << " is " << relativeUri);
 
-        const auto absoluteUri = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI);
-        AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI
-                                                                                                  << " is " << absoluteUri);
+    const auto absoluteUri = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI);
+    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag,
+        "The environment variable value " << AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI << " is " << absoluteUri);
 
-        const auto ec2MetadataDisabled = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
-        AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << AWS_EC2_METADATA_DISABLED
-                                                                                                  << " is " << ec2MetadataDisabled);
+    const auto ec2MetadataDisabled = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
+    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag,
+        "The environment variable value " << AWS_EC2_METADATA_DISABLED << " is " << ec2MetadataDisabled);
 
-        if (!relativeUri.empty())
-        {
-            AddProvider(Aws::MakeShared<TaskRoleCredentialsProvider>(DefaultCredentialsProviderChainTag, relativeUri.c_str()));
-            AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added ECS metadata service credentials provider with relative path: ["
-                    << relativeUri << "] to the provider chain.");
-        }
-        else if (!absoluteUri.empty())
-        {
-            const auto token = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN);
-            AddProvider(Aws::MakeShared<TaskRoleCredentialsProvider>(DefaultCredentialsProviderChainTag,
-                                                                     absoluteUri.c_str(), token.c_str()));
+    if (!relativeUri.empty()) {
+        AddProvider(
+            Aws::MakeShared<TaskRoleCredentialsProvider>(DefaultCredentialsProviderChainTag, relativeUri.c_str()));
+        AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag,
+            "Added ECS metadata service credentials provider with relative path: [" << relativeUri
+                                                                                    << "] to the provider chain.");
+    } else if (!absoluteUri.empty()) {
+        const auto token = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN);
+        AddProvider(Aws::MakeShared<TaskRoleCredentialsProvider>(DefaultCredentialsProviderChainTag,
+            absoluteUri.c_str(),
+            token.c_str()));
 
-            //DO NOT log the value of the authorization token for security purposes.
-            AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added ECS credentials provider with URI: ["
-                    << absoluteUri << "] to the provider chain with a" << (token.empty() ? "n empty " : " non-empty ")
-                    << "authorization token.");
-        }
-        else if (Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true")
-        {
-            AddProvider(Aws::MakeShared<InstanceProfileCredentialsProvider>(DefaultCredentialsProviderChainTag));
-            AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added EC2 metadata service credentials provider to the provider chain.");
-        }
+        //DO NOT log the value of the authorization token for security purposes.
+        AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag,
+            "Added ECS credentials provider with URI: [" << absoluteUri << "] to the provider chain with a"
+                                                         << (token.empty() ? "n empty " : " non-empty ")
+                                                         << "authorization token.");
+    } else if (Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true") {
+        AddProvider(Aws::MakeShared<InstanceProfileCredentialsProvider>(DefaultCredentialsProviderChainTag));
+        AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag,
+            "Added EC2 metadata service credentials provider to the provider chain.");
     }
-
 }
+
+} // namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/aws_provider_chain.hpp
+++ b/cpp/arcticdb/storage/s3/aws_provider_chain.hpp
@@ -9,9 +9,9 @@
 
 namespace arcticdb::storage::s3 {
 
-    class MyAWSCredentialsProviderChain : public Aws::Auth::AWSCredentialsProviderChain {
-    public:
-        MyAWSCredentialsProviderChain();
-    };
+class MyAWSCredentialsProviderChain : public Aws::Auth::AWSCredentialsProviderChain {
+public:
+    MyAWSCredentialsProviderChain();
+};
 
-}
+} // namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage-inl.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage-inl.hpp
@@ -14,169 +14,207 @@
 
 namespace arcticdb::storage::nfs_backed {
 
-inline std::string add_suffix_char(const std::string& str) {
+inline std::string add_suffix_char(const std::string& str)
+{
     return fmt::format("{}*", str);
 }
 
-inline std::string remove_suffix_char(const std::string& str) {
-    return str.substr(0, str.size()-1);
+inline std::string remove_suffix_char(const std::string& str)
+{
+    return str.substr(0, str.size() - 1);
 }
 
 template<typename MixedType, typename StringType, typename NumericType>
-MixedType encode_item(const MixedType& input, bool add_suffix) {
-    return util::variant_match(input,
-    [add_suffix] (const StringType& str) {
-        const auto encoded = util::safe_encode(str);
-        return add_suffix ? MixedType{add_suffix_char(encoded)} : MixedType{encoded};
-    },
-    [](const NumericType& id) {
-        return MixedType{id};
-    });
+MixedType encode_item(const MixedType& input, bool add_suffix)
+{
+    return util::variant_match(
+        input,
+        [add_suffix](const StringType& str) {
+            const auto encoded = util::safe_encode(str);
+            return add_suffix ? MixedType{add_suffix_char(encoded)} : MixedType{encoded};
+        },
+        [](const NumericType& id) { return MixedType{id}; });
 }
 
 template<typename MixedType, typename StringType, typename NumericType>
-MixedType decode_item(const MixedType& input, bool remove_suffix) {
-    return util::variant_match(input,
-    [remove_suffix] (const StringType& str) {
-        return MixedType{util::safe_decode(remove_suffix ? remove_suffix_char(str) : str)};
-    },
-    [](const NumericType& id) {
-       return MixedType{id};
-    });
+MixedType decode_item(const MixedType& input, bool remove_suffix)
+{
+    return util::variant_match(
+        input,
+        [remove_suffix](const StringType& str) {
+            return MixedType{util::safe_decode(remove_suffix ? remove_suffix_char(str) : str)};
+        },
+        [](const NumericType& id) { return MixedType{id}; });
 }
 
-inline VariantKey encode_object_id(const VariantKey& key) {
-    return util::variant_match(key,
-        [] (const AtomKey& k) {
+inline VariantKey encode_object_id(const VariantKey& key)
+{
+    return util::variant_match(
+        key,
+        [](const AtomKey& k) {
             auto encoded_id = encode_item<StreamId, StringId, NumericId>(k.id(), false);
             auto start_index = encode_item<IndexValue, StringIndex, NumericIndex>(k.start_index(), false);
             auto end_index = encode_item<IndexValue, StringIndex, NumericIndex>(k.end_index(), false);
-            return VariantKey{atom_key_builder().version_id(k.version_id()).start_index(start_index)
-            .end_index(end_index).creation_ts(k.creation_ts()).content_hash(k.content_hash())
-            .build(encoded_id, k.type())};
-    },
+            return VariantKey{atom_key_builder()
+                                  .version_id(k.version_id())
+                                  .start_index(start_index)
+                                  .end_index(end_index)
+                                  .creation_ts(k.creation_ts())
+                                  .content_hash(k.content_hash())
+                                  .build(encoded_id, k.type())};
+        },
         [](const RefKey& r) {
-        auto encoded_id = encode_item<StreamId, StringId, NumericId>(r.id(), true);
-        return VariantKey{RefKey{encoded_id, r.type(), r.is_old_type()}};
-    });
+            auto encoded_id = encode_item<StreamId, StringId, NumericId>(r.id(), true);
+            return VariantKey{RefKey{encoded_id, r.type(), r.is_old_type()}};
+        });
 }
 
-inline uint32_t id_to_number(const StreamId& stream_id) {
-    return util::variant_match(stream_id,
-       [] (const NumericId& num_id) { return static_cast<uint32_t>(num_id); },
-       [] (const StringId& str_id) { return murmur3_32(str_id); });
+inline uint32_t id_to_number(const StreamId& stream_id)
+{
+    return util::variant_match(
+        stream_id,
+        [](const NumericId& num_id) { return static_cast<uint32_t>(num_id); },
+        [](const StringId& str_id) { return murmur3_32(str_id); });
 }
 
-inline uint32_t get_id_bucket(const StreamId& id) {
+inline uint32_t get_id_bucket(const StreamId& id)
+{
     return id_to_number(id) % 1000;
 }
 
-inline uint32_t get_hash_bucket(const AtomKey& atom) {
+inline uint32_t get_hash_bucket(const AtomKey& atom)
+{
     return atom.content_hash() % 1000;
 }
 
-inline std::string get_root_folder(const std::string& root_folder, const RefKey& ref) {
+inline std::string get_root_folder(const std::string& root_folder, const RefKey& ref)
+{
     const auto id_bucket = get_id_bucket(ref.id());
     return fmt::format("{}/{:03}", root_folder, id_bucket);
 }
 
-inline std::string get_root_folder(const std::string& root_folder, const AtomKey& atom) {
+inline std::string get_root_folder(const std::string& root_folder, const AtomKey& atom)
+{
     const auto id_bucket = get_id_bucket(atom.id());
     const auto hash_bucket = get_hash_bucket(atom);
     return fmt::format("{}/{:03}/{:03}", root_folder, id_bucket, hash_bucket);
 }
 
-inline std::string get_root_folder(const std::string& root_folder, const VariantKey& vk) {
-    return util::variant_match(vk, [&root_folder] (const auto& k) {
-        return get_root_folder(root_folder, k);
-    });
+inline std::string get_root_folder(const std::string& root_folder, const VariantKey& vk)
+{
+    return util::variant_match(vk, [&root_folder](const auto& k) { return get_root_folder(root_folder, k); });
 }
 
 struct NfsBucketizer {
-    static std::string bucketize(const std::string& root_folder, const VariantKey& vk) {
+    static std::string bucketize(const std::string& root_folder, const VariantKey& vk)
+    {
         return get_root_folder(root_folder, vk);
     }
 
-    static size_t bucketize_length(KeyType key_type) {
+    static size_t bucketize_length(KeyType key_type)
+    {
         return is_ref_key_class(key_type) ? 4 : 8;
     }
 };
 
-inline VariantKey unencode_object_id(const VariantKey& key) {
+inline VariantKey unencode_object_id(const VariantKey& key)
+{
 
-    return util::variant_match(key,
-                        [] (const AtomKey& k) {
-                            auto decoded_id = decode_item<StreamId, StringId, NumericId>(k.id(), false);
-                            auto start_index = decode_item<IndexValue, StringIndex, NumericIndex>(k.start_index(), false);
-                            auto end_index = decode_item<IndexValue, StringIndex, NumericIndex>(k.end_index(), false);
-                            return VariantKey{atom_key_builder().version_id(k.version_id()).start_index(start_index)
-                                .end_index(end_index).creation_ts(k.creation_ts()).content_hash(k.content_hash())
-                                .build(decoded_id, k.type())};
-                        },
-                        [](const RefKey& r) {
-                            auto decoded_id = decode_item<StreamId, StringId, NumericId>(r.id(), true);
-                            return VariantKey{RefKey{decoded_id, r.type(), r.is_old_type()}};
-                        });
+    return util::variant_match(
+        key,
+        [](const AtomKey& k) {
+            auto decoded_id = decode_item<StreamId, StringId, NumericId>(k.id(), false);
+            auto start_index = decode_item<IndexValue, StringIndex, NumericIndex>(k.start_index(), false);
+            auto end_index = decode_item<IndexValue, StringIndex, NumericIndex>(k.end_index(), false);
+            return VariantKey{atom_key_builder()
+                                  .version_id(k.version_id())
+                                  .start_index(start_index)
+                                  .end_index(end_index)
+                                  .creation_ts(k.creation_ts())
+                                  .content_hash(k.content_hash())
+                                  .build(decoded_id, k.type())};
+        },
+        [](const RefKey& r) {
+            auto decoded_id = decode_item<StreamId, StringId, NumericId>(r.id(), true);
+            return VariantKey{RefKey{decoded_id, r.type(), r.is_old_type()}};
+        });
 }
 
-inline void NfsBackedStorage::do_write(Composite<KeySegmentPair>&& kvs) {
-    auto enc = kvs.transform([] (auto&& key_seg) {
+inline void NfsBackedStorage::do_write(Composite<KeySegmentPair>&& kvs)
+{
+    auto enc = kvs.transform([](auto&& key_seg) {
         return KeySegmentPair{encode_object_id(key_seg.variant_key()), std::move(key_seg.segment())};
     });
     s3::detail::do_write_impl(std::move(enc), root_folder_, bucket_name_, s3_client_, NfsBucketizer{});
 }
 
-inline void NfsBackedStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts) {
-    auto enc = kvs.transform([] (auto&& key_seg) {
+inline void NfsBackedStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts)
+{
+    auto enc = kvs.transform([](auto&& key_seg) {
         return KeySegmentPair{encode_object_id(key_seg.variant_key()), std::move(key_seg.segment())};
     });
     s3::detail::do_update_impl(std::move(enc), root_folder_, bucket_name_, s3_client_, NfsBucketizer{});
 }
 
 template<class Visitor>
-void NfsBackedStorage::do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts) {
-    auto func = [v = std::forward<Visitor>(visitor)] (const VariantKey& k, Segment&& seg) mutable {
+void NfsBackedStorage::do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts)
+{
+    auto func = [v = std::forward<Visitor>(visitor)](const VariantKey& k, Segment&& seg) mutable {
         v(unencode_object_id(k), std::move(seg));
     };
 
-    auto enc = ks.transform([] (auto&& key) {
-        return encode_object_id(key);
-    });
+    auto enc = ks.transform([](auto&& key) { return encode_object_id(key); });
 
-    s3::detail::do_read_impl(std::move(enc), std::move(func), root_folder_, bucket_name_, s3_client_, NfsBucketizer{}, opts);
+    s3::detail::do_read_impl(std::move(enc),
+        std::move(func),
+        root_folder_,
+        bucket_name_,
+        s3_client_,
+        NfsBucketizer{},
+        opts);
 }
 
-inline void NfsBackedStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
-    auto enc = ks.transform([] (auto&& key) {
-        return encode_object_id(key);
-    });
+inline void NfsBackedStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts)
+{
+    auto enc = ks.transform([](auto&& key) { return encode_object_id(key); });
     s3::detail::do_remove_impl(std::move(enc), root_folder_, bucket_name_, s3_client_, NfsBucketizer{});
 }
 
 template<class Visitor>
-void NfsBackedStorage::do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix) {
-    auto func = [v = std::move(visitor), prefix=prefix] (VariantKey&& k) mutable {
+void NfsBackedStorage::do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix)
+{
+    auto func = [v = std::move(visitor), prefix = prefix](VariantKey&& k) mutable {
         auto key = unencode_object_id(k);
-        if(prefix.empty() || variant_key_id(key) == StreamId{prefix})
+        if (prefix.empty() || variant_key_id(key) == StreamId{prefix})
             v(std::move(key));
     };
 
-    auto prefix_handler = [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor&, KeyType key_type) {
-        std::string new_prefix;
-        if(!prefix.empty()) {
-            uint32_t id = get_id_bucket(encode_item<StreamId, StringId, NumericId>(StringId{prefix}, is_ref_key_class(key_type)));
-            new_prefix = fmt::format("{:03}", id);
-        }
+    auto prefix_handler =
+        [](const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor&, KeyType key_type) {
+            std::string new_prefix;
+            if (!prefix.empty()) {
+                uint32_t id = get_id_bucket(
+                    encode_item<StreamId, StringId, NumericId>(StringId{prefix}, is_ref_key_class(key_type)));
+                new_prefix = fmt::format("{:03}", id);
+            }
 
-        return !prefix.empty() ? fmt::format("{}/{}", key_type_dir, new_prefix) : key_type_dir;
-    };
+            return !prefix.empty() ? fmt::format("{}/{}", key_type_dir, new_prefix) : key_type_dir;
+        };
 
-    s3::detail::do_iterate_type_impl(key_type, std::move(func), root_folder_, bucket_name_, s3_client_, NfsBucketizer{}, prefix_handler, prefix);
+    s3::detail::do_iterate_type_impl(key_type,
+        std::move(func),
+        root_folder_,
+        bucket_name_,
+        s3_client_,
+        NfsBucketizer{},
+        prefix_handler,
+        prefix);
 }
 
-inline bool NfsBackedStorage::do_key_exists(const VariantKey& key) {
+inline bool NfsBackedStorage::do_key_exists(const VariantKey& key)
+{
     auto encoded_key = encode_object_id(key);
     return s3::detail::do_key_exists_impl(encoded_key, root_folder_, bucket_name_, s3_client_, NfsBucketizer{});
 }
 
-} //namespace arcticdb::nfs_backed
+} // namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -9,12 +9,16 @@
 
 namespace arcticdb::storage::nfs_backed {
 
-NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
-    Parent(library_path, mode),
-    s3_api_(s3::S3ApiInstance::instance()),
-    s3_client_(s3::get_aws_credentials(conf), s3::get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false),
-    root_folder_(s3::get_root_folder(library_path)),
-    bucket_name_(conf.bucket_name()) {
+NfsBackedStorage::NfsBackedStorage(const LibraryPath& library_path, OpenMode mode, const Config& conf)
+    : Parent(library_path, mode),
+      s3_api_(s3::S3ApiInstance::instance()),
+      s3_client_(s3::get_aws_credentials(conf),
+          s3::get_s3_config(conf),
+          Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+          false),
+      root_folder_(s3::get_root_folder(library_path)),
+      bucket_name_(conf.bucket_name())
+{
     if (!conf.prefix().empty()) {
         ARCTICDB_DEBUG(log::version(), "prefix found, using: {}", conf.prefix());
         auto prefix_path = LibraryPath::from_delim_path(conf.prefix(), '.');
@@ -25,7 +29,7 @@ NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mod
     // When linking against libraries built with pre-GCC5 compilers, the num_put facet is not initalized on the classic locale
     // Rather than change the locale globally, which might cause unexpected behaviour in legacy code, just add the required
     // facet here
-    std::locale locale{ std::locale::classic(), new std::num_put<char>()};
+    std::locale locale{std::locale::classic(), new std::num_put<char>()};
     (void)std::locale::global(locale);
     ARCTICDB_DEBUG(log::storage(), "Opened NFS backed storage at {}", root_folder_);
     s3_api_.reset();

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -28,7 +28,7 @@ public:
     friend class S3TestClientAccessor<NfsBackedStorage>;
     using Config = arcticdb::proto::nfs_backed_storage::Config;
 
-    NfsBackedStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
+    NfsBackedStorage(const LibraryPath& lib, OpenMode mode, const Config& conf);
 
 protected:
     void do_write(Composite<KeySegmentPair>&& kvs);
@@ -36,27 +36,38 @@ protected:
     void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts);
 
     template<class Visitor>
-    void do_read(Composite<VariantKey>&& ks, Visitor &&visitor, ReadKeyOpts opts);
+    void do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts);
 
     void do_remove(Composite<VariantKey>&& ks, RemoveOpts opts);
 
     template<class Visitor>
-    void do_iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix);
+    void do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix);
 
     bool do_key_exists(const VariantKey& key);
 
-    bool do_supports_prefix_matching() {
+    bool do_supports_prefix_matching()
+    {
         return true;
     }
 
-    bool do_fast_delete() {
+    bool do_fast_delete()
+    {
         return false;
     }
 
 private:
-    auto& client() { return s3_client_; }
-    const std::string& bucket_name() const { return bucket_name_; }
-    const std::string& root_folder() const { return root_folder_; }
+    auto& client()
+    {
+        return s3_client_;
+    }
+    const std::string& bucket_name() const
+    {
+        return bucket_name_;
+    }
+    const std::string& root_folder() const
+    {
+        return root_folder_;
+    }
 
     std::shared_ptr<storage::s3::S3ApiInstance> s3_api_;
     Aws::S3::S3Client s3_client_;
@@ -72,18 +83,22 @@ public:
     using Config = arcticdb::proto::nfs_backed_storage::Config;
     using StorageType = NfsBackedStorageFactory;
 
-    NfsBackedStorageFactory(const Config &conf) :
-        conf_(conf) {
+    NfsBackedStorageFactory(const Config& conf)
+        : conf_(conf)
+    {
     }
+
 private:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
+    auto do_create_storage(const LibraryPath& lib, OpenMode mode)
+    {
         return NfsBackedStorage(lib, mode, conf_);
     }
 
     Config conf_;
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &bucket_name) {
+inline arcticdb::proto::storage::VariantStorage pack_config(const std::string& bucket_name)
+{
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::nfs_backed_storage::Config cfg;
     cfg.set_bucket_name(bucket_name);
@@ -91,12 +106,11 @@ inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &b
     return output;
 }
 
-inline arcticdb::proto::storage::VariantStorage pack_config(
-    const std::string &bucket_name,
-    const std::string &credential_name,
-    const std::string &credential_key,
-    const std::string &endpoint
-) {
+inline arcticdb::proto::storage::VariantStorage pack_config(const std::string& bucket_name,
+    const std::string& credential_name,
+    const std::string& credential_key,
+    const std::string& endpoint)
+{
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::nfs_backed_storage::Config cfg;
     cfg.set_bucket_name(bucket_name);
@@ -107,7 +121,7 @@ inline arcticdb::proto::storage::VariantStorage pack_config(
     return output;
 }
 
-} //namespace arcticdb::nfs_backed
+} // namespace arcticdb::storage::nfs_backed
 
 #define ARCTICDB_NFS_BACKED_STORAGE_H_
 #include <arcticdb/storage/s3/nfs_backed_storage-inl.hpp>

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -18,19 +18,22 @@
 
 namespace arcticdb::storage::s3 {
 
-S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level) :
-    log_level_(log_level),
-    options_() {
-    if(log_level_ > Aws::Utils::Logging::LogLevel::Off) {
-      Aws::Utils::Logging::InitializeAWSLogging(
-          Aws::MakeShared<Aws::Utils::Logging::DefaultLogSystem>(
-              "v", log_level, "aws_sdk_"));
+S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level)
+    : log_level_(log_level),
+      options_()
+{
+    if (log_level_ > Aws::Utils::Logging::LogLevel::Off) {
+        Aws::Utils::Logging::InitializeAWSLogging(
+            Aws::MakeShared<Aws::Utils::Logging::DefaultLogSystem>("v", log_level, "aws_sdk_"));
     }
     ARCTICDB_RUNTIME_DEBUG(log::storage(), "Begin initializing AWS API");
     Aws::InitAPI(options_);
     // A workaround for https://github.com/aws/aws-sdk-cpp/issues/1410.
-    for (auto name : std::initializer_list<const char*>{
-            "AWS_EC2_METADATA_DISABLED", "AWS_DEFAULT_REGION", "AWS_REGION", "AWS_EC2_METADATA_SERVICE_ENDPOINT" }) {
+    for (auto name : std::initializer_list<const char*>{"AWS_EC2_METADATA_DISABLED",
+             "AWS_DEFAULT_REGION",
+             "AWS_REGION",
+             "AWS_EC2_METADATA_SERVICE_ENDPOINT"})
+    {
         if (!Aws::Environment::GetEnv(name).empty())
             return;
     }
@@ -45,29 +48,32 @@ S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level) :
 #endif
 }
 
-S3ApiInstance::~S3ApiInstance() {
-    if(log_level_ > Aws::Utils::Logging::LogLevel::Off)
+S3ApiInstance::~S3ApiInstance()
+{
+    if (log_level_ > Aws::Utils::Logging::LogLevel::Off)
         Aws::Utils::Logging::ShutdownAWSLogging();
 
     //Aws::ShutdownAPI(options_); This causes a crash on shutdown in Aws::CleanupMonitoring
 }
 
-void S3ApiInstance::init() {
-  	auto log_level = ConfigsMap::instance()->get_int("AWS.LogLevel", 0);
+void S3ApiInstance::init()
+{
+    auto log_level = ConfigsMap::instance()->get_int("AWS.LogLevel", 0);
     S3ApiInstance::instance_ = std::make_shared<S3ApiInstance>(Aws::Utils::Logging::LogLevel(log_level));
 }
 
-std::shared_ptr<S3ApiInstance> S3ApiInstance::instance() {
+std::shared_ptr<S3ApiInstance> S3ApiInstance::instance()
+{
     std::call_once(S3ApiInstance::init_flag_, &S3ApiInstance::init);
     return instance_;
 }
 
-void S3ApiInstance::destroy_instance() {
+void S3ApiInstance::destroy_instance()
+{
     S3ApiInstance::instance_.reset();
 }
 
 std::shared_ptr<S3ApiInstance> S3ApiInstance::instance_;
 std::once_flag S3ApiInstance::init_flag_;
-
 
 } // namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/s3_api.hpp
+++ b/cpp/arcticdb/storage/s3/s3_api.hpp
@@ -15,8 +15,8 @@ namespace arcticdb::storage::s3 {
 
 class S3ApiInstance {
 public:
-  S3ApiInstance(Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Off);
-  ~S3ApiInstance();
+    S3ApiInstance(Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Off);
+    ~S3ApiInstance();
 
     static std::shared_ptr<S3ApiInstance> instance_;
     static std::once_flag init_flag_;
@@ -26,8 +26,8 @@ public:
     static void destroy_instance();
 
 private:
-  Aws::Utils::Logging::LogLevel log_level_;
-  Aws::SDKOptions options_;
+    Aws::Utils::Logging::LogLevel log_level_;
+    Aws::SDKOptions options_;
 };
 
 } //namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/s3_client_accessor.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_accessor.hpp
@@ -17,44 +17,61 @@ namespace arcticdb::storage {
 template<typename StorageType>
 class S3TestClientAccessor {
 public:
-    static auto& get_client(StorageType& storage) { return storage.client(); }
+    static auto& get_client(StorageType& storage)
+    {
+        return storage.client();
+    }
 
-    static auto& get_bucket_name(StorageType& storage) { return storage.bucket_name(); }
+    static auto& get_bucket_name(StorageType& storage)
+    {
+        return storage.bucket_name();
+    }
 
-    static auto& get_root_folder(StorageType& storage) { return storage.root_folder(); }
+    static auto& get_root_folder(StorageType& storage)
+    {
+        return storage.root_folder();
+    }
 };
 
 template<typename StorageType>
 class S3TestForwarder {
     StorageType storage_;
+
 public:
-    S3TestForwarder(const LibraryPath &lib, OpenMode mode, const typename StorageType::Config &conf) :
-    storage_(lib, mode, conf) {
+    S3TestForwarder(const LibraryPath& lib, OpenMode mode, const typename StorageType::Config& conf)
+        : storage_(lib, mode, conf)
+    {
     }
 
-    void do_write(Composite<KeySegmentPair>&& kvs) {
+    void do_write(Composite<KeySegmentPair>&& kvs)
+    {
         storage_.do_write(std::move(kvs));
     }
 
-    void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts) {
+    void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts)
+    {
         storage_.do_update(std::move(kvs), opts);
     }
 
     template<class Visitor>
-        void do_read(Composite<VariantKey>&& ks, Visitor &&visitor) {
+    void do_read(Composite<VariantKey>&& ks, Visitor&& visitor)
+    {
         storage_.do_read(std::move(ks), std::move(visitor), ReadKeyOpts{});
     }
 
-    void do_remove(Composite<VariantKey>&& ks) {
+    void do_remove(Composite<VariantKey>&& ks)
+    {
         storage_.do_remove(std::move(ks), RemoveOpts{});
     }
 
     template<class Visitor>
-        void do_iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix) {
+    void do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix)
+    {
         storage_.do_iterate_type(key_type, std::move(visitor), prefix);
     }
 
-    bool do_key_exists(const VariantKey& key) {
+    bool do_key_exists(const VariantKey& key)
+    {
         return storage_.do_key_exists(key);
     }
 };

--- a/cpp/arcticdb/storage/s3/s3_storage-inl.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage-inl.hpp
@@ -50,109 +50,115 @@ template<class It>
 using Range = folly::Range<It>;
 
 struct FlatBucketizer {
-    static std::string bucketize(const std::string& root_folder, const VariantKey&) {
+    static std::string bucketize(const std::string& root_folder, const VariantKey&)
+    {
         return root_folder;
     }
 
-    static size_t bucketize_length(KeyType) {
+    static size_t bucketize_length(KeyType)
+    {
         return 0;
     }
 };
 
 template<class S3ClientType, class KeyBucketizer>
-void do_write_impl(
-    Composite<KeySegmentPair>&& kvs,
+void do_write_impl(Composite<KeySegmentPair>&& kvs,
     const std::string& root_folder,
     const std::string& bucket_name,
     S3ClientType& s3_client,
-    KeyBucketizer&& bucketizer) {
+    KeyBucketizer&& bucketizer)
+{
     ARCTICDB_SAMPLE(S3StorageWrite, 0)
     auto fmt_db = [](auto&& kv) { return kv.key_type(); };
 
-    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach(
-        [&s3_client, &bucket_name, &root_folder, b=std::move(bucketizer)] (auto&& group) {
-        auto key_type_folder = s3_key_type_folder(root_folder, group.key());
-        ARCTICDB_TRACE(log::storage(), "S3 key_type_folder is {}", key_type_folder);
+    (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db))
+        .foreach ([&s3_client, &bucket_name, &root_folder, b = std::move(bucketizer)](auto&& group) {
+            auto key_type_folder = s3_key_type_folder(root_folder, group.key());
+            ARCTICDB_TRACE(log::storage(), "S3 key_type_folder is {}", key_type_folder);
 
-        ARCTICDB_SUBSAMPLE(S3StorageWriteValues, 0)
-        for (auto& kv : group.values()) {
-            auto& k = kv.variant_key();
-            auto s3_object_name = s3_object_path(b.bucketize(key_type_folder, k), k);
-            auto& seg = kv.segment();
+            ARCTICDB_SUBSAMPLE(S3StorageWriteValues, 0)
+            for (auto& kv : group.values()) {
+                auto& k = kv.variant_key();
+                auto s3_object_name = s3_object_path(b.bucketize(key_type_folder, k), k);
+                auto& seg = kv.segment();
 
-            ARCTICDB_SUBSAMPLE(S3StorageWritePreamble, 0)
-            Aws::S3::Model::PutObjectRequest object_request;
-            object_request.SetBucket(bucket_name.c_str());
-            object_request.SetKey(s3_object_name.c_str());
-            ARCTICDB_RUNTIME_DEBUG(log::storage(), "Set s3 key {}", object_request.GetKey().c_str());
+                ARCTICDB_SUBSAMPLE(S3StorageWritePreamble, 0)
+                Aws::S3::Model::PutObjectRequest object_request;
+                object_request.SetBucket(bucket_name.c_str());
+                object_request.SetKey(s3_object_name.c_str());
+                ARCTICDB_RUNTIME_DEBUG(log::storage(), "Set s3 key {}", object_request.GetKey().c_str());
 
-            std::shared_ptr<Buffer> tmp;
-            auto hdr_size =  seg.segment_header_bytes_size();
-            auto [dst, write_size] = seg.try_internal_write(tmp, hdr_size);
-            util::check(arcticdb::Segment::FIXED_HEADER_SIZE + hdr_size + seg.buffer().bytes() <= write_size,
-                        "Size disparity, fixed header size {} + variable header size {} + buffer size {}  >= total size {}",
-                        arcticdb::Segment::FIXED_HEADER_SIZE,
-                        hdr_size,
-                        seg.buffer().bytes(),
-                        write_size);
-            auto body = std::make_shared<boost::interprocess::bufferstream>(reinterpret_cast<char*>(dst), write_size);
-            util::check(body->good(), "Overflow of bufferstream with size {}", write_size);
-            object_request.SetBody(body);
+                std::shared_ptr<Buffer> tmp;
+                auto hdr_size = seg.segment_header_bytes_size();
+                auto [dst, write_size] = seg.try_internal_write(tmp, hdr_size);
+                util::check(arcticdb::Segment::FIXED_HEADER_SIZE + hdr_size + seg.buffer().bytes() <= write_size,
+                    "Size disparity, fixed header size {} + variable header size {} + buffer size {}  >= total size {}",
+                    arcticdb::Segment::FIXED_HEADER_SIZE,
+                    hdr_size,
+                    seg.buffer().bytes(),
+                    write_size);
+                auto body =
+                    std::make_shared<boost::interprocess::bufferstream>(reinterpret_cast<char*>(dst), write_size);
+                util::check(body->good(), "Overflow of bufferstream with size {}", write_size);
+                object_request.SetBody(body);
 
-            ARCTICDB_SUBSAMPLE(S3StoragePutObject, 0)
-            auto put_object_outcome = s3_client.PutObject(object_request);
+                ARCTICDB_SUBSAMPLE(S3StoragePutObject, 0)
+                auto put_object_outcome = s3_client.PutObject(object_request);
 
-            if (!put_object_outcome.IsSuccess()) {
-                auto& error = put_object_outcome.GetError();
-                util::raise_rte("Failed to write s3 with key '{}' {}: {}",
-                                k,
-                                error.GetExceptionName().c_str(),
-                                error.GetMessage().c_str());
+                if (!put_object_outcome.IsSuccess()) {
+                    auto& error = put_object_outcome.GetError();
+                    util::raise_rte("Failed to write s3 with key '{}' {}: {}",
+                        k,
+                        error.GetExceptionName().c_str(),
+                        error.GetMessage().c_str());
+                }
+                ARCTICDB_RUNTIME_DEBUG(log::storage(),
+                    "Wrote key {}: {}, with {} bytes of data",
+                    variant_key_type(k),
+                    variant_key_view(k),
+                    seg.total_segment_size(hdr_size));
             }
-             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Wrote key {}: {}, with {} bytes of data",
-                                 variant_key_type(k),
-                                 variant_key_view(k),
-                                 seg.total_segment_size(hdr_size));
-        }
-    });
+        });
 }
 
 template<class S3ClientType, class KeyBucketizer>
-void do_update_impl(
-        Composite<KeySegmentPair>&& kvs,
-        const std::string& root_folder,
-        const std::string& bucket_name,
-        S3ClientType& s3_client,
-        KeyBucketizer&& bucketizer) {
+void do_update_impl(Composite<KeySegmentPair>&& kvs,
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    S3ClientType& s3_client,
+    KeyBucketizer&& bucketizer)
+{
     // s3 updates the key if it already exists (our buckets don't have versioning)
     do_write_impl(std::move(kvs), root_folder, bucket_name, s3_client, std::move(bucketizer));
 }
 
 struct UnexpectedS3ErrorException : public std::exception {};
 
-inline bool is_expected_error_type(Aws::S3::S3Errors err) {
-    return err == Aws::S3::S3Errors::NO_SUCH_KEY
-        || err == Aws::S3::S3Errors::NO_SUCH_BUCKET
-        || err == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID
-        || err == Aws::S3::S3Errors::ACCESS_DENIED
-        || err == Aws::S3::S3Errors::RESOURCE_NOT_FOUND;
+inline bool is_expected_error_type(Aws::S3::S3Errors err)
+{
+    return err == Aws::S3::S3Errors::NO_SUCH_KEY || err == Aws::S3::S3Errors::NO_SUCH_BUCKET ||
+           err == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID || err == Aws::S3::S3Errors::ACCESS_DENIED ||
+           err == Aws::S3::S3Errors::RESOURCE_NOT_FOUND;
 }
 
 //TODO Use buffer pool once memory profile and lifetime is well understood
 struct S3StreamBuffer : public std::streambuf {
     ARCTICDB_NO_MOVE_OR_COPY(S3StreamBuffer)
-    S3StreamBuffer() :
+    S3StreamBuffer()
+        :
 #ifdef USE_BUFFER_POOL
-        buffer_(BufferPool::instance()->allocate()) {
+          buffer_(BufferPool::instance()->allocate())
+    {
 #else
-        buffer_(std::make_shared<Buffer>()) {
+          buffer_(std::make_shared<Buffer>()){
 #endif
     }
 
     std::shared_ptr<Buffer> buffer_;
     size_t pos_ = 0;
 
-    std::shared_ptr<Buffer> get_buffer() {
+    std::shared_ptr<Buffer> get_buffer()
+    {
         buffer_->set_bytes(pos_);
         return buffer_;
     }
@@ -160,33 +166,37 @@ struct S3StreamBuffer : public std::streambuf {
 protected:
     std::streamsize xsputn(const char_type* s, std::streamsize n) override;
 
-    int_type overflow(int_type ch) override {
+    int_type overflow(int_type ch) override
+    {
         return xsputn(reinterpret_cast<char*>(&ch), 1);
     }
 };
 
 struct S3IOStream : public std::iostream {
     S3StreamBuffer stream_buf_;
-    S3IOStream() :
-        std::iostream(&stream_buf_) {
+    S3IOStream()
+        : std::iostream(&stream_buf_)
+    {
     }
 
-    std::shared_ptr<Buffer> get_buffer() {
+    std::shared_ptr<Buffer> get_buffer()
+    {
         return stream_buf_.get_buffer();
     }
 };
 
-inline Aws::IOStreamFactory S3StreamFactory() {
+inline Aws::IOStreamFactory S3StreamFactory()
+{
     return [=]() { return Aws::New<S3IOStream>(""); };
 }
 
 template<class KeyType, class S3ClientType, class KeyBucketizer>
-auto get_object(
-    const KeyType &key,
-    const std::string &root_folder,
-    const std::string &bucket_name,
-    S3ClientType &s3_client,
-    KeyBucketizer& b) {
+auto get_object(const KeyType& key,
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    S3ClientType& s3_client,
+    KeyBucketizer& b)
+{
     auto key_type_folder = s3_key_type_folder(root_folder, variant_key_type(key));
     auto s3_object_name = s3_object_path(b.bucketize(key_type_folder, key), key);
 
@@ -198,9 +208,9 @@ auto get_object(
 
     if (!res.IsSuccess() && !is_expected_error_type(res.GetError().GetErrorType())) {
         log::storage().error("Got unexpected error: '{}' {}: {}",
-                             int(res.GetError().GetErrorType()),
-                             res.GetError().GetExceptionName().c_str(),
-                             res.GetError().GetMessage().c_str());
+            int(res.GetError().GetErrorType()),
+            res.GetError().GetExceptionName().c_str(),
+            res.GetError().GetMessage().c_str());
 
         throw UnexpectedS3ErrorException{};
     }
@@ -209,12 +219,12 @@ auto get_object(
 }
 
 template<class KeyType, class S3ClientType, class KeyBucketizer>
-auto head_object(
-    const KeyType &key,
-    const std::string &root_folder,
-    const std::string &bucket_name,
-    S3ClientType &s3_client,
-    KeyBucketizer& b) {
+auto head_object(const KeyType& key,
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    S3ClientType& s3_client,
+    KeyBucketizer& b)
+{
     auto key_type_folder = s3_key_type_folder(root_folder, variant_key_type(key));
     auto s3_object_name = s3_object_path(b.bucketize(key_type_folder, key), key);
 
@@ -225,9 +235,9 @@ auto head_object(
 
     if (!res.IsSuccess() && !is_expected_error_type(res.GetError().GetErrorType())) {
         log::storage().error("Got unexpected error: '{}' {}: {}",
-                             int(res.GetError().GetErrorType()),
-                             res.GetError().GetExceptionName().c_str(),
-                             res.GetError().GetMessage().c_str());
+            int(res.GetError().GetErrorType()),
+            res.GetError().GetExceptionName().c_str(),
+            res.GetError().GetMessage().c_str());
 
         throw UnexpectedS3ErrorException{};
     }
@@ -235,122 +245,123 @@ auto head_object(
     return res;
 }
 
-
 template<class Visitor, class S3ClientType, class KeyBucketizer>
-void do_read_impl(Composite<VariantKey> && ks,
-                  Visitor&& visitor,
-                  const std::string& root_folder,
-                  const std::string& bucket_name,
-                  S3ClientType& s3_client,
-                  KeyBucketizer&& bucketizer,
-                  ReadKeyOpts opts) {
+void do_read_impl(Composite<VariantKey>&& ks,
+    Visitor&& visitor,
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    S3ClientType& s3_client,
+    KeyBucketizer&& bucketizer,
+    ReadKeyOpts opts)
+{
     ARCTICDB_SAMPLE(S3StorageRead, 0)
     auto fmt_db = [](auto&& k) { return variant_key_type(k); };
     std::vector<VariantKey> failed_reads;
 
-    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach(
-        [&s3_client, &bucket_name, &root_folder, b=std::move(bucketizer), &visitor, &failed_reads,
-         opts=opts] (auto&& group) {
+    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db))
+        .foreach (
+            [&s3_client, &bucket_name, &root_folder, b = std::move(bucketizer), &visitor, &failed_reads, opts = opts](
+                auto&& group) {
+                for (auto& k : group.values()) {
+                    auto get_object_outcome = get_object(k, root_folder, bucket_name, s3_client, b);
 
-        for (auto& k : group.values()) {
-            auto get_object_outcome = get_object(
-                k,
-                root_folder,
-                bucket_name,
-                s3_client,
-                b);
+                    if (get_object_outcome.IsSuccess()) {
+                        ARCTICDB_SUBSAMPLE(S3StorageVisitSegment, 0)
+                        auto& retrieved = dynamic_cast<S3IOStream&>(get_object_outcome.GetResult().GetBody());
 
-            if (get_object_outcome.IsSuccess()) {
-                ARCTICDB_SUBSAMPLE(S3StorageVisitSegment, 0)
-                auto& retrieved = dynamic_cast<S3IOStream&>(get_object_outcome.GetResult().GetBody());
+                        visitor(k, Segment::from_buffer(retrieved.get_buffer()));
 
-                visitor(k, Segment::from_buffer(retrieved.get_buffer()));
+                        ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(k), variant_key_view(k));
+                    } else {
+                        auto& error = get_object_outcome.GetError();
+                        if (!opts.dont_warn_about_missing_key) {
+                            log::storage().warn("Failed to find segment for key '{}' {}: {}",
+                                variant_key_view(k),
+                                error.GetExceptionName().c_str(),
+                                error.GetMessage().c_str());
+                        }
 
-                ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(k), variant_key_view(k));
-            }
-            else {
-                auto& error = get_object_outcome.GetError();
-                if (!opts.dont_warn_about_missing_key) {
-                    log::storage().warn("Failed to find segment for key '{}' {}: {}",
-                            variant_key_view(k),
-                            error.GetExceptionName().c_str(),
-                            error.GetMessage().c_str());
+                        failed_reads.push_back(k);
+                    }
                 }
-
-                failed_reads.push_back(k);
-            }
-        }
-    });
-    if(!failed_reads.empty())
+            });
+    if (!failed_reads.empty())
         throw KeyNotFoundException(Composite<VariantKey>{std::move(failed_reads)});
 }
 
 template<class S3ClientType, class KeyBucketizer>
 void do_remove_impl(Composite<VariantKey>&& ks,
-                    const std::string& root_folder,
-                    const std::string& bucket_name,
-                    S3ClientType& s3_client,
-                    KeyBucketizer&& bucketizer) {
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    S3ClientType& s3_client,
+    KeyBucketizer&& bucketizer)
+{
     ARCTICDB_SUBSAMPLE(S3StorageDeleteBatch, 0)
     auto fmt_db = [](auto&& k) { return variant_key_type(k); };
     Aws::S3::Model::DeleteObjectsRequest object_request;
     object_request.WithBucket(bucket_name.c_str());
     Aws::S3::Model::Delete del_objects;
     std::vector<VariantKey> failed_deletes;
-    static const size_t delete_object_limit =
-        std::min(DELETE_OBJECTS_LIMIT,
-                 static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", 1000)));
+    static const size_t delete_object_limit = std::min(DELETE_OBJECTS_LIMIT,
+        static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", 1000)));
 
-    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach(
-        [&s3_client, &root_folder, &del_objects, &object_request, b=std::move(bucketizer), &failed_deletes] (auto&& group) {
-        auto key_type_folder = s3_key_type_folder(root_folder, group.key());
-        for (auto k : folly::enumerate(group.values())) {
-            auto s3_object_name = s3_object_path(b.bucketize(key_type_folder, *k), *k);
-             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Removing s3 object with key {}", s3_object_name);
+    (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db))
+        .foreach ([&s3_client, &root_folder, &del_objects, &object_request, b = std::move(bucketizer), &failed_deletes](
+                      auto&& group) {
+            auto key_type_folder = s3_key_type_folder(root_folder, group.key());
+            for (auto k : folly::enumerate(group.values())) {
+                auto s3_object_name = s3_object_path(b.bucketize(key_type_folder, *k), *k);
+                ARCTICDB_RUNTIME_DEBUG(log::storage(), "Removing s3 object with key {}", s3_object_name);
 
-            del_objects.AddObjects(Aws::S3::Model::ObjectIdentifier().WithKey(s3_object_name.c_str()));
+                del_objects.AddObjects(Aws::S3::Model::ObjectIdentifier().WithKey(s3_object_name.c_str()));
 
-            if (del_objects.GetObjects().size() == delete_object_limit || k.index + 1 == group.size()) {
-                ARCTICDB_SUBSAMPLE(S3StorageDeleteObjects, 0)
-                object_request.SetDelete(del_objects);
-                auto delete_object_outcome = s3_client.DeleteObjects(object_request);
-                if (delete_object_outcome.IsSuccess()) {
-                     ARCTICDB_RUNTIME_DEBUG(log::storage(), "Deleted object with key '{}'", variant_key_view(*k));
-                } else {
-                    // AN-256: Per AWS S3 documentation, deleting non-exist objects is not an error, so not handling
-                    // RemoveOpts.ignores_missing_key_
-                    for(const auto& bad_key : delete_object_outcome.GetResult().GetErrors()) {
-                        auto bad_key_name = bad_key.GetKey().substr(key_type_folder.size(), std::string::npos);
-                        failed_deletes.push_back(
-                            from_tokenized_variant_key(reinterpret_cast<const uint8_t*>(bad_key_name.data()), bad_key_name.size(), group.key()));
+                if (del_objects.GetObjects().size() == delete_object_limit || k.index + 1 == group.size()) {
+                    ARCTICDB_SUBSAMPLE(S3StorageDeleteObjects, 0)
+                    object_request.SetDelete(del_objects);
+                    auto delete_object_outcome = s3_client.DeleteObjects(object_request);
+                    if (delete_object_outcome.IsSuccess()) {
+                        ARCTICDB_RUNTIME_DEBUG(log::storage(), "Deleted object with key '{}'", variant_key_view(*k));
+                    } else {
+                        // AN-256: Per AWS S3 documentation, deleting non-exist objects is not an error, so not handling
+                        // RemoveOpts.ignores_missing_key_
+                        for (const auto& bad_key : delete_object_outcome.GetResult().GetErrors()) {
+                            auto bad_key_name = bad_key.GetKey().substr(key_type_folder.size(), std::string::npos);
+                            failed_deletes.push_back(
+                                from_tokenized_variant_key(reinterpret_cast<const uint8_t*>(bad_key_name.data()),
+                                    bad_key_name.size(),
+                                    group.key()));
+                        }
                     }
+                    del_objects.SetObjects(Aws::Vector<Aws::S3::Model::ObjectIdentifier>());
                 }
-                del_objects.SetObjects(Aws::Vector<Aws::S3::Model::ObjectIdentifier>());
             }
-        }
-    });
+        });
 
-    util::check(del_objects.GetObjects().empty(), "Have {} segment that have not been removed", del_objects.GetObjects().size());
-    if(!failed_deletes.empty())
+    util::check(del_objects.GetObjects().empty(),
+        "Have {} segment that have not been removed",
+        del_objects.GetObjects().size());
+    if (!failed_deletes.empty())
         throw KeyNotFoundException(Composite<VariantKey>(std::move(failed_deletes)));
 }
 
-inline auto default_prefix_handler() {
-    return [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
-        return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
-    };
+inline auto default_prefix_handler()
+{
+    return
+        [](const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
+            return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
+        };
 }
 
 template<class Visitor, class S3ClientType, class KeyBucketizer, class PrefixHandler>
 void do_iterate_type_impl(KeyType key_type,
-                          Visitor&& visitor,
-                          const std::string& root_folder,
-                          const std::string& bucket_name,
-                          S3ClientType& s3_client,
-                          KeyBucketizer&& bucketizer,
-                          PrefixHandler&& prefix_handler = default_prefix_handler(),
-                          const std::string& prefix = std::string{}
-) {
+    Visitor&& visitor,
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    S3ClientType& s3_client,
+    KeyBucketizer&& bucketizer,
+    PrefixHandler&& prefix_handler = default_prefix_handler(),
+    const std::string& prefix = std::string{})
+{
     ARCTICDB_SAMPLE(S3StorageIterateType, 0)
     auto key_type_dir = s3_key_type_folder(root_folder, key_type);
 
@@ -359,9 +370,13 @@ void do_iterate_type_impl(KeyType key_type,
     // the Descriptor.
     // TODO: Set the IndexDescriptor correctly
     KeyDescriptor key_descriptor(prefix,
-        is_ref_key_class(key_type) ? IndexDescriptor::UNKNOWN : IndexDescriptor::TIMESTAMP, FormatType::TOKENIZED);
+        is_ref_key_class(key_type) ? IndexDescriptor::UNKNOWN : IndexDescriptor::TIMESTAMP,
+        FormatType::TOKENIZED);
     auto key_prefix = prefix_handler(prefix, key_type_dir, key_descriptor, key_type);
-    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Searching for objects in bucket {} with prefix {}", bucket_name, key_prefix);
+    ARCTICDB_RUNTIME_DEBUG(log::storage(),
+        "Searching for objects in bucket {} with prefix {}",
+        bucket_name,
+        key_prefix);
     Aws::S3::Model::ListObjectsV2Request objects_request;
     objects_request.WithBucket(bucket_name.c_str());
     objects_request.SetPrefix(key_prefix.c_str());
@@ -378,10 +393,7 @@ void do_iterate_type_impl(KeyType key_type,
             for (auto const& s3_object : object_list) {
                 auto key = s3_object.GetKey().substr(root_folder_size);
                 ARCTICDB_TRACE(log::version(), "Got object_list: {}, key: {}", s3_object.GetKey(), key);
-                auto k = variant_key_from_bytes(
-                    reinterpret_cast<uint8_t*>(key.data()),
-                    key.size(),
-                    key_type);
+                auto k = variant_key_from_bytes(reinterpret_cast<uint8_t*>(key.data()), key.size(), key_type);
 
                 ARCTICDB_DEBUG(log::storage(), "Iterating key {}: {}", variant_key_type(k), variant_key_view(k));
                 ARCTICDB_SUBSAMPLE(S3StorageVisitKey, 0)
@@ -392,47 +404,42 @@ void do_iterate_type_impl(KeyType key_type,
             if (more)
                 objects_request.SetContinuationToken(list_objects_outcome.GetResult().GetNextContinuationToken());
 
-        }
-        else {
+        } else {
             const auto& error = list_objects_outcome.GetError();
             log::storage().warn("Failed to iterate key type with key '{}' {}: {}",
-                                key_type,
-                                error.GetExceptionName().c_str(),
-                                error.GetMessage().c_str());
+                key_type,
+                error.GetExceptionName().c_str(),
+                error.GetMessage().c_str());
             return;
         }
     } while (more);
 }
 
 template<class S3ClientType, class KeyBucketizer>
-bool do_key_exists_impl(
-    const VariantKey& key,
+bool do_key_exists_impl(const VariantKey& key,
     const std::string& root_folder,
     const std::string& bucket_name,
     S3ClientType& s3_client,
-    KeyBucketizer&& bucketizer
-) {
-    auto head_object_outcome = head_object(
-        key,
-        root_folder,
-        bucket_name,
-        s3_client,
-        bucketizer);
+    KeyBucketizer&& bucketizer)
+{
+    auto head_object_outcome = head_object(key, root_folder, bucket_name, s3_client, bucketizer);
 
-    if(!head_object_outcome.IsSuccess()) {
+    if (!head_object_outcome.IsSuccess()) {
         auto& error ARCTICDB_UNUSED = head_object_outcome.GetError();
-        ARCTICDB_DEBUG(log::storage(), "Head object returned false for key {} {} {}:{}",
-                             variant_key_view(key),
-                             int(error.GetErrorType()),
-                             error.GetExceptionName().c_str(),
-                             error.GetMessage().c_str());
+        ARCTICDB_DEBUG(log::storage(),
+            "Head object returned false for key {} {} {}:{}",
+            variant_key_view(key),
+            int(error.GetErrorType()),
+            error.GetExceptionName().c_str(),
+            error.GetMessage().c_str());
     }
 
     return head_object_outcome.IsSuccess();
 }
 } //namespace detail
 
-inline std::string S3Storage::get_key_path(const VariantKey& key) const {
+inline std::string S3Storage::get_key_path(const VariantKey& key) const
+{
     auto b = detail::FlatBucketizer{};
     auto key_type_folder = s3_key_type_folder(root_folder_, variant_key_type(key));
     return s3_object_path(b.bucketize(key_type_folder, key), key);
@@ -440,37 +447,54 @@ inline std::string S3Storage::get_key_path(const VariantKey& key) const {
     // to most of them
 }
 
-inline void S3Storage::do_write(Composite<KeySegmentPair>&& kvs) {
+inline void S3Storage::do_write(Composite<KeySegmentPair>&& kvs)
+{
     detail::do_write_impl(std::move(kvs), root_folder_, bucket_name_, s3_client_, detail::FlatBucketizer{});
 }
 
-inline void S3Storage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts) {
+inline void S3Storage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts)
+{
     detail::do_update_impl(std::move(kvs), root_folder_, bucket_name_, s3_client_, detail::FlatBucketizer{});
 }
 
 template<class Visitor>
-void S3Storage::do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts) {
-    detail::do_read_impl(std::move(ks), std::move(visitor), root_folder_, bucket_name_, s3_client_, detail::FlatBucketizer{}, opts);
+void S3Storage::do_read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts)
+{
+    detail::do_read_impl(std::move(ks),
+        std::move(visitor),
+        root_folder_,
+        bucket_name_,
+        s3_client_,
+        detail::FlatBucketizer{},
+        opts);
 }
 
-inline void S3Storage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
+inline void S3Storage::do_remove(Composite<VariantKey>&& ks, RemoveOpts)
+{
     detail::do_remove_impl(std::move(ks), root_folder_, bucket_name_, s3_client_, detail::FlatBucketizer{});
 }
 
-
-
 template<class Visitor>
-void S3Storage::do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix) {
-    auto prefix_handler = [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor key_descriptor, KeyType) {
-        return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
-    };
+void S3Storage::do_iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix)
+{
+    auto prefix_handler =
+        [](const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor key_descriptor, KeyType) {
+            return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
+        };
 
-    detail::do_iterate_type_impl(key_type, std::move(visitor), root_folder_, bucket_name_, s3_client_, detail::FlatBucketizer{}, std::move(prefix_handler), prefix);
+    detail::do_iterate_type_impl(key_type,
+        std::move(visitor),
+        root_folder_,
+        bucket_name_,
+        s3_client_,
+        detail::FlatBucketizer{},
+        std::move(prefix_handler),
+        prefix);
 }
 
-inline bool S3Storage::do_key_exists(const VariantKey& key) {
+inline bool S3Storage::do_key_exists(const VariantKey& key)
+{
     return detail::do_key_exists_impl(key, root_folder_, bucket_name_, s3_client_, detail::FlatBucketizer{});
 }
-
 
 } // namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/s3_storage_tool-inl.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage_tool-inl.hpp
@@ -12,7 +12,8 @@
 namespace arcticdb::storage::s3 {
 
 template<class Visitor>
-void S3StorageTool::iterate_bucket(Visitor&& visitor, const std::string& prefix) {
+void S3StorageTool::iterate_bucket(Visitor&& visitor, const std::string& prefix)
+{
     Aws::S3::Model::ListObjectsV2Request objects_request;
     objects_request.WithBucket(bucket_name_.c_str());
     if (!prefix.empty())
@@ -32,19 +33,19 @@ void S3StorageTool::iterate_bucket(Visitor&& visitor, const std::string& prefix)
             if (more)
                 objects_request.SetContinuationToken(list_objects_outcome.GetResult().GetNextContinuationToken());
 
-        }
-        else {
+        } else {
             const auto& error = list_objects_outcome.GetError();
             log::storage().error("Failed to iterate bucket '{}' {}:{}",
-                                 bucket_name_,
-                                 error.GetExceptionName().c_str(),
-                                 error.GetMessage().c_str());
+                bucket_name_,
+                error.GetExceptionName().c_str(),
+                error.GetMessage().c_str());
             return;
         }
     } while (more);
 }
 
-inline void S3StorageTool::set_object(const std::string& key, const std::string& data) {
+inline void S3StorageTool::set_object(const std::string& key, const std::string& data)
+{
     Aws::S3::Model::PutObjectRequest object_request;
     object_request.SetBucket(bucket_name_.c_str());
     object_request.SetKey(key.c_str());
@@ -58,16 +59,15 @@ inline void S3StorageTool::set_object(const std::string& key, const std::string&
     if (!put_object_outcome.IsSuccess()) {
         auto& error = put_object_outcome.GetError();
         util::raise_rte("Failed to write s3 with key '{}' {}: {}",
-                        key,
-                        error.GetExceptionName().c_str(),
-                        error.GetMessage().c_str());
+            key,
+            error.GetExceptionName().c_str(),
+            error.GetMessage().c_str());
     }
-    ARCTICDB_DEBUG(log::storage(), "Wrote key {} with {} bytes of data",
-                         key,
-                         data.size());
+    ARCTICDB_DEBUG(log::storage(), "Wrote key {} with {} bytes of data", key, data.size());
 }
 
-inline std::string S3StorageTool::get_object(const std::string& key) {
+inline std::string S3StorageTool::get_object(const std::string& key)
+{
     Aws::S3::Model::GetObjectRequest object_request;
 
     object_request.SetBucket(bucket_name_.c_str());
@@ -78,18 +78,18 @@ inline std::string S3StorageTool::get_object(const std::string& key) {
         auto& retrieved = get_object_outcome.GetResult().GetBody();
         auto vec = storage::stream_to_vector(retrieved);
         return std::string(vec.data(), vec.size());
-    }
-    else {
+    } else {
         auto& error = get_object_outcome.GetError();
         log::storage().warn("Failed to find data for key '{}' {}: {}",
-                            key,
-                            error.GetExceptionName().c_str(),
-                            error.GetMessage().c_str());
+            key,
+            error.GetExceptionName().c_str(),
+            error.GetMessage().c_str());
         return std::string();
     }
 }
 
-inline void S3StorageTool::delete_object(const std::string& key) {
+inline void S3StorageTool::delete_object(const std::string& key)
+{
     Aws::S3::Model::DeleteObjectRequest object_request;
     object_request.WithBucket(bucket_name_.c_str()).WithKey(key.c_str());
 
@@ -99,19 +99,21 @@ inline void S3StorageTool::delete_object(const std::string& key) {
     else {
         const auto& error = delete_object_outcome.GetError();
         log::storage().warn("Failed to delete segment with key '{}': {}",
-                            key,
-                            error.GetExceptionName().c_str(),
-                            error.GetMessage().c_str());
+            key,
+            error.GetExceptionName().c_str(),
+            error.GetMessage().c_str());
     }
 }
 
-inline std::vector<std::string> S3StorageTool::list_bucket(const std::string& prefix) {
+inline std::vector<std::string> S3StorageTool::list_bucket(const std::string& prefix)
+{
     std::vector<std::string> objects;
     iterate_bucket([&](const std::string& str) { objects.push_back(str); }, prefix);
     return objects;
 }
 
-inline std::pair<size_t, size_t> S3StorageTool::get_prefix_info(const std::string& prefix) {
+inline std::pair<size_t, size_t> S3StorageTool::get_prefix_info(const std::string& prefix)
+{
     size_t total_size = 0;
     size_t total_items = 0;
     Aws::S3::Model::ListObjectsV2Request objects_request;
@@ -133,57 +135,56 @@ inline std::pair<size_t, size_t> S3StorageTool::get_prefix_info(const std::strin
             if (more)
                 objects_request.SetContinuationToken(list_objects_outcome.GetResult().GetNextContinuationToken());
 
-        }
-        else {
+        } else {
             const auto& error = list_objects_outcome.GetError();
             log::storage().error("Failed to iterate bucket to get sizes'{}' {}:{}",
-                                 bucket_name_,
-                                 error.GetExceptionName().c_str(),
-                                 error.GetMessage().c_str());
+                bucket_name_,
+                error.GetExceptionName().c_str(),
+                error.GetMessage().c_str());
             return {0, 0};
         }
     } while (more);
     return {total_size, total_items};
 }
 
-inline size_t S3StorageTool::get_file_size(const std::string& key) {
+inline size_t S3StorageTool::get_file_size(const std::string& key)
+{
     Aws::S3::Model::HeadObjectRequest head_request;
     head_request.SetBucket(bucket_name_.c_str());
     head_request.SetKey(key.c_str());
 
     auto object = s3_client_.HeadObject(head_request);
-    if (object.IsSuccess())
-    {
+    if (object.IsSuccess()) {
         auto file_sz = object.GetResultWithOwnership().GetContentLength();
         ARCTICDB_TRACE(log::storage(), "Size of {}: {}", key, file_sz);
         return file_sz;
-    }
-    else
-    {
-        log::storage().error("Head Object error:  {} - {}", object .GetError().GetExceptionName(),
-                             object .GetError().GetMessage());
+    } else {
+        log::storage().error("Head Object error:  {} - {}",
+            object.GetError().GetExceptionName(),
+            object.GetError().GetMessage());
         return 0;
     }
 }
 
+inline void S3StorageTool::delete_bucket(const std::string& prefix)
+{
+    iterate_bucket(
+        [&](const std::string& key) {
+            Aws::S3::Model::DeleteObjectRequest object_request;
+            object_request.WithBucket(bucket_name_.c_str()).WithKey(key.c_str());
 
-inline void S3StorageTool::delete_bucket(const std::string& prefix) {
-    iterate_bucket([&](const std::string& key) {
-                       Aws::S3::Model::DeleteObjectRequest object_request;
-                       object_request.WithBucket(bucket_name_.c_str()).WithKey(key.c_str());
-
-                       auto delete_object_outcome = s3_client_.DeleteObject(object_request);
-                       if (delete_object_outcome.IsSuccess())
-                           ARCTICDB_DEBUG(log::storage(), "Deleted object with key '{}'", key);
-                       else {
-                           const auto& error = delete_object_outcome.GetError();
-                           log::storage().warn("Failed to delete object with key '{}' {}:{}",
-                                               key,
-                                               error.GetExceptionName().c_str(),
-                                               error.GetMessage().c_str());
-                       }
-                   },
-                   prefix);
+            auto delete_object_outcome = s3_client_.DeleteObject(object_request);
+            if (delete_object_outcome.IsSuccess())
+                ARCTICDB_DEBUG(log::storage(), "Deleted object with key '{}'", key);
+            else {
+                const auto& error = delete_object_outcome.GetError();
+                log::storage().warn("Failed to delete object with key '{}' {}:{}",
+                    key,
+                    error.GetExceptionName().c_str(),
+                    error.GetMessage().c_str());
+            }
+        },
+        prefix);
 }
 
 } // namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/s3_storage_tool.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage_tool.cpp
@@ -9,13 +9,17 @@
 
 namespace arcticdb::storage::s3 {
 
-S3StorageTool::S3StorageTool(const Config &conf) :
-    s3_api_(S3ApiInstance::instance()),
-    s3_client_(get_aws_credentials(conf), get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false),
-    bucket_name_(conf.bucket_name()) {
-    std::locale locale{ std::locale::classic(), new std::num_put<char>()};
+S3StorageTool::S3StorageTool(const Config& conf)
+    : s3_api_(S3ApiInstance::instance()),
+      s3_client_(get_aws_credentials(conf),
+          get_s3_config(conf),
+          Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+          false),
+      bucket_name_(conf.bucket_name())
+{
+    std::locale locale{std::locale::classic(), new std::num_put<char>()};
     (void)std::locale::global(locale);
     ARCTICDB_DEBUG(log::storage(), "Created S3 storage tool for bucket {}", bucket_name_);
 }
 
-}  //namespace arcticdb::storage::s3
+} //namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/s3_storage_tool.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage_tool.hpp
@@ -14,10 +14,10 @@ namespace arcticdb::storage::s3 {
 class S3StorageTool {
 public:
     using Config = arcticdb::proto::s3_storage::Config;
-    S3StorageTool(const Config &conf);
+    S3StorageTool(const Config& conf);
 
     template<class Visitor>
-    void iterate_bucket(Visitor &&visitor, const std::string& prefix = std::string());
+    void iterate_bucket(Visitor&& visitor, const std::string& prefix = std::string());
 
     void delete_bucket(const std::string& prefix = std::string());
 

--- a/cpp/arcticdb/storage/s3/s3_utils.hpp
+++ b/cpp/arcticdb/storage/s3/s3_utils.hpp
@@ -17,19 +17,23 @@
 
 namespace arcticdb::storage::s3 {
 
-inline std::string get_root_folder(const LibraryPath& library_path){
+inline std::string get_root_folder(const LibraryPath& library_path)
+{
     return library_path.to_delim_path('/');
 }
 
-inline auto object_name_from_key(const VariantKey& key) {
+inline auto object_name_from_key(const VariantKey& key)
+{
     return to_tokenized_key(key);
 }
 
-inline auto s3_object_path(std::string_view folder, const VariantKey& key) {
+inline auto s3_object_path(std::string_view folder, const VariantKey& key)
+{
     return fmt::format("{}/{}", folder, object_name_from_key(key));
 }
 
-inline auto s3_key_type_folder(const std::string& root_folder, KeyType key_type) {
+inline auto s3_key_type_folder(const std::string& root_folder, KeyType key_type)
+{
     return fmt::format("{}/{}", root_folder, key_type_long_name(key_type));
 }
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -29,50 +29,63 @@ struct StorageBase {}; // marker class for type checking
 
 class DuplicateKeyException : public ArcticSpecificException<ErrorCode::E_DUPLICATE_KEY> {
 public:
-    explicit DuplicateKeyException(VariantKey key) :
-        ArcticSpecificException<ErrorCode::E_DUPLICATE_KEY>(std::string(variant_key_view(key))),
-        key_(std::move(key)) {}
+    explicit DuplicateKeyException(VariantKey key)
+        : ArcticSpecificException<ErrorCode::E_DUPLICATE_KEY>(std::string(variant_key_view(key))),
+          key_(std::move(key))
+    {
+    }
 
-    [[nodiscard]] const VariantKey &key() const {
+    [[nodiscard]] const VariantKey& key() const
+    {
         return key_;
     }
+
 private:
     VariantKey key_;
 };
 
 class NoDataFoundException : public ArcticCategorizedException<ErrorCategory::MISSING_DATA> {
 public:
-    explicit NoDataFoundException(VariantId key) :
-            ArcticCategorizedException<ErrorCategory::MISSING_DATA>(std::visit([](const auto &key) { return fmt::format("{}", key); }, key)),
-            key_(key){
+    explicit NoDataFoundException(VariantId key)
+        : ArcticCategorizedException<ErrorCategory::MISSING_DATA>(
+              std::visit([](const auto& key) { return fmt::format("{}", key); }, key)),
+          key_(key)
+    {
     }
 
-    explicit NoDataFoundException(const std::string& msg) :
-            ArcticCategorizedException<ErrorCategory::MISSING_DATA>(msg) {
+    explicit NoDataFoundException(const std::string& msg)
+        : ArcticCategorizedException<ErrorCategory::MISSING_DATA>(msg)
+    {
     }
 
-    explicit NoDataFoundException(const char* msg) :
-            ArcticCategorizedException<ErrorCategory::MISSING_DATA>(std::string(msg)) {
+    explicit NoDataFoundException(const char* msg)
+        : ArcticCategorizedException<ErrorCategory::MISSING_DATA>(std::string(msg))
+    {
     }
 
-    [[nodiscard]] const VariantId &key() const {
+    [[nodiscard]] const VariantId& key() const
+    {
         util::check(static_cast<bool>(key_), "Key not found");
         return *key_;
     }
+
 private:
     std::optional<VariantId> key_;
 };
 
 class KeyNotFoundException : public ArcticSpecificException<ErrorCode::E_DUPLICATE_KEY> {
 public:
-    explicit KeyNotFoundException(Composite<VariantKey>&& keys) :
-        ArcticSpecificException<ErrorCode::E_DUPLICATE_KEY>(fmt::format("{}", keys)),
-        keys_(std::make_shared<Composite<VariantKey>>(std::move(keys))) {
+    explicit KeyNotFoundException(Composite<VariantKey>&& keys)
+        : ArcticSpecificException<ErrorCode::E_DUPLICATE_KEY>(fmt::format("{}", keys)),
+          keys_(std::make_shared<Composite<VariantKey>>(std::move(keys)))
+    {
     }
 
-    Composite<VariantKey>& keys() {
+    Composite<VariantKey>& keys()
+    {
         return *keys_;
     }
+
 private:
     std::shared_ptr<Composite<VariantKey>> keys_;
     mutable std::string msg_;
@@ -81,84 +94,108 @@ private:
 template<class Impl>
 class Storage : public StorageBase {
 public:
+    Storage(LibraryPath library_path, OpenMode mode)
+        : lib_path_(std::move(library_path)),
+          mode_(mode)
+    {
+    }
 
-    Storage(LibraryPath library_path, OpenMode mode) :
-        lib_path_(std::move(library_path)),
-        mode_(mode) {}
-
-    void write(Composite<KeySegmentPair> &&kvs) {
+    void write(Composite<KeySegmentPair>&& kvs)
+    {
         ARCTICDB_SAMPLE(VariantStorageWrite, 0)
         return derived().do_write(std::move(kvs));
     }
 
-    void write(KeySegmentPair &&kv) {
+    void write(KeySegmentPair&& kv)
+    {
         return write(Composite<KeySegmentPair>{std::move(kv)});
     }
 
-    void update(Composite<KeySegmentPair> &&kvs, UpdateOpts opts) {
+    void update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts)
+    {
         ARCTICDB_SAMPLE(VariantStorageUpdate, 0)
         return derived().do_update(std::move(kvs), opts);
     }
 
-    void update(KeySegmentPair &&kv, UpdateOpts opts) {
+    void update(KeySegmentPair&& kv, UpdateOpts opts)
+    {
         return update(Composite<KeySegmentPair>{std::move(kv)}, opts);
     }
 
     template<class Visitor>
-    void read(Composite<VariantKey> &&ks, Visitor &&visitor, ReadKeyOpts opts) {
+    void read(Composite<VariantKey>&& ks, Visitor&& visitor, ReadKeyOpts opts)
+    {
         return derived().do_read(std::move(ks), std::forward<Visitor>(visitor), opts);
     }
 
     template<class Visitor>
-    void read(VariantKey&& key, Visitor &&visitor, ReadKeyOpts opts) {
+    void read(VariantKey&& key, Visitor&& visitor, ReadKeyOpts opts)
+    {
         return read(Composite<VariantKey>{std::move(key)}, std::forward<Visitor>(visitor), opts);
     }
 
     template<class KeyType>
-    KeySegmentPair read(KeyType&& key, ReadKeyOpts opts) {
+    KeySegmentPair read(KeyType&& key, ReadKeyOpts opts)
+    {
         KeySegmentPair key_seg;
-         read(std::forward<KeyType>(key), [&key_seg](auto && vk, auto &&value) {
-             key_seg.variant_key() = std::forward<VariantKey>(vk);
-             key_seg.segment() = std::forward<Segment>(value);
-        }, opts);
-         return key_seg;
+        read(
+            std::forward<KeyType>(key),
+            [&key_seg](auto&& vk, auto&& value) {
+                key_seg.variant_key() = std::forward<VariantKey>(vk);
+                key_seg.segment() = std::forward<Segment>(value);
+            },
+            opts);
+        return key_seg;
     }
 
-    void remove(Composite<VariantKey> &&ks, RemoveOpts opts) {
+    void remove(Composite<VariantKey>&& ks, RemoveOpts opts)
+    {
         derived().do_remove(std::move(ks), opts);
     }
 
-    void remove(VariantKey&& key, RemoveOpts opts) {
+    void remove(VariantKey&& key, RemoveOpts opts)
+    {
         return remove(Composite<VariantKey>{std::move(key)}, opts);
     }
 
-    bool supports_prefix_matching() {
+    bool supports_prefix_matching()
+    {
         return derived().do_supports_prefix_matching();
     }
 
-    bool fast_delete() {
+    bool fast_delete()
+    {
         return derived().do_fast_delete();
     }
 
-    inline bool key_exists(const VariantKey &key) {
+    inline bool key_exists(const VariantKey& key)
+    {
         return derived().do_key_exists(key);
     }
 
     template<class Visitor>
-    void iterate_type(KeyType key_type, Visitor &&visitor, const std::string &prefix = std::string()) {
+    void iterate_type(KeyType key_type, Visitor&& visitor, const std::string& prefix = std::string())
+    {
         derived().do_iterate_type(key_type, std::forward<Visitor>(visitor), prefix);
     }
 
-    [[nodiscard]] const LibraryPath &library_path() const { return lib_path_; }
-    [[nodiscard]] OpenMode open_mode() const { return mode_; }
+    [[nodiscard]] const LibraryPath& library_path() const
+    {
+        return lib_path_;
+    }
+    [[nodiscard]] OpenMode open_mode() const
+    {
+        return mode_;
+    }
 
 private:
     LibraryPath lib_path_;
     OpenMode mode_;
 
-    Impl &derived() {
-        return *static_cast<Impl *>(this);
+    Impl& derived()
+    {
+        return *static_cast<Impl*>(this);
     }
 };
 
-}
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/storage_exceptions.hpp
+++ b/cpp/arcticdb/storage/storage_exceptions.hpp
@@ -14,24 +14,28 @@
 namespace arcticdb::storage {
 
 class PermissionException : public std::exception {
-  public:
-    PermissionException(const LibraryPath &path, OpenMode mode, std::string_view operation) :
-        lib_path_(path), mode_(mode), msg_(fmt::format(
-        "{} not permitted. lib={}, mode={}", operation, lib_path_, mode_)
-    ) {}
+public:
+    PermissionException(const LibraryPath& path, OpenMode mode, std::string_view operation)
+        : lib_path_(path),
+          mode_(mode),
+          msg_(fmt::format("{} not permitted. lib={}, mode={}", operation, lib_path_, mode_))
+    {
+    }
 
-    const char *what() const noexcept override {
+    const char* what() const noexcept override
+    {
         return msg_.data();
     }
 
-    const LibraryPath &library_path() const {
+    const LibraryPath& library_path() const
+    {
         return lib_path_;
     }
 
-  private:
+private:
     LibraryPath lib_path_;
     OpenMode mode_;
     std::string msg_;
 };
 
-}
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -19,51 +19,41 @@
 
 namespace arcticdb::storage {
 
-std::shared_ptr<VariantStorageFactory> create_storage_factory(
-    const arcticdb::proto::storage::VariantStorage &storage) {
+std::shared_ptr<VariantStorageFactory> create_storage_factory(const arcticdb::proto::storage::VariantStorage& storage)
+{
     std::shared_ptr<VariantStorageFactory> res;
     auto type_name = util::get_arcticdb_pb_type_name(storage.config());
 
     if (type_name == s3::S3Storage::Config::descriptor()->full_name()) {
         s3::S3Storage::Config s3_config;
         storage.config().UnpackTo(&s3_config);
-        res = std::make_shared<VariantStorageFactory>(
-            s3::S3StorageFactory(s3_config)
-        );
+        res = std::make_shared<VariantStorageFactory>(s3::S3StorageFactory(s3_config));
     } else if (type_name == lmdb::LmdbStorage::Config::descriptor()->full_name()) {
         lmdb::LmdbStorage::Config lmbd_config;
         storage.config().UnpackTo(&lmbd_config);
-        res = std::make_shared<VariantStorageFactory>(
-            lmdb::LmdbStorageFactory(lmbd_config)
-        );
+        res = std::make_shared<VariantStorageFactory>(lmdb::LmdbStorageFactory(lmbd_config));
     } else if (type_name == mongo::MongoStorage::Config::descriptor()->full_name()) {
         mongo::MongoStorage::Config mongo_config;
         storage.config().UnpackTo(&mongo_config);
-        res = std::make_shared<VariantStorageFactory>(
-            mongo::MongoStorageFactory(mongo_config)
-        );
+        res = std::make_shared<VariantStorageFactory>(mongo::MongoStorageFactory(mongo_config));
     } else if (type_name == memory::MemoryStorage::Config::descriptor()->full_name()) {
         memory::MemoryStorage::Config memory_config;
-    storage.config().UnpackTo(&memory_config);
-    res = std::make_shared<VariantStorageFactory>(
-            memory::MemoryStorageFactory(memory_config)
-        );
+        storage.config().UnpackTo(&memory_config);
+        res = std::make_shared<VariantStorageFactory>(memory::MemoryStorageFactory(memory_config));
     } else if (type_name == nfs_backed::NfsBackedStorage::Config::descriptor()->full_name()) {
         nfs_backed::NfsBackedStorage::Config nfs_backed_config;
         storage.config().UnpackTo(&nfs_backed_config);
-        res = std::make_shared<VariantStorageFactory>(
-            nfs_backed::NfsBackedStorageFactory(nfs_backed_config)
-        );
+        res = std::make_shared<VariantStorageFactory>(nfs_backed::NfsBackedStorageFactory(nfs_backed_config));
     } else
         throw std::runtime_error(fmt::format("Unknown config type {}", type_name));
 
     return res;
 }
 
-std::unique_ptr<VariantStorage> create_storage(
-    const LibraryPath &library_path,
+std::unique_ptr<VariantStorage> create_storage(const LibraryPath& library_path,
     OpenMode mode,
-    const arcticdb::proto::storage::VariantStorage &storage_config) {
+    const arcticdb::proto::storage::VariantStorage& storage_config)
+{
     return create_storage_factory(storage_config)->create_storage(library_path, mode);
 }
 

--- a/cpp/arcticdb/storage/storage_factory.hpp
+++ b/cpp/arcticdb/storage/storage_factory.hpp
@@ -18,17 +18,18 @@ namespace arcticdb::storage {
 
 template<class Impl>
 class StorageFactory {
-  public:
-
+public:
     StorageFactory() = default;
 
-    auto create_storage(const LibraryPath &lib, OpenMode mode) {
+    auto create_storage(const LibraryPath& lib, OpenMode mode)
+    {
         return derived().do_create_storage(lib, mode);
     }
 
-  private:
-    Impl &derived() {
-        return *static_cast<Impl *>(this);
+private:
+    Impl& derived()
+    {
+        return *static_cast<Impl*>(this);
     }
 };
 

--- a/cpp/arcticdb/storage/storage_options.hpp
+++ b/cpp/arcticdb/storage/storage_options.hpp
@@ -46,4 +46,4 @@ struct UpdateOpts {
     bool upsert_ = false;
 };
 
-}
+} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/storage_utils.hpp
+++ b/cpp/arcticdb/storage/storage_utils.hpp
@@ -12,17 +12,17 @@
 
 namespace arcticdb {
 
-inline auto stream_id_prefix_matcher(const std::string &prefix) {
+inline auto stream_id_prefix_matcher(const std::string& prefix)
+{
     return [&prefix](const StreamId& id) {
         return prefix.empty() || (std::holds_alternative<std::string>(id) &&
-        std::get<std::string>(id).compare(0u, prefix.size(), prefix) == 0); };
+                                     std::get<std::string>(id).compare(0u, prefix.size(), prefix) == 0);
+    };
 }
 
-inline std::vector<VariantKey> filter_keys_on_existence(
-        const std::vector<VariantKey>& keys,
-        const std::shared_ptr<Store>& store,
-        bool pred
-        ){
+inline std::vector<VariantKey>
+filter_keys_on_existence(const std::vector<VariantKey>& keys, const std::shared_ptr<Store>& store, bool pred)
+{
     auto key_existence = folly::collect(store->batch_key_exists(keys)).get();
     std::vector<VariantKey> res;
     for (size_t i = 0; i != keys.size(); i++) {
@@ -33,11 +33,13 @@ inline std::vector<VariantKey> filter_keys_on_existence(
     return res;
 }
 
-inline void filter_keys_on_existence(std::vector<AtomKey>& keys, const std::shared_ptr<Store>& store, bool pred) {
+inline void filter_keys_on_existence(std::vector<AtomKey>& keys, const std::shared_ptr<Store>& store, bool pred)
+{
     std::vector<VariantKey> var_vector;
     var_vector.reserve(keys.size());
-    std::transform(keys.begin(), keys.end(), std::back_inserter(var_vector),
-                   [](auto&& k) { return VariantKey(std::move(k)); });
+    std::transform(keys.begin(), keys.end(), std::back_inserter(var_vector), [](auto&& k) {
+        return VariantKey(std::move(k));
+    });
 
     auto key_existence = store->batch_key_exists(var_vector);
 
@@ -52,4 +54,4 @@ inline void filter_keys_on_existence(std::vector<AtomKey>& keys, const std::shar
     keys.erase(keys_itr, keys.end());
 }
 
-}  //namespace arcticdb
+} //namespace arcticdb

--- a/cpp/arcticdb/storage/store.hpp
+++ b/cpp/arcticdb/storage/store.hpp
@@ -24,9 +24,11 @@ public:
 
     virtual void move_storage(KeyType key_type, timestamp horizon, size_t storage_index) = 0;
 
-    virtual folly::Future<VariantKey> copy(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) = 0;
+    virtual folly::Future<VariantKey>
+    copy(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) = 0;
 
-    virtual VariantKey copy_sync(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) = 0;
+    virtual VariantKey
+    copy_sync(KeyType key_type, const StreamId& stream_id, VersionId version_id, const VariantKey& source_key) = 0;
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -17,375 +17,424 @@
 #include <arcticdb/storage/storage.hpp>
 
 namespace arcticdb {
-    class InMemoryStore : public Store {
+class InMemoryStore : public Store {
 
-    public:
-        InMemoryStore() = default;
+public:
+    InMemoryStore() = default;
 
-        folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair>) override {
-            util::raise_rte("Not implemented");
+    folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair>) override
+    {
+        util::raise_rte("Not implemented");
+    }
+
+    bool batch_all_keys_exist_sync(const std::unordered_set<entity::VariantKey>&) override
+    {
+        util::raise_rte("Not implemented");
+    }
+
+    bool supports_prefix_matching() override
+    {
+        return false;
+    }
+
+    bool fast_delete() override
+    {
+        return false;
+    }
+
+    std::vector<Composite<ProcessingSegment>> batch_read_uncompressed(std::vector<Composite<pipelines::SliceAndKey>>&&,
+        const std::shared_ptr<std::vector<Clause>>&,
+        const StreamDescriptor&,
+        const std::shared_ptr<std::unordered_set<std::string>>&,
+        const BatchReadArgs&) override
+    {
+        throw std::runtime_error("Not implemented for tests");
+    }
+
+    folly::Future<VariantKey> write(KeyType key_type,
+        VersionId gen_id,
+        const StreamId& stream_id,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&& segment) override
+    {
+        auto key = atom_key_builder()
+                       .gen_id(gen_id)
+                       .content_hash(content_hash_)
+                       .creation_ts(PilotedClock::nanos_since_epoch())
+                       .start_index(start_index)
+                       .end_index(end_index)
+                       .build(stream_id, key_type);
+        add_segment(key, std::move(segment));
+        ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
+        return folly::makeFuture(key);
+    }
+
+    folly::Future<entity::VariantKey> write(stream::KeyType key_type,
+        VersionId gen_id,
+        const StreamId& stream_id,
+        timestamp creation_ts,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&& segment) override
+    {
+        auto key = atom_key_builder()
+                       .gen_id(gen_id)
+                       .content_hash(content_hash_)
+                       .creation_ts(creation_ts)
+                       .start_index(start_index)
+                       .end_index(end_index)
+                       .build(stream_id, key_type);
+        add_segment(key, std::move(segment));
+        ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
+        return folly::makeFuture(key);
+    }
+
+    folly::Future<VariantKey>
+    update(const VariantKey& key, SegmentInMemory&& segment, storage::UpdateOpts opts) override
+    {
+        if (!opts.upsert_) {
+            util::check_rte(key_exists(key).get(), "update called with upsert=false but key does not exist");
         }
-
-        bool batch_all_keys_exist_sync(const std::unordered_set<entity::VariantKey>&) override {
-            util::raise_rte("Not implemented");
+        if (std::holds_alternative<AtomKey>(key)) {
+            add_segment(to_atom(key), std::move(segment));
+        } else {
+            add_segment(to_ref(key), std::move(segment));
         }
+        ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
+        return folly::makeFuture(key);
+    }
 
-        bool supports_prefix_matching() override {
-            return false;
+    folly::Future<VariantKey> write(PartialKey pk, SegmentInMemory&& segment) override
+    {
+        return write(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index, std::move(segment));
+    }
+
+    entity::VariantKey write_sync(stream::KeyType key_type,
+        VersionId version_id,
+        const StreamId& stream_id,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&& segment) override
+    {
+        return write(key_type, version_id, stream_id, start_index, end_index, std::move(segment)).get();
+    }
+
+    entity::VariantKey write_sync(PartialKey pk, SegmentInMemory&& segment) override
+    {
+        return write(pk, std::move(segment)).get();
+    }
+
+    entity::VariantKey write_sync(KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment) override
+    {
+        return write(key_type, stream_id, std::move(segment)).get();
+    }
+
+    folly::Future<entity::VariantKey>
+    write(stream::KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment) override
+    {
+        util::check(is_ref_key_class(key_type), "Cannot write ref key with atom key type {}", key_type);
+        auto key = entity::RefKey{stream_id, key_type};
+        add_segment(key, std::move(segment));
+        ARCTICDB_DEBUG(log::storage(), "Mock store adding ref key {}", key);
+        return folly::makeFuture(key);
+    }
+
+    folly::Future<VariantKey>
+    copy(arcticdb::entity::KeyType, const StreamId&, arcticdb::entity::VersionId, const VariantKey&) override
+    {
+        util::raise_rte("Not implemented");
+    }
+
+    VariantKey
+    copy_sync(arcticdb::entity::KeyType, const StreamId&, arcticdb::entity::VersionId, const VariantKey&) override
+    {
+        util::raise_rte("Not implemented");
+    }
+
+    bool key_exists_sync(const entity::VariantKey& key) override
+    {
+        std::lock_guard lock{mutex_};
+        return util::variant_match(
+            key,
+            [&](const RefKey& key) {
+                auto it = seg_by_ref_key_.find(key);
+                return it != seg_by_ref_key_.end();
+            },
+            [&](const AtomKey& key) {
+                auto it = seg_by_atom_key_.find(key);
+                return it != seg_by_atom_key_.end();
+            });
+    }
+
+    folly::Future<bool> key_exists(const entity::VariantKey& key) override
+    {
+        return folly::makeFuture(key_exists_sync(key));
+    }
+
+    std::pair<VariantKey, SegmentInMemory> read_sync(const VariantKey& key, storage::ReadKeyOpts) override
+    {
+        std::lock_guard lock{mutex_};
+        return util::variant_match(
+            key,
+            [&](const RefKey& ref_key) {
+                auto it = seg_by_ref_key_.find(ref_key);
+                //                                           util::check_rte(it != seg_by_ref_key_.end(), "ref key {} not found", ref_key);
+                if (it == seg_by_ref_key_.end())
+                    throw storage::KeyNotFoundException(Composite<VariantKey>(ref_key));
+                ARCTICDB_DEBUG(log::storage(), "Mock store returning ref key {}", ref_key);
+                std::pair<VariantKey, arcticdb::SegmentInMemory> res = {it->first, it->second->clone()};
+                return res;
+            },
+            [&](const AtomKey& atom_key) {
+                auto it = seg_by_atom_key_.find(atom_key);
+                //                                           util::check_rte(it != seg_by_atom_key_.end(), "atom key {} not found", atom_key);
+                if (it == seg_by_atom_key_.end())
+                    throw storage::KeyNotFoundException(Composite<VariantKey>(atom_key));
+                ARCTICDB_DEBUG(log::storage(), "Mock store returning atom key {}", atom_key);
+                std::pair<VariantKey, arcticdb::SegmentInMemory> res = {it->first, it->second->clone()};
+                //seg_by_atom_key_.erase(it);
+                return res;
+            });
+    }
+
+    folly::Future<storage::KeySegmentPair> read_compressed(const entity::VariantKey&, storage::ReadKeyOpts) override
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    folly::Future<std::pair<VariantKey, SegmentInMemory>> read(const VariantKey& key,
+        storage::ReadKeyOpts opts) override
+    {
+        // Anything read_sync() throws should be returned inside the Future, so:
+        return folly::makeFutureWith([&]() { return read_sync(key, opts); });
+    }
+
+    folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&&) override
+    {
+        util::raise_rte("Not implemented");
+    }
+
+    void write_compressed_sync(storage::KeySegmentPair&&) override
+    {
+        util::raise_rte("Not implemented");
+    }
+
+    RemoveKeyResultType remove_key_sync(const entity::VariantKey& key, RemoveOpts opts) override
+    {
+        std::lock_guard lock{mutex_};
+        size_t removed = util::variant_match(
+            key,
+            [&](const AtomKey& ak) { return seg_by_atom_key_.erase(ak); },
+            [&](const RefKey& rk) { return seg_by_ref_key_.erase(rk); });
+        ARCTICDB_DEBUG(log::storage(), "Mock store removed {} {}", removed, key);
+        if (removed == 0 && !opts.ignores_missing_key_) {
+            throw storage::KeyNotFoundException(Composite(VariantKey(key)));
         }
+        return {};
+    }
 
-        bool fast_delete() override {
-            return false;
-        }
+    folly::Future<RemoveKeyResultType> remove_key(const VariantKey& key, storage::RemoveOpts opts) override
+    {
+        return folly::makeFuture(remove_key_sync(key, opts));
+    }
 
-        std::vector<Composite<ProcessingSegment>> batch_read_uncompressed(
-                std::vector<Composite<pipelines::SliceAndKey>> &&,
-                const std::shared_ptr<std::vector<Clause>>&,
-                const StreamDescriptor&,
-                const std::shared_ptr<std::unordered_set<std::string>>&,
-                const BatchReadArgs &) override {
-            throw std::runtime_error("Not implemented for tests");
-        }
+    timestamp current_timestamp() override
+    {
+        return PilotedClock::nanos_since_epoch();
+    }
 
-        folly::Future<VariantKey> write(
-                KeyType key_type,
-                VersionId gen_id,
-                const StreamId& stream_id,
-                IndexValue start_index,
-                IndexValue end_index,
-                SegmentInMemory &&segment
-        ) override {
-            auto key = atom_key_builder().gen_id(gen_id).content_hash(content_hash_).creation_ts(PilotedClock::nanos_since_epoch())
-                    .start_index(start_index).end_index(end_index).build(stream_id, key_type);
-            add_segment(key, std::move(segment));
-            ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
-            return folly::makeFuture(key);
-        }
+    void
+    iterate_type(KeyType kt, std::function<void(entity::VariantKey&&)> func, const std::string& prefix = "") override
+    {
+        auto prefix_matcher = stream_id_prefix_matcher(prefix);
 
-        folly::Future<entity::VariantKey> write(
-                stream::KeyType key_type,
-                VersionId gen_id,
-                const StreamId& stream_id,
-                timestamp creation_ts,
-                IndexValue start_index,
-                IndexValue end_index,
-                SegmentInMemory &&segment
-        ) override {
-            auto key = atom_key_builder().gen_id(gen_id).content_hash(content_hash_).creation_ts(creation_ts)
-                    .start_index(start_index).end_index(end_index).build(stream_id, key_type);
-            add_segment(key, std::move(segment));
-            ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
-            return folly::makeFuture(key);
-        }
-
-        folly::Future<VariantKey>
-        update(const VariantKey& key,
-                SegmentInMemory &&segment,
-                storage::UpdateOpts opts
-        ) override {
-            if (!opts.upsert_) {
-                util::check_rte(key_exists(key).get(), "update called with upsert=false but key does not exist");
+        for (auto it = seg_by_atom_key_.cbegin(), next_it = it; it != seg_by_atom_key_.cend(); it = next_it) {
+            ++next_it;
+            auto key = it->first;
+            if (key.type() == kt && prefix_matcher(key.id())) {
+                ARCTICDB_DEBUG(log::version(), "Iterate type {}", key);
+                func(std::move(key));
             }
-            if (std::holds_alternative<AtomKey>(key)) {
-                add_segment(to_atom(key), std::move(segment));
-            } else {
-                add_segment(to_ref(key), std::move(segment));
-            }
-            ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
-            return folly::makeFuture(key);
         }
 
-        folly::Future<VariantKey>
-        write(
-                PartialKey pk,
-                SegmentInMemory &&segment
-        ) override {
-            return write(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index,
-                         std::move(segment));
-        }
-
-        entity::VariantKey write_sync(
-                stream::KeyType key_type,
-                VersionId version_id,
-                const StreamId& stream_id,
-                IndexValue start_index,
-                IndexValue end_index,
-                SegmentInMemory &&segment) override {
-            return write(key_type, version_id, stream_id, start_index, end_index, std::move(segment)).get();
-        }
-
-        entity::VariantKey write_sync(PartialKey pk, SegmentInMemory &&segment) override {
-            return write(pk, std::move(segment)).get();
-        }
-
-        entity::VariantKey write_sync(
-                KeyType key_type,
-                const StreamId& stream_id,
-                SegmentInMemory &&segment) override {
-            return write(key_type, stream_id, std::move(segment)).get();
-        }
-
-        folly::Future<entity::VariantKey>
-        write(stream::KeyType key_type, const StreamId& stream_id, SegmentInMemory &&segment) override {
-            util::check(is_ref_key_class(key_type), "Cannot write ref key with atom key type {}", key_type);
-            auto key = entity::RefKey{stream_id, key_type};
-            add_segment(key, std::move(segment));
-            ARCTICDB_DEBUG(log::storage(), "Mock store adding ref key {}", key);
-            return folly::makeFuture(key);
-        }
-
-        folly::Future<VariantKey> copy(arcticdb::entity::KeyType, const StreamId&, arcticdb::entity::VersionId, const VariantKey&) override {
-            util::raise_rte("Not implemented");
-        }
-
-        VariantKey copy_sync(arcticdb::entity::KeyType, const StreamId&, arcticdb::entity::VersionId, const VariantKey&) override {
-            util::raise_rte("Not implemented");
-        }
-
-        bool key_exists_sync(const entity::VariantKey &key) override {
-            std::lock_guard lock{mutex_};
-            return util::variant_match(key,
-                                       [&](const RefKey &key) {
-                                           auto it = seg_by_ref_key_.find(key);
-                                           return it != seg_by_ref_key_.end();
-                                       },
-                                       [&](const AtomKey &key) {
-                                           auto it = seg_by_atom_key_.find(key);
-                                           return it != seg_by_atom_key_.end();
-                                       }
-            );
-        }
-
-        folly::Future<bool> key_exists(const entity::VariantKey &key) override {
-            return folly::makeFuture(key_exists_sync(key));
-        }
-
-        std::pair<VariantKey, SegmentInMemory> read_sync(const VariantKey& key, storage::ReadKeyOpts) override {
-            std::lock_guard lock{mutex_};
-            return util::variant_match(key,
-                                       [&] (const RefKey& ref_key) {
-                                           auto it = seg_by_ref_key_.find(ref_key);
-//                                           util::check_rte(it != seg_by_ref_key_.end(), "ref key {} not found", ref_key);
-                                           if (it == seg_by_ref_key_.end())
-                                               throw storage::KeyNotFoundException(Composite<VariantKey>(ref_key));
-                                           ARCTICDB_DEBUG(log::storage(), "Mock store returning ref key {}", ref_key);
-                                           std::pair<VariantKey, arcticdb::SegmentInMemory> res = {it->first, it->second->clone()};
-                                           return res;
-                                       },
-                                       [&] (const AtomKey& atom_key) {
-                                           auto it = seg_by_atom_key_.find(atom_key);
-//                                           util::check_rte(it != seg_by_atom_key_.end(), "atom key {} not found", atom_key);
-                                           if (it == seg_by_atom_key_.end())
-                                               throw storage::KeyNotFoundException(Composite<VariantKey>(atom_key));
-                                           ARCTICDB_DEBUG(log::storage(), "Mock store returning atom key {}", atom_key);
-                                           std::pair<VariantKey, arcticdb::SegmentInMemory> res = {it->first, it->second->clone()};
-                                           //seg_by_atom_key_.erase(it);
-                                           return res;
-                                       });
-        }
-
-        folly::Future<storage::KeySegmentPair> read_compressed(const entity::VariantKey&, storage::ReadKeyOpts) override {
-            throw std::runtime_error("Not implemented");
-        }
-
-        folly::Future<std::pair<VariantKey, SegmentInMemory>> read(const VariantKey& key, storage::ReadKeyOpts opts) override {
-            // Anything read_sync() throws should be returned inside the Future, so:
-            return folly::makeFutureWith([&](){ return read_sync(key, opts); });
-        }
-
-        folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&&) override {
-            util::raise_rte("Not implemented");
-        }
-
-        void write_compressed_sync(storage::KeySegmentPair&&) override {
-            util::raise_rte("Not implemented");
-        }
-
-        RemoveKeyResultType remove_key_sync(const entity::VariantKey &key, RemoveOpts opts) override {
-            std::lock_guard lock{mutex_};
-            size_t removed = util::variant_match(key,
-                [&](const AtomKey &ak) { return seg_by_atom_key_.erase(ak); },
-                [&](const RefKey &rk) { return seg_by_ref_key_.erase(rk); });
-            ARCTICDB_DEBUG(log::storage(), "Mock store removed {} {}", removed, key);
-            if (removed == 0 && !opts.ignores_missing_key_) {
-                throw storage::KeyNotFoundException(Composite(VariantKey(key)));
-            }
-            return {};
-        }
-
-        folly::Future<RemoveKeyResultType> remove_key(const VariantKey &key, storage::RemoveOpts opts) override {
-            return folly::makeFuture(remove_key_sync(key, opts));
-        }
-
-        timestamp current_timestamp() override {
-            return PilotedClock::nanos_since_epoch();
-        }
-
-
-        void iterate_type(KeyType kt, std::function<void(entity::VariantKey &&)> func, const std::string& prefix = "")
-        override {
-            auto prefix_matcher = stream_id_prefix_matcher(prefix);
-
-            for (auto it = seg_by_atom_key_.cbegin(), next_it = it; it != seg_by_atom_key_.cend(); it = next_it) {
-                ++next_it;
-                auto key = it->first;
-                if (key.type() == kt && prefix_matcher(key.id())) {
-                    ARCTICDB_DEBUG(log::version(), "Iterate type {}", key);
-                    func(std::move(key));
-                }
-            }
-
-            for (auto it = seg_by_ref_key_.cbegin(), next_it = it; it != seg_by_ref_key_.cend(); it = next_it) {
-                ++next_it;
-                auto key = it->first;
-                if (key.type() == kt && prefix_matcher(key.id())) {
-                    func(std::move(key));
-                }
+        for (auto it = seg_by_ref_key_.cbegin(), next_it = it; it != seg_by_ref_key_.cend(); it = next_it) {
+            ++next_it;
+            auto key = it->first;
+            if (key.type() == kt && prefix_matcher(key.id())) {
+                func(std::move(key));
             }
         }
+    }
 
-        folly::Future<std::vector<VariantKey>> batch_write(
-                std::vector<std::pair<PartialKey, SegmentInMemory>> &&key_segments,
-                const std::shared_ptr<DeDupMap> &,
-                const BatchWriteArgs &
-        ) override {
-            std::vector<VariantKey> output;
-            for (auto &pair : key_segments) {
-                output.emplace_back(std::get<AtomKey>(write(pair.first, std::move(pair.second)).value()));
-            }
-            return folly::makeFuture(std::move(output));
+    folly::Future<std::vector<VariantKey>> batch_write(
+        std::vector<std::pair<PartialKey, SegmentInMemory>>&& key_segments,
+        const std::shared_ptr<DeDupMap>&,
+        const BatchWriteArgs&) override
+    {
+        std::vector<VariantKey> output;
+        for (auto& pair : key_segments) {
+            output.emplace_back(std::get<AtomKey>(write(pair.first, std::move(pair.second)).value()));
         }
+        return folly::makeFuture(std::move(output));
+    }
 
-        std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey> &keys) override {
-            std::vector<folly::Future<bool>> output;
-            for(const auto& key : keys) {
-                util::variant_match(key,
-                                    [&output, &refs=seg_by_ref_key_] (const RefKey& ref) {
-                    output.push_back(folly::makeFuture<bool>(refs.find(ref) != refs.end()));
-                },
-                [&output, &atoms=seg_by_atom_key_] (const AtomKey& atom) {
+    std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override
+    {
+        std::vector<folly::Future<bool>> output;
+        for (const auto& key : keys) {
+            util::variant_match(
+                key,
+                [&output, &refs = seg_by_ref_key_](
+                    const RefKey& ref) { output.push_back(folly::makeFuture<bool>(refs.find(ref) != refs.end())); },
+                [&output, &atoms = seg_by_atom_key_](const AtomKey& atom) {
                     output.push_back(folly::makeFuture<bool>(atoms.find(atom) != atoms.end()));
                 });
-            }
-            return output;
+        }
+        return output;
+    }
+
+    std::vector<storage::KeySegmentPair>
+    batch_read_compressed(std::vector<entity::VariantKey>&&, const BatchReadArgs&, bool) override
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    std::vector<VariantKey> batch_read_compressed(std::vector<entity::VariantKey>&& keys,
+        std::vector<ReadContinuation>&&,
+        const BatchReadArgs&) override
+    {
+        std::lock_guard lock{mutex_};
+        std::vector<VariantKey> output;
+        for (auto& key : keys)
+            output.push_back(key);
+
+        return output;
+    }
+
+    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(const std::vector<entity::VariantKey>& keys,
+        storage::RemoveOpts opts) override
+    {
+        std::vector<RemoveKeyResultType> output;
+        for (const auto& key : keys) {
+            output.emplace_back(remove_key_sync(key, opts));
         }
 
-        std::vector<storage::KeySegmentPair>
-        batch_read_compressed(std::vector<entity::VariantKey> &&, const BatchReadArgs &, bool) override {
-            throw std::runtime_error("Not implemented");
-        }
+        return output;
+    }
 
-        std::vector<VariantKey> batch_read_compressed(
-                std::vector<entity::VariantKey> &&keys,
-                std::vector<ReadContinuation> &&,
-                const BatchReadArgs &
-        ) override {
-            std::lock_guard lock{mutex_};
-            std::vector<VariantKey> output;
-            for (auto &key : keys)
-                output.push_back(key);
+    void insert_atom_key(const AtomKey& key)
+    {
+        seg_by_atom_key_.insert(std::make_pair(key, std::make_unique<SegmentInMemory>()));
+    }
 
-            return output;
-        }
+    size_t num_atom_keys() const
+    {
+        return seg_by_atom_key_.size();
+    }
 
-        folly::Future<std::vector<RemoveKeyResultType>>
-        remove_keys(const std::vector<entity::VariantKey> &keys, storage::RemoveOpts opts) override {
-            std::vector<RemoveKeyResultType> output;
-            for (const auto &key: keys) {
-                output.emplace_back(remove_key_sync(key, opts));
-            }
+    size_t num_ref_keys() const
+    {
+        return seg_by_ref_key_.size();
+    }
 
-            return output;
-        }
+    size_t num_atom_keys_of_type(KeyType key_type) const
+    {
+        util::check(!is_ref_key_class(key_type), "Num atom keys of type for ref key doesn't make sense");
+        return std::count_if(seg_by_atom_key_.cbegin(), seg_by_atom_key_.cend(), [=](auto& entry) {
+            return entry.first.type() == key_type;
+        });
+    }
 
-        void insert_atom_key(const AtomKey &key) {
-            seg_by_atom_key_.insert(std::make_pair(key, std::make_unique<SegmentInMemory>()));
-        }
+    void move_storage(KeyType, timestamp, size_t) override
+    {
+    }
 
-        size_t num_atom_keys() const { return seg_by_atom_key_.size(); }
+    size_t num_ref_keys_of_type(KeyType key_type) const
+    {
+        util::check(is_ref_key_class(key_type), "Num ref keys of type for non-ref key doesn't make sense");
+        return std::count_if(seg_by_ref_key_.cbegin(), seg_by_ref_key_.cend(), [=](auto& entry) {
+            return entry.first.type() == key_type;
+        });
+    }
 
-        size_t num_ref_keys() const { return seg_by_ref_key_.size(); }
+    HashedValue content_hash_ = 0x42;
 
-        size_t num_atom_keys_of_type(KeyType key_type) const {
-            util::check(!is_ref_key_class(key_type), "Num atom keys of type for ref key doesn't make sense");
-            return std::count_if(seg_by_atom_key_.cbegin(), seg_by_atom_key_.cend(),
-                                 [=](auto &entry) { return entry.first.type() == key_type; });
-        }
+    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>
 
-        void move_storage(KeyType , timestamp , size_t ) override {
-        }
-
-        size_t num_ref_keys_of_type(KeyType key_type) const {
-            util::check(is_ref_key_class(key_type), "Num ref keys of type for non-ref key doesn't make sense");
-            return std::count_if(seg_by_ref_key_.cbegin(), seg_by_ref_key_.cend(),
-                                 [=](auto &entry) { return entry.first.type() == key_type; });
-        }
-
-        HashedValue content_hash_ = 0x42;
-
-        folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>
-
-        read_metadata(const entity::VariantKey &key, storage::ReadKeyOpts) override {
-            return util::variant_match(key,
-                                       [&](const AtomKey &ak) {
-                                           auto it = seg_by_atom_key_.find(ak);
-                                           // util::check_rte(it != seg_by_atom_key_.end(), "atom key {} not found in remove", ak);
-                                           if (it == seg_by_atom_key_.end())
-                                               throw storage::KeyNotFoundException(Composite<VariantKey>(ak));
-                                           ARCTICDB_DEBUG(log::storage(), "Mock store removing data for atom key {}", ak);
-                                           return std::make_pair(std::make_optional<VariantKey>(key), std::make_optional<google::protobuf::Any>(*it->second->metadata()));
-                                       },
-                                       [&](const RefKey &rk) {
-                                           auto it = seg_by_ref_key_.find(rk);
-                                           // util::check_rte(it != seg_by_ref_key_.end(), "ref key {} not found in remove", rk);
-                                           if (it == seg_by_ref_key_.end())
-                                               throw storage::KeyNotFoundException(Composite<VariantKey>(rk));
-                                           ARCTICDB_DEBUG(log::storage(), "Mock store removing data for ref key {}", rk);
-                                           return std::make_pair(std::make_optional<VariantKey>(key), std::make_optional<google::protobuf::Any>(*it->second->metadata()));
-                                       });
-        }
-
-        folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto>>
-        read_metadata_and_descriptor(
-            const entity::VariantKey& key, storage::ReadKeyOpts) override {
-            return util::variant_match(key,
-                                       [&](const AtomKey &ak) {
+    read_metadata(const entity::VariantKey& key, storage::ReadKeyOpts) override
+    {
+        return util::variant_match(
+            key,
+            [&](const AtomKey& ak) {
                 auto it = seg_by_atom_key_.find(ak);
                 // util::check_rte(it != seg_by_atom_key_.end(), "atom key {} not found in remove", ak);
                 if (it == seg_by_atom_key_.end())
                     throw storage::KeyNotFoundException(Composite<VariantKey>(ak));
                 ARCTICDB_DEBUG(log::storage(), "Mock store removing data for atom key {}", ak);
-                return std::make_tuple(key, std::make_optional<google::protobuf::Any>(*it->second->metadata()), it->second->descriptor().proto());
-                },
-                [&](const RefKey &rk) {
+                return std::make_pair(std::make_optional<VariantKey>(key),
+                    std::make_optional<google::protobuf::Any>(*it->second->metadata()));
+            },
+            [&](const RefKey& rk) {
                 auto it = seg_by_ref_key_.find(rk);
                 // util::check_rte(it != seg_by_ref_key_.end(), "ref key {} not found in remove", rk);
                 if (it == seg_by_ref_key_.end())
                     throw storage::KeyNotFoundException(Composite<VariantKey>(rk));
                 ARCTICDB_DEBUG(log::storage(), "Mock store removing data for ref key {}", rk);
-                return std::make_tuple(key, std::make_optional<google::protobuf::Any>(*it->second->metadata()), it->second->descriptor().proto());
+                return std::make_pair(std::make_optional<VariantKey>(key),
+                    std::make_optional<google::protobuf::Any>(*it->second->metadata()));
             });
-        }
+    }
 
-        void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &) override {}
+    folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto>>
+    read_metadata_and_descriptor(const entity::VariantKey& key, storage::ReadKeyOpts) override
+    {
+        return util::variant_match(
+            key,
+            [&](const AtomKey& ak) {
+                auto it = seg_by_atom_key_.find(ak);
+                // util::check_rte(it != seg_by_atom_key_.end(), "atom key {} not found in remove", ak);
+                if (it == seg_by_atom_key_.end())
+                    throw storage::KeyNotFoundException(Composite<VariantKey>(ak));
+                ARCTICDB_DEBUG(log::storage(), "Mock store removing data for atom key {}", ak);
+                return std::make_tuple(key,
+                    std::make_optional<google::protobuf::Any>(*it->second->metadata()),
+                    it->second->descriptor().proto());
+            },
+            [&](const RefKey& rk) {
+                auto it = seg_by_ref_key_.find(rk);
+                // util::check_rte(it != seg_by_ref_key_.end(), "ref key {} not found in remove", rk);
+                if (it == seg_by_ref_key_.end())
+                    throw storage::KeyNotFoundException(Composite<VariantKey>(rk));
+                ARCTICDB_DEBUG(log::storage(), "Mock store removing data for ref key {}", rk);
+                return std::make_tuple(key,
+                    std::make_optional<google::protobuf::Any>(*it->second->metadata()),
+                    it->second->descriptor().proto());
+            });
+    }
 
-        void add_segment(const AtomKey &key, SegmentInMemory &&seg) {
-            std::lock_guard lock{mutex_};
-            ARCTICDB_DEBUG(log::storage(), "Adding segment with key {}", key);
-            seg_by_atom_key_[key] = std::make_unique<SegmentInMemory>(std::move(seg));
-        }
+    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator&) override
+    {
+    }
 
-        void add_segment(const RefKey &key, SegmentInMemory &&seg) {
-            std::lock_guard lock{mutex_};
-            ARCTICDB_DEBUG(log::storage(), "Adding segment with key {}", key);
-            seg_by_ref_key_[key] = std::make_unique<SegmentInMemory>(std::move(seg));
-        }
+    void add_segment(const AtomKey& key, SegmentInMemory&& seg)
+    {
+        std::lock_guard lock{mutex_};
+        ARCTICDB_DEBUG(log::storage(), "Adding segment with key {}", key);
+        seg_by_atom_key_[key] = std::make_unique<SegmentInMemory>(std::move(seg));
+    }
 
+    void add_segment(const RefKey& key, SegmentInMemory&& seg)
+    {
+        std::lock_guard lock{mutex_};
+        ARCTICDB_DEBUG(log::storage(), "Adding segment with key {}", key);
+        seg_by_ref_key_[key] = std::make_unique<SegmentInMemory>(std::move(seg));
+    }
 
-    protected:
-        std::mutex mutex_;
-        std::unordered_map<AtomKey, std::unique_ptr<SegmentInMemory>> seg_by_atom_key_;
-        std::unordered_map<RefKey, std::unique_ptr<SegmentInMemory>> seg_by_ref_key_;
-    };
+protected:
+    std::mutex mutex_;
+    std::unordered_map<AtomKey, std::unique_ptr<SegmentInMemory>> seg_by_atom_key_;
+    std::unordered_map<RefKey, std::unique_ptr<SegmentInMemory>> seg_by_ref_key_;
+};
 
 } //namespace arcticdb

--- a/cpp/arcticdb/storage/test/mongo_server_fixture.hpp
+++ b/cpp/arcticdb/storage/test/mongo_server_fixture.hpp
@@ -10,19 +10,23 @@
 #include <boost/process.hpp>
 #include <gtest/gtest.h>
 
-static const char *TestMongod = "/opt/mongo/bin/mongod";
+static const char* TestMongod = "/opt/mongo/bin/mongod";
 
 class TestMongoStorage : public ::testing::Test {
-  protected:
-    TestMongoServer() :
-        mongod_(TestMongod) {
+protected:
+    TestMongoServer()
+        : mongod_(TestMongod)
+    {
     }
 
-    ~TestMongoServer() {
+    ~TestMongoServer()
+    {
         terminate();
     }
-  private:
-    void terminate() {
+
+private:
+    void terminate()
+    {
         mongod_.terminate();
     }
 

--- a/cpp/arcticdb/storage/test/test_lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_lmdb_storage.cpp
@@ -26,7 +26,8 @@ namespace ac = arcticdb;
 namespace as = arcticdb::storage;
 namespace asl = arcticdb::storage::lmdb;
 
-TEST(TestLmdbStorage, Example) {
+TEST(TestLmdbStorage, Example)
+{
     auto environment_name = as::EnvironmentName{"res"};
     auto storage_name = as::StorageName{"lmdb_01"};
 
@@ -46,22 +47,24 @@ TEST(TestLmdbStorage, Example) {
     storage.write(std::move(kv));
 
     as::KeySegmentPair res;
-    storage.read(k, [&](auto &&k, auto &&seg) {
-        res.atom_key() = std::get<AtomKey>(k);
-        res.segment() = std::move(seg);
-        res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
-    }, storage::ReadKeyOpts{});
+    storage.read(
+        k,
+        [&](auto&& k, auto&& seg) {
+            res.atom_key() = std::get<AtomKey>(k);
+            res.segment() = std::move(seg);
+            res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        },
+        storage::ReadKeyOpts{});
     ASSERT_EQ(res.segment().header().start_ts(), 1234);
 
     res = storage.read(k, as::ReadKeyOpts{});
     ASSERT_EQ(res.segment().header().start_ts(), 1234);
 
     bool executed = false;
-    storage.iterate_type(arcticdb::entity::KeyType::TABLE_DATA,
-                         [&](auto &&found_key) {
-                             ASSERT_EQ(to_atom(found_key), k);
-                             executed = true;
-                         });
+    storage.iterate_type(arcticdb::entity::KeyType::TABLE_DATA, [&](auto&& found_key) {
+        ASSERT_EQ(to_atom(found_key), k);
+        executed = true;
+    });
     ASSERT_TRUE(executed);
 
     as::KeySegmentPair update_kv(k);
@@ -71,26 +74,29 @@ TEST(TestLmdbStorage, Example) {
     storage.update(std::move(update_kv), as::UpdateOpts{});
 
     as::KeySegmentPair update_res;
-    storage.read(k, [&](auto &&k, auto &&seg) {
-        update_res.atom_key() = std::get<AtomKey>(k);
-        update_res.segment() = std::move(seg);
-        update_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
-    }, as::ReadKeyOpts{});
+    storage.read(
+        k,
+        [&](auto&& k, auto&& seg) {
+            update_res.atom_key() = std::get<AtomKey>(k);
+            update_res.segment() = std::move(seg);
+            update_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        },
+        as::ReadKeyOpts{});
     ASSERT_EQ(update_res.segment().header().start_ts(), 4321);
 
     update_res = storage.read(k, as::ReadKeyOpts{});
     ASSERT_EQ(update_res.segment().header().start_ts(), 4321);
 
     executed = false;
-    storage.iterate_type(arcticdb::entity::KeyType::TABLE_DATA,
-                         [&](auto &&found_key) {
-                             ASSERT_EQ(to_atom(found_key), k);
-                             executed = true;
-                         });
+    storage.iterate_type(arcticdb::entity::KeyType::TABLE_DATA, [&](auto&& found_key) {
+        ASSERT_EQ(to_atom(found_key), k);
+        executed = true;
+    });
     ASSERT_TRUE(executed);
 }
 
-TEST(TestLmdbStorage, Strings) {
+TEST(TestLmdbStorage, Strings)
+{
     const auto tsd = create_tsd<DataTypeTag<DataType::ASCII_DYNAMIC64>, Dimension::Dim0>();
     SegmentInMemory s{StreamDescriptor{std::move(tsd)}};
     s.set_scalar(0, timestamp(123));
@@ -134,11 +140,14 @@ TEST(TestLmdbStorage, Strings) {
     storage.write(std::move(kv));
 
     as::KeySegmentPair res;
-    storage.read(save_k, [&](auto &&k, auto &&seg) {
-        res.atom_key() = std::get<AtomKey>(k);
-        res.segment() = std::move(seg);
-        res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
-    }, as::ReadKeyOpts{});
+    storage.read(
+        save_k,
+        [&](auto&& k, auto&& seg) {
+            res.atom_key() = std::get<AtomKey>(k);
+            res.segment() = std::move(seg);
+            res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        },
+        as::ReadKeyOpts{});
     ASSERT_EQ(res.segment().header().start_ts(), 1234);
 
     SegmentInMemory res_mem = decode(std::move(res.segment()));
@@ -147,4 +156,3 @@ TEST(TestLmdbStorage, Strings) {
     ASSERT_EQ(s.string_at(1, 3), res_mem.string_at(1, 3));
     ASSERT_EQ(std::string("baggy"), res_mem.string_at(1, 3));
 }
-

--- a/cpp/arcticdb/storage/test/test_memory_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_memory_storage.cpp
@@ -10,8 +10,8 @@
 #include <arcticdb/util/test/generators.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
 
-
-TEST(InMemory, ReadTwice) {
+TEST(InMemory, ReadTwice)
+{
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
 
@@ -24,10 +24,12 @@ TEST(InMemory, ReadTwice) {
         scalar_field_proto(DataType::UINT8, "thing1"),
     };
 
-    auto test_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
+    auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result1 = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    auto read_result2 = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    auto read_result1 =
+        version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    auto read_result2 =
+        version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
 }

--- a/cpp/arcticdb/storage/test/test_mongo_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_mongo_storage.cpp
@@ -18,7 +18,8 @@ const std::string test_server("mongodb://localhost:27017");
 
 namespace fs = std::filesystem;
 
-TEST(MongoStorage, ClientSession) {
+TEST(MongoStorage, ClientSession)
+{
     return; // need to run local mongo with /opt/mongo/bin/mongod --dbpath /tmp/something
     namespace ac = arcticdb;
     namespace as = arcticdb::storage;
@@ -42,28 +43,29 @@ TEST(MongoStorage, ClientSession) {
 
     as::KeySegmentPair res;
 
-    storage.read(k, [&](auto &&k, auto &&seg) {
-        res.atom_key() = std::get<as::AtomKey>(k);
-        res.segment() = std::move(seg);
-        res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
-    }, as::ReadKeyOpts{});
+    storage.read(
+        k,
+        [&](auto&& k, auto&& seg) {
+            res.atom_key() = std::get<as::AtomKey>(k);
+            res.segment() = std::move(seg);
+            res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        },
+        as::ReadKeyOpts{});
     ASSERT_EQ(res.segment().header().start_ts(), 1234);
 
     res = storage.read(k, as::ReadKeyOpts{});
     ASSERT_EQ(res.segment().header().start_ts(), 1234);
 
     bool executed = false;
-    storage.iterate_type(ac::entity::KeyType::TABLE_DATA,
-                         [&](auto &&found_key) {
-                             ASSERT_EQ(to_atom(found_key), k);
-                             executed = true;
-                         });
+    storage.iterate_type(ac::entity::KeyType::TABLE_DATA, [&](auto&& found_key) {
+        ASSERT_EQ(to_atom(found_key), k);
+        executed = true;
+    });
 
-    storage.iterate_type(ac::entity::KeyType::SNAPSHOT,
-                         [&](auto &&found_key) {
-                             ASSERT_EQ(to_atom(found_key), k);
-                             executed = true;
-                         });
+    storage.iterate_type(ac::entity::KeyType::SNAPSHOT, [&](auto&& found_key) {
+        ASSERT_EQ(to_atom(found_key), k);
+        executed = true;
+    });
     ASSERT_TRUE(executed);
 
     as::KeySegmentPair update_kv(k);
@@ -73,25 +75,28 @@ TEST(MongoStorage, ClientSession) {
 
     as::KeySegmentPair update_res;
 
-    storage.read(k, [&](auto &&k, auto &&seg) {
-        update_res.atom_key() = std::get<as::AtomKey>(k);
-        update_res.segment() = std::move(seg);
-        update_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
-    }, as::ReadKeyOpts{});
+    storage.read(
+        k,
+        [&](auto&& k, auto&& seg) {
+            update_res.atom_key() = std::get<as::AtomKey>(k);
+            update_res.segment() = std::move(seg);
+            update_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        },
+        as::ReadKeyOpts{});
     ASSERT_EQ(update_res.segment().header().start_ts(), 4321);
 
     update_res = storage.read(k, as::ReadKeyOpts{});
     ASSERT_EQ(update_res.segment().header().start_ts(), 4321);
 
     executed = false;
-    storage.iterate_type(ac::entity::KeyType::TABLE_DATA,
-                         [&](auto &&found_key) {
-                             ASSERT_EQ(to_atom(found_key), k);
-                             executed = true;
-                         });
+    storage.iterate_type(ac::entity::KeyType::TABLE_DATA, [&](auto&& found_key) {
+        ASSERT_EQ(to_atom(found_key), k);
+        executed = true;
+    });
     ASSERT_TRUE(executed);
 
-    ac::entity::AtomKey numeric_k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::STREAM_GROUP>(999);
+    ac::entity::AtomKey numeric_k =
+        ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::STREAM_GROUP>(999);
     as::KeySegmentPair numeric_kv(numeric_k);
     numeric_kv.segment().header().set_start_ts(7890);
 
@@ -99,11 +104,14 @@ TEST(MongoStorage, ClientSession) {
 
     as::KeySegmentPair numeric_res;
 
-    storage.read(numeric_k, [&](auto &&k, auto &&seg) {
-        numeric_res.atom_key() = std::get<as::AtomKey>(k);
-        numeric_res.segment() = std::move(seg);
-        numeric_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
-    }, as::ReadKeyOpts{});
+    storage.read(
+        numeric_k,
+        [&](auto&& k, auto&& seg) {
+            numeric_res.atom_key() = std::get<as::AtomKey>(k);
+            numeric_res.segment() = std::move(seg);
+            numeric_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        },
+        as::ReadKeyOpts{});
     ASSERT_EQ(numeric_res.segment().header().start_ts(), 7890);
 
     numeric_res = storage.read(numeric_k, as::ReadKeyOpts{});

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -15,7 +15,8 @@
 struct EnvFunctionShim : ::testing::Test {
     std::unordered_set<const char*> env_vars_to_unset{};
 
-    void setenv(const char* envname, const char* envval, bool) {
+    void setenv(const char* envname, const char* envval, bool)
+    {
         env_vars_to_unset.insert(envname);
 #if (WIN32)
         _putenv_s(envname, envval);
@@ -24,7 +25,8 @@ struct EnvFunctionShim : ::testing::Test {
 #endif
     }
 
-    virtual ~EnvFunctionShim() {
+    virtual ~EnvFunctionShim()
+    {
         for (const char* envname : env_vars_to_unset) {
 #if (WIN32)
             _putenv_s(envname, "");
@@ -34,7 +36,6 @@ struct EnvFunctionShim : ::testing::Test {
         }
     }
 };
-
 
 class ProxyEnvVarSetHttpProxyForHttpsEndpointFixture : public EnvFunctionShim {
 protected:
@@ -88,7 +89,8 @@ protected:
     }
 };
 
-TEST(TestS3Storage, proxy_env_var_parsing) {
+TEST(TestS3Storage, proxy_env_var_parsing)
+{
     using namespace arcticdb::storage::s3;
     using namespace Aws::Http;
     auto instance = arcticdb::storage::s3::S3ApiInstance::instance();
@@ -99,41 +101,38 @@ TEST(TestS3Storage, proxy_env_var_parsing) {
         uint16_t port_;
         std::string username_;
         std::string password_;
-        bool operator==(const Aws::Client::ClientConfiguration& client_config) const {
-            return
-            proxy_scheme_ == client_config.proxyScheme &&
-            host_ == client_config.proxyHost &&
-            port_ == client_config.proxyPort &&
-            username_ == client_config.proxyUserName &&
-            password_ == client_config.proxyPassword;
+        bool operator==(const Aws::Client::ClientConfiguration& client_config) const
+        {
+            return proxy_scheme_ == client_config.proxyScheme && host_ == client_config.proxyHost &&
+                   port_ == client_config.proxyPort && username_ == client_config.proxyUserName &&
+                   password_ == client_config.proxyPassword;
         };
     };
-    std::unordered_map<std::string, ProxyConfig> passing_test_cases {
+    std::unordered_map<std::string, ProxyConfig> passing_test_cases{
         {"http-proxy.com:2222", {Scheme::HTTP, Scheme::HTTP, "http-proxy.com", 2222, "", ""}},
         {"https://https-proxy.com", {Scheme::HTTPS, Scheme::HTTPS, "https-proxy.com", 443, "", ""}},
         // Test setting http proxy for https endpoint
         {"http://http-proxy.com", {Scheme::HTTPS, Scheme::HTTP, "http-proxy.com", 443, "", ""}},
         {"http://username@proxy.com", {Scheme::HTTP, Scheme::HTTP, "proxy.com", 80, "username", ""}},
         {"http://username:pass@proxy.com:2222", {Scheme::HTTP, Scheme::HTTP, "proxy.com", 2222, "username", "pass"}},
-        {"http://username:p@ss@proxy.com:2222", {Scheme::HTTP, Scheme::HTTP, "proxy.com", 2222, "username", "p@ss"}}
-    };
-    for (const auto& [env_var, expected_proxy_config]: passing_test_cases) {
+        {"http://username:p@ss@proxy.com:2222", {Scheme::HTTP, Scheme::HTTP, "proxy.com", 2222, "username", "p@ss"}}};
+    for (const auto& [env_var, expected_proxy_config] : passing_test_cases) {
         auto client_config = parse_proxy_env_var(expected_proxy_config.endpoint_scheme_, env_var.c_str());
         ASSERT_TRUE(client_config.has_value());
         ASSERT_TRUE(expected_proxy_config == client_config);
     }
 
-    std::unordered_map<std::string, ProxyConfig> failing_test_cases {
+    std::unordered_map<std::string, ProxyConfig> failing_test_cases{
         {"http-proxy.com:not-a-valid-port", {Scheme::HTTP, Scheme::HTTP, "", 0, "", ""}},
-        {"https://username:pass@proxy.com:99999", {Scheme::HTTPS, Scheme::HTTP, "", 0, "", ""}}
-    };
-    for (const auto& [env_var, expected_proxy_config]: failing_test_cases) {
+        {"https://username:pass@proxy.com:99999", {Scheme::HTTPS, Scheme::HTTP, "", 0, "", ""}}};
+    for (const auto& [env_var, expected_proxy_config] : failing_test_cases) {
         auto client_config = parse_proxy_env_var(expected_proxy_config.endpoint_scheme_, env_var.c_str());
         ASSERT_FALSE(client_config.has_value());
     }
 }
 
-TEST_F(ProxyEnvVarSetHttpProxyForHttpsEndpointFixture, test_config_resolution_proxy) {
+TEST_F(ProxyEnvVarSetHttpProxyForHttpsEndpointFixture, test_config_resolution_proxy)
+{
     arcticdb::storage::s3::S3Storage::Config s3_config;
     s3_config.set_endpoint("https://test.endpoint.com");
     s3_config.set_https(true);
@@ -143,7 +142,8 @@ TEST_F(ProxyEnvVarSetHttpProxyForHttpsEndpointFixture, test_config_resolution_pr
     ASSERT_EQ(ret_cfg.proxyScheme, Aws::Http::Scheme::HTTP);
 }
 
-TEST_F(ProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
+TEST_F(ProxyEnvVarUpperCaseFixture, test_config_resolution_proxy)
+{
     arcticdb::storage::s3::S3Storage::Config s3_config_http;
     s3_config_http.set_endpoint("http://test.endpoint.com");
     auto ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config_http);
@@ -160,7 +160,8 @@ TEST_F(ProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
     ASSERT_EQ(ret_cfg.proxyScheme, Aws::Http::Scheme::HTTPS);
 }
 
-TEST_F(ProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy) {
+TEST_F(ProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy)
+{
     SKIP_WIN("Env vars are not case-sensitive on Windows");
     arcticdb::storage::s3::S3Storage::Config s3_config_http;
     s3_config_http.set_endpoint("http://test.endpoint.com");
@@ -178,7 +179,8 @@ TEST_F(ProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy) {
     ASSERT_EQ(ret_cfg.proxyScheme, Aws::Http::Scheme::HTTPS);
 }
 
-TEST_F(NoProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
+TEST_F(NoProxyEnvVarUpperCaseFixture, test_config_resolution_proxy)
+{
     arcticdb::storage::s3::S3Storage::Config s3_config;
     s3_config.set_endpoint("http://test.endpoint.com");
     auto ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config);
@@ -188,7 +190,8 @@ TEST_F(NoProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
     ASSERT_EQ(ret_cfg.nonProxyHosts, expected_non_proxy_hosts);
 }
 
-TEST_F(NoProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy) {
+TEST_F(NoProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy)
+{
     SKIP_WIN("Env vars are not case-sensitive on Windows");
     arcticdb::storage::s3::S3Storage::Config s3_config;
     s3_config.set_endpoint("http://test.endpoint.com");

--- a/cpp/arcticdb/storage/test/test_storage_factory.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_factory.cpp
@@ -24,7 +24,8 @@ namespace ac = arcticdb;
 namespace as = arcticdb::storage;
 namespace asl = arcticdb::storage::lmdb;
 
-TEST(TestStorageFactory, LmdbLookup) {
+TEST(TestStorageFactory, LmdbLookup)
+{
     namespace pbs = arcticdb::proto::storage;
     as::EnvironmentName environment_name{"research"};
     as::StorageName storage_name("lmdb_local");
@@ -51,7 +52,8 @@ TEST(TestStorageFactory, LmdbLookup) {
     ASSERT_EQ(config.path(), "./"); //bit non-standard
 }
 
-TEST(TestStorageFactory, LibraryIndex) {
+TEST(TestStorageFactory, LibraryIndex)
+{
     as::EnvironmentName environment_name{"research"};
     as::StorageName storage_name("lmdb_local");
     as::LibraryPath library_path{"a", "b"};
@@ -70,4 +72,3 @@ TEST(TestStorageFactory, LibraryIndex) {
     ASSERT_EQ(l, lib->library_path());
     ASSERT_EQ(as::OpenMode::WRITE, lib->open_mode());
 }
-

--- a/cpp/arcticdb/storage/variant_storage_factory.hpp
+++ b/cpp/arcticdb/storage/variant_storage_factory.hpp
@@ -25,7 +25,8 @@
 
 namespace arcticdb::storage {
 
-using VariantStorageTypes = std::variant<lmdb::LmdbStorage, mongo::MongoStorage, s3::S3Storage, memory::MemoryStorage, nfs_backed::NfsBackedStorage>;
+using VariantStorageTypes = std::
+    variant<lmdb::LmdbStorage, mongo::MongoStorage, s3::S3Storage, memory::MemoryStorage, nfs_backed::NfsBackedStorage>;
 using VariantStorage = variant::VariantStorage<VariantStorageTypes>;
 
 class VariantStorageFactory final : public StorageFactory<VariantStorageFactory> {
@@ -35,26 +36,35 @@ class VariantStorageFactory final : public StorageFactory<VariantStorageFactory>
 
 public:
     template<class T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, VariantStorageFactory>, int> = 0>
-    explicit VariantStorageFactory(T &&v) :
-        factory_variant_(std::move(v)) {}
-
-  protected:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
-        return std::visit([&](auto &&impl) {
-            auto s = impl.create_storage(lib, mode);
-            return std::make_unique<VariantStorage>(std::move(s));
-        }, factory_variant_);
+    explicit VariantStorageFactory(T&& v)
+        : factory_variant_(std::move(v))
+    {
     }
-  private:
-    std::variant<lmdb::LmdbStorageFactory, mongo::MongoStorageFactory, s3::S3StorageFactory, memory::MemoryStorageFactory, nfs_backed::NfsBackedStorageFactory> factory_variant_;
+
+protected:
+    auto do_create_storage(const LibraryPath& lib, OpenMode mode)
+    {
+        return std::visit(
+            [&](auto&& impl) {
+                auto s = impl.create_storage(lib, mode);
+                return std::make_unique<VariantStorage>(std::move(s));
+            },
+            factory_variant_);
+    }
+
+private:
+    std::variant<lmdb::LmdbStorageFactory,
+        mongo::MongoStorageFactory,
+        s3::S3StorageFactory,
+        memory::MemoryStorageFactory,
+        nfs_backed::NfsBackedStorageFactory>
+        factory_variant_;
 };
 
-std::shared_ptr<VariantStorageFactory> create_storage_factory(
-    const arcticdb::proto::storage::VariantStorage &storage);
+std::shared_ptr<VariantStorageFactory> create_storage_factory(const arcticdb::proto::storage::VariantStorage& storage);
 
-std::unique_ptr<VariantStorage> create_storage(
-    const LibraryPath& library_path,
+std::unique_ptr<VariantStorage> create_storage(const LibraryPath& library_path,
     OpenMode mode,
-    const arcticdb::proto::storage::VariantStorage &storage_config);
+    const arcticdb::proto::storage::VariantStorage& storage_config);
 
 } // namespace arcticdb::storage

--- a/cpp/arcticdb/stream/aggregator-inl.hpp
+++ b/cpp/arcticdb/stream/aggregator-inl.hpp
@@ -12,7 +12,8 @@
 namespace arcticdb::stream {
 
 template<class Index, class Schema, class SegmentingPolicy, class DensityPolicy>
-void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::end_row() {
+void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::end_row()
+{
     segment_.end_row();
     stats_.update(row_builder_.nbytes());
     if (segmenting_policy_(stats_)) {
@@ -21,26 +22,32 @@ void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::end_row() {
 }
 
 template<class Index, class Schema, class SegmentingPolicy, class DensityPolicy>
-inline void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::commit_impl() {
+inline void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::commit_impl()
+{
     // TODO critical section here in async scenario
     callback_(std::move(segment_));
     commits_count_++;
-    segment_ = SegmentInMemory(schema_policy_.default_descriptor(), segmenting_policy_.expected_row_size(), false, SparsePolicy::allow_sparse);
+    segment_ = SegmentInMemory(schema_policy_.default_descriptor(),
+        segmenting_policy_.expected_row_size(),
+        false,
+        SparsePolicy::allow_sparse);
     segment_.init_column_map();
     stats_.reset();
 }
 
 template<class Index, class Schema, class SegmentingPolicy, class DensityPolicy>
-inline void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::commit() {
+inline void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::commit()
+{
     if (ARCTICDB_LIKELY(segment_.row_count() > 0 || segment_.metadata())) { // LIKELY
-//        segment_.end_sparse_columns();
+                                                                            //        segment_.end_sparse_columns();
         commit_impl();
     }
 }
 
 template<class Index, class Schema, class SegmentingPolicy, class DensityPolicy>
-inline void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::clear() {
+inline void Aggregator<Index, Schema, SegmentingPolicy, DensityPolicy>::clear()
+{
     segment_.clear();
 }
 
-} // namespace arcticdb
+} // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/aggregator.cpp
+++ b/cpp/arcticdb/stream/aggregator.cpp
@@ -9,14 +9,16 @@
 
 namespace arcticdb::stream {
 
-void AggregationStats::reset() {
+void AggregationStats::reset()
+{
     nbytes = 0;
     count = 0;
     total_rows_ = 0;
     last_active_time_ = util::SysClock::coarse_nanos_since_epoch();
 }
 
-void AggregationStats::update(size_t num_bytes) {
+void AggregationStats::update(size_t num_bytes)
+{
     ++count;
     nbytes += num_bytes;
     if (total_rows_ == 0) {
@@ -25,7 +27,8 @@ void AggregationStats::update(size_t num_bytes) {
     ++total_rows_;
 }
 
-void AggregationStats::update_many(size_t rows, size_t num_bytes) {
+void AggregationStats::update_many(size_t rows, size_t num_bytes)
+{
     ++count;
     nbytes += num_bytes;
     if (total_rows_ == 0) {

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -18,7 +18,6 @@
 #include <arcticdb/util/key_utils.hpp>
 #include <pipeline/frame_utils.hpp>
 
-
 namespace arcticdb::stream {
 
 using namespace arcticdb::pipelines;
@@ -31,66 +30,63 @@ struct AppendMapEntry {
     std::optional<entity::AtomKey> next_key_;
     uint64_t total_rows_ = 0;
 
-    const entity::StreamDescriptor& descriptor() const {
+    const entity::StreamDescriptor& descriptor() const
+    {
         return *slice_and_key_.slice_.desc();
     }
 
-    entity::StreamDescriptor& descriptor() {
+    entity::StreamDescriptor& descriptor()
+    {
         return *slice_and_key_.slice_.desc();
     }
 
-    const pipelines::FrameSlice& slice() const {
+    const pipelines::FrameSlice& slice() const
+    {
         return slice_and_key_.slice_;
     }
 
-    const entity::AtomKey & key() const{
+    const entity::AtomKey& key() const
+    {
         return slice_and_key_.key();
     }
 
-    friend bool operator<(const AppendMapEntry& l, const AppendMapEntry& r) {
+    friend bool operator<(const AppendMapEntry& l, const AppendMapEntry& r)
+    {
         const auto& right_key = r.key();
         const auto& left_key = l.key();
-        if(left_key.start_index() == right_key.start_index())
-            return  left_key.end_index() < right_key.end_index();
+        if (left_key.start_index() == right_key.start_index())
+            return left_key.end_index() < right_key.end_index();
 
         return left_key.start_index() < right_key.start_index();
     }
 };
 
+AppendMapEntry
+entry_from_key(const std::shared_ptr<stream::StreamSource>& store, const entity::AtomKey& key, bool load_data);
 
-AppendMapEntry entry_from_key(
-    const std::shared_ptr<stream::StreamSource>& store,
-    const entity::AtomKey& key,
-    bool load_data);
-
-std::pair<std::optional<entity::AtomKey>, size_t> read_head(
-    const std::shared_ptr<stream::StreamSource>& store,
+std::pair<std::optional<entity::AtomKey>, size_t> read_head(const std::shared_ptr<stream::StreamSource>& store,
     StreamId stream_id);
 
-std::vector<AppendMapEntry> get_incomplete_append_slices_for_stream_id(
-    const std::shared_ptr<Store> &store,
-    const StreamId &stream_id,
+std::vector<AppendMapEntry> get_incomplete_append_slices_for_stream_id(const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
     bool via_iteration,
     bool load_data);
 
-inline bool has_appends_key(
-    const std::shared_ptr<stream::StreamSource>& store,
-    const RefKey& ref_key) {
+inline bool has_appends_key(const std::shared_ptr<stream::StreamSource>& store, const RefKey& ref_key)
+{
     return store->key_exists(ref_key).get();
 }
 
-inline std::vector<AppendMapEntry> load_via_iteration(
-    const std::shared_ptr<Store>& store,
-    const StreamId& stream_id,
-    bool load_data
-) {
+inline std::vector<AppendMapEntry>
+load_via_iteration(const std::shared_ptr<Store>& store, const StreamId& stream_id, bool load_data)
+{
     auto prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
 
     std::vector<AppendMapEntry> output;
 
-    store->iterate_type(KeyType::APPEND_DATA, [&store, load_data, &output, &stream_id] (const auto& vk) {
+    store->iterate_type(KeyType::APPEND_DATA, [&store, load_data, &output, &stream_id](const auto& vk) {
         const auto& key = to_atom(vk);
-        if(key.id() != stream_id)
+        if (key.id() != stream_id)
             return;
 
         auto entry = entry_from_key(store, key, load_data);
@@ -100,30 +96,27 @@ inline std::vector<AppendMapEntry> load_via_iteration(
     return output;
 }
 
-std::set<StreamId> get_incomplete_symbols(const std::shared_ptr<Store>& store) {
+std::set<StreamId> get_incomplete_symbols(const std::shared_ptr<Store>& store)
+{
     std::set<StreamId> output;
 
-    store->iterate_type(KeyType::APPEND_DATA, [&output] (const auto& vk) {
-        output.insert(variant_key_id(vk));
-    });
+    store->iterate_type(KeyType::APPEND_DATA, [&output](const auto& vk) { output.insert(variant_key_id(vk)); });
     return output;
 }
 
-std::set<StreamId> get_incomplete_refs(const std::shared_ptr<Store>& store) {
+std::set<StreamId> get_incomplete_refs(const std::shared_ptr<Store>& store)
+{
     std::set<StreamId> output;
-    store->iterate_type(KeyType::APPEND_REF, [&output] (const auto& vk) {
-        output.insert(variant_key_id(vk));
-    });
+    store->iterate_type(KeyType::APPEND_REF, [&output](const auto& vk) { output.insert(variant_key_id(vk)); });
     return output;
 }
 
-std::set<StreamId> get_active_incomplete_refs(const std::shared_ptr<Store>& store) {
+std::set<StreamId> get_active_incomplete_refs(const std::shared_ptr<Store>& store)
+{
     std::set<StreamId> output;
     std::set<VariantKey> ref_keys;
-    store->iterate_type(KeyType::APPEND_REF, [&ref_keys] (const auto& vk) {
-        ref_keys.insert(vk);
-    });
-    for (const auto& vk: ref_keys) {
+    store->iterate_type(KeyType::APPEND_REF, [&ref_keys](const auto& vk) { ref_keys.insert(vk); });
+    for (const auto& vk : ref_keys) {
         auto stream_id = variant_key_id(vk);
         auto [next_key, _] = read_head(store, stream_id);
         if (next_key && store->key_exists(next_key.value()).get()) {
@@ -133,57 +126,56 @@ std::set<StreamId> get_active_incomplete_refs(const std::shared_ptr<Store>& stor
     return output;
 }
 
-void fix_slice_rowcounts(std::vector<AppendMapEntry>& entries, size_t complete_rowcount) {
-    for(auto& entry : entries) {
+void fix_slice_rowcounts(std::vector<AppendMapEntry>& entries, size_t complete_rowcount)
+{
+    for (auto& entry : entries) {
         complete_rowcount = entry.slice_and_key_.slice_.fix_row_count(complete_rowcount);
     }
 }
 
-void write_parallel(
-    const std::shared_ptr<Store>& store,
-    const StreamId& stream_id,
-    InputTensorFrame&& frame) {
+void write_parallel(const std::shared_ptr<Store>& store, const StreamId& stream_id, InputTensorFrame&& frame)
+{
     // TODO: dynamic bucketize doesn't work with incompletes
     (void)write_incomplete_frame(store, stream_id, std::move(frame), std::nullopt).get();
 }
 
-std::vector<SliceAndKey> get_incomplete(
-    const std::shared_ptr<Store> &store,
-    const StreamId &stream_id,
-    const pipelines::FilterRange &range,
+std::vector<SliceAndKey> get_incomplete(const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
+    const pipelines::FilterRange& range,
     uint64_t last_row,
     bool via_iteration,
-    bool load_data) {
+    bool load_data)
+{
     using namespace arcticdb::pipelines;
 
     std::unique_ptr<arcticdb::proto::descriptors::TimeSeriesDescriptor> unused;
     auto entries = get_incomplete_append_slices_for_stream_id(store, stream_id, via_iteration, load_data);
 
-    util::variant_match(range,
-                        [](const RowRange &) {
-                            util::raise_rte("Only timestamp based ranges supported for filtering.");
-                        },
-                        [&entries](const IndexRange &index_range) {
-                            entries.erase(
-                                std::remove_if(std::begin(entries), std::end(entries), [&] (const auto& entry) {
-                                    return !intersects(index_range, entry.slice_and_key_.key().index_range());
-                                }),
-                                std::end(entries));
-                        },
-                        [](const auto &) {
-                            // Don't know what to do with this index
-                        }
-    );
+    util::variant_match(
+        range,
+        [](const RowRange&) { util::raise_rte("Only timestamp based ranges supported for filtering."); },
+        [&entries](const IndexRange& index_range) {
+            entries.erase(std::remove_if(std::begin(entries),
+                              std::end(entries),
+                              [&](const auto& entry) {
+                                  return !intersects(index_range, entry.slice_and_key_.key().index_range());
+                              }),
+                std::end(entries));
+        },
+        [](const auto&) {
+            // Don't know what to do with this index
+        });
 
     fix_slice_rowcounts(entries, last_row);
     std::vector<SliceAndKey> output;
-    for(const auto& entry : entries)
+    for (const auto& entry : entries)
         output.push_back(entry.slice_and_key_);
 
     return output;
 }
 
-void write_head(const std::shared_ptr<Store>& store, const AtomKey& next_key, size_t total_rows) {
+void write_head(const std::shared_ptr<Store>& store, const AtomKey& next_key, size_t total_rows)
+{
     ARCTICDB_DEBUG(log::version(), "Writing append map head with key {}", next_key);
     auto any = pack_timeseries_descriptor({}, total_rows, next_key, {});
     SegmentInMemory segment;
@@ -191,17 +183,16 @@ void write_head(const std::shared_ptr<Store>& store, const AtomKey& next_key, si
     store->write(KeyType::APPEND_REF, next_key.id(), std::move(segment)).get();
 }
 
-folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(
-    const std::shared_ptr<Store>& store,
+folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     InputTensorFrame&& frame,
-    std::optional<AtomKey>&& next_key)  {
+    std::optional<AtomKey>&& next_key)
+{
     using namespace arcticdb::pipelines;
 
     auto index_range = frame.index_range;
     auto segment = segment_from_frame(std::move(frame), 0, std::move(next_key));
-    return store->write(
-        KeyType::APPEND_DATA,
+    return store->write(KeyType::APPEND_DATA,
         VersionId(0),
         stream_id,
         index_range.start_,
@@ -209,39 +200,37 @@ folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(
         std::move(segment));
 }
 
-void remove_incomplete_segments(
-    const std::shared_ptr<Store>& store,
-    const StreamId& stream_id) {
+void remove_incomplete_segments(const std::shared_ptr<Store>& store, const StreamId& stream_id)
+{
     delete_keys_of_type_for_stream(store, stream_id, KeyType::APPEND_DATA);
 }
 
-
 //TODO move this somewhere else
-StreamDescriptor merge_descriptors(
-    const StreamDescriptor &original,
-    const std::vector<StreamDescriptor::FieldsCollection> &entries,
-    const std::unordered_set<std::string_view> &filtered_set,
-    const std::optional<IndexDescriptor>& default_index) {
+StreamDescriptor merge_descriptors(const StreamDescriptor& original,
+    const std::vector<StreamDescriptor::FieldsCollection>& entries,
+    const std::unordered_set<std::string_view>& filtered_set,
+    const std::optional<IndexDescriptor>& default_index)
+{
 
     std::vector<std::string_view> merged_fields;
     std::unordered_map<std::string_view, arcticdb::proto::descriptors::TypeDescriptor> merged_fields_map;
 
-    for (const auto &field : original.fields()) {
+    for (const auto& field : original.fields()) {
         merged_fields.push_back(field.name());
         merged_fields_map.try_emplace(field.name(), field.type_desc());
     }
 
     auto index = empty_index();
-    if(original.index().uninitialized()) {
-        if(default_index) {
+    if (original.index().uninitialized()) {
+        if (default_index) {
             auto temp_idx = default_index_type_from_descriptor(default_index->proto());
-            util::variant_match(temp_idx, [&merged_fields, &merged_fields_map] (const auto& idx) {
+            util::variant_match(temp_idx, [&merged_fields, &merged_fields_map](const auto& idx) {
                 using IndexType = std::decay_t<decltype(idx)>;
                 merged_fields.emplace_back(idx.name());
-                merged_fields_map.try_emplace(idx.name(), static_cast<TypeDescriptor>(typename IndexType::TypeDescTag{}).proto());
+                merged_fields_map.try_emplace(idx.name(),
+                    static_cast<TypeDescriptor>(typename IndexType::TypeDescTag{}).proto());
             });
-        }
-        else
+        } else
             util::raise_rte("Descriptor has uninitialized index and no default supplied");
     } else {
         index = index_type_from_descriptor(original);
@@ -251,23 +240,26 @@ StreamDescriptor merge_descriptors(
 
     // Merge all the fields for all slices, apart from the index which we already have from the first descriptor.
     // Note that we preserve the ordering as we see columns, especially the index which needs to be column 0.
-    for (const auto &fields : entries) {
-        if(has_index)
-            util::variant_match(index, [&fields] (const auto& idx) { idx.check(fields); });
+    for (const auto& fields : entries) {
+        if (has_index)
+            util::variant_match(index, [&fields](const auto& idx) { idx.check(fields); });
 
         for (size_t idx = has_index ? 1u : 0u; idx < static_cast<size_t>(fields.size()); ++idx) {
             const auto& field = fields[idx];
             auto type_desc = type_desc_from_proto(field.type_desc());
             if (filtered_set.empty() || (filtered_set.find(field.name()) != filtered_set.end())) {
-                if(auto existing = merged_fields_map.find(field.name()); existing != merged_fields_map.end()) {
+                if (auto existing = merged_fields_map.find(field.name()); existing != merged_fields_map.end()) {
                     auto existing_type_desc = type_desc_from_proto(existing->second);
-                    if(existing_type_desc != type_desc) {
+                    if (existing_type_desc != type_desc) {
                         log::version().info("Got incompatible types: {} {}", existing_type_desc, type_desc);
                         auto new_descriptor = has_valid_common_type(existing_type_desc, type_desc);
-                        if(new_descriptor) {
+                        if (new_descriptor) {
                             merged_fields_map[field.name()] = new_descriptor->proto();
                         } else {
-                            util::raise_rte("No valid common type between {} and {} for column {}", existing_type_desc, type_desc, field.name());
+                            util::raise_rte("No valid common type between {} and {} for column {}",
+                                existing_type_desc,
+                                type_desc,
+                                field.name());
                         }
                     }
                 } else {
@@ -278,7 +270,7 @@ StreamDescriptor merge_descriptors(
         }
     }
     StreamDescriptor::FieldsCollection new_fields{};
-    for(const auto& field_name : merged_fields) {
+    for (const auto& field_name : merged_fields) {
         auto new_field = new_fields.Add();
         new_field->set_name(field_name.data(), field_name.size());
         new_field->mutable_type_desc()->CopyFrom(merged_fields_map[field_name]);
@@ -286,44 +278,43 @@ StreamDescriptor merge_descriptors(
     return arcticdb::entity::StreamDescriptor{original.id(), get_descriptor_from_index(index), std::move(new_fields)};
 }
 
-StreamDescriptor merge_descriptors(
-    const StreamDescriptor &original,
-    const std::vector<StreamDescriptor::FieldsCollection> &entries,
-    const std::vector<std::string> &filtered_columns,
-    const std::optional<IndexDescriptor>& default_index) {
+StreamDescriptor merge_descriptors(const StreamDescriptor& original,
+    const std::vector<StreamDescriptor::FieldsCollection>& entries,
+    const std::vector<std::string>& filtered_columns,
+    const std::optional<IndexDescriptor>& default_index)
+{
     std::unordered_set<std::string_view> filtered_set(filtered_columns.begin(), filtered_columns.end());
     return merge_descriptors(original, entries, filtered_set, default_index);
 }
 
-StreamDescriptor merge_descriptors(
-    const StreamDescriptor &original,
-    const std::vector<SliceAndKey> &entries,
-    const std::vector<std::string> &filtered_columns,
-    const std::optional<IndexDescriptor>& default_index) {
+StreamDescriptor merge_descriptors(const StreamDescriptor& original,
+    const std::vector<SliceAndKey>& entries,
+    const std::vector<std::string>& filtered_columns,
+    const std::optional<IndexDescriptor>& default_index)
+{
     std::vector<StreamDescriptor::FieldsCollection> fields;
-    for (const auto &entry : entries) {
+    for (const auto& entry : entries) {
         fields.push_back(entry.slice_.desc()->fields());
     }
     return merge_descriptors(original, fields, filtered_columns, default_index);
 }
 
-StreamDescriptor merge_descriptors(
-    const std::shared_ptr<Store>& store,
-    const StreamDescriptor &original,
-    const std::vector<SliceAndKey> &entries,
-    const std::unordered_set<std::string_view> &filtered_set,
-    const std::optional<IndexDescriptor>& default_index) {
+StreamDescriptor merge_descriptors(const std::shared_ptr<Store>& store,
+    const StreamDescriptor& original,
+    const std::vector<SliceAndKey>& entries,
+    const std::unordered_set<std::string_view>& filtered_set,
+    const std::optional<IndexDescriptor>& default_index)
+{
     std::vector<StreamDescriptor::FieldsCollection> fields;
-    for (const auto &entry : entries) {
+    for (const auto& entry : entries) {
         fields.push_back(entry.segment(store).descriptor().fields());
     }
     return merge_descriptors(original, fields, filtered_set, default_index);
 }
 
-std::vector<AppendMapEntry> load_via_list(
-        const std::shared_ptr<Store>& store,
-        const StreamId& stream_id,
-        bool load_data) {
+std::vector<AppendMapEntry>
+load_via_list(const std::shared_ptr<Store>& store, const StreamId& stream_id, bool load_data)
+{
     using namespace arcticdb::pipelines;
 
     std::unique_ptr<arcticdb::proto::descriptors::TimeSeriesDescriptor> tsd;
@@ -345,17 +336,18 @@ std::vector<AppendMapEntry> load_via_list(
     return output;
 }
 
-std::pair<std::optional<AtomKey>, size_t> read_head(const std::shared_ptr<StreamSource>& store, StreamId stream_id) {
+std::pair<std::optional<AtomKey>, size_t> read_head(const std::shared_ptr<StreamSource>& store, StreamId stream_id)
+{
     auto ref_key = RefKey{std::move(stream_id), KeyType::APPEND_REF};
     auto output = std::make_pair<std::optional<AtomKey>, size_t>(std::nullopt, 0);
 
-    if(!has_appends_key(store, ref_key))
+    if (!has_appends_key(store, ref_key))
         return output;
 
     auto fut = store->read(ref_key);
     auto [key, seg] = std::move(fut).get();
     auto tsd = timeseries_descriptor_from_segment(seg);
-    if(tsd.has_next_key()) {
+    if (tsd.has_next_key()) {
         output.first = decode_key(tsd.next_key());
     }
 
@@ -363,49 +355,52 @@ std::pair<std::optional<AtomKey>, size_t> read_head(const std::shared_ptr<Stream
     return output;
 }
 
-std::pair<arcticdb::proto::descriptors::TimeSeriesDescriptor, std::optional<SegmentInMemory>> get_descriptor_and_data(
-    const std::shared_ptr<StreamSource>& store,
-    const AtomKey& k,
-    bool load_data) {
-    if(load_data) {
+std::pair<arcticdb::proto::descriptors::TimeSeriesDescriptor, std::optional<SegmentInMemory>>
+get_descriptor_and_data(const std::shared_ptr<StreamSource>& store, const AtomKey& k, bool load_data)
+{
+    if (load_data) {
         auto [key, seg] = store->read(k).get();
         auto tsd = timeseries_descriptor_from_any(*seg.metadata());
         return std::make_pair(std::move(tsd), std::make_optional<SegmentInMemory>(std::move(seg)));
     } else {
         auto [key, metadata, descriptor] = store->read_metadata_and_descriptor(k).get();
         util::check(static_cast<bool>(metadata), "Failed to get append metadata from key {}", key);
-        util::check(!std::holds_alternative<StringId>(variant_key_id(key)) || !std::get<StringId>(variant_key_id(key)).empty(), "Unexpected empty id");
+        util::check(!std::holds_alternative<StringId>(variant_key_id(key)) ||
+                        !std::get<StringId>(variant_key_id(key)).empty(),
+            "Unexpected empty id");
         auto tsd = timeseries_descriptor_from_any(metadata.value());
-*       tsd.mutable_stream_descriptor() = std::move(descriptor);
+        *tsd.mutable_stream_descriptor() = std::move(descriptor);
         return std::make_pair(std::move(tsd), std::nullopt);
     }
 }
 
-AppendMapEntry create_entry(const arcticdb::proto::descriptors::TimeSeriesDescriptor& tsd) {
+AppendMapEntry create_entry(const arcticdb::proto::descriptors::TimeSeriesDescriptor& tsd)
+{
     AppendMapEntry entry;
 
-    if(tsd.has_next_key())
+    if (tsd.has_next_key())
         entry.next_key_ = decode_key(tsd.next_key());
 
     entry.total_rows_ = tsd.total_rows();
-   return entry;
+    return entry;
 }
 
-AppendMapEntry entry_from_key(const std::shared_ptr<StreamSource>& store, const AtomKey& key, bool load_data) {
+AppendMapEntry entry_from_key(const std::shared_ptr<StreamSource>& store, const AtomKey& key, bool load_data)
+{
     auto [tsd, seg] = get_descriptor_and_data(store, key, load_data);
     auto entry = create_entry(tsd);
     auto descriptor = std::make_shared<StreamDescriptor>();
     auto index_field_count = tsd.stream_descriptor().index().field_count();
     auto field_count = tsd.stream_descriptor().fields().size();
-    auto frame_slice = FrameSlice{std::make_shared<StreamDescriptor>(std::move(*tsd.mutable_stream_descriptor())), ColRange{index_field_count, field_count}, RowRange{0, entry.total_rows_}};
+    auto frame_slice = FrameSlice{std::make_shared<StreamDescriptor>(std::move(*tsd.mutable_stream_descriptor())),
+        ColRange{index_field_count, field_count},
+        RowRange{0, entry.total_rows_}};
     entry.slice_and_key_ = SliceAndKey{std::move(frame_slice), key, std::move(seg)};
     return entry;
 }
 
-void append_incomplete(
-        const std::shared_ptr<Store>& store,
-        const StreamId& stream_id,
-        InputTensorFrame&& frame) {
+void append_incomplete(const std::shared_ptr<Store>& store, const StreamId& stream_id, InputTensorFrame&& frame)
+{
     using namespace arcticdb::proto::descriptors;
     using namespace arcticdb::stream;
     ARCTICDB_SAMPLE_DEFAULT(AppendIncomplete)
@@ -416,15 +411,16 @@ void append_incomplete(
     auto desc = frame.desc.clone();
     auto new_key = write_incomplete_frame(store, stream_id, std::move(frame), std::move(next_key)).get();
 
-
-    ARCTICDB_DEBUG(log::version(), "Wrote incomplete frame for stream {}, {} rows, total rows {}", stream_id, frame.num_rows, total_rows);
+    ARCTICDB_DEBUG(log::version(),
+        "Wrote incomplete frame for stream {}, {} rows, total rows {}",
+        stream_id,
+        frame.num_rows,
+        total_rows);
     write_head(store, to_atom(new_key), total_rows);
 }
 
-void append_incomplete_segment(
-        const std::shared_ptr<Store>& store,
-        const StreamId& stream_id,
-        SegmentInMemory &&seg) {
+void append_incomplete_segment(const std::shared_ptr<Store>& store, const StreamId& stream_id, SegmentInMemory&& seg)
+{
     using namespace arcticdb::proto::descriptors;
     using namespace arcticdb::stream;
     ARCTICDB_SAMPLE_DEFAULT(AppendIncomplete)
@@ -438,34 +434,34 @@ void append_incomplete_segment(
 
     auto any = pack_timeseries_descriptor({}, seg_row_count, next_key, {});
     seg.set_metadata(std::move(any));
-    auto new_key = store->write(
-            arcticdb::stream::KeyType::APPEND_DATA,
-            0,
-            stream_id,
-            start_index,
-            end_index,
-            std::move(seg)).get();
+    auto new_key =
+        store->write(arcticdb::stream::KeyType::APPEND_DATA, 0, stream_id, start_index, end_index, std::move(seg))
+            .get();
 
     total_rows += seg_row_count;
-    ARCTICDB_DEBUG(log::version(), "Wrote incomplete frame for stream {}, {} rows, total rows {}", stream_id, seg_row_count, total_rows);
+    ARCTICDB_DEBUG(log::version(),
+        "Wrote incomplete frame for stream {}, {} rows, total rows {}",
+        stream_id,
+        seg_row_count,
+        total_rows);
     write_head(store, to_atom(std::move(new_key)), total_rows);
 }
 
-std::vector<AppendMapEntry> get_incomplete_append_slices_for_stream_id(
-        const std::shared_ptr<Store> &store,
-        const StreamId &stream_id,
-        bool via_iteration,
-        bool load_data) {
+std::vector<AppendMapEntry> get_incomplete_append_slices_for_stream_id(const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
+    bool via_iteration,
+    bool load_data)
+{
     using namespace arcticdb::pipelines;
     std::vector<AppendMapEntry> entries;
 
-    if(via_iteration) {
+    if (via_iteration) {
         entries = load_via_iteration(store, stream_id, load_data);
     } else {
         entries = load_via_list(store, stream_id, load_data);
     }
 
-    if(!entries.empty()) {
+    if (!entries.empty()) {
         auto index_desc = entries[0].descriptor().index();
 
         if (index_desc.type() != IndexDescriptor::ROWCOUNT) {
@@ -478,14 +474,12 @@ std::vector<AppendMapEntry> get_incomplete_append_slices_for_stream_id(
     return entries;
 }
 
-std::optional<int64_t> latest_incomplete_timestamp(
-    const std::shared_ptr<Store>& store,
-    const StreamId& stream_id
-    ) {
+std::optional<int64_t> latest_incomplete_timestamp(const std::shared_ptr<Store>& store, const StreamId& stream_id)
+{
     auto [next_key, total_rows] = read_head(store, stream_id);
-    if(next_key && store->key_exists(next_key.value()).get())
+    if (next_key && store->key_exists(next_key.value()).get())
         return next_key.value().end_time();
 
     return std::nullopt;
 }
-}
+} // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/append_map.hpp
+++ b/cpp/arcticdb/stream/append_map.hpp
@@ -20,36 +20,31 @@ struct PythonOutputFrame;
 struct InputTensorFrame;
 using FilterRange = std::variant<std::monostate, IndexRange, RowRange>;
 
-}
+} // namespace arcticdb::pipelines
 
 namespace arcticdb::stream {
-StreamDescriptor merge_descriptors(
-    const StreamDescriptor &original,
-    const std::vector<StreamDescriptor::FieldsCollection> &entries,
-    const std::unordered_set<std::string_view> &filtered_set,
+StreamDescriptor merge_descriptors(const StreamDescriptor& original,
+    const std::vector<StreamDescriptor::FieldsCollection>& entries,
+    const std::unordered_set<std::string_view>& filtered_set,
     const std::optional<IndexDescriptor>& default_index);
 
-entity::StreamDescriptor merge_descriptors(
-    const entity::StreamDescriptor &original,
-    const std::vector<StreamDescriptor::FieldsCollection> &entries,
-    const std::vector<std::string> &filtered_columns,
+entity::StreamDescriptor merge_descriptors(const entity::StreamDescriptor& original,
+    const std::vector<StreamDescriptor::FieldsCollection>& entries,
+    const std::vector<std::string>& filtered_columns,
     const std::optional<entity::IndexDescriptor>& default_index = std::nullopt);
 
-entity::StreamDescriptor merge_descriptors(
-    const entity::StreamDescriptor &original,
-    const std::vector<pipelines::SliceAndKey> &entries,
-    const std::vector<std::string> &filtered_columns,
+entity::StreamDescriptor merge_descriptors(const entity::StreamDescriptor& original,
+    const std::vector<pipelines::SliceAndKey>& entries,
+    const std::vector<std::string>& filtered_columns,
     const std::optional<entity::IndexDescriptor>& default_index = std::nullopt);
 
-entity::StreamDescriptor merge_descriptors(
-    const std::shared_ptr<Store>& store,
-    const entity::StreamDescriptor &original,
-    const std::vector<pipelines::SliceAndKey> &entries,
-    const std::unordered_set<std::string_view> &filtered_set,
+entity::StreamDescriptor merge_descriptors(const std::shared_ptr<Store>& store,
+    const entity::StreamDescriptor& original,
+    const std::vector<pipelines::SliceAndKey>& entries,
+    const std::unordered_set<std::string_view>& filtered_set,
     const std::optional<entity::IndexDescriptor>& default_index = std::nullopt);
 
-std::pair<std::optional<entity::AtomKey>, size_t> read_head(
-    const std::shared_ptr<stream::StreamSource>& store,
+std::pair<std::optional<entity::AtomKey>, size_t> read_head(const std::shared_ptr<stream::StreamSource>& store,
     StreamId stream_id);
 
 std::set<StreamId> get_incomplete_refs(const std::shared_ptr<Store>& store);
@@ -58,47 +53,32 @@ std::set<StreamId> get_incomplete_symbols(const std::shared_ptr<Store>& store);
 
 std::set<StreamId> get_active_incomplete_refs(const std::shared_ptr<Store>& store);
 
-std::vector<pipelines::SliceAndKey> get_incomplete(
-    const std::shared_ptr<Store> &store,
-    const StreamId &stream_id,
-    const pipelines::FilterRange &range,
+std::vector<pipelines::SliceAndKey> get_incomplete(const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
+    const pipelines::FilterRange& range,
     uint64_t last_row,
     bool via_iteration,
     bool load_data);
 
-void remove_incomplete_segments(
-    const std::shared_ptr<Store>& store,
-    const StreamId& stream_id);
+void remove_incomplete_segments(const std::shared_ptr<Store>& store, const StreamId& stream_id);
 
-folly::Future<entity::VariantKey> write_incomplete_frame(
-    const std::shared_ptr<Store>& store,
+folly::Future<entity::VariantKey> write_incomplete_frame(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     pipelines::InputTensorFrame&& frame,
     std::optional<AtomKey>&& next_key);
 
-void write_parallel(
-    const std::shared_ptr<Store>& store,
+void write_parallel(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     pipelines::InputTensorFrame&& frame);
 
-void write_head(
-    const std::shared_ptr<Store>& store,
-    const AtomKey& next_key,
-    size_t total_rows);
+void write_head(const std::shared_ptr<Store>& store, const AtomKey& next_key, size_t total_rows);
 
-void append_incomplete_segment(
-    const std::shared_ptr<Store>& store,
-    const StreamId& stream_id,
-    SegmentInMemory &&seg);
+void append_incomplete_segment(const std::shared_ptr<Store>& store, const StreamId& stream_id, SegmentInMemory&& seg);
 
-void append_incomplete(
-    const std::shared_ptr<Store>& store,
+void append_incomplete(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     pipelines::InputTensorFrame&& frame);
 
-std::optional<int64_t> latest_incomplete_timestamp(
-    const std::shared_ptr<Store>& store,
-    const StreamId& stream_id
-    );
+std::optional<int64_t> latest_incomplete_timestamp(const std::shared_ptr<Store>& store, const StreamId& stream_id);
 
 } //namespace arcticdb::stream

--- a/cpp/arcticdb/stream/index_aggregator.hpp
+++ b/cpp/arcticdb/stream/index_aggregator.hpp
@@ -16,45 +16,55 @@
 
 namespace arcticdb::stream {
 
-inline void write_key_to_segment(SegmentInMemory &segment, const entity::AtomKey &key) {
+inline void write_key_to_segment(SegmentInMemory& segment, const entity::AtomKey& key)
+{
     ARCTICDB_DEBUG(log::storage(), "Writing key row {}", key.view());
-    std::visit([&segment](auto &&val) { segment.set_scalar(int(pipelines::index::Fields::start_index), val); }, key.start_index());
-    std::visit([&segment](auto &&val) { segment.set_scalar(int(pipelines::index::Fields::end_index), val); }, key.end_index());
+    std::visit([&segment](auto&& val) { segment.set_scalar(int(pipelines::index::Fields::start_index), val); },
+        key.start_index());
+    std::visit([&segment](auto&& val) { segment.set_scalar(int(pipelines::index::Fields::end_index), val); },
+        key.end_index());
     segment.set_scalar(int(pipelines::index::Fields::version_id), key.version_id());
-    std::visit([&segment](auto &&val) { segment.set_scalar(int(pipelines::index::Fields::stream_id), val); }, key.id());
+    std::visit([&segment](auto&& val) { segment.set_scalar(int(pipelines::index::Fields::stream_id), val); }, key.id());
     segment.set_scalar(int(pipelines::index::Fields::creation_ts), key.creation_ts());
     segment.set_scalar(int(pipelines::index::Fields::content_hash), key.content_hash());
-    segment.set_scalar(int(pipelines::index::Fields::index_type), static_cast<uint8_t>(stream::get_index_value_type(key)));
+    segment.set_scalar(int(pipelines::index::Fields::index_type),
+        static_cast<uint8_t>(stream::get_index_value_type(key)));
     segment.set_scalar(int(pipelines::index::Fields::key_type), static_cast<uint8_t>(key.type()));
     segment.end_row();
 }
 
 template<class DataIndexType>
 class FlatIndexingPolicy {
-    using Callback = folly::Function<void(SegmentInMemory && )>;
-  public:
-    template<class C>
-    FlatIndexingPolicy(StreamId stream_id, C&& c) :
-        callback_(std::move(c)),
-        schema_(idx_schema(stream_id, DataIndexType::default_index())),
-        segment_(schema_.default_descriptor()) {}
+    using Callback = folly::Function<void(SegmentInMemory&&)>;
 
-    void add_key(const AtomKey &key) {
+public:
+    template<class C>
+    FlatIndexingPolicy(StreamId stream_id, C&& c)
+        : callback_(std::move(c)),
+          schema_(idx_schema(stream_id, DataIndexType::default_index())),
+          segment_(schema_.default_descriptor())
+    {
+    }
+
+    void add_key(const AtomKey& key)
+    {
         write_key_to_segment(segment_, key);
     }
 
-    void commit() {
+    void commit()
+    {
         if (ARCTICDB_LIKELY(!segment_.empty())) {
             callback_(std::move(segment_));
             segment_ = SegmentInMemory(schema_.default_descriptor());
         }
     }
 
-    void set_metadata(google::protobuf::Any &&meta) {
+    void set_metadata(google::protobuf::Any&& meta)
+    {
         segment_.set_metadata(std::move(meta));
     }
 
-  private:
+private:
     Callback callback_;
     FixedSchema schema_;
     SegmentInMemory segment_;
@@ -62,26 +72,30 @@ class FlatIndexingPolicy {
 
 template<class DataIndexType, class IndexingPolicy = FlatIndexingPolicy<DataIndexType>>
 class IndexAggregator {
-  public:
+public:
     template<class C>
-    IndexAggregator(StreamId stream_id, C &&c):
-        indexing_policy_(stream_id, std::move(c)) {}
+    IndexAggregator(StreamId stream_id, C&& c)
+        : indexing_policy_(stream_id, std::move(c))
+    {
+    }
 
-    void add_key(const AtomKey &key) {
+    void add_key(const AtomKey& key)
+    {
         indexing_policy_.add_key(key);
     }
 
-    void commit() {
+    void commit()
+    {
         indexing_policy_.commit();
     }
 
-    void set_metadata(google::protobuf::Any &&meta) {
+    void set_metadata(google::protobuf::Any&& meta)
+    {
         indexing_policy_.set_metadata(std::move(meta));
     }
 
-  private:
+private:
     IndexingPolicy indexing_policy_;
 };
 
 } // namespace arcticdb::stream
-

--- a/cpp/arcticdb/stream/merge.hpp
+++ b/cpp/arcticdb/stream/merge.hpp
@@ -11,29 +11,29 @@
 
 namespace arcticdb::stream {
 template<typename IndexType, typename WrapperType, typename AggregatorType, typename QueueType>
-void do_merge(
-    QueueType& input_streams,
-    AggregatorType& agg,
-    bool add_symbol_column
-    ) {
+void do_merge(QueueType& input_streams, AggregatorType& agg, bool add_symbol_column)
+{
     while (!input_streams.empty()) {
         auto next = input_streams.pop_top();
 
-        agg.start_row(pipelines::index::index_value_from_row(next->row(), IndexDescriptor::TIMESTAMP, 0).value()) ([&next, add_symbol_column](auto &rb) {
-            if(add_symbol_column)
-                rb.set_scalar_by_name("symbol", std::string_view(std::get<StringId>(next->id())), make_scalar_type(DataType::UTF_DYNAMIC64));
+        agg.start_row(pipelines::index::index_value_from_row(next->row(), IndexDescriptor::TIMESTAMP, 0).value())(
+            [&next, add_symbol_column](auto& rb) {
+                if (add_symbol_column)
+                    rb.set_scalar_by_name("symbol",
+                        std::string_view(std::get<StringId>(next->id())),
+                        make_scalar_type(DataType::UTF_DYNAMIC64));
 
-            auto val = next->row().begin();
-            std::advance(val, IndexType::field_count());
-            for(; val != next->row().end(); ++val) {
-                val->visit_field([&rb] (const auto& opt_v, std::string_view name, const TypeDescriptor& type_desc) {
-                    if(opt_v)
-                        rb.set_scalar_by_name(name, opt_v.value(), type_desc);
-                });
-            }
-        });
+                auto val = next->row().begin();
+                std::advance(val, IndexType::field_count());
+                for (; val != next->row().end(); ++val) {
+                    val->visit_field([&rb](const auto& opt_v, std::string_view name, const TypeDescriptor& type_desc) {
+                        if (opt_v)
+                            rb.set_scalar_by_name(name, opt_v.value(), type_desc);
+                    });
+                }
+            });
 
-        if(next->advance())
+        if (next->advance())
             input_streams.emplace(std::move(next));
     }
     agg.commit();

--- a/cpp/arcticdb/stream/protobuf_mappings.hpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.hpp
@@ -16,7 +16,8 @@
 
 namespace arcticdb {
 
-inline arcticdb::proto::descriptors::NormalizationMetadata make_timeseries_norm_meta(const entity::StreamId& stream_id) {
+inline arcticdb::proto::descriptors::NormalizationMetadata make_timeseries_norm_meta(const entity::StreamId& stream_id)
+{
     using namespace arcticdb::proto::descriptors;
     NormalizationMetadata norm_meta;
     NormalizationMetadata_PandasDataFrame pandas;
@@ -32,12 +33,15 @@ inline arcticdb::proto::descriptors::NormalizationMetadata make_timeseries_norm_
 /**
  * Set the minimum defaults into norm_meta. Originally created to synthesize norm_meta for incomplete compaction.
  */
-inline void ensure_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_meta, const entity::StreamId& stream_id, bool set_tz) {
-    if(norm_meta.input_type_case() == arcticdb::proto::descriptors::NormalizationMetadata::INPUT_TYPE_NOT_SET) {
+inline void ensure_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
+    const entity::StreamId& stream_id,
+    bool set_tz)
+{
+    if (norm_meta.input_type_case() == arcticdb::proto::descriptors::NormalizationMetadata::INPUT_TYPE_NOT_SET) {
         norm_meta.CopyFrom(make_timeseries_norm_meta(stream_id));
     }
 
-    if(set_tz && norm_meta.df().common().index().tz().empty())
+    if (set_tz && norm_meta.df().common().index().tz().empty())
         norm_meta.mutable_df()->mutable_common()->mutable_index()->set_tz("UTC");
 }
 

--- a/cpp/arcticdb/stream/python_bindings.cpp
+++ b/cpp/arcticdb/stream/python_bindings.cpp
@@ -23,28 +23,18 @@ namespace py = pybind11;
 namespace arcticdb {
 using namespace arcticdb::python_util;
 
-void register_types(py::module &m) {
+void register_types(py::module& m)
+{
     py::enum_<DataType>(m, "DataType")
 #define DATA_TYPE(__DT__) .value(#__DT__, DataType::__DT__)
-        DATA_TYPE(UINT8)
-        DATA_TYPE(UINT16)
-        DATA_TYPE(UINT32)
-        DATA_TYPE(UINT64)
-        DATA_TYPE(INT8)
-        DATA_TYPE(INT16)
-        DATA_TYPE(INT32)
-        DATA_TYPE(INT64)
-        DATA_TYPE(FLOAT32)
-        DATA_TYPE(FLOAT64)
-        DATA_TYPE(BOOL8)
-        DATA_TYPE(MICROS_UTC64)
-        DATA_TYPE(ASCII_FIXED64)
-        DATA_TYPE(ASCII_DYNAMIC64)
-        //DATA_TYPE(UTF8_STRING)
-        //     DATA_TYPE(BYTES)
-        //   DATA_TYPE(PICKLE)
+        DATA_TYPE(UINT8) DATA_TYPE(UINT16) DATA_TYPE(UINT32) DATA_TYPE(UINT64) DATA_TYPE(INT8) DATA_TYPE(INT16)
+            DATA_TYPE(INT32) DATA_TYPE(INT64) DATA_TYPE(FLOAT32) DATA_TYPE(FLOAT64) DATA_TYPE(BOOL8)
+                DATA_TYPE(MICROS_UTC64) DATA_TYPE(ASCII_FIXED64) DATA_TYPE(ASCII_DYNAMIC64)
+    //DATA_TYPE(UTF8_STRING)
+    //     DATA_TYPE(BYTES)
+    //   DATA_TYPE(PICKLE)
 #undef DATA_TYPE
-        ;
+                    ;
 
     py::enum_<Dimension>(m, "Dimension")
         .value("Dim0", Dimension::Dim0)
@@ -56,14 +46,12 @@ void register_types(py::module &m) {
     python_util::add_repr(py::class_<TypeDescriptor>(m, "TypeDescriptor")
                               .def(py::init<DataType, Dimension>())
                               .def("data_type", &TypeDescriptor::data_type)
-                              .def("dimension", &TypeDescriptor::dimension)
-    );
+                              .def("dimension", &TypeDescriptor::dimension));
     //TODO re-add this constructor
     python_util::add_repr(py::class_<FieldDescriptor>(m, "FieldDescriptor")
                               .def(py::init<TypeDescriptor, std::string>())
                               .def("type_desc", &FieldDescriptor::type_desc)
-                              .def("name", &FieldDescriptor::name)
-    );
+                              .def("name", &FieldDescriptor::name));
 
     py::enum_<IndexDescriptor::Type>(m, "IndexKind")
         .value("TIMESTAMP", IndexDescriptor::TIMESTAMP)
@@ -73,37 +61,34 @@ void register_types(py::module &m) {
     python_util::add_repr(py::class_<IndexDescriptor>(m, "IndexDescriptor")
                               .def(py::init<std::size_t, IndexDescriptor::Type>())
                               .def("field_count", &IndexDescriptor::field_count)
-                              .def("kind", &IndexDescriptor::type)
-    );
+                              .def("kind", &IndexDescriptor::type));
 
     //TODO re-add at the end
-   python_util::add_repr(py::class_<StreamDescriptor>(m, "StreamDescriptor")
-                              .def(py::init([](StreamId stream_id, IndexDescriptor idx_desc, const std::vector<FieldDescriptor>& fields) {
-                                  auto index = default_index_type_from_descriptor(idx_desc.proto());
-                                  return util::variant_match(index, [&stream_id, &fields] (auto idx_type){
-                                      return StreamDescriptor{index_descriptor(stream_id, idx_type, fields_proto_from_range(fields))};
-                                  });
-                              }))
-                              .def("id", &StreamDescriptor::id)
-                              //.def("fields", &StreamDescriptor::fields)
+    python_util::add_repr(
+        py::class_<StreamDescriptor>(m, "StreamDescriptor")
+            .def(py::init([](StreamId stream_id, IndexDescriptor idx_desc, const std::vector<FieldDescriptor>& fields) {
+                auto index = default_index_type_from_descriptor(idx_desc.proto());
+                return util::variant_match(index, [&stream_id, &fields](auto idx_type) {
+                    return StreamDescriptor{index_descriptor(stream_id, idx_type, fields_proto_from_range(fields))};
+                });
+            }))
+            .def("id", &StreamDescriptor::id)
+        //.def("fields", &StreamDescriptor::fields)
     );
 
     py::class_<PyTimestampRange>(m, "TimestampRange")
-        .def(py::init<const py::object &, const py::object &>())
-        .def("as_tuple", [](const PyTimestampRange &rg) {
-            return static_cast<TimestampRange>(rg);
-        })
+        .def(py::init<const py::object&, const py::object&>())
+        .def("as_tuple", [](const PyTimestampRange& rg) { return static_cast<TimestampRange>(rg); })
         .def_property_readonly("start_nanos_utc", &PyTimestampRange::start_nanos_utc)
         .def_property_readonly("end_nanos_utc", &PyTimestampRange::end_nanos_utc);
 
-    m.def("create_timestamp_index_stream_descriptor", [](StreamId tsid,
-                                                         const std::vector<FieldDescriptor> &fields) {
+    m.def("create_timestamp_index_stream_descriptor", [](StreamId tsid, const std::vector<FieldDescriptor>& fields) {
         auto rg = folly::range(fields.begin(), fields.end());
         const auto index = stream::TimeseriesIndex::default_index();
         return index.create_stream_descriptor(tsid, fields_proto_from_range(rg));
     });
 }
-}
+} // namespace arcticdb
 
 namespace arcticdb::stream {
 
@@ -111,55 +96,56 @@ struct SegmentHolder {
     SegmentInMemory segment;
 };
 
-
-void register_stream_bindings(py::module &m) {
+void register_stream_bindings(py::module& m)
+{
 
     using Agg = FixedTimestampAggregator;
     using FixedTickRowBuilder = typename Agg::RowBuilderType;
 
     py::class_<SegmentInMemory>(m, "SegmentInMemory")
-    .def(py::init<>())
-    .def_property_readonly("row_count", &SegmentInMemory::row_count)
-    .def_property_readonly("num_columns", &SegmentInMemory::num_columns)
-    .def_property_readonly("string_pool_size", &SegmentInMemory::string_pool_size)
-    .def("string_pool", &SegmentInMemory::string_pool, py::return_value_policy::reference)
-    .def("column", &SegmentInMemory::column_ref, py::return_value_policy::reference)
-    .def("empty", &SegmentInMemory::empty)
-    .def("metadata",[](const SegmentInMemory & seg){
-        if (!seg.metadata()) return py::bytes();
-        return py::bytes(seg.metadata()->SerializeAsString());
-        }, py::return_value_policy::copy);
+        .def(py::init<>())
+        .def_property_readonly("row_count", &SegmentInMemory::row_count)
+        .def_property_readonly("num_columns", &SegmentInMemory::num_columns)
+        .def_property_readonly("string_pool_size", &SegmentInMemory::string_pool_size)
+        .def("string_pool", &SegmentInMemory::string_pool, py::return_value_policy::reference)
+        .def("column", &SegmentInMemory::column_ref, py::return_value_policy::reference)
+        .def("empty", &SegmentInMemory::empty)
+        .def(
+            "metadata",
+            [](const SegmentInMemory& seg) {
+                if (!seg.metadata())
+                    return py::bytes();
+                return py::bytes(seg.metadata()->SerializeAsString());
+            },
+            py::return_value_policy::copy);
 
     py::class_<SegmentHolder, std::shared_ptr<SegmentHolder>>(m, "SegmentHolder")
         .def(py::init())
         .def_readonly("segment", &SegmentHolder::segment);
 
     py::class_<Agg, std::shared_ptr<Agg>>(m, "FixedTimestampAggregator")
-        .def(py::init([](std::shared_ptr<SegmentHolder> holder, const StreamDescriptor &desc) {
-            return std::make_shared<Agg>(Agg::SchemaPolicy{desc, TimeseriesIndex::default_index()}, [hld = holder](SegmentInMemory &&segment) {
-                hld->segment = std::move(segment);
-            });
+        .def(py::init([](std::shared_ptr<SegmentHolder> holder, const StreamDescriptor& desc) {
+            return std::make_shared<Agg>(Agg::SchemaPolicy{desc, TimeseriesIndex::default_index()},
+                [hld = holder](SegmentInMemory&& segment) { hld->segment = std::move(segment); });
         }))
         .def_property_readonly("row_builder", &Agg::row_builder, py::return_value_policy::reference)
         .def_property_readonly("row_count", &Agg::row_count)
         .def("commit", &Agg::commit)
         .def("rollback_row", &Agg::rollback_row)
-        .def("start_row", &Agg::start_row < timestamp > , py::return_value_policy::reference);
+        .def("start_row", &Agg::start_row<timestamp>, py::return_value_policy::reference);
 
     py::class_<FixedTickRowBuilder>(m, "FixedTickRowBuilder")
-        .def("start_row", [](FixedTickRowBuilder &b, entity::timestamp timestamp) {
-            b.start_row(timestamp);
-        })
+        .def("start_row", [](FixedTickRowBuilder& b, entity::timestamp timestamp) { b.start_row(timestamp); })
         .def("end_row", &FixedTickRowBuilder::end_row)
         .def("rollback_row", &FixedTickRowBuilder::rollback_row)
         .def("__enter__", &FixedTickRowBuilder::self, py::return_value_policy::reference)
-        .def("__exit__", [](FixedTickRowBuilder &b, py::object &type, py::object &, py::object &) {
-            if (!type.is_none())
-                b.rollback_row();
-            else
-                b.end_row();
-
-        })
+        .def("__exit__",
+            [](FixedTickRowBuilder& b, py::object& type, py::object&, py::object&) {
+                if (!type.is_none())
+                    b.rollback_row();
+                else
+                    b.end_row();
+            })
         .def("find_field", &FixedTickRowBuilder::find_field)
 
 #if 0 // python code used to generate the per type method instantiations
@@ -185,151 +171,170 @@ void register_stream_bindings(py::module &m) {
             print(gen_methods(t,t))
         */
 #endif
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::uint8_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::uint8_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::uint8_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::uint8_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_uint8", &FixedTickRowBuilder::set_scalar < std::uint8_t > )
-        .def("set_array_uint8", &FixedTickRowBuilder::set_array < std::uint8_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::uint16_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_uint8", &FixedTickRowBuilder::set_scalar<std::uint8_t>)
+        .def("set_array_uint8", &FixedTickRowBuilder::set_array<std::uint8_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::uint16_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::uint16_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::uint16_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_uint16", &FixedTickRowBuilder::set_scalar < std::uint16_t > )
-        .def("set_array_uint16", &FixedTickRowBuilder::set_array < std::uint16_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::uint32_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_uint16", &FixedTickRowBuilder::set_scalar<std::uint16_t>)
+        .def("set_array_uint16", &FixedTickRowBuilder::set_array<std::uint16_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::uint32_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::uint32_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::uint32_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_uint32", &FixedTickRowBuilder::set_scalar < std::uint32_t > )
-        .def("set_array_uint32", &FixedTickRowBuilder::set_array < std::uint32_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::uint64_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_uint32", &FixedTickRowBuilder::set_scalar<std::uint32_t>)
+        .def("set_array_uint32", &FixedTickRowBuilder::set_array<std::uint32_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::uint64_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::uint64_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::uint64_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_uint64", &FixedTickRowBuilder::set_scalar < std::uint64_t > )
-        .def("set_array_uint64", &FixedTickRowBuilder::set_array < std::uint64_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::int8_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_uint64", &FixedTickRowBuilder::set_scalar<std::uint64_t>)
+        .def("set_array_uint64", &FixedTickRowBuilder::set_array<std::uint64_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::int8_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::int8_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::int8_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_int8", &FixedTickRowBuilder::set_scalar < std::int8_t > )
-        .def("set_array_int8", &FixedTickRowBuilder::set_array < std::int8_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::int16_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_int8", &FixedTickRowBuilder::set_scalar<std::int8_t>)
+        .def("set_array_int8", &FixedTickRowBuilder::set_array<std::int8_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::int16_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::int16_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::int16_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_int16", &FixedTickRowBuilder::set_scalar < std::int16_t > )
-        .def("set_array_int16", &FixedTickRowBuilder::set_array < std::int16_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::int32_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_int16", &FixedTickRowBuilder::set_scalar<std::int16_t>)
+        .def("set_array_int16", &FixedTickRowBuilder::set_array<std::int16_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::int32_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::int32_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::int32_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_int32", &FixedTickRowBuilder::set_scalar < std::int32_t > )
-        .def("set_array_int32", &FixedTickRowBuilder::set_array < std::int32_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < std::int64_t > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_int32", &FixedTickRowBuilder::set_scalar<std::int32_t>)
+        .def("set_array_int32", &FixedTickRowBuilder::set_array<std::int32_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<std::int64_t>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < std::int64_t > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<std::int64_t>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_int64", &FixedTickRowBuilder::set_scalar < std::int64_t > )
-        .def("set_array_int64", &FixedTickRowBuilder::set_array < std::int64_t > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < float > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_int64", &FixedTickRowBuilder::set_scalar<std::int64_t>)
+        .def("set_array_int64", &FixedTickRowBuilder::set_array<std::int64_t>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<float>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < float > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<float>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_float", &FixedTickRowBuilder::set_scalar < float > )
-        .def("set_array_float", &FixedTickRowBuilder::set_array < float > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < double > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_float", &FixedTickRowBuilder::set_scalar<float>)
+        .def("set_array_float", &FixedTickRowBuilder::set_array<float>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<double>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < double > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<double>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_double", &FixedTickRowBuilder::set_scalar < double > )
-        .def("set_array_double", &FixedTickRowBuilder::set_array < double > )
-        .def("set_scalar", &FixedTickRowBuilder::set_scalar < bool > , \
-        R"pydoc(set_scalar value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_scalar_double", &FixedTickRowBuilder::set_scalar<double>)
+        .def("set_array_double", &FixedTickRowBuilder::set_array<double>)
+        .def("set_scalar",
+            &FixedTickRowBuilder::set_scalar<bool>,
+            R"pydoc(set_scalar value at position in the row builder
           Convenience method that will go through the list of overloaded +methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_array", &FixedTickRowBuilder::set_array < bool > , \
-         R"pydoc(set_array value at position in the row builder
+          the non-overloaded version)pydoc")
+        .def("set_array",
+            &FixedTickRowBuilder::set_array<bool>,
+            R"pydoc(set_array value at position in the row builder
           Convenience method that will go through the list of overloaded methods
           until it finds one that is compatible. If you know the type beforehand, please use
-          the non-overloaded version)pydoc") \
-.def("set_scalar_bool", &FixedTickRowBuilder::set_scalar < bool > )
-        .def("set_array_bool", &FixedTickRowBuilder::set_array < bool > )
+          the non-overloaded version)pydoc")
+        .def("set_scalar_bool", &FixedTickRowBuilder::set_scalar<bool>)
+        .def("set_array_bool", &FixedTickRowBuilder::set_array<bool>)
 
         .def("set_string", &FixedTickRowBuilder::set_string)
         .def("set_string_array", &FixedTickRowBuilder::set_string_array)
         .def("set_string_list", &FixedTickRowBuilder::set_string_list);
 
-
     py::class_<TickReader, std::shared_ptr<TickReader>>(m, "TickReader")
-            .def(py::init())
-            .def_property_readonly("row_count", &TickReader::row_count)
-            .def("add_segment", &TickReader::add_segment)
-            .def("at", &TickReader::at);
+        .def(py::init())
+        .def_property_readonly("row_count", &TickReader::row_count)
+        .def("add_segment", &TickReader::add_segment)
+        .def("at", &TickReader::at);
 }
 
 } // namespace arcticdb::stream
-
-

--- a/cpp/arcticdb/stream/python_bindings.hpp
+++ b/cpp/arcticdb/stream/python_bindings.hpp
@@ -12,13 +12,14 @@
 namespace py = pybind11;
 
 namespace arcticdb {
-void register_types(py::module &m);
+void register_types(py::module& m);
 
 namespace stream {
 
-void register_stream_bindings(py::module &m);
+void register_stream_bindings(py::module& m);
 
-inline void register_bindings(py::module &m) {
+inline void register_bindings(py::module& m)
+{
     auto arcticxx_types = m.def_submodule("types", R"pydoc(
     Fundamental types
     -----------------
@@ -35,6 +36,5 @@ inline void register_bindings(py::module &m) {
     arcticdb::stream::register_stream_bindings(arcticxx_stream);
 }
 
-} // namespace arcticdb::stream
+} // namespace stream
 } // namespace arcticdb
-

--- a/cpp/arcticdb/stream/row_builder.hpp
+++ b/cpp/arcticdb/stream/row_builder.hpp
@@ -27,166 +27,195 @@
 
 namespace arcticdb::stream {
 
-template <typename IndexType, typename SchemaType>
-inline IndexType get_index_from_schema(const SchemaType& schema) {
+template<typename IndexType, typename SchemaType>
+inline IndexType get_index_from_schema(const SchemaType& schema)
+{
     util::check(std::holds_alternative<IndexType>(schema.index()), "Schema and aggregator index type mismatch");
     return std::get<IndexType>(schema.index());
 }
 
 template<class Index, class Schema, class Aggregator>
 class RowBuilder {
-  public:
+public:
     using IndexType = Index;
     using SchemaType = Schema;
     using SelfType = RowBuilder<Index, Schema, Aggregator>;
 
-    explicit RowBuilder(Schema& schema, Aggregator& aggregator) :
-        schema_(schema),
-        index_(get_index_from_schema<IndexType, SchemaType>(schema_)),
-        aggregator_(aggregator),
-        nbytes_(0) {
+    explicit RowBuilder(Schema& schema, Aggregator& aggregator)
+        : schema_(schema),
+          index_(get_index_from_schema<IndexType, SchemaType>(schema_)),
+          aggregator_(aggregator),
+          nbytes_(0)
+    {
     }
 
-    RowBuilder(RowBuilder &) = delete;
-    RowBuilder &operator=(RowBuilder &&) = delete;
-    RowBuilder &operator=(RowBuilder &) = delete;
+    RowBuilder(RowBuilder&) = delete;
+    RowBuilder& operator=(RowBuilder&&) = delete;
+    RowBuilder& operator=(RowBuilder&) = delete;
 
-    template<class...Args>
-    void start_row(const Args...args) {
+    template<class... Args>
+    void start_row(const Args... args)
+    {
         reset();
-        if constexpr(sizeof...(Args)> 0) {
-            index().set([&](std::size_t pos, auto arg) {
-                if constexpr (std::is_integral_v<decltype(arg)> || std::is_floating_point_v<decltype(arg)>)
-                    set_scalar_impl(pos, arg);
-                else
-                    set_string_impl(pos, arg);
-            }, args...);
+        if constexpr (sizeof...(Args) > 0) {
+            index().set(
+                [&](std::size_t pos, auto arg) {
+                    if constexpr (std::is_integral_v<decltype(arg)> || std::is_floating_point_v<decltype(arg)>)
+                        set_scalar_impl(pos, arg);
+                    else
+                        set_string_impl(pos, arg);
+                },
+                args...);
         }
     }
 
     template<class RowBuilderSetter>
-    void operator()(RowBuilderSetter &&setter) {
-        SCOPE_FAIL {
+    void operator()(RowBuilderSetter&& setter)
+    {
+        SCOPE_FAIL
+        {
             rollback_row();
         };
         setter(*this);
         end_row();
     }
 
-    void rollback_row() noexcept {
+    void rollback_row() noexcept
+    {
         reset();
     }
 
-    void end_row() {
-        SCOPE_FAIL {
+    void end_row()
+    {
+        SCOPE_FAIL
+        {
             rollback_row();
         };
 
         aggregator_.end_row();
     }
 
-    SelfType &self() {
+    SelfType& self()
+    {
         return *this;
     }
 
-    std::optional<std::size_t> find_field(std::string_view field_name) const {
+    std::optional<std::size_t> find_field(std::string_view field_name) const
+    {
         return descriptor().find_field(field_name);
     }
 
-    template<class T,
-        std::enable_if_t< std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0
-    >
-    void set_array(std::size_t pos, py::array_t<T> &val) {
+    template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    void set_array(std::size_t pos, py::array_t<T>& val)
+    {
         ARCTICDB_SAMPLE(RowBuilderSetArray, 0)
         magic_.check();
         auto info(val.request());
         auto td = get_type_descriptor(info);
         util::check_arg(pos >= index().field_count(),
-                        "expected position > {} (field count), actual {} in set_array", index().field_count(), pos);
+            "expected position > {} (field count), actual {} in set_array",
+            index().field_count(),
+            pos);
         schema_.check(pos, td);
         aggregator_.set_array(pos, val);
         nbytes_ += val.nbytes() + sizeof(shape_t) * val.ndim();
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_scalar(std::size_t pos, T val) {
+    void set_scalar(std::size_t pos, T val)
+    {
         util::check_arg(pos >= index().field_count(),
-                        "expected position > {} (field count), actual {} in set_scalar", index().field_count(), pos);
+            "expected position > {} (field count), actual {} in set_scalar",
+            index().field_count(),
+            pos);
         util::check_range(pos, descriptor().field_count(), "No such position in schema");
         set_scalar_impl(pos, val);
     }
 
     template<class T, std::enable_if_t<std::is_same_v<std::decay_t<T>, std::string>, int> = 0>
-    void set_scalar(std::size_t pos, T val) {
+    void set_scalar(std::size_t pos, T val)
+    {
         set_string(pos, val);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor::Proto &desc) {
+    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor::Proto& desc)
+    {
         aggregator_.set_scalar_by_name(name, val, desc);
         nbytes_ += sizeof(T);
     }
 
     template<class T, std::enable_if_t<std::is_same_v<std::decay_t<T>, std::string_view>, int> = 0>
-    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor::Proto &desc) {
+    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor::Proto& desc)
+    {
         aggregator_.set_string_by_name(name, val, desc);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor &desc) {
+    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor& desc)
+    {
         aggregator_.set_scalar_by_name(name, val, desc.proto());
         nbytes_ += sizeof(T);
     }
 
     template<class T, std::enable_if_t<std::is_same_v<std::decay_t<T>, std::string_view>, int> = 0>
-    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor &desc) {
+    void set_scalar_by_name(std::string_view name, T val, const TypeDescriptor& desc)
+    {
         aggregator_.set_string_by_name(name, val, desc.proto());
     }
 
-    void set_string(std::size_t pos, const std::string &str) {
+    void set_string(std::size_t pos, const std::string& str)
+    {
         check_pos(pos);
         set_string_impl(pos, str);
     }
 
-    void set_string_impl(std::size_t pos, const std::string &str) {
+    void set_string_impl(std::size_t pos, const std::string& str)
+    {
         aggregator_.set_string(pos, str);
     }
 
-    void set_string_array(std::size_t pos, py::array &arr) {
+    void set_string_array(std::size_t pos, py::array& arr)
+    {
         auto info = arr.request();
         schema_.check(pos, TypeDescriptor(DataType::ASCII_FIXED64, Dimension::Dim1));
         util::check_arg(info.strides.size() == 1, "Assumed numpy string array has no strides");
         util::check_arg(info.shape.size() == 1, "Assumed numpy string array has no shapes");
         util::check_arg(info.itemsize == info.strides[0], "Non-contiguous string arrays not currently supported");
-        aggregator_.set_string_array(pos, info.itemsize, info.shape[0], reinterpret_cast<char *>(info.ptr));
+        aggregator_.set_string_array(pos, info.itemsize, info.shape[0], reinterpret_cast<char*>(info.ptr));
     }
 
-    void set_string_list(std::size_t pos, std::vector<std::string> input) {
+    void set_string_list(std::size_t pos, std::vector<std::string> input)
+    {
         schema_.check(pos, TypeDescriptor(DataType::ASCII_DYNAMIC64, Dimension::Dim1));
         aggregator_.set_string_list(pos, input);
     }
 
-    std::size_t nbytes() const {
+    std::size_t nbytes() const
+    {
         return std::size_t(nbytes_);
     }
 
-    Aggregator &aggregator() {
+    Aggregator& aggregator()
+    {
         return *aggregator_;
     }
 
-    const arcticdb::entity::StreamDescriptor &descriptor() const {
+    const arcticdb::entity::StreamDescriptor& descriptor() const
+    {
         return aggregator_.descriptor();
     }
 
-  private:
-
-    void reset() {
+private:
+    void reset()
+    {
         nbytes_ = 0;
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_block(std::size_t pos, T *val, size_t size) {
-        descriptor().fields[pos].type_desc.visit_tag([&](auto &&tag) {
+    void set_block(std::size_t pos, T* val, size_t size)
+    {
+        descriptor().fields[pos].type_desc.visit_tag([&](auto&& tag) {
             using DT = std::decay_t<decltype(tag)>;
             using RawType = typename DT::DataTypeTag::raw_type;
             if constexpr (std::is_same_v<typename DT::DimensionTag, DimensionTag<Dimension::Dim0>>) {
@@ -199,49 +228,61 @@ class RowBuilder {
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_scalar_impl(std::size_t pos, T val) {
-        visit_field(descriptor().fields(pos), [&](auto &&tag) {
+    void set_scalar_impl(std::size_t pos, T val)
+    {
+        visit_field(descriptor().fields(pos), [&](auto&& tag) {
             using RawType = typename std::decay_t<decltype(tag)>::DataTypeTag::raw_type;
 
-            if constexpr (std::is_same_v<typename std::decay_t<decltype(tag)>::DimensionTag, DimensionTag<Dimension::Dim0>>) {
+            if constexpr (std::is_same_v<typename std::decay_t<decltype(tag)>::DimensionTag,
+                              DimensionTag<Dimension::Dim0>>)
+            {
                 RawType conv_val;
-                if constexpr ((std::is_integral_v<T> || std::is_floating_point_v<RawType>) &&
-                    sizeof(RawType) >= sizeof(T)) {
+                if constexpr ((std::is_integral_v<T> || std::is_floating_point_v<RawType>)&&sizeof(RawType) >=
+                              sizeof(T))
+                {
                     conv_val = val;
                     aggregator_.set_scalar(pos, conv_val);
                     nbytes_ += sizeof(RawType);
                 } else {
-                    throw ArcticCategorizedException<ErrorCategory::INTERNAL>(fmt::format(
-                        "Expected type_descriptor={}, type={}; actual value={}, type {}",
-                        data_type_from_proto(descriptor().fields(pos).type_desc()), typeid(conv_val).name(),
-                        val, typeid(val).name()));
+                    throw ArcticCategorizedException<ErrorCategory::INTERNAL>(
+                        fmt::format("Expected type_descriptor={}, type={}; actual value={}, type {}",
+                            data_type_from_proto(descriptor().fields(pos).type_desc()),
+                            typeid(conv_val).name(),
+                            val,
+                            typeid(val).name()));
                 }
             } else {
-                throw ArcticCategorizedException<ErrorCategory::INTERNAL>(fmt::format(
-                    "Expected type_descriptor={}; actual scalar cpp_type={}, value={}",
-                    TypeDescriptor{tag}, typeid(val).name(), val));
+                throw ArcticCategorizedException<ErrorCategory::INTERNAL>(
+                    fmt::format("Expected type_descriptor={}; actual scalar cpp_type={}, value={}",
+                        TypeDescriptor{tag},
+                        typeid(val).name(),
+                        val));
             }
         });
     }
-    
-    const IndexType& index() const {
+
+    const IndexType& index() const
+    {
         return schema_->index();
     }
 
-    IndexType& index() {
+    IndexType& index()
+    {
         return index_;
     }
 
-    void check_pos(std::size_t pos) {
+    void check_pos(std::size_t pos)
+    {
         util::check_arg(pos >= index().field_count(),
-                        "expected position > {} (field count), actual {} in set_string (view)", index().field_count(), pos);
+            "expected position > {} (field count), actual {} in set_string (view)",
+            index().field_count(),
+            pos);
         auto td = aggregator_.descriptor()[pos];
-        util::check_arg(
-                is_sequence_type(data_type_from_proto(td.type_desc())),
-                "Set string called on non-string type column");
+        util::check_arg(is_sequence_type(data_type_from_proto(td.type_desc())),
+            "Set string called on non-string type column");
     }
 
-  private:
+private:
     Schema& schema_;
     IndexType index_;
     Aggregator& aggregator_;
@@ -249,4 +290,4 @@ class RowBuilder {
     util::MagicNum<'R', 'b', 'l', 'd'> magic_;
 };
 
-}
+} // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/schema.hpp
+++ b/cpp/arcticdb/stream/schema.hpp
@@ -22,73 +22,82 @@ namespace arcticdb::stream {
 using namespace arcticdb::entity;
 
 class FixedSchema {
-  public:
-    FixedSchema(StreamDescriptor desc, const Index& index) :
-        desc_(std::move(desc)),
-        index_(std::move(index)){}
-
-    void check(std::size_t pos, TypeDescriptor td) const {
-        util::check_range(pos, desc_.fields().size(), "No field in fixed schema at supplied idx");
-        auto exp_td = type_desc_from_proto(desc_.fields(pos).type_desc());
-        util::check_arg(td == exp_td, "Incompatible type for pos={}, expected {}, actual {}",
-                        pos, exp_td, td
-        );
+public:
+    FixedSchema(StreamDescriptor desc, const Index& index)
+        : desc_(std::move(desc)),
+          index_(std::move(index))
+    {
     }
 
-    StreamDescriptor default_descriptor() const {
+    void check(std::size_t pos, TypeDescriptor td) const
+    {
+        util::check_range(pos, desc_.fields().size(), "No field in fixed schema at supplied idx");
+        auto exp_td = type_desc_from_proto(desc_.fields(pos).type_desc());
+        util::check_arg(td == exp_td, "Incompatible type for pos={}, expected {}, actual {}", pos, exp_td, td);
+    }
+
+    StreamDescriptor default_descriptor() const
+    {
         return desc_.clone();
     }
 
-    position_t get_column_idx_by_name(
-            SegmentInMemory &seg,
-            const std::string& col_name,
-            const TypeDescriptor::Proto&,
-            size_t,
-            size_t) {
+    position_t get_column_idx_by_name(SegmentInMemory& seg,
+        const std::string& col_name,
+        const TypeDescriptor::Proto&,
+        size_t,
+        size_t)
+    {
         auto opt_col = seg.column_index(col_name);
         util::check(static_cast<bool>(opt_col), "Column {} not found", col_name);
         return opt_col.value();
     }
 
-    const Index& index() const {
+    const Index& index() const
+    {
         return index_;
     }
 
-    Index& index() {
+    Index& index()
+    {
         return index_;
     }
 
-    static constexpr bool is_sparse() { return false; }
+    static constexpr bool is_sparse()
+    {
+        return false;
+    }
 
-  private:
+private:
     StreamDescriptor desc_;
     Index index_;
 };
 
-inline StreamDescriptor default_dynamic_descriptor(const StreamDescriptor& desc, const Index& index) {
-    return util::variant_match(index, [&desc] (auto idx) {
-       return idx.create_stream_descriptor(desc.id(), {});
-    });
+inline StreamDescriptor default_dynamic_descriptor(const StreamDescriptor& desc, const Index& index)
+{
+    return util::variant_match(index, [&desc](auto idx) { return idx.create_stream_descriptor(desc.id(), {}); });
 }
 
 class DynamicSchema {
 public:
-    explicit DynamicSchema(const StreamDescriptor& desc, const Index& index) :
-        desc_(default_dynamic_descriptor(desc, index)),
-        index_(index) { }
-
-    void check(std::size_t pos ARCTICDB_UNUSED, TypeDescriptor td ARCTICDB_UNUSED) const {
+    explicit DynamicSchema(const StreamDescriptor& desc, const Index& index)
+        : desc_(default_dynamic_descriptor(desc, index)),
+          index_(index)
+    {
     }
 
-    position_t get_column_idx_by_name(
-        SegmentInMemory &seg,
+    void check(std::size_t pos ARCTICDB_UNUSED, TypeDescriptor td ARCTICDB_UNUSED) const
+    {
+    }
+
+    position_t get_column_idx_by_name(SegmentInMemory& seg,
         std::string_view col_name,
-        const TypeDescriptor::Proto &desc,
+        const TypeDescriptor::Proto& desc,
         size_t expected_size,
-        size_t existing_size) {
+        size_t existing_size)
+    {
         auto opt_col = seg.column_index(col_name);
         if (!opt_col) {
-            const size_t init_size = expected_size > existing_size ? expected_size - existing_size  : 0;
+            const size_t init_size = expected_size > existing_size ? expected_size - existing_size : 0;
             position_t pos = seg.add_column(scalar_field_proto(desc, col_name), init_size, false);
             ARCTICDB_TRACE(log::version(), "Added column {} to position: {}", col_name, pos);
             return pos;
@@ -97,19 +106,25 @@ public:
         }
     }
 
-    const Index& index() const {
+    const Index& index() const
+    {
         return index_;
     }
 
-    Index& index() {
+    Index& index()
+    {
         return index_;
     }
 
-    StreamDescriptor default_descriptor() const {
+    StreamDescriptor default_descriptor() const
+    {
         return desc_.clone();
     }
 
-    static constexpr bool is_sparse() { return true; }
+    static constexpr bool is_sparse()
+    {
+        return true;
+    }
 
 private:
     StreamDescriptor desc_;
@@ -118,4 +133,4 @@ private:
 
 using VariantSchema = std::variant<FixedSchema, DynamicSchema>;
 
-}
+} // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/stream_reader.hpp
+++ b/cpp/arcticdb/stream/stream_reader.hpp
@@ -24,16 +24,22 @@ namespace arcticdb::stream {
 
 template<class SegmentIt, class RowType>
 class RowsFromSegIterator : public IndexRangeFilter {
-  public:
-    RowsFromSegIterator(const IndexRange &index_range, SegmentIt &&seg_it) :
-        IndexRangeFilter(index_range), seg_it_(std::move(seg_it)), seg_(std::nullopt), row_id(0) {}
+public:
+    RowsFromSegIterator(const IndexRange& index_range, SegmentIt&& seg_it)
+        : IndexRangeFilter(index_range),
+          seg_it_(std::move(seg_it)),
+          seg_(std::nullopt),
+          row_id(0)
+    {
+    }
 
-    RowsFromSegIterator &operator=(RowsFromSegIterator &&that) = default;
-    RowsFromSegIterator(RowsFromSegIterator &&that) = default;
-    RowsFromSegIterator &operator=(const RowsFromSegIterator &that) = delete;
-    RowsFromSegIterator(const RowsFromSegIterator &that) = delete;
+    RowsFromSegIterator& operator=(RowsFromSegIterator&& that) = default;
+    RowsFromSegIterator(RowsFromSegIterator&& that) = default;
+    RowsFromSegIterator& operator=(const RowsFromSegIterator& that) = delete;
+    RowsFromSegIterator(const RowsFromSegIterator& that) = delete;
 
-    std::optional<RowType> next(folly::Duration timeout = util::timeout::get_default()) {
+    std::optional<RowType> next(folly::Duration timeout = util::timeout::get_default())
+    {
         prev_seg_ = std::nullopt;
         while (true) {
             while (!seg_) {
@@ -55,7 +61,8 @@ class RowsFromSegIterator : public IndexRangeFilter {
 
             // Not filtering rows where we have a rowcount index - the assumption is that it's essentially an un-indexed blob
             // that we need to segment somehow.
-            auto accept = index_type == IndexDescriptor::ROWCOUNT || accept_index(pipelines::index::index_start_from_row(res.value(), index_type).value());
+            auto accept = index_type == IndexDescriptor::ROWCOUNT ||
+                          accept_index(pipelines::index::index_start_from_row(res.value(), index_type).value());
             if (++row_id == seg_->row_count()) {
                 prev_seg_ = seg_;
                 seg_ = std::nullopt;
@@ -66,7 +73,7 @@ class RowsFromSegIterator : public IndexRangeFilter {
         }
     }
 
-  private:
+private:
     SegmentIt seg_it_;
     std::optional<SegmentInMemory> seg_;
     std::optional<SegmentInMemory> prev_seg_;
@@ -78,23 +85,28 @@ class StreamReader {
     static constexpr size_t IDX_PREFETCH_WINDOW = 256;
     static constexpr size_t DATA_PREFETCH_WINDOW = 32;
 
-  public:
+public:
     using KeyRangeIteratorType = KeyRangeIterator<typename decltype(KeySupplierType()())::const_iterator>;
     using IdxSegmentIteratorType = SegmentIterator<KeyRangeIteratorType, IDX_PREFETCH_WINDOW>;
     using KeysFromSegIteratorType = KeysFromSegIterator<IdxSegmentIteratorType>;
     using DataSegmentIteratorType = SegmentIterator<KeysFromSegIteratorType, DATA_PREFETCH_WINDOW>;
     using RowsIteratorType = RowsFromSegIterator<DataSegmentIteratorType, RowType>;
 
-    StreamReader(KeySupplierType &&gen, std::shared_ptr<StreamSource> store, const storage::ReadKeyOpts opts = storage::ReadKeyOpts{},  const IndexRange &index_range = unspecified_range()) :
-        key_gen_(std::move(gen)),
-        index_range_(index_range),
-        store_(store),
-        opts_(opts),
-        read_timeout_(util::timeout::get_default()) {
+    StreamReader(KeySupplierType&& gen,
+        std::shared_ptr<StreamSource> store,
+        const storage::ReadKeyOpts opts = storage::ReadKeyOpts{},
+        const IndexRange& index_range = unspecified_range())
+        : key_gen_(std::move(gen)),
+          index_range_(index_range),
+          store_(store),
+          opts_(opts),
+          read_timeout_(util::timeout::get_default())
+    {
         ARCTICDB_DEBUG(log::inmem(), "Creating stream reader");
     }
 
-    IdxSegmentIteratorType iterator_indexes() {
+    IdxSegmentIteratorType iterator_indexes()
+    {
         auto idx_key_container = key_gen_();
         auto idx_key_rg = folly::range(idx_key_container.begin(), idx_key_container.end());
         auto key_it = KeyRangeIteratorType(index_range_, idx_key_rg);
@@ -102,54 +114,59 @@ class StreamReader {
         return idx_seg_it;
     }
 
-    DataSegmentIteratorType iterator_segments() {
+    DataSegmentIteratorType iterator_segments()
+    {
         auto idx_seg_it = iterator_indexes();
         auto keys_from_seg = KeysFromSegIteratorType{index_range_, std::move(idx_seg_it)};
         auto res = DataSegmentIteratorType(index_range_, std::move(keys_from_seg), store_);
         return res;
     }
 
-    RowsIteratorType iterator_rows() {
+    RowsIteratorType iterator_rows()
+    {
         auto data_seg_it = iterator_segments();
         auto res = RowsIteratorType(index_range_, std::move(data_seg_it));
         return res;
     }
 
-    auto generate_rows() {
-        return folly::gen::from(key_gen_())
-            | generate_segments_from_keys(*store_, read_timeout_, IDX_PREFETCH_WINDOW, opts_)
-            | generate_keys_from_segments(*store_, entity::KeyType::TABLE_DATA, entity::KeyType::TABLE_INDEX)
-            | generate_segments_from_keys(*store_, read_timeout_, DATA_PREFETCH_WINDOW, opts_)
-            | generate_rows_from_data_segments();
+    auto generate_rows()
+    {
+        return folly::gen::from(key_gen_()) |
+               generate_segments_from_keys(*store_, read_timeout_, IDX_PREFETCH_WINDOW, opts_) |
+               generate_keys_from_segments(*store_, entity::KeyType::TABLE_DATA, entity::KeyType::TABLE_INDEX) |
+               generate_segments_from_keys(*store_, read_timeout_, DATA_PREFETCH_WINDOW, opts_) |
+               generate_rows_from_data_segments();
     }
 
-    auto generate_data_keys() {
-        return folly::gen::from(key_gen_())
-            | generate_segments_from_keys(*store_, read_timeout_, IDX_PREFETCH_WINDOW, opts_)
-            | generate_keys_from_segments(*store_, entity::KeyType::TABLE_DATA, entity::KeyType::TABLE_INDEX);
+    auto generate_data_keys()
+    {
+        return folly::gen::from(key_gen_()) |
+               generate_segments_from_keys(*store_, read_timeout_, IDX_PREFETCH_WINDOW, opts_) |
+               generate_keys_from_segments(*store_, entity::KeyType::TABLE_DATA, entity::KeyType::TABLE_INDEX);
     }
 
-    auto &&generate_rows_from_data_segments() {
-        return folly::gen::map([](auto &&key_seg) {
-            return folly::gen::detail::GeneratorBuilder<RowRef>() + [&](auto &&yield) {
-                auto[key, seg] = std::move(key_seg);
+    auto&& generate_rows_from_data_segments()
+    {
+        return folly::gen::map([](auto&& key_seg) {
+            return folly::gen::detail::GeneratorBuilder<RowRef>() + [&](auto&& yield) {
+                auto [key, seg] = std::move(key_seg);
                 for (std::size_t i = 0; i < seg.row_count(); ++i) {
                     yield(RowRef{i, seg});
                 }
             };
-        })
-        | folly::gen::concat;
+        }) | folly::gen::concat;
     }
 
     template<class Visitor>
-    void foreach_row(Visitor &&visitor) {
+    void foreach_row(Visitor&& visitor)
+    {
         auto it = iterator_rows();
         for (auto opt_val = it.next(); opt_val; opt_val = it.next()) {
             visitor(*opt_val);
         }
     }
 
-  private:
+private:
     KeySupplierType key_gen_;
     IndexRange index_range_;
     std::shared_ptr<StreamSource> store_;
@@ -157,4 +174,4 @@ class StreamReader {
     folly::Duration read_timeout_;
 };
 
-}
+} // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -31,40 +31,33 @@ struct StreamSink {
 
     virtual ~StreamSink() = default;
 
-    [[nodiscard]] virtual folly::Future<entity::VariantKey> write(
-        KeyType key_type,
+    [[nodiscard]] virtual folly::Future<entity::VariantKey> write(KeyType key_type,
         VersionId version_id,
-        const StreamId &stream_id,
+        const StreamId& stream_id,
         IndexValue start_index,
         IndexValue end_index,
-        SegmentInMemory &&segment) = 0;
+        SegmentInMemory&& segment) = 0;
 
-    [[nodiscard]] virtual folly::Future<entity::VariantKey> write(
-            stream::KeyType key_type,
-            VersionId version_id,
-            const StreamId& stream_id,
-            timestamp creation_ts,
-            IndexValue start_index,
-            IndexValue end_index,
-            SegmentInMemory &&segment) = 0;
-
-    [[nodiscard]] virtual folly::Future<entity::VariantKey> write(
-        KeyType key_type,
-        const StreamId &stream_id,
-        SegmentInMemory &&segment) = 0;
-
-    virtual entity::VariantKey write_sync(
-        stream::KeyType key_type,
+    [[nodiscard]] virtual folly::Future<entity::VariantKey> write(stream::KeyType key_type,
         VersionId version_id,
-        const StreamId &stream_id,
+        const StreamId& stream_id,
+        timestamp creation_ts,
         IndexValue start_index,
         IndexValue end_index,
-        SegmentInMemory &&segment) = 0;
+        SegmentInMemory&& segment) = 0;
 
-    [[nodiscard]] virtual folly::Future<entity::VariantKey> update(
-        const VariantKey &key,
-        SegmentInMemory &&segment,
-        storage::UpdateOpts = storage::UpdateOpts{}) = 0;
+    [[nodiscard]] virtual folly::Future<entity::VariantKey>
+    write(KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment) = 0;
+
+    virtual entity::VariantKey write_sync(stream::KeyType key_type,
+        VersionId version_id,
+        const StreamId& stream_id,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&& segment) = 0;
+
+    [[nodiscard]] virtual folly::Future<entity::VariantKey>
+    update(const VariantKey& key, SegmentInMemory&& segment, storage::UpdateOpts = storage::UpdateOpts{}) = 0;
 
     struct PartialKey {
         KeyType key_type;
@@ -73,53 +66,52 @@ struct StreamSink {
         IndexValue start_index;
         IndexValue end_index;
 
-        [[nodiscard]] AtomKey build_key(
-            timestamp creation_ts,
-            ContentHash content_hash) const {
-            return entity::atom_key_builder().gen_id(version_id).start_index(start_index).end_index(end_index)
-                .content_hash(content_hash).creation_ts(creation_ts).build(stream_id, key_type);
+        [[nodiscard]] AtomKey build_key(timestamp creation_ts, ContentHash content_hash) const
+        {
+            return entity::atom_key_builder()
+                .gen_id(version_id)
+                .start_index(start_index)
+                .end_index(end_index)
+                .content_hash(content_hash)
+                .creation_ts(creation_ts)
+                .build(stream_id, key_type);
         }
     };
 
-    [[nodiscard]] virtual folly::Future<entity::VariantKey> write(
-        PartialKey pk,
-        SegmentInMemory &&segment) = 0;
+    [[nodiscard]] virtual folly::Future<entity::VariantKey> write(PartialKey pk, SegmentInMemory&& segment) = 0;
 
-    virtual entity::VariantKey write_sync(
-        PartialKey pk,
-        SegmentInMemory &&segment) = 0;
+    virtual entity::VariantKey write_sync(PartialKey pk, SegmentInMemory&& segment) = 0;
 
-    virtual entity::VariantKey write_sync(
-        KeyType key_type,
-        const StreamId &stream_id,
-        SegmentInMemory &&segment) = 0;
+    virtual entity::VariantKey write_sync(KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment) = 0;
 
     struct BatchWriteArgs {
         std::size_t lib_write_count = 0ULL;
-        BatchWriteArgs() : lib_write_count(0ULL) {}
+        BatchWriteArgs()
+            : lib_write_count(0ULL)
+        {
+        }
     };
 
     [[nodiscard]] virtual folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&& ks) = 0;
 
-    virtual void write_compressed_sync(
-        storage::KeySegmentPair &&ks) = 0;
+    virtual void write_compressed_sync(storage::KeySegmentPair&& ks) = 0;
 
     [[nodiscard]] virtual folly::Future<std::vector<entity::VariantKey>> batch_write(
-        std::vector<std::pair<PartialKey, SegmentInMemory>> &&key_segments,
-        const std::shared_ptr<DeDupMap> &de_dup_map,
-        const BatchWriteArgs &args = BatchWriteArgs()) = 0;
+        std::vector<std::pair<PartialKey, SegmentInMemory>>&& key_segments,
+        const std::shared_ptr<DeDupMap>& de_dup_map,
+        const BatchWriteArgs& args = BatchWriteArgs()) = 0;
 
     [[nodiscard]] virtual folly::Future<folly::Unit> batch_write_compressed(
         std::vector<storage::KeySegmentPair> kvs) = 0;
 
-    [[nodiscard]] virtual folly::Future<RemoveKeyResultType> remove_key(
-        const entity::VariantKey &key, storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
+    [[nodiscard]] virtual folly::Future<RemoveKeyResultType> remove_key(const entity::VariantKey& key,
+        storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
 
-    virtual RemoveKeyResultType remove_key_sync(
-        const entity::VariantKey &key, storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
+    virtual RemoveKeyResultType remove_key_sync(const entity::VariantKey& key,
+        storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
 
-    [[nodiscard]] virtual folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
-        const std::vector<entity::VariantKey> &keys, storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
+    [[nodiscard]] virtual folly::Future<std::vector<RemoveKeyResultType>>
+    remove_keys(const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
 
     virtual timestamp current_timestamp() = 0;
 };

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -27,64 +27,55 @@ struct StreamSource {
 
     virtual ~StreamSource() = default;
 
-    virtual folly::Future<ReadKeyOutput> read(
-        const entity::VariantKey &key,
+    virtual folly::Future<ReadKeyOutput> read(const entity::VariantKey& key,
         storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
-    virtual ReadKeyOutput read_sync(
-        const entity::VariantKey &key,
+    virtual ReadKeyOutput read_sync(const entity::VariantKey& key,
         storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
-    virtual folly::Future<storage::KeySegmentPair> read_compressed(
-        const entity::VariantKey &key,
+    virtual folly::Future<storage::KeySegmentPair> read_compressed(const entity::VariantKey& key,
         storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
-    virtual void iterate_type(
-        KeyType type,
-        std::function<void(entity::VariantKey &&)> func,
-        const std::string &prefix = std::string{}) = 0;
+    virtual void iterate_type(KeyType type,
+        std::function<void(entity::VariantKey&&)> func,
+        const std::string& prefix = std::string{}) = 0;
 
-    [[nodiscard]] virtual folly::Future<bool> key_exists(const entity::VariantKey &key) = 0;
-    virtual bool key_exists_sync(const entity::VariantKey &key) = 0;
+    [[nodiscard]] virtual folly::Future<bool> key_exists(const entity::VariantKey& key) = 0;
+    virtual bool key_exists_sync(const entity::VariantKey& key) = 0;
     virtual bool supports_prefix_matching() = 0;
     virtual bool fast_delete() = 0;
 
-    virtual std::vector<storage::KeySegmentPair> batch_read_compressed(
-        std::vector<entity::VariantKey> &&keys, const BatchReadArgs &args, bool may_fail) = 0;
+    virtual std::vector<storage::KeySegmentPair>
+    batch_read_compressed(std::vector<entity::VariantKey>&& keys, const BatchReadArgs& args, bool may_fail) = 0;
 
-    using ReadContinuation = folly::Function<entity::VariantKey(storage::KeySegmentPair &&)>;
+    using ReadContinuation = folly::Function<entity::VariantKey(storage::KeySegmentPair&&)>;
 
-    virtual std::vector<entity::VariantKey> batch_read_compressed(
-        std::vector<entity::VariantKey> &&keys,
-        std::vector<ReadContinuation> &&continuations,
-        const BatchReadArgs &args) = 0;
+    virtual std::vector<entity::VariantKey> batch_read_compressed(std::vector<entity::VariantKey>&& keys,
+        std::vector<ReadContinuation>&& continuations,
+        const BatchReadArgs& args) = 0;
 
     /**
      * See storage_utils for the wrapper filter_keys_on_existence(vector).
      */
     [[nodiscard]] virtual std::vector<folly::Future<bool>> batch_key_exists(
-            const std::vector<entity::VariantKey> &keys) = 0;
+        const std::vector<entity::VariantKey>& keys) = 0;
 
-    [[nodiscard]] virtual bool batch_all_keys_exist_sync(
-            const std::unordered_set<entity::VariantKey> &keys) = 0;
+    [[nodiscard]] virtual bool batch_all_keys_exist_sync(const std::unordered_set<entity::VariantKey>& keys) = 0;
 
-    using DecodeContinuation = folly::Function<folly::Unit(SegmentInMemory &&)>;
+    using DecodeContinuation = folly::Function<folly::Unit(SegmentInMemory&&)>;
 
     virtual std::vector<Composite<ProcessingSegment>> batch_read_uncompressed(
-        std::vector<Composite<pipelines::SliceAndKey>> &&keys,
+        std::vector<Composite<pipelines::SliceAndKey>>&& keys,
         const std::shared_ptr<std::vector<Clause>>& query,
         const StreamDescriptor& desc,
         const std::shared_ptr<std::unordered_set<std::string>>& filter_columns,
-        const BatchReadArgs &args) = 0;
+        const BatchReadArgs& args) = 0;
 
-    virtual folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(
-        const entity::VariantKey &key,
-        storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
+    virtual folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>
+    read_metadata(const entity::VariantKey& key, storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
-    virtual folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto>> read_metadata_and_descriptor(
-        const entity::VariantKey& key,
-        storage::ReadKeyOpts opts = storage::ReadKeyOpts{}
-        ) = 0;
+    virtual folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor::Proto>>
+    read_metadata_and_descriptor(const entity::VariantKey& key, storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 };
 
 } // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/stream_utils.hpp
+++ b/cpp/arcticdb/stream/stream_utils.hpp
@@ -31,20 +31,21 @@
 namespace arcticdb::stream {
 
 template<class IndexType>
-StreamDescriptor idx_stream_desc(StreamId stream_id, IndexType index) {
+StreamDescriptor idx_stream_desc(StreamId stream_id, IndexType index)
+{
     using DataTypeTag = typename IndexType::TypeDescTag::DataTypeTag;
     // All index segments are row-count indexed in the sense that the keys are
     // already ordered - they don't need an additional index
-    return StreamDescriptor{index_descriptor(stream_id, index, {
-        scalar_field_proto(DataTypeTag::data_type, "start_index"),
-        scalar_field_proto(DataTypeTag::data_type, "end_index"),
-        scalar_field_proto(DataType::UINT64, "version_id"),
-        scalar_field_proto(stream_id_data_type(stream_id), "stream_id"),
-        scalar_field_proto(DataType::UINT64, "creation_ts"),
-        scalar_field_proto(DataType::UINT64, "content_hash"),
-        scalar_field_proto(DataType::UINT8, "index_type"),
-        scalar_field_proto(DataType::UINT8, "key_type")
-    })};
+    return StreamDescriptor{index_descriptor(stream_id,
+        index,
+        {scalar_field_proto(DataTypeTag::data_type, "start_index"),
+            scalar_field_proto(DataTypeTag::data_type, "end_index"),
+            scalar_field_proto(DataType::UINT64, "version_id"),
+            scalar_field_proto(stream_id_data_type(stream_id), "stream_id"),
+            scalar_field_proto(DataType::UINT64, "creation_ts"),
+            scalar_field_proto(DataType::UINT64, "content_hash"),
+            scalar_field_proto(DataType::UINT8, "index_type"),
+            scalar_field_proto(DataType::UINT8, "key_type")})};
 }
 
 // This is an augmented index that allows for column slicing which is used for fixed
@@ -53,32 +54,34 @@ template<class IndexType>
 struct IndexSliceDescriptor : StreamDescriptor {
     using DataTypeTag = typename IndexType::TypeDescTag::DataTypeTag;
 
-    explicit IndexSliceDescriptor(const StreamId &stream_id, bool has_column_groups)
-            : StreamDescriptor(stream_descriptor(stream_id, IndexType(), {
+    explicit IndexSliceDescriptor(const StreamId& stream_id, bool has_column_groups)
+        : StreamDescriptor(stream_descriptor(stream_id,
+              IndexType(),
+              {
 
-        scalar_field_proto(DataTypeTag::data_type, "start_index"),
-        scalar_field_proto(DataTypeTag::data_type, "end_index"),
+                  scalar_field_proto(DataTypeTag::data_type, "start_index"),
+                  scalar_field_proto(DataTypeTag::data_type, "end_index"),
 
-        scalar_field_proto(DataType::UINT64, "version_id"),
-        scalar_field_proto(stream_id_data_type(stream_id), "stream_id"),
-        scalar_field_proto(DataType::UINT64, "creation_ts"),
-        scalar_field_proto(DataType::UINT64, "content_hash"),
-        scalar_field_proto(DataType::UINT8, "index_type"),
-        scalar_field_proto(DataType::UINT8, "key_type"),
+                  scalar_field_proto(DataType::UINT64, "version_id"),
+                  scalar_field_proto(stream_id_data_type(stream_id), "stream_id"),
+                  scalar_field_proto(DataType::UINT64, "creation_ts"),
+                  scalar_field_proto(DataType::UINT64, "content_hash"),
+                  scalar_field_proto(DataType::UINT8, "index_type"),
+                  scalar_field_proto(DataType::UINT8, "key_type"),
 
-        scalar_field_proto(DataType::UINT64, "start_col"),
-        scalar_field_proto(DataType::UINT64, "end_col"),
-        scalar_field_proto(DataType::UINT64, "start_row"),
-        scalar_field_proto(DataType::UINT64, "end_row")
-    })) {
-        if(has_column_groups) {
+                  scalar_field_proto(DataType::UINT64, "start_col"),
+                  scalar_field_proto(DataType::UINT64, "end_col"),
+                  scalar_field_proto(DataType::UINT64, "start_row"),
+                  scalar_field_proto(DataType::UINT64, "end_row")}))
+    {
+        if (has_column_groups) {
             add_field(scalar_field_proto(DataType::UINT64, "hash_bucket"));
             add_field(scalar_field_proto(DataType::UINT64, "num_buckets"));
         }
-
     }
 
-    static stream::FixedSchema schema(const StreamId &stream_id, bool has_column_groups) {
+    static stream::FixedSchema schema(const StreamId& stream_id, bool has_column_groups)
+    {
         IndexSliceDescriptor<IndexType> desc(stream_id, has_column_groups);
         return stream::FixedSchema{desc, IndexType::default_index()};
     }
@@ -88,17 +91,19 @@ struct IndexSliceDescriptor : StreamDescriptor {
 using SliceTypeDescriptorTag = TypeDescriptorTag<DataTypeTag<DataType::UINT64>, DimensionTag<Dimension ::Dim0>>;
 
 template<class IndexType>
-stream::FixedSchema idx_schema(StreamId tsid, const IndexType& index) {
+stream::FixedSchema idx_schema(StreamId tsid, const IndexType& index)
+{
     return stream::FixedSchema{idx_stream_desc(tsid, index), index};
 }
 
-inline entity::KeyType key_type_compat(uint8_t kt) {
-    auto ret = static_cast<KeyType >(kt);
+inline entity::KeyType key_type_compat(uint8_t kt)
+{
+    auto ret = static_cast<KeyType>(kt);
     //TODO would be nice to retire this at some point
-    if(kt > static_cast<uint8_t>(entity::KeyType::UNDEFINED)) {
+    if (kt > static_cast<uint8_t>(entity::KeyType::UNDEFINED)) {
         constexpr char legacy_key_types[] = {'g', 'G', 'd', 'i', 'V', 'v', 'M', 's', 'l'};
-        for(size_t i = 0; i < sizeof(legacy_key_types); ++i) {
-            if(static_cast<char>(kt == legacy_key_types[i])) {
+        for (size_t i = 0; i < sizeof(legacy_key_types); ++i) {
+            if (static_cast<char>(kt == legacy_key_types[i])) {
                 ret = static_cast<entity::KeyType>(i);
                 break;
             }
@@ -109,47 +114,51 @@ inline entity::KeyType key_type_compat(uint8_t kt) {
 }
 
 template<typename FieldType>
-inline KeyType key_type_from_segment(const SegmentInMemory& seg, ssize_t row) {
+inline KeyType key_type_from_segment(const SegmentInMemory& seg, ssize_t row)
+{
     auto key_type_val = seg.scalar_at<uint8_t>(row, int(FieldType::key_type)).value();
     return key_type_compat(key_type_val);
 }
 
 template<typename FieldType>
-inline StreamId stream_id_from_segment(const SegmentInMemory &seg, ssize_t row) {
-    if (const auto fd = seg.descriptor()[int(FieldType::stream_id)]; is_sequence_type(data_type_from_proto(fd.type_desc())))
+inline StreamId stream_id_from_segment(const SegmentInMemory& seg, ssize_t row)
+{
+    if (const auto fd = seg.descriptor()[int(FieldType::stream_id)];
+        is_sequence_type(data_type_from_proto(fd.type_desc())))
         return std::string(seg.string_at(row, int(FieldType::stream_id)).value());
     else
         return seg.scalar_at<timestamp>(row, int(FieldType::stream_id)).value();
 }
 
 template<typename FieldType>
-auto read_key_row_into_builder(const SegmentInMemory& seg, ssize_t i) {
+auto read_key_row_into_builder(const SegmentInMemory& seg, ssize_t i)
+{
     return atom_key_builder()
-            .gen_id(seg.scalar_at<VersionId>(i, int(FieldType::version_id)).value())
-            .creation_ts(seg.scalar_at<timestamp>(i, int(FieldType::creation_ts)).value())
-            .content_hash(seg.scalar_at<uint64_t>(i, int(FieldType::content_hash)).value())
-            .start_index(pipelines::index::index_start_from_segment<SegmentInMemory, FieldType>(seg, i))
-            .end_index(pipelines::index::index_end_from_segment<SegmentInMemory, FieldType>(seg, i));
+        .gen_id(seg.scalar_at<VersionId>(i, int(FieldType::version_id)).value())
+        .creation_ts(seg.scalar_at<timestamp>(i, int(FieldType::creation_ts)).value())
+        .content_hash(seg.scalar_at<uint64_t>(i, int(FieldType::content_hash)).value())
+        .start_index(pipelines::index::index_start_from_segment<SegmentInMemory, FieldType>(seg, i))
+        .end_index(pipelines::index::index_end_from_segment<SegmentInMemory, FieldType>(seg, i));
 }
 
 template<typename FieldType>
-inline entity::AtomKey read_key_row_impl(const SegmentInMemory &seg, ssize_t i) {
+inline entity::AtomKey read_key_row_impl(const SegmentInMemory& seg, ssize_t i)
+{
     auto key_type = key_type_from_segment<FieldType>(seg, i);
     auto stream_id = stream_id_from_segment<FieldType>(seg, i);
-    auto k = read_key_row_into_builder<FieldType>(seg, i)
-            .build(std::move(stream_id), key_type);
+    auto k = read_key_row_into_builder<FieldType>(seg, i).build(std::move(stream_id), key_type);
 
     return k;
 }
 
-inline entity::AtomKey read_key_row(const SegmentInMemory &seg, ssize_t i) {
+inline entity::AtomKey read_key_row(const SegmentInMemory& seg, ssize_t i)
+{
     //TODO remove backwards compat after a decent interval
     try {
         auto k = read_key_row_impl<pipelines::index::Fields>(seg, i);
         ARCTICDB_DEBUG(log::storage(), "Read key from row '{}: {}'", k.type(), k.view());
         return k;
-    }
-    catch(const std::invalid_argument&) {
+    } catch (const std::invalid_argument&) {
         auto k = read_key_row_impl<pipelines::index::LegacyFields>(seg, i);
         ARCTICDB_DEBUG(log::storage(), "Read legacy key from row '{}: {}'", k.type(), k.view());
         return k;
@@ -159,29 +168,39 @@ inline entity::AtomKey read_key_row(const SegmentInMemory &seg, ssize_t i) {
 using KeyMemSegmentPair = std::pair<entity::VariantKey, SegmentInMemory>;
 
 class IndexRangeFilter {
-  public:
-    explicit IndexRangeFilter(IndexRange index_range) : index_range_(std::move(index_range)) {}
+public:
+    explicit IndexRangeFilter(IndexRange index_range)
+        : index_range_(std::move(index_range))
+    {
+    }
 
-    bool accept_index(const IndexValue &index) {
+    bool accept_index(const IndexValue& index)
+    {
         return index_range_.accept(index);
     }
 
     //TODO are we interested in the end field?
-    bool key_within_index_range(const entity::AtomKey &key) {
+    bool key_within_index_range(const entity::AtomKey& key)
+    {
         return accept_index(key.start_index());
     }
 
-  private:
+private:
     IndexRange index_range_;
 };
 
 template<class KeyIt>
 class KeyRangeIterator : public IndexRangeFilter {
-  public:
-    KeyRangeIterator(const IndexRange &index_range, folly::Range<KeyIt> rg) :
-        IndexRangeFilter(index_range), key_rg_(rg), current_(rg.begin()) {}
+public:
+    KeyRangeIterator(const IndexRange& index_range, folly::Range<KeyIt> rg)
+        : IndexRangeFilter(index_range),
+          key_rg_(rg),
+          current_(rg.begin())
+    {
+    }
 
-    std::optional<typename KeyIt::value_type> next(folly::Duration) {
+    std::optional<typename KeyIt::value_type> next(folly::Duration)
+    {
         while (true) {
             if (current_ == key_rg_.end())
                 return std::nullopt;
@@ -192,68 +211,66 @@ class KeyRangeIterator : public IndexRangeFilter {
         }
     }
 
-  private:
+private:
     folly::Range<KeyIt> key_rg_;
     KeyIt current_;
 };
 
-inline auto generate_segments_from_keys(
-    arcticdb::stream::StreamSource &read_store,
+inline auto generate_segments_from_keys(arcticdb::stream::StreamSource& read_store,
     folly::Duration timeout,
     std::size_t prefetch_window,
-    const storage::ReadKeyOpts opts) {
+    const storage::ReadKeyOpts opts)
+{
     using namespace folly::gen;
-    return
-        map([&read_store](auto &&key) {
-            ARCTICDB_DEBUG(log::inmem(), "Getting segment for key {}: {}", key.type(), key.view());
-            return read_store.read(std::forward<decltype(key)>(key));
-        })
-            | window(prefetch_window)
-            | move
-            | map([timeout, opts](auto &&fut_key_seg) {
-                try {
-                    return std::make_optional(std::forward<decltype(fut_key_seg)>(fut_key_seg).get(timeout));
-                } catch(storage::KeyNotFoundException& e) {
-                    if (opts.ignores_missing_key_) {
-                        return std::optional<ReadKeyOutput>();
-                    }
-                    throw storage::KeyNotFoundException(std::move(e.keys()));
-                }
-            })
-            | filter() // By default removes falsy
-            | map([](auto&& opt) { return std::forward<decltype(opt)>(opt).value(); });
+    return map([&read_store](auto&& key) {
+        ARCTICDB_DEBUG(log::inmem(), "Getting segment for key {}: {}", key.type(), key.view());
+        return read_store.read(std::forward<decltype(key)>(key));
+    }) | window(prefetch_window) |
+           move | map([timeout, opts](auto&& fut_key_seg) {
+               try {
+                   return std::make_optional(std::forward<decltype(fut_key_seg)>(fut_key_seg).get(timeout));
+               } catch (storage::KeyNotFoundException& e) {
+                   if (opts.ignores_missing_key_) {
+                       return std::optional<ReadKeyOutput>();
+                   }
+                   throw storage::KeyNotFoundException(std::move(e.keys()));
+               }
+           }) |
+           filter() // By default removes falsy
+           | map([](auto&& opt) { return std::forward<decltype(opt)>(opt).value(); });
 }
 
-inline auto generate_keys_from_segments(
-    arcticdb::stream::StreamSource &read_store,
+inline auto generate_keys_from_segments(arcticdb::stream::StreamSource& read_store,
     entity::KeyType expected_key_type,
-    std::optional<entity::KeyType> expected_index_type = std::nullopt) {
-    return folly::gen::map([expected_key_type, expected_index_type, &read_store](auto &&key_seg) {
-        return folly::gen::detail::GeneratorBuilder<entity::AtomKey>() + [&](auto &&yield) {
+    std::optional<entity::KeyType> expected_index_type = std::nullopt)
+{
+    return folly::gen::map([expected_key_type, expected_index_type, &read_store](auto&& key_seg) {
+        return folly::gen::detail::GeneratorBuilder<entity::AtomKey>() + [&](auto&& yield) {
             std::stack<folly::Future<std::pair<entity::VariantKey, SegmentInMemory>>> key_segs;
             key_segs.push(folly::makeFuture(std::forward<decltype(key_seg)>(key_seg)));
-            while(!key_segs.empty()) {
+            while (!key_segs.empty()) {
                 auto [key, seg] = std::move(key_segs.top()).get();
                 key_segs.pop();
                 for (ssize_t i = 0; i < ssize_t(seg.row_count()); ++i) {
                     auto read_key = read_key_row(seg, i);
-                    if(read_key.type() != expected_key_type) {
+                    if (read_key.type() != expected_key_type) {
                         util::check_arg(expected_index_type && read_key.type() == expected_index_type.value(),
                             "Found unsupported key type in index segment. Expected {} or (index) {}, actual {}",
-                            expected_key_type, expected_index_type.value(), read_key
-                        );
+                            expected_key_type,
+                            expected_index_type.value(),
+                            read_key);
                         key_segs.push(read_store.read(read_key));
                     }
                     yield(read_key);
                 }
             }
         };
-    })
-     | folly::gen::concat;
+    }) | folly::gen::concat;
 }
 
 template<typename SegmentIteratorType>
-std::optional<KeyMemSegmentPair> next_non_empty_segment(SegmentIteratorType &iterator_segments, folly::Duration timeout) {
+std::optional<KeyMemSegmentPair> next_non_empty_segment(SegmentIteratorType& iterator_segments, folly::Duration timeout)
+{
     std::optional<KeyMemSegmentPair> ks_pair;
     while (!ks_pair) {
         ks_pair = std::move(iterator_segments.next(timeout));
@@ -267,24 +284,24 @@ std::optional<KeyMemSegmentPair> next_non_empty_segment(SegmentIteratorType &ite
 
 template<class KeyIt, int prefetch_capacity>
 class SegmentIterator : public IndexRangeFilter {
-  public:
-    SegmentIterator(const IndexRange &index_range,
-                    KeyIt &&key_it,
-                    std::shared_ptr<StreamSource> read_store) :
-        IndexRangeFilter(index_range),
-        key_it_(std::move(key_it)),
-        read_store_(std::move(read_store)){
+public:
+    SegmentIterator(const IndexRange& index_range, KeyIt&& key_it, std::shared_ptr<StreamSource> read_store)
+        : IndexRangeFilter(index_range),
+          key_it_(std::move(key_it)),
+          read_store_(std::move(read_store))
+    {
         init_prefetch();
     }
 
-    SegmentIterator(const TimestampRange &ts_rg,
-                    KeyIt &&key_it,
-                    const std::shared_ptr<StreamSource>& read_store) :
-        SegmentIterator(ts_rg.first, ts_rg.second, std::move(key_it), read_store) {}
+    SegmentIterator(const TimestampRange& ts_rg, KeyIt&& key_it, const std::shared_ptr<StreamSource>& read_store)
+        : SegmentIterator(ts_rg.first, ts_rg.second, std::move(key_it), read_store)
+    {
+    }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(SegmentIterator)
 
-    std::optional<KeyMemSegmentPair> next(folly::Duration timeout) {
+    std::optional<KeyMemSegmentPair> next(folly::Duration timeout)
+    {
         while (true) {
             if (prefetch_buffer_.empty())
                 return std::nullopt;
@@ -298,14 +315,16 @@ class SegmentIterator : public IndexRangeFilter {
         }
     }
 
-  private:
-    void init_prefetch() {
+private:
+    void init_prefetch()
+    {
         for (int p = prefetch_capacity; p != 0 && enqueue_next_key_read_request(); --p) {
             // Do nothing
         }
     }
 
-    bool enqueue_next_key_read_request(folly::Duration timeout = util::timeout::get_default()) {
+    bool enqueue_next_key_read_request(folly::Duration timeout = util::timeout::get_default())
+    {
         if (auto opt_key = key_it_.next(timeout); opt_key) {
             prefetch_buffer_.push_back(std::move(read_store_->read(opt_key.value())));
             return true;
@@ -322,16 +341,24 @@ class SegmentIterator : public IndexRangeFilter {
 
 template<class SegmentIt>
 class KeysFromSegIterator : public IndexRangeFilter {
-  public:
-    KeysFromSegIterator(const IndexRange &index_range, SegmentIt &&seg_it) :
-        IndexRangeFilter(index_range), seg_it_(std::move(seg_it)) {}
+public:
+    KeysFromSegIterator(const IndexRange& index_range, SegmentIt&& seg_it)
+        : IndexRangeFilter(index_range),
+          seg_it_(std::move(seg_it))
+    {
+    }
 
-    KeysFromSegIterator(const IndexRange &index_range, SegmentIt &&seg_it, std::optional<KeyMemSegmentPair> &key_seg) :
-        IndexRangeFilter(index_range), seg_it_(std::move(seg_it)), key_seg_(std::move(key_seg)) {}
+    KeysFromSegIterator(const IndexRange& index_range, SegmentIt&& seg_it, std::optional<KeyMemSegmentPair>& key_seg)
+        : IndexRangeFilter(index_range),
+          seg_it_(std::move(seg_it)),
+          key_seg_(std::move(key_seg))
+    {
+    }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(KeysFromSegIterator)
 
-    std::optional<entity::AtomKey> next(folly::Duration timeout) {
+    std::optional<entity::AtomKey> next(folly::Duration timeout)
+    {
         while (true) {
             if (!key_seg_ && !(row_id = 0, key_seg_ = next_non_empty_segment(seg_it_, timeout)))
                 return std::nullopt;
@@ -345,13 +372,16 @@ class KeysFromSegIterator : public IndexRangeFilter {
                 return std::optional<entity::AtomKey>{val};
         }
     }
-  private:
+
+private:
     SegmentIt seg_it_;
     std::optional<KeyMemSegmentPair> key_seg_;
     std::size_t row_id = 0;
 };
 
-inline std::set<StreamId> filter_by_regex(const std::set<StreamId>& results, const std::optional<std::string> &opt_regex) {
+inline std::set<StreamId> filter_by_regex(const std::set<StreamId>& results,
+    const std::optional<std::string>& opt_regex)
+{
     if (!opt_regex) {
         return results;
     }
@@ -359,7 +389,7 @@ inline std::set<StreamId> filter_by_regex(const std::set<StreamId>& results, con
     util::RegexPattern pattern(opt_regex.value());
     util::Regex regex{pattern};
 
-    for (auto &s_id: results) {
+    for (auto& s_id : results) {
         auto string_id = std::holds_alternative<StringId>(s_id) ? std::get<StringId>(s_id) : std::string();
         if (regex.match(string_id)) {
             filtered_results.insert(s_id);
@@ -368,27 +398,31 @@ inline std::set<StreamId> filter_by_regex(const std::set<StreamId>& results, con
     return filtered_results;
 }
 
-inline std::vector<std::string> get_index_columns_from_descriptor(const arcticdb::proto::descriptors::TimeSeriesDescriptor& descriptor) {
+inline std::vector<std::string> get_index_columns_from_descriptor(
+    const arcticdb::proto::descriptors::TimeSeriesDescriptor& descriptor)
+{
     const auto& norm_info = descriptor.normalization();
     const auto& stream_descriptor = descriptor.stream_descriptor();
     // For explicit integer indexes, the index is actually present in the first column even though the field_count
     // is 0.
     ssize_t index_till;
     const auto& common = norm_info.df().common();
-    if(auto idx_type = common.index_type_case(); idx_type == arcticdb::proto::descriptors::NormalizationMetadata_Pandas::kIndex)
+    if (auto idx_type = common.index_type_case();
+        idx_type == arcticdb::proto::descriptors::NormalizationMetadata_Pandas::kIndex)
         index_till = common.index().is_not_range_index() ? 1 : stream_descriptor.index().field_count();
     else
-        index_till = 1 + common.multi_index().field_count();  //# The value of field_count is len(index) - 1
+        index_till = 1 + common.multi_index().field_count(); //# The value of field_count is len(index) - 1
 
     std::vector<std::string> index_columns;
-    for(auto field_idx = 0; field_idx < index_till; ++field_idx)
+    for (auto field_idx = 0; field_idx < index_till; ++field_idx)
         index_columns.push_back(stream_descriptor.fields(field_idx).name());
 
     return index_columns;
 }
 
-inline IndexRange get_range_from_segment(const Index& index, const SegmentInMemory& segment) {
-    return util::variant_match(index, [&segment] (auto index_type) {
+inline IndexRange get_range_from_segment(const Index& index, const SegmentInMemory& segment)
+{
+    return util::variant_match(index, [&segment](auto index_type) {
         using IndexType = decltype(index_type);
         auto start = IndexType::start_value_for_segment(segment);
         auto end = IndexType::end_value_for_segment(segment);
@@ -396,12 +430,13 @@ inline IndexRange get_range_from_segment(const Index& index, const SegmentInMemo
     });
 }
 
-template <typename ClockType>
+template<typename ClockType>
 storage::KeySegmentPair make_target_key(KeyType key_type,
-                           const StreamId &stream_id,
-                           VersionId version_id,
-                           const VariantKey &source_key,
-                           Segment&& segment) {
+    const StreamId& stream_id,
+    VersionId version_id,
+    const VariantKey& source_key,
+    Segment&& segment)
+{
     if (is_ref_key_class(key_type)) {
         return {RefKey{stream_id, key_type}, std::move(segment)};
     } else {
@@ -411,18 +446,25 @@ storage::KeySegmentPair make_target_key(KeyType key_type,
             auto decoded = decode(std::move(clone));
             auto index = index_type_from_descriptor(decoded.descriptor());
             auto range = get_range_from_segment(index, decoded);
-            auto new_key = atom_key_builder().version_id(version_id).creation_ts(ClockType::nanos_since_epoch()).start_index(range.start_).end_index(
-                range.end_).build(stream_id, key_type);
+            auto new_key = atom_key_builder()
+                               .version_id(version_id)
+                               .creation_ts(ClockType::nanos_since_epoch())
+                               .start_index(range.start_)
+                               .end_index(range.end_)
+                               .build(stream_id, key_type);
 
             return {new_key, std::move(return_segment)};
         } else {
-            auto new_key = atom_key_builder().version_id(version_id).creation_ts(ClockType::nanos_since_epoch()).start_index(
-                to_atom(source_key).start_index()).end_index(to_atom(source_key).end_index()).build(stream_id, key_type);
+            auto new_key = atom_key_builder()
+                               .version_id(version_id)
+                               .creation_ts(ClockType::nanos_since_epoch())
+                               .start_index(to_atom(source_key).start_index())
+                               .end_index(to_atom(source_key).end_index())
+                               .build(stream_id, key_type);
 
             return {new_key, std::move(segment)};
         }
     }
 }
 
-} // namespace arctic::stream
-
+} // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/stream_writer.hpp
+++ b/cpp/arcticdb/stream/stream_writer.hpp
@@ -28,15 +28,15 @@ namespace arcticdb::stream {
 namespace pb = arcticdb::proto::descriptors;
 
 template<class Verifier, class IndexType>
-folly::Future<VariantKey> collect_and_commit(
-    std::vector<folly::Future<VariantKey>> &&fut_keys,
+folly::Future<VariantKey> collect_and_commit(std::vector<folly::Future<VariantKey>>&& fut_keys,
     StreamId stream_id,
     KeyType key_type,
     VersionId version_id,
     std::optional<IndexRange> specified_range,
     std::shared_ptr<StreamSink> store,
-    Verifier &&verifier,
-    google::protobuf::Any &&metadata) {
+    Verifier&& verifier,
+    google::protobuf::Any&& metadata)
+{
 
     // Shared ptr here is used to keep the futures alive until the collect future is ready
     auto commit_keys = std::make_shared<std::vector<folly::Future<VariantKey>>>(std::move(fut_keys));
@@ -46,27 +46,20 @@ folly::Future<VariantKey> collect_and_commit(
     IndexValue start_index;
     IndexValue end_index;
 
-    if(specified_range) {
+    if (specified_range) {
         start_index = specified_range.value().start_;
         end_index = specified_range.value().end_;
-    }
-    else if (!keys.empty()){
+    } else if (!keys.empty()) {
         start_index = to_atom(*keys.begin()).start_index();
         end_index = to_atom(*keys.rbegin()).end_index();
     }
 
     folly::Future<VariantKey> index_key = folly::Future<VariantKey>::makeEmpty();
-    IndexAggregator<IndexType> idx_agg(stream_id, [&](auto &&segment) {
-        index_key = store->write(
-            key_type,
-            version_id,
-            stream_id,
-            start_index,
-            end_index,
-            std::move(segment));
+    IndexAggregator<IndexType> idx_agg(stream_id, [&](auto&& segment) {
+        index_key = store->write(key_type, version_id, stream_id, start_index, end_index, std::move(segment));
     });
 
-    for (auto &&key: keys) {
+    for (auto&& key : keys) {
         verifier(key);
         idx_agg.add_key(to_atom(key));
     }
@@ -79,55 +72,62 @@ folly::Future<VariantKey> collect_and_commit(
 
 template<class Index, class Schema, class SegmentingPolicy = RowCountSegmentPolicy>
 class StreamWriter : boost::noncopyable {
-  public:
+public:
     using IndexType = Index;
     using SegmentingPolicyType = SegmentingPolicy;
     using DataAggregator = Aggregator<Index, Schema, SegmentingPolicyType>;
 
-    StreamWriter(
-        Schema &&schema,
+    StreamWriter(Schema&& schema,
         std::shared_ptr<StreamSink> store,
         VersionId version_id,
         std::optional<IndexRange> index_range = std::nullopt,
-        SegmentingPolicyType &&segmenting_policy = SegmentingPolicyType()) :
-            data_agg_(std::move(schema), [&](auto &&segment) {
-                on_data_segment(std::move(segment));
-            },
-            std::move(segmenting_policy)),
-            store_(store),
-            version_id_(version_id),
-            specified_range_(index_range),
-            written_data_keys_() {}
+        SegmentingPolicyType&& segmenting_policy = SegmentingPolicyType())
+        : data_agg_(
+              std::move(schema),
+              [&](auto&& segment) { on_data_segment(std::move(segment)); },
+              std::move(segmenting_policy)),
+          store_(store),
+          version_id_(version_id),
+          specified_range_(index_range),
+          written_data_keys_()
+    {
+    }
 
-    template<class...Args>
-    typename DataAggregator::RowBuilderType &start_row(Args...args) {
+    template<class... Args>
+    typename DataAggregator::RowBuilderType& start_row(Args... args)
+    {
         return data_agg_.start_row(std::forward<Args>(args)...);
     }
 
-    typename DataAggregator::RowBuilderType &row_builder() {
+    typename DataAggregator::RowBuilderType& row_builder()
+    {
         return data_agg_.row_builder();
     }
 
-    folly::Future<VariantKey> commit(KeyType key_type = KeyType::UNDEFINED) {
-        SCOPE_FAIL {
-            log::root().error("Failure while writing keys for version_id={},stream_id={}", version_id_, stream_id()
-            );
+    folly::Future<VariantKey> commit(KeyType key_type = KeyType::UNDEFINED)
+    {
+        SCOPE_FAIL
+        {
+            log::root().error("Failure while writing keys for version_id={},stream_id={}", version_id_, stream_id());
         };
         data_agg_.commit();
 
         std::scoped_lock l{commit_mutex_};
-        auto verify = [version_id = version_id_, stream_id = stream_id()](const VariantKey &key) {
-            util::check_arg(version_id == to_atom(key).version_id(), "Invalid key expected version_id={}, actual={}",
-                            version_id, key);
-            util::check_arg(stream_id == to_atom(key).id(), "Invalid key, expected symbol={}, actual={}",
-                            stream_id, key);
+        auto verify = [version_id = version_id_, stream_id = stream_id()](const VariantKey& key) {
+            util::check_arg(version_id == to_atom(key).version_id(),
+                "Invalid key expected version_id={}, actual={}",
+                version_id,
+                key);
+            util::check_arg(stream_id == to_atom(key).id(),
+                "Invalid key, expected symbol={}, actual={}",
+                stream_id,
+                key);
         };
 
         if (key_type == KeyType::UNDEFINED)
             key_type = get_key_type_for_index_stream(stream_id());
 
-        return collect_and_commit<decltype(verify), IndexType>(
-            std::move(written_data_keys_),
+        return collect_and_commit<decltype(verify), IndexType>(std::move(written_data_keys_),
             stream_id(),
             key_type,
             version_id_,
@@ -137,50 +137,59 @@ class StreamWriter : boost::noncopyable {
             google::protobuf::Any());
     }
 
-    StreamId stream_id() const {
+    StreamId stream_id() const
+    {
         return data_agg_.descriptor().id();
     }
 
-    VersionId version_id() const {
+    VersionId version_id() const
+    {
         return version_id_;
     }
 
-    DataAggregator &aggregator() { return data_agg_; }
+    DataAggregator& aggregator()
+    {
+        return data_agg_;
+    }
 
-  private:
-    void on_data_segment(SegmentInMemory &&segment) {
+private:
+    void on_data_segment(SegmentInMemory&& segment)
+    {
         auto seg_start = segment_start(segment);
         auto seg_end = segment_end(segment);
 
-        written_data_keys_.push_back(store_->write(
-            get_key_type_for_data_stream(stream_id()),
+        written_data_keys_.push_back(store_->write(get_key_type_for_data_stream(stream_id()),
             version_id_,
             stream_id(),
             seg_start,
             seg_end,
-            std::move(segment)
-        ));
+            std::move(segment)));
     }
 
-    IndexValue segment_start(const SegmentInMemory &segment) const {
+    IndexValue segment_start(const SegmentInMemory& segment) const
+    {
         return data_agg_.index().start_value_for_segment(segment);
     }
 
-    IndexValue segment_end(const SegmentInMemory &segment) const {
+    IndexValue segment_end(const SegmentInMemory& segment) const
+    {
         return data_agg_.index().end_value_for_segment(segment);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_scalar(std::size_t pos, T val) {
+    void set_scalar(std::size_t pos, T val)
+    {
         data_agg_.set_scalar(pos, val);
     }
 
     template<class T, std::enable_if_t<std::is_same_v<std::decay_t<T>, std::string>, int> = 0>
-    void set_scalar(position_t pos, T val) {
+    void set_scalar(position_t pos, T val)
+    {
         data_agg_.set_scalar(pos, val);
     }
 
-    void end_row() {
+    void end_row()
+    {
         data_agg_.end_row();
     }
 

--- a/cpp/arcticdb/stream/test/mock_stores.hpp
+++ b/cpp/arcticdb/stream/test/mock_stores.hpp
@@ -26,125 +26,142 @@
 namespace arcticdb {
 
 template<KeyType key_type>
-class TypeFilteredStore :
-    public InMemoryStore {
-    folly::Future<folly::Unit> iterate_type(
-        KeyType kt, folly::Function<void(entity::VariantKey &&)> func,
-        const std::string &/*prefix*/) override {
+class TypeFilteredStore : public InMemoryStore {
+    folly::Future<folly::Unit>
+    iterate_type(KeyType kt, folly::Function<void(entity::VariantKey&&)> func, const std::string& /*prefix*/) override
+    {
         if (kt == key_type)
-            for (auto &item : seg_by_atom_key_) {
+            for (auto& item : seg_by_atom_key_) {
                 fmt::print("{}", item.first);
                 entity::AtomKey key(item.first);
                 func(std::move(key));
             }
     }
 
-    folly::Future<VariantKey> write(
-        KeyType kt, VersionId version_id,
-        StreamId stream_id, IndexValue start_index, IndexValue end_index,
-        SegmentInMemory &&segment
-    ) override {
+    folly::Future<VariantKey> write(KeyType kt,
+        VersionId version_id,
+        StreamId stream_id,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&& segment) override
+    {
         if (key_type == kt)
             InMemoryStore::write(kt, version_id, stream_id, start_index, end_index, std::move(segment));
 
-        return atom_key_builder().gen_id(version_id).content_hash(content_hash_).creation_ts(creation_ts_)
-                                 .start_index(start_index).end_index(end_index).build(stream_id, key_type);
+        return atom_key_builder()
+            .gen_id(version_id)
+            .content_hash(content_hash_)
+            .creation_ts(creation_ts_)
+            .start_index(start_index)
+            .end_index(end_index)
+            .build(stream_id, key_type);
     }
-
 };
 
-class NullStore :
-    public Store {
+class NullStore : public Store {
 
-  public:
+public:
     NullStore() = default;
 
-    folly::Future<std::pair<AtomKey, arcticdb::SegmentInMemory>> read(const AtomKey &key) override {
+    folly::Future<std::pair<AtomKey, arcticdb::SegmentInMemory>> read(const AtomKey& key) override
+    {
         return std::make_pair(key, arcticdb::SegmentInMemory{});
     }
 
     std::atomic<timestamp> creation_ts{0};
     HashedValue content_hash = 0x42;
 
-    folly::Future<VariantKey>
-    write(
-        KeyType key_type, VersionId gen_id,
-        StreamId tsid, IndexValue start_index, IndexValue end_index,
-        SegmentInMemory &&
-    ) override {
-        auto key = atom_key_builder().gen_id(gen_id).content_hash(content_hash).creation_ts(creation_ts)
-                                     .start_index(start_index).end_index(end_index).build(tsid, key_type);
+    folly::Future<VariantKey> write(KeyType key_type,
+        VersionId gen_id,
+        StreamId tsid,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory&&) override
+    {
+        auto key = atom_key_builder()
+                       .gen_id(gen_id)
+                       .content_hash(content_hash)
+                       .creation_ts(creation_ts)
+                       .start_index(start_index)
+                       .end_index(end_index)
+                       .build(tsid, key_type);
         return folly::makeFuture(key);
     }
 
-    folly::Future<RemoveKeyResultType> remove_key(const VariantKey &key) override {
+    folly::Future<RemoveKeyResultType> remove_key(const VariantKey& key) override
+    {
         return folly::makeFuture({});
     }
 
-    void read_atoms(
-        const std::vector<entity::AtomKey> &,
-        folly::Function<void(std::vector<std::pair<entity::AtomKey, SegmentInMemory >> &&)> &&
-    ) override {
+    void read_atoms(const std::vector<entity::AtomKey>&,
+        folly::Function<void(std::vector<std::pair<entity::AtomKey, SegmentInMemory>>&&)>&&) override
+    {
         throw std::runtime_error("Not implemented");
     }
 
-    void read_refs(
-            const std::vector<entity::RefKey> &,
-            folly::Function<void(std::vector<std::pair<entity::RefKey, SegmentInMemory >> &&)> &&
-    ) override {
+    void read_refs(const std::vector<entity::RefKey>&,
+        folly::Function<void(std::vector<std::pair<entity::RefKey, SegmentInMemory>>&&)>&&) override
+    {
         throw std::runtime_error("Not implemented");
     }
 
-    folly::Future<folly::Unit> iterate_type(KeyType, folly::Function<void(entity::VariantKey &&)>, const std::string &) override {
+    folly::Future<folly::Unit>
+    iterate_type(KeyType, folly::Function<void(entity::VariantKey&&)>, const std::string&) override
+    {
         throw std::runtime_error("Not implemented");
     }
 
     folly::Future<entity::RefKey>
-    write(stream::KeyType /*key_type*/, StreamId /*stream_id*/, SegmentInMemory &&/*segment*/) override {
+    write(stream::KeyType /*key_type*/, StreamId /*stream_id*/, SegmentInMemory&& /*segment*/) override
+    {
         util::raise_rte("Not implemented");
     }
 
-    folly::Future<std::pair<entity::RefKey, SegmentInMemory>> read(const entity::RefKey &/*key*/) override {
+    folly::Future<std::pair<entity::RefKey, SegmentInMemory>> read(const entity::RefKey& /*key*/) override
+    {
         util::raise_rte("Not implemented");
     }
 
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(const std::vector<entity::VariantKey>&) override {
+    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(const std::vector<entity::VariantKey>&) override
+    {
         util::raise_rte("Not implemented");
     }
 
-    folly::Future<std::vector<AtomKey>> batch_write(
-        std::vector<std::pair<PartialKey, SegmentInMemory>> &&,
+    folly::Future<std::vector<AtomKey>> batch_write(std::vector<std::pair<PartialKey, SegmentInMemory>>&&,
         const std::unordered_map<ContentHash, AtomKey>&,
-        const BatchWriteArgs &
-    ) override {
+        const BatchWriteArgs&) override
+    {
         throw std::runtime_error("Not implemented for tests");
     }
 
-    std::vector<folly::Future<storage::KeySegmentPair>>
-    batch_read_compressed(std::vector<entity::VariantKey> &&, const BatchReadArgs &) override {
+    std::vector<folly::Future<storage::KeySegmentPair>> batch_read_compressed(std::vector<entity::VariantKey>&&,
+        const BatchReadArgs&) override
+    {
         throw std::runtime_error("Not implemented for tests");
     }
 
-    virtual std::vector<folly::Future<bool>> batch_key_exists(std::vector<entity::VariantKey> &) {
+    virtual std::vector<folly::Future<bool>> batch_key_exists(std::vector<entity::VariantKey>&)
+    {
         throw std::runtime_error("Not implemented for tests");
     }
 
-        std::vector<folly::Future<VariantKey>>
-    batch_read_compressed(
-        std::vector<entity::VariantKey> &&, std::vector<ReadContinuation> &&,
-        const BatchReadArgs &
-    ) override {
+    std::vector<folly::Future<VariantKey>> batch_read_compressed(std::vector<entity::VariantKey>&&,
+        std::vector<ReadContinuation>&&,
+        const BatchReadArgs&) override
+    {
         throw std::runtime_error("Not implemented for tests");
     }
 
     folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>>
 
-    read_metadata(const entity::VariantKey &) override {
+    read_metadata(const entity::VariantKey&) override
+    {
         util::raise_rte("Not implemented for tests");
     }
 
-    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &) override {}
-
+    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator&) override
+    {
+    }
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -25,14 +25,14 @@
 #include <arcticdb/stream/index.hpp>
 #include <filesystem>
 
-
 namespace fg = folly::gen;
 
 namespace arcticdb {
 
 template<typename T, typename U>
-void check_value(const T& t, const U& u) {
-    if(t != u)
+void check_value(const T& t, const U& u)
+{
+    if (t != u)
         std::cout << "Oops";
 
     ASSERT_EQ(t, u);
@@ -41,13 +41,12 @@ void check_value(const T& t, const U& u) {
 using MockAgg = Aggregator<TimeseriesIndex, FixedSchema, NeverSegmentPolicy>;
 
 template<class SegmentFiller>
-arcticdb::SegmentInMemory fill_test_data_segment(const StreamDescriptor &tsd, SegmentFiller &&filler) {
+arcticdb::SegmentInMemory fill_test_data_segment(const StreamDescriptor& tsd, SegmentFiller&& filler)
+{
     SegmentInMemory seg;
     auto index = index_type_from_descriptor(tsd);
 
-    MockAgg agg{FixedSchema{tsd, index}, [&](auto &&s) {
-        seg = std::move(s);
-    }};
+    MockAgg agg{FixedSchema{tsd, index}, [&](auto&& s) { seg = std::move(s); }};
 
     filler(agg);
     agg.commit();
@@ -55,74 +54,79 @@ arcticdb::SegmentInMemory fill_test_data_segment(const StreamDescriptor &tsd, Se
 }
 
 template<class TsIndexKeyGen>
-SegmentInMemory fill_test_index_segment(const StreamId &tsid, TsIndexKeyGen &&ts_key_gen) {
+SegmentInMemory fill_test_index_segment(const StreamId& tsid, TsIndexKeyGen&& ts_key_gen)
+{
     SegmentInMemory seg;
-    IndexAggregator<TimeseriesIndex> idx_agg{tsid, [&](auto &&s) {
-        seg = std::move(s);
-    }};
+    IndexAggregator<TimeseriesIndex> idx_agg{tsid, [&](auto&& s) { seg = std::move(s); }};
 
-    ts_key_gen.foreach([&](auto &key) {
-        idx_agg.add_key(key);
-    });
+    ts_key_gen.foreach ([&](auto& key) { idx_agg.add_key(key); });
     idx_agg.commit();
     return seg;
 }
 
 struct PilotedClock {
     static std::atomic<timestamp> time_;
-    static timestamp nanos_since_epoch() ARCTICDB_UNUSED {
+    static timestamp nanos_since_epoch() ARCTICDB_UNUSED
+    {
         return PilotedClock::time_++;
     }
 
-    static void reset() ARCTICDB_UNUSED {
+    static void reset() ARCTICDB_UNUSED
+    {
         PilotedClock::time_ = 0;
     }
 };
 
-inline auto get_simple_data_descriptor(const StreamId &id) {
-    return TimeseriesIndex::default_index().create_stream_descriptor(
-        id, {scalar_field_proto(DataType::UINT64, "val")}
-    );
+inline auto get_simple_data_descriptor(const StreamId& id)
+{
+    return TimeseriesIndex::default_index().create_stream_descriptor(id, {scalar_field_proto(DataType::UINT64, "val")});
 }
 
-template <class DataType>
-uint64_t digit_mask() {
+template<class DataType>
+uint64_t digit_mask()
+{
     return (uint64_t(1) << (std::numeric_limits<DataType>::digits - 1)) - 1;
 }
 
 template<typename DataType, std::enable_if_t<std::is_integral_v<DataType>, int> = 0>
-DataType get_integral_value_for_offset(size_t start_val, size_t i) {
+DataType get_integral_value_for_offset(size_t start_val, size_t i)
+{
     return static_cast<DataType>((start_val + i) & digit_mask<DataType>());
 }
 
 template<typename DataType, std::enable_if_t<std::is_floating_point_v<DataType>, int> = 0>
-DataType get_floating_point_value_for_offset(size_t start_val, size_t i) {
-    return DataType(start_val) + i / (10 *digit_mask<DataType>());
+DataType get_floating_point_value_for_offset(size_t start_val, size_t i)
+{
+    return DataType(start_val) + i / (10 * digit_mask<DataType>());
 }
 
 template<typename DataType, class ContainerType, std::enable_if_t<std::is_integral_v<DataType>, int> = 0>
-void fill_test_index_vector(ContainerType &container, DataType, size_t num_rows, size_t start_val) {
+void fill_test_index_vector(ContainerType& container, DataType, size_t num_rows, size_t start_val)
+{
     for (size_t i = 0; i < num_rows; ++i) {
         container.push_back(static_cast<DataType>(start_val + i));
     }
 }
 
 template<typename DataType, class ContainerType, std::enable_if_t<std::is_integral_v<DataType>, int> = 0>
-void fill_test_value_vector(ContainerType &container, DataType, size_t num_rows, size_t start_val) {
+void fill_test_value_vector(ContainerType& container, DataType, size_t num_rows, size_t start_val)
+{
     for (size_t i = 0; i < num_rows; ++i) {
         container.push_back(get_integral_value_for_offset<DataType>(start_val, i));
     }
 }
 
 template<typename DataType, class ContainerType, std::enable_if_t<std::is_floating_point_v<DataType>, int> = 0>
-void fill_test_value_vector(ContainerType &container, DataType, size_t num_rows, size_t start_val) {
+void fill_test_value_vector(ContainerType& container, DataType, size_t num_rows, size_t start_val)
+{
     for (size_t i = 0; i < num_rows; ++i) {
         container.push_back(get_floating_point_value_for_offset<DataType>(start_val, i));
     }
 }
 
 template<typename DataType, class ContainerType, std::enable_if_t<std::is_floating_point_v<DataType>, int> = 0>
-void fill_test_index_vector(ContainerType &container, DataType, size_t num_rows, size_t start_val) {
+void fill_test_index_vector(ContainerType& container, DataType, size_t num_rows, size_t start_val)
+{
     for (auto i = start_val; i < start_val + num_rows; ++i) {
         container.push_back(DataType(i));
     }
@@ -131,21 +135,27 @@ void fill_test_index_vector(ContainerType &container, DataType, size_t num_rows,
 struct DefaultStringGenerator {
     static const stride_t strides_ = 5;
 
-    stride_t strides() { return strides_; }
+    stride_t strides()
+    {
+        return strides_;
+    }
 
-    static void fill_string_vector(std::vector<uint8_t> &vec, size_t num_rows) ARCTICDB_UNUSED {
+    static void fill_string_vector(std::vector<uint8_t>& vec, size_t num_rows) ARCTICDB_UNUSED
+    {
         vec.resize(num_rows * strides_);
-        const char *strings[] = {"dog", "cat", "horse"};
+        const char* strings[] = {"dog", "cat", "horse"};
         for (size_t i = 0; i < num_rows; ++i) {
             memcpy(&vec[i * strides_], &strings[i % 3], sizeof(strings[i % 3]));
         }
     }
 };
 
-template<class ContainerType, typename DTT,
+template<class ContainerType,
+    typename DTT,
     std::enable_if_t<std::is_floating_point_v<typename DTT::raw_type> || std::is_integral_v<typename DTT::raw_type>,
-                     int> = 0>
-NativeTensor test_column(ContainerType &container, DTT, size_t num_rows, size_t start_val, bool is_index) {
+        int> = 0>
+NativeTensor test_column(ContainerType& container, DTT, size_t num_rows, size_t start_val, bool is_index)
+{
     using RawType = typename DTT::raw_type;
     constexpr auto dt = DTT::data_type;
 
@@ -165,7 +175,8 @@ NativeTensor test_column(ContainerType &container, DTT, size_t num_rows, size_t 
 }
 
 template<class ContainerType, typename DTT, class StringGenerator = DefaultStringGenerator>
-NativeTensor test_string_column(ContainerType &vec, DTT, size_t num_rows) {
+NativeTensor test_string_column(ContainerType& vec, DTT, size_t num_rows)
+{
     constexpr auto dt = DTT::data_type;
     shape_t shapes = num_rows;
     stride_t strides;
@@ -180,7 +191,8 @@ NativeTensor test_string_column(ContainerType &vec, DTT, size_t num_rows) {
     return NativeTensor{bytes, 1, &strides, &shapes, dt, elsize, vec.data()};
 }
 
-inline std::vector<entity::FieldDescriptor::Proto> get_test_timeseries_fields() {
+inline std::vector<entity::FieldDescriptor::Proto> get_test_timeseries_fields()
+{
     using namespace arcticdb::entity;
 
     return {
@@ -191,30 +203,34 @@ inline std::vector<entity::FieldDescriptor::Proto> get_test_timeseries_fields() 
     };
 }
 
-inline std::vector<entity::FieldDescriptor::Proto> get_test_simple_fields() {
+inline std::vector<entity::FieldDescriptor::Proto> get_test_simple_fields()
+{
     using namespace arcticdb::entity;
 
     return {
         scalar_field_proto(DataType::UINT32, "index"),
-        scalar_field_proto(DataType::FLOAT64,  "floats"),
+        scalar_field_proto(DataType::FLOAT64, "floats"),
     };
 }
 
 struct TestTensorFrame {
-    TestTensorFrame(StreamDescriptor desc, size_t num_rows) :
-        segment_(std::move(desc), num_rows) {}
+    TestTensorFrame(StreamDescriptor desc, size_t num_rows)
+        : segment_(std::move(desc), num_rows)
+    {
+    }
 
     SegmentInMemory segment_;
     arcticdb::pipelines::InputTensorFrame frame_;
 };
 
 template<class ContainerType, typename DTT>
-void fill_test_column(arcticdb::pipelines::InputTensorFrame &frame,
-                      ContainerType &container,
-                      DTT data_type_tag,
-                      size_t num_rows,
-                      size_t start_val,
-                      bool is_index) {
+void fill_test_column(arcticdb::pipelines::InputTensorFrame& frame,
+    ContainerType& container,
+    DTT data_type_tag,
+    size_t num_rows,
+    size_t start_val,
+    bool is_index)
+{
     using RawType = typename decltype(data_type_tag)::raw_type;
     if (!is_index) {
         if constexpr (std::is_integral_v<RawType> || std::is_floating_point_v<RawType>)
@@ -230,11 +246,12 @@ void fill_test_column(arcticdb::pipelines::InputTensorFrame &frame,
     }
 }
 
-inline void fill_test_frame(SegmentInMemory &segment,
-                            arcticdb::pipelines::InputTensorFrame &frame,
-                            size_t num_rows,
-                            size_t start_val,
-                            size_t opt_row_offset) {
+inline void fill_test_frame(SegmentInMemory& segment,
+    arcticdb::pipelines::InputTensorFrame& frame,
+    size_t num_rows,
+    size_t start_val,
+    size_t opt_row_offset)
+{
     util::check(!segment.descriptor().empty(), "Can't construct test frame with empty descriptor");
 
     auto field = segment.descriptor().begin();
@@ -250,27 +267,29 @@ inline void fill_test_frame(SegmentInMemory &segment,
         visit_field(*field, [&](auto type_desc_tag) {
             using DTT = typename decltype(type_desc_tag)::DataTypeTag;
             fill_test_column(frame,
-                             segment.column(std::distance(segment.descriptor().begin(), field)),
-                             DTT{},
-                             num_rows,
-                             start_val + opt_row_offset,
-                             false);
+                segment.column(std::distance(segment.descriptor().begin(), field)),
+                DTT{},
+                num_rows,
+                start_val + opt_row_offset,
+                false);
         });
     }
     segment.set_row_data(num_rows - 1);
 }
 
 template<typename IndexType>
-StreamDescriptor get_test_descriptor(const StreamId &id, const std::vector<FieldDescriptor::Proto> &fields) {
+StreamDescriptor get_test_descriptor(const StreamId& id, const std::vector<FieldDescriptor::Proto>& fields)
+{
     return IndexType::default_index().create_stream_descriptor(id, folly::Range(fields.begin(), fields.end()));
 }
 
 template<typename IndexType>
-TestTensorFrame get_test_frame(const StreamId &id,
-                               const std::vector<FieldDescriptor::Proto> &fields,
-                               size_t num_rows,
-                               size_t start_val,
-                               size_t opt_row_offset = 0) {
+TestTensorFrame get_test_frame(const StreamId& id,
+    const std::vector<FieldDescriptor::Proto>& fields,
+    size_t num_rows,
+    size_t start_val,
+    size_t opt_row_offset = 0)
+{
     using namespace arcticdb::pipelines;
     TestTensorFrame output(get_test_descriptor<IndexType>(id, fields), num_rows);
 
@@ -286,26 +305,30 @@ TestTensorFrame get_test_frame(const StreamId &id,
     return output;
 }
 
-inline auto get_test_empty_timeseries_segment(StreamId id, size_t num_rows) {
+inline auto get_test_empty_timeseries_segment(StreamId id, size_t num_rows)
+{
     return SegmentInMemory{get_test_descriptor<stream::TimeseriesIndex>(id, get_test_timeseries_fields()), num_rows};
 }
 
-inline auto get_test_timeseries_frame(const StreamId &id, size_t num_rows, size_t start_val) {
+inline auto get_test_timeseries_frame(const StreamId& id, size_t num_rows, size_t start_val)
+{
     return get_test_frame<stream::TimeseriesIndex>(id, get_test_timeseries_fields(), num_rows, start_val);
 }
 
-inline auto get_test_simple_frame(const StreamId &id, size_t num_rows, size_t start_val) {
+inline auto get_test_simple_frame(const StreamId& id, size_t num_rows, size_t start_val)
+{
     return get_test_frame<stream::RowCountIndex>(id, get_test_simple_fields(), num_rows, start_val);
 }
 
-inline std::pair<storage::LibraryPath, arcticdb::proto::storage::LibraryConfig> test_config(const std::string &lib_name) {
+inline std::pair<storage::LibraryPath, arcticdb::proto::storage::LibraryConfig> test_config(const std::string& lib_name)
+{
     auto unique_lib_name = fmt::format("{}_{}", lib_name, util::SysClock::nanos_since_epoch());
     arcticdb::proto::storage::LibraryConfig config;
 
     config.mutable_lib_desc()->set_name(unique_lib_name);
     auto temp_path = std::filesystem::temp_directory_path();
     // on windows, path is only implicitly converted to wstring, not string
-    auto lmdb_config =  arcticdb::storage::lmdb::pack_config(temp_path.string());
+    auto lmdb_config = arcticdb::storage::lmdb::pack_config(temp_path.string());
     auto library_path = storage::LibraryPath::from_delim_path(unique_lib_name);
     auto storage_id = fmt::format("{}_store", unique_lib_name);
     config.mutable_lib_desc()->add_storage_ids(storage_id);
@@ -313,17 +336,15 @@ inline std::pair<storage::LibraryPath, arcticdb::proto::storage::LibraryConfig> 
     return std::make_pair(library_path, config);
 }
 
-inline std::shared_ptr<storage::Library> test_library_from_config(const storage::LibraryPath& lib_path,  const arcticdb::proto::storage::LibraryConfig& lib_cfg) {
+inline std::shared_ptr<storage::Library> test_library_from_config(const storage::LibraryPath& lib_path,
+    const arcticdb::proto::storage::LibraryConfig& lib_cfg)
+{
     auto storage_cfg = lib_cfg.storage_by_id().at(lib_cfg.lib_desc().storage_ids(0));
-    auto vs_cfg = lib_cfg.lib_desc().has_version()
-            ? LibraryDescriptor::VariantStoreConfig{lib_cfg.lib_desc().version()}
-            : std::monostate{};
-    return std::make_shared<storage::Library>(
-            lib_path,
-            storage::create_storages(lib_path, storage::OpenMode::DELETE, storage_cfg),
-            std::move(vs_cfg)
-            );
-
+    auto vs_cfg = lib_cfg.lib_desc().has_version() ? LibraryDescriptor::VariantStoreConfig{lib_cfg.lib_desc().version()}
+                                                   : std::monostate{};
+    return std::make_shared<storage::Library>(lib_path,
+        storage::create_storages(lib_path, storage::OpenMode::DELETE, storage_cfg),
+        std::move(vs_cfg));
 }
 
 /**
@@ -332,7 +353,8 @@ inline std::shared_ptr<storage::Library> test_library_from_config(const storage:
  * Note: the VariantStoreConfig will be monostate. If you need a version store with special config, then inline this
  * function and modify the config.
  */
-inline std::shared_ptr<storage::Library> test_library(const std::string &lib_name) {
+inline std::shared_ptr<storage::Library> test_library(const std::string& lib_name)
+{
     auto [lib_path, config] = test_config(lib_name);
     return test_library_from_config(lib_path, config);
 }
@@ -342,7 +364,8 @@ inline std::shared_ptr<storage::Library> test_library(const std::string &lib_nam
  *
  * See generators.hpp for various in-memory alternatives.
  */
-inline auto test_store(const std::string &lib_name) {
+inline auto test_store(const std::string& lib_name)
+{
     auto library = test_library(lib_name);
     auto version_store = std::make_shared<version_store::PythonVersionStore>(library);
     return version_store;
@@ -352,11 +375,13 @@ struct TestStore : ::testing::Test {
 protected:
     virtual std::string get_name() = 0;
 
-    void SetUp() override {
+    void SetUp() override
+    {
         test_store_ = test_store(get_name());
     }
 
-    void TearDown() override {
+    void TearDown() override
+    {
         test_store_->clear();
     }
 

--- a/cpp/arcticdb/stream/test/test_aggregator.cpp
+++ b/cpp/arcticdb/stream/test/test_aggregator.cpp
@@ -5,7 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-
 #include <arcticdb/stream/row_builder.hpp>
 #include <arcticdb/stream/aggregator.hpp>
 
@@ -22,42 +21,38 @@ struct SegmentsSink {
     std::vector<SegmentInMemory> segments;
 };
 
-TEST(Aggregator, BasicAndSegmenting) {
+TEST(Aggregator, BasicAndSegmenting)
+{
     const auto index = as::TimeseriesIndex::default_index();
-    as::FixedSchema schema{
-        index.create_stream_descriptor(123, {
-            scalar_field_proto(DataType::UINT8, "uint8"),
-        }), index
-    };
+    as::FixedSchema schema{index.create_stream_descriptor(123,
+                               {
+                                   scalar_field_proto(DataType::UINT8, "uint8"),
+                               }),
+        index};
 
     SegmentsSink sink;
 
-    as::FixedTimestampAggregator agg(std::move(schema), [&](SegmentInMemory &&mem) {
-        sink.segments.push_back(std::move(mem));
-    }, as::RowCountSegmentPolicy{8});
+    as::FixedTimestampAggregator agg(
+        std::move(schema),
+        [&](SegmentInMemory&& mem) { sink.segments.push_back(std::move(mem)); },
+        as::RowCountSegmentPolicy{8});
 
     ASSERT_EQ(0, agg.row_count());
 
     for (timestamp i = 0; i < 7; i++) {
-        agg.start_row(timestamp{i})([&](auto &rb) {
-            rb.set_scalar(1, uint8_t(i));
-        });
+        agg.start_row(timestamp{i})([&](auto& rb) { rb.set_scalar(1, uint8_t(i)); });
     }
 
     ASSERT_EQ(7, agg.row_count());
     ASSERT_EQ(0, sink.segments.size());
 
-    agg.start_row(timestamp{8})([](auto &rb) {
-        rb.set_scalar(1, uint8_t{42});
-    });
+    agg.start_row(timestamp{8})([](auto& rb) { rb.set_scalar(1, uint8_t{42}); });
 
     ASSERT_EQ(0, agg.row_count());
     ASSERT_EQ(1, sink.segments.size());
     ASSERT_EQ(8, sink.segments[0].row_count());
 
-    agg.start_row(timestamp{8})([](auto &rb) {
-        rb.set_scalar(1, uint8_t{42});
-    });
+    agg.start_row(timestamp{8})([](auto& rb) { rb.set_scalar(1, uint8_t{42}); });
 
     ASSERT_EQ(1, agg.row_count());
     ASSERT_EQ(1, sink.segments.size());
@@ -67,5 +62,3 @@ TEST(Aggregator, BasicAndSegmenting) {
     ASSERT_EQ(2, sink.segments.size());
     ASSERT_EQ(1, sink.segments[1].row_count());
 }
-
-

--- a/cpp/arcticdb/stream/test/test_append_map.cpp
+++ b/cpp/arcticdb/stream/test/test_append_map.cpp
@@ -13,7 +13,8 @@
 #include <arcticdb/storage/test/in_memory_store.hpp>
 #include <arcticdb/pipeline/read_frame.hpp>
 
-TEST(Append, Simple) {
+TEST(Append, Simple)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
     using namespace arcticdb::pipelines;
@@ -26,7 +27,7 @@ TEST(Append, Simple) {
     pipelines::FilterRange range;
     auto pipeline_context = std::make_shared<PipelineContext>(desc);
     pipeline_context->selected_columns_ = util::BitSet(2);
-    pipeline_context->selected_columns_ ->flip();
+    pipeline_context->selected_columns_->flip();
     pipeline_context->fetch_index_ = util::BitSet(2);
     pipeline_context->fetch_index_.flip();
     async::TaskScheduler scheduler{5};
@@ -38,76 +39,69 @@ TEST(Append, Simple) {
     ASSERT_EQ(allocated_frame.row_count(), size_t(frame.num_rows));
 }
 
-TEST(Append, MergeDescriptorsPromote) {
+TEST(Append, MergeDescriptorsPromote)
+{
     using namespace arcticdb;
 
     StreamId id{"test_desc"};
     IndexDescriptor idx{1u, IndexDescriptor::TIMESTAMP};
 
-    std::vector<FieldDescriptor> fields {
-        FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
+    std::vector<FieldDescriptor> fields{FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
         FieldDescriptor{scalar_field_proto(DataType::INT8, "int8")},
         FieldDescriptor{scalar_field_proto(DataType::INT16, "int16")},
         FieldDescriptor{scalar_field_proto(DataType::UINT8, "uint8")},
-        FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint16")}
-    };
+        FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint16")}};
 
-    StreamDescriptor original{
-        id, idx, fields_proto_from_range(fields)
-    };
+    StreamDescriptor original{id, idx, fields_proto_from_range(fields)};
 
-    std::vector<std::vector<FieldDescriptor>> new_fields {{
-        FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
-        FieldDescriptor{scalar_field_proto(DataType::INT16, "int8")},
-        FieldDescriptor{scalar_field_proto(DataType::INT32, "int16")},
-        FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint8")},
-        FieldDescriptor{scalar_field_proto(DataType::UINT32, "uint16")}
-    }};
+    std::vector<std::vector<FieldDescriptor>> new_fields{
+        {FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
+            FieldDescriptor{scalar_field_proto(DataType::INT16, "int8")},
+            FieldDescriptor{scalar_field_proto(DataType::INT32, "int16")},
+            FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint8")},
+            FieldDescriptor{scalar_field_proto(DataType::UINT32, "uint16")}}};
 
-    auto new_desc = stream::merge_descriptors(original, { fields_proto_from_range(new_fields[0]) }, std::vector<std::string>{});
+    auto new_desc =
+        stream::merge_descriptors(original, {fields_proto_from_range(new_fields[0])}, std::vector<std::string>{});
     auto new_proto = fields_proto_from_range(new_fields[0]);
     google::protobuf::util::MessageDifferencer diff;
-    auto result = std::equal(std::begin(new_desc.fields()), std::end(new_desc.fields()), std::begin(new_proto), std::end(new_proto), [&diff]
-        (const auto& left, const auto& right) {
-        return diff.Compare(left, right);
-    });
+    auto result = std::equal(std::begin(new_desc.fields()),
+        std::end(new_desc.fields()),
+        std::begin(new_proto),
+        std::end(new_proto),
+        [&diff](const auto& left, const auto& right) { return diff.Compare(left, right); });
     ASSERT_EQ(result, true);
 }
 
-
-TEST(Append, MergeDescriptorsNoPromote) {
+TEST(Append, MergeDescriptorsNoPromote)
+{
     using namespace arcticdb;
 
     StreamId id{"test_desc"};
     IndexDescriptor idx{1u, IndexDescriptor::TIMESTAMP};
 
-    std::vector<FieldDescriptor> fields {
-        FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
+    std::vector<FieldDescriptor> fields{FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
         FieldDescriptor{scalar_field_proto(DataType::INT8, "int8")},
         FieldDescriptor{scalar_field_proto(DataType::INT16, "int16")},
         FieldDescriptor{scalar_field_proto(DataType::UINT8, "uint8")},
-        FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint16")}
-    };
+        FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint16")}};
 
-    StreamDescriptor original{
-        id, idx, fields_proto_from_range(fields)
-    };
+    StreamDescriptor original{id, idx, fields_proto_from_range(fields)};
 
-    std::vector<std::vector<FieldDescriptor>> new_fields {{
-      FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
-      FieldDescriptor{scalar_field_proto(DataType::INT8, "int8")},
-      FieldDescriptor{scalar_field_proto(DataType::INT16, "int16")},
-      FieldDescriptor{scalar_field_proto(DataType::UINT8, "uint8")},
-      FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint16")}
-    }};
+    std::vector<std::vector<FieldDescriptor>> new_fields{
+        {FieldDescriptor{scalar_field_proto(DataType::MICROS_UTC64, "time")},
+            FieldDescriptor{scalar_field_proto(DataType::INT8, "int8")},
+            FieldDescriptor{scalar_field_proto(DataType::INT16, "int16")},
+            FieldDescriptor{scalar_field_proto(DataType::UINT8, "uint8")},
+            FieldDescriptor{scalar_field_proto(DataType::UINT16, "uint16")}}};
 
-    auto new_desc = stream::merge_descriptors(original, { fields_proto_from_range(new_fields[0]) }, std::vector<std::string>{});
+    auto new_desc =
+        stream::merge_descriptors(original, {fields_proto_from_range(new_fields[0])}, std::vector<std::string>{});
     google::protobuf::util::MessageDifferencer diff;
-    auto result = std::equal(std::begin(new_desc.fields()), std::end(new_desc.fields()), std::begin(original), std::end(original), [&diff]
-    (const auto& left, const auto& right) {
-        return diff.Compare(left, right);
-    });
+    auto result = std::equal(std::begin(new_desc.fields()),
+        std::end(new_desc.fields()),
+        std::begin(original),
+        std::end(original),
+        [&diff](const auto& left, const auto& right) { return diff.Compare(left, right); });
     ASSERT_EQ(result, true);
 }
-
-

--- a/cpp/arcticdb/stream/test/test_row_builder.cpp
+++ b/cpp/arcticdb/stream/test/test_row_builder.cpp
@@ -17,25 +17,25 @@ struct SegmentHolder {
     arcticdb::SegmentInMemory segment;
 };
 
-TEST(RowBuilder, Basic) {
+TEST(RowBuilder, Basic)
+{
     using namespace arcticdb;
     const auto index = as::TimeseriesIndex::default_index();
-    as::FixedSchema schema{
-        index.create_stream_descriptor(123, {
-            arcticdb::scalar_field_proto(DataType::UINT8, "bbb"),
-            arcticdb::scalar_field_proto(DataType::INT8, "AAA"),
-        }), index
-    };
+    as::FixedSchema schema{index.create_stream_descriptor(123,
+                               {
+                                   arcticdb::scalar_field_proto(DataType::UINT8, "bbb"),
+                                   arcticdb::scalar_field_proto(DataType::INT8, "AAA"),
+                               }),
+        index};
 
     SegmentHolder holder;
 
-    as::FixedTimestampAggregator agg(std::move(schema), [&](SegmentInMemory &&mem) {
-        holder.segment = std::move(mem);
-    });
+    as::FixedTimestampAggregator agg(std::move(schema),
+        [&](SegmentInMemory&& mem) { holder.segment = std::move(mem); });
 
     ASSERT_EQ(agg.row_count(), 0);
 
-    auto &rb = agg.row_builder();
+    auto& rb = agg.row_builder();
 
     ASSERT_TRUE(rb.find_field("AAA"));
     ASSERT_FALSE(rb.find_field("BBB"));
@@ -48,7 +48,7 @@ TEST(RowBuilder, Basic) {
 
     // now using the transactional api with auto commit
     // out of order fields are ok
-    agg.start_row(arcticdb::timestamp{2})([](auto &rb) {
+    agg.start_row(arcticdb::timestamp{2})([](auto& rb) {
         rb.set_scalar(2, int8_t{-66});
         rb.set_scalar(1, uint8_t{42});
     });
@@ -56,10 +56,10 @@ TEST(RowBuilder, Basic) {
     ASSERT_EQ(2, agg.row_count());
 
     // TODO uncomment this once rollback on segment is implemented
-//    ASSERT_THROW(agg.start_row(timestamp{3})([](auto & rb){
-//       rb.set_scalar(1, 666.);
-//    }), std::invalid_argument);
-//    ASSERT_EQ(2, agg.row_count());
+    //    ASSERT_THROW(agg.start_row(timestamp{3})([](auto & rb){
+    //       rb.set_scalar(1, 666.);
+    //    }), std::invalid_argument);
+    //    ASSERT_EQ(2, agg.row_count());
 
     // monotonic index
     ASSERT_THROW(rb.start_row(timestamp{1}), ArcticCategorizedException<ErrorCategory::INTERNAL>);
@@ -82,7 +82,4 @@ TEST(RowBuilder, Basic) {
     rb.set_scalar(1, uint8_t{3});
     rb.set_scalar(2, int8_t{-2});
     rb.end_row();
-
 }
-
-

--- a/cpp/arcticdb/stream/test/test_segment_aggregator.cpp
+++ b/cpp/arcticdb/stream/test/test_segment_aggregator.cpp
@@ -11,7 +11,8 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/test/generators.hpp>
 
-TEST(SegmentAggregator, Basic) {
+TEST(SegmentAggregator, Basic)
+{
     using namespace arcticdb;
 
     std::string symbol{"aggregator"};
@@ -20,13 +21,12 @@ TEST(SegmentAggregator, Basic) {
 
     size_t count = 0;
     for (size_t i = 0; i < 10; ++i) {
-        auto wrapper = SinkWrapper(symbol, {
-            scalar_field_proto(DataType::UINT64, "numbers"),
-            scalar_field_proto(DataType::ASCII_DYNAMIC64, "strings")
-        });
+        auto wrapper = SinkWrapper(symbol,
+            {scalar_field_proto(DataType::UINT64, "numbers"),
+                scalar_field_proto(DataType::ASCII_DYNAMIC64, "strings")});
 
-        for(timestamp j = 0; j < 20; ++j ) {
-            wrapper.aggregator_.start_row(timestamp(count++))([&](auto &&rb) {
+        for (timestamp j = 0; j < 20; ++j) {
+            wrapper.aggregator_.start_row(timestamp(count++))([&](auto&& rb) {
                 rb.set_scalar(1, j);
                 rb.set_string(2, fmt::format("{}", i + j));
             });
@@ -36,12 +36,12 @@ TEST(SegmentAggregator, Basic) {
         segments.emplace_back(std::move(wrapper.segment()));
     }
 
-    SegmentSinkWrapper seg_wrapper(symbol, TimeseriesIndex::default_index(), {
-        FieldDescriptor{scalar_field_proto(DataType::UINT64, "numbers")},
-        FieldDescriptor{scalar_field_proto(DataType::ASCII_DYNAMIC64, "strings")}
-    });
+    SegmentSinkWrapper seg_wrapper(symbol,
+        TimeseriesIndex::default_index(),
+        {FieldDescriptor{scalar_field_proto(DataType::UINT64, "numbers")},
+            FieldDescriptor{scalar_field_proto(DataType::ASCII_DYNAMIC64, "strings")}});
 
-    for(auto& segment : segments) {
+    for (auto& segment : segments) {
         pipelines::FrameSlice slice(segment);
         seg_wrapper.aggregator_.add_segment(std::move(segment), slice, false);
     }
@@ -51,8 +51,8 @@ TEST(SegmentAggregator, Basic) {
 
     count = 0;
     for (size_t i = 0; i < 10; ++i) {
-        for(size_t j = 0; j < 20; ++j ) {
-            ASSERT_EQ(seg.scalar_at<uint64_t >(count, 1), j);
+        for (size_t j = 0; j < 20; ++j) {
+            ASSERT_EQ(seg.scalar_at<uint64_t>(count, 1), j);
             auto str = seg.string_at(count, 2).value();
             ASSERT_EQ(str, fmt::format("{}", i + j));
             ++count;

--- a/cpp/arcticdb/stream/test/test_types.cpp
+++ b/cpp/arcticdb/stream/test/test_types.cpp
@@ -13,32 +13,30 @@
 #include <iostream>
 #include <type_traits>
 
-TEST(TickStreamDesc, FromFields) {
+TEST(TickStreamDesc, FromFields)
+{
     using namespace arcticdb::entity;
     using namespace arcticdb;
-    StreamDescriptor tsd{stream_descriptor(
-        123,
+    StreamDescriptor tsd{stream_descriptor(123,
         stream::TimeseriesIndex::default_index(),
-        {
-            scalar_field_proto(DataType::UINT8, "uint8"),
-            scalar_field_proto(DataType::INT8, "int8")
-        })};
+        {scalar_field_proto(DataType::UINT8, "uint8"), scalar_field_proto(DataType::INT8, "int8")})};
     ASSERT_EQ(fmt::format("{}", tsd),
-              "TSD<tsid=123, idx=IDX<size=1, kind=T>, fields=[time: TD<type=MICROS_UTC64, dim=0>, uint8: TD<type=UINT8, dim=0>, int8: TD<type=INT8, dim=0>]>");
+        "TSD<tsid=123, idx=IDX<size=1, kind=T>, fields=[time: TD<type=MICROS_UTC64, dim=0>, uint8: TD<type=UINT8, "
+        "dim=0>, int8: TD<type=INT8, dim=0>]>");
 }
 
-TEST(DataTypeVisit, VisitTag) {
+TEST(DataTypeVisit, VisitTag)
+{
     using namespace arcticdb::entity;
     using namespace arcticdb;
     TypeDescriptor td(DataType::UINT8, 1);
     td.visit_tag([&](auto type_desc_tag) {
         TypeDescriptor td2 = static_cast<TypeDescriptor>(type_desc_tag);
         ASSERT_EQ(td, td2);
-        using TD=TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension::Dim1>>;
+        using TD = TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension::Dim1>>;
         bool b = std::is_same_v<TD, std::decay_t<decltype(type_desc_tag)>>;
         bool c = std::is_same_v<TD::DataTypeTag::raw_type, uint8_t>;
         ASSERT_TRUE(b);
         ASSERT_TRUE(c);
     });
-
 }

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -21,67 +21,73 @@ namespace arcticdb::toolbox::apy {
 
 using namespace arcticdb::entity;
 
-Segment LibraryTool::read_to_segment(const VariantKey& key) {
-    auto kv = std::visit([lib=lib_](const auto &k) { return lib->read(k); }, key);
+Segment LibraryTool::read_to_segment(const VariantKey& key)
+{
+    auto kv = std::visit([lib = lib_](const auto& k) { return lib->read(k); }, key);
     util::check(kv.has_segment(), "Failed to read key: {}", key);
     return kv.segment();
 }
 
-void LibraryTool::write(VariantKey key, Segment segment) {
+void LibraryTool::write(VariantKey key, Segment segment)
+{
     storage::KeySegmentPair kv{std::move(key), std::move(segment)};
     lib_->write(Composite<storage::KeySegmentPair>{std::move(kv)});
 }
 
-void LibraryTool::remove(VariantKey key) {
+void LibraryTool::remove(VariantKey key)
+{
     lib_->remove(Composite<VariantKey>{std::move(key)}, storage::RemoveOpts{});
 }
 
-void LibraryTool::clear_ref_keys() {
+void LibraryTool::clear_ref_keys()
+{
     auto store = std::make_shared<arcticdb::async::AsyncStore<util::SysClock>>(lib_, codec::default_lz4_codec());
     delete_all_keys_of_type(KeyType::SNAPSHOT_REF, store, false);
 }
 
-std::vector<VariantKey> LibraryTool::find_keys(entity::KeyType kt) {
+std::vector<VariantKey> LibraryTool::find_keys(entity::KeyType kt)
+{
     std::vector<VariantKey> res;
-    lib_->iterate_type(kt, [&](auto &&found_key) {
-        res.emplace_back(found_key);
-    });
+    lib_->iterate_type(kt, [&](auto&& found_key) { res.emplace_back(found_key); });
     return res;
 }
 
-int LibraryTool::count_keys(entity::KeyType kt) {
+int LibraryTool::count_keys(entity::KeyType kt)
+{
     int count = 0;
-    lib_->iterate_type(kt, [&](auto &&found_key ARCTICDB_UNUSED) {
-        count++;
-    });
+    lib_->iterate_type(kt, [&](auto&& found_key ARCTICDB_UNUSED) { count++; });
     return count;
 }
 
-std::vector<bool> LibraryTool::batch_key_exists(const std::vector<VariantKey>& keys) {
+std::vector<bool> LibraryTool::batch_key_exists(const std::vector<VariantKey>& keys)
+{
     auto store = std::make_shared<arcticdb::async::AsyncStore<util::SysClock>>(lib_, codec::default_lz4_codec());
     auto key_exists_fut = store->batch_key_exists(keys);
     return folly::collect(key_exists_fut).get();
 }
 
-std::vector<VariantKey> LibraryTool::find_keys_for_id(entity::KeyType kt, const StreamId &stream_id) {
+std::vector<VariantKey> LibraryTool::find_keys_for_id(entity::KeyType kt, const StreamId& stream_id)
+{
     util::check(std::holds_alternative<StringId>(stream_id), "keys for id only implemented for string ids");
 
     std::vector<VariantKey> res;
-    const auto &string_id = std::get<StringId>(stream_id);
-    lib_->iterate_type(kt, [&](auto &&found_key) {
-        // Only S3 handles the prefix in iterate_type, the others just return everything, thus the additional check.
-        if (variant_key_id(found_key) == stream_id) {
-            res.emplace_back(found_key);
-        }
-    }, string_id);
+    const auto& string_id = std::get<StringId>(stream_id);
+    lib_->iterate_type(
+        kt,
+        [&](auto&& found_key) {
+            // Only S3 handles the prefix in iterate_type, the others just return everything, thus the additional check.
+            if (variant_key_id(found_key) == stream_id) {
+                res.emplace_back(found_key);
+            }
+        },
+        string_id);
     return res;
 }
 
-std::string LibraryTool::get_key_path(const VariantKey& key) {
+std::string LibraryTool::get_key_path(const VariantKey& key)
+{
     std::string out = "";
-    lib_->storage_specific([&out, &key](const storage::s3::S3Storage& s3) {
-        out = s3.get_key_path(key);
-    });
+    lib_->storage_specific([&out, &key](const storage::s3::S3Storage& s3) { out = s3.get_key_path(key); });
     return out;
 }
 

--- a/cpp/arcticdb/toolbox/library_tool.hpp
+++ b/cpp/arcticdb/toolbox/library_tool.hpp
@@ -20,7 +20,7 @@ namespace arcticdb::storage {
 class Library;
 
 class LibraryIndex;
-}
+} // namespace arcticdb::storage
 
 namespace arcticdb::toolbox::apy {
 
@@ -29,7 +29,10 @@ namespace py = pybind11;
 class LibraryTool {
 
 public:
-    explicit LibraryTool(std::shared_ptr<storage::Library> lib) : lib_(std::move(lib)) {}
+    explicit LibraryTool(std::shared_ptr<storage::Library> lib)
+        : lib_(std::move(lib))
+    {
+    }
 
     Segment read_to_segment(const VariantKey& key);
 
@@ -43,7 +46,7 @@ public:
 
     std::string get_key_path(const VariantKey& key);
 
-    std::vector<VariantKey> find_keys_for_id(entity::KeyType kt, const entity::StreamId &stream_id);
+    std::vector<VariantKey> find_keys_for_id(entity::KeyType kt, const entity::StreamId& stream_id);
 
     int count_keys(entity::KeyType kt);
 

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -14,7 +14,8 @@
 
 namespace arcticdb::toolbox::apy {
 
-void register_bindings(py::module &m) {
+void register_bindings(py::module& m)
+{
     auto tools = m.def_submodule("tools", "Library management tool hooks");
     using namespace arcticdb::toolbox::apy;
     using namespace arcticdb::storage;
@@ -22,41 +23,38 @@ void register_bindings(py::module &m) {
     tools.def("print_mem_usage", &util::print_total_mem_usage);
 
     py::class_<LibraryTool, std::shared_ptr<LibraryTool>>(tools, "LibraryTool")
-            .def(py::init<>([](std::shared_ptr<Library> lib) {
-                return std::make_shared<LibraryTool>(lib);
-            }))
-            .def("read_to_segment", &LibraryTool::read_to_segment)
-            .def("write", &LibraryTool::write)
-            .def("remove", &LibraryTool::remove)
-            .def("find_keys", &LibraryTool::find_keys)
-            .def("count_keys", &LibraryTool::count_keys)
-            .def("get_key_path", &LibraryTool::get_key_path)
-            .def("find_keys_for_id", &LibraryTool::find_keys_for_id)
-            .def("clear_ref_keys", &LibraryTool::clear_ref_keys)
-            .def("batch_key_exists", &LibraryTool::batch_key_exists);
+        .def(py::init<>([](std::shared_ptr<Library> lib) { return std::make_shared<LibraryTool>(lib); }))
+        .def("read_to_segment", &LibraryTool::read_to_segment)
+        .def("write", &LibraryTool::write)
+        .def("remove", &LibraryTool::remove)
+        .def("find_keys", &LibraryTool::find_keys)
+        .def("count_keys", &LibraryTool::count_keys)
+        .def("get_key_path", &LibraryTool::get_key_path)
+        .def("find_keys_for_id", &LibraryTool::find_keys_for_id)
+        .def("clear_ref_keys", &LibraryTool::clear_ref_keys)
+        .def("batch_key_exists", &LibraryTool::batch_key_exists);
 
     // S3 Storage tool
     using namespace arcticdb::storage::s3;
     py::class_<S3StorageTool, std::shared_ptr<S3StorageTool>>(tools, "S3Tool")
-            .def(py::init<>([](
-                    const std::string &bucket_name,
-                    const std::string &credential_name,
-                    const std::string &credential_key,
-                    const std::string &endpoint) -> std::shared_ptr<S3StorageTool> {
-                arcticc::pb2::s3_storage_pb2::Config cfg;
-                cfg.set_bucket_name(bucket_name);
-                cfg.set_credential_name(credential_name);
-                cfg.set_credential_key(credential_key);
-                cfg.set_endpoint(endpoint);
-                return std::make_shared<S3StorageTool>(cfg);
-            }))
-            .def("list_bucket", &S3StorageTool::list_bucket)
-            .def("delete_bucket", &S3StorageTool::delete_bucket)
-            .def("write_object", &S3StorageTool::set_object)
-            .def("get_object", &S3StorageTool::get_object)
-            .def("get_prefix_info", &S3StorageTool::get_prefix_info)
-            .def("get_object_size", &S3StorageTool::get_file_size)
-            .def("delete_object", &S3StorageTool::delete_object);
+        .def(py::init<>([](const std::string& bucket_name,
+                            const std::string& credential_name,
+                            const std::string& credential_key,
+                            const std::string& endpoint) -> std::shared_ptr<S3StorageTool> {
+            arcticc::pb2::s3_storage_pb2::Config cfg;
+            cfg.set_bucket_name(bucket_name);
+            cfg.set_credential_name(credential_name);
+            cfg.set_credential_key(credential_key);
+            cfg.set_endpoint(endpoint);
+            return std::make_shared<S3StorageTool>(cfg);
+        }))
+        .def("list_bucket", &S3StorageTool::list_bucket)
+        .def("delete_bucket", &S3StorageTool::delete_bucket)
+        .def("write_object", &S3StorageTool::set_object)
+        .def("get_object", &S3StorageTool::get_object)
+        .def("get_prefix_info", &S3StorageTool::get_prefix_info)
+        .def("get_object_size", &S3StorageTool::get_file_size)
+        .def("delete_object", &S3StorageTool::delete_object);
 }
 
 } // namespace arcticdb::toolbox::apy

--- a/cpp/arcticdb/toolbox/python_bindings.hpp
+++ b/cpp/arcticdb/toolbox/python_bindings.hpp
@@ -20,8 +20,6 @@ namespace arcticdb::toolbox::apy {
 
 namespace py = pybind11;
 
-void register_bindings(py::module &m);
+void register_bindings(py::module& m);
 
 } // namespace arcticdb::toolbox::apy
-
-

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -9,41 +9,51 @@
 
 namespace arcticdb {
 
-void SharedMemoryAllocator::init(){
+void SharedMemoryAllocator::init()
+{
     SharedMemoryAllocator::instance_ = std::make_shared<SharedMemoryAllocator>();
 }
 
-std::shared_ptr<SharedMemoryAllocator> SharedMemoryAllocator::instance() {
+std::shared_ptr<SharedMemoryAllocator> SharedMemoryAllocator::instance()
+{
     std::call_once(SharedMemoryAllocator::init_flag_, &SharedMemoryAllocator::init);
     return SharedMemoryAllocator::instance_;
 }
 
-void SharedMemoryAllocator::destroy_instance() {
+void SharedMemoryAllocator::destroy_instance()
+{
     SharedMemoryAllocator::instance_.reset();
 }
 
 std::shared_ptr<SharedMemoryAllocator> SharedMemoryAllocator::instance_;
 std::once_flag SharedMemoryAllocator::init_flag_;
 
-void TracingData::init() {
+void TracingData::init()
+{
     TracingData::instance_ = std::make_shared<TracingData>();
 }
 
-std::shared_ptr<TracingData> TracingData::instance() {
+std::shared_ptr<TracingData> TracingData::instance()
+{
     std::call_once(TracingData::init_flag_, &TracingData::init);
     return TracingData::instance_;
 }
 
-void TracingData::destroy_instance() {
+void TracingData::destroy_instance()
+{
     TracingData::instance_.reset();
 }
 
 std::shared_ptr<TracingData> TracingData::instance_;
 std::once_flag TracingData::init_flag_;
 
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>::free_count_;
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::LinearClock>::free_count_;
+template<>
+folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>::free_count_;
+template<>
+folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::LinearClock>::free_count_;
 
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::SysClock>::free_count_;
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::SysClock>::free_count_;
-}
+template<>
+folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::SysClock>::free_count_;
+template<>
+folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::SysClock>::free_count_;
+} // namespace arcticdb

--- a/cpp/arcticdb/util/bitset.hpp
+++ b/cpp/arcticdb/util/bitset.hpp
@@ -27,7 +27,8 @@ using BitIndex = bm::bvector<>::rs_index_type;
 
 } // namespace util
 
-constexpr bm::bvector<>::size_type bv_size(uint64_t val) {
+constexpr bm::bvector<>::size_type bv_size(uint64_t val)
+{
     return static_cast<bm::bvector<>::size_type>(val);
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -25,51 +25,70 @@ struct Buffer;
 template<class T, bool owning>
 struct BaseBuffer {
     template<class B, std::enable_if_t<std::is_same_v<std::decay_t<B>, Buffer>, int> = 0>
-    void copy_to(B &dest) const {
+    void copy_to(B& dest) const
+    {
         dest.ensure(derived().bytes());
         std::memcpy(dest.data(), derived().data(), derived().bytes());
     }
 
-    [[nodiscard]] const T &derived() const {
-        return *(static_cast<const T *>(this));
+    [[nodiscard]] const T& derived() const
+    {
+        return *(static_cast<const T*>(this));
     }
 };
 
 struct BufferView : public BaseBuffer<BufferView, false> {
     BufferView() = default;
-    BufferView(uint8_t *data, size_t size) : data_(data), bytes_(size) {}
+    BufferView(uint8_t* data, size_t size)
+        : data_(data),
+          bytes_(size)
+    {
+    }
 
-    friend void swap(BufferView &a, BufferView &b) noexcept {
+    friend void swap(BufferView& a, BufferView& b) noexcept
+    {
         using std::swap;
         swap(a.data_, b.data_);
         swap(a.bytes_, b.bytes_);
     }
 
-    [[nodiscard]] uint8_t *data() { return data_; }
-    [[nodiscard]] const uint8_t *data() const { return data_; }
-    [[nodiscard]] size_t bytes() const { return bytes_; }
+    [[nodiscard]] uint8_t* data()
+    {
+        return data_;
+    }
+    [[nodiscard]] const uint8_t* data() const
+    {
+        return data_;
+    }
+    [[nodiscard]] size_t bytes() const
+    {
+        return bytes_;
+    }
 
-  private:
+private:
     uint8_t* data_ = nullptr;
     size_t bytes_ = 0;
 };
 
 struct Buffer : public BaseBuffer<Buffer, true> {
-    explicit Buffer(size_t size, std::optional<size_t> preamble = std::nullopt) :
-        preamble_bytes_(preamble.value_or(0)) {
+    explicit Buffer(size_t size, std::optional<size_t> preamble = std::nullopt)
+        : preamble_bytes_(preamble.value_or(0))
+    {
         ensure(size);
         check_invariants();
     }
 
     Buffer() = default;
 
-    Buffer(Buffer &&other) noexcept {
+    Buffer(Buffer&& other) noexcept
+    {
         ARCTICDB_TRACE(log::version(), "Buffer {} being move constructed", uintptr_t(this));
-            *this = std::move(other);
+        *this = std::move(other);
         check_invariants();
     }
 
-    Buffer &operator=(Buffer &&b) noexcept {
+    Buffer& operator=(Buffer&& b) noexcept
+    {
         ARCTICDB_TRACE(log::version(), "Buffer {} being move assigned", uintptr_t(this));
         deallocate();
         using std::swap;
@@ -80,11 +99,13 @@ struct Buffer : public BaseBuffer<Buffer, true> {
 
     ARCTICDB_NO_COPY(Buffer)
 
-    ~Buffer() {
+    ~Buffer()
+    {
         deallocate();
     }
 
-    void set_preamble(size_t pos) {
+    void set_preamble(size_t pos)
+    {
         util::check(pos <= capacity_, "Can't set preamble past the end of the buffer");
         preamble_bytes_ = pos;
         ptr_ += pos;
@@ -92,8 +113,9 @@ struct Buffer : public BaseBuffer<Buffer, true> {
         check_invariants();
     }
 
-    void deallocate() {
-        if(data_ != nullptr)
+    void deallocate()
+    {
+        if (data_ != nullptr)
             Allocator::free(std::make_pair(data_, ts_));
 
         data_ = nullptr;
@@ -105,7 +127,8 @@ struct Buffer : public BaseBuffer<Buffer, true> {
         check_invariants();
     }
 
-    void reset() {
+    void reset()
+    {
         preamble_bytes_ = 0;
         ts_ = 0;
         body_bytes_ = 0;
@@ -114,12 +137,25 @@ struct Buffer : public BaseBuffer<Buffer, true> {
         check_invariants();
     }
 
-    [[nodiscard]] bool empty() const { return bytes() == 0; }
-    [[nodiscard]] uint8_t *data() { return ptr_; }
-    [[nodiscard]] const uint8_t *data() const { return ptr_; }
-    [[nodiscard]] size_t bytes() const { return body_bytes_; }
+    [[nodiscard]] bool empty() const
+    {
+        return bytes() == 0;
+    }
+    [[nodiscard]] uint8_t* data()
+    {
+        return ptr_;
+    }
+    [[nodiscard]] const uint8_t* data() const
+    {
+        return ptr_;
+    }
+    [[nodiscard]] size_t bytes() const
+    {
+        return body_bytes_;
+    }
 
-    friend void swap(Buffer &a, Buffer &b) noexcept {
+    friend void swap(Buffer& a, Buffer& b) noexcept
+    {
         ARCTICDB_TRACE(log::version(), "Buffer {} swap {}", uintptr_t(&a), uintptr_t(&b));
         using std::swap;
         a.check_invariants();
@@ -136,26 +172,28 @@ struct Buffer : public BaseBuffer<Buffer, true> {
         b.check_invariants();
     }
 
-    [[nodiscard]] Buffer clone() const {
+    [[nodiscard]] Buffer clone() const
+    {
         ARCTICDB_TRACE(log::version(), "Buffer {} being cloned", uintptr_t(this));
-        Buffer output{ body_bytes_, preamble_bytes_};
-        if(data_ != nullptr && output.data_ != nullptr)
+        Buffer output{body_bytes_, preamble_bytes_};
+        if (data_ != nullptr && output.data_ != nullptr)
             memcpy(output.data_, data_, total_bytes());
 
         return output;
     }
 
     template<typename T>
-    T *ptr_cast(size_t bytes_offset, size_t required_bytes) {
+    T* ptr_cast(size_t bytes_offset, size_t required_bytes)
+    {
         check_invariants();
-        if (bytes_offset  + required_bytes > bytes()) {
-            std::string err = fmt::format("Cursor overflow in reallocating buffer ptr_cast, cannot read {} bytes from a buffer of size {} with cursor "
+        if (bytes_offset + required_bytes > bytes()) {
+            std::string err = fmt::format("Cursor overflow in reallocating buffer ptr_cast, cannot read {} bytes from "
+                                          "a buffer of size {} with cursor "
                                           "at {}, as it would required {} bytes. ",
-                                          required_bytes,
-                                          bytes(),
-                                          bytes_offset,
-                                          bytes_offset + required_bytes
-            );
+                required_bytes,
+                bytes(),
+                bytes_offset,
+                bytes_offset + required_bytes);
             ARCTICDB_TRACE(log::memory(), err);
             throw ArcticCategorizedException<ErrorCategory::INTERNAL>(err);
         }
@@ -164,97 +202,139 @@ struct Buffer : public BaseBuffer<Buffer, true> {
     }
 
     template<typename T>
-    const T *ptr_cast(size_t bytes_offset, size_t required_bytes) const {
+    const T* ptr_cast(size_t bytes_offset, size_t required_bytes) const
+    {
         return const_cast<Buffer*>(this)->ptr_cast<T>(bytes_offset, required_bytes);
     }
 
-    inline void ensure(size_t bytes) {
+    inline void ensure(size_t bytes)
+    {
         ARCTICDB_TRACE(log::version(), "Buffer {} ensure {}", uintptr_t(this), bytes);
-        if(bytes > available())
+        if (bytes > available())
             resize(bytes);
         else {
-            ARCTICDB_TRACE(log::version(), "Buffer {} has sufficient bytes for {}, ptr {} data{}, capacity {}",
-                                uintptr_t(this), bytes, uintptr_t(ptr_), uintptr_t(data_), capacity_, body_bytes_);
+            ARCTICDB_TRACE(log::version(),
+                "Buffer {} has sufficient bytes for {}, ptr {} data{}, capacity {}",
+                uintptr_t(this),
+                bytes,
+                uintptr_t(ptr_),
+                uintptr_t(data_),
+                capacity_,
+                body_bytes_);
         }
 
         body_bytes_ = bytes;
         check_invariants();
     }
 
-    inline void set_bytes(size_t bytes) {
+    inline void set_bytes(size_t bytes)
+    {
         util::check(bytes <= available(), "Can't set bytes to larger than the buffer: {} > {}", bytes, available());
         body_bytes_ = bytes;
         check_invariants();
     }
 
-    inline void assert_size(size_t bytes) const {
-        util::check(bytes <= body_bytes_, "Expected allocation size {} smaller than actual allocation {}", bytes, body_bytes_);
+    inline void assert_size(size_t bytes) const
+    {
+        util::check(bytes <= body_bytes_,
+            "Expected allocation size {} smaller than actual allocation {}",
+            bytes,
+            body_bytes_);
     }
 
-    [[nodiscard]] BufferView view() const {
+    [[nodiscard]] BufferView view() const
+    {
         return {ptr_, body_bytes_};
     }
 
-    uint8_t &operator[](size_t bytes_offset) {
+    uint8_t& operator[](size_t bytes_offset)
+    {
         return ptr_[bytes_offset];
     }
 
-    const uint8_t &operator[](size_t bytes_offset) const {
+    const uint8_t& operator[](size_t bytes_offset) const
+    {
         return ptr_[bytes_offset];
     }
 
-    [[nodiscard]] size_t total_bytes() const {
+    [[nodiscard]] size_t total_bytes() const
+    {
         return preamble_bytes_ + body_bytes_;
     }
 
-    [[nodiscard]] size_t preamble_bytes() const {
+    [[nodiscard]] size_t preamble_bytes() const
+    {
         return preamble_bytes_;
     }
 
-    uint8_t* preamble() {
+    uint8_t* preamble()
+    {
         return data_;
     }
-    
-    size_t available() const {
+
+    size_t available() const
+    {
         return capacity_ >= preamble_bytes_ ? capacity_ - preamble_bytes_ : 0;
     }
 
-  private:
-    inline void resize(size_t bytes) {
+private:
+    inline void resize(size_t bytes)
+    {
         if (bytes == 0) {
             reset();
         } else {
             ARCTICDB_TRACE(log::version(), "{} resizing from {} to {}", uintptr_t(this), capacity_, bytes);
             auto alloc_bytes = bytes + preamble_bytes_;
-            auto [mem_ptr, ts] = ptr_ ?
-                                 Allocator::realloc(std::make_pair(data_, ts_), alloc_bytes)
-                                      :
-                                 Allocator::aligned_alloc(alloc_bytes);
+            auto [mem_ptr, ts] = ptr_ ? Allocator::realloc(std::make_pair(data_, ts_), alloc_bytes)
+                                      : Allocator::aligned_alloc(alloc_bytes);
 
-            ARCTICDB_TRACE(log::codec(), "Allocating {} bytes ({} + {} bytes preamble)", alloc_bytes, bytes, preamble_bytes_);
+            ARCTICDB_TRACE(log::codec(),
+                "Allocating {} bytes ({} + {} bytes preamble)",
+                alloc_bytes,
+                bytes,
+                preamble_bytes_);
             if (mem_ptr) {
                 data_ = mem_ptr;
                 ptr_ = data_ + preamble_bytes_;
                 ts_ = ts;
                 body_bytes_ = bytes;
                 capacity_ = body_bytes_ + preamble_bytes_;
-                ARCTICDB_TRACE(log::version(), "Buffer {} did realloc for {}, ptr {} data {}, capacity {}",
-                                    uintptr_t(this), bytes,  uintptr_t(ptr_), uintptr_t(data_), capacity_, body_bytes_);
+                ARCTICDB_TRACE(log::version(),
+                    "Buffer {} did realloc for {}, ptr {} data {}, capacity {}",
+                    uintptr_t(this),
+                    bytes,
+                    uintptr_t(ptr_),
+                    uintptr_t(data_),
+                    capacity_,
+                    body_bytes_);
             } else
                 throw std::bad_alloc();
         }
         check_invariants();
     }
 
-    void check_invariants() const  {
+    void check_invariants() const
+    {
 #ifdef DEBUG_BUILD
-        util::check(preamble_bytes_ + body_bytes_ <= capacity_, "total_bytes exceeds capacity {} + {} > {}", preamble_bytes_, body_bytes_, capacity_);
-        util::check(total_bytes() == preamble_bytes_ + body_bytes_, "Total bytes calculation is incorrect {} != {} + {}", total_bytes(), preamble_bytes_, body_bytes_);
-        util::check(data_ + preamble_bytes_ == ptr_, "Buffer pointer is in the wrong place {} + {} != {}", uintptr_t(data_), preamble_bytes_, uintptr_t(ptr_));
+        util::check(preamble_bytes_ + body_bytes_ <= capacity_,
+            "total_bytes exceeds capacity {} + {} > {}",
+            preamble_bytes_,
+            body_bytes_,
+            capacity_);
+        util::check(total_bytes() == preamble_bytes_ + body_bytes_,
+            "Total bytes calculation is incorrect {} != {} + {}",
+            total_bytes(),
+            preamble_bytes_,
+            body_bytes_);
+        util::check(data_ + preamble_bytes_ == ptr_,
+            "Buffer pointer is in the wrong place {} + {} != {}",
+            uintptr_t(data_),
+            preamble_bytes_,
+            uintptr_t(ptr_));
 #endif
     }
 
-    uint8_t *data_ = nullptr;
+    uint8_t* data_ = nullptr;
     uint8_t* ptr_ = nullptr;
     size_t capacity_ = 0;
     size_t body_bytes_ = 0;
@@ -263,6 +343,5 @@ struct Buffer : public BaseBuffer<Buffer, true> {
 };
 
 using VariantBuffer = std::variant<std::monostate, std::shared_ptr<Buffer>, BufferView>;
-
 
 } // namespace arcticdb

--- a/cpp/arcticdb/util/buffer_holder.hpp
+++ b/cpp/arcticdb/util/buffer_holder.hpp
@@ -15,11 +15,12 @@ struct BufferHolder {
     std::vector<std::shared_ptr<Column>> columns_;
     std::mutex mutex_;
 
-    std::shared_ptr<Column> get_buffer(const TypeDescriptor& td, bool allow_sparse) {
+    std::shared_ptr<Column> get_buffer(const TypeDescriptor& td, bool allow_sparse)
+    {
         std::lock_guard lock(mutex_);
         auto column = std::make_shared<Column>(td, allow_sparse);
         columns_.emplace_back(column);
         return column;
     }
 };
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/buffer_pool.cpp
+++ b/cpp/arcticdb/util/buffer_pool.cpp
@@ -10,28 +10,30 @@
 
 namespace arcticdb {
 
-std::shared_ptr<BufferPool> BufferPool::instance(){
+std::shared_ptr<BufferPool> BufferPool::instance()
+{
     std::call_once(BufferPool::init_flag_, &BufferPool::init);
     return BufferPool::instance_;
 }
 
-void BufferPool::destroy_instance() {
-    if(instance_)
+void BufferPool::destroy_instance()
+{
+    if (instance_)
         instance_->clear();
     instance_.reset();
 }
 
-void BufferPool::init() {
+void BufferPool::init()
+{
     instance_ = std::make_shared<BufferPool>();
 }
 
-BufferPool::BufferPool() : pool_(
-            [] () { return std::make_shared<Buffer>(); },
-            [] (std::shared_ptr<Buffer> buf) { buf->reset(); }
-    ){
+BufferPool::BufferPool()
+    : pool_([]() { return std::make_shared<Buffer>(); }, [](std::shared_ptr<Buffer> buf) { buf->reset(); })
+{
 }
 
 std::shared_ptr<BufferPool> BufferPool::instance_;
 std::once_flag BufferPool::init_flag_;
 
-}  //namespace arcticdb
+} //namespace arcticdb

--- a/cpp/arcticdb/util/buffer_pool.hpp
+++ b/cpp/arcticdb/util/buffer_pool.hpp
@@ -11,7 +11,6 @@
 
 #include <third_party/recycle/src/recycle/shared_pool.hpp>
 
-
 namespace arcticdb {
 
 struct lock_policy {
@@ -26,21 +25,24 @@ class BufferPool {
     static void init();
 
     recycle::shared_pool<Buffer, lock_policy> pool_;
+
 public:
     static std::shared_ptr<BufferPool> instance();
     static void destroy_instance();
 
     BufferPool();
 
-    auto allocate() {
+    auto allocate()
+    {
         auto output = pool_.allocate();
         ARCTICDB_DEBUG(log::version(), "Pool returning {}", uintptr_t(output.get()));
         return output;
     }
-    
-    void clear() {
+
+    void clear()
+    {
         pool_.free_unused();
     }
 };
 
- } //namespace arcticdb
+} //namespace arcticdb

--- a/cpp/arcticdb/util/clock.hpp
+++ b/cpp/arcticdb/util/clock.hpp
@@ -18,36 +18,36 @@
 namespace arcticdb::util {
 
 class SysClock {
-  public:
-    static entity::timestamp nanos_since_epoch() {
+public:
+    static entity::timestamp nanos_since_epoch()
+    {
         return (*folly::chrono::clock_gettime_ns)(CLOCK_REALTIME);
     }
 #if defined(_WIN32) || defined(__APPLE__)
-    static entity::timestamp coarse_nanos_since_epoch() {
+    static entity::timestamp coarse_nanos_since_epoch()
+    {
         auto t = std::chrono::system_clock::now();
         return std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count();
     }
 #else
-    static entity::timestamp coarse_nanos_since_epoch() {
+    static entity::timestamp coarse_nanos_since_epoch()
+    {
         return (*folly::chrono::clock_gettime_ns)(CLOCK_REALTIME_COARSE);
     }
 #endif
 };
 
-
 struct LinearClock {
     inline static std::atomic<entity::timestamp> time_{0};
 
-    static entity::timestamp nanos_since_epoch() {
+    static entity::timestamp nanos_since_epoch()
+    {
         return LinearClock::time_.fetch_add(1);
     }
-    static entity::timestamp coarse_nanos_since_epoch() {
+    static entity::timestamp coarse_nanos_since_epoch()
+    {
         return LinearClock::time_.fetch_add(1);
     }
 };
 
-
 } // namespace arcticdb::util
-
-
-

--- a/cpp/arcticdb/util/composite.hpp
+++ b/cpp/arcticdb/util/composite.hpp
@@ -28,187 +28,213 @@ struct Composite {
     using ValueVector = std::vector<ValueType>;
     ValueVector values_;
 
-        using RangeType = folly::Range<typename ValueVector::iterator>;
-        using RangePair = std::pair<RangeType, typename RangeType::iterator>;
+    using RangeType = folly::Range<typename ValueVector::iterator>;
+    using RangePair = std::pair<RangeType, typename RangeType::iterator>;
 
-        RangeType get_range() const {
-            return folly::Range(values_);
+    RangeType get_range() const
+    {
+        return folly::Range(values_);
+    }
+
+    RangePair range_pair() const
+    {
+        auto range = get_range();
+        auto pos = range.begin();
+        return {std::move(range), std::move(pos)};
+    }
+
+    template<class ValueType>
+    class CompositeIterator
+        : public boost::iterator_facade<Composite<ValueType>, ValueType, boost::forward_traversal_tag> {
+        Composite* parent_;
+        std::vector<RangePair> ranges_;
+
+    public:
+        explicit CompositeIterator(RangePair&& pair)
+        {
+            ranges_.emplace_back(std::move(pair));
         }
 
-       RangePair range_pair() const {
-            auto range = get_range();
-            auto pos = range.begin();
-            return {std::move(range), std::move(pos)};
+        CompositeIterator() = default;
+
+        const RangePair& current_pair()
+        {
+            return ranges_.back();
         }
 
-        template<class ValueType>
-        class CompositeIterator
-                : public boost::iterator_facade<Composite<ValueType>, ValueType, boost::forward_traversal_tag> {
-            Composite *parent_;
-            std::vector<RangePair> ranges_;
-
-        public:
-            explicit CompositeIterator(RangePair&& pair) {
-                ranges_.emplace_back(std::move(pair));
-            }
-
-            CompositeIterator() = default;
-
-            const RangePair& current_pair() {
-                return ranges_.back();
-            }
-
-            const ValueType& pos() {
-                return *ranges_.back().second;
-            }
-
-            void check_at_end() {
-                while(!ranges_.empty() && current_pair().second == current_pair().first.end())
-                    ranges_.pop_back();
-            }
-
-            void find_next_value() {
-                check_at_end();
-
-                while(!ranges_.empty() && std::holds_alternative<CompositePtr>(pos())) {
-                    ranges_.emplace_back(pos()->get_range());
-                }
-            }
-
-            template<class OtherValue>
-            explicit CompositeIterator(const CompositeIterator<OtherValue> &other)
-                    : parent_(other.parent_), ranges_(other.ranges_) {}
-
-            template<class OtherValue>
-            bool equal(const CompositeIterator<OtherValue> &other) const {
-                return ranges_ = other.ranges_;
-            }
-
-            void increment() { find_next_value(); }
-
-            ValueType &dereference() const {
-                util::check(!ranges_.empty(), "Derefenence on composite iterator at end");
-               return pos();
-            }
-        };
-
-        using value_type = T;
-
-        Composite() = default;
-
-        explicit Composite(T &&t) {
-            values_.emplace_back(std::move(t));
+        const ValueType& pos()
+        {
+            return *ranges_.back().second;
         }
 
-        const ValueType &operator[](size_t idx) const {
-            return values_[idx];
+        void check_at_end()
+        {
+            while (!ranges_.empty() && current_pair().second == current_pair().first.end())
+                ranges_.pop_back();
         }
 
-        ValueType &operator[](size_t idx) {
-            return values_[idx];
-        }
+        void find_next_value()
+        {
+            check_at_end();
 
-        size_t level_1_size() const {
-            return values_.size();
-        }
-
-        explicit Composite(std::vector<T> &&vec) {
-            util::check(!vec.empty(), "Cannot create composite with no values");
-            values_.insert(std::end(values_), std::make_move_iterator(std::begin(vec)),
-                           std::make_move_iterator(std::end(vec)));
-        }
-
-        ARCTICDB_MOVE_ONLY_DEFAULT(Composite)
-
-        [[nodiscard]] bool is_single() const {
-            return values_.size() == 1 && std::holds_alternative<T>(values_[0]);
-        }
-
-        [[nodiscard]] size_t size() const {
-            return std::accumulate(std::begin(values_), std::end(values_), 0, [](size_t n, const ValueType &v) {
-                return util::variant_match(v,
-                                           [n](const T &) { return n + 1; },
-                                           [n](const std::unique_ptr<Composite<T>> &c) { return n + c->size(); }
-                );
-            });
-        }
-
-        [[nodiscard]] bool empty() const {
-            return values_.empty();
-        }
-
-        auto as_range() {
-            std::vector<T> output;
-            broadcast([&output](auto val) {
-                output.emplace_back(std::move(val));
-            });
-            return output;
-        }
-
-        void push_back(T &&value) {
-            values_.emplace_back(std::move(value));
-        }
-
-        void push_back(const T& value) {
-            values_.emplace_back(value);
-        }
-
-        void push_back(Composite<T> &&value) {
-            values_.emplace_back(std::make_unique<Composite<T>>(std::move(value)));
-        }
-
-        template<typename Func>
-        void broadcast(const Func &func) {
-            for (auto &value : values_) {
-                util::variant_match(value,
-                                    [&func](T &val) { func(val); },
-                                    [&func](std::unique_ptr<Composite<T>> &comp) { comp->broadcast(func); }
-                );
+            while (!ranges_.empty() && std::holds_alternative<CompositePtr>(pos())) {
+                ranges_.emplace_back(pos()->get_range());
             }
         }
 
-
-        template<typename Func>
-        void broadcast(const Func &func) const  {
-            for (auto &value : values_) {
-                util::variant_match(value,
-                                    [&func](const T &val) { func(val); },
-                                    [&func](const std::unique_ptr<Composite<T>> &comp) { comp->broadcast(func); }
-                );
-            }
+        template<class OtherValue>
+        explicit CompositeIterator(const CompositeIterator<OtherValue>& other)
+            : parent_(other.parent_),
+              ranges_(other.ranges_)
+        {
         }
 
-        template<typename Func>
-        auto transform(const Func &func) {
-            using ReturnType = std::decay_t<decltype(func(std::declval<T>()))>;
-            Composite<ReturnType> output;
-            broadcast([&func, &output](auto &&val) {
-                output.push_back(func(val));
-            });
-            return output;
+        template<class OtherValue>
+        bool equal(const CompositeIterator<OtherValue>& other) const
+        {
+            return ranges_ = other.ranges_;
         }
 
-        template<typename Func>
-        auto filter(const Func &func) {
-            Composite output;
-            broadcast([&func, &output](auto &&v) {
-                auto val = std::forward<T>(v);
-                if (func(val))
-                    output.push_back(std::move(val));
-            });
-            return output;
+        void increment()
+        {
+            find_next_value();
         }
 
-        template<typename Func, typename U>
-        auto fold(const Func &func, U initial) {
-            broadcast([&initial, &func](auto &v) {
-                initial = func(initial, v);
-            });
-            return initial;
+        ValueType& dereference() const
+        {
+            util::check(!ranges_.empty(), "Derefenence on composite iterator at end");
+            return pos();
         }
     };
 
-    /*
+    using value_type = T;
+
+    Composite() = default;
+
+    explicit Composite(T&& t)
+    {
+        values_.emplace_back(std::move(t));
+    }
+
+    const ValueType& operator[](size_t idx) const
+    {
+        return values_[idx];
+    }
+
+    ValueType& operator[](size_t idx)
+    {
+        return values_[idx];
+    }
+
+    size_t level_1_size() const
+    {
+        return values_.size();
+    }
+
+    explicit Composite(std::vector<T>&& vec)
+    {
+        util::check(!vec.empty(), "Cannot create composite with no values");
+        values_.insert(std::end(values_),
+            std::make_move_iterator(std::begin(vec)),
+            std::make_move_iterator(std::end(vec)));
+    }
+
+    ARCTICDB_MOVE_ONLY_DEFAULT(Composite)
+
+    [[nodiscard]] bool is_single() const
+    {
+        return values_.size() == 1 && std::holds_alternative<T>(values_[0]);
+    }
+
+    [[nodiscard]] size_t size() const
+    {
+        return std::accumulate(std::begin(values_), std::end(values_), 0, [](size_t n, const ValueType& v) {
+            return util::variant_match(
+                v,
+                [n](const T&) { return n + 1; },
+                [n](const std::unique_ptr<Composite<T>>& c) { return n + c->size(); });
+        });
+    }
+
+    [[nodiscard]] bool empty() const
+    {
+        return values_.empty();
+    }
+
+    auto as_range()
+    {
+        std::vector<T> output;
+        broadcast([&output](auto val) { output.emplace_back(std::move(val)); });
+        return output;
+    }
+
+    void push_back(T&& value)
+    {
+        values_.emplace_back(std::move(value));
+    }
+
+    void push_back(const T& value)
+    {
+        values_.emplace_back(value);
+    }
+
+    void push_back(Composite<T>&& value)
+    {
+        values_.emplace_back(std::make_unique<Composite<T>>(std::move(value)));
+    }
+
+    template<typename Func>
+    void broadcast(const Func& func)
+    {
+        for (auto& value : values_) {
+            util::variant_match(
+                value,
+                [&func](T& val) { func(val); },
+                [&func](std::unique_ptr<Composite<T>>& comp) { comp->broadcast(func); });
+        }
+    }
+
+    template<typename Func>
+    void broadcast(const Func& func) const
+    {
+        for (auto& value : values_) {
+            util::variant_match(
+                value,
+                [&func](const T& val) { func(val); },
+                [&func](const std::unique_ptr<Composite<T>>& comp) { comp->broadcast(func); });
+        }
+    }
+
+    template<typename Func>
+    auto transform(const Func& func)
+    {
+        using ReturnType = std::decay_t<decltype(func(std::declval<T>()))>;
+        Composite<ReturnType> output;
+        broadcast([&func, &output](auto&& val) { output.push_back(func(val)); });
+        return output;
+    }
+
+    template<typename Func>
+    auto filter(const Func& func)
+    {
+        Composite output;
+        broadcast([&func, &output](auto&& v) {
+            auto val = std::forward<T>(v);
+            if (func(val))
+                output.push_back(std::move(val));
+        });
+        return output;
+    }
+
+    template<typename Func, typename U>
+    auto fold(const Func& func, U initial)
+    {
+        broadcast([&initial, &func](auto& v) { initial = func(initial, v); });
+        return initial;
+    }
+};
+
+/*
     * Joins the roots of the composites via a common parent:
     *
     *    *            *
@@ -221,18 +247,19 @@ struct Composite {
     *          / \ / \
     *         *  * *  *
     */
-    template<typename T>
-    Composite<T> merge_composites(std::vector<Composite<T>> &&cmp) {
-        auto composites = std::move(cmp);
-        Composite<T> output;
-        for (auto &&composite : composites) {
-            output.push_back(std::move(composite));
-        }
-
-        return output;
+template<typename T>
+Composite<T> merge_composites(std::vector<Composite<T>>&& cmp)
+{
+    auto composites = std::move(cmp);
+    Composite<T> output;
+    for (auto&& composite : composites) {
+        output.push_back(std::move(composite));
     }
 
-    /*
+    return output;
+}
+
+/*
      * Joins the roots of the composites:
      *
      *    *            *
@@ -245,41 +272,43 @@ struct Composite {
      *       |   |   |   |
      *       *   *   *   *
      */
-    template <typename T>
-    Composite<T> merge_composites_shallow(std::vector<Composite<T>>&& cmp){
-        std::vector<Composite<T>> composites = std::move(cmp);
-        Composite<T> output;
-        for(Composite<T>& composite : composites) {
-            for (size_t i = 0; i < composite.level_1_size(); i++){
-                util::variant_match(composite[i],
-                                    [&output] (T& val) { output.push_back(std::move(val)); },
-                                    [&output] (std::unique_ptr<Composite<T>>& comp) {
-                                        auto t_ptr = std::move(comp);
-                                        output.push_back(std::move(*t_ptr));
-                                    }
-                );
-            }
+template<typename T>
+Composite<T> merge_composites_shallow(std::vector<Composite<T>>&& cmp)
+{
+    std::vector<Composite<T>> composites = std::move(cmp);
+    Composite<T> output;
+    for (Composite<T>& composite : composites) {
+        for (size_t i = 0; i < composite.level_1_size(); i++) {
+            util::variant_match(
+                composite[i],
+                [&output](T& val) { output.push_back(std::move(val)); },
+                [&output](std::unique_ptr<Composite<T>>& comp) {
+                    auto t_ptr = std::move(comp);
+                    output.push_back(std::move(*t_ptr));
+                });
         }
-
-        return output;
     }
+
+    return output;
+}
 
 } //namespace arcticdb
 
-
 namespace fmt {
-    template<typename T>
-    struct formatter<arcticdb::Composite<T>> {
-        template<typename ParseContext>
-        constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+template<typename T>
+struct formatter<arcticdb::Composite<T>> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
-        template<typename FormatContext>
-        auto format(const arcticdb::Composite<T> &c, FormatContext &ctx) const {
-            auto it = format_to(ctx.out(), "Composite: ");
-            c.broadcast([&it] (const auto& v) {
-                it = format_to(it, "{}, ", v);
-            });
-            return it;
-        }
-    };
-}
+    template<typename FormatContext>
+    auto format(const arcticdb::Composite<T>& c, FormatContext& ctx) const
+    {
+        auto it = format_to(ctx.out(), "Composite: ");
+        c.broadcast([&it](const auto& v) { it = format_to(it, "{}, ", v); });
+        return it;
+    }
+};
+} // namespace fmt

--- a/cpp/arcticdb/util/configs_map.cpp
+++ b/cpp/arcticdb/util/configs_map.cpp
@@ -10,19 +10,22 @@
 
 namespace arcticdb {
 
-std::shared_ptr<ConfigsMap> ConfigsMap::instance(){
+std::shared_ptr<ConfigsMap> ConfigsMap::instance()
+{
     std::call_once(ConfigsMap::init_flag_, &ConfigsMap::init);
     return ConfigsMap::instance_;
 }
 
-void ConfigsMap::init() {
+void ConfigsMap::init()
+{
     ConfigsMap::instance_ = std::make_shared<ConfigsMap>();
 }
 
 std::shared_ptr<ConfigsMap> ConfigsMap::instance_;
 std::once_flag ConfigsMap::init_flag_;
 
-void read_runtime_config(const RuntimeConfig& config) {
+void read_runtime_config(const RuntimeConfig& config)
+{
     ConfigsMap::instance()->read_proto(config);
 }
 

--- a/cpp/arcticdb/util/configs_map.hpp
+++ b/cpp/arcticdb/util/configs_map.hpp
@@ -25,28 +25,33 @@ public:
     static void init();
     static std::shared_ptr<ConfigsMap> instance();
 
-    ConfigsMap() :
-        mutex_(std::make_unique<std::mutex>()) {
+    ConfigsMap()
+        : mutex_(std::make_unique<std::mutex>())
+    {
     }
 
-#define HANDLE_TYPE(LABEL, TYPE)     \
-    void set_##LABEL(const std::string& label, TYPE val) { \
-        map_of_##LABEL[label] = val; \
-    } \
-\
-    TYPE get_##LABEL(const std::string& label, TYPE default_val) const { \
-        auto it = map_of_##LABEL.find(label); \
-        return it == map_of_##LABEL.cend() ? default_val : it->second; \
-    } \
- \
-    std::optional<TYPE> get_##LABEL(const std::string& label) const { \
-        auto it = map_of_##LABEL.find(label); \
-        return it == map_of_##LABEL.cend() ? std::nullopt : std::make_optional(it->second); \
-    } \
-\
-    void unset_##LABEL(const std::string& label) { \
-        map_of_##LABEL.erase(label); \
-    } \
+#define HANDLE_TYPE(LABEL, TYPE)                                                                                       \
+    void set_##LABEL(const std::string& label, TYPE val)                                                               \
+    {                                                                                                                  \
+        map_of_##LABEL[label] = val;                                                                                   \
+    }                                                                                                                  \
+                                                                                                                       \
+    TYPE get_##LABEL(const std::string& label, TYPE default_val) const                                                 \
+    {                                                                                                                  \
+        auto it = map_of_##LABEL.find(label);                                                                          \
+        return it == map_of_##LABEL.cend() ? default_val : it->second;                                                 \
+    }                                                                                                                  \
+                                                                                                                       \
+    std::optional<TYPE> get_##LABEL(const std::string& label) const                                                    \
+    {                                                                                                                  \
+        auto it = map_of_##LABEL.find(label);                                                                          \
+        return it == map_of_##LABEL.cend() ? std::nullopt : std::make_optional(it->second);                            \
+    }                                                                                                                  \
+                                                                                                                       \
+    void unset_##LABEL(const std::string& label)                                                                       \
+    {                                                                                                                  \
+        map_of_##LABEL.erase(label);                                                                                   \
+    }
 
     // Also update python_module.cpp::register_configs_map_api() if below is changed:
     HANDLE_TYPE(int, int64_t)
@@ -54,7 +59,8 @@ public:
     HANDLE_TYPE(double, double)
 #undef HANDLE_TYPE
 
-    RuntimeConfig to_proto() {
+    RuntimeConfig to_proto()
+    {
         RuntimeConfig output{};
         output.mutable_int_values()->insert(std::cbegin(map_of_int), std::cend(map_of_int));
         output.mutable_string_values()->insert(std::cbegin(map_of_string), std::cend(map_of_string));
@@ -62,18 +68,20 @@ public:
         return output;
     }
 
-    void read_proto(const RuntimeConfig& config) {
-        for(auto& val : config.int_values())
+    void read_proto(const RuntimeConfig& config)
+    {
+        for (auto& val : config.int_values())
             map_of_int.insert(std::make_pair(val.first, val.second));
 
-        for(auto& val : config.string_values())
+        for (auto& val : config.string_values())
             map_of_string.insert(std::make_pair(val.first, val.second));
 
-        for(auto& val : config.double_values())
+        for (auto& val : config.double_values())
             map_of_double.insert(std::make_pair(val.first, val.second));
     }
 
-     static ConfigsMap from_proto(const RuntimeConfig& config) {
+    static ConfigsMap from_proto(const RuntimeConfig& config)
+    {
         ConfigsMap output{};
         output.read_proto(config);
         return output;
@@ -92,14 +100,16 @@ struct ScopedConfig {
     std::string name_;
     std::optional<int64_t> original_;
 
-    ScopedConfig(const std::string& name, int64_t val) :
-            name_(name),
-            original_(ConfigsMap::instance()->get_int(name)) {
+    ScopedConfig(const std::string& name, int64_t val)
+        : name_(name),
+          original_(ConfigsMap::instance()->get_int(name))
+    {
         ConfigsMap::instance()->set_int(name_, val);
     }
 
-    ~ScopedConfig() {
-        if(original_)
+    ~ScopedConfig()
+    {
+        if (original_)
             ConfigsMap::instance()->set_int(name_, original_.value());
         else
             ConfigsMap::instance()->unset_int(name_);

--- a/cpp/arcticdb/util/constructors.hpp
+++ b/cpp/arcticdb/util/constructors.hpp
@@ -7,34 +7,34 @@
 
 #pragma once
 
-#define ARCTICDB_MOVE_ONLY_DEFAULT(__T__) \
-    __T__(__T__ && ) noexcept = default; \
-    __T__& operator=(__T__ && )  noexcept = default; \
-    __T__(const __T__ & ) = delete; \
-    __T__& operator=(const __T__ & ) = delete;
+#define ARCTICDB_MOVE_ONLY_DEFAULT(__T__)                                                                              \
+    __T__(__T__&&) noexcept = default;                                                                                 \
+    __T__& operator=(__T__&&) noexcept = default;                                                                      \
+    __T__(const __T__&) = delete;                                                                                      \
+    __T__& operator=(const __T__&) = delete;
 
-#define ARCTICDB_MOVE_ONLY_DEFAULT_EXCEPT(__T__) \
-    __T__(__T__ && )  = default; \
-    __T__& operator=(__T__ && )  = default; \
-    __T__(const __T__ & ) = delete; \
-    __T__& operator=(const __T__ & ) = delete;
+#define ARCTICDB_MOVE_ONLY_DEFAULT_EXCEPT(__T__)                                                                       \
+    __T__(__T__&&) = default;                                                                                          \
+    __T__& operator=(__T__&&) = default;                                                                               \
+    __T__(const __T__&) = delete;                                                                                      \
+    __T__& operator=(const __T__&) = delete;
 
-#define ARCTICDB_MOVE_COPY_DEFAULT(__T__) \
-    __T__(__T__ && ) noexcept = default; \
-    __T__& operator=(__T__ && )  noexcept = default; \
-    __T__(const __T__ & ) = default; \
-    __T__& operator=(const __T__ & ) = default;
+#define ARCTICDB_MOVE_COPY_DEFAULT(__T__)                                                                              \
+    __T__(__T__&&) noexcept = default;                                                                                 \
+    __T__& operator=(__T__&&) noexcept = default;                                                                      \
+    __T__(const __T__&) = default;                                                                                     \
+    __T__& operator=(const __T__&) = default;
 
-#define ARCTICDB_NO_MOVE_OR_COPY(__T__) \
-    __T__(__T__ && ) noexcept = delete; \
-    __T__& operator=(__T__ && )  noexcept = delete; \
-    __T__(const __T__ & ) = delete; \
-    __T__& operator=(const __T__ & ) = delete;
+#define ARCTICDB_NO_MOVE_OR_COPY(__T__)                                                                                \
+    __T__(__T__&&) noexcept = delete;                                                                                  \
+    __T__& operator=(__T__&&) noexcept = delete;                                                                       \
+    __T__(const __T__&) = delete;                                                                                      \
+    __T__& operator=(const __T__&) = delete;
 
-#define ARCTICDB_NO_COPY(__T__) \
-    __T__(const __T__ & ) = delete; \
-    __T__& operator=(const __T__ & ) = delete;
+#define ARCTICDB_NO_COPY(__T__)                                                                                        \
+    __T__(const __T__&) = delete;                                                                                      \
+    __T__& operator=(const __T__&) = delete;
 
-#define ARCTICDB_MOVE(__T__) \
-    __T__(__T__ && ) noexcept = default; \
-    __T__& operator=(__T__ && )  noexcept = default;
+#define ARCTICDB_MOVE(__T__)                                                                                           \
+    __T__(__T__&&) noexcept = default;                                                                                 \
+    __T__& operator=(__T__&&) noexcept = default;

--- a/cpp/arcticdb/util/container_filter_wrapper.hpp
+++ b/cpp/arcticdb/util/container_filter_wrapper.hpp
@@ -26,9 +26,12 @@ class ContainerFilterWrapper {
     const Container& original_;
     Container filtered_;
     bool use_original_;
+
 public:
-    explicit ContainerFilterWrapper(const Container& original_):
-        original_(original_), filtered_(), use_original_(true){};
+    explicit ContainerFilterWrapper(const Container& original_)
+        : original_(original_),
+          filtered_(),
+          use_original_(true){};
 
     /**
      * The filter should take an item and return true to indicate if the item should be removed.
@@ -36,7 +39,8 @@ public:
      * If the filter throws, the result might be corrupted.
      */
     template<typename Filter>
-    void remove_if(Filter filter) {
+    void remove_if(Filter filter)
+    {
         if (use_original_) {
             auto end = original_.cend();
             for (auto itr = original_.cbegin(); itr != end; itr++) {
@@ -59,7 +63,8 @@ public:
      * Only makes a copy if the argument is not already in the set.
      */
     template<typename C = Container>
-    void insert(const std::enable_if_t<std::is_same_v<C, std::unordered_set<value_type>>, value_type>& val) {
+    void insert(const std::enable_if_t<std::is_same_v<C, std::unordered_set<value_type>>, value_type>& val)
+    {
         if (use_original_) {
             if (original_.count(val) > 0) {
                 return;
@@ -76,7 +81,8 @@ public:
      * Only makes a copy if the argument is in the set.
      */
     template<typename C = Container>
-    void erase(const std::enable_if_t<std::is_same_v<C, std::unordered_set<value_type>>, value_type>& val) {
+    void erase(const std::enable_if_t<std::is_same_v<C, std::unordered_set<value_type>>, value_type>& val)
+    {
         if (use_original_) {
             if (original_.count(val) == 0) {
                 return;
@@ -89,18 +95,26 @@ public:
         filtered_.erase(val);
     }
 
-    void clear() {
+    void clear()
+    {
         use_original_ = false;
         filtered_.clear();
     }
 
     // C++20: Use bitset and Ranges to hide/combine items instead of copying
-    const Container& get() {
+    const Container& get()
+    {
         return use_original_ ? original_ : filtered_;
     }
 
-    const Container& operator*() { return get(); }
-    const Container* operator->() { return &get(); }
+    const Container& operator*()
+    {
+        return get();
+    }
+    const Container* operator->()
+    {
+        return &get();
+    }
 };
 
-}
+} // namespace arcticdb::util

--- a/cpp/arcticdb/util/cursor.hpp
+++ b/cpp/arcticdb/util/cursor.hpp
@@ -20,40 +20,54 @@ namespace arcticdb {
 using namespace arcticdb::entity;
 class Cursor {
 public:
-    Cursor() : cursor_(0) {}
+    Cursor()
+        : cursor_(0)
+    {
+    }
 
-    explicit Cursor(position_t cursor) : cursor_(cursor) {}
+    explicit Cursor(position_t cursor)
+        : cursor_(cursor)
+    {
+    }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(Cursor)
 
-    [[nodiscard]] position_t pos() const {
+    [[nodiscard]] position_t pos() const
+    {
         return cursor_;
     }
 
-    [[nodiscard]] Cursor clone() const {
+    [[nodiscard]] Cursor clone() const
+    {
         return Cursor{cursor_};
     }
 
-    void advance(position_t pos, size_t buffer_size) {
+    void advance(position_t pos, size_t buffer_size)
+    {
         util::check_arg(cursor_ + pos <= position_t(buffer_size),
-                        "Buffer overflow , cannot advance {} in buffer of size {} with cursor at {}",
-                        pos, buffer_size, cursor_);
+            "Buffer overflow , cannot advance {} in buffer of size {} with cursor at {}",
+            pos,
+            buffer_size,
+            cursor_);
 
         cursor_ += pos;
     }
 
-    void commit(size_t buffer_size) {
+    void commit(size_t buffer_size)
+    {
         util::check_arg(cursor_ == 0 || cursor_ < position_t(buffer_size),
-                        "Commit called twice on buffer of size {}",
-                        buffer_size);
+            "Commit called twice on buffer of size {}",
+            buffer_size);
         cursor_ = position_t(buffer_size);
     }
 
-    void reset() {
+    void reset()
+    {
         cursor_ = 0;
     }
 
-    friend bool operator==(const Cursor& left, const Cursor& right) {
+    friend bool operator==(const Cursor& left, const Cursor& right)
+    {
         return left.cursor_ == right.cursor_;
     }
 
@@ -67,10 +81,14 @@ namespace fmt {
 template<>
 struct formatter<arcticdb::Cursor> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const arcticdb::Cursor &c, FormatContext &ctx) const {
+    auto format(const arcticdb::Cursor& c, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}", c.pos());
     }
 };

--- a/cpp/arcticdb/util/cursored_buffer.hpp
+++ b/cpp/arcticdb/util/cursored_buffer.hpp
@@ -21,86 +21,104 @@ private:
 public:
     CursoredBuffer() = default;
 
-    CursoredBuffer(size_t size, bool presize) :
-        cursor_(presize ? static_cast<int64_t>(size) : 0),
-        buffer_(presize ? BufferType::presized(size) : BufferType{size}) { }
+    CursoredBuffer(size_t size, bool presize)
+        : cursor_(presize ? static_cast<int64_t>(size) : 0),
+          buffer_(presize ? BufferType::presized(size) : BufferType{size})
+    {
+    }
 
-    explicit CursoredBuffer(BufferType&& buffer) :
-        cursor_(0),
-        buffer_(std::move(buffer)) {}
-
+    explicit CursoredBuffer(BufferType&& buffer)
+        : cursor_(0),
+          buffer_(std::move(buffer))
+    {
+    }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(CursoredBuffer)
 
-    CursoredBuffer clone() const {
+    CursoredBuffer clone() const
+    {
         CursoredBuffer output;
         output.cursor_ = cursor_.clone();
         output.buffer_ = buffer_.clone();
         return output;
     }
 
-    friend void swap(CursoredBuffer& left, CursoredBuffer& right) {
+    friend void swap(CursoredBuffer& left, CursoredBuffer& right)
+    {
         using std::swap;
         swap(left.buffer_, right.buffer_);
         swap(left.cursor_, right.cursor_);
     }
 
-    uint8_t* ptr() {
+    uint8_t* ptr()
+    {
         return &buffer_[cursor_.pos()];
     }
 
-    [[nodiscard]] position_t cursor_pos() const {
+    [[nodiscard]] position_t cursor_pos() const
+    {
         return cursor_.pos();
     }
 
     template<typename T>
-    void ensure(size_t num = 1) {
+    void ensure(size_t num = 1)
+    {
         buffer_.ensure((num * sizeof(T)) + cursor_.pos());
     }
 
-    void ensure_bytes(size_t bytes) {
+    void ensure_bytes(size_t bytes)
+    {
         buffer_.ensure(cursor_.pos() + bytes);
     }
 
-    uint8_t* ensure_aligned_bytes(size_t bytes) {
+    uint8_t* ensure_aligned_bytes(size_t bytes)
+    {
         return buffer_.ensure(cursor_.pos() + bytes, true);
     }
 
-    void commit() {
+    void commit()
+    {
         cursor_.commit(buffer_.bytes());
     }
 
-    void advance(std::size_t size) {
+    void advance(std::size_t size)
+    {
         cursor_.advance(position_t(size), buffer_.bytes());
     }
 
     template<typename T>
-    [[nodiscard]] size_t size() const {
+    [[nodiscard]] size_t size() const
+    {
         return buffer_.bytes() / sizeof(T);
     }
 
-    [[nodiscard]] const uint8_t* data() const {
+    [[nodiscard]] const uint8_t* data() const
+    {
         return buffer_.data();
     }
 
-    uint8_t* data() {
+    uint8_t* data()
+    {
         return buffer_.data();
     }
 
-    [[nodiscard]] size_t bytes() const {
+    [[nodiscard]] size_t bytes() const
+    {
         return buffer_.bytes();
     }
 
-    const BufferType& buffer() const {
+    const BufferType& buffer() const
+    {
         return buffer_;
     }
 
-    void compact_blocks() {
-        if(buffer_.blocks().size() <=1)
+    void compact_blocks()
+    {
+        if (buffer_.blocks().size() <= 1)
             return;
 
         CursoredBuffer tmp{buffer_.bytes(), false};
-        for(const auto& block : buffer_.blocks()) {
+        for (const auto& block : buffer_.blocks()) {
             tmp.ensure_bytes(block->bytes());
             memcpy(tmp.ptr(), block->data(), block->bytes());
             tmp.commit();
@@ -109,48 +127,56 @@ public:
         std::swap(tmp.buffer_, buffer_);
     }
 
-    BufferType& buffer() {
+    BufferType& buffer()
+    {
         return buffer_;
     }
 
     template<class T>
-    T* pos_cast(size_t required_bytes) {
+    T* pos_cast(size_t required_bytes)
+    {
         return buffer_.template ptr_cast<T>(cursor_.pos(), required_bytes);
     }
 
-    uint8_t *cursor() {
+    uint8_t* cursor()
+    {
         return &buffer_[cursor_.pos()];
     }
 
-    template <typename T>
-    T& typed_cursor() {
+    template<typename T>
+    T& typed_cursor()
+    {
         return *(reinterpret_cast<T*>(cursor()));
     }
 
     template<typename T>
-    const T *ptr_cast(position_t t_pos, size_t required_bytes) const {
-//        return reinterpret_cast<const T *>(buffer_.template ptr_cast<T>(t_pos * sizeof(T), required_bytes));
-        return reinterpret_cast<const T *>(buffer_.template ptr_cast<T>(t_pos * sizeof(T), required_bytes));
+    const T* ptr_cast(position_t t_pos, size_t required_bytes) const
+    {
+        //        return reinterpret_cast<const T *>(buffer_.template ptr_cast<T>(t_pos * sizeof(T), required_bytes));
+        return reinterpret_cast<const T*>(buffer_.template ptr_cast<T>(t_pos * sizeof(T), required_bytes));
     }
 
     template<typename T>
-    T *ptr_cast(position_t pos, size_t required_bytes) {
-        return const_cast<T *>( const_cast<const CursoredBuffer *>( this)->ptr_cast<T>(pos, required_bytes));
+    T* ptr_cast(position_t pos, size_t required_bytes)
+    {
+        return const_cast<T*>(const_cast<const CursoredBuffer*>(this)->ptr_cast<T>(pos, required_bytes));
     }
 
-    [[nodiscard]] bool empty() const {
+    [[nodiscard]] bool empty() const
+    {
         return buffer_.empty();
     }
 
-    void reset() {
+    void reset()
+    {
         cursor_.reset();
     }
 
-    void clear() {
+    void clear()
+    {
         buffer_.clear();
         cursor_.reset();
     }
-
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/util/dump_bytes.hpp
+++ b/cpp/arcticdb/util/dump_bytes.hpp
@@ -12,8 +12,9 @@
 
 // based on this: https://codereview.stackexchange.com/questions/165120/printing-hex-dumps-for-diagnostics
 namespace arcticdb {
-inline std::ostream &hex_dump(std::ostream &os, const void *buffer,
-                       std::size_t buf_size, bool show_printable_chars = true) {
+inline std::ostream&
+hex_dump(std::ostream& os, const void* buffer, std::size_t buf_size, bool show_printable_chars = true)
+{
     if (buffer == nullptr) {
         return os;
     }
@@ -22,16 +23,15 @@ inline std::ostream &hex_dump(std::ostream &os, const void *buffer,
     constexpr std::size_t max_line{8};
     // create a place to store text version of string
     char render_string[max_line + 1];
-    char *rsptr{render_string};
+    char* rsptr{render_string};
     // convenience cast
-    const unsigned char *buf{reinterpret_cast<const unsigned char *>(buffer)};
+    const unsigned char* buf{reinterpret_cast<const unsigned char*>(buffer)};
 
     for (std::size_t line_count = max_line; buf_size; --buf_size, ++buf) {
-        os << std::setw(2) << std::setfill('0') << std::hex
-           << static_cast<unsigned>(*buf) << ' ';
+        os << std::setw(2) << std::setfill('0') << std::hex << static_cast<unsigned>(*buf) << ' ';
         *rsptr++ = std::isprint(*buf) ? *buf : '.';
         if (--line_count == 0) {
-            *rsptr++ = '\0';  // terminate string
+            *rsptr++ = '\0'; // terminate string
             if (show_printable_chars) {
                 os << " | " << render_string;
             }
@@ -56,7 +56,8 @@ inline std::ostream &hex_dump(std::ostream &os, const void *buffer,
     return os;
 }
 
-inline std::string dump_bytes(const void* data, size_t size, size_t max_size = 20u) {
+inline std::string dump_bytes(const void* data, size_t size, size_t max_size = 20u)
+{
     const auto sz = std::min(max_size, size);
     std::ostringstream strm;
     hex_dump(strm, data, sz);

--- a/cpp/arcticdb/util/encoding_conversion.hpp
+++ b/cpp/arcticdb/util/encoding_conversion.hpp
@@ -16,35 +16,41 @@ class EncodingConversion {
     iconv_t iconv_;
 
 public:
-    EncodingConversion (const char* to, const char* from)
-        : iconv_(iconv_open(to,from)) {
-        if (iconv_t(-1) == iconv_ )
-          util::raise_rte("error from iconv_open()");
+    EncodingConversion(const char* to, const char* from)
+        : iconv_(iconv_open(to, from))
+    {
+        if (iconv_t(-1) == iconv_)
+            util::raise_rte("error from iconv_open()");
     }
 
-    ~EncodingConversion () {
+    ~EncodingConversion()
+    {
         if (iconv_t(-1) != iconv_)
             iconv_close(iconv_);
     }
 
-    bool convert(const char* input, size_t input_size, uint8_t* output, size_t& output_size) {
+    bool convert(const char* input, size_t input_size, uint8_t* output, size_t& output_size)
+    {
         return iconv(iconv_, (char**)&input, &input_size, (char**)&output, &output_size) != size_t(-1);
     }
 };
 
 class PortableEncodingConversion {
-    public:
-    PortableEncodingConversion(const char*, const char*) { }
+public:
+    PortableEncodingConversion(const char*, const char*)
+    {
+    }
 
-        static bool convert(const char* input, size_t input_size, uint8_t* output, size_t& output_size) {
-            memset(output, 0, output_size);
-            auto pos = output;
-            for (auto c = 0u; c < input_size; ++c) {
-                *pos = *input++;
-                pos += UNICODE_WIDTH;
-            }
-            return true;
+    static bool convert(const char* input, size_t input_size, uint8_t* output, size_t& output_size)
+    {
+        memset(output, 0, output_size);
+        auto pos = output;
+        for (auto c = 0u; c < input_size; ++c) {
+            *pos = *input++;
+            pos += UNICODE_WIDTH;
         }
-    };
+        return true;
+    }
+};
 
 } //namespace arcticdb

--- a/cpp/arcticdb/util/error_code.cpp
+++ b/cpp/arcticdb/util/error_code.cpp
@@ -11,14 +11,15 @@
 
 namespace arcticdb {
 
-struct ErrorMapTag{};
+struct ErrorMapTag {};
 using ErrorCodeMap = semi::static_map<int, ErrorCodeData, ErrorMapTag>;
 
 #define ERROR_ID(x) []() constexpr { return static_cast<int>(x); }
-ErrorCodeData get_error_code_data(ErrorCode code) {
-    #define ERROR_CODE(code, Name) ErrorCodeMap::get(ERROR_ID(code)) = error_code_data<ErrorCode::Name>;
-        ARCTIC_ERROR_CODES
-    #undef ERROR_CODE
+ErrorCodeData get_error_code_data(ErrorCode code)
+{
+#define ERROR_CODE(code, Name) ErrorCodeMap::get(ERROR_ID(code)) = error_code_data<ErrorCode::Name>;
+    ARCTIC_ERROR_CODES
+#undef ERROR_CODE
 
     return ErrorCodeMap::get(static_cast<int>(code));
 }

--- a/cpp/arcticdb/util/exponential_backoff.hpp
+++ b/cpp/arcticdb/util/exponential_backoff.hpp
@@ -15,19 +15,22 @@
 
 namespace arcticdb {
 
-template <typename HandledExceptionType>
+template<typename HandledExceptionType>
 struct ExponentialBackoff {
 
     size_t min_wait_ms_;
     size_t max_wait_ms_;
     size_t curr_wait_ms_;
 
-    ExponentialBackoff(size_t min_wait_ms, size_t max_wait_ms) :
-        min_wait_ms_(min_wait_ms),
-        max_wait_ms_(max_wait_ms),
-        curr_wait_ms_(min_wait_ms_){}
+    ExponentialBackoff(size_t min_wait_ms, size_t max_wait_ms)
+        : min_wait_ms_(min_wait_ms),
+          max_wait_ms_(max_wait_ms),
+          curr_wait_ms_(min_wait_ms_)
+    {
+    }
 
-    void sleep_ms(size_t ms) {
+    void sleep_ms(size_t ms)
+    {
         std::this_thread::sleep_for(std::chrono::milliseconds(ms));
     }
 
@@ -41,21 +44,22 @@ struct ExponentialBackoff {
         return curr_wait_ms_ != max_wait_ms_;
     }
 
-    template <typename Callable>
-    auto go(Callable&& callable) {
-        return go(std::forward<Callable>(callable), [](){ util::raise_rte("Exhausted retry attempts"); });
+    template<typename Callable>
+    auto go(Callable&& callable)
+    {
+        return go(std::forward<Callable>(callable), []() { util::raise_rte("Exhausted retry attempts"); });
     }
 
     template<typename Callable, typename FailurePolicy>
-    auto go(Callable&& c, FailurePolicy&& failure_policy) {
+    auto go(Callable&& c, FailurePolicy&& failure_policy)
+    {
         do {
             try {
                 return c();
-            }
-            catch (HandledExceptionType&) {
+            } catch (HandledExceptionType&) {
                 log::storage().info("Caught error in backoff, retrying");
             }
-        } while(wait());
+        } while (wait());
 
         failure_policy();
         ARCTICDB_UNREACHABLE

--- a/cpp/arcticdb/util/format_bytes.hpp
+++ b/cpp/arcticdb/util/format_bytes.hpp
@@ -10,15 +10,16 @@
 #include <fmt/format.h>
 
 namespace arcticdb {
-static char bytes_format [] = {' ', 'K', 'M', 'G', 'T', 'P', 'E', 'Z'};
+static char bytes_format[] = {' ', 'K', 'M', 'G', 'T', 'P', 'E', 'Z'};
 
-inline std::string format_bytes(double num, char suffix='B') {
+inline std::string format_bytes(double num, char suffix = 'B')
+{
     for (auto unit : bytes_format) {
-        if(std::abs(num) < 1000.0)
-            return  fmt::format("{:.2f}{}{}", num, unit, suffix);
+        if (std::abs(num) < 1000.0)
+            return fmt::format("{:.2f}{}{}", num, unit, suffix);
 
         num /= 1000.0;
     }
     return fmt::format("{:.2f}{}{}", num, "Y", suffix);
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/format_date.hpp
+++ b/cpp/arcticdb/util/format_date.hpp
@@ -17,9 +17,10 @@ namespace arcticdb::util {
 using Clock = std::chrono::system_clock;
 using TimePoint = std::chrono::time_point<Clock>;
 
-inline std::string format_timestamp(entity::timestamp ts) {
+inline std::string format_timestamp(entity::timestamp ts)
+{
     std::stringstream ss;
-#if  defined(_WIN32) or defined(__APPLE__)
+#if defined(_WIN32) or defined(__APPLE__)
     auto time_point = Clock::time_point(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::nanoseconds(ts)));
 #else
     auto time_point = Clock::time_point(std::chrono::nanoseconds(ts));
@@ -31,4 +32,4 @@ inline std::string format_timestamp(entity::timestamp ts) {
     return ss.str();
 }
 
-}
+} // namespace arcticdb::util

--- a/cpp/arcticdb/util/global_lifetimes.cpp
+++ b/cpp/arcticdb/util/global_lifetimes.cpp
@@ -21,7 +21,8 @@
 
 namespace arcticdb {
 
-ModuleData::~ModuleData() {
+ModuleData::~ModuleData()
+{
     BufferPool::destroy_instance();
     TracingData::destroy_instance();
     SharedMemoryAllocator::destroy_instance();
@@ -33,16 +34,19 @@ ModuleData::~ModuleData() {
     log::Loggers::destroy_instance();
 }
 
-std::shared_ptr<ModuleData> ModuleData::instance() {
+std::shared_ptr<ModuleData> ModuleData::instance()
+{
     std::call_once(ModuleData::init_flag_, &ModuleData::init);
     return instance_;
 }
 
-void ModuleData::destroy_instance() {
+void ModuleData::destroy_instance()
+{
     ModuleData::instance_.reset();
 }
 
-void ModuleData::init() {
+void ModuleData::init()
+{
     ModuleData::instance_ = std::make_shared<ModuleData>();
 
 #if defined(_MSC_VER) && defined(_DEBUG)
@@ -57,7 +61,8 @@ void ModuleData::init() {
 std::shared_ptr<ModuleData> ModuleData::instance_;
 std::once_flag ModuleData::init_flag_;
 
-void shutdown_globals() {
+void shutdown_globals()
+{
     async::TaskScheduler::destroy_instance();
     storage::mongo::MongoInstance::destroy_instance();
     ModuleData::destroy_instance();

--- a/cpp/arcticdb/util/global_lifetimes.hpp
+++ b/cpp/arcticdb/util/global_lifetimes.hpp
@@ -12,7 +12,7 @@
 
 namespace arcticdb {
 
-struct ModuleData{
+struct ModuleData {
     ~ModuleData();
 
     static std::shared_ptr<ModuleData> instance_;
@@ -22,7 +22,6 @@ struct ModuleData{
     static std::shared_ptr<ModuleData> instance();
     static void destroy_instance();
 };
-
 
 void shutdown_globals();
 

--- a/cpp/arcticdb/util/hash.hpp
+++ b/cpp/arcticdb/util/hash.hpp
@@ -25,33 +25,40 @@ constexpr std::size_t DEFAULT_SEED = 0x42;
 }
 
 template<class T, std::size_t seed = DEFAULT_SEED>
-HashedValue hash(T *d, std::size_t count = 1) {
-    return XXH64(reinterpret_cast<const void *>(d), count * sizeof(T), seed);
+HashedValue hash(T* d, std::size_t count = 1)
+{
+    return XXH64(reinterpret_cast<const void*>(d), count * sizeof(T), seed);
 }
 
-inline HashedValue hash(std::string_view sv) {
+inline HashedValue hash(std::string_view sv)
+{
     return hash(sv.data(), sv.size());
 }
 
 class HashAccum {
-  public:
-    explicit HashAccum(HashedValue seed = DEFAULT_SEED) {
+public:
+    explicit HashAccum(HashedValue seed = DEFAULT_SEED)
+    {
         reset(seed);
     }
 
-    void reset(HashedValue seed = DEFAULT_SEED) {
+    void reset(HashedValue seed = DEFAULT_SEED)
+    {
         XXH64_reset(&state_, seed);
     }
 
     template<typename T>
-    void operator()(T *d, std::size_t count = 1) {
+    void operator()(T* d, std::size_t count = 1)
+    {
         XXH64_update(&state_, d, sizeof(T) * count);
     }
 
-    [[nodiscard]] HashedValue digest() const {
+    [[nodiscard]] HashedValue digest() const
+    {
         return XXH64_digest(&state_);
     }
-  private:
+
+private:
     XXH64_state_t state_ = XXH64_state_t{};
 };
 

--- a/cpp/arcticdb/util/home_directory.hpp
+++ b/cpp/arcticdb/util/home_directory.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-
 #ifndef _WIN32
 #include <unistd.h>
 #include <pwd.h>
@@ -17,13 +16,14 @@
 
 namespace arcticdb {
 
-inline std::string get_home_directory() {
-    #ifdef _WIN32
+inline std::string get_home_directory()
+{
+#ifdef _WIN32
     const char* home_drive = getenv("HOMEDRIVE");
     const char* home_path = getenv("HOMEPATH");
     return std::string(home_drive) + std::string(home_path);
-    #else
-    if (const char *home_dir = getenv("HOME"); home_dir != nullptr) {
+#else
+    if (const char* home_dir = getenv("HOME"); home_dir != nullptr) {
         return {home_dir};
     } else {
         auto buffer_size = sysconf(_SC_GETPW_R_SIZE_MAX);
@@ -31,13 +31,13 @@ inline std::string get_home_directory() {
             buffer_size = 16384;
 
         std::string buffer(buffer_size, 0);
-        struct passwd pwd{};
+        struct passwd pwd {};
         struct passwd* user_data = nullptr;
         auto result = getpwuid_r(getuid(), &pwd, buffer.data(), buffer_size, &user_data);
         util::check(user_data != nullptr, "Failed to get user home directory: {}", std::strerror(result));
         return {user_data->pw_dir};
     }
-    #endif
+#endif
 }
 
 } //namespace arcticdb

--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -16,58 +16,75 @@
 namespace arcticdb {
 
 template<class Predicate>
-inline void delete_keys_of_type_if(const std::shared_ptr<Store>& store, Predicate&& predicate, KeyType key_type, const std::string& prefix = std::string(), bool continue_on_error = false) {
+inline void delete_keys_of_type_if(const std::shared_ptr<Store>& store,
+    Predicate&& predicate,
+    KeyType key_type,
+    const std::string& prefix = std::string(),
+    bool continue_on_error = false)
+{
     static const size_t delete_object_limit = ConfigsMap::instance()->get_int("Storage.DeleteBatchSize", 1000);
     std::vector<VariantKey> keys{};
     try {
-        store->iterate_type(key_type, [predicate=std::forward<Predicate>(predicate), store=store, &keys](VariantKey &&key) {
-            if(predicate(key))
-                keys.emplace_back(std::move(key));
+        store->iterate_type(
+            key_type,
+            [predicate = std::forward<Predicate>(predicate), store = store, &keys](VariantKey&& key) {
+                if (predicate(key))
+                    keys.emplace_back(std::move(key));
 
-            if(keys.size() == delete_object_limit) {
-                store->remove_keys(keys).get();
-                keys.clear();
-            }
-        }, prefix);
+                if (keys.size() == delete_object_limit) {
+                    store->remove_keys(keys).get();
+                    keys.clear();
+                }
+            },
+            prefix);
 
-        if(!keys.empty())
+        if (!keys.empty())
             store->remove_keys(keys).get();
-    }
-    catch(const std::exception& ex) {
-        if(continue_on_error)
+    } catch (const std::exception& ex) {
+        if (continue_on_error)
             log::storage().warn("Caught exception {} trying to delete key, continuing", ex.what());
         else
             throw;
     }
 }
 
-inline void delete_keys_of_type_for_stream(const std::shared_ptr<Store>& store, const StreamId& stream_id, KeyType key_type, bool continue_on_error = false) {
+inline void delete_keys_of_type_for_stream(const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
+    KeyType key_type,
+    bool continue_on_error = false)
+{
     auto prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
-    auto match_stream_id =  [&stream_id](const VariantKey & k){ return variant_key_id(k) == stream_id; };
+    auto match_stream_id = [&stream_id](const VariantKey& k) { return variant_key_id(k) == stream_id; };
     delete_keys_of_type_if(store, std::move(match_stream_id), key_type, prefix, continue_on_error);
 }
 
-inline void delete_all_keys_of_type(KeyType key_type, const std::shared_ptr<Store>& store, bool continue_on_error) {
-    auto match_stream_id = [](const VariantKey &){ return true; };
+inline void delete_all_keys_of_type(KeyType key_type, const std::shared_ptr<Store>& store, bool continue_on_error)
+{
+    auto match_stream_id = [](const VariantKey&) { return true; };
     delete_keys_of_type_if(store, std::move(match_stream_id), key_type, std::string{}, continue_on_error);
 }
 
-inline void delete_all_for_stream(const std::shared_ptr<Store>& store, const StreamId& stream_id, bool continue_on_error = false) {
-    foreach_key_type([&store, &stream_id, continue_on_error] (KeyType key_type) { delete_keys_of_type_for_stream(store, stream_id, key_type, continue_on_error); });
+inline void
+delete_all_for_stream(const std::shared_ptr<Store>& store, const StreamId& stream_id, bool continue_on_error = false)
+{
+    foreach_key_type([&store, &stream_id, continue_on_error](KeyType key_type) {
+        delete_keys_of_type_for_stream(store, stream_id, key_type, continue_on_error);
+    });
 }
 
-inline void delete_all(const std::shared_ptr<Store>& store, bool continue_on_error) {
-    foreach_key_type([&store, continue_on_error] (KeyType key_type) {
+inline void delete_all(const std::shared_ptr<Store>& store, bool continue_on_error)
+{
+    foreach_key_type([&store, continue_on_error](KeyType key_type) {
         ARCTICDB_DEBUG(log::version(), "Deleting keys of type {}", key_type);
         delete_all_keys_of_type(key_type, store, continue_on_error);
     });
 }
 
-template<typename KeyContainer, typename = std::enable_if<std::is_base_of_v<AtomKey, typename KeyContainer::value_type>>>
-inline std::vector<AtomKey> get_data_keys(
-    const std::shared_ptr<stream::StreamSource>& store,
-    const KeyContainer& keys,
-    storage::ReadKeyOpts opts) {
+template<typename KeyContainer,
+    typename = std::enable_if<std::is_base_of_v<AtomKey, typename KeyContainer::value_type>>>
+inline std::vector<AtomKey>
+get_data_keys(const std::shared_ptr<stream::StreamSource>& store, const KeyContainer& keys, storage::ReadKeyOpts opts)
+{
     using KeySupplier = folly::Function<KeyContainer()>;
     using StreamReader = arcticdb::stream::StreamReader<AtomKey, KeySupplier, SegmentInMemory::Row>;
     auto gen = [&keys]() { return keys; };
@@ -75,33 +92,34 @@ inline std::vector<AtomKey> get_data_keys(
     return stream_reader.generate_data_keys() | folly::gen::as<std::vector>();
 }
 
-inline std::vector<AtomKey> get_data_keys(
-    const std::shared_ptr<stream::StreamSource>& store,
-    const AtomKey& key,
-    storage::ReadKeyOpts opts) {
+inline std::vector<AtomKey>
+get_data_keys(const std::shared_ptr<stream::StreamSource>& store, const AtomKey& key, storage::ReadKeyOpts opts)
+{
     const std::vector<AtomKey> keys{key};
     return get_data_keys(store, keys, opts);
 }
 
-template<typename KeyContainer, typename = std::enable_if<std::is_base_of_v<AtomKey, typename KeyContainer::value_type>>>
-inline std::unordered_set<AtomKey> get_data_keys_set(
-    const std::shared_ptr<stream::StreamSource>& store,
+template<typename KeyContainer,
+    typename = std::enable_if<std::is_base_of_v<AtomKey, typename KeyContainer::value_type>>>
+inline std::unordered_set<AtomKey> get_data_keys_set(const std::shared_ptr<stream::StreamSource>& store,
     const KeyContainer& keys,
-    storage::ReadKeyOpts opts) {
+    storage::ReadKeyOpts opts)
+{
     auto vec = get_data_keys(store, keys, opts);
     return {vec.begin(), vec.end()};
 }
 
 std::unordered_set<AtomKey> recurse_segment(const std::shared_ptr<stream::StreamSource>& store,
-                                            SegmentInMemory segment,
-                                            std::optional<VersionId> version_id);
+    SegmentInMemory segment,
+    std::optional<VersionId> version_id);
 
 /* Given a [multi-]index key, returns a set containing the top level [multi-]index key itself, and all of the
  * multi-index, index, and data keys referenced by this [multi-]index key.
  * If the version_id argument is provided, the returned set will only contain keys matching that version_id. */
 inline std::unordered_set<AtomKey> recurse_index_key(const std::shared_ptr<stream::StreamSource>& store,
-                                                     const IndexTypeKey& index_key,
-                                                     std::optional<VersionId> version_id=std::nullopt) {
+    const IndexTypeKey& index_key,
+    std::optional<VersionId> version_id = std::nullopt)
+{
     auto segment = store->read_sync(index_key).second;
     auto res = recurse_segment(store, segment, version_id);
     res.emplace(index_key);
@@ -109,62 +127,77 @@ inline std::unordered_set<AtomKey> recurse_index_key(const std::shared_ptr<strea
 }
 
 inline std::unordered_set<AtomKey> recurse_segment(const std::shared_ptr<stream::StreamSource>& store,
-                                                   SegmentInMemory segment,
-                                                   std::optional<VersionId> version_id) {
+    SegmentInMemory segment,
+    std::optional<VersionId> version_id)
+{
     std::unordered_set<AtomKey> res;
     for (size_t idx = 0; idx < segment.row_count(); idx++) {
         auto key = stream::read_key_row(segment, idx);
         if ((version_id && key.version_id() == *version_id) || !version_id) {
             switch (key.type()) {
-                case KeyType::TABLE_DATA:
-                    res.emplace(std::move(key));
-                    break;
-                case KeyType::TABLE_INDEX:
-                case KeyType::MULTI_KEY:
-                    res.merge(recurse_index_key(store, key, version_id));
-                    break;
-                default:
-                    break;
+            case KeyType::TABLE_DATA:
+                res.emplace(std::move(key));
+                break;
+            case KeyType::TABLE_INDEX:
+            case KeyType::MULTI_KEY:
+                res.merge(recurse_index_key(store, key, version_id));
+                break;
+            default:
+                break;
             }
         }
     }
     return res;
 }
 
-inline VersionId get_next_version_from_key(const AtomKey& prev) {
+inline VersionId get_next_version_from_key(const AtomKey& prev)
+{
     auto version = prev.version_id();
     return ++version;
 }
 
-inline VersionId get_next_version_from_key(std::optional<AtomKey> maybe_prev) {
+inline VersionId get_next_version_from_key(std::optional<AtomKey> maybe_prev)
+{
     VersionId version = 0;
     if (maybe_prev) {
-       version = get_next_version_from_key(maybe_prev.value());
+        version = get_next_version_from_key(maybe_prev.value());
     }
 
     return version;
 }
 
-inline AtomKey in_memory_key(KeyType key_type, const StreamId& stream_id, VersionId version_id) {
+inline AtomKey in_memory_key(KeyType key_type, const StreamId& stream_id, VersionId version_id)
+{
     return atom_key_builder().version_id(version_id).build(stream_id, key_type);
 }
 
 template<class Predicate, class Function>
-inline void iterate_keys_of_type_if(const std::shared_ptr<Store>& store, Predicate&& predicate, KeyType key_type, const std::string& prefix, Function&& function) {
+inline void iterate_keys_of_type_if(const std::shared_ptr<Store>& store,
+    Predicate&& predicate,
+    KeyType key_type,
+    const std::string& prefix,
+    Function&& function)
+{
     std::vector<folly::Future<entity::VariantKey>> fut_vec;
-    store->iterate_type(key_type, [predicate=std::forward<Predicate>(predicate), function=std::forward<Function>(function)](const VariantKey &&key) {
-        if(predicate(key)) {
-           function(key);
-        }
-    }, prefix);
+    store->iterate_type(
+        key_type,
+        [predicate = std::forward<Predicate>(predicate), function = std::forward<Function>(function)](
+            const VariantKey&& key) {
+            if (predicate(key)) {
+                function(key);
+            }
+        },
+        prefix);
 }
 
-template <class Function>
-inline void iterate_keys_of_type_for_stream(
-    std::shared_ptr<Store> store, KeyType key_type, const StreamId& stream_id, Function&& function
-    ) {
+template<class Function>
+inline void iterate_keys_of_type_for_stream(std::shared_ptr<Store> store,
+    KeyType key_type,
+    const StreamId& stream_id,
+    Function&& function)
+{
     auto prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
-    auto match_stream_id =  [&stream_id](const VariantKey & k){ return variant_key_id(k) == stream_id; };
+    auto match_stream_id = [&stream_id](const VariantKey& k) { return variant_key_id(k) == stream_id; };
     iterate_keys_of_type_if(store, match_stream_id, key_type, prefix, std::forward<Function>(function));
 }
 

--- a/cpp/arcticdb/util/lock_table.hpp
+++ b/cpp/arcticdb/util/lock_table.hpp
@@ -15,11 +15,13 @@ namespace arcticdb {
 struct Lock {
     std::mutex mutex_;
 
-    void lock() {
+    void lock()
+    {
         mutex_.lock();
     }
 
-    void unlock() {
+    void unlock()
+    {
         mutex_.unlock();
     }
 };
@@ -29,12 +31,14 @@ struct ScopedLock {
 
     ARCTICDB_NO_MOVE_OR_COPY(ScopedLock)
 
-    explicit ScopedLock(std::shared_ptr<Lock> lock) :
-        lock_(std::move(lock)) {
+    explicit ScopedLock(std::shared_ptr<Lock> lock)
+        : lock_(std::move(lock))
+    {
         lock_->lock();
     }
 
-    ~ScopedLock() {
+    ~ScopedLock()
+    {
         lock_->unlock();
     }
 };
@@ -42,15 +46,17 @@ struct ScopedLock {
 class LockTable {
     std::unordered_map<entity::StreamId, std::shared_ptr<Lock>> locks_;
     std::mutex mutex_;
+
 public:
     LockTable() = default;
-    std::shared_ptr<Lock> get_lock_object(const StreamId& stream_id) {
+    std::shared_ptr<Lock> get_lock_object(const StreamId& stream_id)
+    {
         std::lock_guard lock(mutex_);
 
-        if(auto it = locks_.find(stream_id); it != std::end(locks_))
+        if (auto it = locks_.find(stream_id); it != std::end(locks_))
             return it->second;
 
         return locks_.try_emplace(stream_id, std::make_shared<Lock>()).first->second;
     }
 };
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/magic_num.hpp
+++ b/cpp/arcticdb/util/magic_num.hpp
@@ -5,7 +5,7 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#pragma  once
+#pragma once
 
 #include <cstdint>
 #include <climits>
@@ -14,60 +14,71 @@
 namespace arcticdb::util {
 template<char a, char b, char c, char d>
 struct MagicNum {
-    static constexpr uint64_t Magic =
-        a << CHAR_BIT * 0 |
-            b << CHAR_BIT * 1 |
-            c << CHAR_BIT * 2 |
-            d << CHAR_BIT * 3;
+    static constexpr uint64_t Magic = a << CHAR_BIT * 0 | b << CHAR_BIT * 1 | c << CHAR_BIT * 2 | d << CHAR_BIT * 3;
 
-    MagicNum() : magic_(Magic) {}
+    MagicNum()
+        : magic_(Magic)
+    {
+    }
 
     //uint64_t magic() const { return magic_; }
 
-    ~MagicNum() {
+    ~MagicNum()
+    {
         magic_ = ~magic_;
     }
 
-    void check() const { util::check(magic_ == Magic, "Magic number failure, expected {} got {}", Magic, magic_); }
+    void check() const
+    {
+        util::check(magic_ == Magic, "Magic number failure, expected {} got {}", Magic, magic_);
+    }
 
-  private:
+private:
     volatile uint64_t magic_;
 };
 
 template<char a, char b>
 struct SmallMagicNum {
-    static constexpr uint16_t Magic =
-        a << CHAR_BIT * 0 |
-            b << CHAR_BIT * 1;
+    static constexpr uint16_t Magic = a << CHAR_BIT * 0 | b << CHAR_BIT * 1;
 
-    SmallMagicNum() : magic_(Magic) {}
+    SmallMagicNum()
+        : magic_(Magic)
+    {
+    }
 
-    ~SmallMagicNum() {
+    ~SmallMagicNum()
+    {
         magic_ = ~magic_;
     }
 
-    [[nodiscard]] uint16_t magic() const { return magic_; }
+    [[nodiscard]] uint16_t magic() const
+    {
+        return magic_;
+    }
 
-    void check() const { util::check(magic_ == Magic, "Magic number failure, expected {} got {}", Magic, magic_); }
+    void check() const
+    {
+        util::check(magic_ == Magic, "Magic number failure, expected {} got {}", Magic, magic_);
+    }
 
 private:
     volatile uint16_t magic_;
 };
 
-template <typename MagicNumType>
-void check_magic(const uint8_t*& pos) {
+template<typename MagicNumType>
+void check_magic(const uint8_t*& pos)
+{
     const auto magic_num = reinterpret_cast<const MagicNumType*>(pos);
     magic_num->check();
     pos += sizeof(MagicNumType);
 }
 
-template <typename MagicNumType>
-void write_magic(uint8_t*& pos) {
-    const auto magic_num = new(pos) MagicNumType;
+template<typename MagicNumType>
+void write_magic(uint8_t*& pos)
+{
+    const auto magic_num = new (pos) MagicNumType;
     magic_num->check();
     pos += sizeof(MagicNumType);
 }
 
-
-} // namespace arcticdb
-
+} // namespace arcticdb::util

--- a/cpp/arcticdb/util/memory_tracing.hpp
+++ b/cpp/arcticdb/util/memory_tracing.hpp
@@ -19,8 +19,9 @@
 namespace arcticdb::util {
 
 struct MemBytes {
-    static auto suffixes() {
-        static const char *ret[] = {" bytes", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb"};
+    static auto suffixes()
+    {
+        static const char* ret[] = {" bytes", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb"};
         return ret;
     }
 
@@ -30,7 +31,8 @@ struct MemBytes {
 
 constexpr int page_size = 4096;
 
-inline MemBytes pages(uint64_t num_pages) {
+inline MemBytes pages(uint64_t num_pages)
+{
     return {num_pages * page_size};
 }
 
@@ -40,10 +42,14 @@ namespace fmt {
 template<>
 struct formatter<arcticdb::util::MemBytes> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(arcticdb::util::MemBytes bytes, FormatContext &ctx) const {
+    auto format(arcticdb::util::MemBytes bytes, FormatContext& ctx) const
+    {
         using namespace arcticdb::util;
 
         uint8_t s = 0;
@@ -55,7 +61,7 @@ struct formatter<arcticdb::util::MemBytes> {
 
         auto suffixes = MemBytes::suffixes();
         if (count - floor(count) == 0.0)
-            return format_to(ctx.out(), "{:d}{:s}", (int) count, suffixes[s]);
+            return format_to(ctx.out(), "{:d}{:s}", (int)count, suffixes[s]);
         else
             return format_to(ctx.out(), "{:.1f}{:s}", count, suffixes[s]);
     }
@@ -65,33 +71,37 @@ struct formatter<arcticdb::util::MemBytes> {
 
 namespace arcticdb::util {
 
-inline void print_total_mem_usage(const char *file ARCTICDB_UNUSED, int line ARCTICDB_UNUSED, const char *function ARCTICDB_UNUSED) {
+inline void
+print_total_mem_usage(const char* file ARCTICDB_UNUSED, int line ARCTICDB_UNUSED, const char* function ARCTICDB_UNUSED)
+{
     auto pid = getpid();
     auto file_name = fmt::format("/proc/{:d}/statm", pid);
     std::array<int, 7> mem_stat{};
 
     // Don't try to do this with fstream, it doesn't work
-    FILE *statm_file;
+    FILE* statm_file;
     statm_file = fopen(file_name.c_str(), "r");
-    if(statm_file == nullptr) {
+    if (statm_file == nullptr) {
         ARCTICDB_DEBUG(log::memory(), "Unable to read {}", file_name);
         return;
     }
 
-    for(auto i = 0u; i < 7u; ++i){
+    for (auto i = 0u; i < 7u; ++i) {
         // https://stackoverflow.com/questions/7271939/warning-ignoring-return-value-of-scanf-declared-with-attribute-warn-unused-r
         // this "if" is needed to avoid warning of unused return value
-        if(fscanf(statm_file, "%d", &mem_stat[i])){}
+        if (fscanf(statm_file, "%d", &mem_stat[i])) {
+        }
     }
     fclose(statm_file);
-    ARCTICDB_DEBUG(log::memory(), "{} ({}:{}) size {} resident {} share {} text {} data/stack {}",
-                       file,
-                       function,
-                       line,
-                       pages(mem_stat[0]),
-                       pages(mem_stat[1]),
-                       pages(mem_stat[2]),
-                       pages(mem_stat[3]),
-                       pages(mem_stat[5]));
+    ARCTICDB_DEBUG(log::memory(),
+        "{} ({}:{}) size {} resident {} share {} text {} data/stack {}",
+        file,
+        function,
+        line,
+        pages(mem_stat[0]),
+        pages(mem_stat[1]),
+        pages(mem_stat[2]),
+        pages(mem_stat[3]),
+        pages(mem_stat[5]));
 }
-}  //namespace arcticdb::util
+} //namespace arcticdb::util

--- a/cpp/arcticdb/util/movable_priority_queue.hpp
+++ b/cpp/arcticdb/util/movable_priority_queue.hpp
@@ -11,18 +11,22 @@
 
 namespace arcticdb {
 
-template<typename _Tp, typename _Sequence = std::vector<_Tp>, typename _Compare = std::less<typename _Sequence::value_type> >
-class movable_priority_queue: std::priority_queue<_Tp, _Sequence, _Compare> {
+template<typename _Tp,
+    typename _Sequence = std::vector<_Tp>,
+    typename _Compare = std::less<typename _Sequence::value_type>>
+class movable_priority_queue : std::priority_queue<_Tp, _Sequence, _Compare> {
 public:
     typedef typename _Sequence::value_type value_type;
 
-    explicit movable_priority_queue(const _Compare& __x, const _Sequence& __s) :
-        std::priority_queue<_Tp, _Sequence, _Compare>(__x, __s) {}
+    explicit movable_priority_queue(const _Compare& __x, const _Sequence& __s)
+        : std::priority_queue<_Tp, _Sequence, _Compare>(__x, __s)
+    {
+    }
 
-    explicit movable_priority_queue(const _Compare& __x = _Compare(), _Sequence&& __s =
-    _Sequence()) :
-        std::priority_queue<_Tp, _Sequence, _Compare>(__x, std::move(__s)) {}
-
+    explicit movable_priority_queue(const _Compare& __x = _Compare(), _Sequence&& __s = _Sequence())
+        : std::priority_queue<_Tp, _Sequence, _Compare>(__x, std::move(__s))
+    {
+    }
 
     using std::priority_queue<_Tp, _Sequence, _Compare>::empty;
     using std::priority_queue<_Tp, _Sequence, _Compare>::size;
@@ -32,7 +36,8 @@ public:
     using std::priority_queue<_Tp, _Sequence, _Compare>::emplace;
     using std::priority_queue<_Tp, _Sequence, _Compare>::swap;
 
-    value_type pop_top() {
+    value_type pop_top()
+    {
 #ifdef __glibcxx_requires_nonempty
         __glibcxx_requires_nonempty();
 #endif
@@ -43,7 +48,6 @@ public:
         this->c.pop_back();
         return top;
     }
-
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/util/offset_string.cpp
+++ b/cpp/arcticdb/util/offset_string.cpp
@@ -9,5 +9,8 @@
 #include <arcticdb/column_store/string_pool.hpp>
 
 namespace arcticdb {
-OffsetString::operator std::string_view() const { return pool_->get_view(offset()); }
+OffsetString::operator std::string_view() const
+{
+    return pool_->get_view(offset());
+}
 } //namespace arcticdb

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -19,39 +19,54 @@ class OffsetString {
 public:
     using offset_t = entity::position_t;
 
-    explicit OffsetString(offset_t offset, StringPool *pool) :
-        offset_(offset), pool_(pool) {}
+    explicit OffsetString(offset_t offset, StringPool* pool)
+        : offset_(offset),
+          pool_(pool)
+    {
+    }
 
     explicit operator std::string_view() const;
 
-    [[nodiscard]] offset_t offset() const { return offset_; }
+    [[nodiscard]] offset_t offset() const
+    {
+        return offset_;
+    }
 
-  private:
+private:
     entity::position_t offset_;
-    StringPool *pool_;
+    StringPool* pool_;
 };
 
-inline constexpr OffsetString::offset_t not_a_string() { return std::numeric_limits<OffsetString::offset_t>::max(); }
+inline constexpr OffsetString::offset_t not_a_string()
+{
+    return std::numeric_limits<OffsetString::offset_t>::max();
+}
 
-inline constexpr OffsetString::offset_t nan_placeholder() { return not_a_string() - 1; }
+inline constexpr OffsetString::offset_t nan_placeholder()
+{
+    return not_a_string() - 1;
+}
 
 // Returns true if the provided offset does not represent None or NaN
-inline bool is_a_string(OffsetString::offset_t offset) {
+inline bool is_a_string(OffsetString::offset_t offset)
+{
     return offset < nan_placeholder();
 }
 
 // Given a set of string pool offsets, removes any that represent None or NaN
-inline void remove_nones_and_nans(emilib::HashSet<OffsetString::offset_t>& offsets) {
+inline void remove_nones_and_nans(emilib::HashSet<OffsetString::offset_t>& offsets)
+{
     offsets.erase(not_a_string());
     offsets.erase(nan_placeholder());
 }
 
-template <typename LockPtrType>
-inline PyObject* create_py_nan(LockPtrType& lock) {
+template<typename LockPtrType>
+inline PyObject* create_py_nan(LockPtrType& lock)
+{
     lock->lock();
     auto ptr = PyFloat_FromDouble(std::numeric_limits<double>::quiet_NaN());
     lock->unlock();
     util::check(ptr != nullptr, "Got null nan ptr");
     return ptr;
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/optional_defaults.hpp
+++ b/cpp/arcticdb/util/optional_defaults.hpp
@@ -11,11 +11,13 @@
 
 namespace arcticdb {
 
-inline bool opt_true(const std::optional<bool> &opt) {
+inline bool opt_true(const std::optional<bool>& opt)
+{
     return !opt || opt.value();
 }
 
-inline bool opt_false(const std::optional<bool> &opt) {
+inline bool opt_false(const std::optional<bool>& opt)
+{
     return opt && opt.value();
 }
-} //namespace
+} // namespace arcticdb

--- a/cpp/arcticdb/util/pb_util.hpp
+++ b/cpp/arcticdb/util/pb_util.hpp
@@ -19,8 +19,9 @@
 
 namespace arcticdb::util {
 
-template<class Msg, class ExcType=std::invalid_argument>
-[[noreturn]] void raise_error_msg(const char *pattern, const Msg &msg) {
+template<class Msg, class ExcType = std::invalid_argument>
+[[noreturn]] void raise_error_msg(const char* pattern, const Msg& msg)
+{
     std::string s;
     google::protobuf::TextFormat::PrintToString(msg, &s);
     throw ExcType(fmt::format(pattern, s));
@@ -31,11 +32,13 @@ constexpr char TYPE_URL[] = "cxx.arctic.org";
 }
 
 template<class Msg>
-void pack_to_any(const Msg &msg, google::protobuf::Any &any) {
+void pack_to_any(const Msg& msg, google::protobuf::Any& any)
+{
     any.PackFrom(msg, TYPE_URL);
 }
 
-inline folly::StringPiece get_arcticdb_pb_type_name(const google::protobuf::Any &any) {
+inline folly::StringPiece get_arcticdb_pb_type_name(const google::protobuf::Any& any)
+{
     folly::StringPiece sp{any.type_url()};
     if (!sp.startsWith(TYPE_URL)) {
         raise_error_msg("Not a valid arcticdb proto msg", any);
@@ -44,19 +47,22 @@ inline folly::StringPiece get_arcticdb_pb_type_name(const google::protobuf::Any 
 }
 
 template<class Msg>
-bool pb_equals(const Msg &a, const Msg &b) {
+bool pb_equals(const Msg& a, const Msg& b)
+{
     return google::protobuf::util::MessageDifferencer::Equals(a, b);
 }
 
 template<class T>
-std::optional<T> as_opt(T val, const T &sentinel = T()) {
+std::optional<T> as_opt(T val, const T& sentinel = T())
+{
     if (val == sentinel) {
         return std::nullopt;
     }
     return std::make_optional(val);
 }
 
-inline std::string format(const google::protobuf::Message &msg) {
+inline std::string format(const google::protobuf::Message& msg)
+{
     std::string dest;
     google::protobuf::TextFormat::Printer p;
     p.SetExpandAny(true);
@@ -64,11 +70,11 @@ inline std::string format(const google::protobuf::Message &msg) {
     return dest;
 }
 
-inline std::string newlines_to_spaces(const ::google::protobuf::Message& msg) {
+inline std::string newlines_to_spaces(const ::google::protobuf::Message& msg)
+{
     auto out = msg.DebugString();
     std::replace(std::begin(out), std::end(out), '\n', ' ');
     return out;
 }
 
-} // namespace arctic::util
-
+} // namespace arcticdb::util

--- a/cpp/arcticdb/util/preprocess.hpp
+++ b/cpp/arcticdb/util/preprocess.hpp
@@ -14,10 +14,10 @@
 
 #ifndef _WIN32
 #define ARCTICDB_UNUSED __attribute__((unused))
-#define ARCTICDB_UNREACHABLE  __builtin_unreachable();
+#define ARCTICDB_UNREACHABLE __builtin_unreachable();
 
-#define ARCTICDB_VISIBILITY_HIDDEN __attribute__ ((visibility("hidden")))
-#define ARCTICDB_VISIBILITY_DEFAULT  __attribute__ ((visibility ("default")))
+#define ARCTICDB_VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
+#define ARCTICDB_VISIBILITY_DEFAULT __attribute__((visibility("default")))
 
 #define ARCTICDB_LIKELY(condition) __builtin_expect(condition, 1)
 #define ARCTICDB_UNLIKELY(condition) __builtin_expect(condition, 0)

--- a/cpp/arcticdb/util/random.h
+++ b/cpp/arcticdb/util/random.h
@@ -10,48 +10,56 @@ namespace arcticdb {
 
 typedef std::array<uint64_t, 2> seed;
 
-inline seed &ts() {
+inline seed& ts()
+{
     thread_local seed _ts;
     return _ts;
 }
 
-inline void init_random(uint64_t n) {
+inline void init_random(uint64_t n)
+{
     ts()[0] = ts()[1] = n;
 };
 
 // Fast PRNG: see https://en.wikipedia.org/wiki/Xorshift
-inline uint64_t xorshiftadd(seed &s) {
+inline uint64_t xorshiftadd(seed& s)
+{
     util::check_arg(s[0] != 0 || s[1] != 0, "Need to initialize seed before using random");
     uint64_t x = s[0];
     uint64_t const y = s[1];
     s[0] = y;
-    x ^= x << 23; // a
+    x ^= x << 23;                         // a
     s[1] = x ^ y ^ (x >> 17) ^ (y >> 26); // b, c
     return s[1] + y;
 }
 
-inline uint64_t random_int() {
+inline uint64_t random_int()
+{
     return xorshiftadd(ts());
 }
 
-inline double random_double() {
+inline double random_double()
+{
     auto i = random_int();
     double output;
-    memcpy(static_cast<void *>(&output), static_cast<void *>(&i), sizeof(double));
+    memcpy(static_cast<void*>(&output), static_cast<void*>(&i), sizeof(double));
     return output;
 }
 
-inline double random_probability() {
-    return double(random_int()) / std::numeric_limits< uint64_t >::max();
+inline double random_probability()
+{
+    return double(random_int()) / std::numeric_limits<uint64_t>::max();
 }
 
-inline char random_char() {
+inline char random_char()
+{
     auto val = static_cast<char>(random_int());
     char c = 'A' + (val & 0x1F);
     return c; // not quite all of them
 }
 
-inline size_t random_length() {
+inline size_t random_length()
+{
     const size_t MaxLength = 0x1F;
     size_t length = 0;
     while (length == 0)
@@ -60,43 +68,49 @@ inline size_t random_length() {
     return length;
 }
 
-inline std::string random_string(size_t length) {
+inline std::string random_string(size_t length)
+{
     std::string output;
     std::generate_n(std::back_inserter(output), length, random_char);
     return output;
 }
 
-inline std::vector<std::string> random_string_vector(size_t n) {
+inline std::vector<std::string> random_string_vector(size_t n)
+{
     std::vector<std::string> output;
     std::generate_n(std::back_inserter(output), n, [&] { return random_string(random_length()); });
     return output;
 }
 
-struct RandomSelector
-{
+struct RandomSelector {
     using RandomGenerator = std::default_random_engine;
 
     RandomSelector(RandomGenerator gen = RandomGenerator(std::random_device()()))
-    : gen_(gen) {}
+        : gen_(gen)
+    {
+    }
 
-    template <typename Iter>
-    Iter select(Iter start, Iter end) {
+    template<typename Iter>
+    Iter select(Iter start, Iter end)
+    {
         std::uniform_int_distribution<> dis(0, std::distance(start, end) - 1);
         std::advance(start, dis(gen_));
         return start;
     }
 
-    template <typename Iter>
-    Iter operator()(Iter start, Iter end) {
+    template<typename Iter>
+    Iter operator()(Iter start, Iter end)
+    {
         return select(start, end);
     }
 
-    template <typename Container>
-    auto operator()(const Container& c) -> decltype(*begin(c))& {
+    template<typename Container>
+    auto operator()(const Container& c) -> decltype(*begin(c))&
+    {
         return *select(begin(c), end(c));
     }
 
 private:
     RandomGenerator gen_;
 };
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/ranges_from_future.hpp
+++ b/cpp/arcticdb/util/ranges_from_future.hpp
@@ -19,12 +19,14 @@ namespace arcticdb::utils {
  * Pre-C++20 emulation of ranges::views::elements, with the ability to alter the output type.
  * @tparam OutType Override the output type. Must have a c'tor that can accept the element's original type.
  */
-template<size_t n, typename RangeOfPairs,
-        typename OutType=std::remove_const_t<typename std::tuple_element<n, typename RangeOfPairs::value_type>::type>>
-std::vector<OutType> copy_of_elements(const RangeOfPairs& rop) {
+template<size_t n,
+    typename RangeOfPairs,
+    typename OutType = std::remove_const_t<typename std::tuple_element<n, typename RangeOfPairs::value_type>::type>>
+std::vector<OutType> copy_of_elements(const RangeOfPairs& rop)
+{
     std::vector<OutType> as_vector;
     as_vector.reserve(rop.size());
-    for (const auto& pair: rop) {
+    for (const auto& pair : rop) {
         as_vector.emplace_back(std::get<n>(pair));
     }
     return as_vector;
@@ -34,7 +36,8 @@ std::vector<OutType> copy_of_elements(const RangeOfPairs& rop) {
  * Upgradeable to std::views::keys(). This implementation has to copy unfortunately.
  */
 template<typename Map>
-inline auto keys(const Map& map) {
+inline auto keys(const Map& map)
+{
     return copy_of_elements<0>(map);
 }
 
@@ -42,7 +45,8 @@ inline auto keys(const Map& map) {
  * Upgradeable to std::views::values(). This implementation has to copy unfortunately.
  */
 template<typename Map>
-inline auto values(const Map& map) {
+inline auto values(const Map& map)
+{
     return copy_of_elements<1>(map);
 }
 
@@ -51,8 +55,9 @@ inline auto values(const Map& map) {
  */
 // No direct upgrade path to ranges, but trivial given how copy_of_elements is implemented.
 template<typename OutType, typename Map>
-inline auto copy_of_values_as(const Map& map) {
+inline auto copy_of_values_as(const Map& map)
+{
     return copy_of_elements<1, Map, OutType>(map);
 }
 
-}
+} // namespace arcticdb::utils

--- a/cpp/arcticdb/util/ref_counted_map.hpp
+++ b/cpp/arcticdb/util/ref_counted_map.hpp
@@ -18,38 +18,45 @@ class SegmentMap {
     std::atomic<uint64_t> id_;
     std::shared_ptr<Store> store_;
     std::mutex mutex_;
+
 public:
     using const_iterator = ContainerType::const_iterator;
 
-    SegmentMap(const std::shared_ptr<Store>& store) :
-        store_(store) {
+    SegmentMap(const std::shared_ptr<Store>& store)
+        : store_(store)
+    {
     }
 
-    uint64_t insert(std::shared_ptr<SegmentInMemoryImpl>&& seg) {
+    uint64_t insert(std::shared_ptr<SegmentInMemoryImpl>&& seg)
+    {
         const auto id = id_++;
         std::shared_ptr<ValueType> value(
             std::move(seg),
             [this, id](ValueType* v)
                 map_.erase(id);
                 delete v;
-            }
+    }
             );
-        map_.emplace(id, value);
-        return id;
-    }
+            map_.emplace(id, value);
+            return id;
+}
 
-    int size() const {
-        return map_.size();
-    }
+    int size() const
+{
+            return map_.size();
+}
 
-    const_iterator begin() const {
-        return map_.begin();
-    }
+const_iterator begin() const
+{
+            return map_.begin();
+}
 
-    const_iterator end() const {
-        return map_.end();
-    }
+const_iterator end() const
+{
+            return map_.end();
+}
+
 private:
-    container_type map_;
+container_type map_;
 };
 }

--- a/cpp/arcticdb/util/regex_filter.hpp
+++ b/cpp/arcticdb/util/regex_filter.hpp
@@ -28,7 +28,7 @@ protected:
 class RegexPattern : private PcreRegex {
     const std::string& text_;
     HandleType handle_ = nullptr;
-    HelpType help_  = "";
+    HelpType help_ = "";
     Offset offset_ = 0;
     TableType table_ = nullptr;
     ErrorType error_ = 0;
@@ -37,40 +37,47 @@ class RegexPattern : private PcreRegex {
     int capturing_groups_ = 0;
 
 public:
-    explicit RegexPattern(const std::string& pattern) :
-    text_(pattern) {
+    explicit RegexPattern(const std::string& pattern)
+        : text_(pattern)
+    {
         compile_regex();
     }
 
-    [[nodiscard]] bool valid() const {
+    [[nodiscard]] bool valid() const
+    {
         return handle_ != nullptr;
     }
 
-    [[nodiscard]] HandleType handle() const {
+    [[nodiscard]] HandleType handle() const
+    {
         return handle_;
     }
 
-    [[nodiscard]] const std::string& text() const {
+    [[nodiscard]] const std::string& text() const
+    {
         return text_;
     }
 
-    [[nodiscard]] size_t capturing_groups() const {
+    [[nodiscard]] size_t capturing_groups() const
+    {
         return static_cast<size_t>(capturing_groups_);
     }
 
     ARCTICDB_NO_MOVE_OR_COPY(RegexPattern)
 private:
-    void compile_regex() {
+    void compile_regex()
+    {
         handle_ = ::pcre_compile2(text_.data(), options_, &error_, &help_, &offset_, table_);
         util::check(handle_ != nullptr, "Error {} compiling regex {}: {}", error_, text_, help_);
         auto result = get_capturing_groups();
-        if(result != 0) {
+        if (result != 0) {
             handle_ = nullptr;
             util::raise_rte("Failed to get capturing groups for regex {}: {}", text_, result);
         }
     }
 
-    ResultsType get_capturing_groups() {
+    ResultsType get_capturing_groups()
+    {
         return ::pcre_fullinfo(handle_, extra_, PCRE_INFO_CAPTURECOUNT, &capturing_groups_);
     }
 };
@@ -80,19 +87,33 @@ class Regex : private PcreRegex {
     ExtraPtr extra_ = nullptr;
     OptionsType options_ = 0;
     std::vector<int> results_;
+
 public:
     ARCTICDB_NO_MOVE_OR_COPY(Regex);
 
-    explicit Regex(const RegexPattern& pattern) :
-    pattern_(pattern),
-    results_((pattern_.capturing_groups() + 1) * 3, 0) {
+    explicit Regex(const RegexPattern& pattern)
+        : pattern_(pattern),
+          results_((pattern_.capturing_groups() + 1) * 3, 0)
+    {
     }
 
-    bool match(const std::string& text) {
-        ResultsType res = ::pcre_exec(pattern_.handle(), extra_, text.data(), static_cast<int>(text.size()), 0, options_, &results_[0], static_cast<int>(results_.size()));
-        util::check(res >= 0 || res == PCRE_ERROR_NOMATCH, "Invalid result in regex compile with pattern {} and text {}: {}", pattern_.text(), text, res);
+    bool match(const std::string& text)
+    {
+        ResultsType res = ::pcre_exec(pattern_.handle(),
+            extra_,
+            text.data(),
+            static_cast<int>(text.size()),
+            0,
+            options_,
+            &results_[0],
+            static_cast<int>(results_.size()));
+        util::check(res >= 0 || res == PCRE_ERROR_NOMATCH,
+            "Invalid result in regex compile with pattern {} and text {}: {}",
+            pattern_.text(),
+            text,
+            res);
         return res > 0;
     }
 };
 
-}
+} // namespace arcticdb::util

--- a/cpp/arcticdb/util/shared_future.hpp
+++ b/cpp/arcticdb/util/shared_future.hpp
@@ -18,16 +18,20 @@ namespace arcticdb {
 template<typename T>
 class SharedFuture {
 public:
-    SharedFuture() : promise_(std::make_shared<folly::SharedPromise<T>>()) {
+    SharedFuture()
+        : promise_(std::make_shared<folly::SharedPromise<T>>())
+    {
     }
 
     ARCTICDB_MOVE_COPY_DEFAULT(SharedFuture)
 
-    void setValue(T&& val) {
+    void setValue(T&& val)
+    {
         promise_->setValue(std::move(val));
     }
 
-    const T get(folly::FutureExecutor<folly::IOThreadPoolExecutor>& exec) {
+    const T get(folly::FutureExecutor<folly::IOThreadPoolExecutor>& exec)
+    {
         auto f = promise_->getSemiFuture().via(&exec);
         const auto val = std::move(f).get();
         return val;

--- a/cpp/arcticdb/util/simple_string_hash.hpp
+++ b/cpp/arcticdb/util/simple_string_hash.hpp
@@ -10,7 +10,8 @@
 // from https://en.wikipedia.org/wiki/MurmurHash
 
 namespace arcticdb {
-static inline uint32_t murmur_32_scramble(uint32_t k) {
+static inline uint32_t murmur_32_scramble(uint32_t k)
+{
     k *= 0xcc9e2d51;
     k = (k << 15) | (k >> 17);
     k *= 0x1b873593;
@@ -19,7 +20,8 @@ static inline uint32_t murmur_32_scramble(uint32_t k) {
 
 // This is here so that we have deterministic hashing for keys.
 // If you change anything including the seed, you will break things.
-inline uint32_t murmur3_32(const std::string& str) {
+inline uint32_t murmur3_32(const std::string& str)
+{
     constexpr uint32_t seed = 0xbeef;
     uint32_t hash = seed;
     uint32_t k;
@@ -48,10 +50,11 @@ inline uint32_t murmur3_32(const std::string& str) {
     return hash;
 }
 
-inline size_t bucketize(const std::string& name, std::optional<size_t> num_buckets) {
+inline size_t bucketize(const std::string& name, std::optional<size_t> num_buckets)
+{
     auto hash = murmur3_32(name);
     if (!num_buckets.has_value())
         return hash;
     return hash % num_buckets.value();
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/sparse_utils.cpp
+++ b/cpp/arcticdb/util/sparse_utils.cpp
@@ -10,17 +10,15 @@
 
 namespace arcticdb::util {
 
-void scan_object_type_to_sparse(
-    const PyObject* const* ptr,
-    size_t rows_to_write,
-    util::BitMagic& bitset) {
+void scan_object_type_to_sparse(const PyObject* const* ptr, size_t rows_to_write, util::BitMagic& bitset)
+{
 
     namespace py = pybind11;
     auto scan_ptr = ptr;
     py::none none;
     util::BitSet::bulk_insert_iterator inserter(bitset);
     for (size_t idx = 0; idx < rows_to_write; ++idx, ++scan_ptr) {
-        if(*scan_ptr != none.ptr())
+        if (*scan_ptr != none.ptr())
             inserter = bv_size(idx);
     }
     inserter.flush();
@@ -28,4 +26,3 @@ void scan_object_type_to_sparse(
 }
 
 } //namespace arcticdb::util
-

--- a/cpp/arcticdb/util/string_utils.cpp
+++ b/cpp/arcticdb/util/string_utils.cpp
@@ -13,15 +13,18 @@
 
 namespace arcticdb::util {
 
-char from_hex(char c) {
+char from_hex(char c)
+{
     return std::isdigit(c) != 0 ? c - '0' : c - 'A' + 10;
 }
 
-char decode_char(char a, char b) {
+char decode_char(char a, char b)
+{
     return from_hex(a) << 4 | from_hex(b);
 }
 
-std::string safe_encode(const std::string &value) {
+std::string safe_encode(const std::string& value)
+{
     std::ostringstream escaped;
     escaped.fill('0');
     escaped << std::hex;
@@ -35,20 +38,21 @@ std::string safe_encode(const std::string &value) {
         }
 
         escaped << std::uppercase;
-        escaped << escape_char << std::setw(0) << int((unsigned char) c);
+        escaped << escape_char << std::setw(0) << int((unsigned char)c);
         escaped << std::nouppercase;
     }
 
     return escaped.str();
 }
 
-std::string safe_decode(const std::string& value) {
+std::string safe_decode(const std::string& value)
+{
     std::ostringstream unescaped;
     auto pos = 0u;
     const auto len = value.size();
-    while(true) {
-        auto curr = value.find(escape_char, pos)  ;
-        if(curr == std::string::npos) {
+    while (true) {
+        auto curr = value.find(escape_char, pos);
+        if (curr == std::string::npos) {
             unescaped << strv_from_pos(value, pos, len - pos);
             auto test = unescaped.str();
             break;
@@ -58,16 +62,15 @@ std::string safe_decode(const std::string& value) {
         auto test = unescaped.str();
 
         auto is_escaped = len - curr > 2 && std::isxdigit(value[curr + 1]) != 0 && std::isxdigit(value[curr + 2]) != 0;
-        if(is_escaped) {
+        if (is_escaped) {
             unescaped << decode_char(value[curr + 1], value[curr + 2]);
             pos = curr + 3;
-        }  else {
+        } else {
             unescaped << escape_char;
             test = unescaped.str();
             pos = curr + 1;
         }
-
     }
     return unescaped.str();
 }
-} //namespace arcticdb
+} // namespace arcticdb::util

--- a/cpp/arcticdb/util/string_utils.hpp
+++ b/cpp/arcticdb/util/string_utils.hpp
@@ -15,7 +15,8 @@
 
 namespace arcticdb::util {
 
-inline int64_t num_from_strv(std::string_view strv) {
+inline int64_t num_from_strv(std::string_view strv)
+{
     uint64_t val = 0;
     for (auto c : strv)
         val = val * 10 + (c - '0');
@@ -23,17 +24,20 @@ inline int64_t num_from_strv(std::string_view strv) {
     return *reinterpret_cast<int64_t*>(&val);
 };
 
-inline bool string_starts_with(const std::string& prefix, const std::string& str) {
+inline bool string_starts_with(const std::string& prefix, const std::string& str)
+{
     return std::equal(prefix.begin(), prefix.end(), str.begin());
 }
 
-inline std::string&& to_lower(std::string&& str) {
+inline std::string&& to_lower(std::string&& str)
+{
     std::transform(str.begin(), str.end(), str.begin(), ::tolower);
     return std::move(str);
 }
 
 template<uint32_t expected_size>
-std::array<std::string_view, expected_size> split_to_array(std::string_view strv, char delim) {
+std::array<std::string_view, expected_size> split_to_array(std::string_view strv, char delim)
+{
     std::array<std::string_view, expected_size> output;
     auto first = strv.begin();
     auto last = strv.cend();
@@ -52,7 +56,8 @@ std::array<std::string_view, expected_size> split_to_array(std::string_view strv
     return output;
 }
 
-inline std::vector<std::string_view> split_to_vector(std::string_view strv, char delim) {
+inline std::vector<std::string_view> split_to_vector(std::string_view strv, char delim)
+{
     std::vector<std::string_view> output;
     auto first = strv.begin();
     auto last = strv.cend();
@@ -72,12 +77,12 @@ inline std::vector<std::string_view> split_to_vector(std::string_view strv, char
 
 constexpr char escape_char = '~';
 
-inline std::string_view strv_from_pos(const std::string& str, size_t start, size_t length) {
+inline std::string_view strv_from_pos(const std::string& str, size_t start, size_t length)
+{
     return std::string_view{str.data() + start, length};
 }
 
-
-std::string safe_encode(const std::string &value);
+std::string safe_encode(const std::string& value);
 
 std::string safe_decode(const std::string& value);
 

--- a/cpp/arcticdb/util/string_wrapping_value.hpp
+++ b/cpp/arcticdb/util/string_wrapping_value.hpp
@@ -24,32 +24,42 @@ struct StringWrappingValue : BaseType {
     std::string value;
     //TODO might be nice to have view_or_value
     StringWrappingValue() = default;
-    explicit StringWrappingValue(std::string_view s) : value(s) {}
-    explicit StringWrappingValue(const std::string &s) : value(s) {}
-    explicit StringWrappingValue(const char *c) : value(c) {}
+    explicit StringWrappingValue(std::string_view s)
+        : value(s)
+    {
+    }
+    explicit StringWrappingValue(const std::string& s)
+        : value(s)
+    {
+    }
+    explicit StringWrappingValue(const char* c)
+        : value(c)
+    {
+    }
 
     ARCTICDB_MOVE_COPY_DEFAULT(StringWrappingValue)
 
-    friend bool operator==(const StringWrappingValue &l, const StringWrappingValue &r) {
+    friend bool operator==(const StringWrappingValue& l, const StringWrappingValue& r)
+    {
         return l.value == r.value;
     }
 
-    friend bool operator!=(const StringWrappingValue &l, const StringWrappingValue &r) {
+    friend bool operator!=(const StringWrappingValue& l, const StringWrappingValue& r)
+    {
         return !(l == r);
     }
 };
-}
+} // namespace arcticdb::util
 
 namespace std {
 template<typename TagType>
-struct hash<arcticdb::util::StringWrappingValue<TagType>>
-{
+struct hash<arcticdb::util::StringWrappingValue<TagType>> {
     std::size_t operator()(const arcticdb::util::StringWrappingValue<TagType>& s) const
     {
-      return std::hash<std::string>()(s.value);
+        return std::hash<std::string>()(s.value);
     }
 };
-}
+} // namespace std
 
 namespace fmt {
 
@@ -58,15 +68,18 @@ using namespace arcticdb::util;
 template<typename BaseType>
 struct formatter<StringWrappingValue<BaseType>> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const StringWrappingValue<BaseType> &srv, FormatContext &ctx) const {
+    auto format(const StringWrappingValue<BaseType>& srv, FormatContext& ctx) const
+    {
         return format_to(ctx.out(), "{}", srv.value);
     }
 };
 
-}
+} // namespace fmt
 
 //TODO format stuff, integrate with defaultstringviewable
-

--- a/cpp/arcticdb/util/test/config_common.hpp
+++ b/cpp/arcticdb/util/test/config_common.hpp
@@ -14,10 +14,10 @@
 
 namespace arcticdb {
 
-inline auto get_test_environment_config(
-    const arcticdb::storage::LibraryPath& path,
+inline auto get_test_environment_config(const arcticdb::storage::LibraryPath& path,
     const arcticdb::storage::StorageName& storage_name,
-    const arcticdb::storage::EnvironmentName& environment_name) {
+    const arcticdb::storage::EnvironmentName& environment_name)
+{
 
     using namespace arcticdb::storage;
     using MemoryConfig = storage::details::InMemoryConfigResolver::MemoryConfig;
@@ -34,8 +34,8 @@ inline auto get_test_environment_config(
     library_descriptor.add_storage_ids(storage_name.value);
     mem_config.libraries_.insert(std::make_pair(path, library_descriptor));
 
-    std::vector <std::pair<std::string, MemoryConfig>> output;
+    std::vector<std::pair<std::string, MemoryConfig>> output;
     output.emplace_back(environment_name.value, mem_config);
     return output;
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/test/gtest.hpp
+++ b/cpp/arcticdb/util/test/gtest.hpp
@@ -15,10 +15,11 @@
 [build] gtest/internal/gtest-port.h(2075): note: while trying to match the argument list '(int)'
 */
 namespace testing::internal::posix {
-    inline int close(int i) {
-        return ::close(i);
-    }
+inline int close(int i)
+{
+    return ::close(i);
 }
-#endif  // _WIN32
+} // namespace testing::internal::posix
+#endif // _WIN32
 
 #include <gtest/gtest.h>

--- a/cpp/arcticdb/util/test/gtest_main.cpp
+++ b/cpp/arcticdb/util/test/gtest_main.cpp
@@ -7,9 +7,10 @@
 
 #include <gtest/gtest.h>
 #include <arcticdb/util/global_lifetimes.hpp>
-#include <pybind11/pybind11.h>  // Must not directly include Python.h on Windows
+#include <pybind11/pybind11.h> // Must not directly include Python.h on Windows
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
     ::testing::InitGoogleTest(&argc, argv);
     Py_Initialize();
     auto res = RUN_ALL_TESTS();

--- a/cpp/arcticdb/util/test/gtest_utils.hpp
+++ b/cpp/arcticdb/util/test/gtest_utils.hpp
@@ -10,9 +10,14 @@
 #include <fmt/ostream.h>
 #include <arcticdb/entity/variant_key.hpp>
 
-#define MAKE_GTEST_FMT(our_type, fstr) namespace testing::internal { \
-template<> inline void PrintTo(const our_type&val, ::std::ostream* os) { fmt::print(*os, fstr, val); } \
-}
+#define MAKE_GTEST_FMT(our_type, fstr)                                                                                 \
+    namespace testing::internal {                                                                                      \
+    template<>                                                                                                         \
+    inline void PrintTo(const our_type& val, ::std::ostream* os)                                                       \
+    {                                                                                                                  \
+        fmt::print(*os, fstr, val);                                                                                    \
+    }                                                                                                                  \
+    }
 
 // For the most common types, format them by default:
 MAKE_GTEST_FMT(arcticdb::entity::VariantKey, "VariantKey({})")

--- a/cpp/arcticdb/util/test/rapidcheck.hpp
+++ b/cpp/arcticdb/util/test/rapidcheck.hpp
@@ -9,7 +9,8 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations" //TODO experiment with not needing this, at the moment the non-deprecated version segfaults
+#pragma GCC diagnostic ignored                                                                                         \
+    "-Wdeprecated-declarations" //TODO experiment with not needing this, at the moment the non-deprecated version segfaults
 #include <rapidcheck.h>
 #include <rapidcheck/gtest.h>
 #include <rapidcheck/state.h>

--- a/cpp/arcticdb/util/test/rapidcheck_generators.hpp
+++ b/cpp/arcticdb/util/test/rapidcheck_generators.hpp
@@ -13,9 +13,9 @@
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
 
-inline rc::Gen <arcticdb::entity::DataType> gen_numeric_datatype() {
-    return rc::gen::element<arcticdb::entity::DataType>(
-        arcticdb::entity::DataType::INT8,
+inline rc::Gen<arcticdb::entity::DataType> gen_numeric_datatype()
+{
+    return rc::gen::element<arcticdb::entity::DataType>(arcticdb::entity::DataType::INT8,
         arcticdb::entity::DataType::UINT8,
         arcticdb::entity::DataType::INT16,
         arcticdb::entity::DataType::UINT16,
@@ -25,11 +25,11 @@ inline rc::Gen <arcticdb::entity::DataType> gen_numeric_datatype() {
         arcticdb::entity::DataType::UINT64,
         arcticdb::entity::DataType::FLOAT32,
         arcticdb::entity::DataType::FLOAT64,
-        arcticdb::entity::DataType::MICROS_UTC64
-    );
+        arcticdb::entity::DataType::MICROS_UTC64);
 }
 
-inline rc::Gen <arcticdb::entity::Dimension> gen_dimension() {
+inline rc::Gen<arcticdb::entity::Dimension> gen_dimension()
+{
     return rc::gen::element<arcticdb::entity::Dimension>(
         arcticdb::entity::Dimension::Dim0 // Just test scalars for the moment
         //      arcticdb::entity::Dimension::Dim1,
@@ -50,11 +50,11 @@ struct TestDataFrame {
 namespace rc {
 template<>
 struct Arbitrary<arcticdb::entity::TypeDescriptor> {
-    static Gen <arcticdb::entity::TypeDescriptor> arbitrary() {
+    static Gen<arcticdb::entity::TypeDescriptor> arbitrary()
+    {
         return gen::build<arcticdb::entity::TypeDescriptor>(
             gen::set(&arcticdb::entity::TypeDescriptor::data_type_, gen_numeric_datatype()),
-            gen::set(&arcticdb::entity::TypeDescriptor::dimension_, gen_dimension())
-        );
+            gen::set(&arcticdb::entity::TypeDescriptor::dimension_, gen_dimension()));
     }
 };
 
@@ -62,81 +62,83 @@ struct Arbitrary<arcticdb::entity::TypeDescriptor> {
  * FieldDescriptors are given unique names. */
 template<>
 struct Arbitrary<arcticdb::entity::StreamDescriptor> {
-    static Gen <arcticdb::entity::StreamDescriptor> arbitrary() {
+    static Gen<arcticdb::entity::StreamDescriptor> arbitrary()
+    {
         using namespace arcticdb::entity;
         const auto id = *gen::arbitrary<std::string>();
         const auto num_fields = *gen::arbitrary<size_t>();
-        const auto field_names = *gen::container<std::unordered_set<std::string>>(num_fields, gen::nonEmpty(gen::string<std::string>()));
+        const auto field_names =
+            *gen::container<std::unordered_set<std::string>>(num_fields, gen::nonEmpty(gen::string<std::string>()));
         std::vector<FieldDescriptor> field_descriptors;
-        for (const auto& field_name: field_names) {
-            field_descriptors.emplace_back(FieldDescriptor{arcticdb::entity::scalar_field_proto(*gen_numeric_datatype(), field_name)});
+        for (const auto& field_name : field_names) {
+            field_descriptors.emplace_back(
+                FieldDescriptor{arcticdb::entity::scalar_field_proto(*gen_numeric_datatype(), field_name)});
         }
-        return gen::build<StreamDescriptor>(
-            gen::set(&StreamDescriptor::data_, gen::just(
-                (std::make_shared<StreamDescriptor::Proto>(stream_descriptor(arcticdb::entity::StreamId{id}, RowCountIndex{}, fields_proto_from_range(field_descriptors))))))
-        );
+        return gen::build<StreamDescriptor>(gen::set(&StreamDescriptor::data_,
+            gen::just((std::make_shared<StreamDescriptor::Proto>(stream_descriptor(arcticdb::entity::StreamId{id},
+                RowCountIndex{},
+                fields_proto_from_range(field_descriptors)))))));
     }
 };
 
 //TODO rework this, it sucks
 template<>
 struct Arbitrary<TestDataFrame> {
-    static Gen <TestDataFrame> arbitrary() {
+    static Gen<TestDataFrame> arbitrary()
+    {
         auto num_rows = *rc::gen::inRange(2, 10);
         auto num_columns = *rc::gen::inRange(2, 10);
-        return gen::build<TestDataFrame>(
-            gen::set(&TestDataFrame::num_columns_, gen::just(num_columns)),
+        return gen::build<TestDataFrame>(gen::set(&TestDataFrame::num_columns_, gen::just(num_columns)),
             gen::set(&TestDataFrame::num_rows_, gen::just(num_rows)),
             gen::set(&TestDataFrame::types_,
-                     gen::container<std::vector<arcticdb::entity::TypeDescriptor>>(num_rows,
-                                                                                  rc::gen::arbitrary<arcticdb::entity::TypeDescriptor>())),
+                gen::container<std::vector<arcticdb::entity::TypeDescriptor>>(num_rows,
+                    rc::gen::arbitrary<arcticdb::entity::TypeDescriptor>())),
             gen::set(&TestDataFrame::data_,
-                     gen::container<std::vector<std::vector<int>>>(num_columns,
-                                                                   gen::container<std::vector<int>>(num_rows,
-                                                                                                    gen::inRange(0,
-                                                                                                                 100)))),
+                gen::container<std::vector<std::vector<int>>>(num_columns,
+                    gen::container<std::vector<int>>(num_rows, gen::inRange(0, 100)))),
             gen::set(&TestDataFrame::start_ts_, gen::inRange(1, 100)),
             gen::set(&TestDataFrame::timestamp_increments_,
-                     gen::container<std::vector<uint8_t>>(num_rows, gen::inRange(1, 100))),
+                gen::container<std::vector<uint8_t>>(num_rows, gen::inRange(1, 100))),
             gen::set(&TestDataFrame::column_names_,
-                     gen::container<std::vector<std::string>>(num_columns, gen::nonEmpty(gen::string<std::string>())))
-        );
+                gen::container<std::vector<std::string>>(num_columns, gen::nonEmpty(gen::string<std::string>()))));
     }
 };
 
-}
+} // namespace rc
 
 namespace as = arcticdb::stream;
 namespace ac = arcticdb::entity;
 
-inline as::FixedSchema schema_from_test_frame(const TestDataFrame &data_frame, StreamId stream_id) {
+inline as::FixedSchema schema_from_test_frame(const TestDataFrame& data_frame, StreamId stream_id)
+{
     std::vector<FieldDescriptor::Proto> fields;
     for (size_t i = 0; i < data_frame.num_columns_; ++i)
-        fields.emplace_back(arcticdb::entity::scalar_field_proto(data_frame.types_[i].data_type(), data_frame.column_names_[i]));
+        fields.emplace_back(
+            arcticdb::entity::scalar_field_proto(data_frame.types_[i].data_type(), data_frame.column_names_[i]));
 
     const auto index = as::TimeseriesIndex::default_index();
-    return as::FixedSchema{
-        index.create_stream_descriptor(stream_id, fields), index
-    };
+    return as::FixedSchema{index.create_stream_descriptor(stream_id, fields), index};
 }
 
-inline IndexRange test_frame_range(const TestDataFrame &data_frame) {
-    return IndexRange{data_frame.start_ts_, std::accumulate(data_frame.timestamp_increments_.begin(),
-                                                            data_frame.timestamp_increments_.end(),
-                                                            data_frame.start_ts_)};
+inline IndexRange test_frame_range(const TestDataFrame& data_frame)
+{
+    return IndexRange{data_frame.start_ts_,
+        std::accumulate(data_frame.timestamp_increments_.begin(),
+            data_frame.timestamp_increments_.end(),
+            data_frame.start_ts_)};
 }
 
 template<typename WriterType>
-folly::Future<arcticdb::entity::VariantKey> write_frame_data(const TestDataFrame &data_frame, WriterType &writer) {
+folly::Future<arcticdb::entity::VariantKey> write_frame_data(const TestDataFrame& data_frame, WriterType& writer)
+{
     auto timestamp = data_frame.start_ts_ + 1;
     for (size_t row = 0; row < data_frame.num_rows_; ++row) {
-        writer.start_row(timestamp)([&](auto &&rb) {
+        writer.start_row(timestamp)([&](auto&& rb) {
             for (size_t col = 0; col < data_frame.num_columns_; ++col) {
                 data_frame.types_[col].visit_tag([&](auto type_desc_tag) {
                     using raw_type = typename decltype(type_desc_tag)::DataTypeTag::raw_type;
-                    using data_type_tag  =  typename decltype(type_desc_tag)::DataTypeTag;
-                    if (is_sequence_type(data_type_tag::data_type
-                    ))
+                    using data_type_tag = typename decltype(type_desc_tag)::DataTypeTag;
+                    if (is_sequence_type(data_type_tag::data_type))
                         rb.set_string(col + 1, fmt::format("{}", data_frame.data_[col][row]));
                     else
                         rb.set_scalar(col + 1, raw_type(data_frame.data_[col][row]));
@@ -149,36 +151,35 @@ folly::Future<arcticdb::entity::VariantKey> write_frame_data(const TestDataFrame
     return writer.commit();
 }
 
-inline folly::Future<arcticdb::entity::VariantKey> write_test_frame(StreamId stream_id,
-                                                                const TestDataFrame &data_frame,
-                                                                std::shared_ptr<StreamSink> store) {
+inline folly::Future<arcticdb::entity::VariantKey>
+write_test_frame(StreamId stream_id, const TestDataFrame& data_frame, std::shared_ptr<StreamSink> store)
+{
     auto schema = schema_from_test_frame(data_frame, stream_id);
     auto start_end = test_frame_range(data_frame);
     auto gen_id = arcticdb::VersionId(0);
 
-    StreamWriter<TimeseriesIndex, FixedSchema> writer{
-        std::move(schema),
+    StreamWriter<TimeseriesIndex, FixedSchema> writer{std::move(schema),
         store,
         gen_id,
         start_end,
-        RowCountSegmentPolicy{4}
-    };
+        RowCountSegmentPolicy{4}};
 
     return write_frame_data(data_frame, writer);
 }
 
 template<typename ReaderType>
-bool check_read_frame(const TestDataFrame &data_frame, ReaderType &reader, std::vector<std::string> &errors) {
+bool check_read_frame(const TestDataFrame& data_frame, ReaderType& reader, std::vector<std::string>& errors)
+{
     bool success = true;
     auto timestamp = data_frame.start_ts_;
     auto row = 0u;
-    reader.foreach_row([&](auto &&row_ref) {
+    reader.foreach_row([&](auto&& row_ref) {
         timestamp += data_frame.timestamp_increments_[row];
         for (size_t col = 0; col < data_frame.num_columns_; ++col) {
             data_frame.types_[col].visit_tag([&](auto type_desc_tag) {
                 arcticdb::entity::DataType dt = TypeDescriptor(type_desc_tag).data_type();
-                arcticdb::entity::DataType
-                    stored_dt = data_type_from_proto(row_ref.segment().column_descriptor(col + 1).type_desc());
+                arcticdb::entity::DataType stored_dt =
+                    data_type_from_proto(row_ref.segment().column_descriptor(col + 1).type_desc());
                 if (dt != stored_dt) {
                     errors.push_back(fmt::format("Type mismatch {} != {} at pos {}:{}", dt, stored_dt, col, row));
                     success = false;
@@ -186,11 +187,8 @@ bool check_read_frame(const TestDataFrame &data_frame, ReaderType &reader, std::
                 auto dimension = static_cast<uint64_t>(TypeDescriptor(type_desc_tag).dimension());
                 auto stored_dimension = row_ref.segment().column_descriptor(col + 1).type_desc().dimension();
                 if (dimension != stored_dimension) {
-                    errors.push_back(fmt::format("Dimension mismatch {} != {} at pos {}:{}",
-                                                 dimension,
-                                                 stored_dimension,
-                                                 col,
-                                                 row));
+                    errors.push_back(
+                        fmt::format("Dimension mismatch {} != {} at pos {}:{}", dimension, stored_dimension, col, row));
                     success = false;
                 }
 
@@ -198,11 +196,8 @@ bool check_read_frame(const TestDataFrame &data_frame, ReaderType &reader, std::
                 auto value = raw_type(data_frame.data_[col][row]);
                 auto stored_value = row_ref.template scalar_at<raw_type>(col + 1).value();
                 if (value != stored_value) {
-                    errors.push_back(fmt::format("Value mismatch {} != {} at pos {}:{}",
-                                                 value,
-                                                 stored_value,
-                                                 col,
-                                                 row));
+                    errors.push_back(
+                        fmt::format("Value mismatch {} != {} at pos {}:{}", value, stored_value, col, row));
                     success = false;
                 }
             });
@@ -212,14 +207,15 @@ bool check_read_frame(const TestDataFrame &data_frame, ReaderType &reader, std::
     return success;
 }
 
-inline bool check_test_frame(const TestDataFrame &data_frame,
-                             const arcticdb::entity::AtomKey &key,
-                             std::shared_ptr<StreamSource> store,
-                             std::vector<std::string> &errors) {
-    StreamReader<arcticdb::entity::AtomKey, folly::Function<std::vector<arcticdb::entity::AtomKey>()>, arcticdb::SegmentInMemory::Row> stream_reader{
-        [&]() { return std::vector<arcticdb::entity::AtomKey>{key}; },
-        store
-    };
+inline bool check_test_frame(const TestDataFrame& data_frame,
+    const arcticdb::entity::AtomKey& key,
+    std::shared_ptr<StreamSource> store,
+    std::vector<std::string>& errors)
+{
+    StreamReader<arcticdb::entity::AtomKey,
+        folly::Function<std::vector<arcticdb::entity::AtomKey>()>,
+        arcticdb::SegmentInMemory::Row>
+        stream_reader{[&]() { return std::vector<arcticdb::entity::AtomKey>{key}; }, store};
 
     return check_read_frame(data_frame, stream_reader, errors);
 }

--- a/cpp/arcticdb/util/test/rapidcheck_main.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_main.cpp
@@ -8,7 +8,8 @@
 #include <gtest/gtest.h>
 #include <arcticdb/util/global_lifetimes.hpp>
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
     ::testing::InitGoogleTest(&argc, argv);
     auto res = RUN_ALL_TESTS();
     arcticdb::shutdown_globals();

--- a/cpp/arcticdb/util/test/rapidcheck_string_pool.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_string_pool.cpp
@@ -13,15 +13,16 @@
 #include <map>
 #include <string>
 
-RC_GTEST_PROP(StringPool, WriteAndRead, (const std::map<size_t, std::string> &input)) {
+RC_GTEST_PROP(StringPool, WriteAndRead, (const std::map<size_t, std::string>& input))
+{
     using namespace arcticdb;
     StringPool pool;
     std::unordered_map<size_t, OffsetString> strings;
-    for (auto &item : input) {
+    for (auto& item : input) {
         strings.insert(std::make_pair(item.first, pool.get(item.second)));
     }
 
-    for (auto &stored : strings) {
+    for (auto& stored : strings) {
         const std::string_view view(stored.second);
         auto it = input.find(stored.first);
         RC_ASSERT(view == it->second);

--- a/cpp/arcticdb/util/test/test_bitmagic.cpp
+++ b/cpp/arcticdb/util/test/test_bitmagic.cpp
@@ -15,23 +15,25 @@
 #include <msgpack.hpp>
 #include <arcticdb/util/test/generators.hpp>
 
-TEST(BitMagic, Basic) {
+TEST(BitMagic, Basic)
+{
     using namespace arcticdb;
     util::BitMagic bv;
     bv[0] = true;
     bv[3] = true;
 
-    auto count = bv.count_range(0,0);
+    auto count = bv.count_range(0, 0);
     ASSERT_EQ(count, 1);
-    count = bv.count_range(0,3);
+    count = bv.count_range(0, 3);
     ASSERT_EQ(count, 2);
     auto num = bv.get_first();
-    while(num) {
+    while (num) {
         num = bv.get_next(num);
     }
 }
 
-TEST(BitMagic, DensifyAndExpand) {
+TEST(BitMagic, DensifyAndExpand)
+{
     using namespace arcticdb;
     std::vector<float> sample_data;
     const size_t SPARSE_ELEMENTS = 1000;
@@ -49,11 +51,11 @@ TEST(BitMagic, DensifyAndExpand) {
     }
     auto dense_buffer = ChunkedBuffer::presized(sizeof(float) * n_dense);
 
-    auto *ptr = reinterpret_cast<uint8_t *>(&sample_data[0]);
+    auto* ptr = reinterpret_cast<uint8_t*>(&sample_data[0]);
 
     arcticdb::util::densify_buffer_using_bitmap<float>(bv, dense_buffer, ptr);
 
-    auto *dense_array = reinterpret_cast<float *>(dense_buffer.data());
+    auto* dense_array = reinterpret_cast<float*>(dense_buffer.data());
 
     GTEST_ASSERT_EQ(*dense_array, sample_data[1]);
     ++dense_array;
@@ -64,9 +66,9 @@ TEST(BitMagic, DensifyAndExpand) {
 
     // Now expand it back
     arcticdb::util::expand_dense_buffer_using_bitmap<float>(bv, dense_buffer.data(), sparse_buffer.data());
-    auto *sparse_array = reinterpret_cast<float *>(sparse_buffer.data());
+    auto* sparse_array = reinterpret_cast<float*>(sparse_buffer.data());
 
-    for (auto &data: sample_data) {
+    for (auto& data : sample_data) {
         GTEST_ASSERT_EQ(data, *sparse_array);
         ++sparse_array;
     }

--- a/cpp/arcticdb/util/test/test_buffer_pool.cpp
+++ b/cpp/arcticdb/util/test/test_buffer_pool.cpp
@@ -9,11 +9,12 @@
 #include <arcticdb/util/buffer_pool.hpp>
 
 namespace arcticdb {
-    TEST(BufferPool, Basic) {
-        auto buffer = BufferPool::instance()->allocate();
-        buffer->ensure(40);
-        buffer.reset();
-        auto new_buffer = BufferPool::instance()->allocate();
-        ASSERT_EQ(new_buffer->bytes(), 0);
-    }
+TEST(BufferPool, Basic)
+{
+    auto buffer = BufferPool::instance()->allocate();
+    buffer->ensure(40);
+    buffer.reset();
+    auto new_buffer = BufferPool::instance()->allocate();
+    ASSERT_EQ(new_buffer->bytes(), 0);
 }
+} // namespace arcticdb

--- a/cpp/arcticdb/util/test/test_composite.cpp
+++ b/cpp/arcticdb/util/test/test_composite.cpp
@@ -8,38 +8,40 @@
 #include <gtest/gtest.h>
 #include <arcticdb/util/composite.hpp>
 
-
 struct TestThing {
     int info_;
 
-    explicit TestThing(int val) :
-    info_(val) {}
+    explicit TestThing(int val)
+        : info_(val)
+    {
+    }
 };
 
-
-TEST(Composite, TestFold) {
+TEST(Composite, TestFold)
+{
     using namespace arcticdb;
     TestThing single_thing(3);
     Composite<TestThing> c1{std::move(single_thing)};
-    int res = c1.fold([] (int i, const TestThing& thing) { return i + thing.info_; }, 0);
+    int res = c1.fold([](int i, const TestThing& thing) { return i + thing.info_; }, 0);
     ASSERT_EQ(res, 3);
-    res = c1.fold([] (int i, const TestThing& thing) { return i + thing.info_; }, 4);
+    res = c1.fold([](int i, const TestThing& thing) { return i + thing.info_; }, 4);
     ASSERT_EQ(res, 7);
-    std::vector<TestThing> more_things{ TestThing{1}, TestThing{4}, TestThing{3} };
+    std::vector<TestThing> more_things{TestThing{1}, TestThing{4}, TestThing{3}};
     Composite<TestThing> c2(std::move(more_things));
-    res = c2.fold([] (int i, const TestThing& thing) { return i + thing.info_; }, 0);
+    res = c2.fold([](int i, const TestThing& thing) { return i + thing.info_; }, 0);
     ASSERT_EQ(res, 8);
-    res = c2.fold([] (int i, const TestThing& thing) { return i + thing.info_; }, 2);
+    res = c2.fold([](int i, const TestThing& thing) { return i + thing.info_; }, 2);
     ASSERT_EQ(res, 10);
 }
 
-TEST(Composite, IterationSimple) {
+TEST(Composite, IterationSimple)
+{
     using namespace arcticdb;
     Composite<int> comp;
-    for(auto i = 0; i < 10; ++i)
+    for (auto i = 0; i < 10; ++i)
         comp.push_back(i);
 
     int expected = 0;
-    for(auto x : comp.as_range())
+    for (auto x : comp.as_range())
         ASSERT_EQ(x, expected++);
 }

--- a/cpp/arcticdb/util/test/test_cursor.cpp
+++ b/cpp/arcticdb/util/test/test_cursor.cpp
@@ -14,7 +14,8 @@
 #include <arcticdb/util/cursored_buffer.hpp>
 #include <arcticdb/util/error_code.hpp>
 
-TEST(Cursor, Behaviour) {
+TEST(Cursor, Behaviour)
+{
     using namespace arcticdb;
     CursoredBuffer<Buffer> b;
     ASSERT_EQ(b.buffer().bytes(), 0);
@@ -28,14 +29,16 @@ TEST(Cursor, Behaviour) {
     ASSERT_EQ(b.size<uint8_t>(), 100);
     ASSERT_NO_THROW(b.ptr_cast<uint64_t>(5, sizeof(uint64_t)));
     ASSERT_NO_THROW(b.ptr_cast<uint64_t>(11, sizeof(uint64_t)));
-    ASSERT_THROW(b.ptr_cast<uint64_t>(13, sizeof(uint64_t)), ArcticCategorizedException<ErrorCategory::INTERNAL>); // Cursor overflow
+    ASSERT_THROW(b.ptr_cast<uint64_t>(13, sizeof(uint64_t)),
+        ArcticCategorizedException<ErrorCategory::INTERNAL>); // Cursor overflow
     ASSERT_NO_THROW(b.ensure_bytes(20));
     ASSERT_NO_THROW(b.commit());
     ASSERT_EQ(b.size<uint8_t>(), 120);
 }
 
 template<typename BufferType>
-void test_cursor_backing() {
+void test_cursor_backing()
+{
     using namespace arcticdb;
     CursoredBuffer<BufferType> b;
     std::vector<uint64_t> v(100);
@@ -43,7 +46,7 @@ void test_cursor_backing() {
     b.ensure_bytes(400);
     memcpy(b.cursor(), v.data(), 400);
     b.commit();
-    ASSERT_EQ(*b.buffer().template ptr_cast<uint64_t>(0,  sizeof(uint64_t)), 0);
+    ASSERT_EQ(*b.buffer().template ptr_cast<uint64_t>(0, sizeof(uint64_t)), 0);
     ASSERT_EQ(*b.buffer().template ptr_cast<uint64_t>(40 * sizeof(uint64_t), sizeof(uint64_t)), 40);
     ASSERT_EQ(*b.buffer().template ptr_cast<uint64_t>(49 * sizeof(uint64_t), sizeof(uint64_t)), 49);
     b.ensure_bytes(400);
@@ -57,7 +60,8 @@ void test_cursor_backing() {
     ASSERT_EQ(*b.buffer().template ptr_cast<uint64_t>(99 * sizeof(uint64_t), sizeof(uint64_t)), 99);
 }
 
-TEST(Cursor, Values) {
+TEST(Cursor, Values)
+{
     using namespace arcticdb;
     //test_cursor_backing< std::vector<uint8_t>>();
     //test_cursor_backing<Buffer>();

--- a/cpp/arcticdb/util/test/test_error_code.cpp
+++ b/cpp/arcticdb/util/test/test_error_code.cpp
@@ -12,11 +12,12 @@
 
 using ErrorCode = arcticdb::ErrorCode;
 
-TEST(ErrorCode, DoesThrow) {
+TEST(ErrorCode, DoesThrow)
+{
     ASSERT_THROW(arcticdb::normalization::raise<ErrorCode::E_INCOMPATIBLE_OBJECTS>("msg {}", 1),
-            arcticdb::NormalizationException);
+        arcticdb::NormalizationException);
     ASSERT_THROW(arcticdb::normalization::check<ErrorCode::E_INCOMPATIBLE_OBJECTS>(false, "msg {}", 2),
-            arcticdb::NormalizationException);
+        arcticdb::NormalizationException);
 }
 
 // FUTURE: Find a way to test the static_assert in detail::Raise?

--- a/cpp/arcticdb/util/test/test_format_date.cpp
+++ b/cpp/arcticdb/util/test/test_format_date.cpp
@@ -9,12 +9,14 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/format_date.hpp>
 
-TEST(FormatDate, ZeroTs) {
+TEST(FormatDate, ZeroTs)
+{
     using namespace arcticdb;
     ASSERT_EQ("1970-01-01 00:00:00.0", util::format_timestamp(0));
 }
 
-TEST(FormatDate, April2821) {
+TEST(FormatDate, April2821)
+{
     using namespace arcticdb;
 #ifdef _WIN32
     ASSERT_EQ("2021-04-28 16:11:35.0", util::format_timestamp(1619626295213000000));

--- a/cpp/arcticdb/util/test/test_hash.cpp
+++ b/cpp/arcticdb/util/test/test_hash.cpp
@@ -11,7 +11,8 @@
 
 using namespace arcticdb;
 
-TEST(HashAccum, NotCommutative) {
+TEST(HashAccum, NotCommutative)
+{
     HashAccum h1;
     HashAccum h2;
     h1.reset();
@@ -27,10 +28,10 @@ TEST(HashAccum, NotCommutative) {
     h2(&val1);
 
     EXPECT_NE(h1.digest(), h2.digest());
-
 }
 
-TEST(HashComm, Commutative) {
+TEST(HashComm, Commutative)
+{
     using namespace arcticdb;
     using namespace folly::hash;
 
@@ -40,16 +41,99 @@ TEST(HashComm, Commutative) {
     EXPECT_EQ(h, commutative_hash_combine(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
     EXPECT_EQ(h, commutative_hash_combine(10, 2, 3, 4, 5, 6, 7, 8, 9, 1));
 
-    EXPECT_EQ(
-        commutative_hash_combine(12345, 6789),
-        commutative_hash_combine(6789, 12345)
-    );
+    EXPECT_EQ(commutative_hash_combine(12345, 6789), commutative_hash_combine(6789, 12345));
 
-    auto v1 = commutative_hash_combine(0, 1629821389809000000,std::string("FIXT.1.1"),454.0,std::string("IOI"),3224.0,std::string("MA"),std::string("20210824-16:09:49.809"),std::string("GLGMKTLIST2"),std::string("IOIID-1629821389809"),std::string("REPLACE"),std::string("[N/A]"),std::string("437076CG5"),1.0,std::string("US437076CG52"),4,std::string("CORP"),std::string("USD_HGD"),20210826,std::string("BUY"),800000.0,std::string("USD"),std::string("SPREAD"),std::string("20210824-16:07:49"),std::string("20210824-16:05:49"),std::string("912810SX7"),1.0,std::string("MKTX"),std::string("C"),std::string("CONTRA_FIRM"),std::string("Spread"),120.0,std::string("MarketList-Orders"),std::string("Did Not Trade"),std::string("Holding_Bin"),std::string("OneStep"),std::string("4 2"),std::string("YES"),0.0,std::string("N"),std::string("N"),std::string("ILQD"),10467391.0,2.0);
-    auto v2 = commutative_hash_combine(0, 1629821389809000000,std::string("FIXT.1.1"),454.0,std::string("IOI"),3224.0,std::string("MA"),std::string("20210824-16:09:49.809"),std::string("GLGMKTLIST2"),std::string("IOIID-1629821389809"),std::string("REPLACE"),10467391.0,std::string("[N/A]"),std::string("437076CG5"),1.0,std::string("US437076CG52"),4,std::string("CORP"),std::string("USD_HGD"),20210826,std::string("BUY"),800000.0,std::string("USD"),std::string("SPREAD"),std::string("20210824-16:07:49"),std::string("20210824-16:05:49"),std::string("912810SX7"),1.0,std::string("MKTX"),std::string("C"),std::string("CONTRA_FIRM"),std::string("Spread"),120.0,std::string("MarketList-Orders"),std::string("Did Not Trade"),std::string("Holding_Bin"),std::string("OneStep"),std::string("4 2"),std::string("YES"),2.0,0.0,std::string("N"),std::string("N"),std::string("ILQD"));
+    auto v1 = commutative_hash_combine(0,
+        1629821389809000000,
+        std::string("FIXT.1.1"),
+        454.0,
+        std::string("IOI"),
+        3224.0,
+        std::string("MA"),
+        std::string("20210824-16:09:49.809"),
+        std::string("GLGMKTLIST2"),
+        std::string("IOIID-1629821389809"),
+        std::string("REPLACE"),
+        std::string("[N/A]"),
+        std::string("437076CG5"),
+        1.0,
+        std::string("US437076CG52"),
+        4,
+        std::string("CORP"),
+        std::string("USD_HGD"),
+        20210826,
+        std::string("BUY"),
+        800000.0,
+        std::string("USD"),
+        std::string("SPREAD"),
+        std::string("20210824-16:07:49"),
+        std::string("20210824-16:05:49"),
+        std::string("912810SX7"),
+        1.0,
+        std::string("MKTX"),
+        std::string("C"),
+        std::string("CONTRA_FIRM"),
+        std::string("Spread"),
+        120.0,
+        std::string("MarketList-Orders"),
+        std::string("Did Not Trade"),
+        std::string("Holding_Bin"),
+        std::string("OneStep"),
+        std::string("4 2"),
+        std::string("YES"),
+        0.0,
+        std::string("N"),
+        std::string("N"),
+        std::string("ILQD"),
+        10467391.0,
+        2.0);
+    auto v2 = commutative_hash_combine(0,
+        1629821389809000000,
+        std::string("FIXT.1.1"),
+        454.0,
+        std::string("IOI"),
+        3224.0,
+        std::string("MA"),
+        std::string("20210824-16:09:49.809"),
+        std::string("GLGMKTLIST2"),
+        std::string("IOIID-1629821389809"),
+        std::string("REPLACE"),
+        10467391.0,
+        std::string("[N/A]"),
+        std::string("437076CG5"),
+        1.0,
+        std::string("US437076CG52"),
+        4,
+        std::string("CORP"),
+        std::string("USD_HGD"),
+        20210826,
+        std::string("BUY"),
+        800000.0,
+        std::string("USD"),
+        std::string("SPREAD"),
+        std::string("20210824-16:07:49"),
+        std::string("20210824-16:05:49"),
+        std::string("912810SX7"),
+        1.0,
+        std::string("MKTX"),
+        std::string("C"),
+        std::string("CONTRA_FIRM"),
+        std::string("Spread"),
+        120.0,
+        std::string("MarketList-Orders"),
+        std::string("Did Not Trade"),
+        std::string("Holding_Bin"),
+        std::string("OneStep"),
+        std::string("4 2"),
+        std::string("YES"),
+        2.0,
+        0.0,
+        std::string("N"),
+        std::string("N"),
+        std::string("ILQD"));
 
-    std::cout<<v1<<std::endl;
-    std::cout<<v2<<std::endl;
+    std::cout << v1 << std::endl;
+    std::cout << v2 << std::endl;
 
     EXPECT_EQ(v1, v2);
 
@@ -59,27 +143,28 @@ TEST(HashComm, Commutative) {
     float g1 = 1234.5;
     float g2 = 78.65;
 
-    EXPECT_EQ(
-            commutative_hash_combine(f1, f2),
-            commutative_hash_combine(g2, g1)
-    );
+    EXPECT_EQ(commutative_hash_combine(f1, f2), commutative_hash_combine(g2, g1));
 
-    std::cout<<commutative_hash_combine(9726480045861996436ULL, std::string("10442909"))<<std::endl;
-    std::cout<<commutative_hash_combine(17243764687685379754ULL, std::string("[N/A]"))<<std::endl;
-    std::cout<<commutative_hash_combine(9457389251931416297ULL, std::string("98956PAF9"))<<std::endl;
-    std::cout<<commutative_hash_combine(2648263869243483102ULL, std::string("1"))<<std::endl;
-    std::cout<<commutative_hash_combine(10692736793407104629ULL, std::string("US98956PAF99"))<<std::endl;
-    std::cout<<commutative_hash_combine(7633205480517386763ULL, std::string("4"))<<std::endl;
-    std::cout<<commutative_hash_combine(8481507868260942362ULL, std::string("CORP"))<<std::endl;
-    std::cout<<commutative_hash_combine(4419353893253087336ULL, std::string("USD_HGD"))<<std::endl;
-    std::cout<<commutative_hash_combine(10212419605264796417ULL, std::string("20210824"))<<std::endl;
+    std::cout << commutative_hash_combine(9726480045861996436ULL, std::string("10442909")) << std::endl;
+    std::cout << commutative_hash_combine(17243764687685379754ULL, std::string("[N/A]")) << std::endl;
+    std::cout << commutative_hash_combine(9457389251931416297ULL, std::string("98956PAF9")) << std::endl;
+    std::cout << commutative_hash_combine(2648263869243483102ULL, std::string("1")) << std::endl;
+    std::cout << commutative_hash_combine(10692736793407104629ULL, std::string("US98956PAF99")) << std::endl;
+    std::cout << commutative_hash_combine(7633205480517386763ULL, std::string("4")) << std::endl;
+    std::cout << commutative_hash_combine(8481507868260942362ULL, std::string("CORP")) << std::endl;
+    std::cout << commutative_hash_combine(4419353893253087336ULL, std::string("USD_HGD")) << std::endl;
+    std::cout << commutative_hash_combine(10212419605264796417ULL, std::string("20210824")) << std::endl;
 
-    std::cout<<commutative_hash_combine(9726480045861996436ULL, std::string("10442909"), std::string("[N/A]")) <<std::endl;
+    std::cout << commutative_hash_combine(9726480045861996436ULL, std::string("10442909"), std::string("[N/A]"))
+              << std::endl;
 
-    auto h1 = commutative_hash_combine_generic(9726480045861996436ULL, folly::Hash{}, std::string("10442909"), std::string("[N/A]"));
+    auto h1 = commutative_hash_combine_generic(9726480045861996436ULL,
+        folly::Hash{},
+        std::string("10442909"),
+        std::string("[N/A]"));
     auto h2 = commutative_hash_combine_generic(9726480045861996436ULL, folly::Hash{}, std::string("10442909"));
     auto h3 = commutative_hash_combine_generic(h2, folly::Hash{}, std::string("[N/A]"));
-    
+
     auto h4 = commutative_hash_combine_generic(9726480045861996436ULL, folly::Hash{}, std::string("[N/A]"));
     auto h5 = commutative_hash_combine_generic(h4, folly::Hash{}, std::string("10442909"));
 

--- a/cpp/arcticdb/util/test/test_id_transformation.cpp
+++ b/cpp/arcticdb/util/test/test_id_transformation.cpp
@@ -10,12 +10,15 @@
 #include <arcticdb/storage/s3/nfs_backed_storage.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 
-TEST(KeyTransformation, Roundtrip) {
+TEST(KeyTransformation, Roundtrip)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
 
-    auto k = entity::atom_key_builder().gen_id(3).start_index(0).end_index(1).creation_ts(999)
-        .content_hash(12345).build("hello", entity::KeyType::TABLE_DATA);
+    auto k =
+        entity::atom_key_builder().gen_id(3).start_index(0).end_index(1).creation_ts(999).content_hash(12345).build(
+            "hello",
+            entity::KeyType::TABLE_DATA);
 
     nfs_backed::NfsBucketizer b;
     std::string root_folder{"example/test"};

--- a/cpp/arcticdb/util/test/test_ranges_from_future.cpp
+++ b/cpp/arcticdb/util/test/test_ranges_from_future.cpp
@@ -15,7 +15,8 @@
 using namespace arcticdb::utils;
 using namespace testing;
 
-TEST(RangesFromFuture, keys_and_values) {
+TEST(RangesFromFuture, keys_and_values)
+{
     std::unordered_map<int, char> m;
     ASSERT_THAT(keys(m), IsEmpty());
     ASSERT_THAT(values(m), IsEmpty());

--- a/cpp/arcticdb/util/test/test_regex.cpp
+++ b/cpp/arcticdb/util/test/test_regex.cpp
@@ -8,7 +8,8 @@
 #include <gtest/gtest.h>
 #include <arcticdb/util/regex_filter.hpp>
 
-TEST(Regex, Simple) {
+TEST(Regex, Simple)
+{
     using namespace arcticdb;
 
     const std::string match_text = "Hello World";
@@ -19,7 +20,8 @@ TEST(Regex, Simple) {
     ASSERT_EQ(regex.match(no_match), false);
 }
 
-TEST(Regex, Complex) {
+TEST(Regex, Complex)
+{
     using namespace arcticdb;
     std::string match_text = "PANEURO_MACRO/maquity/bondlike/predictors/fidiv_3";
     std::string no_match = "Ubi solitudinem faciunt pacem appellant";
@@ -28,4 +30,3 @@ TEST(Regex, Complex) {
     ASSERT_EQ(regex.match(match_text), true);
     ASSERT_EQ(regex.match(no_match), false);
 }
-

--- a/cpp/arcticdb/util/test/test_runtime_config.cpp
+++ b/cpp/arcticdb/util/test/test_runtime_config.cpp
@@ -8,8 +8,8 @@
 #include <gtest/gtest.h>
 #include <arcticdb/util/configs_map.hpp>
 
-
-TEST(RuntimeConfig, PersistToProtobuf) {
+TEST(RuntimeConfig, PersistToProtobuf)
+{
     using namespace arcticdb;
 
     ConfigsMap test_map;

--- a/cpp/arcticdb/util/test/test_slab_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_slab_allocator.cpp
@@ -18,16 +18,17 @@
 
 using namespace arcticdb;
 
-template <typename MemoryChunk>
+template<typename MemoryChunk>
 using pointer_set = std::unordered_set<typename MemoryChunk::pointer>;
 
 size_t num_threads = std::thread::hardware_concurrency() - 1;
 std::size_t const num_blocks_per_thread = 10000;
 std::size_t const num_loops = 10000;
 
-template <typename MemoryChunk>
-pointer_set<MemoryChunk> call_alloc_and_dealloc(MemoryChunk& mc, std::size_t n, int64_t& execution_time_ms) {
-    
+template<typename MemoryChunk>
+pointer_set<MemoryChunk> call_alloc_and_dealloc(MemoryChunk& mc, std::size_t n, int64_t& execution_time_ms)
+{
+
     pointer_set<MemoryChunk> mcps;
     mcps.reserve(n);
 
@@ -38,12 +39,11 @@ pointer_set<MemoryChunk> call_alloc_and_dealloc(MemoryChunk& mc, std::size_t n, 
 
     auto time_end = std::chrono::high_resolution_clock::now();
 
-    execution_time_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(time_end - time_begin).count();
+    execution_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_end - time_begin).count();
     return mcps;
 }
 
-template <typename MemoryChunk>
+template<typename MemoryChunk>
 void check_sets(const pointer_set<MemoryChunk>& s1, const pointer_set<MemoryChunk>& s2)
 {
     auto end = std::cend(s2);
@@ -52,27 +52,26 @@ void check_sets(const pointer_set<MemoryChunk>& s1, const pointer_set<MemoryChun
             throw std::runtime_error("two sets have the same address");
 }
 
-template <typename MemoryChunk>
+template<typename MemoryChunk>
 void run_test(MemoryChunk& mc, unsigned int K)
 {
     std::vector<int64_t> execution_times(num_threads);
     int64_t avg = 0;
-    for (size_t k = 0; k < K; ++k ) {
+    for (size_t k = 0; k < K; ++k) {
         std::vector<std::future<pointer_set<MemoryChunk>>> v;
-        for (size_t i = 0; i < num_threads; ++i ) {
-            v.emplace_back(std::async(
-                    std::launch::async,
-                    call_alloc_and_dealloc<MemoryChunk>,
-                    std::ref(mc),
-                    num_blocks_per_thread,
-                    std::ref(execution_times[i])));
+        for (size_t i = 0; i < num_threads; ++i) {
+            v.emplace_back(std::async(std::launch::async,
+                call_alloc_and_dealloc<MemoryChunk>,
+                std::ref(mc),
+                num_blocks_per_thread,
+                std::ref(execution_times[i])));
         }
         for (auto& t : v)
             t.wait();
 
         for (size_t i = 0; i < num_threads; ++i) {
-//            std::cout << "Execution time for thread " << i << ": " << execution_times[ i ] << " ms\n";
-            avg += execution_times[i] ;
+            //            std::cout << "Execution time for thread " << i << ": " << execution_times[ i ] << " ms\n";
+            avg += execution_times[i];
         }
 
         std::vector<pointer_set<MemoryChunk>> comparisons;
@@ -82,19 +81,18 @@ void run_test(MemoryChunk& mc, unsigned int K)
 
         std::vector<std::future<void>> exceptions;
         for (size_t i = 0; i < num_threads; ++i) {
-            for (size_t j = i + 1; j < num_threads; ++j){
-                exceptions.emplace_back(std::async(
-                        std::launch::async,
-                        check_sets<MemoryChunk>,
-                        std::ref(comparisons[i]),
-                        std::ref(comparisons[j])));
+            for (size_t j = i + 1; j < num_threads; ++j) {
+                exceptions.emplace_back(std::async(std::launch::async,
+                    check_sets<MemoryChunk>,
+                    std::ref(comparisons[i]),
+                    std::ref(comparisons[j])));
             }
         }
         for (auto& f : exceptions)
             f.get();
 
-        for(const auto& pointers: comparisons) {
-            for (auto* p: pointers) {
+        for (const auto& pointers : comparisons) {
+            for (auto* p : pointers) {
                 mc.deallocate(p);
             }
         }
@@ -102,7 +100,8 @@ void run_test(MemoryChunk& mc, unsigned int K)
     std::cout << "Average execution time: " << avg / execution_times.size() << '\n';
 }
 
-TEST(SlabAlloc, CacheLine128) {
+TEST(SlabAlloc, CacheLine128)
+{
     SKIP_WIN("Slab allocator not supported");
     SlabAllocator<int, 128> mc128{num_blocks_per_thread * num_threads};
     std::cout << "BEGIN: mc128 tests\n";
@@ -111,7 +110,8 @@ TEST(SlabAlloc, CacheLine128) {
     std::cout << "END:   mc128 tests\n\n";
 }
 
-TEST(SlabAlloc, CacheLine32) {
+TEST(SlabAlloc, CacheLine32)
+{
     SKIP_WIN("Slab allocator not supported");
     SlabAllocator<int, 32> mc32{num_blocks_per_thread * num_threads};
     std::cout << "BEGIN: mc32 tests\n";
@@ -120,7 +120,8 @@ TEST(SlabAlloc, CacheLine32) {
     std::cout << "END:   mc32 tests\n";
 }
 
-TEST(SlabAlloc, PageSizeMem) {
+TEST(SlabAlloc, PageSizeMem)
+{
     SKIP_WIN("Slab allocator not supported");
     SlabAllocator<std::byte[4096], 128> mc_page{num_blocks_per_thread * num_threads};
     std::cout << "BEGIN: mc_page tests\n";
@@ -129,23 +130,24 @@ TEST(SlabAlloc, PageSizeMem) {
     std::cout << "END:   mc_page tests\n\n";
 }
 
-TEST(SlabAlloc, Integer) {
+TEST(SlabAlloc, Integer)
+{
     SlabAllocator<int, 128> mc128{1};
-    for (size_t i = 0; i<100; i++) {
+    for (size_t i = 0; i < 100; i++) {
         auto p = mc128.allocate();
         ASSERT_NE(p, nullptr);
         *p = i;
         ASSERT_EQ(*p, i);
         mc128.deallocate(p);
     }
-
 }
 
-TEST(SlabAlloc, Char32) {
+TEST(SlabAlloc, Char32)
+{
     using SlabAllocatorType = SlabAllocator<char[32], 128>;
     SlabAllocatorType mc128{1};
-    for (size_t i = 0; i<100; i++) {
-        auto p = reinterpret_cast<char *>(mc128.allocate());
+    for (size_t i = 0; i < 100; i++) {
+        auto p = reinterpret_cast<char*>(mc128.allocate());
         ASSERT_NE(p, nullptr);
         char src[32] = "1234567812345678123456781234567";
         strcpy(p, src);
@@ -154,11 +156,12 @@ TEST(SlabAlloc, Char32) {
     }
 }
 
-TEST(SlabAlloc, Bytes4096) {
+TEST(SlabAlloc, Bytes4096)
+{
     using SlabAllocatorType = SlabAllocator<std::byte[4096], 128>;
     SlabAllocatorType mc128{1};
-    for (size_t i = 0; i<100; i++) {
-        auto p = reinterpret_cast<std::byte *>(mc128.allocate());
+    for (size_t i = 0; i < 100; i++) {
+        auto p = reinterpret_cast<std::byte*>(mc128.allocate());
         ASSERT_NE(p, nullptr);
         memset(p, 0, 4096);
         for (size_t j = 0; j < 4096; j++) {
@@ -168,34 +171,36 @@ TEST(SlabAlloc, Bytes4096) {
     }
 }
 
-TEST(SlabAlloc, AddrInSlab) {
+TEST(SlabAlloc, AddrInSlab)
+{
     SlabAllocator<std::byte[4096], 128> mc128{100};
     auto p = mc128.allocate();
 
     ASSERT_TRUE(mc128.is_addr_in_slab(p));
-    ASSERT_TRUE(mc128.is_addr_in_slab(p+50));
-    ASSERT_TRUE(mc128.is_addr_in_slab(p+99));
-    ASSERT_FALSE(mc128.is_addr_in_slab(p+100));
-    ASSERT_FALSE(mc128.is_addr_in_slab(p+101));
-    ASSERT_FALSE(mc128.is_addr_in_slab(p+1000));
-
+    ASSERT_TRUE(mc128.is_addr_in_slab(p + 50));
+    ASSERT_TRUE(mc128.is_addr_in_slab(p + 99));
+    ASSERT_FALSE(mc128.is_addr_in_slab(p + 100));
+    ASSERT_FALSE(mc128.is_addr_in_slab(p + 101));
+    ASSERT_FALSE(mc128.is_addr_in_slab(p + 1000));
 }
 
 using SlabAllocType = SlabAllocator<std::byte[4096], 64>;
-std::vector<SlabAllocType::pointer> perform_allocations(SlabAllocType& mc, size_t num) {
+std::vector<SlabAllocType::pointer> perform_allocations(SlabAllocType& mc, size_t num)
+{
     std::vector<SlabAllocType::pointer> res;
-    for(size_t i = 0; i<num; i++) {
+    for (size_t i = 0; i < num; i++) {
         res.push_back(mc.allocate());
     }
     return res;
 }
 
-TEST(SlabAlloc, MultipleThreads) {
+TEST(SlabAlloc, MultipleThreads)
+{
     size_t cap = 10000;
-    SlabAllocType mc (cap);
+    SlabAllocType mc(cap);
     size_t num_thds = 4;
     size_t rounds = 10;
-    for(size_t k = 0; k <rounds; k++) {
+    for (size_t k = 0; k < rounds; k++) {
         ASSERT_EQ(mc.get_approx_free_blocks(), cap);
         std::vector<std::future<std::vector<SlabAllocType::pointer>>> res;
         for (size_t i = 0; i < num_thds; i++) {
@@ -203,7 +208,7 @@ TEST(SlabAlloc, MultipleThreads) {
         }
 
         for (size_t i = 0; i < num_thds; i++) {
-            for (auto &p: res[i].get()) {
+            for (auto& p : res[i].get()) {
                 mc.deallocate(p);
             }
         }
@@ -211,12 +216,13 @@ TEST(SlabAlloc, MultipleThreads) {
     }
 }
 
-TEST(SlabAlloc, Callbacks) {
+TEST(SlabAlloc, Callbacks)
+{
     size_t cap = 10000;
     size_t num_thds = 4;
-    SlabAllocType mc (cap);
+    SlabAllocType mc(cap);
     std::atomic<int> cb_called = 0;
-    mc.add_cb_when_full([&cb_called](){cb_called.fetch_add(1);});
+    mc.add_cb_when_full([&cb_called]() { cb_called.fetch_add(1); });
     std::vector<std::future<std::vector<SlabAllocType::pointer>>> res;
     for (size_t i = 0; i < num_thds; i++) {
         res.push_back(std::async(std::launch::async, perform_allocations, std::ref(mc), cap / num_thds));
@@ -227,7 +233,7 @@ TEST(SlabAlloc, Callbacks) {
     }
     ASSERT_EQ(mc.get_approx_free_blocks(), 0);
     for (size_t i = 0; i < num_thds; i++) {
-        for (auto &p: res2[i]) {
+        for (auto& p : res2[i]) {
             mc.deallocate(p);
         }
     }

--- a/cpp/arcticdb/util/test/test_string_pool.cpp
+++ b/cpp/arcticdb/util/test/test_string_pool.cpp
@@ -16,8 +16,8 @@
 using namespace arcticdb;
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"
 
-
-TEST(StringPool, MultipleReadWrite) {
+TEST(StringPool, MultipleReadWrite)
+{
     StringPool pool;
 
     const size_t VectorSize = 0x100;
@@ -26,7 +26,7 @@ TEST(StringPool, MultipleReadWrite) {
     using map_t = std::unordered_map<std::string, position_t>;
     map_t positions;
 
-    for (auto &s : strings) {
+    for (auto& s : strings) {
         OffsetString str = pool.get(std::string_view(s));
         map_t::const_iterator it;
         if ((it = positions.find(s)) != positions.end())
@@ -37,7 +37,7 @@ TEST(StringPool, MultipleReadWrite) {
 
     const size_t NumTests = 100;
     for (size_t i = 0; i < NumTests; ++i) {
-        auto &s = strings[random_int() & (VectorSize - 1)];
+        auto& s = strings[random_int() & (VectorSize - 1)];
         StringPool::StringType comp_fs(s.data(), s.size());
         OffsetString str = pool.get(s.data(), s.size());
         ASSERT_EQ(str.offset(), positions[s]);
@@ -47,7 +47,8 @@ TEST(StringPool, MultipleReadWrite) {
     }
 }
 
-TEST(StringPool, StressTest) {
+TEST(StringPool, StressTest)
+{
     StringPool pool;
 
     const size_t VectorSize = 0x10000;
@@ -57,7 +58,7 @@ TEST(StringPool, StressTest) {
     auto temp = 0;
     std::string timer_name("ingestion_stress");
     interval_timer timer(timer_name);
-    for (auto &s : strings) {
+    for (auto& s : strings) {
         OffsetString str = pool.get(std::string_view(s));
         temp += str.offset();
     }

--- a/cpp/arcticdb/util/test/test_string_utils.cpp
+++ b/cpp/arcticdb/util/test/test_string_utils.cpp
@@ -8,7 +8,8 @@
 #include <gtest/gtest.h>
 #include <arcticdb/util/string_utils.hpp>
 
-TEST(StringUtils, SafeEncodeNoSpecials) {
+TEST(StringUtils, SafeEncodeNoSpecials)
+{
     using namespace arcticdb;
     std::string simple("testwithnospecialchars");
     auto enc = util::safe_encode(simple);
@@ -16,7 +17,8 @@ TEST(StringUtils, SafeEncodeNoSpecials) {
     ASSERT_EQ(simple, dec);
 }
 
-TEST(StringUtils, SafeEncodeSpecial) {
+TEST(StringUtils, SafeEncodeSpecial)
+{
     using namespace arcticdb;
     std::string simple("testwith/slash");
     auto enc = util::safe_encode(simple);
@@ -25,7 +27,8 @@ TEST(StringUtils, SafeEncodeSpecial) {
     ASSERT_EQ(simple, dec);
 }
 
-TEST(StringUtils, SafeEncodeEscapeChar) {
+TEST(StringUtils, SafeEncodeEscapeChar)
+{
     using namespace arcticdb;
     std::string simple("testwith~escapechar");
     auto enc = util::safe_encode(simple);
@@ -33,7 +36,8 @@ TEST(StringUtils, SafeEncodeEscapeChar) {
     ASSERT_EQ(simple, dec);
 }
 
-TEST(StringUtils, SafeEncodeEncodeCharEnd) {
+TEST(StringUtils, SafeEncodeEncodeCharEnd)
+{
     using namespace arcticdb;
     std::string simple("testwith/");
     auto enc = util::safe_encode(simple);
@@ -41,7 +45,8 @@ TEST(StringUtils, SafeEncodeEncodeCharEnd) {
     ASSERT_EQ(simple, dec);
 }
 
-TEST(StringUtils, SafeEncodeEncodeCharStartEnd) {
+TEST(StringUtils, SafeEncodeEncodeCharStartEnd)
+{
     using namespace arcticdb;
     std::string simple("/testwithboth/");
     auto enc = util::safe_encode(simple);
@@ -49,7 +54,8 @@ TEST(StringUtils, SafeEncodeEncodeCharStartEnd) {
     ASSERT_EQ(simple, dec);
 }
 
-TEST(StringUtils, SafeEncodeMultiple) {
+TEST(StringUtils, SafeEncodeMultiple)
+{
     using namespace arcticdb;
     std::string simple("~test~with");
     auto enc = util::safe_encode(simple);
@@ -57,7 +63,8 @@ TEST(StringUtils, SafeEncodeMultiple) {
     ASSERT_EQ(simple, dec);
 }
 
-TEST(StringUtils, SafeEncodeMixed) {
+TEST(StringUtils, SafeEncodeMixed)
+{
     using namespace arcticdb;
     std::string simple("~test~with/andstuff/");
     auto enc = util::safe_encode(simple);
@@ -65,7 +72,8 @@ TEST(StringUtils, SafeEncodeMixed) {
     ASSERT_EQ(simple, dec);
 }
 
-TEST(StringUtils, SafeEncodeMixedReverse) {
+TEST(StringUtils, SafeEncodeMixedReverse)
+{
     using namespace arcticdb;
     std::string simple("/test~with/andstuff~");
     auto enc = util::safe_encode(simple);

--- a/cpp/arcticdb/util/test/test_tracing_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_tracing_allocator.cpp
@@ -9,7 +9,8 @@
 #include <arcticdb/util/allocator.hpp>
 #include <arcticdb/util/magic_num.hpp>
 
-TEST(Allocator, Tracing) {
+TEST(Allocator, Tracing)
+{
     using AllocType = arcticdb::AllocatorImpl<arcticdb::InMemoryTracingPolicy>;
     AllocType::clear();
     std::vector<std::pair<uint8_t*, arcticdb::entity::timestamp>> blocks;
@@ -32,14 +33,15 @@ TEST(Allocator, Tracing) {
     blocks[0] = new_ptr;
     ASSERT_EQ(AllocType::allocated_bytes(), 130);
 
-    for(auto block : blocks)
+    for (auto block : blocks)
         AllocType::free(block);
 
     ASSERT_EQ(AllocType::allocated_bytes(), 0);
     ASSERT_TRUE(AllocType::empty());
 }
 
-TEST(Allocator, PrintMemUsage) {
+TEST(Allocator, PrintMemUsage)
+{
     arcticdb::log::memory().set_level(spdlog::level::trace);
     arcticdb::util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
 }

--- a/cpp/arcticdb/util/test/test_utils.hpp
+++ b/cpp/arcticdb/util/test/test_utils.hpp
@@ -20,7 +20,8 @@
 using namespace arcticdb;
 
 template<typename DTT, Dimension DIM, NumericId def_tsid = 123, int def_field_count = 4>
-StreamDescriptor::Proto create_tsd(StreamId tsid = def_tsid, std::size_t field_count = def_field_count) {
+StreamDescriptor::Proto create_tsd(StreamId tsid = def_tsid, std::size_t field_count = def_field_count)
+{
 
     using TDT = TypeDescriptorTag<DTT, DimensionTag<DIM>>;
 
@@ -43,8 +44,9 @@ struct TestValue {
     mutable std::vector<ssize_t> strides_;
     raw_type start_val_;
 
-    TestValue(raw_type start_val = raw_type(), size_t num_vals = 20) :
-        start_val_(start_val) {
+    TestValue(raw_type start_val = raw_type(), size_t num_vals = 20)
+        : start_val_(start_val)
+    {
         if (dimensions == Dimension::Dim0) {
             data_.push_back(start_val_);
             return;
@@ -61,18 +63,19 @@ struct TestValue {
             strides_ = {side * itemsize, itemsize};
         }
 
-//        // Adjust strides to the correct size
-//        std::transform(std::begin(strides_),
-//                       std::end(strides_),
-//                       std::begin(strides_),
-//                       [&](auto x) { return x * itemsize; });
+        //        // Adjust strides to the correct size
+        //        std::transform(std::begin(strides_),
+        //                       std::end(strides_),
+        //                       std::begin(strides_),
+        //                       [&](auto x) { return x * itemsize; });
 
         // Fill data
         data_.resize(num_vals);
         fill_impl(dimensions, 0);
     }
 
-    void fill_impl(Dimension dim, int pos) {
+    void fill_impl(Dimension dim, int pos)
+    {
         auto shape = shapes_[size_t(dim) - 1];
         auto stride = strides_[size_t(dim) - 1] / sizeof(raw_type);
 
@@ -85,31 +88,40 @@ struct TestValue {
         }
     }
 
-    raw_type get_scalar() const {
+    raw_type get_scalar() const
+    {
         util::check_arg(dimensions == Dimension::Dim0, "get scalar called on non-scalar test value");
         return data_[0];
     }
 
-    TensorType<raw_type> get_tensor() const {
+    TensorType<raw_type> get_tensor() const
+    {
         util::check_arg(dimensions != Dimension::Dim0, "get tensor called on scalar test value");
         reconstruct_strides();
-        return TensorType<raw_type>{shapes_.data(), ssize_t(dimensions), DataTypeTag::data_type, get_type_size(DataTypeTag::data_type), data_.data()};
+        return TensorType<raw_type>{shapes_.data(),
+            ssize_t(dimensions),
+            DataTypeTag::data_type,
+            get_type_size(DataTypeTag::data_type),
+            data_.data()};
     }
 
-    bool check_tensor(TensorType<raw_type> &t) const {
+    bool check_tensor(TensorType<raw_type>& t) const
+    {
         util::check_arg(dimensions != Dimension::Dim0, "check tensor called on scalar test value");
         auto req = t.request();
-        return check_impl(dimensions, 0, t.shape(), t.strides(), reinterpret_cast<const raw_type *>(req.ptr));
+        return check_impl(dimensions, 0, t.shape(), t.strides(), reinterpret_cast<const raw_type*>(req.ptr));
     }
 
-    bool check(const ssize_t *shapes, const ssize_t *strides, const raw_type *data) const {
+    bool check(const ssize_t* shapes, const ssize_t* strides, const raw_type* data) const
+    {
         if (dimensions == Dimension::Dim0)
             return data_[0] == *data;
 
         return check_impl(dimensions, 0, shapes, strides, data);
     }
 
-    bool check_impl(Dimension dim, int pos, const ssize_t *shapes, const ssize_t *strides, const raw_type *data) const {
+    bool check_impl(Dimension dim, int pos, const ssize_t* shapes, const ssize_t* strides, const raw_type* data) const
+    {
         auto shape = shapes_[size_t(dim) - 1];
         auto stride = strides_[size_t(dim) - 1] / sizeof(raw_type);
         for (int i = 0; i < +shape; ++i) {
@@ -122,7 +134,8 @@ struct TestValue {
         return true;
     }
 
-    void reconstruct_strides() const {
+    void reconstruct_strides() const
+    {
         if (strides_[0] == 0) {
             stride_t stride = sizeof(raw_type);
 
@@ -138,23 +151,26 @@ template<typename TDT>
 struct TestRow {
     using raw_type = typename TDT::DataTypeTag::raw_type;
 
-    TestRow(timestamp ts, size_t num_columns, raw_type start_val = raw_type(), size_t num_vals = 20) :
-        ts_(ts),
-        starts_(num_columns),
-        values_() {
+    TestRow(timestamp ts, size_t num_columns, raw_type start_val = raw_type(), size_t num_vals = 20)
+        : ts_(ts),
+          starts_(num_columns),
+          values_()
+    {
         std::iota(std::begin(starts_), std::end(starts_), start_val);
-        for (auto &s : starts_)
+        for (auto& s : starts_)
             values_.push_back(TestValue<TDT>{s, num_vals});
         auto prev_size = bitset_.size();
         bitset_.resize(num_columns + 1);
         bitset_.set_range(prev_size, bitset_.size() - 1, true);
     }
 
-    bool check(position_t pos, TensorType<raw_type> &t) {
+    bool check(position_t pos, TensorType<raw_type>& t)
+    {
         return values_[pos].check_tensor(t);
     }
 
-    const TestValue<TDT> &operator[](size_t pos) {
+    const TestValue<TDT>& operator[](size_t pos)
+    {
         return values_[pos];
     }
 
@@ -163,4 +179,3 @@ struct TestRow {
     mutable util::BitSet bitset_;
     std::vector<TestValue<TDT>> values_;
 };
-

--- a/cpp/arcticdb/util/timeouts.hpp
+++ b/cpp/arcticdb/util/timeouts.hpp
@@ -11,9 +11,10 @@
 
 namespace arcticdb::util::timeout {
 
-inline folly::Duration get_default() {
+inline folly::Duration get_default()
+{
     static folly::Duration duration(40 * 60 * 1000);
     return duration;
 }
 
-}
+} // namespace arcticdb::util::timeout

--- a/cpp/arcticdb/util/trace.cpp
+++ b/cpp/arcticdb/util/trace.cpp
@@ -7,7 +7,7 @@
 
 #include <arcticdb/util/trace.hpp>
 
-#ifndef  _WIN32
+#ifndef _WIN32
 #include <cxxabi.h>
 #endif
 
@@ -15,16 +15,17 @@
 
 namespace arcticdb {
 
-    std::string get_type_name(const std::type_info & ti){
+std::string get_type_name(const std::type_info& ti)
+{
 #ifndef _WIN32
-        char* demangled = abi::__cxa_demangle(ti.name(), nullptr, nullptr, nullptr);
-        std::string ret = demangled;
-        free(demangled);
-        return ret;
+    char* demangled = abi::__cxa_demangle(ti.name(), nullptr, nullptr, nullptr);
+    std::string ret = demangled;
+    free(demangled);
+    return ret;
 #else
-        //TODO: Implement get_name_type for windows
-        return std::string("");
+    //TODO: Implement get_name_type for windows
+    return std::string("");
 #endif
-    }
-
 }
+
+} // namespace arcticdb

--- a/cpp/arcticdb/util/trace.hpp
+++ b/cpp/arcticdb/util/trace.hpp
@@ -16,6 +16,6 @@
 
 namespace arcticdb {
 
-std::string get_type_name(const std::type_info & );
+std::string get_type_name(const std::type_info&);
 
 }

--- a/cpp/arcticdb/util/type_handler.cpp
+++ b/cpp/arcticdb/util/type_handler.cpp
@@ -9,25 +9,29 @@
 
 namespace arcticdb {
 
-std::shared_ptr<TypeHandlerRegistry> TypeHandlerRegistry::instance(){
+std::shared_ptr<TypeHandlerRegistry> TypeHandlerRegistry::instance()
+{
     std::call_once(TypeHandlerRegistry::init_flag_, &TypeHandlerRegistry::init);
     return TypeHandlerRegistry::instance_;
 }
 
-void TypeHandlerRegistry::init() {
+void TypeHandlerRegistry::init()
+{
     TypeHandlerRegistry::instance_ = std::make_shared<TypeHandlerRegistry>();
 }
 
 std::shared_ptr<TypeHandlerRegistry> TypeHandlerRegistry::instance_;
 std::once_flag TypeHandlerRegistry::init_flag_;
 
-std::shared_ptr<TypeHandler> TypeHandlerRegistry::get_handler(entity::DataType data_type) const {
+std::shared_ptr<TypeHandler> TypeHandlerRegistry::get_handler(entity::DataType data_type) const
+{
     auto it = handlers_.find(data_type);
     return it == std::end(handlers_) ? std::shared_ptr<TypeHandler>{} : it->second;
 }
 
-void TypeHandlerRegistry::register_handler(entity::DataType data_type, TypeHandler&& handler) {
-     handlers_.try_emplace(data_type, std::make_shared<TypeHandler>(std::move(handler)));
+void TypeHandlerRegistry::register_handler(entity::DataType data_type, TypeHandler&& handler)
+{
+    handlers_.try_emplace(data_type, std::make_shared<TypeHandler>(std::move(handler)));
 }
 
-} //namespace arcticc
+} // namespace arcticdb

--- a/cpp/arcticdb/util/type_handler.hpp
+++ b/cpp/arcticdb/util/type_handler.hpp
@@ -21,15 +21,15 @@ namespace arcticdb {
 struct ITypeHandler {
     template<class Base>
     struct Interface : Base {
-        void handle_type(
-            const uint8_t*& data,
+        void handle_type(const uint8_t*& data,
             uint8_t* dest,
             const arcticdb::proto::encoding::EncodedField& encoded_field_info,
             const entity::TypeDescriptor& type_descriptor,
             size_t dest_bytes,
-            std::shared_ptr<BufferHolder> buffers
-            ) { folly::poly_call<0>(*this, data, dest, encoded_field_info, type_descriptor, dest_bytes, buffers); }
-
+            std::shared_ptr<BufferHolder> buffers)
+        {
+            folly::poly_call<0>(*this, data, dest, encoded_field_info, type_descriptor, dest_bytes, buffers);
+        }
     };
 
     template<class T>
@@ -48,8 +48,9 @@ public:
 
     std::shared_ptr<TypeHandler> get_handler(entity::DataType data_type) const;
     void register_handler(entity::DataType data_type, TypeHandler&& handler);
+
 private:
     std::unordered_map<entity::DataType, std::shared_ptr<TypeHandler>> handlers_;
 };
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/util/variant.hpp
+++ b/cpp/arcticdb/util/variant.hpp
@@ -11,17 +11,23 @@
 
 namespace arcticdb::util {
 
-template<class... Ts> struct overload : Ts... { using Ts::operator()...; };
-template<class... Ts> overload(Ts...) -> overload<Ts...>;
+template<class... Ts>
+struct overload : Ts... {
+    using Ts::operator()...;
+};
+template<class... Ts>
+overload(Ts...) -> overload<Ts...>;
 
 template<class Variant, class... Ts>
-auto variant_match(Variant && v, Ts... ts){
+auto variant_match(Variant&& v, Ts... ts)
+{
     return std::visit(overload{ts...}, v);
 }
 
 template<class Variant, class... Ts>
-auto variant_match(const Variant && v, Ts... ts){
+auto variant_match(const Variant&& v, Ts... ts)
+{
     return std::visit(overload{ts...}, v);
 }
 
-} // arctic::util
+} // namespace arcticdb::util

--- a/cpp/arcticdb/version/de_dup_map.hpp
+++ b/cpp/arcticdb/version/de_dup_map.hpp
@@ -13,11 +13,13 @@ using namespace arcticdb::entity;
 
 class DeDupMap {
 public:
-    DeDupMap() :
-            de_dup_map_(std::make_unique<std::unordered_map<ContentHash, std::vector<AtomKey>>>()) {
+    DeDupMap()
+        : de_dup_map_(std::make_unique<std::unordered_map<ContentHash, std::vector<AtomKey>>>())
+    {
     }
 
-    std::optional<AtomKey> get_key_if_present(const AtomKey &key) const {
+    std::optional<AtomKey> get_key_if_present(const AtomKey& key) const
+    {
         if (!de_dup_map_) {
             util::raise_rte("Invalid de dup map object");
         }
@@ -28,11 +30,9 @@ public:
         }
         // Just content hash matching isn't enough, start and end index also need to be matched
         // which uniquely identifies the position of the segment
-        auto key_iterator = std::find_if(std::begin(de_dup_candidates->second), std::end(de_dup_candidates->second),
-                                         [&](const auto &k) {
-                                             return k.start_index() == key.start_index() &&
-                                                    k.end_index() == key.end_index();
-                                         });
+        auto key_iterator = std::find_if(std::begin(de_dup_candidates->second),
+            std::end(de_dup_candidates->second),
+            [&](const auto& k) { return k.start_index() == key.start_index() && k.end_index() == key.end_index(); });
         if (key_iterator == de_dup_candidates->second.end()) {
             return std::nullopt;
         } else {
@@ -40,7 +40,8 @@ public:
         }
     }
 
-    void insert_key(const AtomKey &key) {
+    void insert_key(const AtomKey& key)
+    {
         if (!de_dup_map_) {
             util::raise_rte("Invalid de dup map object");
         }
@@ -54,4 +55,4 @@ private:
     std::unique_ptr<std::unordered_map<ContentHash, std::vector<AtomKey>>> de_dup_map_;
 };
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -23,39 +23,40 @@
 
 namespace arcticdb::version_store {
 
-LocalVersionedEngine::LocalVersionedEngine(
-        const std::shared_ptr<storage::Library>& library) :
-    store_(std::make_shared<async::AsyncStore<util::SysClock>>(library, codec::default_lz4_codec())),
-    symbol_list_(std::make_shared<SymbolList>(version_map_)){
+LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<storage::Library>& library)
+    : store_(std::make_shared<async::AsyncStore<util::SysClock>>(library, codec::default_lz4_codec())),
+      symbol_list_(std::make_shared<SymbolList>(version_map_))
+{
     configure(library->config());
-    ARCTICDB_RUNTIME_DEBUG(log::version(), "Created versioned engine at {} for library path {}  with config {}", uintptr_t(this),
-                         library->library_path(), [&cfg=cfg_]{  return util::format(cfg); });
+    ARCTICDB_RUNTIME_DEBUG(log::version(),
+        "Created versioned engine at {} for library path {}  with config {}",
+        uintptr_t(this),
+        library->library_path(),
+        [&cfg = cfg_] { return util::format(cfg); });
 #ifdef USE_REMOTERY
     auto temp = RemoteryInstance::instance();
 #endif
     ARCTICDB_SAMPLE_THREAD();
     ARCTICDB_SAMPLE(LocalVersionedEngine, 0)
-    if(async::TaskScheduler::is_forked()) {
+    if (async::TaskScheduler::is_forked()) {
         async::TaskScheduler::set_forked(false);
         async::TaskScheduler::reattach_instance();
     }
 }
 
-void LocalVersionedEngine::delete_unreferenced_pruned_indexes(
-        const std::vector<AtomKey> &pruned_indexes,
-        const AtomKey& key_to_keep
-) {
+void LocalVersionedEngine::delete_unreferenced_pruned_indexes(const std::vector<AtomKey>& pruned_indexes,
+    const AtomKey& key_to_keep)
+{
     try {
         if (!pruned_indexes.empty() && !cfg().write_options().delayed_deletes()) {
-            auto [not_in_snaps, in_snaps] = get_index_keys_partitioned_by_inclusion_in_snapshots(
-                    store(),
-                    pruned_indexes.begin()->id(),
-                    pruned_indexes);
+            auto [not_in_snaps, in_snaps] = get_index_keys_partitioned_by_inclusion_in_snapshots(store(),
+                pruned_indexes.begin()->id(),
+                pruned_indexes);
             in_snaps.insert(key_to_keep);
             PreDeleteChecks checks{false, false, false, false, in_snaps};
             delete_trees_responsibly(not_in_snaps, {}, {}, checks);
         }
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         // Best-effort so deliberately swallow
         log::version().warn("Could not prune previous versions due to: {}", ex.what());
     }
@@ -64,23 +65,19 @@ void LocalVersionedEngine::delete_unreferenced_pruned_indexes(
 FrameAndDescriptor LocalVersionedEngine::read_dataframe_internal(
     const std::variant<VersionedItem, StreamId>& identifier,
     ReadQuery& read_query,
-    const ReadOptions& read_options) {
+    const ReadOptions& read_options)
+{
     ARCTICDB_RUNTIME_SAMPLE(ReadDataFrameInternal, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: read_dataframe");
-    return read_dataframe_impl(
-        store(),
-        identifier,
-        read_query,
-        read_options);
+    return read_dataframe_impl(store(), identifier, read_query, read_options);
 }
 
-std::set<StreamId> LocalVersionedEngine::list_streams_internal(
-    std::optional<SnapshotId> snap_name,
+std::set<StreamId> LocalVersionedEngine::list_streams_internal(std::optional<SnapshotId> snap_name,
     const std::optional<std::string>& regex,
     const std::optional<std::string>& prefix,
     const std::optional<bool>& opt_use_symbol_list,
-    const std::optional<bool>& opt_all_symbols
-    ) {
+    const std::optional<bool>& opt_all_symbols)
+{
     ARCTICDB_SAMPLE(ListStreamsInternal, 0)
     auto res = std::set<StreamId>();
     bool use_symbol_list = opt_use_symbol_list.value_or(cfg().symbol_list());
@@ -88,7 +85,7 @@ std::set<StreamId> LocalVersionedEngine::list_streams_internal(
     if (snap_name) {
         res = list_streams_in_snapshot(store(), snap_name.value());
     } else {
-        if(use_symbol_list)
+        if (use_symbol_list)
             res = symbol_list().get_symbol_set(store());
         else
             res = list_streams(store(), version_map(), prefix, opt_false(opt_all_symbols));
@@ -102,14 +99,19 @@ std::set<StreamId> LocalVersionedEngine::list_streams_internal(
     return res;
 }
 
-std::string LocalVersionedEngine::dump_versions(const StreamId& stream_id) {
+std::string LocalVersionedEngine::dump_versions(const StreamId& stream_id)
+{
     return version_map()->dump_entry(store(), stream_id);
 }
 
-std::optional<VersionedItem> LocalVersionedEngine::get_latest_version(
-    const StreamId &stream_id,
-    const VersionQuery& version_query) {
-    auto key = get_latest_undeleted_version(store(), version_map(), stream_id,  opt_true(version_query.skip_compat_), opt_false(version_query.iterate_on_failure_));
+std::optional<VersionedItem> LocalVersionedEngine::get_latest_version(const StreamId& stream_id,
+    const VersionQuery& version_query)
+{
+    auto key = get_latest_undeleted_version(store(),
+        version_map(),
+        stream_id,
+        opt_true(version_query.skip_compat_),
+        opt_false(version_query.iterate_on_failure_));
     if (!key) {
         ARCTICDB_DEBUG(log::version(), "get_latest_version didn't find version for stream_id: {}", stream_id);
         return std::nullopt;
@@ -117,15 +119,21 @@ std::optional<VersionedItem> LocalVersionedEngine::get_latest_version(
     return VersionedItem{std::move(key.value())};
 }
 
-std::optional<VersionedItem> LocalVersionedEngine::get_specific_version(
-    const StreamId &stream_id,
+std::optional<VersionedItem> LocalVersionedEngine::get_specific_version(const StreamId& stream_id,
     VersionId version_id,
-    const VersionQuery& version_query) {
+    const VersionQuery& version_query)
+{
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: get_specific_version");
-    auto key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id, opt_true(version_query.skip_compat_),
-                                                   opt_true(version_query.iterate_on_failure_));
+    auto key = ::arcticdb::get_specific_version(store(),
+        version_map(),
+        stream_id,
+        version_id,
+        opt_true(version_query.skip_compat_),
+        opt_true(version_query.iterate_on_failure_));
     if (!key) {
-        log::version().warn("Version {} for symbol {} is missing, checking snapshots (this can be slow)", version_id, stream_id);
+        log::version().warn("Version {} for symbol {} is missing, checking snapshots (this can be slow)",
+            version_id,
+            stream_id);
         auto index_keys = get_index_keys_in_snapshots(store(), stream_id);
         auto index_key = std::find_if(index_keys.begin(), index_keys.end(), [version_id](const AtomKey& k) {
             return k.version_id() == version_id;
@@ -134,32 +142,39 @@ std::optional<VersionedItem> LocalVersionedEngine::get_specific_version(
             ARCTICDB_DEBUG(log::version(), "Found version {} for symbol {} in snapshot:", version_id, stream_id);
             key = *index_key;
         } else {
-            ARCTICDB_DEBUG(log::version(), "get_specific_version: "
-                                 "version id not found for stream {} version {}", stream_id, version_id);
+            ARCTICDB_DEBUG(log::version(),
+                "get_specific_version: "
+                "version id not found for stream {} version {}",
+                stream_id,
+                version_id);
             return std::nullopt;
         }
     }
     return VersionedItem{std::move(key.value())};
 }
 
-std::optional<VersionedItem> LocalVersionedEngine::get_version_at_time(
-    const StreamId& stream_id,
-    timestamp as_of,
-    const VersionQuery& version_query
-    ) {
+std::optional<VersionedItem>
+LocalVersionedEngine::get_version_at_time(const StreamId& stream_id, timestamp as_of, const VersionQuery& version_query)
+{
 
-    auto version_key =
-        get_version_key_from_time(store(), version_map(), stream_id, as_of, false, opt_true(version_query.iterate_on_failure_));
+    auto version_key = get_version_key_from_time(store(),
+        version_map(),
+        stream_id,
+        as_of,
+        false,
+        opt_true(version_query.iterate_on_failure_));
     std::optional<AtomKey> key;
     if (!version_key) {
         auto index_keys = get_index_keys_in_snapshots(store(), stream_id);
         auto vector_index_keys = std::vector<AtomKey>(index_keys.begin(), index_keys.end());
-        std::sort(std::begin(vector_index_keys), std::end(vector_index_keys),
-                  [](auto& k1, auto& k2) {return k1.creation_ts() > k2.creation_ts();});
+        std::sort(std::begin(vector_index_keys), std::end(vector_index_keys), [](auto& k1, auto& k2) {
+            return k1.creation_ts() > k2.creation_ts();
+        });
         key = get_version_key_from_time_for_versions(as_of, vector_index_keys);
     } else {
         auto version_id = version_key.value().version_id();
-        key = ::arcticdb::get_specific_version(store(), version_map(),
+        key = ::arcticdb::get_specific_version(store(),
+            version_map(),
             stream_id,
             version_id,
             opt_true(version_query.skip_compat_),
@@ -167,18 +182,19 @@ std::optional<VersionedItem> LocalVersionedEngine::get_version_at_time(
     }
 
     if (!key) {
-        log::version().warn("read_dataframe_timestamp: version id not found for stream {} timestamp {}", stream_id, as_of);
+        log::version().warn("read_dataframe_timestamp: version id not found for stream {} timestamp {}",
+            stream_id,
+            as_of);
         return std::nullopt;
     }
 
     return VersionedItem(std::move(key.value()));
 }
 
-std::optional<VersionedItem> LocalVersionedEngine::get_version_from_snapshot(
-    const StreamId& stream_id,
-    const SnapshotId& snap_name
-    ) {
-    auto opt_snapshot =  get_snapshot(store(), snap_name);
+std::optional<VersionedItem> LocalVersionedEngine::get_version_from_snapshot(const StreamId& stream_id,
+    const SnapshotId& snap_name)
+{
+    auto opt_snapshot = get_snapshot(store(), snap_name);
     if (!opt_snapshot) {
         throw storage::NoDataFoundException(snap_name);
     }
@@ -193,55 +209,51 @@ std::optional<VersionedItem> LocalVersionedEngine::get_version_from_snapshot(
     }
     ARCTICDB_DEBUG(log::version(), "read_snapshot: {} id not found for snapshot {}", stream_id, snap_name);
     return std::nullopt;
-
 }
 
-std::optional<VersionedItem> LocalVersionedEngine::get_version_to_read(
-    const StreamId &stream_id,
-    const VersionQuery &version_query
-    ) {
-    return util::variant_match(version_query.content_,
-       [&stream_id, &version_query, that=this](const SpecificVersionQuery &specific) {
+std::optional<VersionedItem> LocalVersionedEngine::get_version_to_read(const StreamId& stream_id,
+    const VersionQuery& version_query)
+{
+    return util::variant_match(
+        version_query.content_,
+        [&stream_id, &version_query, that = this](const SpecificVersionQuery& specific) {
             return that->get_specific_version(stream_id, specific.version_id_, version_query);
         },
-        [&stream_id, that=this](const SnapshotVersionQuery &snapshot) {
+        [&stream_id, that = this](const SnapshotVersionQuery& snapshot) {
             return that->get_version_from_snapshot(stream_id, snapshot.name_);
         },
-        [&stream_id, &version_query, that=this](const TimestampVersionQuery &timestamp) {
+        [&stream_id, &version_query, that = this](const TimestampVersionQuery& timestamp) {
             return that->get_version_at_time(stream_id, timestamp.timestamp_, version_query);
         },
-        [&stream_id, &version_query, that=this](const std::monostate &) {
-            return that->get_latest_version(stream_id, version_query);
-    }
-    );
+        [&stream_id, &version_query, that = this](
+            const std::monostate&) { return that->get_latest_version(stream_id, version_query); });
 }
 
-IndexRange LocalVersionedEngine::get_index_range(
-    const StreamId &stream_id,
-    const VersionQuery& version_query) {
+IndexRange LocalVersionedEngine::get_index_range(const StreamId& stream_id, const VersionQuery& version_query)
+{
     auto version = get_version_to_read(stream_id, version_query);
-    if(!version)
+    if (!version)
         return unspecified_range();
 
     return index::get_index_segment_range(version.value().key_, store());
 }
 
 std::pair<VersionedItem, FrameAndDescriptor> LocalVersionedEngine::read_dataframe_version_internal(
-    const StreamId &stream_id,
+    const StreamId& stream_id,
     const VersionQuery& version_query,
     ReadQuery& read_query,
-    const ReadOptions& read_options) {
+    const ReadOptions& read_options)
+{
     auto version = get_version_to_read(stream_id, version_query);
     std::variant<VersionedItem, StreamId> identifier;
-    if(!version) {
-        if(opt_false(read_options.incompletes_)) {
+    if (!version) {
+        if (opt_false(read_options.incompletes_)) {
             log::version().warn("No index:  Key not found for {}, will attempt to use incomplete segments.", stream_id);
             identifier = stream_id;
-        }
-        else
-            throw storage::NoDataFoundException(fmt::format("read_dataframe_version: version not found for symbol '{}'", stream_id));
-    }
-    else  {
+        } else
+            throw storage::NoDataFoundException(
+                fmt::format("read_dataframe_version: version not found for symbol '{}'", stream_id));
+    } else {
         identifier = version.value();
     }
 
@@ -249,58 +261,60 @@ std::pair<VersionedItem, FrameAndDescriptor> LocalVersionedEngine::read_datafram
     return std::make_pair(version.value_or(VersionedItem{}), std::move(frame_and_descriptor));
 }
 
-std::pair<VersionedItem, std::optional<google::protobuf::Any>> LocalVersionedEngine::read_descriptor_version_internal(
-        const StreamId& stream_id,
-        const VersionQuery& version_query
-    ) {
+std::pair<VersionedItem, std::optional<google::protobuf::Any>>
+LocalVersionedEngine::read_descriptor_version_internal(const StreamId& stream_id, const VersionQuery& version_query)
+{
     ARCTICDB_SAMPLE(ReadDescriptor, 0)
 
     auto version = get_version_to_read(stream_id, version_query);
     version::check<ErrorCode::E_NO_SUCH_VERSION>(static_cast<bool>(version),
-                                                 "Unable to retrieve descriptor data. {}@{}: version not found", stream_id, version_query);
+        "Unable to retrieve descriptor data. {}@{}: version not found",
+        stream_id,
+        version_query);
 
     auto metadata_proto = store()->read_metadata(version->key_).get().second;
     return std::pair{version.value(), metadata_proto};
 }
 
-std::vector<std::pair<VersionedItem, std::optional<google::protobuf::Any>>> LocalVersionedEngine::batch_read_descriptor_internal(
-        const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries) {
+std::vector<std::pair<VersionedItem, std::optional<google::protobuf::Any>>>
+LocalVersionedEngine::batch_read_descriptor_internal(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
     std::vector<folly::Future<std::pair<VersionedItem, std::optional<google::protobuf::Any>>>> results_fut;
-    for (size_t idx=0; idx < stream_ids.size(); idx++) {
+    for (size_t idx = 0; idx < stream_ids.size(); idx++) {
         auto version_query = version_queries.size() > idx ? version_queries[idx] : VersionQuery{};
-        results_fut.push_back(read_descriptor_version_internal(stream_ids[idx],
-                                                              version_query));
+        results_fut.push_back(read_descriptor_version_internal(stream_ids[idx], version_query));
     }
     return folly::collect(results_fut).get();
 }
 
-void LocalVersionedEngine::flush_version_map() {
+void LocalVersionedEngine::flush_version_map()
+{
     version_map()->flush();
 }
 
-std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
-    const StreamId& stream_id,
+std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(const StreamId& stream_id,
     const std::optional<AtomKey>& maybe_prev,
-    const WriteOptions& write_options
-    ){
+    const WriteOptions& write_options)
+{
     auto de_dup_map = std::make_shared<DeDupMap>();
     if (write_options.de_duplication) {
         auto maybe_undeleted_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
         if (maybe_undeleted_prev) {
             // maybe_undeleted_prev is index key
             auto data_keys = get_data_keys(store(), {maybe_undeleted_prev.value()}, storage::ReadKeyOpts{});
-            for (const auto& data_key: data_keys) {
+            for (const auto& data_key : data_keys) {
                 de_dup_map->insert_key(data_key);
             }
-        } else if(maybe_prev && write_options.snapshot_dedup) {
+        } else if (maybe_prev && write_options.snapshot_dedup) {
             // This means we don't have any live versions(all tombstoned), so will try to dedup from snapshot versions
             auto snap_versions = get_index_keys_in_snapshots(store(), stream_id);
-            auto max_iter = std::max_element(std::begin(snap_versions), std::end(snap_versions),
-                                             [](const auto &k1, const auto &k2){return k1.version_id() < k2.version_id();});
+            auto max_iter = std::max_element(std::begin(snap_versions),
+                std::end(snap_versions),
+                [](const auto& k1, const auto& k2) { return k1.version_id() < k2.version_id(); });
             if (max_iter != snap_versions.end()) {
                 auto data_keys = get_data_keys(store(), {*max_iter}, storage::ReadKeyOpts{});
-                for (const auto& data_key: data_keys) {
+                for (const auto& data_key : data_keys) {
                     de_dup_map->insert_key(data_key);
                 }
             }
@@ -309,18 +323,18 @@ std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
     return de_dup_map;
 }
 
-
-VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool dynamic_schema) {
+VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool dynamic_schema)
+{
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto version_id = get_next_version_from_key(maybe_prev.value());
     auto [index_segment_reader, slice_and_keys] = index::read_index_to_vector(store(), maybe_prev.value());
-    if(dynamic_schema) {
-        std::sort(std::begin(slice_and_keys), std::end(slice_and_keys), [](const auto &left, const auto &right) {
+    if (dynamic_schema) {
+        std::sort(std::begin(slice_and_keys), std::end(slice_and_keys), [](const auto& left, const auto& right) {
             return left.key().start_index() < right.key().start_index();
         });
     } else {
-        std::sort(std::begin(slice_and_keys), std::end(slice_and_keys), [](const auto &left, const auto &right) {
+        std::sort(std::begin(slice_and_keys), std::end(slice_and_keys), [](const auto& left, const auto& right) {
             auto lt = std::tie(left.slice_.col_range.first, left.key().start_index());
             auto rt = std::tie(right.slice_.col_range.first, right.key().start_index());
             return lt < rt;
@@ -330,58 +344,51 @@ VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool d
     auto total_rows = adjust_slice_rowcounts(slice_and_keys);
     auto index = index_type_from_descriptor(index_segment_reader.tsd().stream_descriptor());
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
-    auto time_series = make_descriptor(
-        total_rows,
+    auto time_series = make_descriptor(total_rows,
         StreamDescriptor{std::move(*index_segment_reader.mutable_tsd().mutable_stream_descriptor())},
         *index_segment_reader.mutable_tsd().mutable_normalization(),
         std::move(*index_segment_reader.mutable_tsd().mutable_user_meta()),
         std::nullopt,
         bucketize_dynamic);
 
-    auto versioned_item = pipelines::index::index_and_version(index, store(), time_series, std::move(slice_and_keys), stream_id, version_id).get();
+    auto versioned_item = pipelines::index::index_and_version(index,
+        store(),
+        time_series,
+        std::move(slice_and_keys),
+        stream_id,
+        version_id)
+                              .get();
     version_map()->write_version(store(), versioned_item.key_);
     ARCTICDB_DEBUG(log::version(), "sorted index of stream_id: {} , version_id: {}", stream_id, version_id);
     return versioned_item;
 }
 
-VersionedItem LocalVersionedEngine::delete_range_internal(
-    const StreamId& stream_id,
-    const UpdateQuery & query,
-    bool dynamic_schema) {
+VersionedItem
+LocalVersionedEngine::delete_range_internal(const StreamId& stream_id, const UpdateQuery& query, bool dynamic_schema)
+{
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
-    auto versioned_item = delete_range_impl(store(),
-                                            maybe_prev.value(),
-                                            query,
-                                            get_write_options(),
-                                            dynamic_schema);
+    auto versioned_item = delete_range_impl(store(), maybe_prev.value(), query, get_write_options(), dynamic_schema);
     version_map()->write_version(store(), versioned_item.key_);
     return versioned_item;
 }
 
-VersionedItem LocalVersionedEngine::update_internal(
-    const StreamId& stream_id,
+VersionedItem LocalVersionedEngine::update_internal(const StreamId& stream_id,
     const UpdateQuery& query,
     InputTensorFrame&& frame_ref,
     bool upsert,
     bool dynamic_schema,
-    bool prune_previous_versions) {
+    bool prune_previous_versions)
+{
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: update");
     auto frame = std::move(frame_ref);
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
-                                                                        version_map(),
-                                                                        stream_id,
-                                                                        true,
-                                                                        false);
+    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, true, false);
     if (update_info.previous_index_key_.has_value()) {
-        auto versioned_item = update_impl(store(),
-                                          update_info,
-                                          query,
-                                          std::move(frame),
-                                          get_write_options(),
-                                          dynamic_schema);
+        auto versioned_item =
+            update_impl(store(), update_info, query, std::move(frame), get_write_options(), dynamic_schema);
         if (prune_previous_versions) {
-            auto pruned_indexes = version_map()->write_and_prune_previous(store(), versioned_item.key_, update_info.previous_index_key_);
+            auto pruned_indexes =
+                version_map()->write_and_prune_previous(store(), versioned_item.key_, update_info.previous_index_key_);
             delete_unreferenced_pruned_indexes(pruned_indexes, versioned_item.key_);
         } else {
             version_map()->write_version(store(), versioned_item.key_);
@@ -391,15 +398,15 @@ VersionedItem LocalVersionedEngine::update_internal(
         if (upsert) {
             auto write_options = get_write_options();
             write_options.dynamic_schema |= dynamic_schema;
-            auto versioned_item =  write_dataframe_impl(store_,
-                                                        update_info.next_version_id_,
-                                                        std::move(frame),
-                                                        write_options,
-                                                        std::make_shared<DeDupMap>(),
-                                                        false,
-                                                        true);
+            auto versioned_item = write_dataframe_impl(store_,
+                update_info.next_version_id_,
+                std::move(frame),
+                write_options,
+                std::make_shared<DeDupMap>(),
+                false,
+                true);
 
-            if(cfg_.symbol_list())
+            if (cfg_.symbol_list())
                 symbol_list().add_symbol(store_, stream_id);
 
             version_map()->write_version(store(), versioned_item.key_);
@@ -410,52 +417,46 @@ VersionedItem LocalVersionedEngine::update_internal(
     }
 }
 
-VersionedItem LocalVersionedEngine::write_versioned_metadata_internal(
-    const StreamId& stream_id,
+VersionedItem LocalVersionedEngine::write_versioned_metadata_internal(const StreamId& stream_id,
     bool prune_previous_versions,
-    arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
-    ) {
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
-                                                                        version_map(),
-                                                                        stream_id,
-                                                                        true,
-                                                                        false);
+    arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta)
+{
+    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, true, false);
     util::check(update_info.previous_index_key_.has_value(), "No previous version exists for write metadata");
     ARCTICDB_DEBUG(log::version(), "write_versioned_dataframe for stream_id: {}", stream_id);
-    auto index_key = UpdateMetadataTask{store(),
-                                        update_info,
-                                        std::move(user_meta)}();
+    auto index_key = UpdateMetadataTask{store(), update_info, std::move(user_meta)}();
 
-    if(prune_previous_versions) {
+    if (prune_previous_versions) {
         auto versioned_item = VersionedItem{index_key};
-        auto pruned_indexes = version_map()->write_and_prune_previous(store(), index_key, update_info.previous_index_key_);
+        auto pruned_indexes =
+            version_map()->write_and_prune_previous(store(), index_key, update_info.previous_index_key_);
         delete_unreferenced_pruned_indexes(pruned_indexes, versioned_item.key_);
         return versioned_item;
-    }
-    else {
+    } else {
         version_map()->write_version(store(), index_key);
         return VersionedItem{index_key};
     }
 }
 
-VersionedItem LocalVersionedEngine::write_versioned_dataframe_internal(
-    const StreamId& stream_id,
+VersionedItem LocalVersionedEngine::write_versioned_dataframe_internal(const StreamId& stream_id,
     InputTensorFrame&& frame,
     bool prune_previous_versions,
     bool allow_sparse,
-    bool validate_index
-    ) {
+    bool validate_index)
+{
     ARCTICDB_SAMPLE(WriteVersionedDataFrame, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_dataframe");
     auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
     auto version_id = get_next_version_from_key(maybe_prev);
-    ARCTICDB_DEBUG(log::version(), "write_versioned_dataframe for stream_id: {} , version_id = {}", stream_id, version_id);
+    ARCTICDB_DEBUG(log::version(),
+        "write_versioned_dataframe for stream_id: {} , version_id = {}",
+        stream_id,
+        version_id);
     auto write_options = get_write_options();
     auto de_dup_map = get_de_dup_map(stream_id, maybe_prev, write_options);
 
-    auto versioned_item = write_dataframe_impl(
-        store(),
+    auto versioned_item = write_dataframe_impl(store(),
         version_id,
         std::move(frame),
         write_options,
@@ -463,76 +464,79 @@ VersionedItem LocalVersionedEngine::write_versioned_dataframe_internal(
         allow_sparse,
         validate_index);
 
-    if(prune_previous_versions) {
+    if (prune_previous_versions) {
         auto pruned_indexes = version_map()->write_and_prune_previous(store(), versioned_item.key_, maybe_prev);
         delete_unreferenced_pruned_indexes(pruned_indexes, versioned_item.key_);
         return versioned_item;
-    }
-    else {
+    } else {
         version_map()->write_version(store(), versioned_item.key_);
         return versioned_item;
     }
 }
 
-std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor> LocalVersionedEngine::restore_version(
-    const StreamId& stream_id,
-    const VersionQuery& version_query
-    ) {
+std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>
+LocalVersionedEngine::restore_version(const StreamId& stream_id, const VersionQuery& version_query)
+{
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: res    tore_version");
     auto version_to_restore = get_version_to_read(stream_id, version_query);
     version::check<ErrorCode::E_NO_SUCH_VERSION>(static_cast<bool>(version_to_restore),
-                                                 "Unable to restore {}@{}: version not found", stream_id, version_query);
+        "Unable to restore {}@{}: version not found",
+        stream_id,
+        version_query);
     auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
-    ARCTICDB_DEBUG(log::version(), "restore for stream_id: {} , version_id = {}", stream_id, version_to_restore->key_.version_id());
+    ARCTICDB_DEBUG(log::version(),
+        "restore for stream_id: {} , version_id = {}",
+        stream_id,
+        version_to_restore->key_.version_id());
     return AsyncRestoreVersionTask{store(), version_map(), stream_id, version_to_restore->key_, maybe_prev}().get();
 }
 
-std::pair<VersionedItem, std::vector<AtomKey>> LocalVersionedEngine::write_individual_segment(
-    const StreamId& stream_id,
+std::pair<VersionedItem, std::vector<AtomKey>> LocalVersionedEngine::write_individual_segment(const StreamId& stream_id,
     SegmentInMemory&& segment,
-    bool prune_previous_versions
-    ) {
+    bool prune_previous_versions)
+{
     ARCTICDB_SAMPLE(WriteVersionedDataFrame, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_dataframe");
     auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
     auto version_id = get_next_version_from_key(maybe_prev);
-    ARCTICDB_DEBUG(log::version(), "write_versioned_dataframe for stream_id: {} , version_id = {}", stream_id, version_id);
+    ARCTICDB_DEBUG(log::version(),
+        "write_versioned_dataframe for stream_id: {} , version_id = {}",
+        stream_id,
+        version_id);
     auto index = index_type_from_descriptor(segment.descriptor());
     auto range = get_range_from_segment(index, segment);
 
-    stream::StreamSink::PartialKey pk{
-        KeyType::TABLE_DATA, version_id, stream_id, range.start_, range.end_
-    };
+    stream::StreamSink::PartialKey pk{KeyType::TABLE_DATA, version_id, stream_id, range.start_, range.end_};
 
     auto frame_slice = FrameSlice{segment};
     auto descriptor = get_timeseries_descriptor(segment.descriptor(), segment.row_count(), std::nullopt, {});
     auto key = store_->write(pk, std::move(segment)).get();
     std::vector sk{SliceAndKey{frame_slice, to_atom(key)}};
-    auto index_key_fut = index::write_index(index, std::move(descriptor), std::move(sk), IndexPartialKey{stream_id, version_id}, store_);
+    auto index_key_fut =
+        index::write_index(index, std::move(descriptor), std::move(sk), IndexPartialKey{stream_id, version_id}, store_);
     auto versioned_item = VersionedItem{to_atom(std::move(index_key_fut).get())};
 
-    if(prune_previous_versions) {
+    if (prune_previous_versions) {
         auto pruned_indexes = version_map()->write_and_prune_previous(store(), versioned_item.key_, maybe_prev);
         return std::make_pair(versioned_item, std::move(pruned_indexes));
-    }
-    else {
+    } else {
         version_map()->write_version(store(), versioned_item.key_);
         return std::make_pair(versioned_item, std::vector<AtomKey>{});
     }
 }
 
 // Steps of delete_trees_responsibly:
-void copy_versions_nearest_to_target(
-        const MasterSnapshotMap::value_type::second_type& keys_map,
-        const IndexTypeKey& target_key,
-        util::ContainerFilterWrapper<std::unordered_set<IndexTypeKey>>& not_to_delete) {
+void copy_versions_nearest_to_target(const MasterSnapshotMap::value_type::second_type& keys_map,
+    const IndexTypeKey& target_key,
+    util::ContainerFilterWrapper<std::unordered_set<IndexTypeKey>>& not_to_delete)
+{
     const auto target_version = target_key.version_id();
 
     const IndexTypeKey* least_higher_version = nullptr;
     const IndexTypeKey* greatest_lower_version = nullptr;
 
-    for (const auto& pair: keys_map) {
+    for (const auto& pair : keys_map) {
         const auto& key = pair.first;
         if (key != target_key) {
             const auto version = key.version_id();
@@ -546,7 +550,8 @@ void copy_versions_nearest_to_target(
                 }
             } else {
                 log::version().warn("Found two distinct index keys for the same version in snapshots:\n{}\n{}",
-                        key, target_key);
+                    key,
+                    target_key);
             }
         }
     }
@@ -559,9 +564,10 @@ void copy_versions_nearest_to_target(
     }
 }
 
-std::unordered_map<StreamId, VersionId> min_versions_for_each_stream(const std::vector<AtomKey>& keys) {
+std::unordered_map<StreamId, VersionId> min_versions_for_each_stream(const std::vector<AtomKey>& keys)
+{
     std::unordered_map<StreamId, VersionId> out;
-    for (auto& key: keys) {
+    for (auto& key : keys) {
         auto found = out.find(key.id());
         if (found == out.end() || found->second > key.version_id()) {
             out[key.id()] = key.version_id();
@@ -570,12 +576,12 @@ std::unordered_map<StreamId, VersionId> min_versions_for_each_stream(const std::
     return out;
 }
 
-void LocalVersionedEngine::delete_trees_responsibly(
-        const std::vector<IndexTypeKey>& orig_keys_to_delete,
-        const arcticdb::MasterSnapshotMap& snapshot_map,
-        const std::optional<SnapshotId>& snapshot_being_deleted,
-        const PreDeleteChecks& check,
-        const bool dry_run) {
+void LocalVersionedEngine::delete_trees_responsibly(const std::vector<IndexTypeKey>& orig_keys_to_delete,
+    const arcticdb::MasterSnapshotMap& snapshot_map,
+    const std::optional<SnapshotId>& snapshot_being_deleted,
+    const PreDeleteChecks& check,
+    const bool dry_run)
+{
     ARCTICDB_SAMPLE(DeleteTree, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_tree");
 
@@ -597,12 +603,13 @@ void LocalVersionedEngine::delete_trees_responsibly(
                 if (snaps_itr != keys_map.end()) {
                     // Check 1)
                     const auto& snaps = snaps_itr->second;
-                    auto count_for_snapshot_being_deleted = snapshot_being_deleted ?
-                                                            snaps.count(snapshot_being_deleted.value()) : 0;
+                    auto count_for_snapshot_being_deleted =
+                        snapshot_being_deleted ? snaps.count(snapshot_being_deleted.value()) : 0;
                     if (snaps.size() > count_for_snapshot_being_deleted) {
                         log::version().debug(
-                                "Skipping the deletion of index {}:{} because it exists in another snapshot",
-                                target_key.id(), target_key.version_id());
+                            "Skipping the deletion of index {}:{} because it exists in another snapshot",
+                            target_key.id(),
+                            target_key.version_id());
                         return true;
                     }
                 }
@@ -619,35 +626,44 @@ void LocalVersionedEngine::delete_trees_responsibly(
         {
             auto min_vers = min_versions_for_each_stream(orig_keys_to_delete);
 
-            async::submit_tasks_for_range(min_vers,
-                    [store=store(), version_map=version_map(), load_type](auto& sym_version) {
-                        auto load_param = load_type == LoadType::LOAD_DOWNTO
-                                ? LoadParameter{load_type, sym_version.second}
-                                : LoadParameter{load_type};
-                        return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first,
-                                                                     load_param, true});
-                    },
-                    [&entry_map](auto& sym_version, auto&& entry) {
-                        entry_map.emplace(std::move(sym_version.first), entry);
-                    });
+            async::submit_tasks_for_range(
+                min_vers,
+                [store = store(), version_map = version_map(), load_type](auto& sym_version) {
+                    auto load_param = load_type == LoadType::LOAD_DOWNTO ? LoadParameter{load_type, sym_version.second}
+                                                                         : LoadParameter{load_type};
+                    return async::submit_io_task(
+                        CheckReloadTask{store, version_map, sym_version.first, load_param, true});
+                },
+                [&entry_map](auto& sym_version, auto&& entry) {
+                    entry_map.emplace(std::move(sym_version.first), entry);
+                });
         }
 
         keys_to_delete.remove_if([&entry_map, &check, &not_to_delete](const auto& key) {
             const auto entry = entry_map.at(key.id());
             if (check.version_visible && !entry->is_tombstoned(key)) { // Check 1)
                 log::version().debug("Skipping the deletion of index {}:{} because it exists in version map",
-                        key.id(), key.version_id());
+                    key.id(),
+                    key.version_id());
                 return true;
             }
-            get_matching_prev_and_next_versions(entry, key.version_id(), // Check 2)
-                    [](ARCTICDB_UNUSED auto& matching) {},
-                    [&check, &not_to_delete](auto& prev) { if (check.prev_version) not_to_delete.insert(prev);},
-                    [&check, &not_to_delete](auto& next) { if (check.next_version) not_to_delete.insert(next);},
-                    [v=key.version_id()](const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry) {
-                        // Can't use is_indexish_and_not_tombstoned() because the target version's index key might have
-                        // already been tombstoned, so will miss it and thus not able to find the prev/next key.
-                        return is_index_key_type(key.type()) && (key.version_id() == v || !entry->is_tombstoned(key));
-                    });
+            get_matching_prev_and_next_versions(
+                entry,
+                key.version_id(), // Check 2)
+                [](ARCTICDB_UNUSED auto& matching) {},
+                [&check, &not_to_delete](auto& prev) {
+                    if (check.prev_version)
+                        not_to_delete.insert(prev);
+                },
+                [&check, &not_to_delete](auto& next) {
+                    if (check.next_version)
+                        not_to_delete.insert(next);
+                },
+                [v = key.version_id()](const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry) {
+                    // Can't use is_indexish_and_not_tombstoned() because the target version's index key might have
+                    // already been tombstoned, so will miss it and thus not able to find the prev/next key.
+                    return is_index_key_type(key.type()) && (key.version_id() == v || !entry->is_tombstoned(key));
+                });
             return false;
         });
     }
@@ -655,7 +671,7 @@ void LocalVersionedEngine::delete_trees_responsibly(
     // Resolve:
     // Check 2) implementations does not consider that the key they are adding to not_to_delete might actually be in
     // keys_to_delete, so excluding those:
-    for (const auto& key: *keys_to_delete) {
+    for (const auto& key : *keys_to_delete) {
         not_to_delete.erase(key);
     }
 
@@ -680,95 +696,100 @@ void LocalVersionedEngine::delete_trees_responsibly(
 
     vks.clear();
     std::copy_if(std::make_move_iterator(data_keys_to_be_deleted.begin()),
-                 std::make_move_iterator(data_keys_to_be_deleted.end()),
-                 std::back_inserter(vks),
-                 [&](const auto& k) {return !data_keys_not_to_be_deleted.count(k);});
+        std::make_move_iterator(data_keys_to_be_deleted.end()),
+        std::back_inserter(vks),
+        [&](const auto& k) { return !data_keys_not_to_be_deleted.count(k); });
     log::version().debug("Index keys deleted. Proceeding with {} number of data keys", vks.size());
     if (!dry_run) {
         store()->remove_keys(vks, remove_opts).get();
     }
 }
 
-void LocalVersionedEngine::remove_incomplete(
-    const StreamId& stream_id
-    ) {
+void LocalVersionedEngine::remove_incomplete(const StreamId& stream_id)
+{
     stream::remove_incomplete_segments(store_, stream_id);
 }
 
-std::set<StreamId> LocalVersionedEngine::get_incomplete_symbols() {
+std::set<StreamId> LocalVersionedEngine::get_incomplete_symbols()
+{
     return stream::get_incomplete_symbols(store_);
 }
 
-std::set<StreamId> LocalVersionedEngine::get_incomplete_refs() {
+std::set<StreamId> LocalVersionedEngine::get_incomplete_refs()
+{
     return stream::get_incomplete_refs(store_);
 }
 
-std::set<StreamId> LocalVersionedEngine::get_active_incomplete_refs() {
+std::set<StreamId> LocalVersionedEngine::get_active_incomplete_refs()
+{
     return stream::get_active_incomplete_refs(store_);
 }
 
-void LocalVersionedEngine::push_incompletes_to_symbol_list(const std::set<StreamId>& incompletes) {
+void LocalVersionedEngine::push_incompletes_to_symbol_list(const std::set<StreamId>& incompletes)
+{
     auto existing = list_streams_internal(std::nullopt, std::nullopt, std::nullopt, cfg().symbol_list(), false);
-    for(const auto& incomplete : incompletes) {
-        if(existing.find(incomplete) == existing.end())
+    for (const auto& incomplete : incompletes) {
+        if (existing.find(incomplete) == existing.end())
             symbol_list().add_symbol(store_, incomplete);
     }
 }
 
-void LocalVersionedEngine::append_incomplete_frame(
-    const StreamId& stream_id,
-    InputTensorFrame&& frame) const {
+void LocalVersionedEngine::append_incomplete_frame(const StreamId& stream_id, InputTensorFrame&& frame) const
+{
     arcticdb::stream::append_incomplete(store_, stream_id, std::move(frame));
 }
 
-void LocalVersionedEngine::append_incomplete_segment(
-    const StreamId& stream_id,
-    SegmentInMemory &&seg) {
+void LocalVersionedEngine::append_incomplete_segment(const StreamId& stream_id, SegmentInMemory&& seg)
+{
     arcticdb::stream::append_incomplete_segment(store_, stream_id, std::move(seg));
 }
 
-void LocalVersionedEngine::write_parallel_frame(
-    const StreamId& stream_id,
-    InputTensorFrame&& frame) const {
+void LocalVersionedEngine::write_parallel_frame(const StreamId& stream_id, InputTensorFrame&& frame) const
+{
     stream::write_parallel(store_, stream_id, std::move(frame));
 }
 
-VersionedItem LocalVersionedEngine::compact_incomplete_dynamic(
-    const StreamId& stream_id,
+VersionedItem LocalVersionedEngine::compact_incomplete_dynamic(const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     bool append,
     bool convert_int_to_float,
     bool via_iteration,
-    bool sparsify) {
+    bool sparsify)
+{
     log::version().info("Compacting incomplete symbol {}", stream_id);
 
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, true, false);
-    auto versioned_item =  compact_incomplete_impl(
-            store_, stream_id, user_meta, update_info,
-            append, convert_int_to_float, via_iteration, sparsify);
+    auto versioned_item = compact_incomplete_impl(store_,
+        stream_id,
+        user_meta,
+        update_info,
+        append,
+        convert_int_to_float,
+        via_iteration,
+        sparsify);
 
     version_map_->write_version(store_, versioned_item.key_);
 
-    if(cfg_.symbol_list())
+    if (cfg_.symbol_list())
         symbol_list().add_symbol(store_, stream_id);
 
     return versioned_item;
 }
 
-folly::Future<FrameAndDescriptor> async_read_direct(
-    const std::shared_ptr<Store>& store,
+folly::Future<FrameAndDescriptor> async_read_direct(const std::shared_ptr<Store>& store,
     SegmentInMemory&& index_segment,
     const ReadQuery& read_query,
     std::shared_ptr<BufferHolder> buffers,
-    const ReadOptions& read_options) {
+    const ReadOptions& read_options)
+{
     auto index_segment_reader = std::make_shared<index::IndexSegmentReader>(std::move(index_segment));
-    auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor{*index_segment_reader->mutable_tsd().mutable_stream_descriptor()});
+    auto pipeline_context = std::make_shared<PipelineContext>(
+        StreamDescriptor{*index_segment_reader->mutable_tsd().mutable_stream_descriptor()});
     pipeline_context->set_selected_columns(read_query.columns);
     const bool dynamic_schema = opt_false(read_options.dynamic_schema_);
     const bool bucketize_dynamic = index_segment_reader->bucketize_dynamic();
 
-    auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(
-        read_query,
+    auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(read_query,
         pipeline_context,
         dynamic_schema,
         bucketize_dynamic);
@@ -779,31 +800,36 @@ folly::Future<FrameAndDescriptor> async_read_direct(
     mark_index_slices(pipeline_context, dynamic_schema, bucketize_dynamic);
     auto frame = allocate_frame(pipeline_context);
 
-    return fetch_data(frame, pipeline_context, store, dynamic_schema, buffers).then(
-        [pipeline_context, frame, &read_options] (auto&&) mutable {
-            reduce_and_fix_columns(pipeline_context, frame, read_options);
-        }).then(
-            [index_segment_reader, frame] (auto&&) {
-                return FrameAndDescriptor{frame, std::move(index_segment_reader->mutable_tsd()), {}, {}};
-            });
+    return fetch_data(frame, pipeline_context, store, dynamic_schema, buffers)
+        .then([pipeline_context, frame, &read_options](
+                  auto&&) mutable { reduce_and_fix_columns(pipeline_context, frame, read_options); })
+        .then([index_segment_reader, frame](auto&&) {
+            return FrameAndDescriptor{frame, std::move(index_segment_reader->mutable_tsd()), {}, {}};
+        });
 }
 
 std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>> LocalVersionedEngine::batch_read_keys(
-    const std::vector<AtomKey> &keys,
-    const std::vector<ReadQuery> &read_queries,
-    const ReadOptions& read_options) {
+    const std::vector<AtomKey>& keys,
+    const std::vector<ReadQuery>& read_queries,
+    const ReadOptions& read_options)
+{
 
     std::vector<folly::Future<std::pair<entity::VariantKey, SegmentInMemory>>> index_futures;
-    for (auto &index_key: keys) {
+    for (auto& index_key : keys) {
         index_futures.push_back(store()->read(index_key));
     }
     auto indexes = folly::collect(index_futures).get();
 
     std::vector<folly::Future<FrameAndDescriptor>> results_fut;
     auto i = 0u;
-    util::check(read_queries.empty() || read_queries.size() == keys.size(), "Expected read queries to either be empty or equal to size of keys");
-    for (auto&& [index_key, index_segment]: indexes) {
-        results_fut.push_back(async_read_direct(store(), std::move(index_segment), read_queries.empty() ? ReadQuery{} : read_queries[i++], std::make_shared<BufferHolder>(), read_options));
+    util::check(read_queries.empty() || read_queries.size() == keys.size(),
+        "Expected read queries to either be empty or equal to size of keys");
+    for (auto&& [index_key, index_segment] : indexes) {
+        results_fut.push_back(async_read_direct(store(),
+            std::move(index_segment),
+            read_queries.empty() ? ReadQuery{} : read_queries[i++],
+            std::make_shared<BufferHolder>(),
+            read_options));
     }
     Allocator::instance()->trim();
     return std::make_pair(keys, folly::collect(results_fut).get());
@@ -813,107 +839,94 @@ std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     std::vector<ReadQuery>& read_queries,
-    const ReadOptions& read_options) {
+    const ReadOptions& read_options)
+{
 
     std::vector<folly::Future<std::pair<VersionedItem, FrameAndDescriptor>>> results_fut;
-    for (size_t idx=0; idx < stream_ids.size(); idx++) {
+    for (size_t idx = 0; idx < stream_ids.size(); idx++) {
         auto version_query = version_queries.size() > idx ? version_queries[idx] : VersionQuery{};
         auto read_query = read_queries.size() > idx ? read_queries[idx] : ReadQuery{};
-        results_fut.push_back(read_dataframe_version_internal(stream_ids[idx],
-                                                              version_query,
-                                                              read_query,
-                                                              read_options));
+        results_fut.push_back(
+            read_dataframe_version_internal(stream_ids[idx], version_query, read_query, read_options));
     }
     return folly::collect(results_fut).get();
 }
 
-std::vector<AtomKey> LocalVersionedEngine::batch_write_internal(
-    std::vector<VersionId> version_ids,
+std::vector<AtomKey> LocalVersionedEngine::batch_write_internal(std::vector<VersionId> version_ids,
     const std::vector<StreamId>& stream_ids,
     std::vector<InputTensorFrame> frames,
     std::vector<std::shared_ptr<DeDupMap>> de_dup_maps,
-    bool validate_index
-) {
+    bool validate_index)
+{
     ARCTICDB_SAMPLE(WriteDataFrame, 0)
     ARCTICDB_DEBUG(log::version(), "Batch writing {} dataframes", stream_ids.size());
     std::vector<folly::Future<entity::AtomKey>> results_fut;
     for (size_t idx = 0; idx < stream_ids.size(); idx++) {
-        results_fut.push_back(async_write_dataframe_impl(
-            store(),
+        results_fut.push_back(async_write_dataframe_impl(store(),
             version_ids[idx],
             std::move(frames[idx]),
             get_write_options(),
             de_dup_maps[idx],
             false,
-            validate_index
-        ));
+            validate_index));
     }
     return folly::collect(results_fut).get();
 }
 
-
-
-VersionedItem LocalVersionedEngine::append_internal(
-    const StreamId& stream_id,
+VersionedItem LocalVersionedEngine::append_internal(const StreamId& stream_id,
     InputTensorFrame&& frame,
     bool upsert,
     bool prune_previous_versions,
-    bool validate_index) {
+    bool validate_index)
+{
 
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
-                                                                        version_map(),
-                                                                        stream_id,
-                                                                        true,
-                                                                        false);
+    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, true, false);
 
-    if(update_info.previous_index_key_.has_value()) {
-        auto versioned_item = append_impl(store(),
-                                          update_info,
-                                          std::move(frame),
-                                          get_write_options(),
-                                          validate_index);
+    if (update_info.previous_index_key_.has_value()) {
+        auto versioned_item = append_impl(store(), update_info, std::move(frame), get_write_options(), validate_index);
         if (prune_previous_versions) {
-            auto pruned_indexes = version_map()->write_and_prune_previous(store(), versioned_item.key_, update_info.previous_index_key_);
+            auto pruned_indexes =
+                version_map()->write_and_prune_previous(store(), versioned_item.key_, update_info.previous_index_key_);
             delete_unreferenced_pruned_indexes(pruned_indexes, versioned_item.key_);
         } else {
             version_map()->write_version(store(), versioned_item.key_);
         }
         return versioned_item;
     } else {
-        if(upsert) {
+        if (upsert) {
             auto write_options = get_write_options();
-            auto versioned_item =  write_dataframe_impl(store_,
-                                                        update_info.next_version_id_,
-                                                        std::move(frame),
-                                                        write_options,
-                                                        std::make_shared<DeDupMap>(),
-                                                        false,
-                                                        validate_index
-                                                        );
+            auto versioned_item = write_dataframe_impl(store_,
+                update_info.next_version_id_,
+                std::move(frame),
+                write_options,
+                std::make_shared<DeDupMap>(),
+                false,
+                validate_index);
 
-            if(cfg_.symbol_list())
+            if (cfg_.symbol_list())
                 symbol_list().add_symbol(store_, stream_id);
 
             version_map()->write_version(store(), versioned_item.key_);
             return versioned_item;
         } else {
-            util::raise_rte( "Cannot append to non-existent symbol {}", stream_id);
+            util::raise_rte("Cannot append to non-existent symbol {}", stream_id);
         }
     }
 }
 
-std::vector<AtomKey> LocalVersionedEngine::batch_append_internal(
-    std::vector<VersionId> version_ids,
+std::vector<AtomKey> LocalVersionedEngine::batch_append_internal(std::vector<VersionId> version_ids,
     const std::vector<StreamId>& stream_ids,
     std::vector<AtomKey> prevs,
     std::vector<InputTensorFrame> frames,
     const WriteOptions& write_options,
-    bool validate_index) {
+    bool validate_index)
+{
 
     std::vector<folly::Future<AtomKey>> append_futures;
-    for(auto id : folly::enumerate(stream_ids)) {
+    for (auto id : folly::enumerate(stream_ids)) {
         UpdateInfo update_info{prevs[id.index], version_ids[id.index]};
-        append_futures.emplace_back(async_append_impl(store(), update_info, std::move(frames[id.index]), write_options, validate_index));
+        append_futures.emplace_back(
+            async_append_impl(store(), update_info, std::move(frames[id.index]), write_options, validate_index));
     }
 
     return folly::collect(append_futures).get();
@@ -922,39 +935,40 @@ std::vector<AtomKey> LocalVersionedEngine::batch_append_internal(
 struct WarnVersionTypeNotHandled {
     bool warned = false;
 
-    void warn(const StreamId& stream_id) {
+    void warn(const StreamId& stream_id)
+    {
         if (!warned) {
             log::version().warn("Only exact version numbers are supported when using batch read calls."
                                 "The queries passed for '{}', etc. are ignored and the latest versions will be used!",
-                                stream_id);
+                stream_id);
             warned = true;
         }
     }
 };
 
-std::map<StreamId, VersionId> get_sym_versions_from_query(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries) {
+std::map<StreamId, VersionId> get_sym_versions_from_query(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
     std::map<StreamId, VersionId> sym_versions;
     WarnVersionTypeNotHandled warner;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
+    for (const auto& stream_id : folly::enumerate(stream_ids)) {
         const auto& query = version_queries[stream_id.index].content_;
-        if(std::holds_alternative<SpecificVersionQuery>(query))
+        if (std::holds_alternative<SpecificVersionQuery>(query))
             sym_versions[*stream_id] = std::get<SpecificVersionQuery>(query).version_id_;
-         else
+        else
             warner.warn(*stream_id);
     }
     return sym_versions;
 }
 
-std::map<StreamId, VersionVectorType> get_multiple_sym_versions_from_query(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries) {
+std::map<StreamId, VersionVectorType> get_multiple_sym_versions_from_query(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
     std::map<StreamId, VersionVectorType> sym_versions;
     WarnVersionTypeNotHandled warner;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
+    for (const auto& stream_id : folly::enumerate(stream_ids)) {
         const auto& query = version_queries[stream_id.index].content_;
-        if(std::holds_alternative<SpecificVersionQuery>(query))
+        if (std::holds_alternative<SpecificVersionQuery>(query))
             sym_versions[*stream_id].push_back(std::get<SpecificVersionQuery>(query).version_id_);
         else
             warner.warn(*stream_id);
@@ -962,69 +976,78 @@ std::map<StreamId, VersionVectorType> get_multiple_sym_versions_from_query(
     return sym_versions;
 }
 
-std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>> LocalVersionedEngine::batch_restore_version_internal(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries) {
-    util::check(stream_ids.size() == version_queries.size(), "Symbol vs version query size mismatch: {} != {}", stream_ids.size(), version_queries.size());
+std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>>
+LocalVersionedEngine::batch_restore_version_internal(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
+    util::check(stream_ids.size() == version_queries.size(),
+        "Symbol vs version query size mismatch: {} != {}",
+        stream_ids.size(),
+        version_queries.size());
     auto sym_versions = get_sym_versions_from_query(stream_ids, version_queries);
-    util::check(sym_versions.size() == version_queries.size(), "Restore versions requires specific version to be supplied");
+    util::check(sym_versions.size() == version_queries.size(),
+        "Restore versions requires specific version to be supplied");
     auto previous = batch_get_latest_version(store(), version_map(), stream_ids, false);
     auto versions_to_restore = batch_get_specific_version(store(), version_map(), sym_versions);
     std::vector<folly::Future<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>>> fut_vec;
 
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
+    for (const auto& stream_id : folly::enumerate(stream_ids)) {
         auto prev = previous->find(*stream_id);
-        auto maybe_prev = prev == std::end(*previous) ? std::nullopt : std::make_optional<AtomKey>(to_atom(prev->second));
+        auto maybe_prev =
+            prev == std::end(*previous) ? std::nullopt : std::make_optional<AtomKey>(to_atom(prev->second));
 
         auto version = versions_to_restore->find(*stream_id);
         util::check(version != std::end(*versions_to_restore), "Did not find version for symbol {}", *stream_id);
-        fut_vec.emplace_back(async::submit_io_task(AsyncRestoreVersionTask{store(), version_map(), *stream_id, to_atom(version->second), maybe_prev}));
+        fut_vec.emplace_back(async::submit_io_task(
+            AsyncRestoreVersionTask{store(), version_map(), *stream_id, to_atom(version->second), maybe_prev}));
     }
     auto output = folly::collect(fut_vec).get();
 
     std::vector<folly::Future<folly::Unit>> symbol_write_futs;
-    for(const auto& item : output) {
-        symbol_write_futs.emplace_back(async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.first.key_.id())));
+    for (const auto& item : output) {
+        symbol_write_futs.emplace_back(
+            async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.first.key_.id())));
     }
     folly::collect(symbol_write_futs).wait();
     return output;
 }
 
-timestamp LocalVersionedEngine::get_update_time_internal(
-        const StreamId& stream_id,
-        const VersionQuery& version_query
-        ) {
+timestamp LocalVersionedEngine::get_update_time_internal(const StreamId& stream_id, const VersionQuery& version_query)
+{
     auto version = get_version_to_read(stream_id, version_query);
-    if(!version)
+    if (!version)
         throw NoDataFoundException(fmt::format("get_update_time: version not found for symbol", stream_id));
     return version->key_.creation_ts();
 }
 
-std::vector<timestamp> LocalVersionedEngine::batch_get_update_times(
-        const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries) {
-    util::check(stream_ids.size() == version_queries.size(), "Symbol vs version query size mismatch: {} != {}", stream_ids.size(), version_queries.size());
+std::vector<timestamp> LocalVersionedEngine::batch_get_update_times(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
+    util::check(stream_ids.size() == version_queries.size(),
+        "Symbol vs version query size mismatch: {} != {}",
+        stream_ids.size(),
+        version_queries.size());
     std::vector<timestamp> results;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
+    for (const auto& stream_id : folly::enumerate(stream_ids)) {
         const auto& query = version_queries[stream_id.index];
         results.emplace_back(get_update_time_internal(*stream_id, query));
     }
     return results;
 }
 
-SpecificAndLatestVersionKeys LocalVersionedEngine::get_stream_index_map(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries
-    ) {
+SpecificAndLatestVersionKeys LocalVersionedEngine::get_stream_index_map(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
     std::shared_ptr<std::unordered_map<StreamId, AtomKey>> latest_versions;
     std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKey>> specific_versions;
-    if(!version_queries.empty()) {
+    if (!version_queries.empty()) {
         auto sym_versions = get_multiple_sym_versions_from_query(stream_ids, version_queries);
         specific_versions = batch_get_specific_versions(store(), version_map(), sym_versions);
         std::vector<StreamId> latest_ids;
-        std::copy_if(std::begin(stream_ids), std::end(stream_ids), std::back_inserter(latest_ids), [&sym_versions] (const auto& key) {
-            return sym_versions.find(key) == std::end(sym_versions);
-        });
+        std::copy_if(std::begin(stream_ids),
+            std::end(stream_ids),
+            std::back_inserter(latest_ids),
+            [&sym_versions](const auto& key) { return sym_versions.find(key) == std::end(sym_versions); });
         latest_versions = batch_get_latest_version(store(), version_map(), latest_ids, false);
     } else {
         specific_versions = std::make_shared<std::unordered_map<std::pair<StreamId, VersionId>, AtomKey>>();
@@ -1034,114 +1057,134 @@ SpecificAndLatestVersionKeys LocalVersionedEngine::get_stream_index_map(
     return std::make_pair(specific_versions, latest_versions);
 }
 
-std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::batch_read_metadata_internal(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries
-    ) {
+std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>
+LocalVersionedEngine::batch_read_metadata_internal(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
     auto [specific_versions_index_map, latest_versions_index_map] = get_stream_index_map(stream_ids, version_queries);
     auto version_queries_is_empty = version_queries.empty();
     std::vector<folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>> fut_vec;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
-        if(!version_queries_is_empty && std::holds_alternative<SpecificVersionQuery>(version_queries[stream_id.index].content_)){
+    for (const auto& stream_id : folly::enumerate(stream_ids)) {
+        if (!version_queries_is_empty &&
+            std::holds_alternative<SpecificVersionQuery>(version_queries[stream_id.index].content_))
+        {
             const auto& query = version_queries[stream_id.index].content_;
-            auto specific_version_map_key = std::make_pair(*stream_id, std::get<SpecificVersionQuery>(query).version_id_);
+            auto specific_version_map_key =
+                std::make_pair(*stream_id, std::get<SpecificVersionQuery>(query).version_id_);
             auto specific_version_it = specific_versions_index_map->find(specific_version_map_key);
-            if (specific_version_it != specific_versions_index_map->end()){
+            if (specific_version_it != specific_versions_index_map->end()) {
                 fut_vec.push_back(store()->read_metadata(specific_version_it->second));
-            }else{
+            } else {
                 fut_vec.push_back(std::make_pair(std::nullopt, std::nullopt));
             }
-        }else{
+        } else {
             auto last_version_it = latest_versions_index_map->find(*stream_id);
-            if(last_version_it != latest_versions_index_map->end()) {
+            if (last_version_it != latest_versions_index_map->end()) {
                 fut_vec.push_back(store()->read_metadata(last_version_it->second));
-            }else{
-                fut_vec.push_back(std::make_pair(std::nullopt, std::nullopt));   
+            } else {
+                fut_vec.push_back(std::make_pair(std::nullopt, std::nullopt));
             }
         }
     }
     return folly::collect(fut_vec).get();
 }
 
-VersionedItem LocalVersionedEngine::sort_merge_internal(
-    const StreamId& stream_id,
+VersionedItem LocalVersionedEngine::sort_merge_internal(const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     bool append,
     bool convert_int_to_float,
     bool via_iteration,
-    bool sparsify
-    ) {
+    bool sparsify)
+{
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, true, false);
-    auto versioned_item = sort_merge_impl(store_, stream_id, user_meta, update_info, append, convert_int_to_float, via_iteration, sparsify);
+    auto versioned_item = sort_merge_impl(store_,
+        stream_id,
+        user_meta,
+        update_info,
+        append,
+        convert_int_to_float,
+        via_iteration,
+        sparsify);
     version_map()->write_version(store(), versioned_item.key_);
     return versioned_item;
 }
 
-bool LocalVersionedEngine::has_stream(const StreamId & stream_id, const std::optional<bool>& skip_compat, const std::optional<bool>& iterate_on_failure){
+bool LocalVersionedEngine::has_stream(const StreamId& stream_id,
+    const std::optional<bool>& skip_compat,
+    const std::optional<bool>& iterate_on_failure)
+{
 
-    auto opt = get_latest_undeleted_version(store(), version_map(),  stream_id, opt_true(skip_compat), opt_false(iterate_on_failure));
+    auto opt = get_latest_undeleted_version(store(),
+        version_map(),
+        stream_id,
+        opt_true(skip_compat),
+        opt_false(iterate_on_failure));
     return opt.has_value();
 }
 
-StorageLockWrapper LocalVersionedEngine::get_storage_lock(const StreamId& stream_id) {
+StorageLockWrapper LocalVersionedEngine::get_storage_lock(const StreamId& stream_id)
+{
     return StorageLockWrapper{stream_id, store_};
 }
 
-void LocalVersionedEngine::delete_storage() {
+void LocalVersionedEngine::delete_storage()
+{
     delete_all(store_, true);
 }
 
-void LocalVersionedEngine::configure(const storage::LibraryDescriptor::VariantStoreConfig & cfg){
-    util::variant_match(cfg,
-                        [](std::monostate){ /* Unknown config */},
-                        [&cfg=cfg_, version_map=version_map(), store=store()](const arcticdb::proto::storage::VersionStoreConfig & conf){
-        cfg.CopyFrom(conf);
-        if(cfg.has_failure_sim()) {
-            store->set_failure_sim(cfg.failure_sim());
-        }
-        if(cfg.write_options().descriptor()->FindFieldByLowercaseName("fast_tombstone_all")) {
-          version_map->set_fast_tombstone_all(cfg.write_options().fast_tombstone_all());
-        }
-        if(cfg.write_options().has_sync_passive()) {
-            version_map->set_log_changes(cfg.write_options().sync_passive().enabled());
-        }
-        if (cfg.has_prometheus_config()) {
-            PrometheusConfigInstance::instance()->config.CopyFrom(cfg.prometheus_config());
-            ARCTICDB_DEBUG(log::version(), "prometheus configured");
-        }
+void LocalVersionedEngine::configure(const storage::LibraryDescriptor::VariantStoreConfig& cfg)
+{
+    util::variant_match(
+        cfg,
+        [](std::monostate) { /* Unknown config */ },
+        [&cfg = cfg_, version_map = version_map(), store = store()](
+            const arcticdb::proto::storage::VersionStoreConfig& conf) {
+            cfg.CopyFrom(conf);
+            if (cfg.has_failure_sim()) {
+                store->set_failure_sim(cfg.failure_sim());
+            }
+            if (cfg.write_options().descriptor()->FindFieldByLowercaseName("fast_tombstone_all")) {
+                version_map->set_fast_tombstone_all(cfg.write_options().fast_tombstone_all());
+            }
+            if (cfg.write_options().has_sync_passive()) {
+                version_map->set_log_changes(cfg.write_options().sync_passive().enabled());
+            }
+            if (cfg.has_prometheus_config()) {
+                PrometheusConfigInstance::instance()->config.CopyFrom(cfg.prometheus_config());
+                ARCTICDB_DEBUG(log::version(), "prometheus configured");
+            }
         },
-        [](const auto& conf){
-        util::raise_rte(
-            "Configuration of LocalVersionedEngine must use a VersionStoreConfig, actual {}",
-            [&conf]{ util::format(conf); });
-    }
-    );
+        [](const auto& conf) {
+            util::raise_rte("Configuration of LocalVersionedEngine must use a VersionStoreConfig, actual {}",
+                [&conf] { util::format(conf); });
+        });
 }
 
-timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
-    if(auto latest_incomplete = stream::latest_incomplete_timestamp(store(), symbol); latest_incomplete)
+timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol)
+{
+    if (auto latest_incomplete = stream::latest_incomplete_timestamp(store(), symbol); latest_incomplete)
         return latest_incomplete.value();
 
-    if(auto latest_key = get_latest_version(symbol, VersionQuery{}); latest_key)
+    if (auto latest_key = get_latest_version(symbol, VersionQuery{}); latest_key)
         return latest_key.value().key_.end_time();
 
     return -1;
 }
 
-std::unordered_map<KeyType, std::pair<size_t, size_t>> LocalVersionedEngine::scan_object_sizes() {
+std::unordered_map<KeyType, std::pair<size_t, size_t>> LocalVersionedEngine::scan_object_sizes()
+{
     std::unordered_map<KeyType, std::pair<size_t, size_t>> sizes;
-    foreach_key_type([&store=store(), &sizes=sizes](KeyType key_type) {
+    foreach_key_type([&store = store(), &sizes = sizes](KeyType key_type) {
         std::vector<VariantKey> keys;
-        store->iterate_type(key_type, [&keys](const VariantKey &&k) {
-            keys.emplace_back(std::forward<const VariantKey>(k));
-        });
+        store->iterate_type(key_type,
+            [&keys](const VariantKey&& k) { keys.emplace_back(std::forward<const VariantKey>(k)); });
         auto& pair = sizes[key_type];
         pair.first = keys.size();
         std::vector<stream::StreamSource::ReadContinuation> continuations;
         continuations.reserve(keys.size());
         std::atomic<size_t> key_size{0};
-        for(auto i = 0u; i < keys.size(); ++i) {
-            continuations.emplace_back([&key_size] (auto&& ks) {
+        for (auto i = 0u; i < keys.size(); ++i) {
+            continuations.emplace_back([&key_size](auto&& ks) {
                 auto key_seg = std::move(ks);
                 key_size += key_seg.segment().total_segment_size();
                 return key_seg.variant_key();
@@ -1153,27 +1196,30 @@ std::unordered_map<KeyType, std::pair<size_t, size_t>> LocalVersionedEngine::sca
     return sizes;
 }
 
-void LocalVersionedEngine::move_storage(KeyType key_type, timestamp horizon, size_t storage_index) {
+void LocalVersionedEngine::move_storage(KeyType key_type, timestamp horizon, size_t storage_index)
+{
     store_->move_storage(key_type, horizon, storage_index);
 }
 
-void LocalVersionedEngine::force_release_lock(const StreamId& name) {
+void LocalVersionedEngine::force_release_lock(const StreamId& name)
+{
     StorageLock<>::force_release_lock(name, store());
 }
 
-WriteOptions LocalVersionedEngine::get_write_options() const  {
-    return  WriteOptions::from_proto(cfg().write_options());
+WriteOptions LocalVersionedEngine::get_write_options() const
+{
+    return WriteOptions::from_proto(cfg().write_options());
 }
 
-AtomKey LocalVersionedEngine::_test_write_segment(const std::string& symbol) {
-    auto wrapper = SinkWrapper(symbol, {
-        scalar_field_proto(DataType::UINT64, "thing1"),
-        scalar_field_proto(DataType::UINT64, "thing2"),
-        scalar_field_proto(DataType::UINT64, "thing3"),
-        scalar_field_proto(DataType::UINT64, "thing4")
-    });
+AtomKey LocalVersionedEngine::_test_write_segment(const std::string& symbol)
+{
+    auto wrapper = SinkWrapper(symbol,
+        {scalar_field_proto(DataType::UINT64, "thing1"),
+            scalar_field_proto(DataType::UINT64, "thing2"),
+            scalar_field_proto(DataType::UINT64, "thing3"),
+            scalar_field_proto(DataType::UINT64, "thing4")});
 
-    for(size_t j = 0; j < 20; ++j ) {
+    for (size_t j = 0; j < 20; ++j) {
         wrapper.aggregator_.start_row(timestamp(j))([&](auto& rb) {
             rb.set_scalar(1, j);
             rb.set_scalar(2, j + 1);
@@ -1183,14 +1229,17 @@ AtomKey LocalVersionedEngine::_test_write_segment(const std::string& symbol) {
     }
 
     wrapper.aggregator_.commit();
-    return to_atom(store()->write(KeyType::TABLE_DATA, VersionId{}, StreamId{symbol}, 0, 0, std::move(wrapper.segment())).get());
+    return to_atom(
+        store()->write(KeyType::TABLE_DATA, VersionId{}, StreamId{symbol}, 0, 0, std::move(wrapper.segment())).get());
 }
 
-std::shared_ptr<VersionMap> LocalVersionedEngine::_test_get_version_map() {
+std::shared_ptr<VersionMap> LocalVersionedEngine::_test_get_version_map()
+{
     return version_map();
 }
 
-void LocalVersionedEngine::_test_set_store(std::shared_ptr<Store> store) {
+void LocalVersionedEngine::_test_set_store(std::shared_ptr<Store> store)
+{
     set_store(std::move(store));
 }
-} // arcticdb::version_store
+} // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -28,110 +28,76 @@ namespace arcticdb::version_store {
  *
  * Requirements for the latter is fluid, so methods here could be lifted.
  */
-using SpecificAndLatestVersionKeys = std::pair<std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKey>>,
-                                                std::shared_ptr<std::unordered_map<StreamId, AtomKey>>>;
+using SpecificAndLatestVersionKeys =
+    std::pair<std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKey>>,
+        std::shared_ptr<std::unordered_map<StreamId, AtomKey>>>;
 class LocalVersionedEngine : public VersionedEngine {
 
 public:
-    explicit LocalVersionedEngine(
-        const std::shared_ptr<storage::Library>& library);
+    explicit LocalVersionedEngine(const std::shared_ptr<storage::Library>& library);
 
     virtual ~LocalVersionedEngine() = default;
 
-    VersionedItem update_internal(
-        const StreamId& stream_id,
-        const UpdateQuery & query,
+    VersionedItem update_internal(const StreamId& stream_id,
+        const UpdateQuery& query,
         InputTensorFrame&& frame,
         bool upsert,
         bool dynamic_schema,
         bool prune_previous_versions) override;
 
-    VersionedItem append_internal(
-        const StreamId& stream_id,
+    VersionedItem append_internal(const StreamId& stream_id,
         InputTensorFrame&& frame,
         bool upsert,
         bool prune_previous_versions,
         bool validate_index) override;
 
-    VersionedItem delete_range_internal(
-        const StreamId& stream_id,
-        const UpdateQuery& query,
-        bool dynamic_schema) override;
+    VersionedItem
+    delete_range_internal(const StreamId& stream_id, const UpdateQuery& query, bool dynamic_schema) override;
 
-    void append_incomplete_segment(
-        const StreamId& stream_id,
-        SegmentInMemory &&seg) override;
+    void append_incomplete_segment(const StreamId& stream_id, SegmentInMemory&& seg) override;
 
-    std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor> restore_version(
-        const StreamId& id,
-        const VersionQuery& version_query
-        ) override;
-
-    void append_incomplete_frame(
-        const StreamId& stream_id,
-        InputTensorFrame&& frame) const override;
-
-    void remove_incomplete(
-        const StreamId& stream_id
-    ) override;
-
-    std::optional<VersionedItem> get_latest_version(
-        const StreamId &stream_id,
-        const VersionQuery& version_query);
-
-    std::optional<VersionedItem> get_specific_version(
-        const StreamId &stream_id,
-        VersionId version_id,
-        const VersionQuery& version_query);
-
-    std::optional<VersionedItem> get_version_at_time(
-        const StreamId& stream_id,
-        timestamp as_of,
-        const VersionQuery& version_query);
-
-    std::optional<VersionedItem> get_version_from_snapshot(
-        const StreamId& stream_id,
-        const SnapshotId& snap_name
-    );
-
-    IndexRange get_index_range(
-        const StreamId &stream_id,
+    std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor> restore_version(const StreamId& id,
         const VersionQuery& version_query) override;
 
-    std::optional<VersionedItem> get_version_to_read(
-        const StreamId& stream_id,
-        const VersionQuery& version_query
-    );
+    void append_incomplete_frame(const StreamId& stream_id, InputTensorFrame&& frame) const override;
 
-    FrameAndDescriptor read_dataframe_internal(
-        const std::variant<VersionedItem, StreamId>& identifier,
+    void remove_incomplete(const StreamId& stream_id) override;
+
+    std::optional<VersionedItem> get_latest_version(const StreamId& stream_id, const VersionQuery& version_query);
+
+    std::optional<VersionedItem>
+    get_specific_version(const StreamId& stream_id, VersionId version_id, const VersionQuery& version_query);
+
+    std::optional<VersionedItem>
+    get_version_at_time(const StreamId& stream_id, timestamp as_of, const VersionQuery& version_query);
+
+    std::optional<VersionedItem> get_version_from_snapshot(const StreamId& stream_id, const SnapshotId& snap_name);
+
+    IndexRange get_index_range(const StreamId& stream_id, const VersionQuery& version_query) override;
+
+    std::optional<VersionedItem> get_version_to_read(const StreamId& stream_id, const VersionQuery& version_query);
+
+    FrameAndDescriptor read_dataframe_internal(const std::variant<VersionedItem, StreamId>& identifier,
         ReadQuery& read_query,
         const ReadOptions& read_options) override;
 
-    std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(
-        const StreamId &stream_id,
+    std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(const StreamId& stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,
         const ReadOptions& read_options) override;
 
-    std::pair<VersionedItem, std::optional<google::protobuf::Any>> read_descriptor_version_internal(
-            const StreamId& stream_id,
-            const VersionQuery& version_query);
+    std::pair<VersionedItem, std::optional<google::protobuf::Any>>
+    read_descriptor_version_internal(const StreamId& stream_id, const VersionQuery& version_query);
 
-    void write_parallel_frame(
-        const StreamId& stream_id,
-        InputTensorFrame&& frame) const override;
+    void write_parallel_frame(const StreamId& stream_id, InputTensorFrame&& frame) const override;
 
-    bool has_stream(
-        const StreamId & stream_id,
+    bool has_stream(const StreamId& stream_id,
         const std::optional<bool>& skip_compat,
-        const std::optional<bool>& iterate_on_failure
-    ) override;
+        const std::optional<bool>& iterate_on_failure) override;
 
-    void delete_tree(
-        const std::vector<IndexTypeKey>& idx_to_be_deleted,
-        const PreDeleteChecks& checks = default_pre_delete_checks
-    ) override {
+    void delete_tree(const std::vector<IndexTypeKey>& idx_to_be_deleted,
+        const PreDeleteChecks& checks = default_pre_delete_checks) override
+    {
         auto snapshot_map = get_master_snapshots_map(store());
         delete_trees_responsibly(idx_to_be_deleted, snapshot_map, std::nullopt, checks);
     };
@@ -144,41 +110,31 @@ public:
      * to exclude it from shared data check
      * @param dry_run Only do the check, but don't actually delete anything.
      */
-    void delete_trees_responsibly(
-        const std::vector<IndexTypeKey>& idx_to_be_deleted,
+    void delete_trees_responsibly(const std::vector<IndexTypeKey>& idx_to_be_deleted,
         const arcticdb::MasterSnapshotMap& snapshot_map,
         const std::optional<SnapshotId>& snapshot_being_deleted = std::nullopt,
         const PreDeleteChecks& check = default_pre_delete_checks,
-        bool dry_run = false
-    );
+        bool dry_run = false);
 
-    std::set<StreamId> list_streams_internal(
-        std::optional<SnapshotId> snap_name,
+    std::set<StreamId> list_streams_internal(std::optional<SnapshotId> snap_name,
         const std::optional<std::string>& regex,
         const std::optional<std::string>& prefix,
         const std::optional<bool>& opt_use_symbol_list,
-        const std::optional<bool>& opt_all_symbols
-    ) override;
+        const std::optional<bool>& opt_all_symbols) override;
 
-    VersionedItem  write_versioned_dataframe_internal(
-        const StreamId& stream_id,
+    VersionedItem write_versioned_dataframe_internal(const StreamId& stream_id,
         InputTensorFrame&& frame,
         bool prune_previous_versions,
         bool allow_sparse,
-        bool validate_index
-    ) override;
+        bool validate_index) override;
 
-    VersionedItem write_versioned_metadata_internal(
-        const StreamId& stream_id,
+    VersionedItem write_versioned_metadata_internal(const StreamId& stream_id,
         bool prune_previous_versions,
-        arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
-    );
+        arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta);
 
-    std::pair<VersionedItem, std::vector<AtomKey>> write_individual_segment(
-        const StreamId& stream_id,
+    std::pair<VersionedItem, std::vector<AtomKey>> write_individual_segment(const StreamId& stream_id,
         SegmentInMemory&& segment,
-        bool prune_previous_versions
-    ) override;
+        bool prune_previous_versions) override;
 
     std::set<StreamId> get_incomplete_symbols() override;
     std::set<StreamId> get_incomplete_refs() override;
@@ -188,34 +144,28 @@ public:
 
     void flush_version_map() override;
 
-    VersionedItem sort_merge_internal(
-        const StreamId& stream_id,
+    VersionedItem sort_merge_internal(const StreamId& stream_id,
         const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
         bool append,
         bool convert_int_to_float,
         bool via_iteration,
-        bool sparsify
-        );
+        bool sparsify);
 
-    std::vector<AtomKey> batch_write_internal(
-        std::vector<VersionId> version_ids,
+    std::vector<AtomKey> batch_write_internal(std::vector<VersionId> version_ids,
         const std::vector<StreamId>& stream_ids,
         std::vector<InputTensorFrame> frames,
         std::vector<std::shared_ptr<DeDupMap>> de_dup_maps,
-        bool validate_index
-    );
+        bool validate_index);
 
-    std::vector<AtomKey> batch_append_internal(
-        std::vector<VersionId> version_ids,
+    std::vector<AtomKey> batch_append_internal(std::vector<VersionId> version_ids,
         const std::vector<StreamId>& stream_ids,
         std::vector<AtomKey> prevs,
         std::vector<InputTensorFrame> frames,
         const WriteOptions& write_options,
         bool validate_index);
 
-    std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>> batch_read_keys(
-        const std::vector<AtomKey> &keys,
-        const std::vector<ReadQuery> &read_queries,
+    std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>> batch_read_keys(const std::vector<AtomKey>& keys,
+        const std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
     std::vector<std::pair<VersionedItem, FrameAndDescriptor>> batch_read_internal(
@@ -225,29 +175,27 @@ public:
         const ReadOptions& read_options);
 
     std::vector<std::pair<VersionedItem, std::optional<google::protobuf::Any>>> batch_read_descriptor_internal(
-            const std::vector<StreamId>& stream_ids,
-            const std::vector<VersionQuery>& version_queries);
-
-    std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>> batch_restore_version_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
-    timestamp get_update_time_internal(const StreamId &stream_id, const VersionQuery &version_query);
+    std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>>
+    batch_restore_version_internal(const std::vector<StreamId>& stream_ids,
+        const std::vector<VersionQuery>& version_queries);
 
-    std::vector<timestamp> batch_get_update_times(
-            const std::vector<StreamId>& stream_ids,
-            const std::vector<VersionQuery>& version_queries);
+    timestamp get_update_time_internal(const StreamId& stream_id, const VersionQuery& version_query);
 
-    std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> batch_read_metadata_internal(
-        const std::vector<StreamId>& stream_ids,
+    std::vector<timestamp> batch_get_update_times(const std::vector<StreamId>& stream_ids,
+        const std::vector<VersionQuery>& version_queries);
+
+    std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>
+    batch_read_metadata_internal(const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
     StorageLockWrapper get_storage_lock(const StreamId& stream_id) override;
 
     void delete_storage() override;
 
-    void configure(
-        const storage::LibraryDescriptor::VariantStoreConfig & cfg) final;
+    void configure(const storage::LibraryDescriptor::VariantStoreConfig& cfg) final;
 
     WriteOptions get_write_options() const override;
 
@@ -257,36 +205,34 @@ public:
 
     VersionedItem sort_index(const StreamId& stream_id, bool dynamic_schema) override;
 
-    void move_storage(
-        KeyType key_type,
-        timestamp horizon,
-        size_t storage_index) override;
+    void move_storage(KeyType key_type, timestamp horizon, size_t storage_index) override;
 
     void force_release_lock(const StreamId& name);
 
-    std::shared_ptr<DeDupMap> get_de_dup_map(
-        const StreamId& stream_id,
+    std::shared_ptr<DeDupMap> get_de_dup_map(const StreamId& stream_id,
         const std::optional<AtomKey>& maybe_prev,
-        const WriteOptions& write_options
-    );
+        const WriteOptions& write_options);
 
     std::unordered_map<KeyType, std::pair<size_t, size_t>> scan_object_sizes();
-    std::shared_ptr<Store>& _test_get_store() { return store_; }
+    std::shared_ptr<Store>& _test_get_store()
+    {
+        return store_;
+    }
     AtomKey _test_write_segment(const std::string& symbol);
-    void _test_set_validate_version_map() {
+    void _test_set_validate_version_map()
+    {
         version_map()->set_validate(true);
     }
     void _test_set_store(std::shared_ptr<Store> store);
     std::shared_ptr<VersionMap> _test_get_version_map();
 
 protected:
-    VersionedItem compact_incomplete_dynamic(
-            const StreamId& stream_id,
-            const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
-            bool append,
-            bool convert_int_to_float,
-            bool via_iteration,
-            bool sparsify);
+    VersionedItem compact_incomplete_dynamic(const StreamId& stream_id,
+        const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
+        bool append,
+        bool convert_int_to_float,
+        bool via_iteration,
+        bool sparsify);
 
     /**
      * Take tombstoned indexes that have been pruned in the version map and perform the actual deletion
@@ -294,19 +240,32 @@ protected:
      *
      * @param pruned_indexes Must all share the same id() and should be tombstoned.
      */
-    void delete_unreferenced_pruned_indexes(
-            const std::vector<AtomKey> &pruned_indexes,
-            const AtomKey& key_to_keep
-    );
+    void delete_unreferenced_pruned_indexes(const std::vector<AtomKey>& pruned_indexes, const AtomKey& key_to_keep);
 
-    std::shared_ptr<Store>& store() override { return store_; }
-    const arcticdb::proto::storage::VersionStoreConfig& cfg() const override { return cfg_; }
-    std::shared_ptr<VersionMap>& version_map() override { return version_map_; }
-    SymbolList& symbol_list() override { return *symbol_list_; }
-    std::shared_ptr<SymbolList> symbol_list_ptr() { return symbol_list_; }
+    std::shared_ptr<Store>& store() override
+    {
+        return store_;
+    }
+    const arcticdb::proto::storage::VersionStoreConfig& cfg() const override
+    {
+        return cfg_;
+    }
+    std::shared_ptr<VersionMap>& version_map() override
+    {
+        return version_map_;
+    }
+    SymbolList& symbol_list() override
+    {
+        return *symbol_list_;
+    }
+    std::shared_ptr<SymbolList> symbol_list_ptr()
+    {
+        return symbol_list_;
+    }
 
-    void set_store(std::shared_ptr<Store> store) override {
-        store_ = std::move(store) ;
+    void set_store(std::shared_ptr<Store> store) override
+    {
+        store_ = std::move(store);
     }
 
     /**
@@ -317,17 +276,14 @@ protected:
      * have specified a version. The second one contains all the Atom keys of the last undeleted version for those 
      * queries that we haven't specified any version.
      */
-    SpecificAndLatestVersionKeys get_stream_index_map(
-        const std::vector<StreamId>& stream_ids,
+    SpecificAndLatestVersionKeys get_stream_index_map(const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
-
 private:
-
     std::shared_ptr<Store> store_;
     arcticdb::proto::storage::VersionStoreConfig cfg_;
     std::shared_ptr<VersionMap> version_map_ = std::make_shared<VersionMap>();
     std::shared_ptr<SymbolList> symbol_list_;
 };
 
-} // arcticdb::version_store
+} // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/op_log.cpp
+++ b/cpp/arcticdb/version/op_log.cpp
@@ -8,51 +8,58 @@
 #include <arcticdb/version/op_log.hpp>
 
 namespace arcticdb {
-    OpLog::OpLog(AtomKey&& key) {
-        key_ = std::move(key);
-    }
+OpLog::OpLog(AtomKey&& key)
+{
+    key_ = std::move(key);
+}
 
-    OpLog::OpLog(StringId id, VersionId version_id, const std::string& action, timestamp creation_ts):
-    id_(id),
-    version_id_(version_id),
-    action_(action),
-    creation_ts_(creation_ts)
-    {}
+OpLog::OpLog(StringId id, VersionId version_id, const std::string& action, timestamp creation_ts)
+    : id_(id),
+      version_id_(version_id),
+      action_(action),
+      creation_ts_(creation_ts)
+{
+}
 
-    const StringId& OpLog::id() const {
-        if (key_.has_value()) {
-            return std::get<StringId>((*key_).start_index());
-        } else {
-            return id_;
-        }
-    }
-
-    VersionId OpLog::version_id() const {
-        if (key_.has_value()) {
-            return (*key_).version_id();
-        } else {
-            return version_id_;
-        }
-    }
-
-    const std::string& OpLog::action() const {
-        if (key_.has_value()) {
-            return std::get<std::string>((*key_).id());
-        } else {
-            return action_;
-        }
-    }
-
-    timestamp OpLog::creation_ts() const {
-        if (key_.has_value()) {
-            return (*key_).creation_ts();
-        } else {
-            return creation_ts_;
-        }
-    }
-
-    AtomKey&& OpLog::extract_key() {
-        util::check(key_.has_value(), "Cannot extract Atomkey from OpLog");
-        return std::move(*key_);
+const StringId& OpLog::id() const
+{
+    if (key_.has_value()) {
+        return std::get<StringId>((*key_).start_index());
+    } else {
+        return id_;
     }
 }
+
+VersionId OpLog::version_id() const
+{
+    if (key_.has_value()) {
+        return (*key_).version_id();
+    } else {
+        return version_id_;
+    }
+}
+
+const std::string& OpLog::action() const
+{
+    if (key_.has_value()) {
+        return std::get<std::string>((*key_).id());
+    } else {
+        return action_;
+    }
+}
+
+timestamp OpLog::creation_ts() const
+{
+    if (key_.has_value()) {
+        return (*key_).creation_ts();
+    } else {
+        return creation_ts_;
+    }
+}
+
+AtomKey&& OpLog::extract_key()
+{
+    util::check(key_.has_value(), "Cannot extract Atomkey from OpLog");
+    return std::move(*key_);
+}
+} // namespace arcticdb

--- a/cpp/arcticdb/version/op_log.hpp
+++ b/cpp/arcticdb/version/op_log.hpp
@@ -11,47 +11,51 @@
 #include <arcticdb/entity/types.hpp>
 
 namespace arcticdb {
-    using namespace arcticdb::entity;
-    class OpLog {
-    public:
-        OpLog() = delete;
-        OpLog(AtomKey&& key);
-        OpLog(StringId id, VersionId version_id, const std::string& action, timestamp creation_ts);
+using namespace arcticdb::entity;
+class OpLog {
+public:
+    OpLog() = delete;
+    OpLog(AtomKey&& key);
+    OpLog(StringId id, VersionId version_id, const std::string& action, timestamp creation_ts);
 
-        ARCTICDB_MOVE_COPY_DEFAULT(OpLog)
+    ARCTICDB_MOVE_COPY_DEFAULT(OpLog)
 
-        const StringId& id() const;
-        VersionId version_id() const;
-        const std::string& action() const;
-        timestamp creation_ts() const;
+    const StringId& id() const;
+    VersionId version_id() const;
+    const std::string& action() const;
+    timestamp creation_ts() const;
 
-        AtomKey&& extract_key();
+    AtomKey&& extract_key();
 
-    private:
-        std::optional<AtomKey> key_;
-        // Represents the symbol or snapshot name
-        StringId id_;
-        // Unused for snapshot creation/deletion op logs
-        VersionId version_id_;
-        std::string action_;
-        timestamp creation_ts_;
-    };
-}
+private:
+    std::optional<AtomKey> key_;
+    // Represents the symbol or snapshot name
+    StringId id_;
+    // Unused for snapshot creation/deletion op logs
+    VersionId version_id_;
+    std::string action_;
+    timestamp creation_ts_;
+};
+} // namespace arcticdb
 
 namespace fmt {
-    template<>
-    struct formatter<arcticdb::OpLog> {
-        template<typename ParseContext>
-        constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+template<>
+struct formatter<arcticdb::OpLog> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
 
-        template<typename FormatContext>
-        auto format(const arcticdb::OpLog &op_log, FormatContext &ctx) const {
-            return format_to(ctx.out(),
-                             "{} {} v{} at {}",
-                             op_log.action(),
-                             op_log.id(),
-                             op_log.version_id(),
-                             op_log.creation_ts());
-        }
-    };
-}
+    template<typename FormatContext>
+    auto format(const arcticdb::OpLog& op_log, FormatContext& ctx) const
+    {
+        return format_to(ctx.out(),
+            "{} {} v{} at {}",
+            op_log.action(),
+            op_log.id(),
+            op_log.version_id(),
+            op_log.creation_ts());
+    }
+};
+} // namespace fmt

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -23,37 +23,34 @@
 
 namespace arcticdb::version_store {
 
-void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception) {
+void register_bindings(py::module& m, py::exception<arcticdb::ArcticException>& base_exception)
+{
     auto version = m.def_submodule("version_store", "Versioned storage implementation apis");
 
     py::register_exception<NoSuchVersionException>(version, "NoSuchVersionException", base_exception.ptr());
     py::register_exception<StreamDescriptorMismatch>(version, "StreamDescriptorMismatch", base_exception.ptr());
 
     py::class_<AtomKey, std::shared_ptr<AtomKey>>(version, "AtomKey")
-    .def(py::init())
-    .def(py::init<StreamId, VersionId, timestamp, ContentHash, IndexValue, IndexValue, KeyType>())
-    .def("change_id", &AtomKey::change_id)
-    .def_property_readonly("id", &AtomKey::id)
-    .def_property_readonly("version_id", &AtomKey::version_id)
-    .def_property_readonly("creation_ts", &AtomKey::creation_ts)
-    .def_property_readonly("content_hash", &AtomKey::content_hash)
-    .def_property_readonly("start_index", &AtomKey::start_index)
-    .def_property_readonly("end_index", &AtomKey::end_index)
-    .def_property_readonly("type", [](const AtomKey& self) {return self.type();})
-    .def("__repr__", &AtomKey::view)
-    ;
+        .def(py::init())
+        .def(py::init<StreamId, VersionId, timestamp, ContentHash, IndexValue, IndexValue, KeyType>())
+        .def("change_id", &AtomKey::change_id)
+        .def_property_readonly("id", &AtomKey::id)
+        .def_property_readonly("version_id", &AtomKey::version_id)
+        .def_property_readonly("creation_ts", &AtomKey::creation_ts)
+        .def_property_readonly("content_hash", &AtomKey::content_hash)
+        .def_property_readonly("start_index", &AtomKey::start_index)
+        .def_property_readonly("end_index", &AtomKey::end_index)
+        .def_property_readonly("type", [](const AtomKey& self) { return self.type(); })
+        .def("__repr__", &AtomKey::view);
 
     py::class_<RefKey, std::shared_ptr<RefKey>>(version, "RefKey")
-    .def(py::init())
-    .def(py::init<StreamId, KeyType>())
-    .def_property_readonly("id", &RefKey::id)
-    .def_property_readonly("type", [](const RefKey& self) {return self.type();})
-    .def("__repr__", &RefKey::view)
-    ;
-
-    py::class_<Value, std::shared_ptr<Value>>(version, "ValueType")
         .def(py::init())
-        ;
+        .def(py::init<StreamId, KeyType>())
+        .def_property_readonly("id", &RefKey::id)
+        .def_property_readonly("type", [](const RefKey& self) { return self.type(); })
+        .def("__repr__", &RefKey::view);
+
+    py::class_<Value, std::shared_ptr<Value>>(version, "ValueType").def(py::init());
 
     version.def("ValueBool", &construct_value<bool>);
     version.def("ValueUint8", &construct_value<uint8_t>);
@@ -80,29 +77,29 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
     version.def("Value", &construct_string_value);
 
     py::class_<ValueSet, std::shared_ptr<ValueSet>>(version, "ValueSet")
-    .def(py::init([](std::vector<std::string>&& value_list){
-        return std::make_shared<ValueSet>(std::move(value_list));
-    }))
-    .def(py::init([](py::array value_list){
-        return std::make_shared<ValueSet>(value_list);
-    }))
-    ;
+        .def(py::init(
+            [](std::vector<std::string>&& value_list) { return std::make_shared<ValueSet>(std::move(value_list)); }))
+        .def(py::init([](py::array value_list) { return std::make_shared<ValueSet>(value_list); }));
 
     py::class_<ClauseBuilder>(version, "ClauseBuilder")
-            .def(py::init())
-            .def("add_ProjectClause", &ClauseBuilder::add_ProjectClause)
-            .def("add_FilterClause", &ClauseBuilder::add_FilterClause)
-            .def("prepare_AggregationClause", &ClauseBuilder::prepare_AggregationClause)
-            .def("add_MeanAggregationOperator", [&](ClauseBuilder& v,  std::string input_column, std::string output_column) {
+        .def(py::init())
+        .def("add_ProjectClause", &ClauseBuilder::add_ProjectClause)
+        .def("add_FilterClause", &ClauseBuilder::add_FilterClause)
+        .def("prepare_AggregationClause", &ClauseBuilder::prepare_AggregationClause)
+        .def("add_MeanAggregationOperator",
+            [&](ClauseBuilder& v, std::string input_column, std::string output_column) {
                 return v.add_MeanAggregationOperator(ColumnName(input_column), ColumnName(output_column));
             })
-            .def("add_SumAggregationOperator", [&](ClauseBuilder& v,  std::string input_column, std::string output_column) {
+        .def("add_SumAggregationOperator",
+            [&](ClauseBuilder& v, std::string input_column, std::string output_column) {
                 return v.add_SumAggregationOperator(ColumnName(input_column), ColumnName(output_column));
             })
-            .def("add_MaxAggregationOperator", [&](ClauseBuilder& v,  std::string input_column, std::string output_column) {
-              return v.add_MaxAggregationOperator(ColumnName(input_column), ColumnName(output_column));
+        .def("add_MaxAggregationOperator",
+            [&](ClauseBuilder& v, std::string input_column, std::string output_column) {
+                return v.add_MaxAggregationOperator(ColumnName(input_column), ColumnName(output_column));
             })
-            .def("add_MinAggregationOperator", [&](ClauseBuilder& v,  std::string input_column, std::string output_column) {
+        .def("add_MinAggregationOperator",
+            [&](ClauseBuilder& v, std::string input_column, std::string output_column) {
                 return v.add_MinAggregationOperator(ColumnName(input_column), ColumnName(output_column));
             })
         .def("finalize_AggregationClause", &ClauseBuilder::finalize_AggregationClause);
@@ -127,7 +124,7 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
 
     using FrameDataWrapper = arcticdb::pipelines::FrameDataWrapper;
     py::class_<FrameDataWrapper, std::shared_ptr<FrameDataWrapper>>(version, "FrameDataWrapper")
-            .def_property_readonly("data", &FrameDataWrapper::data);
+        .def_property_readonly("data", &FrameDataWrapper::data);
 
     using PythonOutputFrame = arcticdb::pipelines::PythonOutputFrame;
     py::class_<PythonOutputFrame>(version, "PythonOutputFrame")
@@ -135,16 +132,14 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
         .def(py::init<>([](const SegmentInMemory& segment_in_memory) {
             return PythonOutputFrame(segment_in_memory, std::make_shared<BufferHolder>());
         }))
-        .def_property_readonly("value", [](py::object & obj){
-            auto& fd = obj.cast<PythonOutputFrame&>();
-            return fd.arrays(obj);
-        })
-        .def_property_readonly("offset", [](PythonOutputFrame& self) {
-            return self.frame().offset();
-        })
+        .def_property_readonly("value",
+            [](py::object& obj) {
+                auto& fd = obj.cast<PythonOutputFrame&>();
+                return fd.arrays(obj);
+            })
+        .def_property_readonly("offset", [](PythonOutputFrame& self) { return self.frame().offset(); })
         .def_property_readonly("names", &PythonOutputFrame::names, py::return_value_policy::reference)
         .def_property_readonly("index_columns", &PythonOutputFrame::index_columns, py::return_value_policy::reference);
-
 
     // TODO: add repr.
     py::class_<VersionedItem>(version, "VersionedItem")
@@ -156,414 +151,367 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
         .def_property_readonly("row_range", &pipelines::FrameSlice::rows);
 
     py::class_<pipelines::RowRange, std::shared_ptr<pipelines::RowRange>>(version, "RowRange")
-        .def(py::init([](std::size_t start, std::size_t end){
-            return RowRange(start, end);
-        }))
+        .def(py::init([](std::size_t start, std::size_t end) { return RowRange(start, end); }))
         .def_property_readonly("start", &pipelines::RowRange::start)
         .def_property_readonly("end", &pipelines::RowRange::end)
         .def_property_readonly("diff", &pipelines::RowRange::diff);
 
     py::class_<pipelines::HeadRange, std::shared_ptr<pipelines::HeadRange>>(version, "HeadRange")
-    .def(py::init([](int64_t n){
-        return HeadRange{n};
-    }));
+        .def(py::init([](int64_t n) { return HeadRange{n}; }));
 
     py::class_<pipelines::TailRange, std::shared_ptr<pipelines::TailRange>>(version, "TailRange")
-    .def(py::init([](int64_t n){
-        return TailRange{n};
-    }));
+        .def(py::init([](int64_t n) { return TailRange{n}; }));
 
     py::class_<pipelines::SignedRowRange, std::shared_ptr<pipelines::SignedRowRange>>(version, "SignedRowRange")
-    .def(py::init([](int64_t start, int64_t end){
-        return SignedRowRange{start, end};
-    }));
+        .def(py::init([](int64_t start, int64_t end) {
+            return SignedRowRange{start, end};
+        }));
 
     py::class_<pipelines::ColRange, std::shared_ptr<pipelines::ColRange>>(version, "ColRange")
         .def_property_readonly("start", &pipelines::ColRange::start)
         .def_property_readonly("end", &pipelines::ColRange::end)
         .def_property_readonly("diff", &pipelines::ColRange::diff);
 
-
-
-    auto adapt_read_dfs = [](std::vector<ReadResult> && ret) -> py::list {
+    auto adapt_read_dfs = [](std::vector<ReadResult>&& ret) -> py::list {
         py::list lst;
-        for (auto &res: ret) {
+        for (auto& res : ret) {
             auto pynorm = python_util::pb_to_python(res.norm_meta);
             auto pyuser_meta = python_util::pb_to_python(res.user_meta);
             auto multi_key_meta = python_util::pb_to_python(res.multi_key_meta);
-            lst.append(py::make_tuple(res.item, std::move(res.frame_data), pynorm, pyuser_meta, multi_key_meta, res.multi_keys));
+            lst.append(py::make_tuple(res.item,
+                std::move(res.frame_data),
+                pynorm,
+                pyuser_meta,
+                multi_key_meta,
+                res.multi_keys));
         }
         return lst;
     };
 
     py::class_<IndexRange>(version, "IndexRange")
-            .def(py::init([](timestamp start, timestamp end){
-                return IndexRange(start, end);
-            }))
-            .def_property_readonly("start_ts",[](const IndexRange&self){
-                return std::get<timestamp>(self.start_);
-            })
-            .def_property_readonly("end_ts",[](const IndexRange&self){
-                return std::get<timestamp>(self.end_);
-            });
+        .def(py::init([](timestamp start, timestamp end) { return IndexRange(start, end); }))
+        .def_property_readonly("start_ts", [](const IndexRange& self) { return std::get<timestamp>(self.start_); })
+        .def_property_readonly("end_ts", [](const IndexRange& self) { return std::get<timestamp>(self.end_); });
 
     py::class_<ReadQuery>(version, "PythonVersionStoreReadQuery")
-            .def(py::init())
-            .def_readwrite("columns",&ReadQuery::columns)
-            .def_readwrite("row_range",&ReadQuery::row_range)
-            .def_readwrite("row_filter",&ReadQuery::row_filter)
-            .def("set_clause_builder", &ReadQuery::set_clause_builder);
+        .def(py::init())
+        .def_readwrite("columns", &ReadQuery::columns)
+        .def_readwrite("row_range", &ReadQuery::row_range)
+        .def_readwrite("row_filter", &ReadQuery::row_filter)
+        .def("set_clause_builder", &ReadQuery::set_clause_builder);
 
     py::enum_<OperationType>(version, "OperationType")
-            .value("ABS", OperationType::ABS)
-            .value("NEG", OperationType::NEG)
-            .value("IDENTITY", OperationType::IDENTITY)
-            .value("NOT", OperationType::NOT)
-            .value("ADD", OperationType::ADD)
-            .value("SUB", OperationType::SUB)
-            .value("MUL", OperationType::MUL)
-            .value("DIV", OperationType::DIV)
-            .value("EQ", OperationType::EQ)
-            .value("NE", OperationType::NE)
-            .value("LT", OperationType::LT)
-            .value("LE", OperationType::LE)
-            .value("GT", OperationType::GT)
-            .value("GE", OperationType::GE)
-            .value("ISIN", OperationType::ISIN)
-            .value("ISNOTIN", OperationType::ISNOTIN)
-            .value("AND", OperationType::AND)
-            .value("OR", OperationType::OR)
-            .value("XOR", OperationType::XOR);
+        .value("ABS", OperationType::ABS)
+        .value("NEG", OperationType::NEG)
+        .value("IDENTITY", OperationType::IDENTITY)
+        .value("NOT", OperationType::NOT)
+        .value("ADD", OperationType::ADD)
+        .value("SUB", OperationType::SUB)
+        .value("MUL", OperationType::MUL)
+        .value("DIV", OperationType::DIV)
+        .value("EQ", OperationType::EQ)
+        .value("NE", OperationType::NE)
+        .value("LT", OperationType::LT)
+        .value("LE", OperationType::LE)
+        .value("GT", OperationType::GT)
+        .value("GE", OperationType::GE)
+        .value("ISIN", OperationType::ISIN)
+        .value("ISNOTIN", OperationType::ISNOTIN)
+        .value("AND", OperationType::AND)
+        .value("OR", OperationType::OR)
+        .value("XOR", OperationType::XOR);
 
     py::enum_<SortedValue>(version, "SortedValue")
-            .value("UNKNOWN", SortedValue::UNKNOWN)
-            .value("UNSORTED", SortedValue::UNSORTED)
-            .value("ASCENDING", SortedValue::ASCENDING)
-            .value("DESCENDING", SortedValue::DESCENDING);
+        .value("UNKNOWN", SortedValue::UNKNOWN)
+        .value("UNSORTED", SortedValue::UNSORTED)
+        .value("ASCENDING", SortedValue::ASCENDING)
+        .value("DESCENDING", SortedValue::DESCENDING);
 
-    py::class_<ColumnName>(version, "ColumnName")
-            .def(py::init([](const std::string& name) {
-                return ColumnName(name);
-            }));
+    py::class_<ColumnName>(version, "ColumnName").def(py::init([](const std::string& name) {
+        return ColumnName(name);
+    }));
 
-    py::class_<ValueName>(version, "ValueName")
-            .def(py::init([](const std::string& name) {
-                return ValueName(name);
-            }));
+    py::class_<ValueName>(version, "ValueName").def(py::init([](const std::string& name) { return ValueName(name); }));
 
-    py::class_<ValueSetName>(version, "ValueSetName")
-    .def(py::init([](const std::string& name) {
+    py::class_<ValueSetName>(version, "ValueSetName").def(py::init([](const std::string& name) {
         return ValueSetName(name);
     }));
 
-    py::class_<ExpressionName>(version, "ExpressionName")
-            .def(py::init([](const std::string& name) {
-                return ExpressionName(name);
-            }));
+    py::class_<ExpressionName>(version, "ExpressionName").def(py::init([](const std::string& name) {
+        return ExpressionName(name);
+    }));
 
     py::class_<ExpressionNode, std::shared_ptr<ExpressionNode>>(version, "ExpressionNode")
-            .def(py::init([](VariantNode left, VariantNode right, OperationType operation_type) {
-                return ExpressionNode(left, right, operation_type);
-            }))
-            .def(py::init([](VariantNode left, OperationType operation_type) {
-                return ExpressionNode(left, operation_type);
-            }));
+        .def(py::init([](VariantNode left, VariantNode right, OperationType operation_type) {
+            return ExpressionNode(left, right, operation_type);
+        }))
+        .def(py::init(
+            [](VariantNode left, OperationType operation_type) { return ExpressionNode(left, operation_type); }));
 
     py::enum_<ExecutionContext::Optimisation>(version, "ExecutionContextOptimisation")
-            .value("SPEED", ExecutionContext::Optimisation::SPEED)
-            .value("MEMORY", ExecutionContext::Optimisation::MEMORY);
+        .value("SPEED", ExecutionContext::Optimisation::SPEED)
+        .value("MEMORY", ExecutionContext::Optimisation::MEMORY);
 
     py::class_<ExecutionContext, std::shared_ptr<ExecutionContext>>(version, "ExecutionContext")
-            .def(py::init())
-            .def("add_column", &ExecutionContext::add_column)
-            .def("add_expression_node", &ExecutionContext::add_expression_node)
-            .def("add_value", &ExecutionContext::add_value)
-            .def("add_value_set", &ExecutionContext::add_value_set)
-            .def_readwrite("root_node_name", &ExecutionContext::root_node_name_)
-            .def_readwrite("optimisation", &ExecutionContext::optimisation_);
+        .def(py::init())
+        .def("add_column", &ExecutionContext::add_column)
+        .def("add_expression_node", &ExecutionContext::add_expression_node)
+        .def("add_value", &ExecutionContext::add_value)
+        .def("add_value_set", &ExecutionContext::add_value_set)
+        .def_readwrite("root_node_name", &ExecutionContext::root_node_name_)
+        .def_readwrite("optimisation", &ExecutionContext::optimisation_);
 
     py::class_<UpdateQuery>(version, "PythonVersionStoreUpdateQuery")
-            .def(py::init())
-            .def_readwrite("row_filter",&UpdateQuery::row_filter);
+        .def(py::init())
+        .def_readwrite("row_filter", &UpdateQuery::row_filter);
 
     py::class_<PythonVersionStore>(version, "PythonVersionStore")
         .def(py::init<std::shared_ptr<storage::Library>>())
         .def("write_partitioned_dataframe",
-             &PythonVersionStore::write_partitioned_dataframe,
-             "Write a dataframe to the store")
-        .def("delete_snapshot",
-             &PythonVersionStore::delete_snapshot,
-             "Delete snapshot from store")
-        .def("delete",
-             &PythonVersionStore::delete_all_versions,
-             "Delete all versions of the given symbol")
-        .def("delete_range",
-             &PythonVersionStore::delete_range,
-             "Delete the date range from the symbol")
-        .def("delete_version",
-             &PythonVersionStore::delete_version,
-             "Delete specific version of the given symbol")
-         .def("prune_previous_versions",
-              &PythonVersionStore::prune_previous_versions,
-              "Delete all but the latest version of the given symbol")
+            &PythonVersionStore::write_partitioned_dataframe,
+            "Write a dataframe to the store")
+        .def("delete_snapshot", &PythonVersionStore::delete_snapshot, "Delete snapshot from store")
+        .def("delete", &PythonVersionStore::delete_all_versions, "Delete all versions of the given symbol")
+        .def("delete_range", &PythonVersionStore::delete_range, "Delete the date range from the symbol")
+        .def("delete_version", &PythonVersionStore::delete_version, "Delete specific version of the given symbol")
+        .def("prune_previous_versions",
+            &PythonVersionStore::prune_previous_versions,
+            "Delete all but the latest version of the given symbol")
         .def("sort_index",
-             &PythonVersionStore::sort_index,
-             "Sort the index of a time series whose segments are internally sorted")
-        .def("append",
-             &PythonVersionStore::append,
-             "Append a dataframe to the most recent version")
+            &PythonVersionStore::sort_index,
+            "Sort the index of a time series whose segments are internally sorted")
+        .def("append", &PythonVersionStore::append, "Append a dataframe to the most recent version")
         .def("append_incomplete",
-             &PythonVersionStore::append_incomplete,
-             "Append a partial dataframe to the most recent version")
-         .def("write_parallel",
-             &PythonVersionStore::write_parallel,
-             "Append to a symbol in parallel")
-         .def("write_metadata",
-             &PythonVersionStore::write_metadata,
-             "Create a new version with new metadata and data from the last version")
-         .def("remove_incomplete",
-             &PythonVersionStore::remove_incomplete,
-             "Delete incomplete segments")
-         .def("compact_incomplete",
-             &PythonVersionStore::compact_incomplete,
-             py::arg("stream_id"),
-             py::arg("append"),
-             py::arg("convert_int_to_float"),
-             py::arg("via_iteration") = true,
-             py::arg("sparsify") = false,
-             py::arg("user_meta") = std::nullopt,
-             "Compact incomplete segments")
-         .def("sort_merge",
-             &PythonVersionStore::sort_merge,
-             py::arg("stream_id"),
-             py::arg("user_meta") = std::nullopt,
-             py::arg("append") = false,
-             py::arg("convert_int_to_float") = false,
-             py::arg("via_iteration") = true,
-             py::arg("sparsify") = false,
-             "sort_merge will sort and merge incomplete segments. The segments do not have to be ordered - incomplete segments can contain interleaved time periods but the final result will be fully ordered")
-        .def("compact_library",
-             &PythonVersionStore::compact_library,
-             "Compact the whole library wherever necessary")
+            &PythonVersionStore::append_incomplete,
+            "Append a partial dataframe to the most recent version")
+        .def("write_parallel", &PythonVersionStore::write_parallel, "Append to a symbol in parallel")
+        .def("write_metadata",
+            &PythonVersionStore::write_metadata,
+            "Create a new version with new metadata and data from the last version")
+        .def("remove_incomplete", &PythonVersionStore::remove_incomplete, "Delete incomplete segments")
+        .def("compact_incomplete",
+            &PythonVersionStore::compact_incomplete,
+            py::arg("stream_id"),
+            py::arg("append"),
+            py::arg("convert_int_to_float"),
+            py::arg("via_iteration") = true,
+            py::arg("sparsify") = false,
+            py::arg("user_meta") = std::nullopt,
+            "Compact incomplete segments")
+        .def("sort_merge",
+            &PythonVersionStore::sort_merge,
+            py::arg("stream_id"),
+            py::arg("user_meta") = std::nullopt,
+            py::arg("append") = false,
+            py::arg("convert_int_to_float") = false,
+            py::arg("via_iteration") = true,
+            py::arg("sparsify") = false,
+            "sort_merge will sort and merge incomplete segments. The segments do not have to be ordered - incomplete "
+            "segments can contain interleaved time periods but the final result will be fully ordered")
+        .def("compact_library", &PythonVersionStore::compact_library, "Compact the whole library wherever necessary")
         .def("get_incomplete_symbols",
-             &PythonVersionStore::get_incomplete_symbols,
-             "Get all the symbols that have incomplete entries")
+            &PythonVersionStore::get_incomplete_symbols,
+            "Get all the symbols that have incomplete entries")
         .def("get_incomplete_refs",
-             &PythonVersionStore::get_incomplete_refs,
-             "Get all the symbols that have incomplete entries")
+            &PythonVersionStore::get_incomplete_refs,
+            "Get all the symbols that have incomplete entries")
         .def("get_active_incomplete_refs",
-             &PythonVersionStore::get_active_incomplete_refs,
-             "Get all the symbols that have incomplete entries and some appended data")
+            &PythonVersionStore::get_active_incomplete_refs,
+            "Get all the symbols that have incomplete entries and some appended data")
         .def("push_incompletes_to_symbol_list",
-             &PythonVersionStore::push_incompletes_to_symbol_list,
-             "Push all the symbols that have incomplete entries to the symbol list")
-        .def("update",
-             &PythonVersionStore::update,
-             "Update the most recent version of a dataframe")
-        .def("snapshot",
-             &PythonVersionStore::snapshot,
-             "Create a snapshot")
-        .def("list_snapshots",
-             &PythonVersionStore::list_snapshots,
-             "List all snapshots")
-        .def("add_to_snapshot",
-             &PythonVersionStore::add_to_snapshot,
-             "Add an item to a snapshot")
-        .def("remove_from_snapshot",
-             &PythonVersionStore::remove_from_snapshot,
-             "Remove an item from a snapshot")
+            &PythonVersionStore::push_incompletes_to_symbol_list,
+            "Push all the symbols that have incomplete entries to the symbol list")
+        .def("update", &PythonVersionStore::update, "Update the most recent version of a dataframe")
+        .def("snapshot", &PythonVersionStore::snapshot, "Create a snapshot")
+        .def("list_snapshots", &PythonVersionStore::list_snapshots, "List all snapshots")
+        .def("add_to_snapshot", &PythonVersionStore::add_to_snapshot, "Add an item to a snapshot")
+        .def("remove_from_snapshot", &PythonVersionStore::remove_from_snapshot, "Remove an item from a snapshot")
         .def("clear",
-             &PythonVersionStore::clear,
-             "Delete everything. Don't use this unless you want to delete everything")
+            &PythonVersionStore::clear,
+            "Delete everything. Don't use this unless you want to delete everything")
         .def("empty",
-             &PythonVersionStore::empty,
-             "Returns True if there are no keys of any type in the library, and False otherwise")
+            &PythonVersionStore::empty,
+            "Returns True if there are no keys of any type in the library, and False otherwise")
         .def("force_delete_symbol",
-             &PythonVersionStore::force_delete_symbol,
-             "Delete everything. Don't use this unless you want to delete everything")
+            &PythonVersionStore::force_delete_symbol,
+            "Delete everything. Don't use this unless you want to delete everything")
         .def("_get_all_tombstoned_versions",
-             &PythonVersionStore::get_all_tombstoned_versions,
-             "Get a list of all the versions for a symbol which are tombstoned")
+            &PythonVersionStore::get_all_tombstoned_versions,
+            "Get a list of all the versions for a symbol which are tombstoned")
         .def("delete_storage",
-             &PythonVersionStore::delete_storage,
-             "Delete everything. Don't use this unless you want to delete everything")
+            &PythonVersionStore::delete_storage,
+            "Delete everything. Don't use this unless you want to delete everything")
         .def("write_versioned_dataframe",
-             &PythonVersionStore::write_versioned_dataframe,
-             "Write the most recent version of this dataframe to the store")
+            &PythonVersionStore::write_versioned_dataframe,
+            "Write the most recent version of this dataframe to the store")
         .def("write_versioned_composite_data",
-             &PythonVersionStore::write_versioned_composite_data,
-             "Allows the user to write multiple dataframes in a batch with one version entity")
+            &PythonVersionStore::write_versioned_composite_data,
+            "Allows the user to write multiple dataframes in a batch with one version entity")
         .def("write_dataframe_specific_version",
             &PythonVersionStore::write_dataframe_specific_version,
-             "Write a specific  version of this dataframe to the store")
-        .def("read_dataframe_version",
-             [&](PythonVersionStore& v,  StreamId sid, const VersionQuery& version_query, ReadQuery& read_query, const ReadOptions& read_options){
+            "Write a specific  version of this dataframe to the store")
+        .def(
+            "read_dataframe_version",
+            [&](PythonVersionStore& v,
+                StreamId sid,
+                const VersionQuery& version_query,
+                ReadQuery& read_query,
+                const ReadOptions& read_options) {
                 return adapt_read_df(v.read_dataframe_version(sid, version_query, read_query, read_options));
-              },
-             "Read the specified version of the dataframe from the store")
-        .def("read_index",
-             [&](PythonVersionStore& v,  StreamId sid, const VersionQuery& version_query){
-                 return adapt_read_df(v.read_index(sid, version_query));
-             },
-             "Read the most recent dataframe from the store")
-        .def("read_latest_dataframe_merged",
-             [&](PythonVersionStore& v, StreamId target_id, std::vector<StreamId> &sids, ReadQuery &query, const ReadOptions read_options){
-                 return adapt_read_df(v.read_dataframe_merged(target_id, sids, VersionQuery{}, query, read_options));
-             },
-             "Read the most recent dataframe from the store")
-         .def("get_update_time",
-              &PythonVersionStore::get_update_time,
-             "Get the most recent update time for the stream ids")
-         .def("get_update_times",
-              &PythonVersionStore::get_update_times,
-             "Get the most recent update time for a list of stream ids")
-         .def("scan_object_sizes",
-              &PythonVersionStore::scan_object_sizes,
-            "Scan the sizes of object")
+            },
+            "Read the specified version of the dataframe from the store")
+        .def(
+            "read_index",
+            [&](PythonVersionStore& v, StreamId sid, const VersionQuery& version_query) {
+                return adapt_read_df(v.read_index(sid, version_query));
+            },
+            "Read the most recent dataframe from the store")
+        .def(
+            "read_latest_dataframe_merged",
+            [&](PythonVersionStore& v,
+                StreamId target_id,
+                std::vector<StreamId>& sids,
+                ReadQuery& query,
+                const ReadOptions read_options) {
+                return adapt_read_df(v.read_dataframe_merged(target_id, sids, VersionQuery{}, query, read_options));
+            },
+            "Read the most recent dataframe from the store")
+        .def("get_update_time",
+            &PythonVersionStore::get_update_time,
+            "Get the most recent update time for the stream ids")
+        .def("get_update_times",
+            &PythonVersionStore::get_update_times,
+            "Get the most recent update time for a list of stream ids")
+        .def("scan_object_sizes", &PythonVersionStore::scan_object_sizes, "Scan the sizes of object")
         .def("find_version",
-             &PythonVersionStore::get_version_to_read,
-             "Check if a specific stream has been written to previously")
-        .def("list_streams",
-             &PythonVersionStore::list_streams,
-             "List all the stream ids that have been written")
+            &PythonVersionStore::get_version_to_read,
+            "Check if a specific stream has been written to previously")
+        .def("list_streams", &PythonVersionStore::list_streams, "List all the stream ids that have been written")
         .def("read_metadata",
-             &PythonVersionStore::read_metadata,
-             "Get back the metadata and version info for a symbol.")
-         .def("fix_symbol_trees",
-             &PythonVersionStore::fix_symbol_trees,
-             "Regenerate symbol tree by adding indexes from snapshots")
-         .def("flush_version_map",
-             &PythonVersionStore::flush_version_map,
-             "Flush the version cache")
-        .def("read_descriptor",
-             &PythonVersionStore::read_descriptor,
-             "Get back the descriptor for a symbol.")
+            &PythonVersionStore::read_metadata,
+            "Get back the metadata and version info for a symbol.")
+        .def("fix_symbol_trees",
+            &PythonVersionStore::fix_symbol_trees,
+            "Regenerate symbol tree by adding indexes from snapshots")
+        .def("flush_version_map", &PythonVersionStore::flush_version_map, "Flush the version cache")
+        .def("read_descriptor", &PythonVersionStore::read_descriptor, "Get back the descriptor for a symbol.")
         .def("batch_read_descriptor",
-             &PythonVersionStore::batch_read_descriptor,
-             "Get back the descriptor of a list of symbols.")
-        .def("restore_version",
-             [&](PythonVersionStore& v,  StreamId sid, const VersionQuery& version_query) {
+            &PythonVersionStore::batch_read_descriptor,
+            "Get back the descriptor of a list of symbols.")
+        .def(
+            "restore_version",
+            [&](PythonVersionStore& v, StreamId sid, const VersionQuery& version_query) {
                 auto [vit, tsd] = v.restore_version(sid, version_query);
-                ReadResult res{
-                    vit,
-                    PythonOutputFrame{
-                            SegmentInMemory{StreamDescriptor{std::move(*tsd.mutable_stream_descriptor())}},
+                ReadResult res{vit,
+                    PythonOutputFrame{SegmentInMemory{StreamDescriptor{std::move(*tsd.mutable_stream_descriptor())}},
+                        std::make_shared<BufferHolder>()},
+                    tsd.normalization(),
+                    tsd.user_meta(),
+                    tsd.multi_key_meta(),
+                    std::vector<entity::AtomKey>{}};
+                return adapt_read_df(std::move(res));
+            },
+            "Restore a previous version of a symbol.")
+        .def("check_ref_key", &PythonVersionStore::check_ref_key, "Fix reference keys.")
+        .def("dump_versions", &PythonVersionStore::dump_versions, "Dump version data.")
+        .def("_set_validate_version_map",
+            &PythonVersionStore::_test_set_validate_version_map,
+            "Validate the version map.")
+        .def("_clear_symbol_list_keys",
+            &PythonVersionStore::_clear_symbol_list_keys,
+            "Delete all ref keys of type SYMBOL_LIST.")
+        .def("reload_symbol_list", &PythonVersionStore::reload_symbol_list, "Regenerate symbol list for library.")
+
+        .def("write_partitioned_dataframe",
+            &PythonVersionStore::write_partitioned_dataframe,
+            "Write a dataframe and partition it into sub symbols using partition key")
+        .def("fix_ref_key", &PythonVersionStore::fix_ref_key, "Fix reference keys.")
+        .def("remove_and_rewrite_version_keys",
+            &PythonVersionStore::remove_and_rewrite_version_keys,
+            "Remove all version keys and rewrite all indexes - useful in case a version has been tombstoned but not "
+            "deleted")
+        .def("force_release_lock", &PythonVersionStore::force_release_lock, "Force release a lock.")
+        .def(
+            "batch_read",
+            [&](PythonVersionStore& v,
+                const std::vector<StreamId>& stream_ids,
+                const std::vector<VersionQuery>& version_queries,
+                std::vector<ReadQuery> read_queries,
+                const ReadOptions& read_options) {
+                return adapt_read_dfs(v.batch_read(stream_ids, version_queries, read_queries, read_options));
+            },
+            "Read a dataframe from the store")
+        .def(
+            "batch_read_keys",
+            [&](PythonVersionStore& v, std::vector<AtomKey> atom_keys) {
+                return adapt_read_dfs(frame_to_read_result(v.batch_read_keys(atom_keys, {}, ReadOptions{})));
+            },
+            "Read a specific version of a dataframe from the store")
+        .def("batch_write", &PythonVersionStore::batch_write, "Batch write latest versions of multiple symbols.")
+        .def("batch_read_metadata",
+            &PythonVersionStore::batch_read_metadata,
+            "Batch read the metadata of a list of symbols for the latest version")
+        .def("batch_write_metadata",
+            &PythonVersionStore::batch_write_metadata,
+            "Batch write the metadata of a list of symbols")
+        .def("batch_append", &PythonVersionStore::batch_append, "Batch append to a list of symbols")
+        .def(
+            "batch_restore_version",
+            [&](PythonVersionStore& v,
+                const std::vector<StreamId>& ids,
+                const std::vector<VersionQuery>& version_queries) {
+                auto results = v.batch_restore_version(ids, version_queries);
+                std::vector<py::object> output;
+                output.reserve(results.size());
+                for (auto& [vit, tsd] : results) {
+                    ReadResult res{vit,
+                        {SegmentInMemory{StreamDescriptor{std::move(*tsd.mutable_stream_descriptor())}},
                             std::make_shared<BufferHolder>()},
                         tsd.normalization(),
                         tsd.user_meta(),
                         tsd.multi_key_meta(),
-                        std::vector<entity::AtomKey>{}
-                };
-                return adapt_read_df(std::move(res)); },
-             "Restore a previous version of a symbol.")
-        .def("check_ref_key",
-             &PythonVersionStore::check_ref_key,
-             "Fix reference keys.")
-        .def("dump_versions",
-             &PythonVersionStore::dump_versions,
-             "Dump version data.")
-        .def("_set_validate_version_map",
-             &PythonVersionStore::_test_set_validate_version_map,
-             "Validate the version map.")
-        .def("_clear_symbol_list_keys",
-             &PythonVersionStore::_clear_symbol_list_keys,
-             "Delete all ref keys of type SYMBOL_LIST.")
-        .def("reload_symbol_list",
-             &PythonVersionStore::reload_symbol_list,
-             "Regenerate symbol list for library.")
-
-        .def("write_partitioned_dataframe",
-             &PythonVersionStore::write_partitioned_dataframe,
-             "Write a dataframe and partition it into sub symbols using partition key")
-        .def("fix_ref_key",
-             &PythonVersionStore::fix_ref_key,
-             "Fix reference keys.")
-        .def("remove_and_rewrite_version_keys",
-             &PythonVersionStore::remove_and_rewrite_version_keys,
-             "Remove all version keys and rewrite all indexes - useful in case a version has been tombstoned but not deleted")
-        .def("force_release_lock",
-             &PythonVersionStore::force_release_lock,
-             "Force release a lock.")
-        .def("batch_read",
-             [&](PythonVersionStore& v, const std::vector<StreamId> &stream_ids,  const std::vector<VersionQuery>& version_queries, std::vector<ReadQuery> read_queries, const ReadOptions& read_options){
-                 return adapt_read_dfs(v.batch_read(stream_ids, version_queries, read_queries, read_options));
-             },
-             "Read a dataframe from the store")
-        .def("batch_read_keys",
-             [&](PythonVersionStore& v, std::vector<AtomKey> atom_keys) {
-                 return adapt_read_dfs(frame_to_read_result(v.batch_read_keys(atom_keys, {}, ReadOptions{})));
-             },
-             "Read a specific version of a dataframe from the store")
-        .def("batch_write",
-             &PythonVersionStore::batch_write,
-             "Batch write latest versions of multiple symbols.")
-        .def("batch_read_metadata",
-             &PythonVersionStore::batch_read_metadata,
-             "Batch read the metadata of a list of symbols for the latest version")
-        .def("batch_write_metadata",
-             &PythonVersionStore::batch_write_metadata,
-             "Batch write the metadata of a list of symbols")
-        .def("batch_append",
-             &PythonVersionStore::batch_append,
-             "Batch append to a list of symbols")
-        .def("batch_restore_version",
-             [&](PythonVersionStore& v, const std::vector<StreamId>& ids, const std::vector<VersionQuery>& version_queries){
-                 auto results = v.batch_restore_version(ids, version_queries);
-                 std::vector<py::object> output;
-                 output.reserve(results.size());
-                 for(auto& [vit, tsd] : results) {
-                     ReadResult res{vit,
-                                    {SegmentInMemory{StreamDescriptor{std::move(*tsd.mutable_stream_descriptor())}}, std::make_shared<BufferHolder>()},
-                                tsd.normalization(),
-                                tsd.user_meta(),
-                                tsd.multi_key_meta(),
-                                {}};
-                     output.emplace_back(adapt_read_df(std::move(res)));
-                 }
-                 return output;
-             },
-           "Batch restore a group of versions to the versions indicated")
-        .def("list_versions",[](
-                PythonVersionStore& v,
-                const std::optional<StreamId> & s_id,
-                const std::optional<SnapshotId> & snap_id,
+                        {}};
+                    output.emplace_back(adapt_read_df(std::move(res)));
+                }
+                return output;
+            },
+            "Batch restore a group of versions to the versions indicated")
+        .def(
+            "list_versions",
+            [](PythonVersionStore& v,
+                const std::optional<StreamId>& s_id,
+                const std::optional<SnapshotId>& snap_id,
                 const std::optional<bool>& latest,
                 const std::optional<bool>& iterate_on_failure,
-                const std::optional<bool>& skip_snapshots
-                ){
-                 return v.list_versions(s_id, snap_id, latest, iterate_on_failure, skip_snapshots);
-             },
-             "List all the version ids for this store.")
+                const std::optional<bool>& skip_snapshots) {
+                return v.list_versions(s_id, snap_id, latest, iterate_on_failure, skip_snapshots);
+            },
+            "List all the version ids for this store.")
         .def("_compact_version_map",
-             &PythonVersionStore::_compact_version_map,
-             "Compact the version map contents for a given symbol")
+            &PythonVersionStore::_compact_version_map,
+            "Compact the version map contents for a given symbol")
         .def("get_storage_lock",
-             &PythonVersionStore::get_storage_lock,
-             "Get a coarse-grained storage lock in the library")
-        .def("list_incompletes",
-             &PythonVersionStore::list_incompletes,
-             "List incomplete chunks for stream id")
+            &PythonVersionStore::get_storage_lock,
+            "Get a coarse-grained storage lock in the library")
+        .def("list_incompletes", &PythonVersionStore::list_incompletes, "List incomplete chunks for stream id")
         .def("_get_version_history",
-             &PythonVersionStore::get_version_history,
-             "Returns a list of index and tombstone keys in chronological order")
-        .def("latest_timestamp",
-             &PythonVersionStore::latest_timestamp,
-             "Returns latest timestamp of a symbol")
-        ;
+            &PythonVersionStore::get_version_history,
+            "Returns a list of index and tombstone keys in chronological order")
+        .def("latest_timestamp", &PythonVersionStore::latest_timestamp, "Returns latest timestamp of a symbol");
 
     m.def("get_version_string", &get_arcticdb_version_string);
 
     m.def("read_runtime_config", [](const py::object object) {
         auto config = RuntimeConfig{};
-         python_util::pb_from_python(object, config);
-         read_runtime_config(config);
+        python_util::pb_from_python(object, config);
+        read_runtime_config(config);
     });
 
     py::class_<LocalVersionedEngine>(version, "VersionedEngine")
-      .def(py::init<std::shared_ptr<storage::Library>>())
-      .def("read_versioned_dataframe",
-           &LocalVersionedEngine::read_dataframe_version_internal,
-           "Read a dataframe from the store");
+        .def(py::init<std::shared_ptr<storage::Library>>())
+        .def("read_versioned_dataframe",
+            &LocalVersionedEngine::read_dataframe_version_internal,
+            "Read a dataframe from the store");
 }
 
 } //namespace arcticdb::version_store

--- a/cpp/arcticdb/version/python_bindings.hpp
+++ b/cpp/arcticdb/version/python_bindings.hpp
@@ -14,6 +14,6 @@ namespace py = pybind11;
 
 namespace arcticdb::version_store {
 
-void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception);
+void register_bindings(py::module& m, py::exception<arcticdb::ArcticException>& base_exception);
 
 } //namespace arcticdb::version_store

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -14,25 +14,23 @@ using namespace arcticdb::stream;
 
 namespace arcticdb {
 
-void write_snapshot_entry(
-        std::shared_ptr <StreamSink> store,
-        std::vector <AtomKey> &keys,
-        const SnapshotId &snapshot_id,
-        const py::object &user_meta,
-        bool log_changes,
-        KeyType key_type
-) {
+void write_snapshot_entry(std::shared_ptr<StreamSink> store,
+    std::vector<AtomKey>& keys,
+    const SnapshotId& snapshot_id,
+    const py::object& user_meta,
+    bool log_changes,
+    KeyType key_type)
+{
     ARCTICDB_SAMPLE(WriteJournalEntry, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write snapshot entry");
-    IndexAggregator <RowCountIndex> snapshot_agg(snapshot_id, [&](auto &&segment) {
-        store->write(key_type, snapshot_id, std::move(segment)).get();
-    });
+    IndexAggregator<RowCountIndex> snapshot_agg(snapshot_id,
+        [&](auto&& segment) { store->write(key_type, snapshot_id, std::move(segment)).get(); });
 
     // Most of the searches in snapshot are for a given symbol, this helps us do a binary search on the segment
     // on read time.
-    std::sort(keys.begin(), keys.end(), [](const AtomKey &l, const AtomKey &r) {return l.id() < r.id(); });
+    std::sort(keys.begin(), keys.end(), [](const AtomKey& l, const AtomKey& r) { return l.id() < r.id(); });
 
-    for (const auto &key: keys) {
+    for (const auto& key : keys) {
         snapshot_agg.add_key(key);
     }
     // Serialize and store the python metadata in the journal entry for snapshot.
@@ -50,12 +48,11 @@ void write_snapshot_entry(
     }
 }
 
-void tombstone_snapshot(
-    std::shared_ptr<StreamSink> store,
+void tombstone_snapshot(std::shared_ptr<StreamSink> store,
     const RefKey& key,
     SegmentInMemory&& segment_in_memory,
-    bool log_changes
-) {
+    bool log_changes)
+{
     store->remove_key_sync(key); // Make the snapshot "disappear" to normal APIs
     if (log_changes) {
         log_delete_snapshot(store, key.id());
@@ -65,27 +62,22 @@ void tombstone_snapshot(
     store->write(KeyType::SNAPSHOT_TOMBSTONE, new_key, std::move(segment_in_memory)).get();
 }
 
-void tombstone_snapshot(
-        std::shared_ptr<StreamSink> store,
-        storage::KeySegmentPair&& key_segment_pair,
-        bool log_changes
-        ) {
+void tombstone_snapshot(std::shared_ptr<StreamSink> store, storage::KeySegmentPair&& key_segment_pair, bool log_changes)
+{
     store->remove_key(key_segment_pair.ref_key()).get(); // Make the snapshot "disappear" to normal APIs
     if (log_changes) {
         log_delete_snapshot(store, key_segment_pair.ref_key().id());
     }
     // Append a timestamp to the ID so that other snapshot(s) can reuse the same snapshot name before the cleanup job:
-    std::string new_key = fmt::format("{}@{:x}", key_segment_pair.ref_key(), util::SysClock::coarse_nanos_since_epoch() / 1'000'000);
+    std::string new_key =
+        fmt::format("{}@{:x}", key_segment_pair.ref_key(), util::SysClock::coarse_nanos_since_epoch() / 1'000'000);
     key_segment_pair.ref_key() = RefKey(new_key, KeyType::SNAPSHOT_TOMBSTONE);
     store->write_compressed(std::move(key_segment_pair)).get();
 }
 
 // Returns true if snapshot with given key is successfully tombstoned, or false if the snapshot with this key doesn't exist
-void tombstone_snapshot(
-        std::shared_ptr<Store> store,
-        const RefKey& key,
-        bool log_changes
-        ) {
+void tombstone_snapshot(std::shared_ptr<Store> store, const RefKey& key, bool log_changes)
+{
     try {
         auto key_segment_pair = store->read_compressed(key).get();
         tombstone_snapshot(store, std::move(key_segment_pair), log_changes);
@@ -96,32 +88,36 @@ void tombstone_snapshot(
     }
 }
 
-void iterate_snapshots(std::shared_ptr <Store> store, folly::Function<void(entity::VariantKey & )> visitor) {
+void iterate_snapshots(std::shared_ptr<Store> store, folly::Function<void(entity::VariantKey&)> visitor)
+{
     ARCTICDB_SAMPLE(IterateSnapshots, 0)
 
     std::vector<VariantKey> snap_variant_keys;
     std::unordered_set<SnapshotId> seen;
 
-    store->iterate_type(KeyType::SNAPSHOT_REF, [&](VariantKey &&vk) {
-        util::check(std::holds_alternative<RefKey>(vk), "Expected shapshot ref to be reference type, got {}", variant_key_view(vk));
+    store->iterate_type(KeyType::SNAPSHOT_REF, [&](VariantKey&& vk) {
+        util::check(std::holds_alternative<RefKey>(vk),
+            "Expected shapshot ref to be reference type, got {}",
+            variant_key_view(vk));
         auto ref_key = std::get<RefKey>(vk);
         seen.insert(ref_key.id());
         snap_variant_keys.emplace_back(ref_key);
     });
 
-    store->iterate_type(KeyType::SNAPSHOT, [&](VariantKey &&vk) {
-        const auto &key = to_atom(vk);
+    store->iterate_type(KeyType::SNAPSHOT, [&](VariantKey&& vk) {
+        const auto& key = to_atom(vk);
         if (seen.find(key.id()) == seen.end()) {
             snap_variant_keys.push_back(key);
         }
     });
 
-    for (auto& vk: snap_variant_keys) {
+    for (auto& vk : snap_variant_keys) {
         try {
             visitor(vk);
         } catch (storage::KeyNotFoundException& e) {
             e.keys().broadcast([&vk, &e](const VariantKey& key) {
-                if (key != vk) throw storage::KeyNotFoundException(std::move(e.keys()));
+                if (key != vk)
+                    throw storage::KeyNotFoundException(std::move(e.keys()));
             });
             log::version().info("Ignored exception due to {} being deleted during iterate_snapshots().");
         }
@@ -129,19 +125,16 @@ void iterate_snapshots(std::shared_ptr <Store> store, folly::Function<void(entit
 }
 
 std::optional<size_t>
-row_id_for_stream_in_snapshot_segment(SegmentInMemory &seg, bool using_ref_key, StreamId stream_id) {
+row_id_for_stream_in_snapshot_segment(SegmentInMemory& seg, bool using_ref_key, StreamId stream_id)
+{
     if (using_ref_key) {
         // With ref keys we are sure the snapshot segment has the index atom keys sorted by stream_id.
-        auto lb = std::lower_bound(std::begin(seg), std::end(seg), stream_id,
-                                   [&](auto &row, StreamId t) {
-                                       auto row_stream_id = stream_id_from_segment<pipelines::index::Fields>(
-                                               seg,
-                                               row.row_id_);
-                                       return row_stream_id < t;
-                                   });
+        auto lb = std::lower_bound(std::begin(seg), std::end(seg), stream_id, [&](auto& row, StreamId t) {
+            auto row_stream_id = stream_id_from_segment<pipelines::index::Fields>(seg, row.row_id_);
+            return row_stream_id < t;
+        });
 
-        if (lb == std::end(seg) ||
-            stream_id_from_segment<pipelines::index::Fields>(seg, lb->row_id_) != stream_id) {
+        if (lb == std::end(seg) || stream_id_from_segment<pipelines::index::Fields>(seg, lb->row_id_) != stream_id) {
             return std::nullopt;
         }
         return std::distance(std::begin(seg), lb);
@@ -156,12 +149,11 @@ row_id_for_stream_in_snapshot_segment(SegmentInMemory &seg, bool using_ref_key, 
     return std::nullopt;
 }
 
-std::unordered_map<VariantKey, SnapshotRefData> get_snapshots_and_index_keys(
-        const std::shared_ptr<Store>& store
-        ) {
+std::unordered_map<VariantKey, SnapshotRefData> get_snapshots_and_index_keys(const std::shared_ptr<Store>& store)
+{
     ARCTICDB_SAMPLE(GetSnapshotsAndIndexKeys, 0)
     std::unordered_map<VariantKey, SnapshotRefData> res;
-    iterate_snapshots(store, [&store, &res](const VariantKey &vk) {
+    iterate_snapshots(store, [&store, &res](const VariantKey& vk) {
         try {
             auto segment = store->read_sync(vk).second;
             std::unordered_set<VariantKey> index_keys;
@@ -180,24 +172,25 @@ std::unordered_map<VariantKey, SnapshotRefData> get_snapshots_and_index_keys(
     return res;
 }
 
-std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(
-        std::shared_ptr <Store> store,
-        const StreamId &stream_id) {
+std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(std::shared_ptr<Store> store, const StreamId& stream_id)
+{
     ARCTICDB_SAMPLE(GetIndexKeysInSnapshot, 0)
 
     std::unordered_set<entity::AtomKey> index_keys_in_snapshots{};
 
-    iterate_snapshots(store, [&](VariantKey &vk) {
+    iterate_snapshots(store, [&](VariantKey& vk) {
         bool snapshot_using_ref = variant_key_type(vk) == KeyType::SNAPSHOT_REF;
         SegmentInMemory snapshot_segment = store->read_sync(vk).second;
         if (snapshot_segment.row_count() == 0) {
             // Snapshot has no rows, just skip this.
-            ARCTICDB_DEBUG(log::version(), "Snapshot: {} does not have index keys (searching for symbol: {}), skipping.",
-                    variant_key_id(vk), stream_id);
-          return;
+            ARCTICDB_DEBUG(log::version(),
+                "Snapshot: {} does not have index keys (searching for symbol: {}), skipping.",
+                variant_key_id(vk),
+                stream_id);
+            return;
         }
-        auto opt_idx_for_stream_id = row_id_for_stream_in_snapshot_segment(
-                snapshot_segment, snapshot_using_ref, stream_id);
+        auto opt_idx_for_stream_id =
+            row_id_for_stream_in_snapshot_segment(snapshot_segment, snapshot_using_ref, stream_id);
         if (opt_idx_for_stream_id) {
             auto stream_idx = opt_idx_for_stream_id.value();
             index_keys_in_snapshots.insert(read_key_row(snapshot_segment, stream_idx));
@@ -211,15 +204,15 @@ std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(
  * Returned pair has first: keys not in snapshots, second: keys in snapshots.
  */
 std::pair<std::vector<AtomKey>, std::unordered_set<AtomKey>> get_index_keys_partitioned_by_inclusion_in_snapshots(
-        std::shared_ptr <Store> store,
-        const StreamId& stream_id,
-        const std::vector<entity::AtomKey> &all_index_keys
-) {
+    std::shared_ptr<Store> store,
+    const StreamId& stream_id,
+    const std::vector<entity::AtomKey>& all_index_keys)
+{
     ARCTICDB_SAMPLE(GetIndexKeysPartitionedByInclusionInSnapshots, 0)
     auto index_keys_in_snapshot = get_index_keys_in_snapshots(store, stream_id);
 
     std::vector<entity::AtomKey> index_keys_not_in_snapshot;
-    for (const auto &index_key: all_index_keys) {
+    for (const auto& index_key : all_index_keys) {
         if (!index_keys_in_snapshot.count(index_key)) {
             index_keys_not_in_snapshot.emplace_back(index_key);
         }
@@ -228,11 +221,12 @@ std::pair<std::vector<AtomKey>, std::unordered_set<AtomKey>> get_index_keys_part
     return std::make_pair(index_keys_not_in_snapshot, index_keys_in_snapshot);
 }
 
-std::optional<VariantKey> get_snapshot_key(std::shared_ptr <Store> store, const SnapshotId &snap_name) {
+std::optional<VariantKey> get_snapshot_key(std::shared_ptr<Store> store, const SnapshotId& snap_name)
+{
     ARCTICDB_SAMPLE(getSnapshot, 0)
 
     auto maybe_ref_key = RefKey{std::move(snap_name), KeyType::SNAPSHOT_REF};
-    if(store->key_exists_sync(maybe_ref_key))
+    if (store->key_exists_sync(maybe_ref_key))
         return maybe_ref_key;
 
     // Fall back to iteration
@@ -240,27 +234,31 @@ std::optional<VariantKey> get_snapshot_key(std::shared_ptr <Store> store, const 
     std::optional<std::pair<VariantKey, SegmentInMemory>> opt_segment = std::nullopt;
 
     std::optional<VariantKey> ret;
-    store->iterate_type(KeyType::SNAPSHOT, [&ret, &snap_name](VariantKey &&vk) {
-        auto snap_key = to_atom(vk);
-        if (snap_key.id() == snap_name) {
-            ret = snap_key;
-        }
-    }, fmt::format("{}", snap_name));
+    store->iterate_type(
+        KeyType::SNAPSHOT,
+        [&ret, &snap_name](VariantKey&& vk) {
+            auto snap_key = to_atom(vk);
+            if (snap_key.id() == snap_name) {
+                ret = snap_key;
+            }
+        },
+        fmt::format("{}", snap_name));
     return ret;
 }
 
-std::optional<std::pair<VariantKey, SegmentInMemory>> get_snapshot(std::shared_ptr <Store> store, const SnapshotId &snap_name) {
+std::optional<std::pair<VariantKey, SegmentInMemory>> get_snapshot(std::shared_ptr<Store> store,
+    const SnapshotId& snap_name)
+{
     ARCTICDB_SAMPLE(getSnapshot, 0)
     auto opt_snap_key = get_snapshot_key(store, snap_name);
-    if(!opt_snap_key)
+    if (!opt_snap_key)
         return std::nullopt;
 
     return store->read_sync(*opt_snap_key);
 }
 
-std::set<StreamId> list_streams_in_snapshot(
-        const std::shared_ptr<Store>& store,
-        SnapshotId snap_name) {
+std::set<StreamId> list_streams_in_snapshot(const std::shared_ptr<Store>& store, SnapshotId snap_name)
+{
     ARCTICDB_SAMPLE(ListStreamsInSnapshot, 0)
     std::set<StreamId> res;
     auto opt_snap_key = get_snapshot(store, snap_name);
@@ -278,9 +276,8 @@ std::set<StreamId> list_streams_in_snapshot(
 }
 
 namespace {
-std::vector<AtomKey> get_versions_from_segment(
-    const SegmentInMemory& snapshot_segment
-    ) {
+std::vector<AtomKey> get_versions_from_segment(const SegmentInMemory& snapshot_segment)
+{
     std::vector<AtomKey> res;
     for (size_t idx = 0; idx < snapshot_segment.row_count(); idx++) {
         auto stream_index = read_key_row(snapshot_segment, idx);
@@ -289,9 +286,8 @@ std::vector<AtomKey> get_versions_from_segment(
     return res;
 }
 
-py::object get_metadata_from_segment(
-    const SegmentInMemory& snapshot_segment
-    ) {
+py::object get_metadata_from_segment(const SegmentInMemory& snapshot_segment)
+{
     auto metadata_proto = snapshot_segment.metadata();
     py::object pyobj;
     if (metadata_proto) {
@@ -304,30 +300,27 @@ py::object get_metadata_from_segment(
     return pyobj;
 }
 
-std::vector<AtomKey> get_versions_from_snapshot(
-    const std::shared_ptr<Store>& store,
-    const VariantKey& vk) {
+std::vector<AtomKey> get_versions_from_snapshot(const std::shared_ptr<Store>& store, const VariantKey& vk)
+{
 
     auto snapshot_segment = store->read_sync(vk).second;
     return get_versions_from_segment(snapshot_segment);
 }
 } //namespace
 
-std::pair<std::vector<AtomKey>, py::object> get_versions_and_metadata_from_snapshot(
-    const std::shared_ptr<Store>& store,
-    const VariantKey& vk
-    ) {
+std::pair<std::vector<AtomKey>, py::object> get_versions_and_metadata_from_snapshot(const std::shared_ptr<Store>& store,
+    const VariantKey& vk)
+{
     auto snapshot_segment = store->read_sync(vk).second;
     return {get_versions_from_segment(snapshot_segment), get_metadata_from_segment(snapshot_segment)};
 }
 
-SnapshotMap get_versions_from_snapshots(
-        const std::shared_ptr<Store>& store
-) {
+SnapshotMap get_versions_from_snapshots(const std::shared_ptr<Store>& store)
+{
     ARCTICDB_SAMPLE(GetVersionsFromSnapshot, 0)
     SnapshotMap res;
 
-    iterate_snapshots(store, [&](VariantKey &vk) {
+    iterate_snapshots(store, [&](VariantKey& vk) {
         SnapshotId snapshot_id{fmt::format("{}", variant_key_id(vk))};
         res[snapshot_id] = get_versions_from_snapshot(store, vk);
     });
@@ -336,24 +329,24 @@ SnapshotMap get_versions_from_snapshots(
 }
 
 //TODO I don't love having py:object here, return the protobuf and convert at the outer edge
-py::object get_metadata_for_snapshot(std::shared_ptr <Store> store, VariantKey& snap_key) {
-   auto seg = store->read_sync(snap_key).second;
-   return get_metadata_from_segment(seg);
+py::object get_metadata_for_snapshot(std::shared_ptr<Store> store, VariantKey& snap_key)
+{
+    auto seg = store->read_sync(snap_key).second;
+    return get_metadata_from_segment(seg);
 }
 
-MasterSnapshotMap get_master_snapshots_map(
-        std::shared_ptr<Store> store,
-        const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>& get_keys_in_snapshot
-) {
+MasterSnapshotMap get_master_snapshots_map(std::shared_ptr<Store> store,
+    const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>& get_keys_in_snapshot)
+{
     MasterSnapshotMap out;
-    iterate_snapshots(store, [&](VariantKey &sk) {
+    iterate_snapshots(store, [&](VariantKey& sk) {
         auto snapshot_id = variant_key_id(sk);
         auto snapshot_segment = store->read_sync(sk).second;
         for (size_t idx = 0; idx < snapshot_segment.row_count(); idx++) {
             auto stream_index = read_key_row(snapshot_segment, idx);
             out[stream_index.id()][stream_index].insert(snapshot_id);
             if (get_keys_in_snapshot) {
-                auto[wanted_snap_key, sink] = get_keys_in_snapshot.value();
+                auto [wanted_snap_key, sink] = get_keys_in_snapshot.value();
                 if (wanted_snap_key == sk) {
                     sink.push_back(stream_index);
                 }
@@ -363,4 +356,4 @@ MasterSnapshotMap get_master_snapshots_map(
     return out;
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -25,107 +25,78 @@ using namespace arcticdb::stream;
 namespace arcticdb {
 
 struct SnapshotRefData {
-    explicit SnapshotRefData(SegmentInMemory&& snapshot_segment,
-                             std::unordered_set<VariantKey>&& index_keys):
-                             snapshot_segment_(std::move(snapshot_segment)),
-                             index_keys_(std::move(index_keys)) {
-
+    explicit SnapshotRefData(SegmentInMemory&& snapshot_segment, std::unordered_set<VariantKey>&& index_keys)
+        : snapshot_segment_(std::move(snapshot_segment)),
+          index_keys_(std::move(index_keys))
+    {
     }
     SegmentInMemory snapshot_segment_;
     std::unordered_set<VariantKey> index_keys_;
 };
 
-void write_snapshot_entry(
-    std::shared_ptr <StreamSink> store,
-    std::vector <AtomKey> &keys,
-    const SnapshotId &snapshot_id,
-    const py::object &user_meta,
+void write_snapshot_entry(std::shared_ptr<StreamSink> store,
+    std::vector<AtomKey>& keys,
+    const SnapshotId& snapshot_id,
+    const py::object& user_meta,
     bool log_changes,
-    KeyType key_type = KeyType::SNAPSHOT_REF
-);
+    KeyType key_type = KeyType::SNAPSHOT_REF);
 
-void tombstone_snapshot(
-    std::shared_ptr<StreamSink> store,
+void tombstone_snapshot(std::shared_ptr<StreamSink> store,
     const RefKey& key,
     SegmentInMemory&& segment_in_memory,
-    bool log_changes
-);
+    bool log_changes);
 
-void tombstone_snapshot(
-        std::shared_ptr<StreamSink> store,
-        storage::KeySegmentPair&& key_segment_pair,
-        bool log_changes
-        );
+void tombstone_snapshot(std::shared_ptr<StreamSink> store,
+    storage::KeySegmentPair&& key_segment_pair,
+    bool log_changes);
 
-void tombstone_snapshot(
-        std::shared_ptr<Store> store,
-        const RefKey& key,
-        bool log_changes
-        );
+void tombstone_snapshot(std::shared_ptr<Store> store, const RefKey& key, bool log_changes);
 
+void iterate_snapshots(std::shared_ptr<Store> store, folly::Function<void(entity::VariantKey&)> visitor);
 
-void iterate_snapshots(std::shared_ptr <Store> store, folly::Function<void(entity::VariantKey & )> visitor);
-
-std::optional<size_t> row_id_for_stream_in_snapshot_segment(
-    SegmentInMemory &seg,
-    bool using_ref_key,
-    StreamId stream_id);
+std::optional<size_t>
+row_id_for_stream_in_snapshot_segment(SegmentInMemory& seg, bool using_ref_key, StreamId stream_id);
 
 // Get a set of the index keys of a particular symbol that exist in any snapshot
-std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(
-    std::shared_ptr <Store> store,
-    const StreamId &stream_id);
+std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(std::shared_ptr<Store> store,
+    const StreamId& stream_id);
 
 std::pair<std::vector<AtomKey>, std::unordered_set<AtomKey>> get_index_keys_partitioned_by_inclusion_in_snapshots(
-    std::shared_ptr <Store> store,
+    std::shared_ptr<Store> store,
     const StreamId& stream_id,
-    const std::vector<entity::AtomKey> &all_index_keys
-);
+    const std::vector<entity::AtomKey>& all_index_keys);
 
-std::pair<std::vector<AtomKey>, py::object> get_versions_and_metadata_from_snapshot(
-    const std::shared_ptr<Store>& store,
-    const VariantKey& vk
-    );
+std::pair<std::vector<AtomKey>, py::object> get_versions_and_metadata_from_snapshot(const std::shared_ptr<Store>& store,
+    const VariantKey& vk);
 
-std::optional<VariantKey> get_snapshot_key(
-    std::shared_ptr <Store> store,
-    const SnapshotId &snap_name);
+std::optional<VariantKey> get_snapshot_key(std::shared_ptr<Store> store, const SnapshotId& snap_name);
 
-std::optional<std::pair<VariantKey, SegmentInMemory>> get_snapshot(
-    std::shared_ptr <Store> store,
-    const SnapshotId &snap_name);
+std::optional<std::pair<VariantKey, SegmentInMemory>> get_snapshot(std::shared_ptr<Store> store,
+    const SnapshotId& snap_name);
 
-std::set<StreamId> list_streams_in_snapshot(
-    const std::shared_ptr<Store>& store,
-    SnapshotId snap_name);
+std::set<StreamId> list_streams_in_snapshot(const std::shared_ptr<Store>& store, SnapshotId snap_name);
 
 using SnapshotMap = std::unordered_map<SnapshotId, std::vector<AtomKey>>;
 
-SnapshotMap get_versions_from_snapshots(
-    const std::shared_ptr<Store>& store
-    );
+SnapshotMap get_versions_from_snapshots(const std::shared_ptr<Store>& store);
 
 // Returns a map from snapshot keys to it's associated segment, and the [multi-]index keys in that segment
-std::unordered_map<VariantKey, SnapshotRefData> get_snapshots_and_index_keys(
-    const std::shared_ptr<Store>& store
-    );
+std::unordered_map<VariantKey, SnapshotRefData> get_snapshots_and_index_keys(const std::shared_ptr<Store>& store);
 
-py::object get_metadata_for_snapshot(std::shared_ptr <Store> store, VariantKey& snap_key);
+py::object get_metadata_for_snapshot(std::shared_ptr<Store> store, VariantKey& snap_key);
 
 /**
  * Stream id (symbol) -> all index keys in snapshots -> which snapshot contained that key.
  */
 using MasterSnapshotMap =
-        std::unordered_map<StreamId, std::unordered_map<IndexTypeKey, std::unordered_set<SnapshotId>>>;
+    std::unordered_map<StreamId, std::unordered_map<IndexTypeKey, std::unordered_set<SnapshotId>>>;
 
 /**
  * Map the index keys in every snapshot.
  * @param get_keys_in_snapshot If set, the VariantKey in the tuple should be a SNAPSHOT[_REF] key and the index keys in
  * that snapshot will be passed to the second item.
  */
-MasterSnapshotMap get_master_snapshots_map(
-    std::shared_ptr<Store> store,
+MasterSnapshotMap get_master_snapshots_map(std::shared_ptr<Store> store,
     const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>& get_keys_in_snapshot =
-            std::nullopt
-);
-}
+        std::nullopt);
+} // namespace arcticdb

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -11,232 +11,235 @@ namespace arcticdb {
 
 using namespace arcticdb::stream;
 
-static const StreamId compaction_id {CompactionId};
+static const StreamId compaction_id{CompactionId};
 
-    SymbolList::CollectionType SymbolList::load_symbols(const std::shared_ptr<Store>& store, bool no_compaction) {
-        auto all_keys = get_all_symbol_list_keys(store);
-        auto maybe_last_compaction = last_compaction(all_keys);
-        if(!maybe_last_compaction && !no_compaction) {
-            SYMBOL_LIST_RUNTIME_LOG("Failed to find most recent compaction, reloading all");
-            StorageLock lock{CompactionLockName};
-            timestamp creation_ts = store->current_timestamp();
-            // We choose the creation_ts for the compacted key just before we do the version key iteration
-            auto symbols = load_from_version_keys(store);
-            try {
-                if (lock.try_lock(store)) {
-                    SYMBOL_LIST_RUNTIME_LOG("Got lock");
-                    OnExit on_exit([&, store = store]() { lock.unlock(store); });
-                    write_symbols(store, symbols, compaction_id, creation_ts).get();
-                    delete_keys(store, all_keys);
-                } else {
-                    SYMBOL_LIST_RUNTIME_LOG("Not writing symbols as another write is in progress");
-                }
-            } catch (const storage::PermissionException& ex) {
-                SYMBOL_LIST_RUNTIME_LOG("Can't compact symbol list in read-only mode");
-            } catch (const std::system_error& ex) {
-                SYMBOL_LIST_RUNTIME_LOG("Caught error in symbol list write: {}", ex.what());
-            }
-            // Acceptable to swallow the exceptions above and return symbols because it is loaded from the source
-            // (version keys) without involving the (inaccessible) symbol list cache:
-            return symbols;
-        }
-        else {
-            if(all_keys.size() > max_delta_ && !no_compaction) {
-                SYMBOL_LIST_RUNTIME_LOG("Symbol chain too long, doing compaction");
-                return compact(store, all_keys);
-            }
-            else {
-                auto compaction_and_deltas = KeyVector{all_keys.begin() + maybe_last_compaction.value_or(0), all_keys.end()};
-                return load_from_storage(store, compaction_and_deltas);
-            }
-        }
-    }
-
-    SymbolList::CollectionType SymbolList::compact(std::shared_ptr<Store> store, const std::vector<AtomKey>& symbol_keys) {
+SymbolList::CollectionType SymbolList::load_symbols(const std::shared_ptr<Store>& store, bool no_compaction)
+{
+    auto all_keys = get_all_symbol_list_keys(store);
+    auto maybe_last_compaction = last_compaction(all_keys);
+    if (!maybe_last_compaction && !no_compaction) {
+        SYMBOL_LIST_RUNTIME_LOG("Failed to find most recent compaction, reloading all");
+        StorageLock lock{CompactionLockName};
+        timestamp creation_ts = store->current_timestamp();
+        // We choose the creation_ts for the compacted key just before we do the version key iteration
+        auto symbols = load_from_version_keys(store);
         try {
-            StorageLock lock{CompactionLockName};
-            SYMBOL_LIST_RUNTIME_LOG("Doing symbol list compaction with {} keys", symbol_keys.size());
-            if(lock.try_lock(store)) {
+            if (lock.try_lock(store)) {
                 SYMBOL_LIST_RUNTIME_LOG("Got lock");
-                OnExit on_exit([&, store=store] () { lock.unlock(store); });
-                // Rescan keys inside the lock just in case another compaction
-                // is just finishing (N.B. unlikely)
-                auto all_symbols = get_all_symbol_list_keys(store);
-                auto symbols = load_from_storage(store, all_symbols);
-                write_symbols(store, symbols, compaction_id, symbol_keys.rbegin()->creation_ts()).get();
-
-
-                delete_keys(store, all_symbols);
-                return symbols;
+                OnExit on_exit([&, store = store]() { lock.unlock(store); });
+                write_symbols(store, symbols, compaction_id, creation_ts).get();
+                delete_keys(store, all_keys);
             } else {
-                SYMBOL_LIST_RUNTIME_LOG("Didn't get lock, not compacting");
+                SYMBOL_LIST_RUNTIME_LOG("Not writing symbols as another write is in progress");
             }
-        } catch(const storage::PermissionException& ex) {
-            SYMBOL_LIST_RUNTIME_LOG("Can't compact symbol list in read-only mode, loading from storage");
+        } catch (const storage::PermissionException& ex) {
+            SYMBOL_LIST_RUNTIME_LOG("Can't compact symbol list in read-only mode");
         } catch (const std::system_error& ex) {
             SYMBOL_LIST_RUNTIME_LOG("Caught error in symbol list write: {}", ex.what());
         }
+        // Acceptable to swallow the exceptions above and return symbols because it is loaded from the source
+        // (version keys) without involving the (inaccessible) symbol list cache:
+        return symbols;
+    } else {
+        if (all_keys.size() > max_delta_ && !no_compaction) {
+            SYMBOL_LIST_RUNTIME_LOG("Symbol chain too long, doing compaction");
+            return compact(store, all_keys);
+        } else {
+            auto compaction_and_deltas =
+                KeyVector{all_keys.begin() + maybe_last_compaction.value_or(0), all_keys.end()};
+            return load_from_storage(store, compaction_and_deltas);
+        }
+    }
+}
 
-        SYMBOL_LIST_RUNTIME_LOG("Fallback load_from_storage");
-        auto all_symbols = get_all_symbol_list_keys(store);
-        return load_from_storage(store, all_symbols);
+SymbolList::CollectionType SymbolList::compact(std::shared_ptr<Store> store, const std::vector<AtomKey>& symbol_keys)
+{
+    try {
+        StorageLock lock{CompactionLockName};
+        SYMBOL_LIST_RUNTIME_LOG("Doing symbol list compaction with {} keys", symbol_keys.size());
+        if (lock.try_lock(store)) {
+            SYMBOL_LIST_RUNTIME_LOG("Got lock");
+            OnExit on_exit([&, store = store]() { lock.unlock(store); });
+            // Rescan keys inside the lock just in case another compaction
+            // is just finishing (N.B. unlikely)
+            auto all_symbols = get_all_symbol_list_keys(store);
+            auto symbols = load_from_storage(store, all_symbols);
+            write_symbols(store, symbols, compaction_id, symbol_keys.rbegin()->creation_ts()).get();
+
+            delete_keys(store, all_symbols);
+            return symbols;
+        } else {
+            SYMBOL_LIST_RUNTIME_LOG("Didn't get lock, not compacting");
+        }
+    } catch (const storage::PermissionException& ex) {
+        SYMBOL_LIST_RUNTIME_LOG("Can't compact symbol list in read-only mode, loading from storage");
+    } catch (const std::system_error& ex) {
+        SYMBOL_LIST_RUNTIME_LOG("Caught error in symbol list write: {}", ex.what());
     }
 
-    void SymbolList::write_journal(const std::shared_ptr<Store>& store, const StreamId& symbol, std::string action) {
-        SegmentInMemory seg{journal_stream_descriptor(action, symbol)};
-        util::variant_match(symbol,
-            [&seg] (const StringId& id) {
-                seg.set_string(0, id);
+    SYMBOL_LIST_RUNTIME_LOG("Fallback load_from_storage");
+    auto all_symbols = get_all_symbol_list_keys(store);
+    return load_from_storage(store, all_symbols);
+}
+
+void SymbolList::write_journal(const std::shared_ptr<Store>& store, const StreamId& symbol, std::string action)
+{
+    SegmentInMemory seg{journal_stream_descriptor(action, symbol)};
+    util::variant_match(
+        symbol,
+        [&seg](const StringId& id) { seg.set_string(0, id); },
+        [&seg](const NumericId& id) { seg.set_scalar<uint64_t>(0, id); });
+
+    seg.end_row();
+    store
+        ->write_sync(KeyType::SYMBOL_LIST, 0, StreamId{action}, IndexValue{symbol}, IndexValue{symbol}, std::move(seg));
+}
+
+SymbolList::CollectionType SymbolList::load_from_version_keys(const std::shared_ptr<Store>& store)
+{
+    std::vector<StreamId> stream_ids;
+    store->iterate_type(KeyType::VERSION_REF, [&](const auto& key) {
+        auto id = variant_key_id(key);
+        stream_ids.push_back(id);
+    });
+    auto res = batch_get_latest_version(store, version_map_, stream_ids, false);
+
+    CollectionType symbols{};
+    for (const auto& map_pair : *res) {
+        symbols.insert(map_pair.first);
+    }
+
+    version_map_->flush();
+    return symbols;
+}
+
+folly::Future<VariantKey> SymbolList::write_symbols(const std::shared_ptr<Store>& store,
+    const CollectionType& symbols,
+    const StreamId& stream_id,
+    timestamp creation_ts)
+{
+
+    SYMBOL_LIST_RUNTIME_LOG("Writing {} symbols to symbol list cache", symbols.size());
+    SegmentInMemory list_segment{symbol_stream_descriptor(stream_id)};
+
+    for (const auto& symbol : symbols) {
+        ARCTICDB_DEBUG(log::version(), "Writing symbol '{}' to list", symbol);
+        util::variant_match(
+            type_holder_,
+            [&](const StringId&) {
+                util::check(std::holds_alternative<StringId>(symbol),
+                    "Cannot write string symbol name, existing symbols are numeric");
+                list_segment.set_string(0, std::get<StringId>(symbol));
             },
-            [&seg] (const NumericId& id) {
-                seg.set_scalar<uint64_t>(0, id);
+            [&](const NumericId&) {
+                util::check(std::holds_alternative<NumericId>(symbol),
+                    "Cannot write numeric symbol name, existing symbols are strings");
+                list_segment.set_scalar(0, std::get<NumericId>(symbol));
             });
-
-        seg.end_row();
-        store->write_sync(KeyType::SYMBOL_LIST, 0, StreamId{action}, IndexValue{symbol}, IndexValue{symbol},
-                std::move(seg));
+        list_segment.end_row();
     }
-
-    SymbolList::CollectionType SymbolList::load_from_version_keys(const std::shared_ptr<Store>& store) {
-        std::vector<StreamId> stream_ids;
-        store->iterate_type(KeyType::VERSION_REF, [&] (const auto& key) {
-            auto id = variant_key_id(key);
-            stream_ids.push_back(id);
-        });
-        auto res = batch_get_latest_version(store, version_map_, stream_ids, false);
-
-        CollectionType symbols{};
-        for(const auto& map_pair: *res) {
-            symbols.insert(map_pair.first);
-        }
-
-        version_map_->flush();
-        return symbols;
+    if (symbols.empty()) {
+        google::protobuf::Any any = {};
+        arcticdb::proto::descriptors::SymbolListDescriptor metadata;
+        metadata.set_enabled(true);
+        any.PackFrom(metadata);
+        list_segment.set_metadata(std::move(any));
     }
+    return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, 0, 0, std::move(list_segment));
+}
 
-    folly::Future<VariantKey> SymbolList::write_symbols(
-        const std::shared_ptr<Store>& store,
-        const CollectionType& symbols,
-        const StreamId& stream_id,
-        timestamp creation_ts)  {
-
-        SYMBOL_LIST_RUNTIME_LOG("Writing {} symbols to symbol list cache", symbols.size());
-        SegmentInMemory list_segment{symbol_stream_descriptor(stream_id)};
-
-        for(const auto& symbol : symbols) {
-            ARCTICDB_DEBUG(log::version(), "Writing symbol '{}' to list", symbol);
-            util::variant_match(type_holder_,
-                [&](const StringId&) {
-                    util::check(std::holds_alternative<StringId>(symbol), "Cannot write string symbol name, existing symbols are numeric");
-                    list_segment.set_string(0, std::get<StringId>(symbol));
-                },
-                [&](const NumericId&) {
-                    util::check(std::holds_alternative<NumericId>(symbol), "Cannot write numeric symbol name, existing symbols are strings");
-                    list_segment.set_scalar(0, std::get<NumericId>(symbol));
-                }
-            );
-            list_segment.end_row();
-        }
-        if(symbols.empty()) {
-            google::protobuf::Any any = {};
-            arcticdb::proto::descriptors::SymbolListDescriptor metadata;
-            metadata.set_enabled(true);
-            any.PackFrom(metadata);
-            list_segment.set_metadata(std::move(any));
-        }
-        return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, 0, 0, std::move(list_segment));
-    }
-
-    SymbolList::CollectionType SymbolList::load_from_storage(const std::shared_ptr<StreamSource>& store, const std::vector<AtomKey>& keys) {
-        SYMBOL_LIST_RUNTIME_LOG("Loading from storage");
-        bool read_compaction = false;
-        CollectionType symbols{};
-        for(const auto& key : keys) {
-            if(key.id() == compaction_id) {
-                read_list_from_storage(store, key, symbols);
-                read_compaction = true;
-            }
-            else {
-                const auto& action = key.id();
-                const auto& symbol = key.start_index();
-                if(action == StreamId{DeleteSymbol}) {
-                    ARCTICDB_DEBUG(log::version(), "Got delete action for symbol '{}'", symbol);
-                    symbols.erase(symbol);
-                }
-                else {
-                    ARCTICDB_DEBUG(log::version(), "Got insert action for symbol '{}'", symbol);
-                    symbols.insert(symbol);
-                }
-            }
-        }
-        SYMBOL_LIST_RUNTIME_LOG("Post load, got {} symbols", symbols.size());
-        if(!read_compaction) {
-            SYMBOL_LIST_RUNTIME_LOG("Read no compacted segment from symbol list of size {}", keys.size());
-        }
-        return symbols;
-    }
-
-    void SymbolList::read_list_from_storage(const std::shared_ptr<StreamSource>& store, const AtomKey& key,
-            CollectionType& symbols) {
-        auto key_seg = store->read(key).get();
-        ARCTICDB_DEBUG(log::version(), "Reading list from storage with key {}", key);
-        auto field_desc = key_seg.second.descriptor().field_at(0);
-        if(!field_desc)
-            util::raise_rte("Expected at least one column in symbol list with key {}", key);
-
-        auto data_type = data_type_from_proto(field_desc->type_desc());
-        if (key_seg.second.row_count() > 0) {
-            for (auto row : key_seg.second) {
-                if (data_type == DataType::UINT64) {
-                    row.visit_scalar_type(0, uint64_t{}, [&](auto val) {
-                        ARCTICDB_DEBUG(log::version(), "Reading numeric symbol {}", val.value());
-                        symbols.insert(StreamId{safe_convert_to_numeric_id(val.value(), "Numeric symbol")});
-                    });
-                } else if (data_type == DataType::ASCII_DYNAMIC64) {
-                    row.visit_string(0, [&](const auto &val) {
-                        ARCTICDB_DEBUG(log::version(), "Reading string symbol '{}'", val.value());
-                        symbols.insert(StreamId{std::string{val.value()}});
-                    });
-                } else {
-                    util::raise_rte("Encountered unknown key type");
-                }
+SymbolList::CollectionType SymbolList::load_from_storage(const std::shared_ptr<StreamSource>& store,
+    const std::vector<AtomKey>& keys)
+{
+    SYMBOL_LIST_RUNTIME_LOG("Loading from storage");
+    bool read_compaction = false;
+    CollectionType symbols{};
+    for (const auto& key : keys) {
+        if (key.id() == compaction_id) {
+            read_list_from_storage(store, key, symbols);
+            read_compaction = true;
+        } else {
+            const auto& action = key.id();
+            const auto& symbol = key.start_index();
+            if (action == StreamId{DeleteSymbol}) {
+                ARCTICDB_DEBUG(log::version(), "Got delete action for symbol '{}'", symbol);
+                symbols.erase(symbol);
+            } else {
+                ARCTICDB_DEBUG(log::version(), "Got insert action for symbol '{}'", symbol);
+                symbols.insert(symbol);
             }
         }
     }
-
-    SymbolList::KeyVector SymbolList::get_all_symbol_list_keys(const std::shared_ptr<StreamSource>& store) const {
-        std::vector<AtomKey> output;
-        store->iterate_type(KeyType::SYMBOL_LIST, [&] (auto&& key) -> void {
-            output.push_back(to_atom(key));
-        });
-
-        std::sort(output.begin(), output.end(), [] (const AtomKey& left, const AtomKey& right) {
-            return left.creation_ts() < right.creation_ts();
-        });
-        return output;
+    SYMBOL_LIST_RUNTIME_LOG("Post load, got {} symbols", symbols.size());
+    if (!read_compaction) {
+        SYMBOL_LIST_RUNTIME_LOG("Read no compacted segment from symbol list of size {}", keys.size());
     }
+    return symbols;
+}
 
-    void SymbolList::delete_keys(
-            std::shared_ptr<Store> store, const KeyVector& lists) {
-        std::vector<VariantKey> vars;
-        vars.reserve(lists.size());
-        for(const auto& atom_key: lists)
-            vars.emplace_back(VariantKey{atom_key});
-        store->remove_keys(vars).get();
+void SymbolList::read_list_from_storage(const std::shared_ptr<StreamSource>& store,
+    const AtomKey& key,
+    CollectionType& symbols)
+{
+    auto key_seg = store->read(key).get();
+    ARCTICDB_DEBUG(log::version(), "Reading list from storage with key {}", key);
+    auto field_desc = key_seg.second.descriptor().field_at(0);
+    if (!field_desc)
+        util::raise_rte("Expected at least one column in symbol list with key {}", key);
+
+    auto data_type = data_type_from_proto(field_desc->type_desc());
+    if (key_seg.second.row_count() > 0) {
+        for (auto row : key_seg.second) {
+            if (data_type == DataType::UINT64) {
+                row.visit_scalar_type(0, uint64_t{}, [&](auto val) {
+                    ARCTICDB_DEBUG(log::version(), "Reading numeric symbol {}", val.value());
+                    symbols.insert(StreamId{safe_convert_to_numeric_id(val.value(), "Numeric symbol")});
+                });
+            } else if (data_type == DataType::ASCII_DYNAMIC64) {
+                row.visit_string(0, [&](const auto& val) {
+                    ARCTICDB_DEBUG(log::version(), "Reading string symbol '{}'", val.value());
+                    symbols.insert(StreamId{std::string{val.value()}});
+                });
+            } else {
+                util::raise_rte("Encountered unknown key type");
+            }
+        }
     }
+}
 
-    std::optional<SymbolList::KeyVector::difference_type> SymbolList::last_compaction(const KeyVector& keys) {
-        auto pos = std::find_if(keys.rbegin(), keys.rend(), [] (const auto& key) {
-            return key.id() == compaction_id;
-        }) ;
+SymbolList::KeyVector SymbolList::get_all_symbol_list_keys(const std::shared_ptr<StreamSource>& store) const
+{
+    std::vector<AtomKey> output;
+    store->iterate_type(KeyType::SYMBOL_LIST, [&](auto&& key) -> void { output.push_back(to_atom(key)); });
 
-        if(pos == keys.rend())
-            return std::nullopt;
+    std::sort(output.begin(), output.end(), [](const AtomKey& left, const AtomKey& right) {
+        return left.creation_ts() < right.creation_ts();
+    });
+    return output;
+}
 
-        auto forward_pos = std::distance(std::begin(keys), pos.base()) - 1;
-        util::check(keys[forward_pos].id() == compaction_id,
-                "Compaction point {} is incorrect in vector of size {}", forward_pos, keys.size());
-        return std::make_optional(forward_pos);
-    }
+void SymbolList::delete_keys(std::shared_ptr<Store> store, const KeyVector& lists)
+{
+    std::vector<VariantKey> vars;
+    vars.reserve(lists.size());
+    for (const auto& atom_key : lists)
+        vars.emplace_back(VariantKey{atom_key});
+    store->remove_keys(vars).get();
+}
+
+std::optional<SymbolList::KeyVector::difference_type> SymbolList::last_compaction(const KeyVector& keys)
+{
+    auto pos = std::find_if(keys.rbegin(), keys.rend(), [](const auto& key) { return key.id() == compaction_id; });
+
+    if (pos == keys.rend())
+        return std::nullopt;
+
+    auto forward_pos = std::distance(std::begin(keys), pos.base()) - 1;
+    util::check(keys[forward_pos].id() == compaction_id,
+        "Compaction point {} is incorrect in vector of size {}",
+        forward_pos,
+        keys.size());
+    return std::make_optional(forward_pos);
+}
 
 } //namespace arcticdb

--- a/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
+++ b/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
@@ -20,18 +20,20 @@
 #include <arcticdb/version/test/version_map_model.hpp>
 #include <arcticdb/version/version_functions.hpp>
 
-template <typename Model>
-void check_latest_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
+template<typename Model>
+void check_latest_versions(const Model& s0, MapStorePair& sut, std::string symbol)
+{
     using namespace arcticdb;
-    auto prev = get_latest_version(sut.store_,sut.map_, symbol, true, true);
+    auto prev = get_latest_version(sut.store_, sut.map_, symbol, true, true);
     auto sut_version_id = prev ? prev.value().version_id() : 0;
     auto model_prev = s0.get_latest_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
     RC_ASSERT(sut_version_id == model_version_id);
 }
 
-template <typename Model>
-void check_latest_undeleted_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
+template<typename Model>
+void check_latest_undeleted_versions(const Model& s0, MapStorePair& sut, std::string symbol)
+{
     using namespace arcticdb;
     auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, true, true);
     auto sut_version_id = prev ? prev.value().version_id() : 0;
@@ -40,169 +42,204 @@ void check_latest_undeleted_versions(const Model&  s0, MapStorePair &sut, std::s
     RC_ASSERT(sut_version_id == model_version_id);
 }
 
-template <typename Model>
+template<typename Model>
 struct WriteVersion : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit WriteVersion(const Model& s0) ARCTICDB_UNUSED:
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
+    explicit WriteVersion(const Model& s0) ARCTICDB_UNUSED : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
+    }
 
-    void apply(Model &s0) const override {
+    void apply(Model& s0) const override
+    {
         s0.write_version(symbol_);
     }
 
-    void run(const Model& s0, MapStorePair &sut) const override {
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         check_latest_versions(s0, sut, symbol_);
         sut.write_version(symbol_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "WriteVersion(" << symbol_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct SetUseFastTombstoneAll : rc::state::Command<Model, MapStorePair> {
     bool value_;
 
-    explicit SetUseFastTombstoneAll(const Model&) ARCTICDB_UNUSED:
-        value_(*rc::gen::arbitrary<bool>()) {}
-
-    void apply(Model &) const override {
+    explicit SetUseFastTombstoneAll(const Model&) ARCTICDB_UNUSED : value_(*rc::gen::arbitrary<bool>())
+    {
     }
 
-    void run(const Model& , MapStorePair & sut) const override {
+    void apply(Model&) const override
+    {
+    }
+
+    void run(const Model&, MapStorePair& sut) const override
+    {
         sut.map_->set_fast_tombstone_all(value_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "SetUseFastTombstoneAll(" << value_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct DeleteAllVersions : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit DeleteAllVersions(const Model& s0) :
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
+    explicit DeleteAllVersions(const Model& s0)
+        : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
+    }
 
-    void apply(Model &s0) const override {
+    void apply(Model& s0) const override
+    {
         s0.delete_all_versions(symbol_);
     }
 
-    void run(const Model&, MapStorePair &sut) const override {
+    void run(const Model&, MapStorePair& sut) const override
+    {
         sut.delete_all_versions(symbol_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "WriteVersion(" << symbol_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct WriteAndPrunePreviousVersion : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit WriteAndPrunePreviousVersion(const Model& s0) ARCTICDB_UNUSED :
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
+    explicit WriteAndPrunePreviousVersion(const Model& s0) ARCTICDB_UNUSED : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
+    }
 
-    void apply(Model &s0) const override {
+    void apply(Model& s0) const override
+    {
         s0.write_and_prune_previous(symbol_);
     }
 
-    void run(const Model& s0, MapStorePair &sut) const override {
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         check_latest_versions(s0, sut, symbol_);
         sut.write_and_prune_previous(symbol_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "WriteAndPrunePreviousVersion(" << symbol_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct GetLatestVersion : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit GetLatestVersion(const Model& s0) ARCTICDB_UNUSED :
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
-
-    void apply(Model &) const override {
+    explicit GetLatestVersion(const Model& s0) ARCTICDB_UNUSED : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
     }
 
-    void run(const Model&  s0, MapStorePair &sut) const override {
+    void apply(Model&) const override
+    {
+    }
+
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         ARCTICDB_DEBUG(log::version(), "MapStorePair: get_latest_version");
         check_latest_versions(s0, sut, symbol_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "GetLatestVersion(" << symbol_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct GetLatestUndeletedVersion : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit GetLatestUndeletedVersion(const Model& s0) ARCTICDB_UNUSED :
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
-
-    void apply(Model &) const override {
+    explicit GetLatestUndeletedVersion(const Model& s0) ARCTICDB_UNUSED : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
     }
 
-    void run(const Model&  s0, MapStorePair &sut) const override {
+    void apply(Model&) const override
+    {
+    }
+
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         check_latest_versions(s0, sut, symbol_);
         ARCTICDB_DEBUG(log::version(), "MapStorePair: get latest undeleted");
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "GetLatestVersion(" << symbol_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct Compact : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit Compact(const Model& s0) :
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
-
-    void apply(Model &) const override {
+    explicit Compact(const Model& s0)
+        : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
     }
 
-    void run(const Model& s0, MapStorePair &sut) const override {
+    void apply(Model&) const override
+    {
+    }
+
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         ARCTICDB_DEBUG(log::version(), "MapStorePair: compact");
         sut.map_->compact(sut.store_, symbol_);
         check_latest_versions(s0, sut, symbol_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "Compact(" << symbol_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct DeleteRefKey : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit DeleteRefKey(const Model& s0) :
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
-
-    void apply(Model &) const override {
+    explicit DeleteRefKey(const Model& s0)
+        : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
     }
 
-    void run(const Model& s0, MapStorePair &sut) const override {
+    void apply(Model&) const override
+    {
+    }
+
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         RefKey ref_key{symbol_, KeyType::VERSION_REF};
         try {
             sut.store_->remove_key_sync(ref_key, storage::RemoveOpts{});
-        } catch (const std::invalid_argument& ) {
+        } catch (const std::invalid_argument&) {
             // Don't care
         }
         check_latest_versions(s0, sut, symbol_);
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "Compact(" << symbol_ << ")";
     }
 };
@@ -211,87 +248,96 @@ template<typename Model>
 struct CompactAndRemoveDeleted : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit CompactAndRemoveDeleted(const Model& s0)  ARCTICDB_UNUSED:
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
-
-    void apply(Model &) const override {
+    explicit CompactAndRemoveDeleted(const Model& s0) ARCTICDB_UNUSED : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
     }
 
-    void run(const Model& s0, MapStorePair &sut) const override {
+    void apply(Model&) const override
+    {
+    }
+
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         ARCTICDB_DEBUG(log::version(), "MapStorePair: compact and remove deleted");
         sut.map_->compact_and_remove_deleted_indexes(sut.store_, symbol_);
         check_latest_versions(s0, sut, symbol_);
     }
 
-    void show(std::ostream &os) const override {
-    os << "Compact(" << symbol_ << ")";
+    void show(std::ostream& os) const override
+    {
+        os << "Compact(" << symbol_ << ")";
     }
 };
 
-template <typename Model>
+template<typename Model>
 struct GetAllVersions : rc::state::Command<Model, MapStorePair> {
     std::string symbol_;
 
-    explicit GetAllVersions(const Model& s0) ARCTICDB_UNUSED :
-        symbol_(*rc::gen::elementOf(s0.symbols_)) {}
-
-    void apply(Model &) const override {
+    explicit GetAllVersions(const Model& s0) ARCTICDB_UNUSED : symbol_(*rc::gen::elementOf(s0.symbols_))
+    {
     }
 
-    void run(const Model& s0, MapStorePair &sut) const override {
+    void apply(Model&) const override
+    {
+    }
+
+    void run(const Model& s0, MapStorePair& sut) const override
+    {
         auto model_versions = s0.get_all_versions(symbol_);
         using namespace arcticdb;
         auto sut_version = get_all_versions(sut.store_, sut.map_, symbol_, true, true);
         RC_ASSERT(model_versions.size() == sut_version.size());
 
-        for(auto i = size_t{0}; i < model_versions.size(); ++i)
+        for (auto i = size_t{0}; i < model_versions.size(); ++i)
             RC_ASSERT(model_versions[i] == sut_version[i].version_id());
     }
 
-    void show(std::ostream &os) const override {
+    void show(std::ostream& os) const override
+    {
         os << "GetAllVersions(" << symbol_ << ")";
     }
 };
 
-RC_GTEST_PROP(VersionMap, Rapidcheck, ()) {
+RC_GTEST_PROP(VersionMap, Rapidcheck, ())
+{
     VersionMapModel initial_state;
     ScopedConfig max_blocks("VersionMap.MaxVersionBlocks", 1);
     ScopedConfig reload_interval("VersionMap.ReloadInterval", 0);
     auto num_symbols = *rc::gen::inRange(size_t{1}, size_t{5});
-    initial_state.symbols_ = *rc::gen::container<std::vector<std::string>>(num_symbols, rc::gen::nonEmpty(rc::gen::string<std::string>()));
+    initial_state.symbols_ =
+        *rc::gen::container<std::vector<std::string>>(num_symbols, rc::gen::nonEmpty(rc::gen::string<std::string>()));
     MapStorePair sut(false);
     rc::state::check(initial_state,
         sut,
-        rc::state::gen::execOneOfWithArgs<
-            WriteVersion<VersionMapModel>,
+        rc::state::gen::execOneOfWithArgs<WriteVersion<VersionMapModel>,
             WriteAndPrunePreviousVersion<VersionMapModel>,
             GetLatestVersion<VersionMapModel>,
             GetAllVersions<VersionMapModel>,
             DeleteAllVersions<VersionMapModel>,
-          //  DeleteRefKey<VersionMapModel>,
-            Compact<VersionMapModel>>()
-    );
+            //  DeleteRefKey<VersionMapModel>,
+            Compact<VersionMapModel>>());
 }
 
-RC_GTEST_PROP(VersionMap, RapidcheckTombstones, ()) {
+RC_GTEST_PROP(VersionMap, RapidcheckTombstones, ())
+{
     VersionMapTombstonesModel initial_state;
     auto num_symbols = *rc::gen::inRange(size_t{1}, size_t{5});
-    initial_state.symbols_ = *rc::gen::container<std::vector<std::string>>(num_symbols, rc::gen::nonEmpty(rc::gen::string<std::string>()));
+    initial_state.symbols_ =
+        *rc::gen::container<std::vector<std::string>>(num_symbols, rc::gen::nonEmpty(rc::gen::string<std::string>()));
     ScopedConfig max_blocks("VersionMap.MaxVersionBlocks", 1);
     ScopedConfig reload_interval("VersionMap.ReloadInterval", 0);
     MapStorePair sut(true);
     sut.map_->set_validate(true);
     rc::state::check(initial_state,
-                     sut,
-                     rc::state::gen::execOneOfWithArgs<
-                         WriteVersion<VersionMapTombstonesModel>,
-                         WriteAndPrunePreviousVersion<VersionMapTombstonesModel>,
-                         GetLatestVersion<VersionMapTombstonesModel>,
-                         GetAllVersions<VersionMapTombstonesModel>,
-                         DeleteAllVersions<VersionMapTombstonesModel>,
-                         Compact<VersionMapTombstonesModel>,
-                         SetUseFastTombstoneAll<VersionMapTombstonesModel>>()
-                         //CompactAndRemoveDeleted<VersionMapTombstonesModel>>()
+        sut,
+        rc::state::gen::execOneOfWithArgs<WriteVersion<VersionMapTombstonesModel>,
+            WriteAndPrunePreviousVersion<VersionMapTombstonesModel>,
+            GetLatestVersion<VersionMapTombstonesModel>,
+            GetAllVersions<VersionMapTombstonesModel>,
+            DeleteAllVersions<VersionMapTombstonesModel>,
+            Compact<VersionMapTombstonesModel>,
+            SetUseFastTombstoneAll<VersionMapTombstonesModel>>()
+        //CompactAndRemoveDeleted<VersionMapTombstonesModel>>()
 
     );
 }

--- a/cpp/arcticdb/version/test/test_append.cpp
+++ b/cpp/arcticdb/version/test/test_append.cpp
@@ -9,24 +9,20 @@
 
 #include <arcticdb/util/test/generators.hpp>
 
-
-TEST(Append, OutOfOrder) {
+TEST(Append, OutOfOrder)
+{
     using namespace arcticdb;
     auto engine = get_test_engine();
 
     SegmentsSink sink;
-    auto commit_func = [&](SegmentInMemory &&mem) {
-        sink.segments_.push_back(std::move(mem));
-    };
+    auto commit_func = [&](SegmentInMemory&& mem) { sink.segments_.push_back(std::move(mem)); };
 
-    auto agg = get_test_aggregator(std::move(commit_func), "test", {
-        FieldDescriptor{scalar_field_proto(DataType::UINT64, "uint64")}
-    });
+    auto agg = get_test_aggregator(std::move(commit_func),
+        "test",
+        {FieldDescriptor{scalar_field_proto(DataType::UINT64, "uint64")}});
 
     for (size_t i = 0; i < 10; ++i) {
-        agg.start_row(timestamp(i))([&](auto &rb) {
-            rb.set_scalar(1, i * 3);
-        });
+        agg.start_row(timestamp(i))([&](auto& rb) { rb.set_scalar(1, i * 3); });
     }
     agg.commit();
     auto& seg = sink.segments_[0];

--- a/cpp/arcticdb/version/test/test_merge.cpp
+++ b/cpp/arcticdb/version/test/test_merge.cpp
@@ -15,19 +15,18 @@
 
 struct MergeReadsTestStore : arcticdb::TestStore {
 protected:
-    std::string get_name() override {
+    std::string get_name() override
+    {
         return "test.merge_streams";
     }
 };
 
-TEST_F(MergeReadsTestStore, SimpleStaticSchema) {
+TEST_F(MergeReadsTestStore, SimpleStaticSchema)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using MergeAggregator =  Aggregator<TimeseriesIndex,
-                                          FixedSchema,
-                                          stream::RowCountSegmentPolicy,
-                                          stream::SparseColumnPolicy>;
-
+    using MergeAggregator =
+        Aggregator<TimeseriesIndex, FixedSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     using MergeSinkWrapper = SinkWrapperImpl<MergeAggregator>;
     const auto NumTests = 10;
@@ -35,27 +34,23 @@ TEST_F(MergeReadsTestStore, SimpleStaticSchema) {
     const std::string stream_id1("test_merge_1");
     const std::string stream_id2("test_merge_2");
 
-    MergeSinkWrapper wrapper1(stream_id1, {
-        scalar_field_proto(DataType::UINT64, "thing1"),
-        scalar_field_proto(DataType::UINT64, "thing2")}
-        );
+    MergeSinkWrapper wrapper1(stream_id1,
+        {scalar_field_proto(DataType::UINT64, "thing1"), scalar_field_proto(DataType::UINT64, "thing2")});
 
     auto& aggregator1 = wrapper1.aggregator_;
 
-    MergeSinkWrapper wrapper2(stream_id2, {
-        scalar_field_proto(DataType::UINT64, "thing1"),
-        scalar_field_proto(DataType::UINT64, "thing2")}
-    );
+    MergeSinkWrapper wrapper2(stream_id2,
+        {scalar_field_proto(DataType::UINT64, "thing1"), scalar_field_proto(DataType::UINT64, "thing2")});
 
     auto& aggregator2 = wrapper2.aggregator_;
 
-    for(timestamp i = 0; i < NumTests; i += 2) {
-        aggregator1.start_row(i)([&] (auto&& rb) {
+    for (timestamp i = 0; i < NumTests; i += 2) {
+        aggregator1.start_row(i)([&](auto&& rb) {
             rb.set_scalar(1, i);
             rb.set_scalar(2, i + 1);
         });
 
-        aggregator2.start_row(i + 1)([&] (auto&& rb) {
+        aggregator2.start_row(i + 1)([&](auto&& rb) {
             rb.set_scalar(1, i + 1);
             rb.set_scalar(2, i + 2);
         });
@@ -69,10 +64,14 @@ TEST_F(MergeReadsTestStore, SimpleStaticSchema) {
 
     const std::string target_id("some_merged_stuff");
     pipelines::ReadQuery read_query;
-    auto read_result = test_store_->read_dataframe_merged(target_id, {stream_id1, stream_id2}, pipelines::VersionQuery{}, read_query, ReadOptions{});
+    auto read_result = test_store_->read_dataframe_merged(target_id,
+        {stream_id1, stream_id2},
+        pipelines::VersionQuery{},
+        read_query,
+        ReadOptions{});
     const auto& frame = read_result.frame_data.frame();
 
-    for(timestamp i = 0; i < NumTests; i += 2) {
+    for (timestamp i = 0; i < NumTests; i += 2) {
         check_value(frame.scalar_at<uint64_t>(i, 2).value(), uint64_t(i));
         check_value(frame.scalar_at<uint64_t>(i, 3).value(), uint64_t(i + 1));
         check_value(frame.scalar_at<uint64_t>(i + 1, 2).value(), uint64_t(i + 1));
@@ -80,14 +79,12 @@ TEST_F(MergeReadsTestStore, SimpleStaticSchema) {
     }
 }
 
-TEST_F(MergeReadsTestStore, SparseTarget) {
+TEST_F(MergeReadsTestStore, SparseTarget)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using MergeAggregator =  Aggregator<TimeseriesIndex,
-                                        FixedSchema,
-                                        stream::RowCountSegmentPolicy,
-                                        stream::SparseColumnPolicy>;
-
+    using MergeAggregator =
+        Aggregator<TimeseriesIndex, FixedSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     using MergeSinkWrapper = SinkWrapperImpl<MergeAggregator>;
     const auto NumTests = 10;
@@ -95,27 +92,23 @@ TEST_F(MergeReadsTestStore, SparseTarget) {
     const std::string stream_id1("test_merge_1");
     const std::string stream_id2("test_merge_2");
 
-    MergeSinkWrapper wrapper1(stream_id1, {
-        scalar_field_proto(DataType::UINT64, "thing1"),
-        scalar_field_proto(DataType::UINT64, "thing2")}
-    );
+    MergeSinkWrapper wrapper1(stream_id1,
+        {scalar_field_proto(DataType::UINT64, "thing1"), scalar_field_proto(DataType::UINT64, "thing2")});
 
     auto& aggregator1 = wrapper1.aggregator_;
 
-    MergeSinkWrapper wrapper2(stream_id2, {
-        scalar_field_proto(DataType::UINT64, "thing1"),
-        scalar_field_proto(DataType::UINT64, "thing3")}
-    );
+    MergeSinkWrapper wrapper2(stream_id2,
+        {scalar_field_proto(DataType::UINT64, "thing1"), scalar_field_proto(DataType::UINT64, "thing3")});
 
     auto& aggregator2 = wrapper2.aggregator_;
 
-    for(timestamp i = 0; i < NumTests; i += 2) {
-        aggregator1.start_row(i)([&] (auto&& rb) {
+    for (timestamp i = 0; i < NumTests; i += 2) {
+        aggregator1.start_row(i)([&](auto&& rb) {
             rb.set_scalar(1, i);
             rb.set_scalar(2, i + 1);
         });
 
-        aggregator2.start_row(i + 1)([&] (auto&& rb) {
+        aggregator2.start_row(i + 1)([&](auto&& rb) {
             rb.set_scalar(1, i + 1);
             rb.set_scalar(2, i + 2);
         });
@@ -131,10 +124,14 @@ TEST_F(MergeReadsTestStore, SparseTarget) {
     ReadOptions read_options;
     read_options.set_allow_sparse(true);
     pipelines::ReadQuery read_query;
-    auto read_result = test_store_->read_dataframe_merged(target_id, {stream_id1, stream_id2}, pipelines::VersionQuery{}, read_query, read_options);
+    auto read_result = test_store_->read_dataframe_merged(target_id,
+        {stream_id1, stream_id2},
+        pipelines::VersionQuery{},
+        read_query,
+        read_options);
     const auto& frame = read_result.frame_data.frame();
 
-    for(timestamp i = 0; i < NumTests; i += 2) {
+    for (timestamp i = 0; i < NumTests; i += 2) {
         check_value(frame.scalar_at<uint64_t>(i, 2).value(), uint64_t(i));
         check_value(frame.scalar_at<uint64_t>(i, 3).value(), uint64_t(i + 1));
         check_value(frame.scalar_at<uint64_t>(i, 4).value(), uint64_t(0));
@@ -144,10 +141,12 @@ TEST_F(MergeReadsTestStore, SparseTarget) {
     }
 }
 
-TEST_F(MergeReadsTestStore, SparseSource) {
+TEST_F(MergeReadsTestStore, SparseSource)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
     using DynamicSinkWrapper = SinkWrapperImpl<DynamicAggregator>;
     const auto NumTests = 12;
 
@@ -159,23 +158,23 @@ TEST_F(MergeReadsTestStore, SparseSource) {
     DynamicSinkWrapper wrapper2(stream_id2, {});
     auto& aggregator2 = wrapper2.aggregator_;
 
-    for(timestamp i = 0; i < NumTests; i += 4) {
-        aggregator1.start_row(i)([&] (auto&& rb) {
+    for (timestamp i = 0; i < NumTests; i += 4) {
+        aggregator1.start_row(i)([&](auto&& rb) {
             rb.set_scalar_by_name("first", int64_t(i), make_scalar_type(DataType::INT64));
             rb.set_scalar_by_name("second", int64_t(i + 1), make_scalar_type(DataType::INT64));
         });
 
-        aggregator2.start_row(i + 1)([&] (auto&& rb) {
+        aggregator2.start_row(i + 1)([&](auto&& rb) {
             rb.set_scalar_by_name("first", int64_t(i + 1), make_scalar_type(DataType::INT64));
             rb.set_scalar_by_name("third", int64_t(i + 2), make_scalar_type(DataType::INT64));
         });
 
-        aggregator1.start_row(i + 2)([&] (auto&& rb) {
+        aggregator1.start_row(i + 2)([&](auto&& rb) {
             rb.set_scalar_by_name("first", int64_t(i + 2), make_scalar_type(DataType::INT64));
             rb.set_scalar_by_name("third", int64_t(i + 3), make_scalar_type(DataType::INT64));
         });
 
-        aggregator2.start_row(i + 3)([&] (auto&& rb) {
+        aggregator2.start_row(i + 3)([&](auto&& rb) {
             rb.set_scalar_by_name("first", int64_t(i + 3), make_scalar_type(DataType::INT64));
             rb.set_scalar_by_name("fourth", int64_t(i + 4), make_scalar_type(DataType::INT64));
         });
@@ -191,10 +190,14 @@ TEST_F(MergeReadsTestStore, SparseSource) {
     ReadOptions read_options;
     read_options.set_allow_sparse(true);
     pipelines::ReadQuery read_query;
-    auto read_result = test_store_->read_dataframe_merged(target_id, {stream_id1, stream_id2}, pipelines::VersionQuery{}, read_query, read_options);
+    auto read_result = test_store_->read_dataframe_merged(target_id,
+        {stream_id1, stream_id2},
+        pipelines::VersionQuery{},
+        read_query,
+        read_options);
     const auto& frame = read_result.frame_data.frame();
 
-    for(timestamp i = 0; i < NumTests; i += 4) {
+    for (timestamp i = 0; i < NumTests; i += 4) {
         check_value(frame.scalar_at<uint64_t>(i, 2).value(), uint64_t(i));
         check_value(frame.scalar_at<uint64_t>(i, 3).value(), uint64_t(i + 1));
         check_value(frame.scalar_at<uint64_t>(i, 4).value(), uint64_t(0));

--- a/cpp/arcticdb/version/test/test_snapshot.cpp
+++ b/cpp/arcticdb/version/test/test_snapshot.cpp
@@ -20,7 +20,8 @@
 #include <chrono>
 #include <thread>
 
-TEST(SnapshotCreate, Basic) {
+TEST(SnapshotCreate, Basic)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -29,7 +30,8 @@ TEST(SnapshotCreate, Basic) {
     InstanceUri instance_uri("localhost");
     auto library_path = LibraryPath::from_delim_path("test.test", '.');
     auto temp_path = std::filesystem::temp_directory_path();
-    auto library = std::make_shared<Library>(create_library(library_path, OpenMode::WRITE, arcticdb::storage::lmdb::pack_config(temp_path)));
+    auto library = std::make_shared<Library>(
+        create_library(library_path, OpenMode::WRITE, arcticdb::storage::lmdb::pack_config(temp_path)));
     auto version_store = std::make_shared<version_store::PythonVersionStore>(library);
     auto store = version_store->_test_get_store();
 
@@ -41,18 +43,15 @@ TEST(SnapshotCreate, Basic) {
 
     std::string stream_id("test_versioned_engine_write");
     VersionId version_id(0);
-    FixedSchema schema{
-            RowCountIndex::create_stream_descriptor(stream_id, {
-                    FieldDescriptor(TypeDescriptor(c1_dt, Dimension::Dim0)),
-                    FieldDescriptor(TypeDescriptor(c2_dt, Dimension::Dim0))
-            })
-    };
+    FixedSchema schema{RowCountIndex::create_stream_descriptor(stream_id,
+        {FieldDescriptor(TypeDescriptor(c1_dt, Dimension::Dim0)),
+            FieldDescriptor(TypeDescriptor(c2_dt, Dimension::Dim0))})};
 
     constexpr size_t num_rows = 100;
 
     std::vector<uint32_t> col1{num_rows};
     std::vector<double> col2{num_rows};
-    for(size_t i = 0; i < num_rows; ++i) {
+    for (size_t i = 0; i < num_rows; ++i) {
         col1.push_back(i);
         col2.push_back(double(i) / 2);
     }
@@ -60,13 +59,12 @@ TEST(SnapshotCreate, Basic) {
     stride_t c1_strides = sizeof(c1_type);
     shape_t c1_shapes = num_rows;
     ssize_t c1_bytes = c1_shapes * c1_strides;
-    auto t1 = [&]{ return NativeTensor{c1_bytes, 1, &c1_strides, &c1_shapes, c1_dt, col1.data()}; };
-
+    auto t1 = [&] { return NativeTensor{c1_bytes, 1, &c1_strides, &c1_shapes, c1_dt, col1.data()}; };
 
     stride_t c2_strides = sizeof(c2_type);
     shape_t c2_shapes = num_rows;
     ssize_t c2_bytes = c2_shapes * c2_strides;
-    auto t2 = [&]{ return NativeTensor{c2_bytes, 1, &c2_strides, &c2_shapes, c2_dt, col2.data()}; };
+    auto t2 = [&] { return NativeTensor{c2_bytes, 1, &c2_strides, &c2_shapes, c2_dt, col2.data()}; };
 
     write::SlicingPolicy slicing = write::FixedSlicer{};
 
@@ -82,7 +80,6 @@ TEST(SnapshotCreate, Basic) {
     frame.num_rows = num_rows;
 
     auto fut = write::write_frame(pk, std::move(frame), slicing, store);
-
 
     auto version_key = std::move(fut.wait().value());
     ::sleep(1);

--- a/cpp/arcticdb/version/test/test_sparse.cpp
+++ b/cpp/arcticdb/version/test/test_sparse.cpp
@@ -17,15 +17,18 @@
 
 struct SparseTestStore : arcticdb::TestStore {
 protected:
-    std::string get_name() override {
+    std::string get_name() override
+    {
         return "test.sparse";
     }
 };
 
-TEST(Sparse, Simple) {
+TEST(Sparse, Simple)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
     using DynamicSinkWrapper = SinkWrapperImpl<DynamicAggregator>;
 
     const std::string stream_id("test_sparse");
@@ -33,13 +36,11 @@ TEST(Sparse, Simple) {
     DynamicSinkWrapper wrapper(stream_id, {});
     auto& aggregator = wrapper.aggregator_;
 
-    aggregator.start_row(timestamp{0})([](auto& rb) {
-        rb.set_scalar_by_name("first", uint32_t(5), make_scalar_type(DataType::UINT32));
-    });
+    aggregator.start_row(timestamp{0})(
+        [](auto& rb) { rb.set_scalar_by_name("first", uint32_t(5), make_scalar_type(DataType::UINT32)); });
 
-    aggregator.start_row(timestamp{1})([](auto& rb) {
-        rb.set_scalar_by_name("second", uint64_t(6), make_scalar_type(DataType::UINT64));
-    });
+    aggregator.start_row(timestamp{1})(
+        [](auto& rb) { rb.set_scalar_by_name("second", uint64_t(6), make_scalar_type(DataType::UINT64)); });
 
     wrapper.aggregator_.commit();
 
@@ -55,10 +56,12 @@ TEST(Sparse, Simple) {
     ASSERT_EQ(val4, 6);
 }
 
-TEST_F(SparseTestStore, SimpleRoundtrip) {
+TEST_F(SparseTestStore, SimpleRoundtrip)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
     using DynamicSinkWrapper = SinkWrapperImpl<DynamicAggregator>;
 
     const std::string stream_id("test_sparse");
@@ -66,13 +69,11 @@ TEST_F(SparseTestStore, SimpleRoundtrip) {
     DynamicSinkWrapper wrapper(stream_id, {});
     auto& aggregator = wrapper.aggregator_;
 
-    aggregator.start_row(timestamp{0})([](auto& rb) {
-        rb.set_scalar_by_name("first",  uint32_t(5), make_scalar_type(DataType::UINT32));
-    });
+    aggregator.start_row(timestamp{0})(
+        [](auto& rb) { rb.set_scalar_by_name("first", uint32_t(5), make_scalar_type(DataType::UINT32)); });
 
-    aggregator.start_row(timestamp{1})([](auto& rb) {
-        rb.set_scalar_by_name("second",  uint64_t(6), make_scalar_type(DataType::UINT64));
-    });
+    aggregator.start_row(timestamp{1})(
+        [](auto& rb) { rb.set_scalar_by_name("second", uint64_t(6), make_scalar_type(DataType::UINT64)); });
 
     wrapper.aggregator_.commit();
 
@@ -84,8 +85,10 @@ TEST_F(SparseTestStore, SimpleRoundtrip) {
     read_options.set_incompletes(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame =read_result.frame_data.frame();;
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
 
     ASSERT_EQ(frame.row_count(), 2);
     auto val1 = frame.scalar_at<uint32_t>(0, 1);
@@ -98,10 +101,12 @@ TEST_F(SparseTestStore, SimpleRoundtrip) {
     ASSERT_EQ(val4, 6);
 }
 
-TEST_F(SparseTestStore, DenseToSparse) {
+TEST_F(SparseTestStore, DenseToSparse)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
     using DynamicSinkWrapper = SinkWrapperImpl<DynamicAggregator>;
 
     const std::string stream_id("test_sparse");
@@ -109,19 +114,16 @@ TEST_F(SparseTestStore, DenseToSparse) {
     DynamicSinkWrapper wrapper(stream_id, {});
     auto& aggregator = wrapper.aggregator_;
 
-    for(auto i = 0; i < 5; ++i) {
-        aggregator.start_row(timestamp{i})([&](auto &rb) {
-            rb.set_scalar_by_name("first",  uint32_t(i + 1), make_scalar_type(DataType::UINT32));
-        });
+    for (auto i = 0; i < 5; ++i) {
+        aggregator.start_row(timestamp{i})(
+            [&](auto& rb) { rb.set_scalar_by_name("first", uint32_t(i + 1), make_scalar_type(DataType::UINT32)); });
     }
 
-    aggregator.start_row(timestamp{5})([](auto& rb) {
-        rb.set_scalar_by_name("second",  uint64_t(6), make_scalar_type(DataType::UINT64));
-    });
+    aggregator.start_row(timestamp{5})(
+        [](auto& rb) { rb.set_scalar_by_name("second", uint64_t(6), make_scalar_type(DataType::UINT64)); });
 
-    aggregator.start_row(timestamp{6})([](auto& rb) {
-        rb.set_scalar_by_name("first",  uint32_t(7), make_scalar_type(DataType::UINT32));
-    });
+    aggregator.start_row(timestamp{6})(
+        [](auto& rb) { rb.set_scalar_by_name("first", uint32_t(7), make_scalar_type(DataType::UINT32)); });
 
     wrapper.aggregator_.commit();
 
@@ -133,12 +135,13 @@ TEST_F(SparseTestStore, DenseToSparse) {
     read_options.set_incompletes(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame =read_result.frame_data.frame();;
-
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
 
     ASSERT_EQ(frame.row_count(), 7);
-    for(int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 5; ++i) {
         auto val1 = frame.scalar_at<uint32_t>(i, 1);
         ASSERT_EQ(val1, i + 1);
     }
@@ -148,10 +151,12 @@ TEST_F(SparseTestStore, DenseToSparse) {
     ASSERT_EQ(val3, 7);
 }
 
-TEST_F(SparseTestStore, SimpleRoundtripStrings) {
+TEST_F(SparseTestStore, SimpleRoundtripStrings)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
     using DynamicSinkWrapper = SinkWrapperImpl<DynamicAggregator>;
 
     const std::string stream_id("test_sparse");
@@ -160,11 +165,15 @@ TEST_F(SparseTestStore, SimpleRoundtripStrings) {
     auto& aggregator = wrapper.aggregator_;
 
     aggregator.start_row(timestamp{0})([](auto& rb) {
-        rb.set_scalar_by_name(std::string_view{"first"}, std::string_view{"five"}, make_scalar_type(DataType::UTF_DYNAMIC64));
+        rb.set_scalar_by_name(std::string_view{"first"},
+            std::string_view{"five"},
+            make_scalar_type(DataType::UTF_DYNAMIC64));
     });
 
     aggregator.start_row(timestamp{1})([](auto& rb) {
-        rb.set_scalar_by_name(std::string_view{"second"}, std::string_view{"six"}, make_scalar_type(DataType::UTF_FIXED64));
+        rb.set_scalar_by_name(std::string_view{"second"},
+            std::string_view{"six"},
+            make_scalar_type(DataType::UTF_FIXED64));
     });
 
     wrapper.aggregator_.commit();
@@ -177,8 +186,10 @@ TEST_F(SparseTestStore, SimpleRoundtripStrings) {
     read_options.set_incompletes(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame = read_result.frame_data.frame();;
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
 
     ASSERT_EQ(frame.row_count(), 2);
     auto val1 = frame.scalar_at<PyObject*>(0, 1);
@@ -195,11 +206,13 @@ TEST_F(SparseTestStore, SimpleRoundtripStrings) {
     ASSERT_EQ(val4, "six");
 }
 
-TEST_F(SparseTestStore, Multiblock) {
+TEST_F(SparseTestStore, Multiblock)
+{
     SKIP_WIN("Works OK but fills up LMDB");
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::NeverSegmentPolicy, stream::SparseColumnPolicy>;
     using DynamicSinkWrapper = SinkWrapperImpl<DynamicAggregator>;
 
     const std::string stream_id("test_sparse");
@@ -209,13 +222,13 @@ TEST_F(SparseTestStore, Multiblock) {
 
     constexpr size_t num_rows = 1000000;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
-        aggregator.start_row(timestamp(i))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"first"},  uint32_t(i + 1), make_scalar_type(DataType::UINT32));
+    for (size_t i = 0; i < num_rows; i += 2) {
+        aggregator.start_row(timestamp(i))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"first"}, uint32_t(i + 1), make_scalar_type(DataType::UINT32));
         });
 
-        aggregator.start_row(timestamp(i + 1))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"second"},  uint64_t(i + 2), make_scalar_type(DataType::UINT64));
+        aggregator.start_row(timestamp(i + 1))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"second"}, uint64_t(i + 2), make_scalar_type(DataType::UINT64));
         });
     }
 
@@ -229,47 +242,50 @@ TEST_F(SparseTestStore, Multiblock) {
     read_options.set_incompletes(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame =read_result.frame_data.frame();;
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
+    for (size_t i = 0; i < num_rows; i += 2) {
         ASSERT_EQ(frame.row_count(), num_rows);
         auto val1 = frame.scalar_at<uint32_t>(i, 1);
         ASSERT_EQ(val1, i + 1);
         auto val2 = frame.scalar_at<uint64_t>(i, 2);
         ASSERT_EQ(val2, 0);
-        auto val3 = frame.scalar_at<uint32_t>(i+ 1, 1);
+        auto val3 = frame.scalar_at<uint32_t>(i + 1, 1);
         ASSERT_EQ(val3, 0);
         auto val4 = frame.scalar_at<uint64_t>(i + 1, 2);
         ASSERT_EQ(val4, i + 2);
     }
 }
 
-TEST_F(SparseTestStore, Segment) {
+TEST_F(SparseTestStore, Segment)
+{
     SKIP_WIN("Works OK but fills up LMDB");
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     const std::string stream_id("test_sparse");
     const auto index = TimeseriesIndex::default_index();
-    DynamicSchema schema{
-        index.create_stream_descriptor(stream_id, {}), index
-    };
+    DynamicSchema schema{index.create_stream_descriptor(stream_id, {}), index};
 
-    DynamicAggregator aggregator(std::move(schema), [&](SegmentInMemory &&segment) {
-        test_store_->append_incomplete_segment(stream_id, std::move(segment));
-    }, RowCountSegmentPolicy{1000});
+    DynamicAggregator aggregator(
+        std::move(schema),
+        [&](SegmentInMemory&& segment) { test_store_->append_incomplete_segment(stream_id, std::move(segment)); },
+        RowCountSegmentPolicy{1000});
 
     constexpr size_t num_rows = 1000000;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
-        aggregator.start_row(timestamp(i))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"first"},  uint32_t(i + 1), make_scalar_type(DataType::UINT32));
+    for (size_t i = 0; i < num_rows; i += 2) {
+        aggregator.start_row(timestamp(i))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"first"}, uint32_t(i + 1), make_scalar_type(DataType::UINT32));
         });
 
-        aggregator.start_row(timestamp(i + 1))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"second"},  uint64_t(i + 2), make_scalar_type(DataType::UINT64));
+        aggregator.start_row(timestamp(i + 1))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"second"}, uint64_t(i + 2), make_scalar_type(DataType::UINT64));
         });
     }
 
@@ -280,54 +296,58 @@ TEST_F(SparseTestStore, Segment) {
     read_options.set_incompletes(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame =read_result.frame_data.frame();;
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
+    for (size_t i = 0; i < num_rows; i += 2) {
         ASSERT_EQ(frame.row_count(), num_rows);
         auto val1 = frame.scalar_at<uint32_t>(i, 1);
         ASSERT_EQ(val1, i + 1);
         auto val2 = frame.scalar_at<uint64_t>(i, 2);
         ASSERT_EQ(val2, 0);
-        auto val3 = frame.scalar_at<uint32_t>(i+ 1, 1);
+        auto val3 = frame.scalar_at<uint32_t>(i + 1, 1);
         ASSERT_EQ(val3, 0);
         auto val4 = frame.scalar_at<uint64_t>(i + 1, 2);
         ASSERT_EQ(val4, i + 2);
     }
 }
 
-TEST_F(SparseTestStore, SegmentWithExistingIndex) {
+TEST_F(SparseTestStore, SegmentWithExistingIndex)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     const std::string stream_id("test_sparse");
 
     const auto index = TimeseriesIndex::default_index();
-    DynamicSchema schema{
-        index.create_stream_descriptor(stream_id, {}), index
-    };
+    DynamicSchema schema{index.create_stream_descriptor(stream_id, {}), index};
 
     bool written = false;
-    DynamicAggregator aggregator(std::move(schema), [&](SegmentInMemory &&segment) {
-        if(!written) {
-            test_store_->write_individual_segment(stream_id, std::move(segment), false);
-            written = true;
-        }
-        else {
-            test_store_->append_incomplete_segment(stream_id, std::move(segment));
-        }
-    }, RowCountSegmentPolicy{1000});
+    DynamicAggregator aggregator(
+        std::move(schema),
+        [&](SegmentInMemory&& segment) {
+            if (!written) {
+                test_store_->write_individual_segment(stream_id, std::move(segment), false);
+                written = true;
+            } else {
+                test_store_->append_incomplete_segment(stream_id, std::move(segment));
+            }
+        },
+        RowCountSegmentPolicy{1000});
 
     constexpr size_t num_rows = 100000;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
-        aggregator.start_row(timestamp(i))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"first"},  uint32_t(i + 1), make_scalar_type(DataType::UINT32));
+    for (size_t i = 0; i < num_rows; i += 2) {
+        aggregator.start_row(timestamp(i))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"first"}, uint32_t(i + 1), make_scalar_type(DataType::UINT32));
         });
 
-        aggregator.start_row(timestamp(i + 1))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"second"},  uint64_t(i + 2), make_scalar_type(DataType::UINT64));
+        aggregator.start_row(timestamp(i + 1))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"second"}, uint64_t(i + 2), make_scalar_type(DataType::UINT64));
         });
     }
 
@@ -338,54 +358,58 @@ TEST_F(SparseTestStore, SegmentWithExistingIndex) {
     read_options.set_incompletes(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame =read_result.frame_data.frame();;
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
 
     ASSERT_EQ(frame.row_count(), num_rows);
-    for(size_t i = 0; i < num_rows; i += 2) {
+    for (size_t i = 0; i < num_rows; i += 2) {
         auto val1 = frame.scalar_at<uint32_t>(i, 1);
         check_value(val1, i + 1);
         auto val2 = frame.scalar_at<uint64_t>(i, 2);
         check_value(val2, 0);
-        auto val3 = frame.scalar_at<uint32_t>(i+ 1, 1);
+        auto val3 = frame.scalar_at<uint32_t>(i + 1, 1);
         check_value(val3, 0);
         auto val4 = frame.scalar_at<uint64_t>(i + 1, 2);
         check_value(val4, i + 2);
     }
 }
 
-TEST_F(SparseTestStore, SegmentAndFilterColumn) {
+TEST_F(SparseTestStore, SegmentAndFilterColumn)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     const std::string stream_id("test_sparse");
 
     const auto index = TimeseriesIndex::default_index();
-    DynamicSchema schema{
-        index.create_stream_descriptor(stream_id, {}), index
-    };
+    DynamicSchema schema{index.create_stream_descriptor(stream_id, {}), index};
 
     bool written = false;
-    DynamicAggregator aggregator(std::move(schema), [&](SegmentInMemory &&segment) {
-        if(!written) {
-            test_store_->write_individual_segment(stream_id, std::move(segment), false);
-            written = true;
-        }
-        else {
-            test_store_->append_incomplete_segment(stream_id, std::move(segment));
-        }
-    }, RowCountSegmentPolicy{1000});
+    DynamicAggregator aggregator(
+        std::move(schema),
+        [&](SegmentInMemory&& segment) {
+            if (!written) {
+                test_store_->write_individual_segment(stream_id, std::move(segment), false);
+                written = true;
+            } else {
+                test_store_->append_incomplete_segment(stream_id, std::move(segment));
+            }
+        },
+        RowCountSegmentPolicy{1000});
 
     constexpr size_t num_rows = 100000;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
-        aggregator.start_row(timestamp(i))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"first"},  uint32_t(i + 1), make_scalar_type(DataType::UINT32));
+    for (size_t i = 0; i < num_rows; i += 2) {
+        aggregator.start_row(timestamp(i))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"first"}, uint32_t(i + 1), make_scalar_type(DataType::UINT32));
         });
 
-        aggregator.start_row(timestamp(i + 1))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"second"},  uint64_t(i + 2), make_scalar_type(DataType::UINT64));
+        aggregator.start_row(timestamp(i + 1))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"second"}, uint64_t(i + 2), make_scalar_type(DataType::UINT64));
         });
     }
 
@@ -397,50 +421,54 @@ TEST_F(SparseTestStore, SegmentAndFilterColumn) {
     pipelines::ReadQuery read_query;
     read_query.columns = {"time", "first"};
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame =read_result.frame_data.frame();;
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
     ASSERT_EQ(frame.row_count(), num_rows);
     ASSERT_EQ(frame.descriptor().field_count(), 2);
 
-    for(size_t i = 0; i < num_rows; i += 2) {
+    for (size_t i = 0; i < num_rows; i += 2) {
         auto val1 = frame.scalar_at<uint32_t>(i, 1);
         ASSERT_EQ(val1, i + 1);
-        auto val3 = frame.scalar_at<uint32_t>(i+ 1, 1);
+        auto val3 = frame.scalar_at<uint32_t>(i + 1, 1);
         ASSERT_EQ(val3, 0);
     }
 }
 
-TEST_F(SparseTestStore, SegmentWithRangeFilter) {
+TEST_F(SparseTestStore, SegmentWithRangeFilter)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     const std::string stream_id("test_sparse");
     const auto index = TimeseriesIndex::default_index();
-    DynamicSchema schema{
-        index.create_stream_descriptor(stream_id, {}), index
-    };
+    DynamicSchema schema{index.create_stream_descriptor(stream_id, {}), index};
 
     bool written = false;
-    DynamicAggregator aggregator(std::move(schema), [&](SegmentInMemory &&segment) {
-        if(!written) {
-            test_store_->write_individual_segment(stream_id, std::move(segment), false);
-            written = true;
-        }
-        else {
-            test_store_->append_incomplete_segment(stream_id, std::move(segment));
-        }
-    }, RowCountSegmentPolicy{1000});
+    DynamicAggregator aggregator(
+        std::move(schema),
+        [&](SegmentInMemory&& segment) {
+            if (!written) {
+                test_store_->write_individual_segment(stream_id, std::move(segment), false);
+                written = true;
+            } else {
+                test_store_->append_incomplete_segment(stream_id, std::move(segment));
+            }
+        },
+        RowCountSegmentPolicy{1000});
 
     constexpr size_t num_rows = 10000;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
-        aggregator.start_row(timestamp(i))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"first"},  uint32_t(i + 1), make_scalar_type(DataType::UINT32));
+    for (size_t i = 0; i < num_rows; i += 2) {
+        aggregator.start_row(timestamp(i))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"first"}, uint32_t(i + 1), make_scalar_type(DataType::UINT32));
         });
 
-        aggregator.start_row(timestamp(i + 1))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"second"},  uint64_t(i + 2), make_scalar_type(DataType::UINT64));
+        aggregator.start_row(timestamp(i + 1))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"second"}, uint64_t(i + 2), make_scalar_type(DataType::UINT64));
         });
     }
 
@@ -451,46 +479,53 @@ TEST_F(SparseTestStore, SegmentWithRangeFilter) {
     read_options.set_incompletes(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = IndexRange(timestamp{3000}, timestamp{6999});
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
-    const auto& frame =read_result.frame_data.frame();;
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    const auto& frame = read_result.frame_data.frame();
+    ;
 
     ASSERT_EQ(frame.row_count(), 4000);
-    for(size_t i = 0; i < frame.row_count(); i += 2) {
+    for (size_t i = 0; i < frame.row_count(); i += 2) {
         auto val1 = frame.scalar_at<uint32_t>(i, 1);
         ASSERT_EQ(val1, i + 3001);
         auto val2 = frame.scalar_at<uint64_t>(i, 2);
         ASSERT_EQ(val2, 0);
-        auto val3 = frame.scalar_at<uint32_t>(i+ 1, 1);
+        auto val3 = frame.scalar_at<uint32_t>(i + 1, 1);
         ASSERT_EQ(val3, 0);
         auto val4 = frame.scalar_at<uint64_t>(i + 1, 2);
         ASSERT_EQ(val4, i + 3002);
     }
 }
 
-TEST_F(SparseTestStore, Compact) {
+TEST_F(SparseTestStore, Compact)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     const std::string stream_id("test_sparse");
     const auto index = TimeseriesIndex::default_index();
-    DynamicSchema schema{
-        index.create_stream_descriptor(stream_id, {}), index
-    };
+    DynamicSchema schema{index.create_stream_descriptor(stream_id, {}), index};
 
-    DynamicAggregator aggregator(std::move(schema), [&](SegmentInMemory &&segment) {
-        test_store_->append_incomplete_segment(stream_id, std::move(segment));
-    }, RowCountSegmentPolicy{10});
+    DynamicAggregator aggregator(
+        std::move(schema),
+        [&](SegmentInMemory&& segment) { test_store_->append_incomplete_segment(stream_id, std::move(segment)); },
+        RowCountSegmentPolicy{10});
 
     constexpr size_t num_rows = 100;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
-        aggregator.start_row(timestamp(i))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"first"}, uint32_t(i + 1), TypeDescriptor{DataType::UINT32, Dimension::Dim0});
+    for (size_t i = 0; i < num_rows; i += 2) {
+        aggregator.start_row(timestamp(i))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"first"},
+                uint32_t(i + 1),
+                TypeDescriptor{DataType::UINT32, Dimension::Dim0});
         });
 
-        aggregator.start_row(timestamp(i + 1))([&](auto &rb) {
-            rb.set_scalar_by_name(std::string_view{"second"}, uint64_t(i + 2), TypeDescriptor{DataType::UINT64, Dimension::Dim0});
+        aggregator.start_row(timestamp(i + 1))([&](auto& rb) {
+            rb.set_scalar_by_name(std::string_view{"second"},
+                uint64_t(i + 2),
+                TypeDescriptor{DataType::UINT64, Dimension::Dim0});
         });
     }
 
@@ -501,49 +536,55 @@ TEST_F(SparseTestStore, Compact) {
     read_options.set_dynamic_schema(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
     const auto& frame = read_result.frame_data.frame();
 
     ASSERT_EQ(frame.row_count(), num_rows);
-    for(size_t i = 0; i < num_rows; i += 2) {
+    for (size_t i = 0; i < num_rows; i += 2) {
         auto val1 = frame.scalar_at<uint32_t>(i, 1);
         ASSERT_EQ(val1, i + 1);
         auto val2 = frame.scalar_at<uint64_t>(i, 2);
         ASSERT_EQ(val2, 0);
-        auto val3 = frame.scalar_at<uint32_t>(i+ 1, 1);
+        auto val3 = frame.scalar_at<uint32_t>(i + 1, 1);
         ASSERT_EQ(val3, 0);
         auto val4 = frame.scalar_at<uint64_t>(i + 1, 2);
         ASSERT_EQ(val4, i + 2);
     }
 }
 
-TEST_F(SparseTestStore, CompactWithStrings) {
+TEST_F(SparseTestStore, CompactWithStrings)
+{
     using namespace arcticdb;
     using namespace arcticdb::stream;
-    using DynamicAggregator =  Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
+    using DynamicAggregator =
+        Aggregator<TimeseriesIndex, DynamicSchema, stream::RowCountSegmentPolicy, stream::SparseColumnPolicy>;
 
     const std::string stream_id("test_sparse");
 
     const auto index = TimeseriesIndex::default_index();
-    DynamicSchema schema{
-        index.create_stream_descriptor(stream_id, {}), index
-    };
+    DynamicSchema schema{index.create_stream_descriptor(stream_id, {}), index};
 
-    DynamicAggregator aggregator(std::move(schema), [&](SegmentInMemory &&segment) {
-        test_store_->append_incomplete_segment(stream_id, std::move(segment));
-    }, RowCountSegmentPolicy{10});
+    DynamicAggregator aggregator(
+        std::move(schema),
+        [&](SegmentInMemory&& segment) { test_store_->append_incomplete_segment(stream_id, std::move(segment)); },
+        RowCountSegmentPolicy{10});
 
     constexpr size_t num_rows = 100;
 
-    for(size_t i = 0; i < num_rows; i += 2) {
-        aggregator.start_row(timestamp(i))([&](auto &rb) {
+    for (size_t i = 0; i < num_rows; i += 2) {
+        aggregator.start_row(timestamp(i))([&](auto& rb) {
             auto val = fmt::format("{}", i + 1);
-            rb.set_scalar_by_name(std::string_view{"first"}, std::string_view{val}, make_scalar_type(DataType::UTF_DYNAMIC64));
+            rb.set_scalar_by_name(std::string_view{"first"},
+                std::string_view{val},
+                make_scalar_type(DataType::UTF_DYNAMIC64));
         });
 
-        aggregator.start_row(timestamp(i + 1))([&](auto &rb) {
+        aggregator.start_row(timestamp(i + 1))([&](auto& rb) {
             auto val = fmt::format("{}", i + 2);
-            rb.set_scalar_by_name(std::string_view{"second"}, std::string_view{val}, make_scalar_type(DataType::UTF_FIXED64));
+            rb.set_scalar_by_name(std::string_view{"second"},
+                std::string_view{val},
+                make_scalar_type(DataType::UTF_FIXED64));
         });
     }
 
@@ -554,11 +595,12 @@ TEST_F(SparseTestStore, CompactWithStrings) {
     read_options.set_dynamic_schema(true);
     pipelines::ReadQuery read_query;
     read_query.row_filter = universal_range();
-    auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
+    auto read_result =
+        test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options);
     const auto& frame = read_result.frame_data.frame();
     ASSERT_EQ(frame.row_count(), num_rows);
 
-    for(size_t i = 0; i < num_rows; i += 2) {
+    for (size_t i = 0; i < num_rows; i += 2) {
         auto val1 = frame.scalar_at<PyObject*>(i, 1);
         auto str_wrapper = convert::py_unicode_to_buffer(val1.value());
         auto expected = fmt::format("{}", i + 1);

--- a/cpp/arcticdb/version/test/test_version_common.hpp
+++ b/cpp/arcticdb/version/test/test_version_common.hpp
@@ -17,11 +17,11 @@ namespace fg = folly::gen;
 const uint64_t NumVersions = 10;
 const uint64_t NumValues = 10;
 
-inline std::vector<uint64_t> generate_version_values(uint64_t version) {
+inline std::vector<uint64_t> generate_version_values(uint64_t version)
+{
     std::vector<uint64_t> output;
     for (uint64_t i = 0; i < NumValues; ++i)
         output.push_back(version++ * 3);
 
     return output;
 }
-

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -24,20 +24,20 @@
 
 struct VersionStoreTest : arcticdb::TestStore {
 protected:
-    std::string get_name() override {
+    std::string get_name() override
+    {
         return "test.version_store";
     }
 };
 
-auto write_version_frame(
-    const StreamId& stream_id,
+auto write_version_frame(const StreamId& stream_id,
     VersionId v_id,
     arcticdb::version_store::PythonVersionStore& pvs,
     size_t rows = 1000000,
     bool update_version_map = false,
     size_t start_val = 0,
-    const std::shared_ptr<arcticdb::DeDupMap>& de_dup_map = std::make_shared<arcticdb::DeDupMap>()
-) {
+    const std::shared_ptr<arcticdb::DeDupMap>& de_dup_map = std::make_shared<arcticdb::DeDupMap>())
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -57,7 +57,8 @@ auto write_version_frame(
     return key;
 }
 
-TEST(PythonVersionStore, FreesMemory) {
+TEST(PythonVersionStore, FreesMemory)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -72,7 +73,8 @@ TEST(PythonVersionStore, FreesMemory) {
     ASSERT_TRUE(Allocator::empty());
 }
 
-TEST(PythonVersionStore, DeleteDatabase) {
+TEST(PythonVersionStore, DeleteDatabase)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -87,7 +89,8 @@ TEST(PythonVersionStore, DeleteDatabase) {
     ASSERT_EQ(mock_store->num_ref_keys(), 0);
 }
 
-TEST(PythonVersionStore, WriteWithPruneVersions) {
+TEST(PythonVersionStore, WriteWithPruneVersions)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -101,7 +104,8 @@ TEST(PythonVersionStore, WriteWithPruneVersions) {
     ASSERT_EQ(mock_store->num_atom_keys_of_type(KeyType::TABLE_INDEX), 1);
 }
 
-TEST(PythonVersionStore, DeleteAllVersions) {
+TEST(PythonVersionStore, DeleteAllVersions)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -117,7 +121,8 @@ TEST(PythonVersionStore, DeleteAllVersions) {
     ASSERT_EQ(mock_store->num_atom_keys_of_type(KeyType::TABLE_INDEX), 0);
 }
 
-TEST(PythonVersionStore, IterationVsRefWrite) {
+TEST(PythonVersionStore, IterationVsRefWrite)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -154,14 +159,17 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     version_map->load_via_iteration(mock_store, stream_id, iter_entry_compact);
     version_map->load_via_ref_key(mock_store, stream_id, LoadParameter{LoadType::LOAD_ALL}, ref_entry_compact);
 
-    EXPECT_EQ(std::string(iter_entry_compact->head_.value().view()), std::string(ref_entry_compact->head_.value().view()));
+    EXPECT_EQ(std::string(iter_entry_compact->head_.value().view()),
+        std::string(ref_entry_compact->head_.value().view()));
     ASSERT_EQ(iter_entry_compact->keys_.size(), ref_entry_compact->keys_.size());
     for (size_t idx = 0; idx != iter_entry_compact->keys_.size(); idx++) {
-        EXPECT_EQ(std::string(iter_entry_compact->keys_[idx].view()), std::string(ref_entry_compact->keys_[idx].view()));
+        EXPECT_EQ(std::string(iter_entry_compact->keys_[idx].view()),
+            std::string(ref_entry_compact->keys_[idx].view()));
     }
 }
 
-TEST_F(VersionStoreTest, SortMerge) {
+TEST_F(VersionStoreTest, SortMerge)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -173,32 +181,31 @@ TEST_F(VersionStoreTest, SortMerge) {
     StreamId symbol{"compact_me"};
 
     for (auto i = 0; i < 10; ++i) {
-        auto wrapper = SinkWrapper(symbol, {
-            scalar_field_proto(DataType::UINT64, "thing1"),
-            scalar_field_proto(DataType::UINT64,  "thing2")
-        });
+        auto wrapper = SinkWrapper(symbol,
+            {scalar_field_proto(DataType::UINT64, "thing1"), scalar_field_proto(DataType::UINT64, "thing2")});
 
-        for(auto j = 0; j < 20; ++j ) {
-            wrapper.aggregator_.start_row(timestamp(count++))([&](auto &&rb) {
+        for (auto j = 0; j < 20; ++j) {
+            wrapper.aggregator_.start_row(timestamp(count++))([&](auto&& rb) {
                 rb.set_scalar(1, j);
                 rb.set_scalar(2, i + j);
             });
         }
 
         wrapper.aggregator_.commit();
-        data.emplace_back( SegmentToInputFrameAdapter{std::move(wrapper.segment())});
+        data.emplace_back(SegmentToInputFrameAdapter{std::move(wrapper.segment())});
     }
     std::mt19937 mt{42};
     std::shuffle(data.begin(), data.end(), mt);
 
-    for(auto&& frame : data) {
+    for (auto&& frame : data) {
         test_store_->append_incomplete_frame(symbol, std::move(frame.input_frame_));
     }
 
     test_store_->sort_merge_internal(symbol, std::nullopt, true, false, false, false);
 }
 
-TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
+TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -210,15 +217,14 @@ TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
     StreamId symbol{"compact_me_dynamic"};
 
     for (size_t i = 0; i < 10; ++i) {
-        auto wrapper = SinkWrapper(symbol, {
-            scalar_field_proto(DataType::UINT64, "thing1"),
-            scalar_field_proto(DataType::UINT64, "thing2"),
-            scalar_field_proto(DataType::UINT64, "thing3"),
-            scalar_field_proto(DataType::UINT64, "thing4")
-        });
+        auto wrapper = SinkWrapper(symbol,
+            {scalar_field_proto(DataType::UINT64, "thing1"),
+                scalar_field_proto(DataType::UINT64, "thing2"),
+                scalar_field_proto(DataType::UINT64, "thing3"),
+                scalar_field_proto(DataType::UINT64, "thing4")});
 
-        for(size_t j = 0; j < 20; ++j ) {
-            wrapper.aggregator_.start_row(timestamp(count++))([&](auto &&rb) {
+        for (size_t j = 0; j < 20; ++j) {
+            wrapper.aggregator_.start_row(timestamp(count++))([&](auto&& rb) {
                 rb.set_scalar(1, j);
                 rb.set_scalar(2, i);
                 rb.set_scalar(3, i + j);
@@ -228,12 +234,12 @@ TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
 
         wrapper.aggregator_.commit();
         wrapper.segment().drop_column((i % 3) + 1);
-        data.emplace_back( SegmentToInputFrameAdapter{std::move(wrapper.segment())});
+        data.emplace_back(SegmentToInputFrameAdapter{std::move(wrapper.segment())});
     }
     std::mt19937 mt{42};
     std::shuffle(data.begin(), data.end(), mt);
 
-    for(auto& frame : data) {
+    for (auto& frame : data) {
         test_store_->write_parallel_frame(symbol, std::move(frame.input_frame_));
     }
 
@@ -243,26 +249,26 @@ TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
     const auto& seg = read_result.frame_data.frame();
 
     count = 0;
-    auto col1_pos = seg.column_index( "thing1").value();
-    auto col2_pos = seg.column_index( "thing2").value();
-    auto col3_pos = seg.column_index( "thing3").value();
-    auto col4_pos = seg.column_index( "thing4").value();
+    auto col1_pos = seg.column_index("thing1").value();
+    auto col2_pos = seg.column_index("thing2").value();
+    auto col3_pos = seg.column_index("thing3").value();
+    auto col4_pos = seg.column_index("thing4").value();
 
     for (size_t i = 0; i < 10; ++i) {
         auto dropped_column = (i % 3) + 1;
-        for(size_t j = 0; j < 20; ++j ) {
+        for (size_t j = 0; j < 20; ++j) {
             auto idx = seg.scalar_at<uint64_t>(count, 0);
             ASSERT_EQ(idx.value(), count);
             auto v1 = seg.scalar_at<uint64_t>(count, col1_pos);
             auto expected = dropped_column == 1 ? 0 : j;
             ASSERT_EQ(v1.value(), expected);
-            auto v2 = seg.scalar_at<uint64_t>(count , col2_pos);
+            auto v2 = seg.scalar_at<uint64_t>(count, col2_pos);
             expected = dropped_column == 2 ? 0 : i;
             ASSERT_EQ(v2.value(), expected);
             auto v3 = seg.scalar_at<uint64_t>(count, col3_pos);
             expected = dropped_column == 3 ? 0 : i + j;
             ASSERT_EQ(v3.value(), expected);
-            auto v4 = seg.scalar_at<uint64_t>(count , col4_pos);
+            auto v4 = seg.scalar_at<uint64_t>(count, col4_pos);
             expected = dropped_column == 4 ? 0 : i * j;
             ASSERT_EQ(v4.value(), expected);
             ++count;
@@ -270,7 +276,8 @@ TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
     }
 }
 
-TEST_F(VersionStoreTest, GetIncompleteSymbols) {
+TEST_F(VersionStoreTest, GetIncompleteSymbols)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -291,12 +298,13 @@ TEST_F(VersionStoreTest, GetIncompleteSymbols) {
     auto& frame3 = wrapper3.frame_;
     test_store_->append_incomplete_frame(stream_id3, std::move(frame3));
 
-    std::set<StreamId> expected{ stream_id1, stream_id2, stream_id3};
+    std::set<StreamId> expected{stream_id1, stream_id2, stream_id3};
     auto result = test_store_->get_incomplete_symbols();
     ASSERT_EQ(result, expected);
 }
 
-TEST_F(VersionStoreTest, StressBatchWrite) {
+TEST_F(VersionStoreTest, StressBatchWrite)
+{
     SKIP_WIN("Works OK but fills up LMDB");
     using namespace arcticdb;
     using namespace arcticdb::storage;
@@ -309,7 +317,7 @@ TEST_F(VersionStoreTest, StressBatchWrite) {
     std::vector<VersionId> version_ids;
     std::vector<std::shared_ptr<DeDupMap>> dedup_maps;
 
-    for(int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 1000; ++i) {
         auto symbol = fmt::format("symbol_{}", i);
         symbols.emplace_back(symbol);
         version_ids.push_back(0);
@@ -323,98 +331,116 @@ TEST_F(VersionStoreTest, StressBatchWrite) {
     test_store_->batch_write_internal(version_ids, symbols, frames, dedup_maps, false);
 }
 
-TEST_F(VersionStoreTest, StressBatchReadUncompressed) {
+TEST_F(VersionStoreTest, StressBatchReadUncompressed)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
     using namespace arcticdb::pipelines;
 
     std::vector<StreamId> symbols;
-    for(int i = 0; i < 10; ++i) {
+    for (int i = 0; i < 10; ++i) {
         auto symbol = fmt::format("symbol_{}", i);
         symbols.emplace_back(symbol);
 
-        for(int j = 0; j < 10; ++j) {
+        for (int j = 0; j < 10; ++j) {
             auto wrapper = get_test_simple_frame(symbol, 10, i + j);
             test_store_->write_versioned_dataframe_internal(symbol, std::move(wrapper.frame_), false, false, false);
         }
 
-        for(int k = 1; k < 10; ++k) {
+        for (int k = 1; k < 10; ++k) {
             test_store_->delete_version(symbol, k);
         }
     }
 
     std::vector<ReadQuery> read_queries;
     auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>{}, read_queries, ReadOptions{});
-    for(auto version : folly::enumerate(latest_versions)) {
+    for (auto version : folly::enumerate(latest_versions)) {
         auto expected = get_test_simple_frame(version->item.symbol(), 10, version.index);
         bool equal = expected.segment_ == version->frame_data.frame();
         ASSERT_EQ(equal, true);
     }
 }
 
-#define THREE_SIMPLE_KEYS \
-    auto key1 = atom_key_builder().version_id(1).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(3).start_index( \
-        4).end_index(5).build(id, KeyType::TABLE_INDEX); \
-    auto key2 = atom_key_builder().version_id(2).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(4).start_index(  \
-        5).end_index(6).build(id, KeyType::TABLE_INDEX); \
-    auto key3 = atom_key_builder().version_id(3).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(5).start_index(  \
-        6).end_index(7).build(id, KeyType::TABLE_INDEX);
+#define THREE_SIMPLE_KEYS                                                                                              \
+    auto key1 = atom_key_builder()                                                                                     \
+                    .version_id(1)                                                                                     \
+                    .creation_ts(PilotedClock::nanos_since_epoch())                                                    \
+                    .content_hash(3)                                                                                   \
+                    .start_index(4)                                                                                    \
+                    .end_index(5)                                                                                      \
+                    .build(id, KeyType::TABLE_INDEX);                                                                  \
+    auto key2 = atom_key_builder()                                                                                     \
+                    .version_id(2)                                                                                     \
+                    .creation_ts(PilotedClock::nanos_since_epoch())                                                    \
+                    .content_hash(4)                                                                                   \
+                    .start_index(5)                                                                                    \
+                    .end_index(6)                                                                                      \
+                    .build(id, KeyType::TABLE_INDEX);                                                                  \
+    auto key3 = atom_key_builder()                                                                                     \
+                    .version_id(3)                                                                                     \
+                    .creation_ts(PilotedClock::nanos_since_epoch())                                                    \
+                    .content_hash(5)                                                                                   \
+                    .start_index(6)                                                                                    \
+                    .end_index(7)                                                                                      \
+                    .build(id, KeyType::TABLE_INDEX);
 
+TEST(VersionStore, TestReadTimestampAt)
+{
 
-TEST(VersionStore, TestReadTimestampAt) {
+    using namespace arcticdb;
+    using namespace arcticdb::storage;
+    using namespace arcticdb::stream;
+    using namespace arcticdb::pipelines;
+    PilotedClock::reset();
 
-  using namespace arcticdb;
-  using namespace arcticdb::storage;
-  using namespace arcticdb::stream;
-  using namespace arcticdb::pipelines;
-  PilotedClock::reset();
+    StreamId id{"test"};
+    THREE_SIMPLE_KEYS
 
-  StreamId id{"test"};
-  THREE_SIMPLE_KEYS
+    auto [version_store, mock_store] = python_version_store_in_memory();
 
-  auto [version_store, mock_store] = python_version_store_in_memory();
+    auto version_map = version_store._test_get_version_map();
+    version_map->write_version(mock_store, key1);
+    auto key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
+    ASSERT_EQ(key.value().content_hash(), 3);
 
-  auto version_map = version_store._test_get_version_map();
-  version_map->write_version(mock_store, key1);
-  auto key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
-  ASSERT_EQ(key.value().content_hash(), 3);
+    version_map->write_version(mock_store, key2);
+    key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
+    ASSERT_EQ(key.value().content_hash(), 3);
+    key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
+    ASSERT_EQ(key.value().content_hash(), 4);
 
-  version_map->write_version(mock_store, key2);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
-  ASSERT_EQ(key.value().content_hash(), 3);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
-  ASSERT_EQ(key.value().content_hash(), 4);
-
-  version_map->write_version(mock_store, key3);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
-  ASSERT_EQ(key.value().content_hash(), 3);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
-  ASSERT_EQ(key.value().content_hash(), 4);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(2), true, false);
-  ASSERT_EQ(key.value().content_hash(), 5);
+    version_map->write_version(mock_store, key3);
+    key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
+    ASSERT_EQ(key.value().content_hash(), 3);
+    key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
+    ASSERT_EQ(key.value().content_hash(), 4);
+    key = get_version_key_from_time(mock_store, version_map, id, timestamp(2), true, false);
+    ASSERT_EQ(key.value().content_hash(), 5);
 }
 
-TEST(VersionStore, TestReadTimestampAtInequality) {
+TEST(VersionStore, TestReadTimestampAtInequality)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
     using namespace arcticdb::pipelines;
 
-  PilotedClock::reset();
-  StreamId id{"test"};
+    PilotedClock::reset();
+    StreamId id{"test"};
 
-  THREE_SIMPLE_KEYS
-  auto [version_store, mock_store] = python_version_store_in_memory();
+    THREE_SIMPLE_KEYS
+    auto [version_store, mock_store] = python_version_store_in_memory();
 
-  auto version_map = version_store._test_get_version_map();
-  version_map->write_version(mock_store, key1);
-  auto key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
-  ASSERT_EQ(static_cast<bool>(key), true);
-  ASSERT_EQ(key.value().content_hash(), 3);
+    auto version_map = version_store._test_get_version_map();
+    version_map->write_version(mock_store, key1);
+    auto key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
+    ASSERT_EQ(static_cast<bool>(key), true);
+    ASSERT_EQ(key.value().content_hash(), 3);
 }
 
-TEST(VersionStore, UpdateWithin) {
+TEST(VersionStore, UpdateWithin)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -429,36 +455,36 @@ TEST(VersionStore, UpdateWithin) {
     size_t num_rows{100};
     size_t start_val{0};
 
-    std::vector<FieldDescriptor::Proto> fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing4")
-    };
+        scalar_field_proto(DataType::UINT16, "thing4")};
 
-    auto test_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
+    auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
 
     RowRange update_range{10, 15};
     size_t update_val{1};
-    auto update_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
+    auto update_frame =
+        get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
     const auto& seg = read_result.second.frame_;
 
-    for(auto i = 0u; i < num_rows; ++i) {
+    for (auto i = 0u; i < num_rows; ++i) {
         auto expected = i;
-        if(update_range.contains(i))
+        if (update_range.contains(i))
             expected += update_val;
 
-        auto val1 = seg.scalar_at<uint8_t >(i, 1);
+        auto val1 = seg.scalar_at<uint8_t>(i, 1);
         ASSERT_EQ(val1.value(), expected);
     }
 }
 
-TEST(VersionStore, UpdateBefore) {
+TEST(VersionStore, UpdateBefore)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -471,36 +497,36 @@ TEST(VersionStore, UpdateBefore) {
     size_t num_rows{100};
     size_t start_val{10};
 
-    std::vector<FieldDescriptor::Proto> fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing4")
-    };
+        scalar_field_proto(DataType::UINT16, "thing4")};
 
-    auto test_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
+    auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
 
     RowRange update_range{0, 10};
     size_t update_val{1};
-    auto update_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
+    auto update_frame =
+        get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
     const auto& seg = read_result.second.frame_;
 
-    for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
+    for (auto i = 0u; i < num_rows + update_range.diff(); ++i) {
         auto expected = i;
-        if(update_range.contains(i))
+        if (update_range.contains(i))
             expected += update_val;
 
-        auto val1 = seg.scalar_at<uint8_t >(i, 1);
+        auto val1 = seg.scalar_at<uint8_t>(i, 1);
         ASSERT_EQ(val1.value(), expected);
     }
 }
 
-TEST(VersionStore, UpdateAfter) {
+TEST(VersionStore, UpdateAfter)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -513,36 +539,36 @@ TEST(VersionStore, UpdateAfter) {
     size_t num_rows{100};
     size_t start_val{0};
 
-    std::vector<FieldDescriptor::Proto> fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing4")
-    };
+        scalar_field_proto(DataType::UINT16, "thing4")};
 
-    auto test_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
+    auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
 
     RowRange update_range{100, 110};
     size_t update_val{1};
-    auto update_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
+    auto update_frame =
+        get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
     const auto& seg = read_result.second.frame_;
 
-    for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
+    for (auto i = 0u; i < num_rows + update_range.diff(); ++i) {
         auto expected = i;
-        if(update_range.contains(i))
+        if (update_range.contains(i))
             expected += update_val;
 
-        auto val1 = seg.scalar_at<uint8_t >(i, 1);
+        auto val1 = seg.scalar_at<uint8_t>(i, 1);
         ASSERT_EQ(val1.value(), expected);
     }
 }
 
-TEST(VersionStore, UpdateIntersectBefore) {
+TEST(VersionStore, UpdateIntersectBefore)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -555,12 +581,10 @@ TEST(VersionStore, UpdateIntersectBefore) {
     size_t num_rows{100};
     size_t start_val{5};
 
-    std::vector<FieldDescriptor::Proto> fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing4")
-    };
+        scalar_field_proto(DataType::UINT16, "thing4")};
 
     auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
@@ -572,9 +596,8 @@ TEST(VersionStore, UpdateIntersectBefore) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    const auto& seg = read_result.second.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
         auto expected = i;
@@ -586,7 +609,8 @@ TEST(VersionStore, UpdateIntersectBefore) {
     }
 }
 
-TEST(VersionStore, UpdateIntersectAfter) {
+TEST(VersionStore, UpdateIntersectAfter)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -599,12 +623,10 @@ TEST(VersionStore, UpdateIntersectAfter) {
     size_t num_rows{100};
     size_t start_val{0};
 
-    std::vector<FieldDescriptor::Proto> fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing4")
-    };
+        scalar_field_proto(DataType::UINT16, "thing4")};
 
     auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
@@ -616,9 +638,8 @@ TEST(VersionStore, UpdateIntersectAfter) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    const auto& seg = read_result.second.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
         auto expected = i;
@@ -630,7 +651,8 @@ TEST(VersionStore, UpdateIntersectAfter) {
     }
 }
 
-TEST(VersionStore, UpdateWithinSchemaChange) {
+TEST(VersionStore, UpdateWithinSchemaChange)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -643,37 +665,36 @@ TEST(VersionStore, UpdateWithinSchemaChange) {
     size_t num_rows{100};
     size_t start_val{0};
 
-    std::vector<FieldDescriptor::Proto> fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing4")
-    };
+        scalar_field_proto(DataType::UINT16, "thing4")};
 
     auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
-    version_store.
-        write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
+    version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
 
     RowRange update_range{10, 15};
     size_t update_val{1};
 
-    std::vector<FieldDescriptor::Proto> update_fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> update_fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing5")
-    };
+        scalar_field_proto(DataType::UINT16, "thing5")};
 
-    auto update_frame = get_test_frame<stream::TimeseriesIndex>(symbol, update_fields, update_range.diff(), update_range.first, update_val);
+    auto update_frame = get_test_frame<stream::TimeseriesIndex>(symbol,
+        update_fields,
+        update_range.diff(),
+        update_range.first,
+        update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, true, false);
 
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
-    const auto &seg = read_result.second.frame_;
+    const auto& seg = read_result.second.frame_;
 
-    for (auto i = 0u;i < num_rows; ++i) {
+    for (auto i = 0u; i < num_rows; ++i) {
         auto expected = i;
         if (update_range.contains(i))
             expected += update_val;
@@ -691,7 +712,8 @@ TEST(VersionStore, UpdateWithinSchemaChange) {
     }
 }
 
-TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
+TEST(VersionStore, UpdateWithinTypeAndSchemaChange)
+{
     using namespace arcticdb;
     using namespace arcticdb::storage;
     using namespace arcticdb::stream;
@@ -705,12 +727,10 @@ TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
     size_t num_rows{100};
     size_t start_val{0};
 
-    std::vector<FieldDescriptor::Proto> fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT8, "thing2"),
         scalar_field_proto(DataType::UINT16, "thing3"),
-        scalar_field_proto(DataType::UINT16, "thing4")
-    };
+        scalar_field_proto(DataType::UINT16, "thing4")};
 
     auto test_frame = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
@@ -718,23 +738,25 @@ TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
     RowRange update_range{10, 15};
     size_t update_val{1};
 
-    std::vector<FieldDescriptor::Proto> update_fields{
-        scalar_field_proto(DataType::UINT8, "thing1"),
+    std::vector<FieldDescriptor::Proto> update_fields{scalar_field_proto(DataType::UINT8, "thing1"),
         scalar_field_proto(DataType::UINT16, "thing2"),
         scalar_field_proto(DataType::UINT32, "thing3"),
-        scalar_field_proto(DataType::UINT32, "thing5")
-    };
+        scalar_field_proto(DataType::UINT32, "thing5")};
 
-    auto update_frame = get_test_frame<stream::TimeseriesIndex>(symbol, update_fields, update_range.diff(), update_range.first, update_val);
+    auto update_frame = get_test_frame<stream::TimeseriesIndex>(symbol,
+        update_fields,
+        update_range.diff(),
+        update_range.first,
+        update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, true, false);
 
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
-    const auto &seg = read_result.second.frame_;
+    const auto& seg = read_result.second.frame_;
 
-    for (auto i = 0u;i < num_rows; ++i) {
+    for (auto i = 0u; i < num_rows; ++i) {
         auto expected = i;
         if (update_range.contains(i))
             expected += update_val;
@@ -752,7 +774,8 @@ TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
     }
 }
 
-TEST(VersionStore, TestWriteAppendMapHead) {
+TEST(VersionStore, TestWriteAppendMapHead)
+{
 
     using namespace arcticdb;
     using namespace arcticdb::storage;
@@ -765,19 +788,21 @@ TEST(VersionStore, TestWriteAppendMapHead) {
     auto version_store = get_test_engine();
     size_t num_rows{100};
 
-    std::vector<FieldDescriptor> fields{
-        FieldDescriptor{ scalar_field_proto(DataType::UINT8, "thing1") },
-        FieldDescriptor{ scalar_field_proto(DataType::UINT8, "thing2") },
-        FieldDescriptor{ scalar_field_proto(DataType::UINT16, "thing3") },
-        FieldDescriptor{scalar_field_proto(DataType::UINT16, "thing4") }
-    };
+    std::vector<FieldDescriptor> fields{FieldDescriptor{scalar_field_proto(DataType::UINT8, "thing1")},
+        FieldDescriptor{scalar_field_proto(DataType::UINT8, "thing2")},
+        FieldDescriptor{scalar_field_proto(DataType::UINT16, "thing3")},
+        FieldDescriptor{scalar_field_proto(DataType::UINT16, "thing4")}};
 
-    auto key = atom_key_builder().version_id(0).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(0).build(symbol, KeyType::APPEND_DATA);
+    auto key = atom_key_builder()
+                   .version_id(0)
+                   .creation_ts(PilotedClock::nanos_since_epoch())
+                   .content_hash(0)
+                   .build(symbol, KeyType::APPEND_DATA);
 
-    auto descriptor = StreamDescriptor{symbol, IndexDescriptor{1u, IndexDescriptor::TIMESTAMP}, fields_proto_from_range(fields)};
+    auto descriptor =
+        StreamDescriptor{symbol, IndexDescriptor{1u, IndexDescriptor::TIMESTAMP}, fields_proto_from_range(fields)};
     stream::write_head(version_store._test_get_store(), key, num_rows);
     auto [next_key, total_rows] = stream::read_head(version_store._test_get_store(), symbol);
     ASSERT_EQ(next_key, key);
     ASSERT_EQ(total_rows, num_rows);
 }
-

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -9,13 +9,13 @@
 
 namespace arcticdb {
 
-std::deque<AtomKey> backwards_compat_delete_all_versions(
-    const std::shared_ptr<Store> store,
+std::deque<AtomKey> backwards_compat_delete_all_versions(const std::shared_ptr<Store> store,
     std::shared_ptr<VersionMap>& version_map,
-    const StreamId& stream_id
-    ) {
+    const StreamId& stream_id)
+{
     std::deque<AtomKey> output;
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
+    auto entry =
+        version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
     output.assign(std::begin(indexes), std::end(indexes));
 
@@ -27,11 +27,15 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
     return output;
 }
 
-std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<Store> store, std::shared_ptr<VersionMap>& version_map, const AtomKey &key) {
+std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<Store> store,
+    std::shared_ptr<VersionMap>& version_map,
+    const AtomKey& key)
+{
     log::version().debug("Version map pruning previous versions for stream {}", key.id());
 
     std::vector<AtomKey> output;
-    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
+    auto entry =
+        version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
 
     auto old_entry = *entry;
     entry->clear();
@@ -39,9 +43,9 @@ std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<S
     version_map->remove_entry_version_keys(store, old_entry, key.id());
     output = old_entry.get_indexes(false);
 
-    if(version_map->log_changes())
+    if (version_map->log_changes())
         log_write(store, key.id(), key.version_id());
 
     return output;
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/version/test/version_map_model.hpp
+++ b/cpp/arcticdb/version/test/version_map_model.hpp
@@ -16,48 +16,59 @@
 namespace arcticdb {
 
 AtomKey make_test_index_key(std::string id,
-                           VersionId version_id,
-                           KeyType key_type,
-                           IndexValue index_start = 0,
-                           IndexValue index_end = 0,
-                           timestamp creation_ts = PilotedClock::nanos_since_epoch()) {
-    return atom_key_builder().version_id(version_id).start_index(index_start).end_index(index_end).creation_ts(
-            creation_ts)
-        .content_hash(0).build(id, key_type);
+    VersionId version_id,
+    KeyType key_type,
+    IndexValue index_start = 0,
+    IndexValue index_end = 0,
+    timestamp creation_ts = PilotedClock::nanos_since_epoch())
+{
+    return atom_key_builder()
+        .version_id(version_id)
+        .start_index(index_start)
+        .end_index(index_end)
+        .creation_ts(creation_ts)
+        .content_hash(0)
+        .build(id, key_type);
 }
 
 struct MapStorePair {
     const bool tombstones_;
 
-    MapStorePair(bool tombstones) :
-    tombstones_(tombstones),
-    store_(std::make_shared<InMemoryStore>()) {
+    MapStorePair(bool tombstones)
+        : tombstones_(tombstones),
+          store_(std::make_shared<InMemoryStore>())
+    {
     }
 
-    void write_version(const std::string &id) {
+    void write_version(const std::string& id)
+    {
         log::version().info("MapStorePair, write version {}", id);
         auto prev = get_latest_version(store_, map_, id, true, true);
         auto version_id = prev ? prev.value().version_id() + 1 : 0;
         map_->write_version(store_, make_test_index_key(id, version_id, KeyType::TABLE_INDEX));
     }
 
-    void delete_all_versions(const std::string &id) {
+    void delete_all_versions(const std::string& id)
+    {
         log::version().info("MapStorePair, delete_all_versions {}", id);
-        if(tombstones_)
+        if (tombstones_)
             map_->delete_all_versions(store_, id);
         else
             backwards_compat_delete_all_versions(store_, map_, id);
     }
 
-    void write_and_prune_previous(const std::string &id) {
+    void write_and_prune_previous(const std::string& id)
+    {
         log::version().info("MapStorePair, write_and_prune_previous version {}", id);
         auto prev = get_latest_version(store_, map_, id, true, true);
         auto version_id = prev ? prev.value().version_id() + 1 : 0;
 
-        if(tombstones_)
-            map_->write_and_prune_previous(store_,  make_test_index_key(id, version_id, KeyType::TABLE_INDEX), prev);
+        if (tombstones_)
+            map_->write_and_prune_previous(store_, make_test_index_key(id, version_id, KeyType::TABLE_INDEX), prev);
         else
-            backwards_compat_write_and_prune_previous(store_, map_, make_test_index_key(id, version_id, KeyType::TABLE_INDEX));
+            backwards_compat_write_and_prune_previous(store_,
+                map_,
+                make_test_index_key(id, version_id, KeyType::TABLE_INDEX));
     }
 
     std::shared_ptr<VersionMap> map_ = std::make_shared<VersionMap>();
@@ -68,13 +79,15 @@ struct VersionMapModel {
     std::unordered_map<StringId, std::set<VersionId, std::greater<VersionId>>> data_;
     std::vector<std::string> symbols_;
 
-    std::optional<VersionId> get_latest_version(const std::string &id) const {
+    std::optional<VersionId> get_latest_version(const std::string& id) const
+    {
         auto it = data_.find(id);
         return it == data_.end() || it->second.empty() ? std::nullopt
                                                        : std::make_optional<VersionId>(*it->second.begin());
     }
 
-    std::vector<VersionId> get_all_versions(const std::string &id) const {
+    std::vector<VersionId> get_all_versions(const std::string& id) const
+    {
         std::vector<VersionId> output;
         auto it = data_.find(id);
         if (it != data_.end()) {
@@ -83,17 +96,20 @@ struct VersionMapModel {
         return output;
     }
 
-    void write_version(const std::string &id) {
+    void write_version(const std::string& id)
+    {
         auto prev = get_latest_version(id);
         auto version_id = prev ? prev.value() + 1 : 0;
         data_[id].insert(version_id);
     }
 
-    void delete_all_versions(const std::string &id) {
+    void delete_all_versions(const std::string& id)
+    {
         data_[id].clear();
     }
 
-    void write_and_prune_previous(const std::string &id) {
+    void write_and_prune_previous(const std::string& id)
+    {
         auto prev = get_latest_version(id);
         VersionId version_id{0};
         if (prev) {
@@ -109,61 +125,68 @@ struct VersionMapTombstonesModel {
     std::unordered_map<StringId, std::unordered_set<VersionId>> tombstones_;
     std::vector<std::string> symbols_;
 
-    VersionMapTombstonesModel() {
-    };
+    VersionMapTombstonesModel(){};
 
-    std::optional<VersionId> get_latest_version(const std::string &id) const {
+    std::optional<VersionId> get_latest_version(const std::string& id) const
+    {
         log::version().info("VersionMapTombstonesModel, get_latest_version {}", id);
         auto it = data_.find(id);
         return it == data_.end() || it->second.empty() ? std::nullopt
                                                        : std::make_optional<VersionId>(*it->second.begin());
     }
 
-    std::optional<VersionId> get_latest_undeleted_version(const std::string &id) const {
+    std::optional<VersionId> get_latest_undeleted_version(const std::string& id) const
+    {
         log::version().info("VersionMapTombstonesModel, get_latest_undeleted_version {}", id);
         auto it = data_.find(id);
-        if(it == data_.end()) return std::nullopt;
+        if (it == data_.end())
+            return std::nullopt;
 
         auto tombstones = tombstones_.find(id);
-        for(auto v : it->second) {
-            if(tombstones == tombstones_.end() || tombstones->second.find(v) == tombstones->second.end())
+        for (auto v : it->second) {
+            if (tombstones == tombstones_.end() || tombstones->second.find(v) == tombstones->second.end())
                 return v;
         }
-        return  std::nullopt;
+        return std::nullopt;
     }
 
-    std::vector<VersionId> get_all_versions(const std::string &id) const {
+    std::vector<VersionId> get_all_versions(const std::string& id) const
+    {
         log::version().info("VersionMapTombstonesModel, get_all_versions", id);
         std::vector<VersionId> output;
         auto it = data_.find(id);
         if (it != data_.end()) {
             auto tombstones = tombstones_.find(id);
-            std::copy_if(std::begin(it->second), std::end(it->second), std::back_inserter(output), [&] (auto v) {
+            std::copy_if(std::begin(it->second), std::end(it->second), std::back_inserter(output), [&](auto v) {
                 return tombstones == tombstones_.end() || tombstones->second.find(v) == tombstones->second.end();
             });
         }
         return output;
     }
 
-    void write_version(const std::string &id) {
+    void write_version(const std::string& id)
+    {
         log::version().info("VersionMapTombstonesModel, write version {}", id);
         auto prev = get_latest_version(id);
         auto version_id = prev ? prev.value() + 1 : 0;
         data_[id].insert(version_id);
     }
 
-    void delete_versions(const std::vector<VersionId> versions, const std::string& id) {
+    void delete_versions(const std::vector<VersionId> versions, const std::string& id)
+    {
         log::version().info("VersionMapTombstonesModel, delete_versions {}", id);
         auto& tombstones = tombstones_[id];
-        for(auto v : versions)
+        for (auto v : versions)
             tombstones.insert(v);
     }
 
-    void delete_all_versions(const std::string &id) {
+    void delete_all_versions(const std::string& id)
+    {
         delete_versions(get_all_versions(id), id);
     }
 
-    void write_and_prune_previous(const std::string &id) {
+    void write_and_prune_previous(const std::string& id)
+    {
         log::version().info("VersionMapTombstonesModel, write_and_prune_previous version {}", id);
         auto prev = get_latest_version(id);
         VersionId version_id{0};

--- a/cpp/arcticdb/version/version_constants.hpp
+++ b/cpp/arcticdb/version/version_constants.hpp
@@ -8,12 +8,12 @@
 #pragma once
 
 namespace arcticdb {
-    static const char* const WriteVersionId = "__write__";
-    static const char* const TombstoneVersionId = "__tombstone__";
-    static const char* const TombstoneAllVersionId = "__tombstone_all__";
-    static const char* const CreateSnapshotId = "__create_snapshot__";
-    static const char* const DeleteSnapshotId = "__delete_snapshot__";
-    static const char* const LastSyncId = "__last_sync__";
-    static const char* const LastBackupId = "__last_backup__";
-    static const char* const StorageLogId = "__storage_log__";
-}
+static const char* const WriteVersionId = "__write__";
+static const char* const TombstoneVersionId = "__tombstone__";
+static const char* const TombstoneAllVersionId = "__tombstone_all__";
+static const char* const CreateSnapshotId = "__create_snapshot__";
+static const char* const DeleteSnapshotId = "__delete_snapshot__";
+static const char* const LastSyncId = "__last_sync__";
+static const char* const LastBackupId = "__last_backup__";
+static const char* const StorageLogId = "__storage_log__";
+} // namespace arcticdb

--- a/cpp/arcticdb/version/version_core-inl.hpp
+++ b/cpp/arcticdb/version/version_core-inl.hpp
@@ -15,42 +15,47 @@
 
 namespace arcticdb {
 
-template <typename IndexType, typename SegmentationPolicy, typename DensityPolicy, typename Callable>
-void merge_frames_for_keys_impl(
-    const StreamId& target_id,
+template<typename IndexType, typename SegmentationPolicy, typename DensityPolicy, typename Callable>
+void merge_frames_for_keys_impl(const StreamId& target_id,
     const IndexType& index,
     SegmentationPolicy segmentation_policy,
     const std::vector<AtomKey>& index_keys,
-    const pipelines::ReadQuery &query,
-    std::shared_ptr <Store> store,
-    Callable&& func) {
+    const pipelines::ReadQuery& query,
+    std::shared_ptr<Store> store,
+    Callable&& func)
+{
     ARCTICDB_DEBUG(log::version(), "Merging keys");
     using namespace arcticdb::pipelines;
     using KeySupplier = folly::Function<std::vector<entity::AtomKey>()>;
     using StreamReaderType = arcticdb::stream::StreamReader<AtomKey, KeySupplier, SegmentInMemory::Row>;
 
     struct StreamMergeWrapper {
-        StreamMergeWrapper(
-            KeySupplier &&key_supplier,
-            std::shared_ptr <StreamSource> store,
-            const IndexRange &index_range,
-            StreamId id) :
-            stream_reader_(std::move(key_supplier), std::move(store), storage::ReadKeyOpts{}, index_range),
-            iterator_(stream_reader_.iterator_rows()),
-            row_(iterator_.next()),
-            id_(std::move(id)){
+        StreamMergeWrapper(KeySupplier&& key_supplier,
+            std::shared_ptr<StreamSource> store,
+            const IndexRange& index_range,
+            StreamId id)
+            : stream_reader_(std::move(key_supplier), std::move(store), storage::ReadKeyOpts{}, index_range),
+              iterator_(stream_reader_.iterator_rows()),
+              row_(iterator_.next()),
+              id_(std::move(id))
+        {
         }
 
-        bool advance() {
+        bool advance()
+        {
             row_ = iterator_.next();
             return static_cast<bool>(row_);
         }
 
-        SegmentInMemory::Row& row() {
+        SegmentInMemory::Row& row()
+        {
             return row_.value();
         }
 
-        const StreamId& id() const { return id_; }
+        const StreamId& id() const
+        {
+            return id_;
+        }
 
     private:
         StreamReaderType stream_reader_;
@@ -63,38 +68,55 @@ void merge_frames_for_keys_impl(
     if (std::holds_alternative<IndexRange>(query.row_filter))
         index_range = std::get<IndexRange>(query.row_filter);
 
-    auto compare =
-        [=](const std::unique_ptr <StreamMergeWrapper> &left, const std::unique_ptr <StreamMergeWrapper> &right) {
-            return pipelines::index::index_value_from_row(left->row(), IndexDescriptor::TIMESTAMP, 0) > pipelines::index::index_value_from_row(right->row(), IndexDescriptor::TIMESTAMP, 0);
-        };
+    auto compare = [=](const std::unique_ptr<StreamMergeWrapper>& left,
+                       const std::unique_ptr<StreamMergeWrapper>& right) {
+        return pipelines::index::index_value_from_row(left->row(), IndexDescriptor::TIMESTAMP, 0) >
+               pipelines::index::index_value_from_row(right->row(), IndexDescriptor::TIMESTAMP, 0);
+    };
 
-    movable_priority_queue<std::unique_ptr<StreamMergeWrapper>, std::vector<std::unique_ptr<StreamMergeWrapper>>, decltype(compare)> input_streams{compare};
+    movable_priority_queue<std::unique_ptr<StreamMergeWrapper>,
+        std::vector<std::unique_ptr<StreamMergeWrapper>>,
+        decltype(compare)>
+        input_streams{compare};
 
     for (const auto& index_key : index_keys) {
-        auto key_func = [index_key]() { return std::vector<AtomKey> {index_key}; };
-        input_streams.emplace(std::make_unique<StreamMergeWrapper>(std::move(key_func), store, index_range, index_key.id()));
+        auto key_func = [index_key]() { return std::vector<AtomKey>{index_key}; };
+        input_streams.emplace(
+            std::make_unique<StreamMergeWrapper>(std::move(key_func), store, index_range, index_key.id()));
     }
 
     using AggregatorType = Aggregator<IndexType, DynamicSchema, SegmentationPolicy, DensityPolicy>;
-    AggregatorType agg{DynamicSchema{index.create_stream_descriptor(target_id, {}), index}, std::move(func), std::move(segmentation_policy)};
+    AggregatorType agg{DynamicSchema{index.create_stream_descriptor(target_id, {}), index},
+        std::move(func),
+        std::move(segmentation_policy)};
     do_merge<IndexType, StreamMergeWrapper, AggregatorType, decltype(input_streams)>(input_streams, agg, true);
 }
 
-template <typename SegmentationPolicy, typename Callable>
-void merge_frames_for_keys(
-    const StreamId& target_id,
+template<typename SegmentationPolicy, typename Callable>
+void merge_frames_for_keys(const StreamId& target_id,
     stream::Index&& index,
     SegmentationPolicy&& segmentation_policy,
     stream::VariantColumnPolicy density_policy,
-    const std::vector <AtomKey>& index_keys,
-    const pipelines::ReadQuery &query,
-    std::shared_ptr <Store> store,
-    Callable&& func) {
-    std::visit([&] (auto idx, auto density) {
-        merge_frames_for_keys_impl<decltype(idx), SegmentationPolicy, decltype(density), std::decay_t<decltype(func)>>(
-            target_id, idx, std::move(segmentation_policy), index_keys, query, store, std::move(func));
-    }, index, density_policy);
-
+    const std::vector<AtomKey>& index_keys,
+    const pipelines::ReadQuery& query,
+    std::shared_ptr<Store> store,
+    Callable&& func)
+{
+    std::visit(
+        [&](auto idx, auto density) {
+            merge_frames_for_keys_impl<decltype(idx),
+                SegmentationPolicy,
+                decltype(density),
+                std::decay_t<decltype(func)>>(target_id,
+                idx,
+                std::move(segmentation_policy),
+                index_keys,
+                query,
+                store,
+                std::move(func));
+        },
+        index,
+        density_policy);
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -32,7 +32,9 @@
 
 namespace arcticdb::version_store {
 
-void modify_descriptor(const std::shared_ptr<pipelines::PipelineContext>& pipeline_context, const ReadOptions& read_options) {
+void modify_descriptor(const std::shared_ptr<pipelines::PipelineContext>& pipeline_context,
+    const ReadOptions& read_options)
+{
 
     if (opt_false(read_options.force_strings_to_object_) || opt_false(read_options.force_strings_to_fixed_))
         pipeline_context->orig_desc_ = pipeline_context->desc_;
@@ -40,105 +42,112 @@ void modify_descriptor(const std::shared_ptr<pipelines::PipelineContext>& pipeli
     auto& desc = *pipeline_context->desc_;
     if (opt_false(read_options.force_strings_to_object_)) {
         auto& fields = desc.mutable_fields();
-        std::transform(
-            std::begin(fields),
-            std::end(fields),
-            std::begin(fields),
-            [](auto& field_desc) {
-                if (data_type_from_proto(field_desc.type_desc()) == DataType::ASCII_FIXED64)
-                    set_data_type(DataType::ASCII_DYNAMIC64, *field_desc.mutable_type_desc());
+        std::transform(std::begin(fields), std::end(fields), std::begin(fields), [](auto& field_desc) {
+            if (data_type_from_proto(field_desc.type_desc()) == DataType::ASCII_FIXED64)
+                set_data_type(DataType::ASCII_DYNAMIC64, *field_desc.mutable_type_desc());
 
-                if (data_type_from_proto(field_desc.type_desc()) == DataType::UTF_FIXED64)
-                    set_data_type(DataType::UTF_DYNAMIC64, *field_desc.mutable_type_desc());
+            if (data_type_from_proto(field_desc.type_desc()) == DataType::UTF_FIXED64)
+                set_data_type(DataType::UTF_DYNAMIC64, *field_desc.mutable_type_desc());
 
-                return field_desc;
-            });
-    }
-    else if (opt_false(read_options.force_strings_to_fixed_)) {
+            return field_desc;
+        });
+    } else if (opt_false(read_options.force_strings_to_fixed_)) {
         auto& fields = desc.mutable_fields();
-        std::transform(
-            std::begin(fields),
-            std::end(fields),
-            std::begin(fields),
-            [](auto& field_desc) {
-                if (data_type_from_proto(field_desc.type_desc()) == DataType::ASCII_DYNAMIC64)
-                    set_data_type(DataType::ASCII_FIXED64, *field_desc.mutable_type_desc());
+        std::transform(std::begin(fields), std::end(fields), std::begin(fields), [](auto& field_desc) {
+            if (data_type_from_proto(field_desc.type_desc()) == DataType::ASCII_DYNAMIC64)
+                set_data_type(DataType::ASCII_FIXED64, *field_desc.mutable_type_desc());
 
-                if (data_type_from_proto(field_desc.type_desc()) == DataType::UTF_DYNAMIC64)
-                    set_data_type(DataType::UTF_FIXED64, *field_desc.mutable_type_desc());
+            if (data_type_from_proto(field_desc.type_desc()) == DataType::UTF_DYNAMIC64)
+                set_data_type(DataType::UTF_FIXED64, *field_desc.mutable_type_desc());
 
-                return field_desc;
-            });
+            return field_desc;
+        });
     }
 }
 
-VersionedItem write_dataframe_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem write_dataframe_impl(const std::shared_ptr<Store>& store,
     VersionId version_id,
     pipelines::InputTensorFrame&& frame,
     const WriteOptions& options,
     const std::shared_ptr<DeDupMap>& de_dup_map,
     bool sparsify_floats,
-    bool validate_index
-    ) {
-    auto atom_key_fut = async_write_dataframe_impl(store, version_id, std::move(frame), options, de_dup_map, sparsify_floats, validate_index);
+    bool validate_index)
+{
+    auto atom_key_fut = async_write_dataframe_impl(store,
+        version_id,
+        std::move(frame),
+        options,
+        de_dup_map,
+        sparsify_floats,
+        validate_index);
 
     ARCTICDB_SUBSAMPLE_DEFAULT(WaitForWriteCompletion)
     auto atom_key = std::move(atom_key_fut).get();
     auto versioned_item = VersionedItem(std::move(atom_key));
-    ARCTICDB_DEBUG(log::version(), "write_dataframe_impl stream_id: {} , version_id: {}, {} rows", frame.desc.id(), version_id, frame.num_rows);
+    ARCTICDB_DEBUG(log::version(),
+        "write_dataframe_impl stream_id: {} , version_id: {}, {} rows",
+        frame.desc.id(),
+        version_id,
+        frame.num_rows);
     return versioned_item;
 }
 
-folly::Future<entity::AtomKey> async_write_dataframe_impl(
-    const std::shared_ptr<Store>& store,
+folly::Future<entity::AtomKey> async_write_dataframe_impl(const std::shared_ptr<Store>& store,
     VersionId version_id,
     InputTensorFrame&& frame,
     const WriteOptions& options,
-    const std::shared_ptr<DeDupMap> &de_dup_map,
+    const std::shared_ptr<DeDupMap>& de_dup_map,
     bool sparsify_floats,
-    bool validate_index
-    ) {
+    bool validate_index)
+{
     ARCTICDB_SAMPLE(DoWrite, 0)
 
     // Slice the frame according to the write options
     frame.set_bucketize_dynamic(options.bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, frame);
     auto partial_key = IndexPartialKey{frame.desc.id(), version_id};
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(!validate_index || frame.desc.get_sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING || !std::holds_alternative<stream::TimeseriesIndex>(frame.index),
-                "When calling write with validate_index enabled, input data must be sorted.");
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+        !validate_index || frame.desc.get_sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING ||
+            !std::holds_alternative<stream::TimeseriesIndex>(frame.index),
+        "When calling write with validate_index enabled, input data must be sorted.");
     return write_frame(partial_key, std::move(frame), slicing_arg, store, de_dup_map, sparsify_floats);
 }
 
 namespace {
-IndexDescriptor::Proto check_index_match(const arcticdb::stream::Index& index, const IndexDescriptor::Proto& desc) {
+IndexDescriptor::Proto check_index_match(const arcticdb::stream::Index& index, const IndexDescriptor::Proto& desc)
+{
     if (std::holds_alternative<stream::TimeseriesIndex>(index))
         util::check(desc.kind() == IndexDescriptor::TIMESTAMP,
-                    "Index mismatch, cannot update a non-timeseries-indexed frame with a timeseries");
+            "Index mismatch, cannot update a non-timeseries-indexed frame with a timeseries");
     else
         util::check(desc.kind() == IndexDescriptor::ROWCOUNT,
-                    "Index mismatch, cannot update a timeseries with a non-timeseries-indexed frame");
+            "Index mismatch, cannot update a timeseries with a non-timeseries-indexed frame");
 
     return desc;
 }
-}
+} // namespace
 
-folly::Future<AtomKey> async_append_impl(
-    const std::shared_ptr<Store>& store,
+folly::Future<AtomKey> async_append_impl(const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     InputTensorFrame&& frame,
     const WriteOptions& options,
-    bool validate_index) {
+    bool validate_index)
+{
 
-    util::check(update_info.previous_index_key_.has_value(), "Cannot append as there is no previous index key to append to");
+    util::check(update_info.previous_index_key_.has_value(),
+        "Cannot append as there is no previous index key to append to");
     const StreamId stream_id = frame.desc.id();
     ARCTICDB_DEBUG(log::version(), "append stream_id: {} , version_id: {}", stream_id, update_info.next_version_id_);
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     auto row_offset = index_segment_reader.tsd().total_rows();
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(!validate_index || (frame.desc.get_sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING && index_segment_reader.tsd().stream_descriptor().sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING) || 
-        !std::holds_alternative<stream::TimeseriesIndex>(frame.index),
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+        !validate_index ||
+            (frame.desc.get_sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING &&
+                index_segment_reader.tsd().stream_descriptor().sorted() ==
+                    arcticdb::proto::descriptors::SortedValue::ASCENDING) ||
+            !std::holds_alternative<stream::TimeseriesIndex>(frame.index),
         "validate_index set but input data index is not sorted.");
 
     frame.set_offset(static_cast<ssize_t>(row_offset));
@@ -146,46 +155,58 @@ folly::Future<AtomKey> async_append_impl(
 
     frame.set_bucketize_dynamic(bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, frame);
-    return append_frame(IndexPartialKey{stream_id, update_info.next_version_id_}, std::move(frame), slicing_arg, index_segment_reader, store, options.dynamic_schema, options.ignore_sort_order);
+    return append_frame(IndexPartialKey{stream_id, update_info.next_version_id_},
+        std::move(frame),
+        slicing_arg,
+        index_segment_reader,
+        store,
+        options.dynamic_schema,
+        options.ignore_sort_order);
 }
 
-VersionedItem append_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem append_impl(const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     InputTensorFrame&& frame,
     const WriteOptions& options,
-    bool validate_index) {
+    bool validate_index)
+{
 
     ARCTICDB_SUBSAMPLE_DEFAULT(WaitForWriteCompletion)
-    auto version_key_fut = async_append_impl(store,
-                                             update_info,
-                                             std::move(frame),
-                                             options,
-                                             validate_index);
+    auto version_key_fut = async_append_impl(store, update_info, std::move(frame), options, validate_index);
     auto version_key = std::move(version_key_fut).get();
     auto versioned_item = VersionedItem(to_atom(std::move(version_key)));
-    ARCTICDB_DEBUG(log::version(), "write_dataframe_impl stream_id: {} , version_id: {}", versioned_item.symbol(), update_info.next_version_id_);
+    ARCTICDB_DEBUG(log::version(),
+        "write_dataframe_impl stream_id: {} , version_id: {}",
+        versioned_item.symbol(),
+        update_info.next_version_id_);
     return versioned_item;
 }
 
 namespace {
-bool is_before(const IndexRange& a, const IndexRange& b) {
+bool is_before(const IndexRange& a, const IndexRange& b)
+{
     return a.start_ < b.start_;
 }
 
-bool is_after(const IndexRange& a, const IndexRange& b) {
+bool is_after(const IndexRange& a, const IndexRange& b)
+{
     return a.end_ > b.end_;
 }
 
-template <class KeyContainer>
-    void ensure_keys_line_up(const KeyContainer& slice_and_keys) {
+template<class KeyContainer>
+void ensure_keys_line_up(const KeyContainer& slice_and_keys)
+{
     std::optional<size_t> start;
     std::optional<size_t> end;
     SliceAndKey prev{};
-    for(const auto& sk : slice_and_keys) {
+    for (const auto& sk : slice_and_keys) {
         util::check(!start || sk.slice_.row_range.first == end.value(),
-                    "Can't update as there is a sorting mismatch at key {} relative to previous key {} - expected index {} got {}",
-                    sk, prev, end.value(), start.value());
+            "Can't update as there is a sorting mismatch at key {} relative to previous key {} - expected index {} got "
+            "{}",
+            sk,
+            prev,
+            end.value(),
+            start.value());
 
         start = sk.slice_.row_range.first;
         end = sk.slice_.row_range.second;
@@ -198,22 +219,27 @@ inline std::pair<std::vector<SliceAndKey>, std::vector<SliceAndKey>> intersectin
     const IndexRange& front_range,
     const IndexRange& back_range,
     VersionId version_id,
-    const std::shared_ptr<Store>& store) {
+    const std::shared_ptr<Store>& store)
+{
     std::vector<SliceAndKey> intersect_before;
     std::vector<SliceAndKey> intersect_after;
 
     for (const auto& affected_slice_and_key : affected_keys) {
         const auto& affected_range = affected_slice_and_key.key().index_range();
-        if (intersects(affected_range, front_range) && !overlaps(affected_range, front_range)
-        && is_before(affected_range, front_range)) {
-            auto front_overlap_key = rewrite_partial_segment(affected_slice_and_key, front_range, version_id, false, store);
+        if (intersects(affected_range, front_range) && !overlaps(affected_range, front_range) &&
+            is_before(affected_range, front_range))
+        {
+            auto front_overlap_key =
+                rewrite_partial_segment(affected_slice_and_key, front_range, version_id, false, store);
             if (front_overlap_key)
                 intersect_before.push_back(front_overlap_key.value());
         }
 
-        if (intersects(affected_range, back_range) && !overlaps(affected_range, back_range)
-        && is_after(affected_range, back_range)) {
-            auto back_overlap_key = rewrite_partial_segment(affected_slice_and_key, back_range, version_id, true, store);
+        if (intersects(affected_range, back_range) && !overlaps(affected_range, back_range) &&
+            is_after(affected_range, back_range))
+        {
+            auto back_overlap_key =
+                rewrite_partial_segment(affected_slice_and_key, back_range, version_id, true, store);
             if (back_overlap_key)
                 intersect_after.push_back(back_overlap_key.value());
         }
@@ -223,77 +249,99 @@ inline std::pair<std::vector<SliceAndKey>, std::vector<SliceAndKey>> intersectin
 
 } // namespace
 
-VersionedItem delete_range_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem delete_range_impl(const std::shared_ptr<Store>& store,
     const AtomKey& prev,
     const UpdateQuery& query,
-    const WriteOptions&& ,
-    bool dynamic_schema) {
+    const WriteOptions&&,
+    bool dynamic_schema)
+{
 
     const StreamId& stream_id = prev.id();
     auto version_id = get_next_version_from_key(prev);
     util::check(std::holds_alternative<IndexRange>(query.row_filter), "Delete range requires index range argument");
     const auto& index_range = std::get<IndexRange>(query.row_filter);
-    ARCTICDB_DEBUG(log::version(), "Delete range in versioned dataframe for stream_id: {} , version_id = {}", stream_id, version_id);
+    ARCTICDB_DEBUG(log::version(),
+        "Delete range in versioned dataframe for stream_id: {} , version_id = {}",
+        stream_id,
+        version_id);
 
     auto index_segment_reader = index::get_index_reader(prev, store);
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot delete date range of pickled data");
     auto index = index_type_from_descriptor(index_segment_reader.tsd().stream_descriptor());
-    util::check(std::holds_alternative<TimeseriesIndex>(index), "Delete in range will not work as expected with a non-timeseries index");
+    util::check(std::holds_alternative<TimeseriesIndex>(index),
+        "Delete in range will not work as expected with a non-timeseries index");
 
     std::vector<FilterQuery<index::IndexSegmentReader>> queries =
-            build_update_query_filters<index::IndexSegmentReader>(query.row_filter, index, index_range, dynamic_schema, index_segment_reader.bucketize_dynamic());
+        build_update_query_filters<index::IndexSegmentReader>(query.row_filter,
+            index,
+            index_range,
+            dynamic_schema,
+            index_segment_reader.bucketize_dynamic());
     auto combined = combine_filter_functions(queries);
     auto affected_keys = filter_index(index_segment_reader, std::move(combined));
     std::vector<SliceAndKey> unaffected_keys;
     std::set_difference(std::begin(index_segment_reader),
-                        std::end(index_segment_reader),
-                        std::begin(affected_keys),
-                        std::end(affected_keys),
-                        std::back_inserter(unaffected_keys));
+        std::end(index_segment_reader),
+        std::begin(affected_keys),
+        std::end(affected_keys),
+        std::back_inserter(unaffected_keys));
 
-    auto [intersect_before, intersect_after] = intersecting_segments(affected_keys, index_range, index_range, version_id, store);
+    auto [intersect_before, intersect_after] =
+        intersecting_segments(affected_keys, index_range, index_range, version_id, store);
 
-    auto orig_filter_range = std::holds_alternative<std::monostate>(query.row_filter) ? get_query_index_range(index, index_range) : query.row_filter;
+    auto orig_filter_range = std::holds_alternative<std::monostate>(query.row_filter)
+                                 ? get_query_index_range(index, index_range)
+                                 : query.row_filter;
 
     size_t row_count = 0;
-    auto flattened_slice_and_keys = flatten_and_fix_rows(std::vector<std::vector<SliceAndKey>>{
-        strictly_before(orig_filter_range, unaffected_keys),
-        std::move(intersect_before),
-        std::move(intersect_after),
-        strictly_after(orig_filter_range, unaffected_keys)},
-                                                         row_count
-                                                         );
+    auto flattened_slice_and_keys =
+        flatten_and_fix_rows(std::vector<std::vector<SliceAndKey>>{strictly_before(orig_filter_range, unaffected_keys),
+                                 std::move(intersect_before),
+                                 std::move(intersect_after),
+                                 strictly_after(orig_filter_range, unaffected_keys)},
+            row_count);
 
     std::sort(std::begin(flattened_slice_and_keys), std::end(flattened_slice_and_keys));
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     auto time_series = make_descriptor(row_count, std::move(index_segment_reader), std::nullopt, bucketize_dynamic);
-    auto version_key_fut = util::variant_match(index, [&time_series, &flattened_slice_and_keys, &stream_id, &version_id, &store] (auto idx) {
-        using IndexType = decltype(idx);
-        return pipelines::index::write_index<IndexType>(std::move(time_series), std::move(flattened_slice_and_keys), IndexPartialKey{stream_id, version_id}, store);
-    });
+    auto version_key_fut = util::variant_match(index,
+        [&time_series, &flattened_slice_and_keys, &stream_id, &version_id, &store](auto idx) {
+            using IndexType = decltype(idx);
+            return pipelines::index::write_index<IndexType>(std::move(time_series),
+                std::move(flattened_slice_and_keys),
+                IndexPartialKey{stream_id, version_id},
+                store);
+        });
     auto version_key = std::move(version_key_fut).get();
     auto versioned_item = VersionedItem(to_atom(std::move(version_key)));
     ARCTICDB_DEBUG(log::version(), "updated stream_id: {} , version_id: {}", stream_id, version_id);
     return versioned_item;
 }
 
-VersionedItem update_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem update_impl(const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     const UpdateQuery& query,
     InputTensorFrame&& frame,
     const WriteOptions&& options,
-    bool dynamic_schema) {
-    util::check(update_info.previous_index_key_.has_value(), "Cannot update as there is no previous index key to update into");
+    bool dynamic_schema)
+{
+    util::check(update_info.previous_index_key_.has_value(),
+        "Cannot update as there is no previous index key to update into");
     const StreamId stream_id = frame.desc.id();
-    ARCTICDB_DEBUG(log::version(), "Update versioned dataframe for stream_id: {} , version_id = {}", stream_id, update_info.previous_index_key_->version_id());
+    ARCTICDB_DEBUG(log::version(),
+        "Update versioned dataframe for stream_id: {} , version_id = {}",
+        stream_id,
+        update_info.previous_index_key_->version_id());
 
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot update pickled data");
     auto index_desc = check_index_match(frame.index, index_segment_reader.tsd().stream_descriptor().index());
     util::check(index_desc.kind() == IndexDescriptor::TIMESTAMP, "Update not supported for non-timeseries indexes");
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(frame.desc.get_sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING && std::holds_alternative<stream::TimeseriesIndex>(frame.index) && index_segment_reader.mutable_tsd().stream_descriptor().sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING,
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(frame.desc.get_sorted() ==
+                                                       arcticdb::proto::descriptors::SortedValue::ASCENDING &&
+                                                   std::holds_alternative<stream::TimeseriesIndex>(frame.index) &&
+                                                   index_segment_reader.mutable_tsd().stream_descriptor().sorted() ==
+                                                       arcticdb::proto::descriptors::SortedValue::ASCENDING,
         "When calling update on sorted data, the input data must be sorted.");
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     (void)check_and_mark_slices(index_segment_reader, dynamic_schema, false, std::nullopt, bucketize_dynamic);
@@ -301,73 +349,91 @@ VersionedItem update_impl(
     fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, frame);
 
     std::vector<FilterQuery<index::IndexSegmentReader>> queries =
-        build_update_query_filters<index::IndexSegmentReader>(query.row_filter, frame.index, frame.index_range, dynamic_schema, index_segment_reader.bucketize_dynamic());
+        build_update_query_filters<index::IndexSegmentReader>(query.row_filter,
+            frame.index,
+            frame.index_range,
+            dynamic_schema,
+            index_segment_reader.bucketize_dynamic());
     auto combined = combine_filter_functions(queries);
     auto affected_keys = filter_index(index_segment_reader, std::move(combined));
     std::vector<SliceAndKey> unaffected_keys;
     std::set_difference(std::begin(index_segment_reader),
-                        std::end(index_segment_reader),
-                        std::begin(affected_keys),
-                        std::end(affected_keys),
-                        std::back_inserter(unaffected_keys));
+        std::end(index_segment_reader),
+        std::begin(affected_keys),
+        std::end(affected_keys),
+        std::back_inserter(unaffected_keys));
 
     frame.set_bucketize_dynamic(bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, frame);
 
-    auto fut_slice_keys = slice_and_write(frame, slicing_arg, get_partial_key_gen(frame, IndexPartialKey{stream_id, update_info.next_version_id_}), store);
+    auto fut_slice_keys = slice_and_write(frame,
+        slicing_arg,
+        get_partial_key_gen(frame, IndexPartialKey{stream_id, update_info.next_version_id_}),
+        store);
     auto new_slice_and_keys = folly::collect(fut_slice_keys).wait().value();
     std::sort(std::begin(new_slice_and_keys), std::end(new_slice_and_keys));
 
     IndexRange orig_filter_range;
-    auto[intersect_before, intersect_after] = util::variant_match(query.row_filter,
-                        [&](std::monostate) {
-                            util::check(std::holds_alternative<TimeseriesIndex>(frame.index), "Update with row count index is not permitted");
-                            orig_filter_range = frame.index_range;
-                            auto front_range = new_slice_and_keys.begin()->key().index_range();
-                            auto back_range = new_slice_and_keys.rbegin()->key().index_range();
-                            back_range.adjust_open_closed_interval();
-                            return intersecting_segments(affected_keys, front_range, back_range, update_info.next_version_id_, store);
-                        },
-                        [&](const IndexRange& idx_range) {
-                            orig_filter_range = idx_range;
-                            return intersecting_segments(affected_keys, idx_range, idx_range, update_info.next_version_id_, store);
-                        },
-                        [](const RowRange&) {
-                            util::raise_rte("Unexpected row_range in update query");
-                            return std::pair(std::vector<SliceAndKey>{}, std::vector<SliceAndKey>{});  // unreachable
-                        }
-    );
+    auto [intersect_before, intersect_after] = util::variant_match(
+        query.row_filter,
+        [&](std::monostate) {
+            util::check(std::holds_alternative<TimeseriesIndex>(frame.index),
+                "Update with row count index is not permitted");
+            orig_filter_range = frame.index_range;
+            auto front_range = new_slice_and_keys.begin()->key().index_range();
+            auto back_range = new_slice_and_keys.rbegin()->key().index_range();
+            back_range.adjust_open_closed_interval();
+            return intersecting_segments(affected_keys, front_range, back_range, update_info.next_version_id_, store);
+        },
+        [&](const IndexRange& idx_range) {
+            orig_filter_range = idx_range;
+            return intersecting_segments(affected_keys, idx_range, idx_range, update_info.next_version_id_, store);
+        },
+        [](const RowRange&) {
+            util::raise_rte("Unexpected row_range in update query");
+            return std::pair(std::vector<SliceAndKey>{}, std::vector<SliceAndKey>{}); // unreachable
+        });
 
     size_t row_count = 0;
-    auto flattened_slice_and_keys = flatten_and_fix_rows(std::vector<std::vector<SliceAndKey>>{
-        strictly_before(orig_filter_range, unaffected_keys),
-        std::move(intersect_before),
-        std::move(new_slice_and_keys),
-        std::move(intersect_after),
-        strictly_after(orig_filter_range, unaffected_keys)},
-                                                         row_count
-                                                         );
+    auto flattened_slice_and_keys =
+        flatten_and_fix_rows(std::vector<std::vector<SliceAndKey>>{strictly_before(orig_filter_range, unaffected_keys),
+                                 std::move(intersect_before),
+                                 std::move(new_slice_and_keys),
+                                 std::move(intersect_after),
+                                 strictly_after(orig_filter_range, unaffected_keys)},
+            row_count);
 
     std::sort(std::begin(flattened_slice_and_keys), std::end(flattened_slice_and_keys));
-    auto desc = stream::merge_descriptors(StreamDescriptor{std::move(*index_segment_reader.mutable_tsd().mutable_stream_descriptor())}, { frame.desc.fields() }, {});
+    auto desc = stream::merge_descriptors(
+        StreamDescriptor{std::move(*index_segment_reader.mutable_tsd().mutable_stream_descriptor())},
+        {frame.desc.fields()},
+        {});
     // At this stage the updated data must be sorted
     desc.set_sorted(arcticdb::entity::SortedValue::ASCENDING);
-    auto time_series = make_descriptor(row_count, std::move(desc), frame.norm_meta, std::move(frame.user_meta), std::nullopt, bucketize_dynamic);
+    auto time_series = make_descriptor(row_count,
+        std::move(desc),
+        frame.norm_meta,
+        std::move(frame.user_meta),
+        std::nullopt,
+        bucketize_dynamic);
     auto index = index_type_from_descriptor(time_series.stream_descriptor());
 
-    auto version_key_fut = util::variant_match(index, [&time_series, &flattened_slice_and_keys, &stream_id, &update_info, &store] (auto idx) {
-        using IndexType = decltype(idx);
-        return index::write_index<IndexType>(std::move(time_series), std::move(flattened_slice_and_keys), IndexPartialKey{stream_id, update_info.next_version_id_}, store);
-    });
+    auto version_key_fut = util::variant_match(index,
+        [&time_series, &flattened_slice_and_keys, &stream_id, &update_info, &store](auto idx) {
+            using IndexType = decltype(idx);
+            return index::write_index<IndexType>(std::move(time_series),
+                std::move(flattened_slice_and_keys),
+                IndexPartialKey{stream_id, update_info.next_version_id_},
+                store);
+        });
     auto version_key = std::move(version_key_fut).get();
     auto versioned_item = VersionedItem(to_atom(std::move(version_key)));
     ARCTICDB_DEBUG(log::version(), "updated stream_id: {} , version_id: {}", stream_id, update_info.next_version_id_);
     return versioned_item;
 }
 
-FrameAndDescriptor read_multi_key(
-    const std::shared_ptr<Store>& store,
-    const SegmentInMemory& index_key_seg) {
+FrameAndDescriptor read_multi_key(const std::shared_ptr<Store>& store, const SegmentInMemory& index_key_seg)
+{
     const auto& multi_index_seg = index_key_seg;
     arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
     multi_index_seg.metadata()->UnpackTo(&tsd);
@@ -395,38 +461,40 @@ FrameAndDescriptor read_multi_key(
  * segments will be retrieved from storage and decompressed before being passed to a MemSegmentProcessingTask which
  * will process all clauses up until a reducing clause.
  */
-std::vector<SliceAndKey> read_and_process(
-    const std::shared_ptr<Store>& store,
+std::vector<SliceAndKey> read_and_process(const std::shared_ptr<Store>& store,
     const std::shared_ptr<PipelineContext>& pipeline_context,
     const ReadQuery& read_query,
     const ReadOptions& read_options,
-    size_t start_from
-    ) {
+    size_t start_from)
+{
     std::vector<Composite<SliceAndKey>> rows;
-    if(!read_query.query_->empty()) {
-        if(auto execution_context = read_query.query_->begin()->execution_context(); execution_context) {
+    if (!read_query.query_->empty()) {
+        if (auto execution_context = read_query.query_->begin()->execution_context(); execution_context) {
             execution_context->set_descriptor(pipeline_context->descriptor());
             execution_context->set_norm_meta_descriptor(pipeline_context->norm_meta_);
         }
 
-        for(auto& clause : *read_query.query_) {
-            if(auto execution_context = clause.execution_context(); execution_context)
+        for (auto& clause : *read_query.query_) {
+            if (auto execution_context = clause.execution_context(); execution_context)
                 execution_context->set_dynamic_schema(opt_false(read_options.dynamic_schema_));
         }
     }
 
-    std::sort(std::begin(pipeline_context->slice_and_keys_), std::end(pipeline_context->slice_and_keys_), [] (const SliceAndKey& left, const SliceAndKey& right) {
-        return std::tie(left.slice().row_range.first, left.slice().col_range.first) < std::tie(right.slice().row_range.first, right.slice().col_range.first);
-    });
+    std::sort(std::begin(pipeline_context->slice_and_keys_),
+        std::end(pipeline_context->slice_and_keys_),
+        [](const SliceAndKey& left, const SliceAndKey& right) {
+            return std::tie(left.slice().row_range.first, left.slice().col_range.first) <
+                   std::tie(right.slice().row_range.first, right.slice().col_range.first);
+        });
 
     auto sk_it = std::begin(pipeline_context->slice_and_keys_);
     std::advance(sk_it, start_from);
-    while(sk_it != std::end(pipeline_context->slice_and_keys_)) {
+    while (sk_it != std::end(pipeline_context->slice_and_keys_)) {
         RowRange row_range{sk_it->slice().row_range};
         auto sk = Composite{std::move(*sk_it)};
         // Iterate through all SliceAndKeys that contain data for the same RowRange - i.e., iterate along column segments
         // for same row group
-        while(++sk_it != std::end(pipeline_context->slice_and_keys_) && sk_it->slice().row_range == row_range) {
+        while (++sk_it != std::end(pipeline_context->slice_and_keys_) && sk_it->slice().row_range == row_range) {
             sk.push_back(std::move(*sk_it));
         }
 
@@ -434,7 +502,7 @@ std::vector<SliceAndKey> read_and_process(
         rows.emplace_back(std::move(sk));
     }
     std::shared_ptr<std::unordered_set<std::string>> filter_columns;
-    if(pipeline_context->overall_column_bitset_) {
+    if (pipeline_context->overall_column_bitset_) {
         filter_columns = std::make_shared<std::unordered_set<std::string>>();
         auto en = pipeline_context->overall_column_bitset_->first();
         auto en_end = pipeline_context->overall_column_bitset_->end();
@@ -443,28 +511,33 @@ std::vector<SliceAndKey> read_and_process(
         }
     }
 
-    auto parallel_output = store->batch_read_uncompressed(std::move(rows), read_query.query_, pipeline_context->descriptor(), filter_columns, BatchReadArgs{});
+    auto parallel_output = store->batch_read_uncompressed(std::move(rows),
+        read_query.query_,
+        pipeline_context->descriptor(),
+        filter_columns,
+        BatchReadArgs{});
 
     size_t clause_index = 0;
     for (const auto& clause : *read_query.query_) {
         if (clause.requires_repartition()) {
-            std::vector<Composite<ProcessingSegment>> composites = clause.repartition(std::move(parallel_output)).value();
+            std::vector<Composite<ProcessingSegment>> composites =
+                clause.repartition(std::move(parallel_output)).value();
 
             std::vector<folly::Future<Composite<ProcessingSegment>>> batch;
             std::vector<Composite<ProcessingSegment>> res;
             res.reserve(composites.size());
-            for (auto&& val : composites){
-                auto clause_copy = std::make_shared<std::vector<Clause>>(read_query.query_->begin() + clause_index + 1, read_query.query_->end());
-                batch.emplace_back(
-                        async::submit_cpu_task(
-                                async::MemSegmentPassthroughProcessingTask(store, clause_copy, std::move(val))
-                        )
-                );
+            for (auto&& val : composites) {
+                auto clause_copy = std::make_shared<std::vector<Clause>>(read_query.query_->begin() + clause_index + 1,
+                    read_query.query_->end());
+                batch.emplace_back(async::submit_cpu_task(
+                    async::MemSegmentPassthroughProcessingTask(store, clause_copy, std::move(val))));
             }
 
-            if(!batch.empty()) {
+            if (!batch.empty()) {
                 auto segments = folly::collect(batch).get();
-                res.insert(std::end(res), std::make_move_iterator(std::begin(segments)), std::make_move_iterator(std::end(segments)));
+                res.insert(std::end(res),
+                    std::make_move_iterator(std::begin(segments)),
+                    std::make_move_iterator(std::end(segments)));
             }
 
             parallel_output = std::move(res);
@@ -474,8 +547,8 @@ std::vector<SliceAndKey> read_and_process(
     }
 
     //TODO split pipeline context into load_context and output_context
-        for(auto clause  = read_query.query_->rbegin(); clause != read_query.query_->rend(); ++clause ) {
-        if(clause->execution_context() && clause->execution_context()->output_descriptor_)
+    for (auto clause = read_query.query_->rbegin(); clause != read_query.query_->rend(); ++clause) {
+        if (clause->execution_context() && clause->execution_context()->output_descriptor_)
             pipeline_context->set_descriptor(clause->execution_context()->output_descriptor_.value());
     }
 
@@ -484,9 +557,10 @@ std::vector<SliceAndKey> read_and_process(
 }
 
 SegmentInMemory read_direct(const std::shared_ptr<Store>& store,
-                            const std::shared_ptr<PipelineContext>& pipeline_context,
-                            std::shared_ptr<BufferHolder> buffers,
-                            const ReadOptions& read_options) {
+    const std::shared_ptr<PipelineContext>& pipeline_context,
+    std::shared_ptr<BufferHolder> buffers,
+    const ReadOptions& read_options)
+{
     ARCTICDB_DEBUG(log::version(), "Allocating frame");
     ARCTICDB_SAMPLE_DEFAULT(ReadDirect)
     auto frame = allocate_frame(pipeline_context);
@@ -498,24 +572,28 @@ SegmentInMemory read_direct(const std::shared_ptr<Store>& store,
     return frame;
 }
 
-void add_index_columns_to_query(const ReadQuery& read_query, const arcticdb::proto::descriptors::TimeSeriesDescriptor& desc) {
-    if(!read_query.columns.empty()) {
+void add_index_columns_to_query(const ReadQuery& read_query,
+    const arcticdb::proto::descriptors::TimeSeriesDescriptor& desc)
+{
+    if (!read_query.columns.empty()) {
         auto index_columns = stream::get_index_columns_from_descriptor(desc);
-        if(index_columns.empty())
+        if (index_columns.empty())
             return;
 
         std::vector<std::string> index_columns_to_add;
-        for(const auto& index_column : index_columns) {
-            if(std::find(std::begin(read_query.columns), std::end(read_query.columns), index_column) == std::end(read_query.columns))
+        for (const auto& index_column : index_columns) {
+            if (std::find(std::begin(read_query.columns), std::end(read_query.columns), index_column) ==
+                std::end(read_query.columns))
                 index_columns_to_add.push_back(index_column);
         }
-        read_query.columns.insert(std::begin(read_query.columns), std::begin(index_columns_to_add), std::end(index_columns_to_add));
+        read_query.columns.insert(std::begin(read_query.columns),
+            std::begin(index_columns_to_add),
+            std::end(index_columns_to_add));
     }
 }
 
-FrameAndDescriptor read_index_impl(
-    const std::shared_ptr<Store>& store,
-    const VersionedItem& version) {
+FrameAndDescriptor read_index_impl(const std::shared_ptr<Store>& store, const VersionedItem& version)
+{
     auto fut_index = store->read(version.key_);
     auto [index_key, index_seg] = std::move(fut_index).get();
     arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
@@ -526,31 +604,40 @@ FrameAndDescriptor read_index_impl(
 
 namespace {
 
-void ensure_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_meta, const StreamId& stream_id, bool set_tz) {
-    if(norm_meta.input_type_case() == arcticdb::proto::descriptors::NormalizationMetadata::INPUT_TYPE_NOT_SET)
+void ensure_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
+    const StreamId& stream_id,
+    bool set_tz)
+{
+    if (norm_meta.input_type_case() == arcticdb::proto::descriptors::NormalizationMetadata::INPUT_TYPE_NOT_SET)
         norm_meta.CopyFrom(make_timeseries_norm_meta(stream_id));
 
-    if(set_tz && norm_meta.df().common().index().tz().empty())
+    if (set_tz && norm_meta.df().common().index().tz().empty())
         norm_meta.mutable_df()->mutable_common()->mutable_index()->set_tz("UTC");
 }
 
-void check_column_and_date_range_filterable(const pipelines::index::IndexSegmentReader& index_segment_reader, const ReadQuery& read_query) {
-    util::check(!index_segment_reader.is_pickled()
-    || (read_query.columns.empty() && std::holds_alternative<std::monostate>(read_query.row_filter)),
-    "The data for this symbol is pickled and does not support date_range, row_range, or column queries");
-    util::check(index_segment_reader.has_timestamp_index() || !std::holds_alternative<IndexRange>(read_query.row_filter),
-            "Cannot apply date range filter to symbol with non-timestamp index");
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(index_segment_reader.tsd().stream_descriptor().sorted() == arcticdb::proto::descriptors::SortedValue::UNKNOWN ||
-        index_segment_reader.tsd().stream_descriptor().sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING ||
-        !std::holds_alternative<IndexRange>(read_query.row_filter),
-            "When filtering data using date_range, the symbol must be sorted in ascending order. ArcticDB believes it is not sorted in ascending order and cannot therefore filter the data using date_range.");
+void check_column_and_date_range_filterable(const pipelines::index::IndexSegmentReader& index_segment_reader,
+    const ReadQuery& read_query)
+{
+    util::check(!index_segment_reader.is_pickled() ||
+                    (read_query.columns.empty() && std::holds_alternative<std::monostate>(read_query.row_filter)),
+        "The data for this symbol is pickled and does not support date_range, row_range, or column queries");
+    util::check(index_segment_reader.has_timestamp_index() ||
+                    !std::holds_alternative<IndexRange>(read_query.row_filter),
+        "Cannot apply date range filter to symbol with non-timestamp index");
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(index_segment_reader.tsd().stream_descriptor().sorted() ==
+                                                       arcticdb::proto::descriptors::SortedValue::UNKNOWN ||
+                                                   index_segment_reader.tsd().stream_descriptor().sorted() ==
+                                                       arcticdb::proto::descriptors::SortedValue::ASCENDING ||
+                                                   !std::holds_alternative<IndexRange>(read_query.row_filter),
+        "When filtering data using date_range, the symbol must be sorted in ascending order. ArcticDB believes it is "
+        "not sorted in ascending order and cannot therefore filter the data using date_range.");
 }
-}
+} // namespace
 
-std::optional<pipelines::index::IndexSegmentReader> get_index_segment_reader(
-    const std::shared_ptr<Store>& store,
+std::optional<pipelines::index::IndexSegmentReader> get_index_segment_reader(const std::shared_ptr<Store>& store,
     const std::shared_ptr<PipelineContext>& pipeline_context,
-    const VersionedItem& version_info) {
+    const VersionedItem& version_info)
+{
     std::pair<entity::VariantKey, SegmentInMemory> index_key_seg;
     try {
         index_key_seg = store->read_sync(version_info.key_);
@@ -566,15 +653,14 @@ std::optional<pipelines::index::IndexSegmentReader> get_index_segment_reader(
     return std::make_optional<pipelines::index::IndexSegmentReader>(std::move(index_key_seg.second));
 }
 
-void read_indexed_keys_to_pipeline(
-    const std::shared_ptr<Store>& store,
+void read_indexed_keys_to_pipeline(const std::shared_ptr<Store>& store,
     const std::shared_ptr<PipelineContext>& pipeline_context,
     const VersionedItem& version_info,
     ReadQuery& read_query,
-    const ReadOptions& read_options
-    ) {
+    const ReadOptions& read_options)
+{
     auto maybe_reader = get_index_segment_reader(store, pipeline_context, version_info);
-    if(!maybe_reader)
+    if (!maybe_reader)
         return;
 
     auto index_segment_reader = std::move(maybe_reader.value());
@@ -585,47 +671,48 @@ void read_indexed_keys_to_pipeline(
 
     read_query.calculate_row_filter(static_cast<int64_t>(index_segment_reader.tsd().total_rows()));
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
-    pipeline_context->desc_ = StreamDescriptor{std::move(*index_segment_reader.mutable_tsd().mutable_stream_descriptor())};
+    pipeline_context->desc_ =
+        StreamDescriptor{std::move(*index_segment_reader.mutable_tsd().mutable_stream_descriptor())};
 
     bool dynamic_schema = opt_false(read_options.dynamic_schema_);
-    auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(
-        read_query,
+    auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(read_query,
         pipeline_context,
         dynamic_schema,
         bucketize_dynamic);
 
     pipeline_context->slice_and_keys_ = filter_index(index_segment_reader, combine_filter_functions(queries));
     pipeline_context->total_rows_ = pipeline_context->calc_rows();
-    pipeline_context->norm_meta_ = std::make_shared<arcticdb::proto::descriptors::NormalizationMetadata>(std::move(*index_segment_reader.mutable_tsd().mutable_normalization()));
-    pipeline_context->user_meta_ = std::make_unique<arcticdb::proto::descriptors::UserDefinedMetadata>(std::move(*index_segment_reader.mutable_tsd().mutable_user_meta()));
+    pipeline_context->norm_meta_ = std::make_shared<arcticdb::proto::descriptors::NormalizationMetadata>(
+        std::move(*index_segment_reader.mutable_tsd().mutable_normalization()));
+    pipeline_context->user_meta_ = std::make_unique<arcticdb::proto::descriptors::UserDefinedMetadata>(
+        std::move(*index_segment_reader.mutable_tsd().mutable_user_meta()));
     pipeline_context->bucketize_dynamic_ = bucketize_dynamic;
 }
 
-void read_incompletes_to_pipeline(
-    const std::shared_ptr<Store>& store,
+void read_incompletes_to_pipeline(const std::shared_ptr<Store>& store,
     std::shared_ptr<PipelineContext>& pipeline_context,
     const ReadQuery& read_query,
     const ReadOptions& read_options,
     bool convert_int_to_float,
     bool via_iteration,
-    bool sparsify) {
+    bool sparsify)
+{
 
-    auto incomplete_segments = stream::get_incomplete(
-        store,
+    auto incomplete_segments = stream::get_incomplete(store,
         pipeline_context->stream_id_,
         read_query.row_filter,
         pipeline_context->last_slice_row(),
         via_iteration,
         false);
 
-    if(incomplete_segments.empty())
+    if (incomplete_segments.empty())
         return;
 
     // Mark the start point of the incompletes, so we know that there is no column slicing after this point
     pipeline_context->incompletes_after_ = pipeline_context->slice_and_keys_.size();
 
     // If there are only incompletes we need to add the index here
-    if(pipeline_context->slice_and_keys_.empty()) {
+    if (pipeline_context->slice_and_keys_.empty()) {
         auto tsd = timeseries_descriptor_from_any(*incomplete_segments.begin()->segment(store).metadata());
         add_index_columns_to_query(read_query, tsd);
     }
@@ -641,18 +728,26 @@ void read_incompletes_to_pipeline(
         ensure_norm_meta(*pipeline_context->norm_meta_, pipeline_context->stream_id_, sparsify);
     }
 
-    pipeline_context->desc_ = stream::merge_descriptors(pipeline_context->descriptor(), incomplete_segments, read_query.columns);
+    pipeline_context->desc_ =
+        stream::merge_descriptors(pipeline_context->descriptor(), incomplete_segments, read_query.columns);
     modify_descriptor(pipeline_context, read_options);
     if (convert_int_to_float) {
         stream::convert_descriptor_types(*pipeline_context->desc_);
     }
 
     generate_filtered_field_descriptors(pipeline_context, read_query.columns);
-    pipeline_context->slice_and_keys_.insert(std::end(pipeline_context->slice_and_keys_), std::begin(incomplete_segments),  std::end(incomplete_segments));
+    pipeline_context->slice_and_keys_.insert(std::end(pipeline_context->slice_and_keys_),
+        std::begin(incomplete_segments),
+        std::end(incomplete_segments));
     pipeline_context->total_rows_ = pipeline_context->calc_rows();
 }
 
-void copy_frame_data_to_buffer(const SegmentInMemory& destination, size_t target_index, SegmentInMemory& source, size_t source_index, const RowRange& row_range) {
+void copy_frame_data_to_buffer(const SegmentInMemory& destination,
+    size_t target_index,
+    SegmentInMemory& source,
+    size_t source_index,
+    const RowRange& row_range)
+{
     auto num_rows = row_range.diff();
     if (num_rows == 0) {
         return;
@@ -669,18 +764,21 @@ void copy_frame_data_to_buffer(const SegmentInMemory& destination, size_t target
     auto dst_ptr = buffer.data() + offset;
 
     auto type_promotion_error_msg = fmt::format("Can't promote type {} to type {} in field {}",
-                                                src_column.type(), dst_column.type(), destination.field(target_index).name());
+        src_column.type(),
+        dst_column.type(),
+        destination.field(target_index).name());
 
     if (trivially_compatible_types(src_column.type(), dst_column.type())) {
         memcpy(dst_ptr, src_ptr, total_size);
     } else if (has_valid_type_promotion(src_column.type(), dst_column.type())) {
-        dst_column.type().visit_tag([&src_ptr, &dst_ptr, &src_column, &type_promotion_error_msg, num_rows] (auto dest_desc_tag) {
-            using DestinationType =  typename decltype(dest_desc_tag)::DataTypeTag::raw_type;
-            src_column.type().visit_tag([&src_ptr, &dst_ptr, &type_promotion_error_msg, num_rows] (auto src_desc_tag ) {
-                using SourceType =  typename decltype(src_desc_tag)::DataTypeTag::raw_type;
-                if constexpr(std::is_arithmetic_v<SourceType> && std::is_arithmetic_v<DestinationType>) {
-                    auto typed_src_ptr = reinterpret_cast<SourceType *>(src_ptr);
-                    auto typed_dst_ptr = reinterpret_cast<DestinationType *>(dst_ptr);
+        dst_column.type().visit_tag([&src_ptr, &dst_ptr, &src_column, &type_promotion_error_msg, num_rows](
+                                        auto dest_desc_tag) {
+            using DestinationType = typename decltype(dest_desc_tag)::DataTypeTag::raw_type;
+            src_column.type().visit_tag([&src_ptr, &dst_ptr, &type_promotion_error_msg, num_rows](auto src_desc_tag) {
+                using SourceType = typename decltype(src_desc_tag)::DataTypeTag::raw_type;
+                if constexpr (std::is_arithmetic_v<SourceType> && std::is_arithmetic_v<DestinationType>) {
+                    auto typed_src_ptr = reinterpret_cast<SourceType*>(src_ptr);
+                    auto typed_dst_ptr = reinterpret_cast<DestinationType*>(dst_ptr);
                     for (auto i = 0u; i < num_rows; ++i) {
                         *typed_dst_ptr++ = static_cast<DestinationType>(*typed_src_ptr++);
                     }
@@ -694,7 +792,10 @@ void copy_frame_data_to_buffer(const SegmentInMemory& destination, size_t target
     }
 }
 
-void copy_segments_to_frame(const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context, const SegmentInMemory& frame) {
+void copy_segments_to_frame(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<PipelineContext>& pipeline_context,
+    const SegmentInMemory& frame)
+{
     for (auto context_row : folly::enumerate(*pipeline_context)) {
         auto& segment = context_row->slice_and_key().segment(store);
         const auto index_field_count = get_index_field_count(frame);
@@ -709,12 +810,20 @@ void copy_segments_to_frame(const std::shared_ptr<Store>& store, const std::shar
             if (!frame_loc_opt)
                 continue;
 
-            copy_frame_data_to_buffer(frame, *frame_loc_opt, segment, field_col, context_row->slice_and_key().slice_.row_range);
+            copy_frame_data_to_buffer(frame,
+                *frame_loc_opt,
+                segment,
+                field_col,
+                context_row->slice_and_key().slice_.row_range);
         }
     }
 }
 
-SegmentInMemory prepare_output_frame(std::vector<SliceAndKey>&& items, const std::shared_ptr<PipelineContext>& pipeline_context, const std::shared_ptr<Store>& store, const ReadOptions& read_options) {
+SegmentInMemory prepare_output_frame(std::vector<SliceAndKey>&& items,
+    const std::shared_ptr<PipelineContext>& pipeline_context,
+    const std::shared_ptr<Store>& store,
+    const ReadOptions& read_options)
+{
     pipeline_context->clear_vectors();
     pipeline_context->slice_and_keys_ = std::move(items);
     std::sort(std::begin(pipeline_context->slice_and_keys_), std::end(pipeline_context->slice_and_keys_));
@@ -723,7 +832,7 @@ SegmentInMemory prepare_output_frame(std::vector<SliceAndKey>&& items, const std
     mark_index_slices(pipeline_context, dynamic_schema, pipeline_context->bucketize_dynamic_);
     pipeline_context->ensure_vectors();
 
-    for(auto row : *pipeline_context) {
+    for (auto row : *pipeline_context) {
         row.set_compacted(false);
         row.set_descriptor(row.slice_and_key().segment(store).descriptor_ptr());
         row.set_string_pool(row.slice_and_key().segment(store).string_pool_ptr());
@@ -735,30 +844,34 @@ SegmentInMemory prepare_output_frame(std::vector<SliceAndKey>&& items, const std
     return frame;
 }
 
-FrameAndDescriptor read_dataframe_impl(
-    const std::shared_ptr<Store>& store,
+FrameAndDescriptor read_dataframe_impl(const std::shared_ptr<Store>& store,
     const std::variant<VersionedItem, StreamId>& version_info,
     ReadQuery& read_query,
-    const ReadOptions& read_options
-    ) {
+    const ReadOptions& read_options)
+{
     using namespace arcticdb::pipelines;
     auto pipeline_context = std::make_shared<PipelineContext>();
 
-    if(std::holds_alternative<StreamId>(version_info)) {
+    if (std::holds_alternative<StreamId>(version_info)) {
         pipeline_context->stream_id_ = std::get<StreamId>(version_info);
     } else {
         pipeline_context->stream_id_ = std::get<VersionedItem>(version_info).key_.id();
-        read_indexed_keys_to_pipeline(store, pipeline_context, std::get<VersionedItem>(version_info), read_query, read_options);
+        read_indexed_keys_to_pipeline(store,
+            pipeline_context,
+            std::get<VersionedItem>(version_info),
+            read_query,
+            read_options);
     }
 
-    if(pipeline_context->multi_key_)
+    if (pipeline_context->multi_key_)
         return read_multi_key(store, *pipeline_context->multi_key_);
 
-    if(opt_false(read_options.incompletes_)) {
-        util::check(std::holds_alternative<IndexRange>(read_query.row_filter), "Streaming read requires date range filter");
+    if (opt_false(read_options.incompletes_)) {
+        util::check(std::holds_alternative<IndexRange>(read_query.row_filter),
+            "Streaming read requires date range filter");
         const auto& query_range = std::get<IndexRange>(read_query.row_filter);
         const auto existing_range = pipeline_context->index_range();
-        if(!existing_range.specified_ || query_range.end_ > existing_range.end_)
+        if (!existing_range.specified_ || query_range.end_ > existing_range.end_)
             read_incompletes_to_pipeline(store, pipeline_context, read_query, read_options, false, false, false);
     }
 
@@ -767,16 +880,19 @@ FrameAndDescriptor read_dataframe_impl(
     ARCTICDB_DEBUG(log::version(), "Fetching data to frame");
     SegmentInMemory frame;
     auto buffers = std::make_shared<BufferHolder>();
-    if(!read_query.query_->empty()) {
+    if (!read_query.query_->empty()) {
         ARCTICDB_SAMPLE(RunPipelineAndOutput, 0)
-        util::check_rte(!pipeline_context->is_pickled(),"Cannot filter pickled data");
+        util::check_rte(!pipeline_context->is_pickled(), "Cannot filter pickled data");
         auto segs = read_and_process(store, pipeline_context, read_query, read_options, 0u);
 
         frame = prepare_output_frame(std::move(segs), pipeline_context, store, read_options);
     } else {
         ARCTICDB_SAMPLE(MarkAndReadDirect, 0)
-        util::check_rte(!(pipeline_context->is_pickled() && std::holds_alternative<RowRange>(read_query.row_filter)), "Cannot use head/tail/row_range with pickled data, use plain read instead");
-        mark_index_slices(pipeline_context, opt_false(read_options.dynamic_schema_), pipeline_context->bucketize_dynamic_);
+        util::check_rte(!(pipeline_context->is_pickled() && std::holds_alternative<RowRange>(read_query.row_filter)),
+            "Cannot use head/tail/row_range with pickled data, use plain read instead");
+        mark_index_slices(pipeline_context,
+            opt_false(read_options.dynamic_schema_),
+            pipeline_context->bucketize_dynamic_);
         frame = read_direct(store, pipeline_context, buffers, read_options);
     }
 
@@ -785,66 +901,81 @@ FrameAndDescriptor read_dataframe_impl(
     return {frame, make_descriptor(pipeline_context, {}, pipeline_context->bucketize_dynamic_), {}, buffers};
 }
 
-VersionedItem collate_and_write(
-    const std::shared_ptr<Store>& store,
+VersionedItem collate_and_write(const std::shared_ptr<Store>& store,
     const std::shared_ptr<PipelineContext>& pipeline_context,
     const std::vector<FrameSlice>& slices,
     std::vector<VariantKey> keys,
     size_t append_after,
-    const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta
-    ) {
+    const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta)
+{
     util::check(keys.size() == slices.size(), "Mismatch between slices size and key size");
     arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
     tsd.set_total_rows(pipeline_context->total_rows_);
     //TODO eliminate copies
     tsd.mutable_stream_descriptor()->CopyFrom(pipeline_context->descriptor().proto());
     tsd.mutable_normalization()->CopyFrom(*pipeline_context->norm_meta_);
-    if(user_meta)
+    if (user_meta)
         tsd.mutable_user_meta()->CopyFrom(*user_meta);
 
     auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
-    return util::variant_match(index, [&store, &pipeline_context, &slices, &keys, &append_after, &tsd] (auto idx) {
+    return util::variant_match(index, [&store, &pipeline_context, &slices, &keys, &append_after, &tsd](auto idx) {
         using IndexType = decltype(idx);
-        index::IndexWriter<IndexType> writer(store, IndexPartialKey{pipeline_context->stream_id_, pipeline_context->version_id_}, std::move(tsd));
+        index::IndexWriter<IndexType> writer(store,
+            IndexPartialKey{pipeline_context->stream_id_, pipeline_context->version_id_},
+            std::move(tsd));
         auto end = std::begin(pipeline_context->slice_and_keys_);
         std::advance(end, append_after);
-        ARCTICDB_DEBUG(log::version(), "Adding {} existing keys and {} new keys: ", std::distance(std::begin(pipeline_context->slice_and_keys_), end), keys.size());
-        for(auto sk = std::begin(pipeline_context->slice_and_keys_); sk < end; ++sk)
+        ARCTICDB_DEBUG(log::version(),
+            "Adding {} existing keys and {} new keys: ",
+            std::distance(std::begin(pipeline_context->slice_and_keys_), end),
+            keys.size());
+        for (auto sk = std::begin(pipeline_context->slice_and_keys_); sk < end; ++sk)
             writer.add(sk->key(), sk->slice());
 
         for (auto key : folly::enumerate(keys)) {
             writer.add(to_atom(*key), slices[key.index]);
         }
-        auto index_key =  writer.commit();
+        auto index_key = writer.commit();
         return VersionedItem{to_atom(std::move(index_key).get())};
     });
 }
 
-VersionedItem sort_merge_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem sort_merge_impl(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& norm_meta,
     const UpdateInfo& update_info,
     bool append,
     bool convert_int_to_float,
     bool via_iteration,
-    bool sparsify
-    ) {
+    bool sparsify)
+{
     auto pipeline_context = std::make_shared<PipelineContext>();
     pipeline_context->stream_id_ = stream_id;
     pipeline_context->version_id_ = update_info.next_version_id_;
     ReadQuery read_query;
 
-    if(append && update_info.previous_index_key_.has_value())
-        read_indexed_keys_to_pipeline(store, pipeline_context, *(update_info.previous_index_key_), read_query, ReadOptions{});
+    if (append && update_info.previous_index_key_.has_value())
+        read_indexed_keys_to_pipeline(store,
+            pipeline_context,
+            *(update_info.previous_index_key_),
+            read_query,
+            ReadOptions{});
 
     auto num_versioned_rows = pipeline_context->total_rows_;
 
-    read_incompletes_to_pipeline(store, pipeline_context, read_query, ReadOptions{}, convert_int_to_float, via_iteration, sparsify);
+    read_incompletes_to_pipeline(store,
+        pipeline_context,
+        read_query,
+        ReadOptions{},
+        convert_int_to_float,
+        via_iteration,
+        sparsify);
 
     std::vector<entity::VariantKey> delete_keys;
-    for(auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
-        util::check(sk->slice_and_key().key().type() == KeyType::APPEND_DATA, "Deleting incorrect key type {}", sk->slice_and_key().key().type());
+    for (auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
+        util::check(sk->slice_and_key().key().type() == KeyType::APPEND_DATA,
+            "Deleting incorrect key type {}",
+            sk->slice_and_key().key().type());
         delete_keys.emplace_back(sk->slice_and_key().key());
     }
 
@@ -852,90 +983,85 @@ VersionedItem sort_merge_impl(
     std::vector<folly::Future<VariantKey>> fut_vec;
     std::optional<SegmentInMemory> last_indexed;
     auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
-    util::variant_match(index,
-        [&](const stream::TimeseriesIndex &timeseries_index) {
-        read_query.query_->emplace_back(SortClause{timeseries_index.name()});
+    util::variant_match(
+        index,
+        [&](const stream::TimeseriesIndex& timeseries_index) {
+            read_query.query_->emplace_back(SortClause{timeseries_index.name()});
             ExecutionContext remove_column_partition_context{};
             remove_column_partition_context.set_descriptor(pipeline_context->descriptor());
-            read_query.query_->emplace_back(RemoveColumnPartitioningClause{std::make_shared<ExecutionContext>(std::move(remove_column_partition_context))});
+            read_query.query_->emplace_back(RemoveColumnPartitioningClause{
+                std::make_shared<ExecutionContext>(std::move(remove_column_partition_context))});
             const auto split_size = ConfigsMap::instance()->get_int("Split.RowCount", 10000);
             read_query.query_->emplace_back(SplitClause{static_cast<size_t>(split_size)});
             ExecutionContext merge_clause_context{};
             merge_clause_context.set_descriptor(pipeline_context->descriptor());
-            read_query.query_->emplace_back(MergeClause{timeseries_index, DenseColumnPolicy{}, stream_id, std::make_shared<ExecutionContext>(std::move(merge_clause_context))});
-            auto segments = read_and_process(store, pipeline_context, read_query, ReadOptions{}, pipeline_context->incompletes_after());
+            read_query.query_->emplace_back(MergeClause{timeseries_index,
+                DenseColumnPolicy{},
+                stream_id,
+                std::make_shared<ExecutionContext>(std::move(merge_clause_context))});
+            auto segments = read_and_process(store,
+                pipeline_context,
+                read_query,
+                ReadOptions{},
+                pipeline_context->incompletes_after());
             pipeline_context->total_rows_ = num_versioned_rows + get_slice_rowcounts(segments);
 
             auto index = index_type_from_descriptor(pipeline_context->descriptor());
             stream::SegmentAggregator<TimeseriesIndex, DynamicSchema, RowCountSegmentPolicy, SparseColumnPolicy>
-            aggregator{
-                [&slices](FrameSlice slice) {
-                    slices.emplace_back(std::move(slice));
-                    },
+                aggregator{[&slices](FrameSlice slice) { slices.emplace_back(std::move(slice)); },
                     DynamicSchema{pipeline_context->descriptor(), index},
-                    [pipeline_context=pipeline_context, &fut_vec, &store](SegmentInMemory &&segment) {
-                    auto local_index_start = TimeseriesIndex::start_value_for_segment(segment);
-                    auto local_index_end = TimeseriesIndex::end_value_for_segment(segment);
-                    stream::StreamSink::PartialKey
-                    pk{KeyType::TABLE_DATA, pipeline_context->version_id_, pipeline_context->stream_id_, local_index_start, local_index_end};
-                    fut_vec.emplace_back(store->write(pk, std::move(segment)));
-                }};
+                    [pipeline_context = pipeline_context, &fut_vec, &store](SegmentInMemory&& segment) {
+                        auto local_index_start = TimeseriesIndex::start_value_for_segment(segment);
+                        auto local_index_end = TimeseriesIndex::end_value_for_segment(segment);
+                        stream::StreamSink::PartialKey pk{KeyType::TABLE_DATA,
+                            pipeline_context->version_id_,
+                            pipeline_context->stream_id_,
+                            local_index_start,
+                            local_index_end};
+                        fut_vec.emplace_back(store->write(pk, std::move(segment)));
+                    }};
 
-            for(auto sk = segments.begin(); sk != segments.end(); ++sk) {
-                aggregator.add_segment(
-                    std::move(sk->segment(store)),
-                    sk->slice(),
-                    convert_int_to_float);
+            for (auto sk = segments.begin(); sk != segments.end(); ++sk) {
+                aggregator.add_segment(std::move(sk->segment(store)), sk->slice(), convert_int_to_float);
 
                 sk->unset_segment();
             }
             aggregator.commit();
         },
-        [&](const auto &) {
-            util::raise_rte("Not supported index type for sort merge implementation");
-        }
-        );
+        [&](const auto&) { util::raise_rte("Not supported index type for sort merge implementation"); });
 
     auto keys = folly::collect(fut_vec).get();
-    auto vit = collate_and_write(
-        store,
-        pipeline_context,
-        slices,
-        keys,
-        pipeline_context->incompletes_after(),
-        norm_meta);
+    auto vit =
+        collate_and_write(store, pipeline_context, slices, keys, pipeline_context->incompletes_after(), norm_meta);
 
     store->remove_keys(delete_keys).get();
     return vit;
 }
 
-
-template <typename IndexType, typename SchemaType, typename SegmentationPolicy, typename DensityPolicy>
-void do_compact(
-    const std::shared_ptr<PipelineContext>& pipeline_context,
+template<typename IndexType, typename SchemaType, typename SegmentationPolicy, typename DensityPolicy>
+void do_compact(const std::shared_ptr<PipelineContext>& pipeline_context,
     std::vector<folly::Future<VariantKey>>& fut_vec,
     std::vector<FrameSlice>& slices,
     const std::shared_ptr<Store>& store,
-    bool convert_int_to_float) {
-    stream::SegmentAggregator<IndexType, SchemaType, SegmentationPolicy, DensityPolicy>
-    aggregator{
-        [&slices](FrameSlice slice) {
-            slices.emplace_back(std::move(slice));
-            },
-            SchemaType{pipeline_context->descriptor(), index_type_from_descriptor(pipeline_context->descriptor())},
-            [&fut_vec, &store, &pipeline_context](SegmentInMemory &&segment) {
+    bool convert_int_to_float)
+{
+    stream::SegmentAggregator<IndexType, SchemaType, SegmentationPolicy, DensityPolicy> aggregator{
+        [&slices](FrameSlice slice) { slices.emplace_back(std::move(slice)); },
+        SchemaType{pipeline_context->descriptor(), index_type_from_descriptor(pipeline_context->descriptor())},
+        [&fut_vec, &store, &pipeline_context](SegmentInMemory&& segment) {
             auto local_index_start = IndexType::start_value_for_segment(segment);
             auto local_index_end = IndexType::end_value_for_segment(segment);
-            stream::StreamSink::PartialKey
-            pk{KeyType::TABLE_DATA, pipeline_context->version_id_, pipeline_context->stream_id_, local_index_start, local_index_end};
+            stream::StreamSink::PartialKey pk{KeyType::TABLE_DATA,
+                pipeline_context->version_id_,
+                pipeline_context->stream_id_,
+                local_index_start,
+                local_index_end};
             fut_vec.emplace_back(store->write(pk, std::move(segment)));
-            },
-            SegmentationPolicy{}
-    };
+        },
+        SegmentationPolicy{}};
 
-    for(auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
-        aggregator.add_segment(
-            std::move(sk->slice_and_key().segment(store)),
+    for (auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
+        aggregator.add_segment(std::move(sk->slice_and_key().segment(store)),
             sk->slice_and_key().slice(),
             convert_int_to_float);
 
@@ -944,15 +1070,15 @@ void do_compact(
     aggregator.commit();
 }
 
-VersionedItem compact_incomplete_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem compact_incomplete_impl(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     const UpdateInfo& update_info,
     bool append,
     bool convert_int_to_float,
     bool via_iteration,
-    bool sparsify) {
+    bool sparsify)
+{
 
     auto pipeline_context = std::make_shared<PipelineContext>();
     pipeline_context->stream_id_ = stream_id;
@@ -962,19 +1088,31 @@ VersionedItem compact_incomplete_impl(
     read_options.set_dynamic_schema(true);
 
     std::optional<SegmentInMemory> last_indexed;
-    if(append && update_info.previous_index_key_.has_value())
-        read_indexed_keys_to_pipeline(store, pipeline_context, *(update_info.previous_index_key_), read_query, read_options);
+    if (append && update_info.previous_index_key_.has_value())
+        read_indexed_keys_to_pipeline(store,
+            pipeline_context,
+            *(update_info.previous_index_key_),
+            read_query,
+            read_options);
 
     auto prev_size = pipeline_context->slice_and_keys_.size();
-    read_incompletes_to_pipeline(store, pipeline_context, ReadQuery{}, ReadOptions{}, convert_int_to_float, via_iteration, sparsify);
+    read_incompletes_to_pipeline(store,
+        pipeline_context,
+        ReadQuery{},
+        ReadOptions{},
+        convert_int_to_float,
+        via_iteration,
+        sparsify);
     if (pipeline_context->slice_and_keys_.size() == prev_size) {
         util::raise_rte("No incomplete segments found for {}", stream_id);
     }
     const auto& first_seg = pipeline_context->slice_and_keys_.begin()->segment(store);
 
     std::vector<entity::VariantKey> delete_keys;
-    for(auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
-        util::check(sk->slice_and_key().key().type() == KeyType::APPEND_DATA, "Deleting incorrect key type {}", sk->slice_and_key().key().type());
+    for (auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
+        util::check(sk->slice_and_key().key().type() == KeyType::APPEND_DATA,
+            "Deleting incorrect key type {}",
+            sk->slice_and_key().key().type());
         delete_keys.emplace_back(sk->slice_and_key().key());
     }
 
@@ -982,36 +1120,28 @@ VersionedItem compact_incomplete_impl(
     std::vector<FrameSlice> slices;
     auto index = index_type_from_descriptor(first_seg.descriptor());
 
-    util::variant_match(index, [
-        &fut_vec, &slices, sparsify, pipeline_context=pipeline_context, &store, convert_int_to_float] (auto idx) {
-        using IndexType = decltype(idx);
+    util::variant_match(index,
+        [&fut_vec, &slices, sparsify, pipeline_context = pipeline_context, &store, convert_int_to_float](auto idx) {
+            using IndexType = decltype(idx);
 
-        if(sparsify) {
-            do_compact<IndexType, DynamicSchema, RowCountSegmentPolicy, SparseColumnPolicy>(
-                pipeline_context,
-                fut_vec,
-                slices,
-                store,
-                convert_int_to_float);
-        } else {
-            do_compact<IndexType, FixedSchema, RowCountSegmentPolicy, DenseColumnPolicy>(
-                pipeline_context,
-                fut_vec,
-                slices,
-                store,
-                convert_int_to_float);
-        }
-    });
+            if (sparsify) {
+                do_compact<IndexType, DynamicSchema, RowCountSegmentPolicy, SparseColumnPolicy>(pipeline_context,
+                    fut_vec,
+                    slices,
+                    store,
+                    convert_int_to_float);
+            } else {
+                do_compact<IndexType, FixedSchema, RowCountSegmentPolicy, DenseColumnPolicy>(pipeline_context,
+                    fut_vec,
+                    slices,
+                    store,
+                    convert_int_to_float);
+            }
+        });
 
     auto keys = folly::collect(fut_vec).get();
-    auto vit = collate_and_write(
-        store,
-        pipeline_context,
-        slices,
-        keys,
-        pipeline_context->incompletes_after(),
-        user_meta
-        );
+    auto vit =
+        collate_and_write(store, pipeline_context, slices, keys, pipeline_context->incompletes_after(), user_meta);
 
     store->remove_keys(delete_keys).get();
     return vit;

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -28,72 +28,57 @@ namespace arcticdb::version_store {
 using namespace arcticdb::entity;
 using namespace arcticdb::pipelines;
 
-VersionedItem write_dataframe_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem write_dataframe_impl(const std::shared_ptr<Store>& store,
     VersionId version_id,
     InputTensorFrame&& frame,
     const WriteOptions& options,
     const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
     bool allow_sparse = false,
-    bool validate_index = false
-);
+    bool validate_index = false);
 
-folly::Future<entity::AtomKey> async_write_dataframe_impl(
-    const std::shared_ptr<Store>& store,
+folly::Future<entity::AtomKey> async_write_dataframe_impl(const std::shared_ptr<Store>& store,
     VersionId version_id,
     InputTensorFrame&& frame,
     const WriteOptions& options,
     const std::shared_ptr<DeDupMap>& de_dup_map,
     bool allow_sparse,
-    bool validate_index
-);
+    bool validate_index);
 
-folly::Future<AtomKey> async_append_impl(
-    const std::shared_ptr<Store>& store,
+folly::Future<AtomKey> async_append_impl(const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     InputTensorFrame&& frame,
     const WriteOptions& options,
     bool validate_index);
 
-VersionedItem append_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem append_impl(const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     InputTensorFrame&& frame,
     const WriteOptions& options,
     bool validate_index);
 
-VersionedItem update_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem update_impl(const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
-    const UpdateQuery & query,
+    const UpdateQuery& query,
     InputTensorFrame&& frame,
     const WriteOptions&& options,
     bool dynamic_schema);
 
-VersionedItem delete_range_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem delete_range_impl(const std::shared_ptr<Store>& store,
     const AtomKey& prev,
     const UpdateQuery& query,
     const WriteOptions&& options,
     bool dynamic_schema);
 
-FrameAndDescriptor read_multi_key(
-    const std::shared_ptr<Store>& store,
-    const SegmentInMemory& index_key_seg);
+FrameAndDescriptor read_multi_key(const std::shared_ptr<Store>& store, const SegmentInMemory& index_key_seg);
 
-FrameAndDescriptor read_dataframe_impl(
-    const std::shared_ptr<Store>& store,
+FrameAndDescriptor read_dataframe_impl(const std::shared_ptr<Store>& store,
     const std::variant<VersionedItem, StreamId>& version_info,
-    ReadQuery & read_query,
-    const ReadOptions& read_options
-    );
+    ReadQuery& read_query,
+    const ReadOptions& read_options);
 
-FrameAndDescriptor read_index_impl(
-    const std::shared_ptr<Store>& store,
-    const VersionedItem& version);
+FrameAndDescriptor read_index_impl(const std::shared_ptr<Store>& store, const VersionedItem& version);
 
-VersionedItem compact_incomplete_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem compact_incomplete_impl(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     const UpdateInfo& update_info,
@@ -102,31 +87,26 @@ VersionedItem compact_incomplete_impl(
     bool via_iteration,
     bool sparsify);
 
-VersionedItem sort_merge_impl(
-    const std::shared_ptr<Store>& store,
+VersionedItem sort_merge_impl(const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     const UpdateInfo& update_info,
     bool append,
     bool convert_int_to_float,
     bool via_iteration,
-    bool sparsify
-    );
+    bool sparsify);
 
-void modify_descriptor(
-    const std::shared_ptr<pipelines::PipelineContext>& pipeline_context,
+void modify_descriptor(const std::shared_ptr<pipelines::PipelineContext>& pipeline_context,
     const ReadOptions& read_options);
 
-template <typename IndexType, typename SchemaType, typename SegmentationPolicy, typename DensityPolicy>
-void do_compact(
-    const std::shared_ptr<PipelineContext>& pipeline_context,
+template<typename IndexType, typename SchemaType, typename SegmentationPolicy, typename DensityPolicy>
+void do_compact(const std::shared_ptr<PipelineContext>& pipeline_context,
     std::vector<folly::Future<VariantKey>>& fut_vec,
     std::vector<FrameSlice>& slices,
     const std::shared_ptr<Store>& store,
     bool convert_int_to_float);
 
-void read_indexed_keys_to_pipeline(
-    const std::shared_ptr<Store>& store,
+void read_indexed_keys_to_pipeline(const std::shared_ptr<Store>& store,
     const std::shared_ptr<PipelineContext>& pipeline_context,
     const VersionedItem& version_info,
     ReadQuery& read_query,

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -10,89 +10,112 @@
 #include <arcticdb/version/version_map.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
 
-
 namespace arcticdb {
 
-inline std::optional<AtomKey> get_latest_undeleted_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
+inline std::optional<AtomKey> get_latest_undeleted_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
     bool skip_compat,
-    bool iterate_on_failure) {
+    bool iterate_on_failure)
+{
     ARCTICDB_RUNTIME_SAMPLE(GetLatestUndeletedVersion, 0)
-    const auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED},
-                                                 skip_compat, iterate_on_failure, __FUNCTION__);
+    const auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_LATEST_UNDELETED},
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     return entry->get_first_index(false);
 }
 
-inline std::optional<AtomKey> get_latest_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
+inline std::optional<AtomKey> get_latest_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
     bool skip_compat,
-    bool iterate_on_failure) {
+    bool iterate_on_failure)
+{
     ARCTICDB_SAMPLE(GetLatestVersion, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_LATEST}, skip_compat,
-                                           iterate_on_failure, __FUNCTION__);
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_LATEST},
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     return entry->get_first_index(true);
 }
 
 // The next version ID returned will be 0 for brand new symbols, or one greater than the largest ever version created so far
-inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_id(
-        const std::shared_ptr<Store> &store,
-        const std::shared_ptr<VersionMap> &version_map,
-        const StreamId &stream_id,
-        bool skip_compat,
-        bool iterate_on_failure) {
+inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_id(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
+    bool skip_compat,
+    bool iterate_on_failure)
+{
     ARCTICDB_SAMPLE(GetLatestUndeletedVersionAndHighestVersionId, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED},
-                                           skip_compat, iterate_on_failure, __FUNCTION__);
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_LATEST_UNDELETED},
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     auto latest_version = entry->get_first_index(true);
     auto latest_undeleted_version = entry->get_first_index(false);
     VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
     return {latest_undeleted_version, next_version_id};
 }
 
-inline std::vector<AtomKey> get_all_versions(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
+inline std::vector<AtomKey> get_all_versions(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
     bool skip_compat,
-    bool iterate_on_failure) {
+    bool iterate_on_failure)
+{
     ARCTICDB_SAMPLE(GetAllVersions, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, skip_compat,
-                                           iterate_on_failure, __FUNCTION__);
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_ALL},
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     return entry->get_indexes(false);
 }
 
-inline std::optional<AtomKey> get_specific_version(
-        const std::shared_ptr<Store> &store,
-        const std::shared_ptr<VersionMap> &version_map,
-        const StreamId &stream_id,
-        VersionId version_id,
-        bool skip_compat,
-        bool iterate_on_failure,
-        bool include_deleted = false) {
+inline std::optional<AtomKey> get_specific_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
+    VersionId version_id,
+    bool skip_compat,
+    bool iterate_on_failure,
+    bool include_deleted = false)
+{
     ARCTICDB_SAMPLE(GetSpecificVersion, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_DOWNTO, version_id},
-                                           skip_compat, iterate_on_failure, __FUNCTION__);
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_DOWNTO, version_id},
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     auto indexes = entry->get_indexes(include_deleted);
-    for (auto &index :  indexes) {
+    for (auto& index : indexes) {
         if (index.version_id() == version_id)
             return index;
     }
     return std::nullopt;
 }
 
-inline std::optional<AtomKey> get_prev_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
+inline std::optional<AtomKey> get_prev_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
     VersionId version_id,
     bool skip_compat,
-    bool iterate_on_failure) {
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, skip_compat,
-                                           iterate_on_failure, __FUNCTION__);
+    bool iterate_on_failure)
+{
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_ALL},
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     auto prev_id = get_prev_version_in_entry(entry, version_id);
     if (prev_id) {
         return get_specific_version(store, version_map, stream_id, prev_id.value(), skip_compat, iterate_on_failure);
@@ -101,15 +124,19 @@ inline std::optional<AtomKey> get_prev_version(
     }
 }
 
-inline std::optional<AtomKey> get_next_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
+inline std::optional<AtomKey> get_next_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
     VersionId version_id,
     bool skip_compat,
-    bool iterate_on_failure) {
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_DOWNTO, version_id},
-                                           skip_compat, iterate_on_failure, __FUNCTION__);
+    bool iterate_on_failure)
+{
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_DOWNTO, version_id},
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     auto next_id = get_next_version_in_entry(entry, version_id);
     if (next_id) {
         return get_specific_version(store, version_map, stream_id, next_id.value(), skip_compat, iterate_on_failure);
@@ -118,23 +145,23 @@ inline std::optional<AtomKey> get_next_version(
     }
 }
 
-inline bool is_indexish_and_not_tombstoned(const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry) {
+inline bool is_indexish_and_not_tombstoned(const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry)
+{
     return is_index_key_type(key.type()) && !entry->is_tombstoned(key);
 }
 
-template<typename MatchingAcceptor, typename PrevAcceptor, typename NextAcceptor,
-        typename KeyFilter>
-inline bool get_matching_prev_and_next_versions(
-        const std::shared_ptr<VersionMapEntry> entry,
-        VersionId version_id,
-        MatchingAcceptor matching_acceptor,
-        PrevAcceptor prev_acceptor,
-        NextAcceptor next_acceptor,
-        KeyFilter key_filter) {
+template<typename MatchingAcceptor, typename PrevAcceptor, typename NextAcceptor, typename KeyFilter>
+inline bool get_matching_prev_and_next_versions(const std::shared_ptr<VersionMapEntry> entry,
+    VersionId version_id,
+    MatchingAcceptor matching_acceptor,
+    PrevAcceptor prev_acceptor,
+    NextAcceptor next_acceptor,
+    KeyFilter key_filter)
+{
     bool found_version = false;
     const IndexTypeKey* last = nullptr;
 
-    for (const auto& item: entry->keys_) {
+    for (const auto& item : entry->keys_) {
         if (key_filter(item, entry)) {
             if (item.version_id() == version_id) {
                 found_version = true;
@@ -153,56 +180,58 @@ inline bool get_matching_prev_and_next_versions(
     return found_version;
 }
 
-inline bool has_undeleted_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &id) {
+inline bool has_undeleted_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& id)
+{
     return static_cast<bool>(get_latest_undeleted_version(store, version_map, id, true, false));
 }
 
-inline void insert_if_undeleted(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const VariantKey &key,
-    std::set<StreamId> &res) {
+inline void insert_if_undeleted(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const VariantKey& key,
+    std::set<StreamId>& res)
+{
     auto id = variant_key_id(key);
     if (has_undeleted_version(store, version_map, id))
         res.insert(std::move(id));
 }
 
-inline std::unordered_map<VersionId, bool> get_all_tombstoned_versions(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id) {
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false,
-                                           __FUNCTION__);
+inline std::unordered_map<VersionId, bool> get_all_tombstoned_versions(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id)
+{
+    auto entry =
+        version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
     std::unordered_map<VersionId, bool> result;
-    for (auto key: entry->get_tombstoned_indexes())
-            result[key.version_id()] = store->key_exists(key).get();
+    for (auto key : entry->get_tombstoned_indexes())
+        result[key.version_id()] = store->key_exists(key).get();
 
     return result;
 }
 
-inline version_store::TombstoneVersionResult tombstone_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
+inline version_store::TombstoneVersionResult tombstone_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
     VersionId version_id,
-    bool allow_tombstoning_beyond_latest_version=false,
-    const std::optional<timestamp>& creation_ts=std::nullopt) {
+    bool allow_tombstoning_beyond_latest_version = false,
+    const std::optional<timestamp>& creation_ts = std::nullopt)
+{
     ARCTICDB_DEBUG(log::version(), "Tombstoning version {} for stream {}", version_id, stream_id);
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_UNDELETED}, true, false,
-                                           __FUNCTION__);
+    auto entry =
+        version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_UNDELETED}, true, false, __FUNCTION__);
     // Might as well do the previous/next version check while we find the required version_id.
     // But if entry is empty, it's possible the load failed (since iterate_on_failure=false above), so set the flag
     // to defer the check to delete_tree() (instead of reloading in case eager delete is disabled).
     version_store::TombstoneVersionResult res(entry->empty());
-    get_matching_prev_and_next_versions(entry, version_id,
-            [&res](auto& matching){res.keys_to_delete.push_back(matching);},
-            [&res](auto& prev){res.could_share_data.emplace(prev);},
-            [&res](auto& next){res.could_share_data.emplace(next);},
-            is_indexish_and_not_tombstoned // Entry could be cached with deleted keys even if LOAD_UNDELETED
-            );
+    get_matching_prev_and_next_versions(
+        entry,
+        version_id,
+        [&res](auto& matching) { res.keys_to_delete.push_back(matching); },
+        [&res](auto& prev) { res.could_share_data.emplace(prev); },
+        [&res](auto& next) { res.could_share_data.emplace(next); },
+        is_indexish_and_not_tombstoned // Entry could be cached with deleted keys even if LOAD_UNDELETED
+    );
 
     AtomKey tombstone;
     if (res.keys_to_delete.empty()) {
@@ -215,7 +244,8 @@ inline version_store::TombstoneVersionResult tombstone_version(
                 auto latest_key = get_latest_version(store, version_map, stream_id, true, false);
                 if (!latest_key || latest_key.value().version_id() < version_id)
                     util::raise_rte("Can't delete version {} for symbol {} - it's higher than the latest version",
-                            stream_id, version_id);
+                        stream_id,
+                        version_id);
             }
             // We will write a tombstone key even when the index_key is not found
             tombstone = version_map->write_tombstone(store, version_id, stream_id, entry, creation_ts);
@@ -232,15 +262,15 @@ inline version_store::TombstoneVersionResult tombstone_version(
     return res;
 }
 
-inline std::optional<AtomKey> get_version_key_from_time_for_versions(
-    timestamp from_time,
-    const std::vector<AtomKey> &version_keys) {
+inline std::optional<AtomKey> get_version_key_from_time_for_versions(timestamp from_time,
+    const std::vector<AtomKey>& version_keys)
+{
     // get_all_versions will hold the lock
     // Version keys are sorted in reverse order
-    auto at_or_after = std::lower_bound(version_keys.begin(), version_keys.end(), from_time,
-                                        [](const AtomKey &v_key, timestamp cmp) {
-                                            return v_key.creation_ts() > cmp;
-                                        });
+    auto at_or_after =
+        std::lower_bound(version_keys.begin(), version_keys.end(), from_time, [](const AtomKey& v_key, timestamp cmp) {
+            return v_key.creation_ts() > cmp;
+        });
     // If iterator points to the last element, we didn't have any versions before that or empty
     if (at_or_after == version_keys.end()) {
         return std::nullopt;
@@ -248,29 +278,29 @@ inline std::optional<AtomKey> get_version_key_from_time_for_versions(
     return *at_or_after;
 }
 
-inline std::optional<AtomKey> get_version_key_from_time(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
+inline std::optional<AtomKey> get_version_key_from_time(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
     timestamp from_time,
     bool skip_compat,
-    bool iterate_on_failure) {
+    bool iterate_on_failure)
+{
     // get_all_versions will hold the lock
     auto all_versions = get_all_versions(store, version_map, stream_id, skip_compat, iterate_on_failure);
     return get_version_key_from_time_for_versions(from_time, all_versions);
 }
 
-inline bool delete_version_if_undeleted(
-        const std::shared_ptr<Store> &store,
-        const std::shared_ptr<VersionMap> &version_map,
-        const StreamId &stream_id,
-        VersionId version_id) {
+inline bool delete_version_if_undeleted(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
+    VersionId version_id)
+{
     const auto entry = version_map->check_reload(store,
-                                                 stream_id,
-                                                 LoadParameter{LoadType::LOAD_DOWNTO, version_id},
-                                                 true,
-                                                 true,
-                                                 __FUNCTION__);
+        stream_id,
+        LoadParameter{LoadType::LOAD_DOWNTO, version_id},
+        true,
+        true,
+        __FUNCTION__);
     if (!entry->is_tombstoned(version_id)) {
         auto tombstone_result = tombstone_version(store, version_map, stream_id, version_id, true);
         return tombstone_result.no_undeleted_left;
@@ -279,87 +309,99 @@ inline bool delete_version_if_undeleted(
     }
 }
 
-inline bool delete_version_and_previous_versions(
-        const std::shared_ptr<Store> &store,
-        const std::shared_ptr<VersionMap> &version_map,
-        const StreamId &stream_id,
-        VersionId version_id) {
-    if (auto deleted_key = get_specific_version(
-            store, version_map, stream_id, version_id, true, false); deleted_key) {
-        auto entry = version_map->check_reload(store, deleted_key->id(),
-                                              LoadParameter{LoadType::LOAD_UNDELETED},
-                                              true, false,
-                                              __FUNCTION__);
+inline bool delete_version_and_previous_versions(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
+    VersionId version_id)
+{
+    if (auto deleted_key = get_specific_version(store, version_map, stream_id, version_id, true, false); deleted_key) {
+        auto entry = version_map->check_reload(store,
+            deleted_key->id(),
+            LoadParameter{LoadType::LOAD_UNDELETED},
+            true,
+            false,
+            __FUNCTION__);
         version_map->write_tombstone_all_key(store, deleted_key.value(), entry);
     }
     auto symbol_deleted = !has_undeleted_version(store, version_map, stream_id);
     return symbol_deleted;
 }
 
-inline std::vector<AtomKey> get_index_and_tombstone_keys(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id) {
-    const auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, true,
-                                                 __FUNCTION__);
+inline std::vector<AtomKey> get_index_and_tombstone_keys(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id)
+{
+    const auto entry =
+        version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, true, __FUNCTION__);
     std::vector<AtomKey> res;
 
     // Copying both TABLE_INDEX and TOMBSTONE (entry->keys_ stores both - refer read_segment_with_keys)
-    std::copy_if(std::begin(entry->keys_), std::end(entry->keys_), std::back_inserter(res),
-                 [&](const auto &key) { return is_index_or_tombstone(key); });
+    std::copy_if(std::begin(entry->keys_), std::end(entry->keys_), std::back_inserter(res), [&](const auto& key) {
+        return is_index_or_tombstone(key);
+    });
 
     return res;
 }
 
 // Will return the TABLE_INDEX key even if it is tombstoned
-inline std::optional<AtomKey> get_index_key(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id,
-    VersionId version_id) {
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_DOWNTO, version_id}, true,
-                                           true, __FUNCTION__);
+inline std::optional<AtomKey> get_index_key(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
+    VersionId version_id)
+{
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_DOWNTO, version_id},
+        true,
+        true,
+        __FUNCTION__);
     auto all_index_keys = entry->get_indexes(true);
-    auto it = std::find_if(std::begin(all_index_keys), std::end(all_index_keys),
-                           [&](const auto &k) { return k.version_id() == version_id; });
+    auto it = std::find_if(std::begin(all_index_keys), std::end(all_index_keys), [&](const auto& k) {
+        return k.version_id() == version_id;
+    });
     return it == all_index_keys.end() ? std::nullopt : std::make_optional(*it);
 }
 
-inline std::optional<AtomKey> get_tombstone_key(
-        const std::shared_ptr<Store> &store,
-        const std::shared_ptr<VersionMap> &version_map,
-        const StreamId &stream_id,
-        VersionId version_id) {
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_DOWNTO, version_id}, true,
-                                           true, __FUNCTION__);
+inline std::optional<AtomKey> get_tombstone_key(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const StreamId& stream_id,
+    VersionId version_id)
+{
+    auto entry = version_map->check_reload(store,
+        stream_id,
+        LoadParameter{LoadType::LOAD_DOWNTO, version_id},
+        true,
+        true,
+        __FUNCTION__);
     auto tombstone_it = entry->tombstones_.find(version_id);
-    return tombstone_it != entry->tombstones_.end() ?  std::make_optional(tombstone_it->second) : std::nullopt;
+    return tombstone_it != entry->tombstones_.end() ? std::make_optional(tombstone_it->second) : std::nullopt;
 }
 
-inline std::set<StreamId> list_streams(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const std::optional<std::string> &prefix,
-    bool all_symbols
-) {
+inline std::set<StreamId> list_streams(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const std::optional<std::string>& prefix,
+    bool all_symbols)
+{
     ARCTICDB_SAMPLE(ListStreams, 0)
     std::set<StreamId> res;
     if (prefix && store->supports_prefix_matching()) {
         ARCTICDB_DEBUG(log::version(), "Storage backend supports prefix matching");
-        store->iterate_type(KeyType::VERSION_REF, [&store, &res, &version_map, all_symbols](auto &&vk) {
-                                auto key = std::forward<VariantKey>(vk);
-                                util::check(!variant_key_id_empty(key), "Unexpected empty id in key {}", key);
-                                if(all_symbols)
-                                    res.insert(variant_key_id(key));
-                                else
-                                    insert_if_undeleted(store, version_map, key, res);
-                            },
-                            prefix.value());
+        store->iterate_type(
+            KeyType::VERSION_REF,
+            [&store, &res, &version_map, all_symbols](auto&& vk) {
+                auto key = std::forward<VariantKey>(vk);
+                util::check(!variant_key_id_empty(key), "Unexpected empty id in key {}", key);
+                if (all_symbols)
+                    res.insert(variant_key_id(key));
+                else
+                    insert_if_undeleted(store, version_map, key, res);
+            },
+            prefix.value());
     } else {
-        store->iterate_type(KeyType::VERSION_REF, [&store, &res, &version_map, all_symbols](auto &&vk) {
+        store->iterate_type(KeyType::VERSION_REF, [&store, &res, &version_map, all_symbols](auto&& vk) {
             const auto key = std::forward<VariantKey>(vk);
             util::check(!variant_key_id_empty(key), "Unexpected empty id in key {}", key);
-            if(all_symbols)
+            if (all_symbols)
                 res.insert(variant_key_id(key));
             else
                 insert_if_undeleted(store, version_map, key, res);
@@ -368,4 +410,4 @@ inline std::set<StreamId> list_streams(
     return res;
 }
 
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/version/version_log.cpp
+++ b/cpp/arcticdb/version/version_log.cpp
@@ -10,81 +10,84 @@
 #include <arcticdb/util/variant.hpp>
 
 namespace arcticdb {
-    StreamDescriptor log_compacted_stream_descriptor(const StreamId& stream_id,
-                                                     DataType symbol_datatype) {
-        return StreamDescriptor{stream_descriptor(stream_id, RowCountIndex(), {
+StreamDescriptor log_compacted_stream_descriptor(const StreamId& stream_id, DataType symbol_datatype)
+{
+    return StreamDescriptor{stream_descriptor(stream_id,
+        RowCountIndex(),
+        {
             scalar_field_proto(symbol_datatype, "symbol"),
             scalar_field_proto(DataType::UINT64, "version_id"),
             scalar_field_proto(DataType::ASCII_DYNAMIC64, "action"),
             scalar_field_proto(DataType::MICROS_UTC64, "creation_ts"),
-            } )};
-    }
+        })};
+}
 
-    void delete_op_logs(const std::shared_ptr<Store>& store,
-                        std::variant<std::vector<AtomKey>, std::vector<OpLog>>&& op_logs) {
-        std::vector<VariantKey> vars;
-        util::variant_match(op_logs,
+void delete_op_logs(const std::shared_ptr<Store>& store,
+    std::variant<std::vector<AtomKey>, std::vector<OpLog>>&& op_logs)
+{
+    std::vector<VariantKey> vars;
+    util::variant_match(
+        op_logs,
         [&vars](std::vector<AtomKey>& keys) {
             vars.reserve(keys.size());
-            for (auto& key: keys) {
+            for (auto& key : keys) {
                 vars.emplace_back(std::move(key));
             }
         },
         [&vars](std::vector<OpLog>& logs) {
             vars.reserve(logs.size());
-            for (auto& log: logs) {
+            for (auto& log : logs) {
                 vars.emplace_back(log.extract_key());
             }
         });
-        store->remove_keys(vars).get();
-    }
-
-    std::vector<OpLog> get_op_logs(std::shared_ptr<Store> store) {
-        std::vector<OpLog> op_logs;
-        store->iterate_type(KeyType::LOG,
-                            [&op_logs](auto&& vk) {
-            auto key = std::forward<VariantKey>(vk);
-            if (is_recognized_log_action(variant_key_id(key))) {
-                op_logs.emplace_back(std::move(to_atom(key)));
-            }
-        });
-        std::sort(std::begin(op_logs), std::end(op_logs),
-                  [](const OpLog &l, const OpLog &r) {
-            return l.creation_ts() < r.creation_ts();
-        });
-        return op_logs;
-    }
-
-    std::vector<AtomKey> get_compacted_op_log_keys(std::shared_ptr<Store> store) {
-        std::vector<AtomKey> res;
-        store->iterate_type(KeyType::LOG_COMPACTED,
-                            [&res](auto&& vk) {
-            auto key = std::forward<VariantKey>(vk);
-            if (variant_key_id(key) == StreamId{StorageLogId}) {
-                res.emplace_back(std::move(to_atom(key)));
-            }
-        });
-        std::sort(std::begin(res), std::end(res),
-                  [](const AtomKey &l, const AtomKey &r) {
-            return l.creation_ts() < r.creation_ts();
-        });
-        return res;
-    }
-
-    std::vector<OpLog> get_op_logs_from_compacted_op_log_keys(std::shared_ptr<Store> store,
-                                                              const std::vector<AtomKey>& compacted_op_log_keys) {
-        std::vector<OpLog> op_logs;
-        for (const auto& compacted_op_log_key: compacted_op_log_keys) {
-            auto seg = store->read_sync(compacted_op_log_key).second;
-            for (auto it = seg.begin(); it != seg.end(); it++) {
-                std::string id{it->string_at(0).value()};
-                VersionId version_id{it->scalar_at<VersionId>(1).value()};
-                std::string action{it->string_at(2).value()};
-                timestamp creation_ts{it->scalar_at<timestamp>(3).value()};
-
-                op_logs.emplace_back(id, version_id, action, creation_ts);
-            }
-        }
-        return op_logs;
-    }
+    store->remove_keys(vars).get();
 }
+
+std::vector<OpLog> get_op_logs(std::shared_ptr<Store> store)
+{
+    std::vector<OpLog> op_logs;
+    store->iterate_type(KeyType::LOG, [&op_logs](auto&& vk) {
+        auto key = std::forward<VariantKey>(vk);
+        if (is_recognized_log_action(variant_key_id(key))) {
+            op_logs.emplace_back(std::move(to_atom(key)));
+        }
+    });
+    std::sort(std::begin(op_logs), std::end(op_logs), [](const OpLog& l, const OpLog& r) {
+        return l.creation_ts() < r.creation_ts();
+    });
+    return op_logs;
+}
+
+std::vector<AtomKey> get_compacted_op_log_keys(std::shared_ptr<Store> store)
+{
+    std::vector<AtomKey> res;
+    store->iterate_type(KeyType::LOG_COMPACTED, [&res](auto&& vk) {
+        auto key = std::forward<VariantKey>(vk);
+        if (variant_key_id(key) == StreamId{StorageLogId}) {
+            res.emplace_back(std::move(to_atom(key)));
+        }
+    });
+    std::sort(std::begin(res), std::end(res), [](const AtomKey& l, const AtomKey& r) {
+        return l.creation_ts() < r.creation_ts();
+    });
+    return res;
+}
+
+std::vector<OpLog> get_op_logs_from_compacted_op_log_keys(std::shared_ptr<Store> store,
+    const std::vector<AtomKey>& compacted_op_log_keys)
+{
+    std::vector<OpLog> op_logs;
+    for (const auto& compacted_op_log_key : compacted_op_log_keys) {
+        auto seg = store->read_sync(compacted_op_log_key).second;
+        for (auto it = seg.begin(); it != seg.end(); it++) {
+            std::string id{it->string_at(0).value()};
+            VersionId version_id{it->scalar_at<VersionId>(1).value()};
+            std::string action{it->string_at(2).value()};
+            timestamp creation_ts{it->scalar_at<timestamp>(3).value()};
+
+            op_logs.emplace_back(id, version_id, action, creation_ts);
+        }
+    }
+    return op_logs;
+}
+} // namespace arcticdb

--- a/cpp/arcticdb/version/version_log.hpp
+++ b/cpp/arcticdb/version/version_log.hpp
@@ -17,64 +17,69 @@
 #include <folly/futures/Future.h>
 
 namespace arcticdb {
-    using namespace arcticdb::entity;
-    using namespace arcticdb::stream;
-    // Log events for passive sync
-    inline StreamDescriptor log_stream_descriptor(const StreamId& event) {
-        return StreamDescriptor{stream_descriptor(event, RowCountIndex(), {})};
-    };
+using namespace arcticdb::entity;
+using namespace arcticdb::stream;
+// Log events for passive sync
+inline StreamDescriptor log_stream_descriptor(const StreamId& event)
+{
+    return StreamDescriptor{stream_descriptor(event, RowCountIndex(), {})};
+};
 
-    inline void log_event(const std::shared_ptr<StreamSink>& store, const StreamId& id, std::string action, VersionId version_id=0) {
-        SegmentInMemory seg{log_stream_descriptor(action)};
-        store->write_sync(KeyType::LOG, version_id, StreamId{action}, IndexValue{id}, IndexValue{id}, std::move(seg));
-    }
+inline void
+log_event(const std::shared_ptr<StreamSink>& store, const StreamId& id, std::string action, VersionId version_id = 0)
+{
+    SegmentInMemory seg{log_stream_descriptor(action)};
+    store->write_sync(KeyType::LOG, version_id, StreamId{action}, IndexValue{id}, IndexValue{id}, std::move(seg));
+}
 
-    inline void log_write(const std::shared_ptr<StreamSink>& store, const StreamId& symbol,  VersionId version_id) {
-        log_event(store, symbol, WriteVersionId, version_id);
-    }
+inline void log_write(const std::shared_ptr<StreamSink>& store, const StreamId& symbol, VersionId version_id)
+{
+    log_event(store, symbol, WriteVersionId, version_id);
+}
 
-    inline void log_tombstone(const std::shared_ptr<StreamSink>& store, const StreamId& symbol,  VersionId version_id) {
-        log_event(store, symbol, TombstoneVersionId, version_id);
-    }
+inline void log_tombstone(const std::shared_ptr<StreamSink>& store, const StreamId& symbol, VersionId version_id)
+{
+    log_event(store, symbol, TombstoneVersionId, version_id);
+}
 
-    inline void log_tombstone_all(const std::shared_ptr<StreamSink>& store, const StreamId& symbol,  VersionId version_id) {
-        log_event(store, symbol, TombstoneAllVersionId, version_id);
-    }
+inline void log_tombstone_all(const std::shared_ptr<StreamSink>& store, const StreamId& symbol, VersionId version_id)
+{
+    log_event(store, symbol, TombstoneAllVersionId, version_id);
+}
 
-    inline void log_create_snapshot(const std::shared_ptr<StreamSink>& store, const SnapshotId& snapshot_id) {
-        log_event(store, snapshot_id, CreateSnapshotId);
-    }
+inline void log_create_snapshot(const std::shared_ptr<StreamSink>& store, const SnapshotId& snapshot_id)
+{
+    log_event(store, snapshot_id, CreateSnapshotId);
+}
 
-    inline void log_delete_snapshot(const std::shared_ptr<StreamSink>& store, const SnapshotId& snapshot_id) {
-        log_event(store, snapshot_id, DeleteSnapshotId);
-    }
+inline void log_delete_snapshot(const std::shared_ptr<StreamSink>& store, const SnapshotId& snapshot_id)
+{
+    log_event(store, snapshot_id, DeleteSnapshotId);
+}
 
-    // Compact log events
-    StreamDescriptor log_compacted_stream_descriptor(const StreamId& stream_id,
-                                                     DataType symbol_datatype = DataType::ASCII_DYNAMIC64);
+// Compact log events
+StreamDescriptor log_compacted_stream_descriptor(const StreamId& stream_id,
+    DataType symbol_datatype = DataType::ASCII_DYNAMIC64);
 
-    inline bool is_recognized_log_action(const StreamId& id) {
-        return
-        id == StreamId{WriteVersionId} ||
-        id == StreamId{TombstoneVersionId} ||
-        id == StreamId{TombstoneAllVersionId} ||
-        id == StreamId{CreateSnapshotId} ||
-        id == StreamId{DeleteSnapshotId};
-    }
+inline bool is_recognized_log_action(const StreamId& id)
+{
+    return id == StreamId{WriteVersionId} || id == StreamId{TombstoneVersionId} ||
+           id == StreamId{TombstoneAllVersionId} || id == StreamId{CreateSnapshotId} ||
+           id == StreamId{DeleteSnapshotId};
+}
 
-    inline StreamDescriptor ts_stream_descriptor(const StreamId &stream_id) {
-        return StreamDescriptor{
-            stream_descriptor(stream_id, stream::RowCountIndex(),
-                {scalar_field_proto(DataType::UINT64, "ts")})
-        };
-    }
+inline StreamDescriptor ts_stream_descriptor(const StreamId& stream_id)
+{
+    return StreamDescriptor{
+        stream_descriptor(stream_id, stream::RowCountIndex(), {scalar_field_proto(DataType::UINT64, "ts")})};
+}
 
-    inline SegmentInMemory ts_segment(const StreamId &name, uint64_t timestamp) {
-        SegmentInMemory output{ts_stream_descriptor(name)};
-        output.set_scalar(0, timestamp);
-        output.end_row();
-        return output;
-    }
-;
+inline SegmentInMemory ts_segment(const StreamId& name, uint64_t timestamp)
+{
+    SegmentInMemory output{ts_stream_descriptor(name)};
+    output.set_scalar(0, timestamp);
+    output.end_row();
+    return output;
+};
 
- } //namespace arcticdb
+} //namespace arcticdb

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -37,7 +37,7 @@
 
 namespace arcticdb {
 
-template<class Clock=util::SysClock>
+template<class Clock = util::SysClock>
 class VersionMapImpl {
     /*
      * VersionMap at it's core is an in-memory map of {StreamId: VersionMapEntry}.
@@ -103,7 +103,7 @@ class VersionMapImpl {
      * Methods already declared with const& were not touched during this change.
      */
     using StreamIdArg = const StreamId&;
-    using MapType =  std::map<StreamId, std::shared_ptr<VersionMapEntry>>;
+    using MapType = std::map<StreamId, std::shared_ptr<VersionMapEntry>>;
 
     static constexpr uint64_t DEFAULT_CLOCK_UNSYNC_TOLERANCE = ONE_SECOND * 2;
     static constexpr uint64_t DEFAULT_RELOAD_INTERVAL = ONE_SECOND * 2;
@@ -120,60 +120,67 @@ public:
 
     ARCTICDB_NO_MOVE_OR_COPY(VersionMapImpl)
 
-    void set_validate(bool value) {
+    void set_validate(bool value)
+    {
         validate_ = value;
     }
 
-    void set_fast_tombstone_all(bool value) {
+    void set_fast_tombstone_all(bool value)
+    {
         fast_tombstone_all_ = value;
     }
 
-    void set_log_changes(bool value) {
+    void set_log_changes(bool value)
+    {
         log_changes_ = value;
     }
 
-    bool log_changes() const {
+    bool log_changes() const
+    {
         return log_changes_;
     }
 
-    void set_reload_interval(timestamp interval) {
+    void set_reload_interval(timestamp interval)
+    {
         reload_interval_ = std::make_optional<timestamp>(interval);
     }
 
-    bool validate() const {
+    bool validate() const
+    {
         return validate_;
     }
 
-    void follow_version_chain(
-        const std::shared_ptr<Store>& store,
+    void follow_version_chain(const std::shared_ptr<Store>& store,
         const VersionMapEntry& ref_entry,
         const std::shared_ptr<VersionMapEntry>& entry,
-        const LoadParameter& load_params) const {
+        const LoadParameter& load_params) const
+    {
         auto next_key = ref_entry.head_;
         entry->head_ = ref_entry.head_;
         auto loaded_until = std::numeric_limits<VersionId>::max();
 
-        if ((load_params.load_type_ == LoadType::LOAD_LATEST || load_params.load_type_ == LoadType::LOAD_LATEST_UNDELETED ) && is_index_key_type(ref_entry.keys_[0].type())) {
+        if ((load_params.load_type_ == LoadType::LOAD_LATEST ||
+                load_params.load_type_ == LoadType::LOAD_LATEST_UNDELETED) &&
+            is_index_key_type(ref_entry.keys_[0].type()))
+        {
             entry->keys_.push_back(ref_entry.keys_[0]);
         } else {
             do {
                 auto [key, seg] = store->read_sync(next_key.value());
                 std::tie(next_key, loaded_until) = read_segment_with_keys(seg, entry);
-            } while (next_key
-            && need_to_load_further(load_params, loaded_until)
-            && load_latest_ongoing(load_params, entry)
-            && looking_for_undeleted(load_params, entry));
+            } while (next_key && need_to_load_further(load_params, loaded_until) &&
+                     load_latest_ongoing(load_params, entry) && looking_for_undeleted(load_params, entry));
 
-            if(load_params.load_type_ == LoadType::LOAD_DOWNTO)
+            if (load_params.load_type_ == LoadType::LOAD_DOWNTO)
                 entry->loaded_until_ = loaded_until;
         }
     }
 
-    void load_via_ref_key(
-        std::shared_ptr<Store> store,
+    void load_via_ref_key(std::shared_ptr<Store> store,
         const StreamId& stream_id,
         const LoadParameter load_params,
-         const std::shared_ptr<VersionMapEntry>& entry) {
+        const std::shared_ptr<VersionMapEntry>& entry)
+    {
         load_params.validate();
         auto max_trials = ConfigsMap::instance()->get_int("VersionMap.MaxReadRefTrials", 2);
         while (max_trials--) {
@@ -185,57 +192,62 @@ public:
 
                 follow_version_chain(store, ref_entry, entry, load_params);
 
-            } catch (const std::exception &err) {
+            } catch (const std::exception& err) {
                 // We retry to read via ref key because it could have been modified by someone else (e.g. compaction)
                 log::version().warn(
-                        "Loading versions from storage via ref key failed with error: {} for stream {}. Retrying",
-                        err.what(), stream_id);
+                    "Loading versions from storage via ref key failed with error: {} for stream {}. Retrying",
+                    err.what(),
+                    stream_id);
                 entry->head_.reset();
                 entry->keys_.clear();
                 continue;
             }
             break;
         }
-        util::check_rte(max_trials >= 0,"Couldn't read via ref key even after multiple trials");
+        util::check_rte(max_trials >= 0, "Couldn't read via ref key even after multiple trials");
         if (validate_)
             entry->validate();
     }
 
-    void flush() {
+    void flush()
+    {
         std::lock_guard lock(map_mutex_);
         map_.clear();
     }
 
-    void load_via_iteration(
-        std::shared_ptr<Store> store,
+    void load_via_iteration(std::shared_ptr<Store> store,
         StreamIdArg stream_id,
         std::shared_ptr<VersionMapEntry>& entry,
-        bool use_index_keys_for_iteration=false) const {
+        bool use_index_keys_for_iteration = false) const
+    {
         ARCTICDB_DEBUG(log::version(), "Attempting to iterate version keys");
-        auto match_stream_id = [&stream_id](const AtomKey &k) { return k.id() == stream_id; };
-        entry = build_version_map_entry_with_predicate_iteration(store, match_stream_id, stream_id,
-                    use_index_keys_for_iteration ? std::vector<KeyType>{KeyType::TABLE_INDEX, KeyType::MULTI_KEY}:
-                                                   std::vector<KeyType>{KeyType::VERSION},
-                    !use_index_keys_for_iteration);
+        auto match_stream_id = [&stream_id](const AtomKey& k) { return k.id() == stream_id; };
+        entry = build_version_map_entry_with_predicate_iteration(store,
+            match_stream_id,
+            stream_id,
+            use_index_keys_for_iteration ? std::vector<KeyType>{KeyType::TABLE_INDEX, KeyType::MULTI_KEY}
+                                         : std::vector<KeyType>{KeyType::VERSION},
+            !use_index_keys_for_iteration);
 
         if (validate_)
             entry->validate();
     }
 
-    void write_version(std::shared_ptr<Store> store, const AtomKey &key) {
+    void write_version(std::shared_ptr<Store> store, const AtomKey& key)
+    {
         auto entry = check_reload(store, key.id(), LoadParameter{LoadType::LOAD_LATEST}, false, false, __FUNCTION__);
 
         do_write(store, key, entry);
         if (validate_)
             entry->validate();
-        if(log_changes_)
+        if (log_changes_)
             log_write(store, key.id(), key.version_id());
     }
 
-    AtomKey write_tombstone_all_key(
-            const std::shared_ptr<Store>& store,
-            const AtomKey& previous_key,
-            const std::shared_ptr<VersionMapEntry>& entry) {
+    AtomKey write_tombstone_all_key(const std::shared_ptr<Store>& store,
+        const AtomKey& previous_key,
+        const std::shared_ptr<VersionMapEntry>& entry)
+    {
         auto tombstone_key = get_tombstone_all_key(previous_key, store->current_timestamp());
         entry->try_set_tombstone_all(tombstone_key);
         do_write(store, tombstone_key, entry);
@@ -250,27 +262,26 @@ public:
      * @param first_key_to_tombstone The first key in the version chain that should be tombstoned. When empty
      * then the first index key onwards is tombstoned, so the whole chain is tombstoned.
      */
-    std::vector<AtomKey> tombstone_from_key_or_all(
-            std::shared_ptr<Store> store,
-            const StreamId& stream_id,
-            std::optional<AtomKey> first_key_to_tombstone = std::nullopt
-            ) {
+    std::vector<AtomKey> tombstone_from_key_or_all(std::shared_ptr<Store> store,
+        const StreamId& stream_id,
+        std::optional<AtomKey> first_key_to_tombstone = std::nullopt)
+    {
         return tombstone_from_key_or_all_internal(store, stream_id, first_key_to_tombstone);
     }
 
-    std::string dump_entry(const std::shared_ptr<Store> store, const StreamId& stream_id) {
+    std::string dump_entry(const std::shared_ptr<Store> store, const StreamId& stream_id)
+    {
         const auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
         return entry->dump();
     }
 
-    std::vector<AtomKey> write_and_prune_previous(
-        std::shared_ptr<Store> store,
-        const AtomKey &key, const
-        std::optional<AtomKey>& previous_key) {
+    std::vector<AtomKey> write_and_prune_previous(std::shared_ptr<Store> store,
+        const AtomKey& key,
+        const std::optional<AtomKey>& previous_key)
+    {
         ARCTICDB_DEBUG(log::version(), "Version map pruning previous versions for stream {}", key.id());
         auto load_type = fast_tombstone_all_ ? LoadType::LOAD_UNDELETED : LoadType::LOAD_ALL;
-        auto entry = check_reload(store, key.id(), LoadParameter{load_type}, true, false,
-                             __FUNCTION__);
+        auto entry = check_reload(store, key.id(), LoadParameter{load_type}, true, false, __FUNCTION__);
         auto result = tombstone_from_key_or_all_internal(store, key.id(), previous_key, entry);
 
         do_write(store, key, entry);
@@ -281,7 +292,8 @@ public:
         return result;
     }
 
-    std::deque<AtomKey> delete_all_versions(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    std::deque<AtomKey> delete_all_versions(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         ARCTICDB_DEBUG(log::version(), "Version map deleting all versions for stream {}", stream_id);
         std::deque<AtomKey> output;
         auto index_keys = tombstone_from_key_or_all(store, stream_id);
@@ -289,28 +301,34 @@ public:
         return output;
     }
 
-    bool requires_compaction(const std::shared_ptr<VersionMapEntry>& entry) const {
-        int64_t num_blocks = std::count_if(entry->keys_.cbegin(), entry->keys_.cend(),
-                                            [](const AtomKey &key) { return key.type() == KeyType::VERSION; });
+    bool requires_compaction(const std::shared_ptr<VersionMapEntry>& entry) const
+    {
+        int64_t num_blocks = std::count_if(entry->keys_.cbegin(), entry->keys_.cend(), [](const AtomKey& key) {
+            return key.type() == KeyType::VERSION;
+        });
 
         const auto max_blocks = ConfigsMap::instance()->get_int("VersionMap.MaxVersionBlocks", 5);
         if (num_blocks < max_blocks) {
-            ARCTICDB_DEBUG(log::version(), "Not compacting as number of blocks {} is less than the permitted {}", num_blocks,
-                                 max_blocks);
+            ARCTICDB_DEBUG(log::version(),
+                "Not compacting as number of blocks {} is less than the permitted {}",
+                num_blocks,
+                max_blocks);
             return false;
         } else {
             return true;
         }
     }
 
-    void compact_and_remove_deleted_indexes(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void compact_and_remove_deleted_indexes(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
         auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
         if (!requires_compaction(entry))
             return;
 
-        auto latest_version = std::find_if(std::begin(entry->keys_), std::end(entry->keys_),
-                                           [](const auto &key) { return is_index_key_type(key.type()); });
+        auto latest_version = std::find_if(std::begin(entry->keys_), std::end(entry->keys_), [](const auto& key) {
+            return is_index_key_type(key.type());
+        });
         const auto new_version_id = latest_version->version_id();
 
         auto new_entry = std::make_shared<VersionMapEntry>();
@@ -321,14 +339,14 @@ public:
 
         std::advance(latest_version, 1);
 
-        for (const auto &key : folly::Range{latest_version, entry->keys_.end()}) {
+        for (const auto& key : folly::Range{latest_version, entry->keys_.end()}) {
             if (is_index_key_type(key.type())) {
                 const auto tombstone = entry->is_tombstoned(key);
                 if (tombstone) {
                     if (!store->key_exists(key).get())
                         ARCTICDB_DEBUG(log::version(), "Removing deleted key {}", key);
                     else {
-                        if(tombstone.value().type() == KeyType::TOMBSTONE_ALL)
+                        if (tombstone.value().type() == KeyType::TOMBSTONE_ALL)
                             new_entry->try_set_tombstone_all(tombstone.value());
                         else
                             new_entry->tombstones_.insert(std::make_pair(key.version_id(), tombstone.value()));
@@ -348,18 +366,18 @@ public:
         std::swap(entry, new_entry);
     }
 
-    AtomKey update_version_key(
-        std::shared_ptr<Store> store,
+    AtomKey update_version_key(std::shared_ptr<Store> store,
         const VariantKey& version_key,
         const std::vector<AtomKey>& index_keys,
-        StreamIdArg stream_id) const {
+        StreamIdArg stream_id) const
+    {
         folly::Future<VariantKey> journal_key_fut = folly::Future<VariantKey>::makeEmpty();
 
-        IndexAggregator<RowCountIndex> version_agg(stream_id, [&journal_key_fut, &store, &version_key](auto &&segment) {
+        IndexAggregator<RowCountIndex> version_agg(stream_id, [&journal_key_fut, &store, &version_key](auto&& segment) {
             journal_key_fut = store->update(version_key, std::forward<SegmentInMemory>(segment)).wait();
         });
 
-        for (auto &key : index_keys) {
+        for (auto& key : index_keys) {
             version_agg.add_key(key);
         }
 
@@ -367,10 +385,9 @@ public:
         return to_atom(std::move(journal_key_fut).get());
     }
 
-    std::shared_ptr<VersionMapEntry> compact_entry(
-        std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
-        const std::shared_ptr<VersionMapEntry>& entry) {
+    std::shared_ptr<VersionMapEntry>
+    compact_entry(std::shared_ptr<Store> store, StreamIdArg stream_id, const std::shared_ptr<VersionMapEntry>& entry)
+    {
         // For compacting an entry, we compact from the second version key in the chain
         // This makes it concurrent safe (when use_tombstones is enabled)
         // The first version key is in head and the second version key is first in entry.keys_
@@ -378,25 +395,30 @@ public:
         util::check(entry->head_.value().type() == KeyType::VERSION, "Type of head must be version");
         auto new_entry = std::make_shared<VersionMapEntry>(*entry);
 
-        auto parent = std::find_if(std::begin(new_entry->keys_), std::end(new_entry->keys_),
-                [](const auto& k){return k.type() == KeyType ::VERSION;});
+        auto parent = std::find_if(std::begin(new_entry->keys_), std::end(new_entry->keys_), [](const auto& k) {
+            return k.type() == KeyType ::VERSION;
+        });
 
         // Copy version keys to be removed
         std::vector<VariantKey> version_keys_compacted;
-        std::copy_if(parent + 1, std::end(new_entry->keys_), std::back_inserter(version_keys_compacted),
-                [](const auto& k){return k.type() == KeyType::VERSION;});
+        std::copy_if(parent + 1,
+            std::end(new_entry->keys_),
+            std::back_inserter(version_keys_compacted),
+            [](const auto& k) { return k.type() == KeyType::VERSION; });
 
         // Copy index keys to be compacted
         std::vector<AtomKey> index_keys_compacted;
-        std::copy_if(parent + 1, std::end(new_entry->keys_), std::back_inserter(index_keys_compacted),
-                     [](const auto& k){return is_index_or_tombstone(k);});
+        std::copy_if(parent + 1,
+            std::end(new_entry->keys_),
+            std::back_inserter(index_keys_compacted),
+            [](const auto& k) { return is_index_or_tombstone(k); });
 
         update_version_key(store, *parent, index_keys_compacted, stream_id);
         store->remove_keys(version_keys_compacted).get();
 
         new_entry->keys_.erase(std::remove_if(parent + 1,
-                std::end(new_entry->keys_),
-                [](const auto& k){return k.type() == KeyType::VERSION;}),
+                                   std::end(new_entry->keys_),
+                                   [](const auto& k) { return k.type() == KeyType::VERSION; }),
             std::end(new_entry->keys_));
 
         new_entry->validate();
@@ -404,13 +426,14 @@ public:
     }
 
     /** To be run as a stand-alone job only because it calls flush(). */
-    void compact_if_necessary_stand_alone(const std::shared_ptr<Store>& store, size_t batch_size) {
+    void compact_if_necessary_stand_alone(const std::shared_ptr<Store>& store, size_t batch_size)
+    {
         auto map = get_num_version_entries(store, batch_size);
         size_t max_blocks = ConfigsMap::instance()->get_int("VersionMap.MaxVersionBlocks", 5);
         const auto total_symbols = map.size();
         size_t num_sym_compacted = 0;
-        for(const auto& [symbol, size] : map) {
-            if(size < max_blocks)
+        for (const auto& [symbol, size] : map) {
+            if (size < max_blocks)
                 continue;
 
             try {
@@ -427,7 +450,8 @@ public:
         log::version().info("Compacted {} out of {} total symbols", num_sym_compacted, total_symbols);
     }
 
-    void compact(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void compact(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
         auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
         if (entry->empty()) {
@@ -449,8 +473,9 @@ public:
         std::swap(entry, new_entry);
     }
 
-    void overwrite_symbol_tree(
-            std::shared_ptr<Store> store, StreamIdArg stream_id, const std::vector<AtomKey>& index_keys) {
+    void
+    overwrite_symbol_tree(std::shared_ptr<Store> store, StreamIdArg stream_id, const std::vector<AtomKey>& index_keys)
+    {
         auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
         auto old_entry = *entry;
         if (!index_keys.empty()) {
@@ -463,14 +488,13 @@ public:
         remove_entry_version_keys(store, old_entry, stream_id);
     }
 
-
-    std::shared_ptr<VersionMapEntry> check_reload(
-        std::shared_ptr<Store> store,
+    std::shared_ptr<VersionMapEntry> check_reload(std::shared_ptr<Store> store,
         StreamIdArg stream_id,
         const LoadParameter load_param,
         bool skip_compat,
         bool iterate_on_failure,
-        const char* function ARCTICDB_UNUSED) {
+        const char* function ARCTICDB_UNUSED)
+    {
         ARCTICDB_DEBUG(log::version(), "Check reload in function {}", function);
 
         if (has_cached_entry(stream_id, load_param))
@@ -482,10 +506,8 @@ public:
         return storage_reload(store, stream_id, load_param, iterate_on_failure);
     }
 
-    void do_write(
-        std::shared_ptr<Store> store,
-        const AtomKey &key,
-        const std::shared_ptr<VersionMapEntry> &entry) {
+    void do_write(std::shared_ptr<Store> store, const AtomKey& key, const std::shared_ptr<VersionMapEntry>& entry)
+    {
         if (validate_)
             entry->validate();
 
@@ -495,43 +517,47 @@ public:
         write_symbol_ref(store, key, journal_key);
     }
 
-    AtomKey write_tombstone(
-        std::shared_ptr<Store> store,
+    AtomKey write_tombstone(std::shared_ptr<Store> store,
         const std::variant<AtomKey, VersionId>& key,
         StreamIdArg stream_id,
         const std::shared_ptr<VersionMapEntry>& entry,
-        const std::optional<timestamp>& creation_ts=std::nullopt) {
+        const std::optional<timestamp>& creation_ts = std::nullopt)
+    {
         if (validate_)
             entry->validate();
 
-        auto tombstone = util::variant_match(key, [&stream_id, store, &creation_ts](const auto &k){
-            return index_to_tombstone(k, stream_id, creation_ts.has_value() ? creation_ts.value() : store->current_timestamp());
+        auto tombstone = util::variant_match(key, [&stream_id, store, &creation_ts](const auto& k) {
+            return index_to_tombstone(k,
+                stream_id,
+                creation_ts.has_value() ? creation_ts.value() : store->current_timestamp());
         });
         do_write(store, tombstone, entry);
-        if(log_changes_)
+        if (log_changes_)
             log_tombstone(store, tombstone.id(), tombstone.version_id());
 
         return tombstone;
     }
 
-    void remove_entry_version_keys(
-        const std::shared_ptr<Store>& store,
+    void remove_entry_version_keys(const std::shared_ptr<Store>& store,
         const std::shared_ptr<VersionMapEntry>& entry,
-        const StreamId &stream_id) const {
-       return remove_entry_version_keys(store, *entry, stream_id);
+        const StreamId& stream_id) const
+    {
+        return remove_entry_version_keys(store, *entry, stream_id);
     }
 
-    void remove_entry_version_keys(
-        const std::shared_ptr<Store>& store,
+    void remove_entry_version_keys(const std::shared_ptr<Store>& store,
         const VersionMapEntry& entry,
-        const StreamId &stream_id) const {
+        const StreamId& stream_id) const
+    {
         if (entry.head_) {
-            util::check(entry.head_.value().id() == stream_id, "Id mismatch for entry {} vs symbol {}",
-                        entry.head_.value().id(), stream_id);
+            util::check(entry.head_.value().id() == stream_id,
+                "Id mismatch for entry {} vs symbol {}",
+                entry.head_.value().id(),
+                stream_id);
             store->remove_key_sync(entry.head_.value());
         }
         std::vector<folly::Future<Store::RemoveKeyResultType>> key_futs;
-        for (const auto &key : entry.keys_) {
+        for (const auto& key : entry.keys_) {
             util::check(key.id() == stream_id, "Id mismatch for entry {} vs symbol {}", key.id(), stream_id);
             if (key.type() == KeyType::VERSION)
                 key_futs.emplace_back(store->remove_key(key));
@@ -540,10 +566,9 @@ public:
     }
 
 private:
-    void write_to_entry(
-        const std::shared_ptr<VersionMapEntry>& entry,
-        const AtomKey& key,
-        const AtomKey& journal_key) const {
+    void
+    write_to_entry(const std::shared_ptr<VersionMapEntry>& entry, const AtomKey& key, const AtomKey& journal_key) const
+    {
         if (entry->head_)
             entry->unshift_key(entry->head_.value());
 
@@ -554,7 +579,8 @@ private:
             entry->validate();
     }
 
-    bool has_cached_entry(const StreamId &stream_id, const LoadParameter load_param) const {
+    bool has_cached_entry(const StreamId& stream_id, const LoadParameter load_param) const
+    {
         load_param.validate();
         MapType::const_iterator entry;
         std::optional<VersionMapEntry> output;
@@ -566,79 +592,95 @@ private:
                 return false;
             }
         }
-        const timestamp reload_interval = reload_interval_.value_or(ConfigsMap::instance()->get_int("VersionMap.ReloadInterval", DEFAULT_RELOAD_INTERVAL));
+        const timestamp reload_interval = reload_interval_.value_or(
+            ConfigsMap::instance()->get_int("VersionMap.ReloadInterval", DEFAULT_RELOAD_INTERVAL));
 
         if (const timestamp cache_timing = now() - entry->second->last_reload_time_; cache_timing > reload_interval) {
             ARCTICDB_DEBUG(log::version(),
-                    "Latest read time {} too long ago for last acceptable cached timing {} (cache period {})",
-                    entry->second->last_reload_time_, cache_timing, reload_interval);
+                "Latest read time {} too long ago for last acceptable cached timing {} (cache period {})",
+                entry->second->last_reload_time_,
+                cache_timing,
+                reload_interval);
 
             return false;
         }
 
         if (entry->second->load_type_ < load_param.load_type_) {
-            ARCTICDB_DEBUG(log::version(), "Required load type {} exceeds existing load type {}, will reload", load_param.load_type_, entry->second->load_type_);
+            ARCTICDB_DEBUG(log::version(),
+                "Required load type {} exceeds existing load type {}, will reload",
+                load_param.load_type_,
+                entry->second->load_type_);
             return false;
         }
 
-        if(entry->second->load_type_ == LoadType::LOAD_DOWNTO && ((
-            load_param.load_type_ == LoadType::LOAD_DOWNTO && entry->second->loaded_until_ > load_param.load_until_.value())
-            || load_param.load_type_ == LoadType::LOAD_UNDELETED)) {
-            ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {}", load_param.load_until_.value(), entry->second->loaded_until_);
+        if (entry->second->load_type_ == LoadType::LOAD_DOWNTO &&
+            ((load_param.load_type_ == LoadType::LOAD_DOWNTO &&
+                 entry->second->loaded_until_ > load_param.load_until_.value()) ||
+                load_param.load_type_ == LoadType::LOAD_UNDELETED))
+        {
+            ARCTICDB_DEBUG(log::version(),
+                "Not loaded as far as required value {}, only have {}",
+                load_param.load_until_.value(),
+                entry->second->loaded_until_);
             return false;
         }
 
-        if(load_param.load_type_ == LoadType::LOAD_UNDELETED && !entry->second->tombstone_all_ &&
-           entry->second->load_type_ != LoadType::LOAD_UNDELETED)
+        if (load_param.load_type_ == LoadType::LOAD_UNDELETED && !entry->second->tombstone_all_ &&
+            entry->second->load_type_ != LoadType::LOAD_UNDELETED)
             return false;
 
         ARCTICDB_DEBUG(log::version(), "{} Using cached entry for symbol {}", uintptr_t(this), stream_id);
         return true;
     }
 
-    std::shared_ptr<VersionMapEntry>& get_entry(const StreamId& stream_id) {
+    std::shared_ptr<VersionMapEntry>& get_entry(const StreamId& stream_id)
+    {
         std::lock_guard lock(map_mutex_);
-        if(auto result = map_.find(stream_id); result != std::end(map_))
+        if (auto result = map_.find(stream_id); result != std::end(map_))
             return result->second;
 
         return map_.try_emplace(stream_id, std::make_shared<VersionMapEntry>()).first->second;
     }
 
-    AtomKey write_entry_to_storage(std::shared_ptr<Store> store, const StreamId &stream_id, VersionId version_id,
-                                   const std::shared_ptr<VersionMapEntry> &entry) {
+    AtomKey write_entry_to_storage(std::shared_ptr<Store> store,
+        const StreamId& stream_id,
+        VersionId version_id,
+        const std::shared_ptr<VersionMapEntry>& entry)
+    {
         folly::Future<VariantKey> journal_key_fut = folly::Future<VariantKey>::makeEmpty();
         entry->validate_types();
 
-        IndexAggregator<RowCountIndex> version_agg(stream_id, [&store, &journal_key_fut, &version_id, &stream_id](auto &&segment) {
-            stream::StreamSink::PartialKey pk{
-                    KeyType::VERSION,
+        IndexAggregator<RowCountIndex> version_agg(stream_id,
+            [&store, &journal_key_fut, &version_id, &stream_id](auto&& segment) {
+                stream::StreamSink::PartialKey pk{KeyType::VERSION,
                     version_id,
                     stream_id,
                     IndexValue(0),
                     IndexValue(0)};
 
-            journal_key_fut = store->write_sync(pk, std::forward<SegmentInMemory>(segment));
-        });
+                journal_key_fut = store->write_sync(pk, std::forward<SegmentInMemory>(segment));
+            });
 
-        for (const auto &key : entry->keys_) {
+        for (const auto& key : entry->keys_) {
             version_agg.add_key(key);
         }
 
         version_agg.commit();
-        auto journal_key =  to_atom(std::move(journal_key_fut).get());
+        auto journal_key = to_atom(std::move(journal_key_fut).get());
         write_symbol_ref(store, *entry->keys_.cbegin(), journal_key);
         return journal_key;
     }
 
-    bool has_stored_entry(std::shared_ptr<StreamSource> store, const StreamId &stream_id) const {
+    bool has_stored_entry(std::shared_ptr<StreamSource> store, const StreamId& stream_id) const
+    {
         return static_cast<bool>(get_symbol_ref_key(store, stream_id));
     }
 
-    std::shared_ptr<VersionMapEntry> storage_reload(
-        std::shared_ptr<Store> store,
+    std::shared_ptr<VersionMapEntry> storage_reload(std::shared_ptr<Store> store,
         StreamIdArg stream_id,
         const LoadParameter load_param,
-        bool iterate_on_failure) {
+        bool iterate_on_failure)
+    {
         /*
          * Goes to the storage for a given symbol, and recreates the VersionMapEntry from preferably the ref key
          * structure, and if that fails it then goes and builds that from iterating all keys from storage which can
@@ -647,8 +689,8 @@ private:
 
         auto entry = get_entry(stream_id);
         entry->clear();
-        const auto clock_unsync_tolerance = ConfigsMap::instance()->get_int("VersionMap.UnsyncTolerance",
-                                                                            DEFAULT_CLOCK_UNSYNC_TOLERANCE);
+        const auto clock_unsync_tolerance =
+            ConfigsMap::instance()->get_int("VersionMap.UnsyncTolerance", DEFAULT_CLOCK_UNSYNC_TOLERANCE);
         entry->last_reload_time_ = Clock::nanos_since_epoch() - clock_unsync_tolerance;
         entry->load_type_ = load_param.load_type_;
 
@@ -656,16 +698,16 @@ private:
             auto temp = std::make_shared<VersionMapEntry>(*entry);
             load_via_ref_key(store, stream_id, load_param, temp);
             std::swap(*entry, *temp);
-        }
-        catch (const std::runtime_error &err) {
+        } catch (const std::runtime_error& err) {
             ARCTICDB_DEBUG(log::version(),
-                    "Loading versions from storage via ref key failed with error: {}, if iterate_on_failure is set will continue to load via iteration",
-                    err.what());
+                "Loading versions from storage via ref key failed with error: {}, if iterate_on_failure is set will "
+                "continue to load via iteration",
+                err.what());
         }
         // Load via iteration always does a full load & sort, as we don't want to rely on things being in a particular
         // order in the storage
         if (iterate_on_failure && entry->empty()) {
-            (void) load_via_iteration(store, stream_id, entry);
+            (void)load_via_iteration(store, stream_id, entry);
             entry->load_type_ = LoadType::LOAD_ALL;
         }
 
@@ -676,22 +718,19 @@ private:
         return entry;
     }
 
-    folly::Future<VariantKey> journal_single_key(
-        std::shared_ptr<StreamSink> store,
-        const AtomKey &key,
-        std::optional<AtomKey> prev_journal_key) {
+    folly::Future<VariantKey>
+    journal_single_key(std::shared_ptr<StreamSink> store, const AtomKey& key, std::optional<AtomKey> prev_journal_key)
+    {
         ARCTICDB_SAMPLE(WriteJournalEntry, 0)
         ARCTICDB_DEBUG(log::version(), "Version map writing version for key {}", key);
 
         folly::Future<VariantKey> journal_key = folly::Future<VariantKey>::makeEmpty();
-        IndexAggregator<RowCountIndex> journal_agg(key.id(), [&store, &journal_key, &key](auto &&segment) {
-            stream::StreamSink::PartialKey pk{
-                KeyType::VERSION,
+        IndexAggregator<RowCountIndex> journal_agg(key.id(), [&store, &journal_key, &key](auto&& segment) {
+            stream::StreamSink::PartialKey pk{KeyType::VERSION,
                 key.version_id(),
                 key.id(),
                 IndexValue(0),
-                IndexValue(0)
-            };
+                IndexValue(0)};
 
             journal_key = store->write_sync(pk, std::forward<SegmentInMemory>(segment));
         });
@@ -703,31 +742,32 @@ private:
         return journal_key;
     }
 
-    timestamp now() const {
+    timestamp now() const
+    {
         return Clock::nanos_since_epoch();
     }
 
-    std::shared_ptr<VersionMapEntry> rewrite_entry(
-        std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
-        const std::shared_ptr<VersionMapEntry>& entry) {
+    std::shared_ptr<VersionMapEntry>
+    rewrite_entry(std::shared_ptr<Store> store, StreamIdArg stream_id, const std::shared_ptr<VersionMapEntry>& entry)
+    {
         auto new_entry = std::make_shared<VersionMapEntry>();
-        std::copy_if(std::begin(entry->keys_), std::end(entry->keys_), std::back_inserter(new_entry->keys_),
-                     [](const auto &key) {
-                         return is_index_or_tombstone(key);
-                     });
+        std::copy_if(std::begin(entry->keys_),
+            std::end(entry->keys_),
+            std::back_inserter(new_entry->keys_),
+            [](const auto& key) { return is_index_or_tombstone(key); });
         auto version_id = new_entry->get_first_index(true).value().version_id();
         new_entry->head_ = write_entry_to_storage(store, stream_id, version_id, new_entry);
         remove_entry_version_keys(store, entry, stream_id);
 
-        if(validate_)
+        if (validate_)
             new_entry->validate();
 
         return new_entry;
     }
 
 public:
-    bool check_ref_key(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    bool check_ref_key(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         auto entry_iteration = std::make_shared<VersionMapEntry>();
         load_via_iteration(store, stream_id, entry_iteration);
         auto maybe_latest_pair = get_latest_key_pair(entry_iteration);
@@ -745,13 +785,15 @@ public:
         }
 
         util::check(static_cast<bool>(ref_entry.head_), "Expected head to be set");
-        if(maybe_latest_pair.value().first != ref_entry.keys_[0] || maybe_latest_pair.value().second != ref_entry.head_.value()) {
+        if (maybe_latest_pair.value().first != ref_entry.keys_[0] ||
+            maybe_latest_pair.value().second != ref_entry.head_.value())
+        {
             log::version().warn("Ref entry is incorrect for stream {}, either {} != {} or {} != {}",
-                    stream_id,
-                    maybe_latest_pair.value().first,
-                    ref_entry.head_.value(),
-                    maybe_latest_pair.value().second,
-                    ref_entry.keys_[0]);
+                stream_id,
+                maybe_latest_pair.value().first,
+                ref_entry.head_.value(),
+                maybe_latest_pair.value().second,
+                ref_entry.keys_[0]);
             return false;
         }
 
@@ -760,15 +802,16 @@ public:
             load_via_ref_key(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, entry_ref);
             entry_ref->validate();
         } catch (const std::exception& err) {
-            log::version().warn(
-                    "Loading versions from storage via ref key failed with error: {} for stream {}",
-                    err.what(), stream_id);
+            log::version().warn("Loading versions from storage via ref key failed with error: {} for stream {}",
+                err.what(),
+                stream_id);
             return false;
         }
         return true;
     }
 
-    void scan_and_rewrite(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void scan_and_rewrite(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         log::version().warn("Version map scanning and rewriting  versions for stream {}", stream_id);
         auto entry = get_entry(stream_id);
         entry->clear();
@@ -778,7 +821,8 @@ public:
         (void)rewrite_entry(store, stream_id, entry);
     }
 
-    void remove_and_rewrite_version_keys(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void remove_and_rewrite_version_keys(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         log::version().warn("Rewriting all index keys for {}", stream_id);
         auto entry = get_entry(stream_id);
         auto old_entry = entry;
@@ -790,8 +834,9 @@ public:
         remove_entry_version_keys(store, old_entry, stream_id);
     }
 
-    void fix_ref_key(std::shared_ptr<Store> store, StreamIdArg stream_id) {
-        if(check_ref_key(store, stream_id)) {
+    void fix_ref_key(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
+        if (check_ref_key(store, stream_id)) {
             log::version().warn("Key {} is fine, not fixing", stream_id);
             return;
         }
@@ -800,35 +845,42 @@ public:
         scan_and_rewrite(store, stream_id);
     }
 
-    std::vector<AtomKey> find_deleted_version_keys_for_entry(
-        std::shared_ptr<Store> store,
+    std::vector<AtomKey> find_deleted_version_keys_for_entry(std::shared_ptr<Store> store,
         StreamIdArg stream_id,
-        const std::shared_ptr<VersionMapEntry>& entry) {
+        const std::shared_ptr<VersionMapEntry>& entry)
+    {
         std::vector<AtomKey> missing_versions;
 
-        iterate_keys_of_type_for_stream(store, KeyType::TABLE_INDEX, stream_id, [&entry, &missing_versions] (const auto& vk) {
-            const auto& key = to_atom(vk);
-            auto it = std::find_if(std::begin(entry->keys_), std::end(entry->keys_), [&] (const auto& entry_key) {
-                return entry_key.type() == KeyType::VERSION
-                    && std::tie(key.id(), key.version_id()) == std::tie(entry_key.id(), entry_key.version_id());
+        iterate_keys_of_type_for_stream(store,
+            KeyType::TABLE_INDEX,
+            stream_id,
+            [&entry, &missing_versions](const auto& vk) {
+                const auto& key = to_atom(vk);
+                auto it = std::find_if(std::begin(entry->keys_), std::end(entry->keys_), [&](const auto& entry_key) {
+                    return entry_key.type() == KeyType::VERSION &&
+                           std::tie(key.id(), key.version_id()) == std::tie(entry_key.id(), entry_key.version_id());
+                });
+                if (it == std::end(entry->keys_)) {
+                    util::check(static_cast<bool>(entry->head_) || entry->empty(),
+                        "Expected head to be set after load via iteration");
+                    if (!entry->head_ || std::tie(key.id(), key.version_id()) !=
+                                             std::tie(entry->head_.value().id(), entry->head_.value().version_id()))
+                        missing_versions.push_back(key);
+                }
             });
-            if(it == std::end(entry->keys_)) {
-                util::check(static_cast<bool>(entry->head_) || entry->empty(), "Expected head to be set after load via iteration");
-                if(!entry->head_ || std::tie(key.id(), key.version_id()) != std::tie(entry->head_.value().id(), entry->head_.value().version_id()))
-                    missing_versions.push_back(key);
-            }
-        });
         return missing_versions;
     }
 
-    std::vector<AtomKey> find_deleted_version_keys(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    std::vector<AtomKey> find_deleted_version_keys(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         auto entry = std::make_shared<VersionMapEntry>();
         load_via_iteration(store, stream_id, entry);
         return find_deleted_version_keys_for_entry(store, stream_id, entry);
     }
 
-    void recover_deleted(std::shared_ptr<Store> store, StreamIdArg stream_id) {
-        auto &entry = get_entry(stream_id);
+    void recover_deleted(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
+        auto& entry = get_entry(stream_id);
         entry->clear();
         load_via_iteration(store, stream_id, entry);
 
@@ -839,24 +891,32 @@ public:
         rewrite_entry(store, stream_id, entry);
     }
 
-    std::shared_ptr<Lock> get_lock_object(const StreamId& stream_id) {
+    std::shared_ptr<Lock> get_lock_object(const StreamId& stream_id)
+    {
         return lock_table_->get_lock_object(stream_id);
     }
 
 private:
     // Backwards compat stuff
-    AtomKey rewrite_old_journal_keys(std::shared_ptr<Store> store, const StreamId &stream_id, const std::shared_ptr<VersionMapEntry>& entry) {
+    AtomKey rewrite_old_journal_keys(std::shared_ptr<Store> store,
+        const StreamId& stream_id,
+        const std::shared_ptr<VersionMapEntry>& entry)
+    {
         util::check(!entry->keys_.empty(), "Can't rewrite empty version journal entry");
         auto version_id = entry->keys_[0].version_id();
         entry->head_ = std::make_optional(write_entry_to_storage(store, stream_id, version_id, entry));
         return entry->head_.value();
     }
 
-    std::shared_ptr<VersionMapEntry> load_from_old_journal_keys(std::shared_ptr<StreamSource> store, const StreamId &stream_id) {
+    std::shared_ptr<VersionMapEntry> load_from_old_journal_keys(std::shared_ptr<StreamSource> store,
+        const StreamId& stream_id)
+    {
         ARCTICDB_DEBUG(log::version(), "Attempting to iterate old journal keys");
-        auto match_stream_id = [&stream_id](const AtomKey &k) { return k.id() == stream_id; };
-        auto old_entry = build_version_map_entry_with_predicate_iteration(store, match_stream_id, stream_id,
-                                                                          {KeyType::VERSION_JOURNAL});
+        auto match_stream_id = [&stream_id](const AtomKey& k) { return k.id() == stream_id; };
+        auto old_entry = build_version_map_entry_with_predicate_iteration(store,
+            match_stream_id,
+            stream_id,
+            {KeyType::VERSION_JOURNAL});
         auto index_keys = old_entry->get_indexes(false);
         std::sort(index_keys.begin(), index_keys.end(), std::greater<>());
         auto entry = std::make_shared<VersionMapEntry>();
@@ -864,7 +924,8 @@ private:
         return entry;
     }
 
-    std::shared_ptr<VersionMapEntry> do_backwards_compat_check(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    std::shared_ptr<VersionMapEntry> do_backwards_compat_check(std::shared_ptr<Store> store, StreamIdArg stream_id)
+    {
         ARCTICDB_TRACE(log::version(), "Didn't find a ref entry, scanning for old-style journal keys");
         auto entry = get_entry(stream_id);
         if (auto old_entry = load_from_old_journal_keys(store, stream_id); !old_entry->keys_.empty()) {
@@ -875,34 +936,36 @@ private:
         return entry;
     }
 
-    std::vector<AtomKey> tombstone_from_key_or_all_internal(std::shared_ptr<Store> store, const StreamId& stream_id,
-                                                            std::optional<AtomKey> first_key_to_tombstone = std::nullopt,
-                                                            std::shared_ptr<VersionMapEntry> entry = nullptr) {
+    std::vector<AtomKey> tombstone_from_key_or_all_internal(std::shared_ptr<Store> store,
+        const StreamId& stream_id,
+        std::optional<AtomKey> first_key_to_tombstone = std::nullopt,
+        std::shared_ptr<VersionMapEntry> entry = nullptr)
+    {
         if (!entry) {
             auto load_type = fast_tombstone_all_ ? LoadType::LOAD_UNDELETED : LoadType::LOAD_ALL;
-            entry = check_reload(store, stream_id, LoadParameter{load_type}, true, false,
-                                 __FUNCTION__);
+            entry = check_reload(store, stream_id, LoadParameter{load_type}, true, false, __FUNCTION__);
         }
         if (!first_key_to_tombstone)
             first_key_to_tombstone = entry->get_first_index(false);
 
         std::vector<AtomKey> output;
         for (const auto& key : entry->keys_) {
-            if (is_index_key_type(key.type()) && !entry->is_tombstoned(key)
-                && key.version_id() <= first_key_to_tombstone->version_id()) {
+            if (is_index_key_type(key.type()) && !entry->is_tombstoned(key) &&
+                key.version_id() <= first_key_to_tombstone->version_id())
+            {
                 output.emplace_back(key);
             }
         }
 
         if (!output.empty()) {
-            if(fast_tombstone_all_) {
+            if (fast_tombstone_all_) {
                 auto tombstone_key = write_tombstone_all_key(store, first_key_to_tombstone.value(), entry);
 
-                if(log_changes_)
+                if (log_changes_)
                     log_tombstone_all(store, stream_id, tombstone_key.version_id());
 
             } else {
-                for (const auto &index : output) {
+                for (const auto& index : output) {
                     auto tombstone = write_tombstone(store, index, index.id(), entry);
                     entry->tombstones_.insert(std::make_pair(index.version_id(), std::move(tombstone)));
                 }
@@ -910,11 +973,12 @@ private:
         }
 
         // Get rid of tombstone_all key if not set on this library
-        if(!fast_tombstone_all_ && entry->tombstone_all_) {
+        if (!fast_tombstone_all_ && entry->tombstone_all_) {
             auto all_indexes = entry->get_indexes(true);
-            for(const auto& index_key : all_indexes) {
-                if(entry->is_tombstoned_via_tombstone_all(index_key.version_id()) &&
-                   !entry->has_individual_tombstone(index_key.version_id())) {
+            for (const auto& index_key : all_indexes) {
+                if (entry->is_tombstoned_via_tombstone_all(index_key.version_id()) &&
+                    !entry->has_individual_tombstone(index_key.version_id()))
+                {
                     auto tombstone = index_to_tombstone(index_key, index_key.id(), store->current_timestamp());
                     entry->tombstones_.try_emplace(tombstone.version_id(), tombstone);
                     entry->keys_.push_front(tombstone);
@@ -922,12 +986,11 @@ private:
             }
 
             remove_entry_version_keys(store, entry, stream_id);
-            entry->keys_.erase(std::remove_if(
-                                       std::begin(entry->keys_),
-                                       std::end(entry->keys_),
-                                       [](const auto& k){
-                                           return k.type() == KeyType::TOMBSTONE_ALL || k.type() == KeyType::VERSION; }),
-                               std::end(entry->keys_));
+            entry->keys_.erase(
+                std::remove_if(std::begin(entry->keys_),
+                    std::end(entry->keys_),
+                    [](const auto& k) { return k.type() == KeyType::TOMBSTONE_ALL || k.type() == KeyType::VERSION; }),
+                std::end(entry->keys_));
 
             auto version_id = all_indexes.begin()->version_id();
             entry->head_ = write_entry_to_storage(store, stream_id, version_id, entry);

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -15,48 +15,50 @@
 namespace arcticdb {
 
 inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_latest_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const std::vector<StreamId> &stream_ids,
-    bool include_deleted) {
+    const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const std::vector<StreamId>& stream_ids,
+    bool include_deleted)
+{
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
     const LoadParameter load_param{include_deleted ? LoadType::LOAD_LATEST : LoadType::LOAD_LATEST_UNDELETED};
     auto output = std::make_shared<std::unordered_map<StreamId, AtomKey>>();
 
-    async::submit_tasks_for_range(stream_ids,
-            [store, version_map, &load_param](auto& stream_id) {
-                return async::submit_io_task(CheckReloadTask{store, version_map, stream_id, load_param});
-            },
-            [output, include_deleted](auto& id, auto&& entry) {
-                auto index_key = entry->get_first_index(include_deleted);
-                if (index_key)
-                    (*output)[id] = *index_key;
-            });
+    async::submit_tasks_for_range(
+        stream_ids,
+        [store, version_map, &load_param](auto& stream_id) {
+            return async::submit_io_task(CheckReloadTask{store, version_map, stream_id, load_param});
+        },
+        [output, include_deleted](auto& id, auto&& entry) {
+            auto index_key = entry->get_first_index(include_deleted);
+            if (index_key)
+                (*output)[id] = *index_key;
+        });
 
     return output;
 }
 
 // The logic here is the same as get_latest_undeleted_version_and_next_version_id
 inline std::unordered_map<StreamId, version_store::UpdateInfo> batch_get_latest_undeleted_version_and_next_version_id(
-        const std::shared_ptr<Store> &store,
-        const std::shared_ptr<VersionMap> &version_map,
-        const std::vector<StreamId> &stream_ids) {
+    const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const std::vector<StreamId>& stream_ids)
+{
     ARCTICDB_SAMPLE(BatchGetLatestUndeletedVersionAndNextVersionId, 0)
     std::unordered_map<StreamId, version_store::UpdateInfo> output;
 
-    async::submit_tasks_for_range(stream_ids,
-                                  [store, version_map](auto& stream_id) {
-        return async::submit_io_task(CheckReloadTask{store,
-                                                     version_map,
-                                                     stream_id,
-                                                     LoadParameter{LoadType::LOAD_LATEST_UNDELETED}});
+    async::submit_tasks_for_range(
+        stream_ids,
+        [store, version_map](auto& stream_id) {
+            return async::submit_io_task(
+                CheckReloadTask{store, version_map, stream_id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED}});
         },
         [&output](auto& id, auto&& entry) {
-        auto latest_version = entry->get_first_index(true);
-        auto latest_undeleted_version = entry->get_first_index(false);
-        VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
-        output[id] =  {latest_undeleted_version, next_version_id};
-    });
+            auto latest_version = entry->get_first_index(true);
+            auto latest_undeleted_version = entry->get_first_index(false);
+            VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
+            output[id] = {latest_undeleted_version, next_version_id};
+        });
 
     return output;
 }
@@ -64,21 +66,23 @@ inline std::unordered_map<StreamId, version_store::UpdateInfo> batch_get_latest_
 inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_specific_version(
     const std::shared_ptr<Store>& store,
     const std::shared_ptr<VersionMap>& version_map,
-    std::map<StreamId, VersionId>& sym_versions) {
+    std::map<StreamId, VersionId>& sym_versions)
+{
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
     auto output = std::make_shared<std::unordered_map<StreamId, AtomKey>>();
 
-    async::submit_tasks_for_range(sym_versions,
-                                  [store, version_map](auto& sym_version) {
-        LoadParameter load_param{LoadType::LOAD_DOWNTO, sym_version.second};
-        return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
+    async::submit_tasks_for_range(
+        sym_versions,
+        [store, version_map](auto& sym_version) {
+            LoadParameter load_param{LoadType::LOAD_DOWNTO, sym_version.second};
+            return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
         },
         [output](auto& sym_version, auto&& entry) {
-        auto index_key = find_index_key_for_version_id(sym_version.second, entry);
-        if (index_key) {
-            (*output)[sym_version.first] = *index_key;
-        }
-    });
+            auto index_key = find_index_key_for_version_id(sym_version.second, entry);
+            if (index_key) {
+                (*output)[sym_version.first] = *index_key;
+            }
+        });
 
     return output;
 }
@@ -90,56 +94,59 @@ using VersionVectorType = std::vector<VersionId>;
  * @return Does not guarantee the returned keys actually exist in storage.
  */
 inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKey>> batch_get_specific_versions(
-        const std::shared_ptr<Store>& store,
-        const std::shared_ptr<VersionMap>& version_map,
-        std::map<StreamId, VersionVectorType>& sym_versions) {
+    const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    std::map<StreamId, VersionVectorType>& sym_versions)
+{
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
     auto output = std::make_shared<std::unordered_map<std::pair<StreamId, VersionId>, AtomKey>>();
 
-    async::submit_tasks_for_range(sym_versions,
-            [store, version_map](auto& sym_version) {
-                auto first_version = *std::min_element(std::begin(sym_version.second), std::end(sym_version.second));
-                LoadParameter load_param{LoadType::LOAD_DOWNTO, first_version};
-                return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
-            },
-            [output, &sym_versions](auto& sym_version, auto&& entry) {
-                auto sym_it = sym_versions.find(sym_version.first);
-                util::check(sym_it != sym_versions.end(), "Failed to find versions for symbol {}", sym_version.first);
-                const auto& versions = sym_it->second;
-                for(auto version : versions) {
-                    auto index_key = find_index_key_for_version_id(version, entry);
-                    if (index_key) {
-                        (*output)[std::pair(sym_version.first, version)] = *index_key;
-                    }
+    async::submit_tasks_for_range(
+        sym_versions,
+        [store, version_map](auto& sym_version) {
+            auto first_version = *std::min_element(std::begin(sym_version.second), std::end(sym_version.second));
+            LoadParameter load_param{LoadType::LOAD_DOWNTO, first_version};
+            return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
+        },
+        [output, &sym_versions](auto& sym_version, auto&& entry) {
+            auto sym_it = sym_versions.find(sym_version.first);
+            util::check(sym_it != sym_versions.end(), "Failed to find versions for symbol {}", sym_version.first);
+            const auto& versions = sym_it->second;
+            for (auto version : versions) {
+                auto index_key = find_index_key_for_version_id(version, entry);
+                if (index_key) {
+                    (*output)[std::pair(sym_version.first, version)] = *index_key;
                 }
-            });
+            }
+        });
 
     return output;
 }
 
-inline void batch_write_version(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const std::vector<AtomKey> &keys) {
+inline void batch_write_version(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const std::vector<AtomKey>& keys)
+{
     std::vector<folly::Future<folly::Unit>> results;
     results.reserve(keys.size());
-    for (const auto &key : keys) {
+    for (const auto& key : keys) {
         results.emplace_back(async::submit_io_task(WriteVersionTask{store, version_map, key}));
     }
 
     folly::collect(results).wait();
 }
 
-inline void batch_write_and_prune_previous(
-    const std::shared_ptr<Store> &store,
-    const std::shared_ptr<VersionMap> &version_map,
-    const std::vector<AtomKey> &keys,
-    const std::unordered_map<StreamId, version_store::UpdateInfo>& stream_update_info_map) {
+inline void batch_write_and_prune_previous(const std::shared_ptr<Store>& store,
+    const std::shared_ptr<VersionMap>& version_map,
+    const std::vector<AtomKey>& keys,
+    const std::unordered_map<StreamId, version_store::UpdateInfo>& stream_update_info_map)
+{
     std::vector<folly::Future<folly::Unit>> results;
     results.reserve(keys.size());
-    for (const auto &key : keys) {
+    for (const auto& key : keys) {
         auto previous_index_key = stream_update_info_map.at(key.id()).previous_index_key_;
-        results.emplace_back(async::submit_io_task(WriteAndPrunePreviousTask{store, version_map, key, previous_index_key}));
+        results.emplace_back(
+            async::submit_io_task(WriteAndPrunePreviousTask{store, version_map, key, previous_index_key}));
     }
 
     folly::collect(results).wait();

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -48,43 +48,47 @@ using namespace arcticdb::storage;
 
 constexpr auto coarse_nano = &util::SysClock::coarse_nanos_since_epoch;
 
-PythonVersionStore::PythonVersionStore(const std::shared_ptr<storage::Library>& library) :
-    LocalVersionedEngine(library) {
+PythonVersionStore::PythonVersionStore(const std::shared_ptr<storage::Library>& library)
+    : LocalVersionedEngine(library)
+{
 }
 
-VersionedItem PythonVersionStore::write_dataframe_specific_version(
-    const StreamId& stream_id,
+VersionedItem PythonVersionStore::write_dataframe_specific_version(const StreamId& stream_id,
     const py::tuple& item,
     const py::object& norm,
     const py::object& user_meta,
-    VersionId version_id
-    ) {
+    VersionId version_id)
+{
     ARCTICDB_SAMPLE(WriteDataFrame, 0)
 
-    ARCTICDB_DEBUG(log::version(), "write_dataframe_specific_version stream_id: {} , version_id: {}", stream_id, version_id);
-    if (auto version_key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id, false, true); version_key) {
+    ARCTICDB_DEBUG(log::version(),
+        "write_dataframe_specific_version stream_id: {} , version_id: {}",
+        stream_id,
+        version_id);
+    if (auto version_key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id, false, true);
+        version_key)
+    {
         log::version().warn("Symbol stream_id: {} already exists with version_id: {}", stream_id, version_id);
         return {std::move(version_key.value())};
     }
 
-    auto versioned_item = write_dataframe_impl(
-        store(),
+    auto versioned_item = write_dataframe_impl(store(),
         VersionId(version_id),
         convert::py_ndf_to_frame(stream_id, item, norm, user_meta),
         get_write_options());
 
     version_map()->write_version(store(), versioned_item.key_);
-    if(cfg().symbol_list())
+    if (cfg().symbol_list())
         symbol_list().add_symbol(store(), stream_id);
 
     return versioned_item;
 }
 
-std::vector<InputTensorFrame> create_input_tensor_frames(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<py::tuple> &items,
-    const std::vector<py::object> &norms,
-    const std::vector<py::object> &user_metas) {
+std::vector<InputTensorFrame> create_input_tensor_frames(const std::vector<StreamId>& stream_ids,
+    const std::vector<py::tuple>& items,
+    const std::vector<py::object>& norms,
+    const std::vector<py::object>& user_metas)
+{
     std::vector<InputTensorFrame> output;
     output.reserve(stream_ids.size());
     for (size_t idx = 0; idx < stream_ids.size(); idx++) {
@@ -96,44 +100,45 @@ std::vector<InputTensorFrame> create_input_tensor_frames(
 std::vector<VersionedItem> PythonVersionStore::batch_write_index_keys_to_version_map(
     const std::vector<AtomKey>& index_keys,
     const std::unordered_map<StreamId, UpdateInfo>& stream_update_info_map,
-    bool prune_previous_versions) {
+    bool prune_previous_versions)
+{
 
-    if(prune_previous_versions)
+    if (prune_previous_versions)
         batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_map);
     else
         batch_write_version(store(), version_map(), index_keys);
 
     std::vector<VersionedItem> output(index_keys.size());
-    for(auto key : folly::enumerate(index_keys))
+    for (auto key : folly::enumerate(index_keys))
         output[key.index] = *key;
 
     std::vector<folly::Future<folly::Unit>> symbol_write_futs;
-    for(const auto& item : output) {
-        symbol_write_futs.emplace_back(async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.key_.id())));
+    for (const auto& item : output) {
+        symbol_write_futs.emplace_back(
+            async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.key_.id())));
     }
     folly::collect(symbol_write_futs).wait();
 
     return output;
 }
 
-std::vector<VersionedItem> PythonVersionStore::batch_write(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<py::tuple> &items,
-    const std::vector<py::object> &norms,
-    const std::vector<py::object> &user_metas,
+std::vector<VersionedItem> PythonVersionStore::batch_write(const std::vector<StreamId>& stream_ids,
+    const std::vector<py::tuple>& items,
+    const std::vector<py::object>& norms,
+    const std::vector<py::object>& user_metas,
     bool prune_previous_versions,
-    bool validate_index) {
+    bool validate_index)
+{
 
     std::vector<VersionId> version_ids;
     auto write_options = get_write_options();
-    auto stream_update_info_map = batch_get_latest_undeleted_version_and_next_version_id(store(),
-                                                                                         version_map(),
-                                                                                         stream_ids);
+    auto stream_update_info_map =
+        batch_get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_ids);
     std::vector<std::shared_ptr<DeDupMap>> de_dup_maps;
-    for (const auto &stream_id: stream_ids) {
+    for (const auto& stream_id : stream_ids) {
         const auto& update_info = stream_update_info_map.at(stream_id);
         version_ids.push_back(update_info.next_version_id_);
-        if(cfg().write_options().de_duplication()) {
+        if (cfg().write_options().de_duplication()) {
             auto de_dup_map = get_de_dup_map(stream_id, update_info.previous_index_key_, write_options);
             de_dup_maps.push_back(de_dup_map);
         } else {
@@ -141,48 +146,60 @@ std::vector<VersionedItem> PythonVersionStore::batch_write(
         }
     }
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
-    auto index_keys = batch_write_internal(std::move(version_ids), stream_ids, std::move(frames), std::move(de_dup_maps), validate_index);
+    auto index_keys = batch_write_internal(std::move(version_ids),
+        stream_ids,
+        std::move(frames),
+        std::move(de_dup_maps),
+        validate_index);
     return batch_write_index_keys_to_version_map(index_keys, stream_update_info_map, prune_previous_versions);
 }
 
-std::vector<VersionedItem> PythonVersionStore::batch_append(
-    const std::vector<StreamId> &stream_ids,
-    const std::vector<py::tuple> &items,
-    const std::vector<py::object> &norms,
-    const std::vector<py::object> &user_metas,
+std::vector<VersionedItem> PythonVersionStore::batch_append(const std::vector<StreamId>& stream_ids,
+    const std::vector<py::tuple>& items,
+    const std::vector<py::object>& norms,
+    const std::vector<py::object>& user_metas,
     bool prune_previous_versions,
-    bool validate_index) {
+    bool validate_index)
+{
     auto write_options = get_write_options();
-    auto stream_update_info_map = batch_get_latest_undeleted_version_and_next_version_id(store(),
-                                                                                         version_map(),
-                                                                                         stream_ids);
+    auto stream_update_info_map =
+        batch_get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_ids);
     std::vector<VersionId> version_ids;
     std::vector<AtomKey> existing_keys;
-    for (const auto &stream_id: stream_ids) {
+    for (const auto& stream_id : stream_ids) {
         auto update_info = stream_update_info_map.at(stream_id);
-        util::check(update_info.previous_index_key_.has_value(), "Can't batch append to nonexistent symbol {}", stream_id);
+        util::check(update_info.previous_index_key_.has_value(),
+            "Can't batch append to nonexistent symbol {}",
+            stream_id);
         version_ids.push_back(update_info.next_version_id_);
         existing_keys.push_back(*(update_info.previous_index_key_));
     }
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
-    auto index_keys = batch_append_internal(std::move(version_ids), stream_ids, std::move(existing_keys), std::move(frames), write_options, validate_index);
+    auto index_keys = batch_append_internal(std::move(version_ids),
+        stream_ids,
+        std::move(existing_keys),
+        std::move(frames),
+        write_options,
+        validate_index);
     return batch_write_index_keys_to_version_map(index_keys, stream_update_info_map, prune_previous_versions);
 }
 
-void PythonVersionStore::_clear_symbol_list_keys() {
+void PythonVersionStore::_clear_symbol_list_keys()
+{
     symbol_list().clear(store());
 }
 
-void PythonVersionStore::reload_symbol_list() {
+void PythonVersionStore::reload_symbol_list()
+{
     symbol_list().reload(store());
 }
 
 // To be sorted on timestamp
 using VersionResult = std::tuple<StreamId, VersionId, timestamp, std::vector<SnapshotId>, bool>;
 struct VersionComp {
-    bool operator() (const VersionResult& v1, const VersionResult& v2) const {
-        return std::tie(std::get<0>(v1), std::get<2>(v1)) >
-        std::tie(std::get<0>(v2), std::get<2>(v2));
+    bool operator()(const VersionResult& v1, const VersionResult& v2) const
+    {
+        return std::tie(std::get<0>(v1), std::get<2>(v1)) > std::tie(std::get<0>(v2), std::get<2>(v2));
     }
 };
 
@@ -191,27 +208,26 @@ using SymbolVersionTimestampMap = std::unordered_map<std::pair<StreamId, Version
 
 using VersionResultVector = std::vector<VersionResult>;
 
-VersionResultVector list_versions_for_snapshot(
-    const std::set<StreamId>& stream_ids,
+VersionResultVector list_versions_for_snapshot(const std::set<StreamId>& stream_ids,
     std::optional<SnapshotId> snap_name,
     SnapshotMap& versions_for_snapshots,
-    SymbolVersionToSnapshotMap& snapshots_for_symbol) {
+    SymbolVersionToSnapshotMap& snapshots_for_symbol)
+{
 
     VersionResultVector res;
     util::check(versions_for_snapshots.count(snap_name.value()) != 0, "Snapshot not found");
     std::unordered_map<StreamId, AtomKey> version_for_stream_in_snapshot;
-    for (const auto& key_in_snap: versions_for_snapshots[snap_name.value()]) {
+    for (const auto& key_in_snap : versions_for_snapshots[snap_name.value()]) {
         util::check(version_for_stream_in_snapshot.count(key_in_snap.id()) == 0,
-                    "More than 1 version found for a symbol in snap");
+            "More than 1 version found for a symbol in snap");
         version_for_stream_in_snapshot[key_in_snap.id()] = key_in_snap;
     }
 
-    for (auto &s_id: stream_ids) {
+    for (auto& s_id : stream_ids) {
         // Return only those versions which are in the snapshot
         const auto& version_key = version_for_stream_in_snapshot[s_id];
 
-        res.emplace_back(
-            s_id,
+        res.emplace_back(s_id,
             version_key.version_id(),
             version_key.creation_ts(),
             snapshots_for_symbol[{s_id, version_key.version_id()}],
@@ -222,97 +238,89 @@ VersionResultVector list_versions_for_snapshot(
     return res;
 }
 
-void get_snapshot_version_info(
-    const std::shared_ptr<Store>& store,
+void get_snapshot_version_info(const std::shared_ptr<Store>& store,
     SymbolVersionToSnapshotMap& snapshots_for_symbol,
     SymbolVersionTimestampMap& creation_ts_for_version_symbol,
-    std::optional<SnapshotMap>& versions_for_snapshots) {
+    std::optional<SnapshotMap>& versions_for_snapshots)
+{
     // We will need to construct this map even if we are getting symbols for one snapshot
     // The symbols might appear in more than 1 snapshot and "snapshots" needs to be populated
     // After SNAPSHOT_REF key introduction, this operation is no longer slow
     versions_for_snapshots = get_versions_from_snapshots(store);
 
-    for (const auto &[snap_id, index_keys]: *versions_for_snapshots) {
-        for (const auto &index_key: index_keys) {
+    for (const auto& [snap_id, index_keys] : *versions_for_snapshots) {
+        for (const auto& index_key : index_keys) {
             snapshots_for_symbol[{index_key.id(), index_key.version_id()}].push_back(snap_id);
             creation_ts_for_version_symbol[{index_key.id(), index_key.version_id()}] = index_key.creation_ts();
         }
     }
 
-    for(auto& [sid, version_vector]  : snapshots_for_symbol)
+    for (auto& [sid, version_vector] : snapshots_for_symbol)
         std::sort(std::begin(version_vector), std::end(version_vector));
 }
 
-
-VersionResultVector get_latest_versions_for_symbols(
-    const std::shared_ptr<Store>& store,
+VersionResultVector get_latest_versions_for_symbols(const std::shared_ptr<Store>& store,
     const std::shared_ptr<VersionMap>& version_map,
     const std::set<StreamId>& stream_ids,
     SymbolVersionToSnapshotMap& snapshots_for_symbol,
-    bool do_iterate
-) {
+    bool do_iterate)
+{
     VersionResultVector res;
     std::unordered_set<std::pair<StreamId, VersionId>> unpruned_versions;
-    for (auto &s_id: stream_ids) {
-            auto version_key = get_latest_undeleted_version(store, version_map, s_id, true, do_iterate).value();
-            res.emplace_back(
-                s_id,
-                version_key.version_id(),
-                version_key.creation_ts(),
-                snapshots_for_symbol[{s_id, version_key.version_id()}],
-                false);
-
+    for (auto& s_id : stream_ids) {
+        auto version_key = get_latest_undeleted_version(store, version_map, s_id, true, do_iterate).value();
+        res.emplace_back(s_id,
+            version_key.version_id(),
+            version_key.creation_ts(),
+            snapshots_for_symbol[{s_id, version_key.version_id()}],
+            false);
     }
     std::sort(res.begin(), res.end(), VersionComp());
     return res;
 }
 
-
-VersionResultVector get_all_versions_for_symbols(
-    const std::shared_ptr<Store>& store,
+VersionResultVector get_all_versions_for_symbols(const std::shared_ptr<Store>& store,
     const std::shared_ptr<VersionMap>& version_map,
     const std::set<StreamId>& stream_ids,
     SymbolVersionToSnapshotMap& snapshots_for_symbol,
     const SymbolVersionTimestampMap& creation_ts_for_version_symbol,
-    bool do_iterate
-    ) {
+    bool do_iterate)
+{
     VersionResultVector res;
     std::unordered_set<std::pair<StreamId, VersionId>> unpruned_versions;
-    for (auto &s_id: stream_ids) {
-            auto all_versions = get_all_versions(store, version_map, s_id, false, do_iterate);
-            unpruned_versions = {};
-            for (const auto &entry: all_versions) {
-                unpruned_versions.emplace(s_id, entry.version_id());
-                res.emplace_back(
-                    s_id,
-                    entry.version_id(),
-                    entry.creation_ts(),
-                    snapshots_for_symbol[{s_id, entry.version_id()}],
-                    false);
+    for (auto& s_id : stream_ids) {
+        auto all_versions = get_all_versions(store, version_map, s_id, false, do_iterate);
+        unpruned_versions = {};
+        for (const auto& entry : all_versions) {
+            unpruned_versions.emplace(s_id, entry.version_id());
+            res.emplace_back(s_id,
+                entry.version_id(),
+                entry.creation_ts(),
+                snapshots_for_symbol[{s_id, entry.version_id()}],
+                false);
+        }
+        for (const auto& [sym_version, creation_ts] : creation_ts_for_version_symbol) {
+            // For all symbol, version combinations in snapshots, check if they have been pruned, and if so
+            // use the information from the snapshot indexes and set deleted to true.
+            if (sym_version.first == s_id && unpruned_versions.find(sym_version) == std::end(unpruned_versions)) {
+                res.emplace_back(sym_version.first,
+                    sym_version.second,
+                    creation_ts,
+                    snapshots_for_symbol[sym_version],
+                    true);
             }
-            for (const auto &[sym_version, creation_ts]: creation_ts_for_version_symbol) {
-                // For all symbol, version combinations in snapshots, check if they have been pruned, and if so
-                // use the information from the snapshot indexes and set deleted to true.
-                if (sym_version.first == s_id && unpruned_versions.find(sym_version) == std::end(unpruned_versions)) {
-                    res.emplace_back(
-                        sym_version.first,
-                        sym_version.second,
-                        creation_ts,
-                        snapshots_for_symbol[sym_version],
-                        true);
-                }
-            }
+        }
     }
     std::sort(res.begin(), res.end(), VersionComp());
     return res;
 }
 
-VersionResultVector PythonVersionStore::list_versions(
-    const std::optional<StreamId> &stream_id,
-    const std::optional<SnapshotId> &snap_name,
+VersionResultVector PythonVersionStore::list_versions(const std::optional<StreamId>& stream_id,
+    const std::optional<SnapshotId>& snap_name,
     const std::optional<bool>& latest_only,
     const std::optional<bool>& iterate_on_failure,
-    const std::optional<bool>& skip_snapshots) {
+    const std::optional<bool>& skip_snapshots)
+{
     ARCTICDB_SAMPLE(ListVersions, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: list_versions");
     VersionResultVector res;
@@ -330,24 +338,34 @@ VersionResultVector PythonVersionStore::list_versions(
     SymbolVersionToSnapshotMap snapshots_for_symbol;
     SymbolVersionTimestampMap creation_ts_for_version_symbol;
     std::optional<SnapshotMap> versions_for_snapshots;
-    if(do_snapshots) {
-        get_snapshot_version_info(store(), snapshots_for_symbol, creation_ts_for_version_symbol, versions_for_snapshots);
+    if (do_snapshots) {
+        get_snapshot_version_info(store(),
+            snapshots_for_symbol,
+            creation_ts_for_version_symbol,
+            versions_for_snapshots);
 
         if (snap_name)
             return list_versions_for_snapshot(stream_ids, snap_name, *versions_for_snapshots, snapshots_for_symbol);
     }
 
-   if(opt_false(latest_only))
-       return get_latest_versions_for_symbols(store(), version_map(), stream_ids, snapshots_for_symbol, do_iterate);
-   else
-       return get_all_versions_for_symbols(store(), version_map(), stream_ids, snapshots_for_symbol, creation_ts_for_version_symbol, do_iterate);
+    if (opt_false(latest_only))
+        return get_latest_versions_for_symbols(store(), version_map(), stream_ids, snapshots_for_symbol, do_iterate);
+    else
+        return get_all_versions_for_symbols(store(),
+            version_map(),
+            stream_ids,
+            snapshots_for_symbol,
+            creation_ts_for_version_symbol,
+            do_iterate);
 }
 
-std::vector<std::pair<SnapshotId, py::object>> PythonVersionStore::list_snapshots(const std::optional<bool> load_metadata) {
+std::vector<std::pair<SnapshotId, py::object>> PythonVersionStore::list_snapshots(
+    const std::optional<bool> load_metadata)
+{
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: list_snapshots");
     auto snap_ids = std::vector<std::pair<SnapshotId, py::object>>();
     auto fetch_metadata = opt_false(load_metadata);
-    iterate_snapshots(store(), [store=store(), &snap_ids, fetch_metadata](VariantKey &vk) {
+    iterate_snapshots(store(), [store = store(), &snap_ids, fetch_metadata](VariantKey& vk) {
         auto snapshot_meta_as_pyobject = fetch_metadata ? get_metadata_for_snapshot(store, vk) : py::none{};
         auto snapshot_id = fmt::format("{}", variant_key_id(vk));
         snap_ids.emplace_back(snapshot_id, snapshot_meta_as_pyobject);
@@ -356,49 +374,53 @@ std::vector<std::pair<SnapshotId, py::object>> PythonVersionStore::list_snapshot
     return snap_ids;
 }
 
-void PythonVersionStore::add_to_snapshot(
-    const SnapshotId& snap_name,
+void PythonVersionStore::add_to_snapshot(const SnapshotId& snap_name,
     const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries
-    ) {
-    util::check(version_queries.empty() || stream_ids.size() == version_queries.size(), "List length mismatch in add_to_snapshot: {} != {}", stream_ids.size(), version_queries.size());
-    auto opt_snapshot =  get_snapshot(store(), snap_name);
+    const std::vector<VersionQuery>& version_queries)
+{
+    util::check(version_queries.empty() || stream_ids.size() == version_queries.size(),
+        "List length mismatch in add_to_snapshot: {} != {}",
+        stream_ids.size(),
+        version_queries.size());
+    auto opt_snapshot = get_snapshot(store(), snap_name);
     if (!opt_snapshot) {
         throw NoDataFoundException(snap_name);
     }
     auto [snap_key, snap_segment] = opt_snapshot.value();
     auto [snapshot_contents, user_meta] = get_versions_and_metadata_from_snapshot(store(), snap_key);
     auto [specific_versions_index_map, latest_versions_index_map] = get_stream_index_map(stream_ids, version_queries);
-    for(const auto& latest_version : *latest_versions_index_map) {
-        specific_versions_index_map->try_emplace(std::make_pair(latest_version.first, latest_version.second.version_id()), latest_version.second);
+    for (const auto& latest_version : *latest_versions_index_map) {
+        specific_versions_index_map->try_emplace(
+            std::make_pair(latest_version.first, latest_version.second.version_id()),
+            latest_version.second);
     }
 
-    auto missing = filter_keys_on_existence(
-            utils::copy_of_values_as<VariantKey>(*specific_versions_index_map), store(), false);
+    auto missing =
+        filter_keys_on_existence(utils::copy_of_values_as<VariantKey>(*specific_versions_index_map), store(), false);
     util::check(missing.empty(), "Cannot snapshot version(s) that have been deleted: {}", missing);
 
     std::vector<AtomKey> deleted_keys;
     std::vector<AtomKey> retained_keys;
     std::unordered_set<StreamId> affected_keys;
-    for(const auto& [id_version, key] : *specific_versions_index_map) {
+    for (const auto& [id_version, key] : *specific_versions_index_map) {
         auto [it, inserted] = affected_keys.insert(id_version.first);
         util::check(inserted, "Multiple elements in add_to_snapshot with key {}", id_version.first);
     }
 
-    for(auto&& key : snapshot_contents) {
+    for (auto&& key : snapshot_contents) {
         auto new_version = affected_keys.find(key.id());
-        if(new_version == std::end(affected_keys)) {
+        if (new_version == std::end(affected_keys)) {
             retained_keys.emplace_back(std::move(key));
         } else {
             deleted_keys.emplace_back(std::move(key));
         }
     }
 
-    for(auto&& [id, key] : *specific_versions_index_map)
+    for (auto&& [id, key] : *specific_versions_index_map)
         retained_keys.emplace_back(std::move(key));
 
     std::sort(std::begin(retained_keys), std::end(retained_keys));
-    if(variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
+    if (variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
         tombstone_snapshot(store(), to_ref(snap_key), std::move(snap_segment), version_map()->log_changes());
     } else {
         delete_tree(deleted_keys);
@@ -409,14 +431,16 @@ void PythonVersionStore::add_to_snapshot(
     write_snapshot_entry(store(), retained_keys, snap_name, user_meta, version_map()->log_changes());
 }
 
-void PythonVersionStore::remove_from_snapshot(
-    const SnapshotId& snap_name,
+void PythonVersionStore::remove_from_snapshot(const SnapshotId& snap_name,
     const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionId>& version_ids
-    ) {
-    util::check(stream_ids.size() == version_ids.size(), "List length mismatch in remove_from_snapshot: {} != {}", stream_ids.size(), version_ids.size());
+    const std::vector<VersionId>& version_ids)
+{
+    util::check(stream_ids.size() == version_ids.size(),
+        "List length mismatch in remove_from_snapshot: {} != {}",
+        stream_ids.size(),
+        version_ids.size());
 
-    auto opt_snapshot =  get_snapshot(store(), snap_name);
+    auto opt_snapshot = get_snapshot(store(), snap_name);
     if (!opt_snapshot) {
         throw NoDataFoundException(snap_name);
     }
@@ -425,21 +449,21 @@ void PythonVersionStore::remove_from_snapshot(
 
     using SymbolVersion = std::pair<StreamId, VersionId>;
     std::unordered_set<SymbolVersion> symbol_versions;
-    for(auto i = 0u; i < stream_ids.size(); ++i) {
+    for (auto i = 0u; i < stream_ids.size(); ++i) {
         symbol_versions.emplace(stream_ids[i], version_ids[i]);
     }
 
     std::vector<AtomKey> deleted_keys;
     std::vector<AtomKey> retained_keys;
-    for(auto&& key : snapshot_contents) {
-        if(symbol_versions.find(SymbolVersion{key.id(), key.version_id()}) == symbol_versions.end()) {
+    for (auto&& key : snapshot_contents) {
+        if (symbol_versions.find(SymbolVersion{key.id(), key.version_id()}) == symbol_versions.end()) {
             retained_keys.emplace_back(std::move(key));
         } else {
             deleted_keys.emplace_back(std::move(key));
         }
     }
 
-    if(variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
+    if (variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
         tombstone_snapshot(store(), to_ref(snap_key), std::move(snap_segment), version_map()->log_changes());
     } else {
         delete_tree(deleted_keys);
@@ -450,12 +474,11 @@ void PythonVersionStore::remove_from_snapshot(
     write_snapshot_entry(store(), retained_keys, snap_name, user_meta, version_map()->log_changes());
 }
 
-void PythonVersionStore::snapshot(
-    const SnapshotId &snap_name,
-    const py::object &user_meta,
-    const std::vector<StreamId> &skip_symbols,
-    std::map<StreamId, VersionId> &versions
-    ) {
+void PythonVersionStore::snapshot(const SnapshotId& snap_name,
+    const py::object& user_meta,
+    const std::vector<StreamId>& skip_symbols,
+    std::map<StreamId, VersionId>& versions)
+{
     ARCTICDB_SAMPLE(CreateSnapshot, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: snapshot");
 
@@ -468,7 +491,7 @@ void PythonVersionStore::snapshot(
     logger.set_level(spdlog::level::err);
     auto val = get_snapshot_key(store(), snap_name).has_value();
     logger.set_level(current_level);
-    
+
     util::check(!val, "Snapshot with name {} already exists", snap_name);
 
     auto index_keys = std::vector<AtomKey>();
@@ -477,8 +500,11 @@ void PythonVersionStore::snapshot(
         auto skip_symbols_set = std::set<StreamId>(skip_symbols.begin(), skip_symbols.end());
         auto all_symbols = list_streams();
         std::vector<StreamId> filtered_symbols;
-        std::set_difference(all_symbols.begin(), all_symbols.end(), skip_symbols_set.begin(),
-                skip_symbols_set.end(), std::back_inserter(filtered_symbols));
+        std::set_difference(all_symbols.begin(),
+            all_symbols.end(),
+            skip_symbols_set.begin(),
+            skip_symbols_set.end(),
+            std::back_inserter(filtered_symbols));
 
         if (filtered_symbols.empty()) {
             log::version().warn("No valid symbols in the library, skipping creation for snapshot: {}", snap_name);
@@ -490,8 +516,7 @@ void PythonVersionStore::snapshot(
     } else {
         auto sym_index_map = batch_get_specific_version(store(), version_map(), versions);
         index_keys = utils::values(*sym_index_map);
-        auto missing = filter_keys_on_existence(
-                utils::copy_of_values_as<VariantKey>(*sym_index_map), store(), false);
+        auto missing = filter_keys_on_existence(utils::copy_of_values_as<VariantKey>(*sym_index_map), store(), false);
         util::check(missing.empty(), "Cannot snapshot version(s) that have been deleted: {}", missing);
     }
 
@@ -499,23 +524,22 @@ void PythonVersionStore::snapshot(
     write_snapshot_entry(store(), index_keys, snap_name, user_meta, version_map()->log_changes());
 }
 
-std::set<StreamId> PythonVersionStore::list_streams(
-    const std::optional<SnapshotId>& snap_name,
+std::set<StreamId> PythonVersionStore::list_streams(const std::optional<SnapshotId>& snap_name,
     const std::optional<std::string>& regex,
     const std::optional<std::string>& prefix,
     const std::optional<bool>& opt_use_symbol_list,
     const std::optional<bool>& opt_all_symbols
 
-    ) {
+)
+{
     return list_streams_internal(snap_name, regex, prefix, opt_use_symbol_list, opt_all_symbols);
 }
 
-VersionedItem PythonVersionStore::write_partitioned_dataframe(
-    const StreamId& stream_id,
-    const py::tuple &item,
-    const py::object &norm_meta,
-    const std::vector<std::string>& partition_value
-    ) {
+VersionedItem PythonVersionStore::write_partitioned_dataframe(const StreamId& stream_id,
+    const py::tuple& item,
+    const py::object& norm_meta,
+    const std::vector<std::string>& partition_value)
+{
     ARCTICDB_SAMPLE(WritePartitionedDataFrame, 0)
     auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
     auto version_id = get_next_version_from_key(maybe_prev);
@@ -530,8 +554,7 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     std::vector<entity::AtomKey> index_keys;
     for (size_t idx = 0; idx < partitioned_dfs.size(); idx++) {
         auto subkeyname = fmt::format("{}-{}", stream_id, partition_value[idx]);
-        auto versioned_item = write_dataframe_impl(
-            store(),
+        auto versioned_item = write_dataframe_impl(store(),
             version_id,
             convert::py_ndf_to_frame(subkeyname, partitioned_dfs[idx], norm_meta, py::none()),
             write_options,
@@ -541,16 +564,19 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     }
 
     folly::Future<VariantKey> multi_key_fut = folly::Future<VariantKey>::makeEmpty();
-    IndexAggregator <RowCountIndex> multi_index_agg(stream_id, [&stream_id, version_id, &multi_key_fut, store=store()](auto &&segment) {
-        multi_key_fut = store->write(KeyType::PARTITION,
-                                     version_id,  // version_id
-                                     stream_id,
-                                     0,  // start_index
-                                     0,  // end_index
-                                     std::forward<decltype(segment)>(segment)).wait();
-    });
+    IndexAggregator<RowCountIndex> multi_index_agg(stream_id,
+        [&stream_id, version_id, &multi_key_fut, store = store()](auto&& segment) {
+            multi_key_fut = store
+                                ->write(KeyType::PARTITION,
+                                    version_id, // version_id
+                                    stream_id,
+                                    0, // start_index
+                                    0, // end_index
+                                    std::forward<decltype(segment)>(segment))
+                                .wait();
+        });
 
-    for (const auto& index_key: index_keys) {
+    for (const auto& index_key : index_keys) {
         multi_index_agg.add_key(index_key);
     }
 
@@ -559,20 +585,22 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     //    TODO: now store this in the version key for this symbol
 }
 
-VersionedItem PythonVersionStore::write_versioned_composite_data(
-    const StreamId& stream_id,
-    const py::object &metastruct,
-    const std::vector<StreamId> &sub_keys,
-    const std::vector<py::tuple> &items,
-    const std::vector<py::object> &norm_metas,
-    const py::object &user_meta
-    ) {
+VersionedItem PythonVersionStore::write_versioned_composite_data(const StreamId& stream_id,
+    const py::object& metastruct,
+    const std::vector<StreamId>& sub_keys,
+    const std::vector<py::tuple>& items,
+    const std::vector<py::object>& norm_metas,
+    const py::object& user_meta)
+{
     ARCTICDB_SAMPLE(WriteVersionedMultiKey, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_composite_data");
     auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
     auto version_id = get_next_version_from_key(maybe_prev);
-    ARCTICDB_DEBUG(log::version(), "write_versioned_composite_data for stream_id: {} , version_id = {}", stream_id, version_id);
+    ARCTICDB_DEBUG(log::version(),
+        "write_versioned_composite_data for stream_id: {} , version_id = {}",
+        stream_id,
+        version_id);
     // TODO: Assuming each sub key is always going to have the same version attached to it.
     std::vector<VersionId> version_ids;
     std::vector<py::object> user_metas;
@@ -587,73 +615,82 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     }
 
     auto frames = create_input_tensor_frames(sub_keys, items, norm_metas, user_metas);
-    auto index_keys = batch_write_internal(std::move(version_ids), sub_keys, std::move(frames), std::move(de_dup_maps), false);
+    auto index_keys =
+        batch_write_internal(std::move(version_ids), sub_keys, std::move(frames), std::move(de_dup_maps), false);
     auto multi_key = write_multi_index_entry(store(), index_keys, stream_id, metastruct, user_meta, version_id);
     auto versioned_item = VersionedItem(to_atom(multi_key));
     version_map()->write_version(store(), versioned_item.key_);
 
-    if(cfg().symbol_list())
+    if (cfg().symbol_list())
         symbol_list().add_symbol(store(), stream_id);
 
     return versioned_item;
 }
 
-VersionedItem PythonVersionStore::write_versioned_dataframe(
-    const StreamId& stream_id,
+VersionedItem PythonVersionStore::write_versioned_dataframe(const StreamId& stream_id,
     const py::tuple& item,
     const py::object& norm,
     const py::object& user_meta,
     bool prune_previous_versions,
     bool sparsify_floats,
-    bool validate_index) {
+    bool validate_index)
+{
     ARCTICDB_SAMPLE(WriteVersionedDataframe, 0)
     auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta);
-    auto versioned_item = write_versioned_dataframe_internal(stream_id, std::move(frame), prune_previous_versions, sparsify_floats, validate_index);
+    auto versioned_item = write_versioned_dataframe_internal(stream_id,
+        std::move(frame),
+        prune_previous_versions,
+        sparsify_floats,
+        validate_index);
 
-    if(cfg().symbol_list())
+    if (cfg().symbol_list())
         symbol_list().add_symbol(store(), stream_id);
 
     return versioned_item;
 }
 
-VersionedItem PythonVersionStore::append(
-    const StreamId& stream_id,
-    const py::tuple &item,
-    const py::object &norm,
-    const py::object & user_meta,
+VersionedItem PythonVersionStore::append(const StreamId& stream_id,
+    const py::tuple& item,
+    const py::object& norm,
+    const py::object& user_meta,
     bool upsert,
     bool prune_previous_versions,
-    bool validate_index) {
-    return append_internal(stream_id, convert::py_ndf_to_frame(stream_id, item, norm, user_meta), upsert,
-                           prune_previous_versions, validate_index);
+    bool validate_index)
+{
+    return append_internal(stream_id,
+        convert::py_ndf_to_frame(stream_id, item, norm, user_meta),
+        upsert,
+        prune_previous_versions,
+        validate_index);
 }
 
-VersionedItem PythonVersionStore::update(
-        const StreamId &stream_id,
-        const UpdateQuery &query,
-        const py::tuple &item,
-        const py::object &norm,
-        const py::object &user_meta,
-        bool upsert,
-        bool dynamic_schema,
-        bool prune_previous_versions) {
-    return update_internal(stream_id, query,
-                           convert::py_ndf_to_frame(stream_id, item, norm, user_meta), upsert,
-                           dynamic_schema, prune_previous_versions);
-}
-
-VersionedItem PythonVersionStore::delete_range(
-    const StreamId& stream_id,
+VersionedItem PythonVersionStore::update(const StreamId& stream_id,
     const UpdateQuery& query,
-    bool dynamic_schema) {
+    const py::tuple& item,
+    const py::object& norm,
+    const py::object& user_meta,
+    bool upsert,
+    bool dynamic_schema,
+    bool prune_previous_versions)
+{
+    return update_internal(stream_id,
+        query,
+        convert::py_ndf_to_frame(stream_id, item, norm, user_meta),
+        upsert,
+        dynamic_schema,
+        prune_previous_versions);
+}
+
+VersionedItem PythonVersionStore::delete_range(const StreamId& stream_id, const UpdateQuery& query, bool dynamic_schema)
+{
     return delete_range_internal(stream_id, query, dynamic_schema);
 }
 
-void PythonVersionStore::append_incomplete(
-    const StreamId& stream_id,
-    const py::tuple &item,
-    const py::object &norm,
-    const py::object & user_meta) const {
+void PythonVersionStore::append_incomplete(const StreamId& stream_id,
+    const py::tuple& item,
+    const py::object& norm,
+    const py::object& user_meta) const
+{
 
     using namespace arcticdb::entity;
     using namespace arcticdb::stream;
@@ -664,22 +701,21 @@ void PythonVersionStore::append_incomplete(
     append_incomplete_frame(stream_id, std::move(frame));
 }
 
-VersionedItem PythonVersionStore::write_metadata(
-    const StreamId& stream_id,
-    const py::object & user_meta,
-    bool prune_previous_versions) {
+VersionedItem
+PythonVersionStore::write_metadata(const StreamId& stream_id, const py::object& user_meta, bool prune_previous_versions)
+{
     arcticdb::proto::descriptors::UserDefinedMetadata user_meta_proto;
     python_util::pb_from_python(user_meta, user_meta_proto);
     return write_versioned_metadata_internal(stream_id, prune_previous_versions, std::move(user_meta_proto));
 }
 
-VersionedItem PythonVersionStore::compact_incomplete(
-        const StreamId& stream_id,
-        bool append,
-        bool convert_int_to_float,
-        bool via_iteration /*= true */,
-        bool sparsify /*= false */,
-        const std::optional<py::object>& user_meta /* = std::nullopt */) {
+VersionedItem PythonVersionStore::compact_incomplete(const StreamId& stream_id,
+    bool append,
+    bool convert_int_to_float,
+    bool via_iteration /*= true */,
+    bool sparsify /*= false */,
+    const std::optional<py::object>& user_meta /* = std::nullopt */)
+{
     std::optional<arcticdb::proto::descriptors::UserDefinedMetadata> meta;
     if (user_meta && !user_meta->is_none()) {
         meta = std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>();
@@ -688,14 +724,13 @@ VersionedItem PythonVersionStore::compact_incomplete(
     return compact_incomplete_dynamic(stream_id, meta, append, convert_int_to_float, via_iteration, sparsify);
 }
 
-VersionedItem PythonVersionStore::sort_merge(
-        const StreamId& stream_id,
-        const py::object& user_meta,
-        bool append,
-        bool convert_int_to_float,
-        bool via_iteration,
-        bool sparsify
-) {
+VersionedItem PythonVersionStore::sort_merge(const StreamId& stream_id,
+    const py::object& user_meta,
+    bool append,
+    bool convert_int_to_float,
+    bool via_iteration,
+    bool sparsify)
+{
     std::optional<arcticdb::proto::descriptors::UserDefinedMetadata> meta;
     if (!user_meta.is_none()) {
         meta = std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>();
@@ -704,11 +739,11 @@ VersionedItem PythonVersionStore::sort_merge(
     return sort_merge_internal(stream_id, meta, append, convert_int_to_float, via_iteration, sparsify);
 }
 
-void PythonVersionStore::write_parallel(
-    const StreamId& stream_id,
-    const py::tuple &item,
-    const py::object &norm,
-    const py::object & user_meta) const {
+void PythonVersionStore::write_parallel(const StreamId& stream_id,
+    const py::tuple& item,
+    const py::object& norm,
+    const py::object& user_meta) const
+{
     using namespace arcticdb::entity;
     using namespace arcticdb::stream;
     using namespace arcticdb::pipelines;
@@ -717,11 +752,13 @@ void PythonVersionStore::write_parallel(
     write_parallel_frame(stream_id, std::move(frame));
 }
 
-std::unordered_map<VersionId, bool> PythonVersionStore::get_all_tombstoned_versions(const StreamId &stream_id) {
+std::unordered_map<VersionId, bool> PythonVersionStore::get_all_tombstoned_versions(const StreamId& stream_id)
+{
     return ::arcticdb::get_all_tombstoned_versions(store(), version_map(), stream_id);
 }
 
-FrameAndDescriptor create_frame(const StreamId& target_id, SegmentInMemory seg, const ReadOptions& read_options) {
+FrameAndDescriptor create_frame(const StreamId& target_id, SegmentInMemory seg, const ReadOptions& read_options)
+{
     auto context = std::make_shared<PipelineContext>(seg, in_memory_key(KeyType::TABLE_DATA, target_id, VersionId{0}));
     seg.unsparsify();
     reduce_and_fix_columns(context, seg, read_options);
@@ -730,71 +767,74 @@ FrameAndDescriptor create_frame(const StreamId& target_id, SegmentInMemory seg, 
     return FrameAndDescriptor{std::move(seg), desc, {}, {}};
 }
 
-ReadResult PythonVersionStore::read_dataframe_merged(
-    const StreamId& target_id,
-    const std::vector<StreamId> &stream_ids,
+ReadResult PythonVersionStore::read_dataframe_merged(const StreamId& target_id,
+    const std::vector<StreamId>& stream_ids,
     const VersionQuery&, // TODO batch_get_specific_version
-    const ReadQuery &query,
-    const ReadOptions& read_options) {
+    const ReadQuery& query,
+    const ReadOptions& read_options)
+{
     if (stream_ids.empty())
         util::raise_rte("No symbols given");
 
     auto stream_index_map = batch_get_latest_version(store(), version_map(), stream_ids, false);
     std::vector<AtomKey> index_keys;
-    std::transform(stream_index_map->begin(), stream_index_map->end(), std::back_inserter(index_keys),
-                   [](auto &stream_key) { return to_atom(stream_key.second); });
+    std::transform(stream_index_map->begin(),
+        stream_index_map->end(),
+        std::back_inserter(index_keys),
+        [](auto& stream_key) { return to_atom(stream_key.second); });
 
-    if(stream_index_map->empty())
+    if (stream_index_map->empty())
         throw NoDataFoundException("No data found for any symbols");
 
     auto [key, metadata, descriptor] = store()->read_metadata_and_descriptor(stream_index_map->begin()->second).get();
     auto index = index_type_from_descriptor(descriptor);
 
     FrameAndDescriptor final_frame;
-    VariantColumnPolicy density_policy = read_options.allow_sparse_ ? VariantColumnPolicy{SparseColumnPolicy{}} : VariantColumnPolicy{DenseColumnPolicy{}};
+    VariantColumnPolicy density_policy = read_options.allow_sparse_ ? VariantColumnPolicy{SparseColumnPolicy{}}
+                                                                    : VariantColumnPolicy{DenseColumnPolicy{}};
 
-    merge_frames_for_keys(
-        target_id,
+    merge_frames_for_keys(target_id,
         std::move(index),
         NeverSegmentPolicy{},
         density_policy,
         index_keys,
         query,
         store(),
-        [&final_frame, &target_id, &read_options](auto &&seg) {
-            final_frame = create_frame(target_id, std::forward<decltype(seg)>(seg), read_options);
-        });
+        [&final_frame, &target_id, &read_options](
+            auto&& seg) { final_frame = create_frame(target_id, std::forward<decltype(seg)>(seg), read_options); });
 
     const auto version = VersionedItem{to_atom((*stream_index_map)[stream_ids[0]])};
     return create_python_read_result(version, std::move(final_frame));
 }
 
-std::vector<ReadResult> PythonVersionStore::batch_read(
-    const std::vector<StreamId>& stream_ids,
+std::vector<ReadResult> PythonVersionStore::batch_read(const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     std::vector<ReadQuery>& read_queries,
-    const ReadOptions& read_options) {
+    const ReadOptions& read_options)
+{
 
     auto versions_and_frames = batch_read_internal(stream_ids, version_queries, read_queries, read_options);
     std::vector<ReadResult> res;
-    for (auto&& [version, frame_and_descriptor]: versions_and_frames) {
+    for (auto&& [version, frame_and_descriptor] : versions_and_frames) {
         res.emplace_back(create_python_read_result(version, std::move(frame_and_descriptor)));
     }
     return res;
 }
 
-ReadResult PythonVersionStore::read_dataframe_version(
-    const StreamId &stream_id,
+ReadResult PythonVersionStore::read_dataframe_version(const StreamId& stream_id,
     const VersionQuery& version_query,
     ReadQuery& read_query,
-    const ReadOptions& read_options) {
-    auto [versioned_item, frame_and_descriptor] =  read_dataframe_version_internal(stream_id, version_query, read_query, read_options);
+    const ReadOptions& read_options)
+{
+    auto [versioned_item, frame_and_descriptor] =
+        read_dataframe_version_internal(stream_id, version_query, read_query, read_options);
     return create_python_read_result(versioned_item, std::move(frame_and_descriptor));
 }
 
-void PythonVersionStore::delete_snapshot(const SnapshotId& snap_name) {
+void PythonVersionStore::delete_snapshot(const SnapshotId& snap_name)
+{
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_snapshot");
-    auto opt_snapshot =  get_snapshot(store(), snap_name);
+    auto opt_snapshot = get_snapshot(store(), snap_name);
     if (!opt_snapshot) {
         throw NoDataFoundException(snap_name);
     }
@@ -811,66 +851,63 @@ void PythonVersionStore::delete_snapshot(const SnapshotId& snap_name) {
     }
 }
 
-void PythonVersionStore::delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key) {
+void PythonVersionStore::delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key)
+{
     ARCTICDB_DEBUG(log::version(), "Deleting data of Snapshot {}", snap_name);
 
     std::vector<AtomKey> index_keys_in_current_snapshot;
-    auto snap_map = get_master_snapshots_map(
-        store(),
-        std::tie(snap_key, index_keys_in_current_snapshot));
+    auto snap_map = get_master_snapshots_map(store(), std::tie(snap_key, index_keys_in_current_snapshot));
 
     ARCTICDB_DEBUG(log::version(), "Deleting Snapshot {}", snap_name);
     store()->remove_key(snap_key).get();
 
     try {
-        delete_trees_responsibly(
-            index_keys_in_current_snapshot,
-            snap_map,
-            snap_name);
+        delete_trees_responsibly(index_keys_in_current_snapshot, snap_map, snap_name);
         ARCTICDB_DEBUG(log::version(), "Deleted orphaned index keys in snapshot {}", snap_name);
-    } catch(const std::exception &ex) {
+    } catch (const std::exception& ex) {
         log::version().warn("Garbage collection of unreachable deleted index keys failed due to: {}", ex.what());
     }
 }
 
-std::vector<SnapshotVariantKey> ARCTICDB_UNUSED iterate_snapshot_tombstones (
-    const std::string& limit_stream_id,
+std::vector<SnapshotVariantKey> ARCTICDB_UNUSED iterate_snapshot_tombstones(const std::string& limit_stream_id,
     std::set<IndexTypeKey>& candidates,
-    const std::shared_ptr<Store>& store) {
+    const std::shared_ptr<Store>& store)
+{
 
     std::vector<SnapshotVariantKey> snap_tomb_keys;
     if (limit_stream_id.empty()) {
-        store->iterate_type(KeyType::SNAPSHOT_TOMBSTONE, [&store, &candidates, &snap_tomb_keys](VariantKey&& snap_tomb_key) {
-            ARCTICDB_DEBUG(log::version(), "Processing {}", snap_tomb_key);
-            std::vector<IndexTypeKey> indexes{};
-            auto snap_seg = store->read_sync(snap_tomb_key).second;
-            auto before = candidates.size();
+        store->iterate_type(KeyType::SNAPSHOT_TOMBSTONE,
+            [&store, &candidates, &snap_tomb_keys](VariantKey&& snap_tomb_key) {
+                ARCTICDB_DEBUG(log::version(), "Processing {}", snap_tomb_key);
+                std::vector<IndexTypeKey> indexes{};
+                auto snap_seg = store->read_sync(snap_tomb_key).second;
+                auto before = candidates.size();
 
-            for (size_t idx = 0; idx < snap_seg.row_count(); idx++) {
-                auto key = read_key_row(snap_seg, static_cast<ssize_t>(idx));
-                if (candidates.count(key) == 0) { // Snapshots often hold the same keys, so worthwhile optimisation
-                    indexes.emplace_back(std::move(key));
+                for (size_t idx = 0; idx < snap_seg.row_count(); idx++) {
+                    auto key = read_key_row(snap_seg, static_cast<ssize_t>(idx));
+                    if (candidates.count(key) == 0) { // Snapshots often hold the same keys, so worthwhile optimisation
+                        indexes.emplace_back(std::move(key));
+                    }
                 }
-            }
 
-            if (!indexes.empty()) {
-                filter_keys_on_existence(indexes, store, true);
-                candidates.insert(std::move_iterator(indexes.begin()), std::move_iterator(indexes.end()));
-                indexes.clear();
-            }
+                if (!indexes.empty()) {
+                    filter_keys_on_existence(indexes, store, true);
+                    candidates.insert(std::move_iterator(indexes.begin()), std::move_iterator(indexes.end()));
+                    indexes.clear();
+                }
 
-            log::version().info("Processed {} keys from snapshot {}. {} are unique.",
-                                snap_seg.row_count(), variant_key_id(snap_tomb_key), candidates.size() - before);
-            snap_tomb_keys.emplace_back(std::move(snap_tomb_key));
-        });
+                log::version().info("Processed {} keys from snapshot {}. {} are unique.",
+                    snap_seg.row_count(),
+                    variant_key_id(snap_tomb_key),
+                    candidates.size() - before);
+                snap_tomb_keys.emplace_back(std::move(snap_tomb_key));
+            });
     }
     return snap_tomb_keys;
 }
 
-void PythonVersionStore::delete_version(
-    const StreamId& stream_id,
-    const VersionId& version_id
-    ) {
+void PythonVersionStore::delete_version(const StreamId& stream_id, const VersionId& version_id)
+{
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_version");
     auto result = ::arcticdb::tombstone_version(store(), version_map(), stream_id, version_id);
@@ -879,31 +916,39 @@ void PythonVersionStore::delete_version(
         delete_tree(result.keys_to_delete, result);
     }
 
-    if(result.no_undeleted_left && cfg().symbol_list()) {
+    if (result.no_undeleted_left && cfg().symbol_list()) {
         symbol_list().remove_symbol(store(), stream_id);
     }
 }
 
-void PythonVersionStore::fix_symbol_trees(const std::vector<StreamId>& symbols) {
+void PythonVersionStore::fix_symbol_trees(const std::vector<StreamId>& symbols)
+{
     auto snaps = get_master_snapshots_map(store());
     for (const auto& sym : symbols) {
         auto index_keys_from_symbol_tree = get_all_versions(store(), version_map(), sym, true, true);
-        for(const auto& [key, map] : snaps[sym]) {
+        for (const auto& [key, map] : snaps[sym]) {
             index_keys_from_symbol_tree.push_back(key);
         }
-        std::sort(std::begin(index_keys_from_symbol_tree), std::end(index_keys_from_symbol_tree),
-                  [&](const auto& k1, const auto& k2){return k1.version_id() > k2.version_id();});
-        auto last = std::unique(std::begin(index_keys_from_symbol_tree), std::end(index_keys_from_symbol_tree),
-                                [&](const auto& k1, const auto& k2){return k1.version_id() == k2.version_id();});
+        std::sort(std::begin(index_keys_from_symbol_tree),
+            std::end(index_keys_from_symbol_tree),
+            [&](const auto& k1, const auto& k2) { return k1.version_id() > k2.version_id(); });
+        auto last = std::unique(std::begin(index_keys_from_symbol_tree),
+            std::end(index_keys_from_symbol_tree),
+            [&](const auto& k1, const auto& k2) { return k1.version_id() == k2.version_id(); });
         index_keys_from_symbol_tree.erase(last, index_keys_from_symbol_tree.end());
         version_map()->overwrite_symbol_tree(store(), sym, index_keys_from_symbol_tree);
     }
 }
 
-void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
+void PythonVersionStore::prune_previous_versions(const StreamId& stream_id)
+{
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: prune_previous_versions stream_id={}", stream_id);
-    const auto entry = version_map()->check_reload(store(), stream_id, LoadParameter{LoadType::LOAD_UNDELETED},
-                                                 true, false, __FUNCTION__);
+    const auto entry = version_map()->check_reload(store(),
+        stream_id,
+        LoadParameter{LoadType::LOAD_UNDELETED},
+        true,
+        false,
+        __FUNCTION__);
     auto latest = entry->get_first_index(false);
     util::check(latest.has_value(), "Cannot prune previous versions for non-existent symbol {}", stream_id);
 
@@ -918,7 +963,8 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
     delete_unreferenced_pruned_indexes(pruned_indexes, latest.value());
 }
 
-void PythonVersionStore::delete_all_versions(const StreamId& stream_id) {
+void PythonVersionStore::delete_all_versions(const StreamId& stream_id)
+{
     ARCTICDB_SAMPLE(DeleteAllVersions, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_all_versions");
@@ -927,55 +973,56 @@ void PythonVersionStore::delete_all_versions(const StreamId& stream_id) {
         return;
     }
     auto all_index_keys = version_map()->delete_all_versions(store(), stream_id);
-    ARCTICDB_DEBUG(log::version(), "Version heads deleted for symbol {}. Proceeding with index keys total of {}", stream_id, all_index_keys.size());
+    ARCTICDB_DEBUG(log::version(),
+        "Version heads deleted for symbol {}. Proceeding with index keys total of {}",
+        stream_id,
+        all_index_keys.size());
     if (!cfg().write_options().delayed_deletes()) {
         delete_tree({all_index_keys.begin(), all_index_keys.end()});
     } else {
         ARCTICDB_DEBUG(log::version(), "Not deleting data for {}", stream_id);
     }
 
-    if(cfg().symbol_list())
+    if (cfg().symbol_list())
         symbol_list().remove_symbol(store(), stream_id);
     ARCTICDB_DEBUG(log::version(), "Delete of Symbol {} successful", stream_id);
 }
 
-std::vector<timestamp> PythonVersionStore::get_update_times(
-        const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries) {
+std::vector<timestamp> PythonVersionStore::get_update_times(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
     return batch_get_update_times(stream_ids, version_queries);
 }
 
-timestamp PythonVersionStore::get_update_time(
-        const StreamId& stream_id,
-        const VersionQuery& version_query) {
+timestamp PythonVersionStore::get_update_time(const StreamId& stream_id, const VersionQuery& version_query)
+{
     return get_update_time_internal(stream_id, version_query);
 }
 
 namespace {
-py::object metadata_protobuf_to_pyobject(std::optional<google::protobuf::Any> metadata_proto) {
+py::object metadata_protobuf_to_pyobject(std::optional<google::protobuf::Any> metadata_proto)
+{
     py::object pyobj;
 
     if (metadata_proto) {
         arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
         metadata_proto.value().UnpackTo(&tsd);
         pyobj = python_util::pb_to_python(tsd.user_meta());
-    }
-    else {
+    } else {
         pyobj = pybind11::none();
     }
     return pyobj;
 }
-}
+} // namespace
 
-std::pair<VersionedItem, py::object> PythonVersionStore::read_metadata(
-    const StreamId& stream_id,
-    const VersionQuery& version_query
-    ) {
+std::pair<VersionedItem, py::object> PythonVersionStore::read_metadata(const StreamId& stream_id,
+    const VersionQuery& version_query)
+{
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: read_metadata");
     ARCTICDB_SAMPLE(ReadMetadata, 0)
 
     auto version = get_version_to_read(stream_id, version_query);
-    if(!version)
+    if (!version)
         throw NoDataFoundException(fmt::format("read_metadata: version not found for symbol", stream_id));
 
     auto metadata_proto = store()->read_metadata(version.value().key_).get().second;
@@ -983,71 +1030,69 @@ std::pair<VersionedItem, py::object> PythonVersionStore::read_metadata(
     return std::pair{version.value(), pyobj};
 }
 
-std::vector<VersionedItem> PythonVersionStore::batch_write_metadata(
-    std::vector<StreamId> stream_ids,
+std::vector<VersionedItem> PythonVersionStore::batch_write_metadata(std::vector<StreamId> stream_ids,
     const std::vector<py::object>& user_meta,
-    bool prune_previous_versions) {
+    bool prune_previous_versions)
+{
     std::vector<std::pair<VersionedItem, py::object>> results;
     std::vector<AtomKey> keys_to_read;
-    auto stream_update_info_map = batch_get_latest_undeleted_version_and_next_version_id(store(),
-                                                                                         version_map(),
-                                                                                         stream_ids);
+    auto stream_update_info_map =
+        batch_get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_ids);
     std::vector<folly::Future<AtomKey>> fut_vec;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
+    for (const auto& stream_id : folly::enumerate(stream_ids)) {
         arcticdb::proto::descriptors::UserDefinedMetadata user_meta_proto;
         python_util::pb_from_python(user_meta[stream_id.index], user_meta_proto);
         const auto& update_info = stream_update_info_map.at(*stream_id);
         util::check(update_info.previous_index_key_.has_value(),
-                    "Failed to find latest version to write metadata to for symbol {}",
-                    *stream_id);
-        fut_vec.push_back(async::submit_io_task(UpdateMetadataTask{store(),
-                                                                   update_info,
-                                                                   std::move(user_meta_proto)}));
+            "Failed to find latest version to write metadata to for symbol {}",
+            *stream_id);
+        fut_vec.push_back(async::submit_io_task(UpdateMetadataTask{store(), update_info, std::move(user_meta_proto)}));
     }
     auto index_keys = folly::collect(fut_vec).get();
-    if(prune_previous_versions) {
+    if (prune_previous_versions) {
         batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_map);
     } else {
         batch_write_version(store(), version_map(), index_keys);
     }
 
     std::vector<VersionedItem> output(index_keys.size());
-    for(auto key : folly::enumerate(index_keys))
+    for (auto key : folly::enumerate(index_keys))
         output[key.index] = std::move(*key);
 
     return output;
 }
 
-std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>> PythonVersionStore::batch_restore_version(
-    const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries) {
+std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>>
+PythonVersionStore::batch_restore_version(const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
     return batch_restore_version_internal(stream_ids, version_queries);
 }
 
 std::vector<std::pair<VersionedItem, py::object>> PythonVersionStore::batch_read_metadata(
     const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries) {
+    const std::vector<VersionQuery>& version_queries)
+{
     ARCTICDB_SAMPLE(BatchReadMetadata, 0)
     auto metadata = batch_read_metadata_internal(stream_ids, version_queries);
 
     std::vector<std::pair<VersionedItem, py::object>> results;
-    for (auto [key, meta_proto]: metadata) {
-            if(meta_proto.has_value()) {
-                VersionedItem version{std::move(to_atom(*key))};
-                auto res = std::make_pair(version, metadata_protobuf_to_pyobject(meta_proto));
-                results.push_back(res);
-            }else{
-                auto res = std::make_pair(VersionedItem(), py::none());
-                results.push_back(res);   
-            }
+    for (auto [key, meta_proto] : metadata) {
+        if (meta_proto.has_value()) {
+            VersionedItem version{std::move(to_atom(*key))};
+            auto res = std::make_pair(version, metadata_protobuf_to_pyobject(meta_proto));
+            results.push_back(res);
+        } else {
+            auto res = std::make_pair(VersionedItem(), py::none());
+            results.push_back(res);
+        }
     }
     return results;
 }
 
-std::pair<VersionedItem, py::object> PythonVersionStore::read_descriptor(
-    const StreamId& stream_id,
-    const VersionQuery& version_query
-    ) {
+std::pair<VersionedItem, py::object> PythonVersionStore::read_descriptor(const StreamId& stream_id,
+    const VersionQuery& version_query)
+{
     auto [version, metadata_proto] = read_descriptor_version_internal(stream_id, version_query);
     py::object pyobj;
     if (metadata_proto.has_value()) {
@@ -1061,9 +1106,10 @@ std::pair<VersionedItem, py::object> PythonVersionStore::read_descriptor(
 }
 
 std::vector<std::pair<VersionedItem, py::object>> PythonVersionStore::batch_read_descriptor(
-        const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries){
-    
+    const std::vector<StreamId>& stream_ids,
+    const std::vector<VersionQuery>& version_queries)
+{
+
     auto vector_descriptors = batch_read_descriptor_internal(stream_ids, version_queries);
     std::vector<std::pair<VersionedItem, py::object>> output_vector;
     for (auto [version, metadata_proto] : vector_descriptors) {
@@ -1080,38 +1126,41 @@ std::vector<std::pair<VersionedItem, py::object>> PythonVersionStore::batch_read
     return output_vector;
 }
 
-ReadResult PythonVersionStore::read_index(
-    const StreamId& stream_id,
-    const VersionQuery& version_query
-    ) {
+ReadResult PythonVersionStore::read_index(const StreamId& stream_id, const VersionQuery& version_query)
+{
     ARCTICDB_SAMPLE(ReadDescriptor, 0)
 
     py::object pyobj;
     auto version = get_version_to_read(stream_id, version_query);
-    if(!version)
+    if (!version)
         throw NoDataFoundException(fmt::format("read_index: version not found for symbol '{}'", stream_id));
 
     auto res = read_index_impl(store(), version.value());
     return make_read_result_from_frame(res, version->key_);
 }
 
-std::vector<AtomKey> PythonVersionStore::get_version_history(const StreamId& stream_id) {
+std::vector<AtomKey> PythonVersionStore::get_version_history(const StreamId& stream_id)
+{
     return get_index_and_tombstone_keys(store(), version_map(), stream_id);
 }
 
-void PythonVersionStore::_compact_version_map(const StreamId& id) {
+void PythonVersionStore::_compact_version_map(const StreamId& id)
+{
     version_map()->compact(store(), id);
 }
 
-void PythonVersionStore::compact_library(size_t batch_size) {
+void PythonVersionStore::compact_library(size_t batch_size)
+{
     version_map()->compact_if_necessary_stand_alone(store(), batch_size);
 }
 
-std::vector<SliceAndKey> PythonVersionStore::list_incompletes(const StreamId& stream_id) {
+std::vector<SliceAndKey> PythonVersionStore::list_incompletes(const StreamId& stream_id)
+{
     return stream::get_incomplete(store(), stream_id, unspecified_range(), 0u, true, false);
 }
 
-void PythonVersionStore::clear() {
+void PythonVersionStore::clear()
+{
     if (store()->fast_delete()) {
         // Most storage backends have a fast deletion method for a db/collection equivalent, eg. drop() for mongo and
         // lmdb and iterating each key is always going to be suboptimal.
@@ -1122,15 +1171,14 @@ void PythonVersionStore::clear() {
     delete_all(store(), true);
 }
 
-bool PythonVersionStore::empty() {
+bool PythonVersionStore::empty()
+{
     // No good way to break out of these iterations, so use exception for flow control
     try {
-        foreach_key_type([store=store()](KeyType key_type) {
+        foreach_key_type([store = store()](KeyType key_type) {
             // Skip symbol list keys, as these can be generated by list_symbols calls even if the lib is empty
             if (key_type != KeyType::SYMBOL_LIST) {
-                store->iterate_type(key_type, [](VariantKey&&) {
-                    throw std::exception();
-                });
+                store->iterate_type(key_type, [](VariantKey&&) { throw std::exception(); });
             }
         });
     } catch (...) {
@@ -1139,7 +1187,8 @@ bool PythonVersionStore::empty() {
     return true;
 }
 
-void PythonVersionStore::force_delete_symbol(const StreamId& stream_id) {
+void PythonVersionStore::force_delete_symbol(const StreamId& stream_id)
+{
     version_map()->delete_all_versions(store(), stream_id);
     delete_all_for_stream(store(), stream_id, true);
 }

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -48,233 +48,186 @@ namespace as = arcticdb::stream;
  */
 class PythonVersionStore : public LocalVersionedEngine {
 
-  public:
-    explicit PythonVersionStore(
-        const std::shared_ptr<storage::Library>& library);
+public:
+    explicit PythonVersionStore(const std::shared_ptr<storage::Library>& library);
 
-    VersionedItem write_dataframe_specific_version(
-        const StreamId& stream_id,
+    VersionedItem write_dataframe_specific_version(const StreamId& stream_id,
         const py::tuple& item,
         const py::object& norm,
         const py::object& user_meta,
         VersionId version_id);
 
-    VersionedItem write_versioned_dataframe(
-        const StreamId& stream_id,
-        const py::tuple &item,
-        const py::object &norm,
-        const py::object & user_meta,
+    VersionedItem write_versioned_dataframe(const StreamId& stream_id,
+        const py::tuple& item,
+        const py::object& norm,
+        const py::object& user_meta,
         bool prune_previous_versions,
         bool allow_sparse,
         bool validate_index);
 
-    VersionedItem write_versioned_composite_data(
-        const StreamId& stream_id,
-        const py::object &metastruct,
-        const std::vector<StreamId> &sub_keys,  // TODO: make this optional?
-        const std::vector<py::tuple> &items,
-        const std::vector<py::object> &norm_metas,
-        const py::object &user_meta);
+    VersionedItem write_versioned_composite_data(const StreamId& stream_id,
+        const py::object& metastruct,
+        const std::vector<StreamId>& sub_keys, // TODO: make this optional?
+        const std::vector<py::tuple>& items,
+        const std::vector<py::object>& norm_metas,
+        const py::object& user_meta);
 
-    VersionedItem write_partitioned_dataframe(
-        const StreamId& stream_id,
-        const py::tuple &item,
-        const py::object &norm_meta,
+    VersionedItem write_partitioned_dataframe(const StreamId& stream_id,
+        const py::tuple& item,
+        const py::object& norm_meta,
         const std::vector<std::string>& partition_cols);
 
-    ReadResult read_partitioned_dataframe(
-        const StreamId& stream_id,
-        const ReadQuery& query,
-        const ReadOptions& read_options);
+    ReadResult
+    read_partitioned_dataframe(const StreamId& stream_id, const ReadQuery& query, const ReadOptions& read_options);
 
-    VersionedItem append(
-        const StreamId& stream_id,
-        const py::tuple &item,
-        const py::object &norm,
-        const py::object & user_meta,
+    VersionedItem append(const StreamId& stream_id,
+        const py::tuple& item,
+        const py::object& norm,
+        const py::object& user_meta,
         bool upsert,
         bool prune_previous_versions,
         bool validate_index);
 
-    VersionedItem update(
-        const StreamId& stream_id,
-        const UpdateQuery & query,
-        const py::tuple &item,
-        const py::object &norm,
-        const py::object & user_meta,
+    VersionedItem update(const StreamId& stream_id,
+        const UpdateQuery& query,
+        const py::tuple& item,
+        const py::object& norm,
+        const py::object& user_meta,
         bool upsert,
         bool dynamic_schema,
         bool prune_previous_versions);
 
-    VersionedItem delete_range(
-        const StreamId& stream_id,
-        const UpdateQuery& query,
-        bool dynamic_schema);
+    VersionedItem delete_range(const StreamId& stream_id, const UpdateQuery& query, bool dynamic_schema);
 
-    void append_incomplete(
-        const StreamId& stream_id,
-        const py::tuple &item,
-        const py::object &norm,
-        const py::object & user_meta) const;
+    void append_incomplete(const StreamId& stream_id,
+        const py::tuple& item,
+        const py::object& norm,
+        const py::object& user_meta) const;
 
-    VersionedItem compact_incomplete(
-            const StreamId& stream_id,
-            bool append,
-            bool convert_int_to_float,
-            bool via_iteration = true,
-            bool sparsify = false,
-            const std::optional<py::object>& user_meta = std::nullopt);
+    VersionedItem compact_incomplete(const StreamId& stream_id,
+        bool append,
+        bool convert_int_to_float,
+        bool via_iteration = true,
+        bool sparsify = false,
+        const std::optional<py::object>& user_meta = std::nullopt);
 
-    void write_parallel(
-        const StreamId& stream_id,
-        const py::tuple &item,
-        const py::object &norm,
-        const py::object & user_meta) const;
+    void write_parallel(const StreamId& stream_id,
+        const py::tuple& item,
+        const py::object& norm,
+        const py::object& user_meta) const;
 
-    VersionedItem write_metadata(
-        const StreamId& stream_id,
-        const py::object & user_meta,
-        bool prune_previous_versions);
+    VersionedItem write_metadata(const StreamId& stream_id, const py::object& user_meta, bool prune_previous_versions);
 
-    ReadResult read_dataframe_version(
-        const StreamId &stream_id,
+    ReadResult read_dataframe_version(const StreamId& stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,
         const ReadOptions& read_options);
 
-    VersionedItem sort_merge(
-            const StreamId& stream_id,
-            const py::object& user_meta,
-            bool append,
-            bool convert_int_to_float,
-            bool via_iteration,
-            bool sparsify
-            );
+    VersionedItem sort_merge(const StreamId& stream_id,
+        const py::object& user_meta,
+        bool append,
+        bool convert_int_to_float,
+        bool via_iteration,
+        bool sparsify);
 
-    ReadResult read_dataframe_merged(
-        const StreamId& target_id,
-        const std::vector<StreamId> &stream_ids,
+    ReadResult read_dataframe_merged(const StreamId& target_id,
+        const std::vector<StreamId>& stream_ids,
         const VersionQuery& version_query,
-        const ReadQuery &query,
+        const ReadQuery& query,
         const ReadOptions& read_options);
 
-    std::pair<VersionedItem, py::object> read_metadata(
-        const StreamId& stream_id,
-        const VersionQuery& version_query
-    );
+    std::pair<VersionedItem, py::object> read_metadata(const StreamId& stream_id, const VersionQuery& version_query);
 
-    std::vector<std::pair<VersionedItem, py::object>> batch_read_descriptor(
-        const std::vector<StreamId>& stream_ids,
+    std::vector<std::pair<VersionedItem, py::object>> batch_read_descriptor(const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
-    std::pair<VersionedItem, py::object> read_descriptor(
-        const StreamId& stream_id,
-        const VersionQuery& version_query);
+    std::pair<VersionedItem, py::object> read_descriptor(const StreamId& stream_id, const VersionQuery& version_query);
 
-    ReadResult read_index(
-        const StreamId& stream_id,
-        const VersionQuery& version_query);
+    ReadResult read_index(const StreamId& stream_id, const VersionQuery& version_query);
 
-    void delete_snapshot(
-        const SnapshotId& snap_name);
+    void delete_snapshot(const SnapshotId& snap_name);
 
-    void delete_version(
-        const StreamId& stream_id,
-        const VersionId& version_id);
+    void delete_version(const StreamId& stream_id, const VersionId& version_id);
 
-    void prune_previous_versions(
-        const StreamId& stream_id);
+    void prune_previous_versions(const StreamId& stream_id);
 
-    void delete_all_versions(
-        const StreamId& stream_id);
+    void delete_all_versions(const StreamId& stream_id);
 
-    std::vector<timestamp> get_update_times(
-        const std::vector<StreamId>& stream_ids,
+    std::vector<timestamp> get_update_times(const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
-    timestamp get_update_time(
-        const StreamId& stream_id,
-        const VersionQuery& version_query);
+    timestamp get_update_time(const StreamId& stream_id, const VersionQuery& version_query);
 
-    inline void fix_ref_key(StreamId stream_id) {
+    inline void fix_ref_key(StreamId stream_id)
+    {
         version_map()->fix_ref_key(store(), std::move(stream_id));
     }
 
-    inline void remove_and_rewrite_version_keys(StreamId stream_id) {
+    inline void remove_and_rewrite_version_keys(StreamId stream_id)
+    {
         version_map()->remove_and_rewrite_version_keys(store(), std::move(stream_id));
     }
 
-    inline bool check_ref_key(StreamId stream_id) {
+    inline bool check_ref_key(StreamId stream_id)
+    {
         return version_map()->check_ref_key(store(), std::move(stream_id));
     }
 
-    void snapshot(
-        const SnapshotId &snap_name,
-        const py::object &user_meta,
-        const std::vector<StreamId> &skip_symbols,
-        std::map<StreamId, VersionId> &versions);
+    void snapshot(const SnapshotId& snap_name,
+        const py::object& user_meta,
+        const std::vector<StreamId>& skip_symbols,
+        std::map<StreamId, VersionId>& versions);
 
     std::vector<std::pair<SnapshotId, py::object>> list_snapshots(const std::optional<bool> load_metadata);
 
-    void add_to_snapshot(
-        const SnapshotId& snap_name,
+    void add_to_snapshot(const SnapshotId& snap_name,
         const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries
-        );
+        const std::vector<VersionQuery>& version_queries);
 
-    void remove_from_snapshot(
-        const SnapshotId& snap_name,
+    void remove_from_snapshot(const SnapshotId& snap_name,
         const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionId>& version_ids
-        );
+        const std::vector<VersionId>& version_ids);
 
     std::vector<std::tuple<StreamId, VersionId, timestamp, std::vector<SnapshotId>, bool>> list_versions(
-        const std::optional<StreamId> &stream_id,
+        const std::optional<StreamId>& stream_id,
         const std::optional<SnapshotId>& snap_name,
-        const std::optional<bool> &latest_only,
+        const std::optional<bool>& latest_only,
         const std::optional<bool>& iterate_on_failure,
         const std::optional<bool>& skip_snapshots);
 
     // Batch methods
-    std::vector<VersionedItem> batch_write(
-        const std::vector<StreamId> &stream_ids,
-        const std::vector<py::tuple> &items,
-        const std::vector<py::object> &norms,
-        const std::vector<py::object> &user_metas,
+    std::vector<VersionedItem> batch_write(const std::vector<StreamId>& stream_ids,
+        const std::vector<py::tuple>& items,
+        const std::vector<py::object>& norms,
+        const std::vector<py::object>& user_metas,
         bool prune_previous_versions,
         bool validate_index);
 
-    std::vector<VersionedItem> batch_write_metadata(
-        std::vector<StreamId> stream_ids,
+    std::vector<VersionedItem> batch_write_metadata(std::vector<StreamId> stream_ids,
         const std::vector<py::object>& user_meta,
         bool prune_previous_versions);
 
-    std::vector<VersionedItem> batch_append(
-        const std::vector<StreamId> &stream_ids,
-        const std::vector<py::tuple> &items,
-        const std::vector<py::object> &norms,
-        const std::vector<py::object> &user_metas,
+    std::vector<VersionedItem> batch_append(const std::vector<StreamId>& stream_ids,
+        const std::vector<py::tuple>& items,
+        const std::vector<py::object>& norms,
+        const std::vector<py::object>& user_metas,
         bool prune_previous_versions,
         bool ensre_sorted);
 
-    std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>> batch_restore_version(
-        const std::vector<StreamId>& id,
-        const std::vector<VersionQuery>& version_query);
+    std::vector<std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>>
+    batch_restore_version(const std::vector<StreamId>& id, const std::vector<VersionQuery>& version_query);
 
-    std::vector<ReadResult> batch_read(
-        const std::vector<StreamId>& stream_ids,
+    std::vector<ReadResult> batch_read(const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, py::object>> batch_read_metadata(
-        const std::vector<StreamId>& stream_ids,
+    std::vector<std::pair<VersionedItem, py::object>> batch_read_metadata(const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
-    std::set<StreamId> list_streams(
-        const std::optional<SnapshotId>& snap_name = std::nullopt,
-        const std::optional<std::string> &regex = std::nullopt,
-        const std::optional<std::string> &prefix = std::nullopt,
+    std::set<StreamId> list_streams(const std::optional<SnapshotId>& snap_name = std::nullopt,
+        const std::optional<std::string>& regex = std::nullopt,
+        const std::optional<std::string>& prefix = std::nullopt,
         const std::optional<bool>& use_symbol_list = std::nullopt,
         const std::optional<bool>& all_symbols = std::nullopt);
 
@@ -289,31 +242,30 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     void fix_symbol_trees(const std::vector<StreamId>& symbols);
 
-    std::unordered_map<VersionId, bool> get_all_tombstoned_versions(const StreamId &stream_id);
+    std::unordered_map<VersionId, bool> get_all_tombstoned_versions(const StreamId& stream_id);
 
     std::vector<SliceAndKey> list_incompletes(const StreamId& stream_id);
 
     std::vector<AtomKey> get_version_history(const StreamId& stream_id);
 
 private:
-
-    std::vector<VersionedItem> batch_write_index_keys_to_version_map(
-        const std::vector<AtomKey>& index_keys,
+    std::vector<VersionedItem> batch_write_index_keys_to_version_map(const std::vector<AtomKey>& index_keys,
         const std::unordered_map<StreamId, UpdateInfo>& stream_update_info_map,
         bool prune_previous_versions);
 
     void delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key);
 };
 
-inline std::vector<ReadResult> frame_to_read_result(std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>>&& keys_frame_and_descriptors) {
+inline std::vector<ReadResult> frame_to_read_result(
+    std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>>&& keys_frame_and_descriptors)
+{
     auto& keys = keys_frame_and_descriptors.first;
     auto& frame_and_descriptors = keys_frame_and_descriptors.second;
 
     std::vector<ReadResult> read_results;
     read_results.reserve(keys.size());
     for (auto fd : folly::enumerate(frame_and_descriptors)) {
-        read_results.emplace_back(ReadResult(
-            VersionedItem{std::move(keys[fd.index])},
+        read_results.emplace_back(ReadResult(VersionedItem{std::move(keys[fd.index])},
             PythonOutputFrame{fd->frame_, fd->buffers_},
             fd->desc_.normalization(),
             fd->desc_.user_meta(),

--- a/cpp/arcticdb/version/version_store_objects.hpp
+++ b/cpp/arcticdb/version/version_store_objects.hpp
@@ -40,11 +40,14 @@ struct PreDeleteChecks {
      * For example, certain callers to delete_tree() already performed some of the checks above, so can disable the
      * corresponding flags and put the results here.
      */
-    std::unordered_set<IndexTypeKey> could_share_data {};
+    std::unordered_set<IndexTypeKey> could_share_data{};
 
-    LoadType calc_load_type() const {
-        if (prev_version) return LoadType::LOAD_ALL;
-        if (version_visible | next_version) return LoadType::LOAD_DOWNTO;
+    LoadType calc_load_type() const
+    {
+        if (prev_version)
+            return LoadType::LOAD_ALL;
+        if (version_visible | next_version)
+            return LoadType::LOAD_DOWNTO;
         return LoadType::NOT_LOADED;
     }
 };
@@ -55,8 +58,10 @@ static const PreDeleteChecks default_pre_delete_checks;
  * Output from tombstone_version() with additional fields on top of PreDeleteChecks. Safe to be sliced to the latter.
  */
 struct TombstoneVersionResult : PreDeleteChecks {
-    explicit TombstoneVersionResult(bool entry_already_scanned) :
-        PreDeleteChecks{true, entry_already_scanned, entry_already_scanned, entry_already_scanned, {}} {}
+    explicit TombstoneVersionResult(bool entry_already_scanned)
+        : PreDeleteChecks{true, entry_already_scanned, entry_already_scanned, entry_already_scanned, {}}
+    {
+    }
 
     /**
      * The index key that just got tombstoned, if any.
@@ -88,4 +93,4 @@ struct UpdateInfo {
     VersionId next_version_id_;
 };
 
-} // namespace
+} // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/version_utils.cpp
+++ b/cpp/arcticdb/version/version_utils.cpp
@@ -16,17 +16,18 @@ using namespace arcticdb::storage;
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;
 
-
-std::unordered_map<entity::StreamId, size_t> get_num_version_entries(const std::shared_ptr<Store>& store, size_t batch_size)  {
+std::unordered_map<entity::StreamId, size_t> get_num_version_entries(const std::shared_ptr<Store>& store,
+    size_t batch_size)
+{
     std::unordered_map<entity::StreamId, size_t> output;
     size_t max_blocks = ConfigsMap::instance()->get_int("VersionMap.MaxVersionBlocks", 5);
-    store->iterate_type(entity::KeyType::VERSION, [&output, batch_size, max_blocks] (const VariantKey& key) {
+    store->iterate_type(entity::KeyType::VERSION, [&output, batch_size, max_blocks](const VariantKey& key) {
         ++output[variant_key_id(key)];
         if (output.size() >= batch_size) {
             // remove half of them which are under max_blocks
             // otherwise memory would blow up for big libraries
             auto iter = output.begin();
-            while(iter != output.end()) {
+            while (iter != output.end()) {
                 auto copy = iter;
                 iter++;
                 if (copy->second < max_blocks) {
@@ -41,33 +42,36 @@ std::unordered_map<entity::StreamId, size_t> get_num_version_entries(const std::
     return output;
 }
 
-void fix_stream_ids_of_index_keys(
-    const std::shared_ptr<Store> &store,
-    const StreamId &stream_id,
-    const std::shared_ptr<VersionMapEntry> &entry) {
-    for (auto &key : entry->keys_) {
+void fix_stream_ids_of_index_keys(const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
+    const std::shared_ptr<VersionMapEntry>& entry)
+{
+    for (auto& key : entry->keys_) {
         if (is_index_key_type(key.type()) && key.id() != stream_id) {
-            log::version().warn("Mismatch in stream_id - {} != {} in version: {}. Rewriting", key.id(), stream_id,
-                                key.version_id());
+            log::version().warn("Mismatch in stream_id - {} != {} in version: {}. Rewriting",
+                key.id(),
+                stream_id,
+                key.version_id());
             try {
                 auto data_kvs = store->batch_read_compressed({key}, BatchReadArgs{}, false);
-                util::check(data_kvs.size() == 1, "Unexpected size of data_kvs {} in fix_stream_ids_of_index_keys",
-                            data_kvs.size());
+                util::check(data_kvs.size() == 1,
+                    "Unexpected size of data_kvs {} in fix_stream_ids_of_index_keys",
+                    data_kvs.size());
                 data_kvs[0].atom_key() = atom_key_builder()
-                    .version_id(key.version_id())
-                    .creation_ts(key.creation_ts())
-                    .start_index(key.start_index())
-                    .end_index(key.end_index())
-                    .content_hash(key.content_hash())
-                    .build(stream_id, key.type());
+                                             .version_id(key.version_id())
+                                             .creation_ts(key.creation_ts())
+                                             .start_index(key.start_index())
+                                             .end_index(key.end_index())
+                                             .content_hash(key.content_hash())
+                                             .build(stream_id, key.type());
                 AtomKey new_key = data_kvs[0].atom_key();
                 store->batch_write_compressed(std::move(data_kvs)).get();
                 key = new_key;
                 // We don't delete the old index key - it could be referred in a snapshot (TODO: fix that as well)
-            } catch (const std::exception &ex) {
+            } catch (const std::exception& ex) {
                 log::version().info("Could not fix stream_id for {} due to {}", key.version_id(), ex.what());
             }
         }
     }
 }
-}
+} // namespace arcticdb

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -24,28 +24,29 @@ using namespace arcticdb::storage;
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;
 
-inline entity::VariantKey write_multi_index_entry(
-    std::shared_ptr<StreamSink> store,
-    std::vector<AtomKey> &keys,
-    const StreamId &stream_id,
-    const py::object &metastruct,
-    const py::object &user_meta,
-    VersionId version_id
-    ) {
+inline entity::VariantKey write_multi_index_entry(std::shared_ptr<StreamSink> store,
+    std::vector<AtomKey>& keys,
+    const StreamId& stream_id,
+    const py::object& metastruct,
+    const py::object& user_meta,
+    VersionId version_id)
+{
     ARCTICDB_SAMPLE(WriteJournalEntry, 0)
     ARCTICDB_DEBUG(log::version(), "Version map writing multi key");
     folly::Future<VariantKey> multi_key_fut = folly::Future<VariantKey>::makeEmpty();
 
-    IndexAggregator<RowCountIndex> multi_index_agg(stream_id, [&](auto &&segment) {
-        multi_key_fut = store->write(KeyType::MULTI_KEY,
-                                     version_id,  // version_id
-                                     stream_id,
-                                     0,  // start_index
-                                     0,  // end_index
-                                     std::forward<SegmentInMemory>(segment)).wait();
+    IndexAggregator<RowCountIndex> multi_index_agg(stream_id, [&](auto&& segment) {
+        multi_key_fut = store
+                            ->write(KeyType::MULTI_KEY,
+                                version_id, // version_id
+                                stream_id,
+                                0, // start_index
+                                0, // end_index
+                                std::forward<SegmentInMemory>(segment))
+                            .wait();
     });
 
-    for (auto &key: keys) {
+    for (auto& key : keys) {
         multi_index_agg.add_key(to_atom(key));
     }
     google::protobuf::Any any = {};
@@ -68,9 +69,9 @@ inline entity::VariantKey write_multi_index_entry(
     return multi_key_fut.wait().value();
 }
 
-inline std::pair<std::optional<AtomKey>, VersionId> read_segment_with_keys(
-    const SegmentInMemory &seg,
-    VersionMapEntry& entry) {
+inline std::pair<std::optional<AtomKey>, VersionId> read_segment_with_keys(const SegmentInMemory& seg,
+    VersionMapEntry& entry)
+{
     ssize_t row = 0;
     std::optional<AtomKey> next;
     VersionId oldest_loaded = std::numeric_limits<VersionId>::max();
@@ -83,7 +84,7 @@ inline std::pair<std::optional<AtomKey>, VersionId> read_segment_with_keys(
         } else if (key.type() == KeyType::TOMBSTONE) {
             entry.tombstones_.try_emplace(key.version_id(), key);
             entry.keys_.push_back(key);
-        } else if (key.type() == KeyType::TOMBSTONE_ALL){
+        } else if (key.type() == KeyType::TOMBSTONE_ALL) {
             entry.try_set_tombstone_all(key);
             entry.keys_.push_back(key);
         } else if (key.type() == KeyType::VERSION) {
@@ -99,39 +100,45 @@ inline std::pair<std::optional<AtomKey>, VersionId> read_segment_with_keys(
     return std::make_pair(next, oldest_loaded);
 }
 
-inline std::pair<std::optional<AtomKey>, VersionId> read_segment_with_keys(
-    const SegmentInMemory &seg,
-    const std::shared_ptr<VersionMapEntry>& entry) {
+inline std::pair<std::optional<AtomKey>, VersionId> read_segment_with_keys(const SegmentInMemory& seg,
+    const std::shared_ptr<VersionMapEntry>& entry)
+{
     return read_segment_with_keys(seg, *entry);
 }
 
 template<class Predicate>
 std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteration(
-    const std::shared_ptr<StreamSource> &store,
-    Predicate &&predicate,
-    const StreamId &stream_id,
+    const std::shared_ptr<StreamSource>& store,
+    Predicate&& predicate,
+    const StreamId& stream_id,
     std::vector<KeyType> key_types,
-    bool perform_read_segment_with_keys=true) {
+    bool perform_read_segment_with_keys = true)
+{
 
     auto prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
     auto output = std::make_shared<VersionMapEntry>();
     std::vector<AtomKey> read_keys;
-    for(auto key_type: key_types) {
-        store->iterate_type(key_type, [&predicate, &read_keys, &store, &output, &perform_read_segment_with_keys](VariantKey &&vk) {
-            const auto &key = to_atom(std::move(vk));
-            if (!predicate(key))
-                return;
+    for (auto key_type : key_types) {
+        store->iterate_type(
+            key_type,
+            [&predicate, &read_keys, &store, &output, &perform_read_segment_with_keys](VariantKey&& vk) {
+                const auto& key = to_atom(std::move(vk));
+                if (!predicate(key))
+                    return;
 
-            read_keys.push_back(key);
-            ARCTICDB_DEBUG(log::storage(), "Version map iterating key {}", key);
-            if (perform_read_segment_with_keys) {
-                auto [kv, seg] = store->read(to_atom(key)).get();
-                read_segment_with_keys(seg, output);
-            }
-        }, prefix);
+                read_keys.push_back(key);
+                ARCTICDB_DEBUG(log::storage(), "Version map iterating key {}", key);
+                if (perform_read_segment_with_keys) {
+                    auto [kv, seg] = store->read(to_atom(key)).get();
+                    read_segment_with_keys(seg, output);
+                }
+            },
+            prefix);
     }
     if (!perform_read_segment_with_keys) {
-        output->keys_.insert(output->keys_.end(), std::move_iterator(read_keys.begin()), std::move_iterator(read_keys.end()));
+        output->keys_.insert(output->keys_.end(),
+            std::move_iterator(read_keys.begin()),
+            std::move_iterator(read_keys.end()));
         output->sort();
         // output->head_ isnt populated in this case
         return output;
@@ -139,25 +146,23 @@ std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteratio
         if (output->keys_.empty())
             return output;
         util::check(!read_keys.empty(), "Expected there to be some read keys");
-        auto latest_key = std::max_element(std::begin(read_keys), std::end(read_keys),
-                                           [](const auto &left, const auto &right) {
-            return left.creation_ts() < right.creation_ts();
-        });
+        auto latest_key = std::max_element(std::begin(read_keys),
+            std::end(read_keys),
+            [](const auto& left, const auto& right) { return left.creation_ts() < right.creation_ts(); });
         output->sort();
         output->head_ = *latest_key;
     }
 
     return output;
-    }
+}
 
-    inline void check_is_version(const AtomKey &key) {
-        util::check(key.type() == KeyType::VERSION, "Expected version key type but got {}", key);
-    }
+inline void check_is_version(const AtomKey& key)
+{
+    util::check(key.type() == KeyType::VERSION, "Expected version key type but got {}", key);
+}
 
-
-inline std::optional<RefKey> get_symbol_ref_key(
-    const std::shared_ptr<StreamSource>& store,
-    const StreamId& stream_id) {
+inline std::optional<RefKey> get_symbol_ref_key(const std::shared_ptr<StreamSource>& store, const StreamId& stream_id)
+{
     auto ref_key = RefKey{stream_id, KeyType::VERSION_REF};
     if (store->key_exists_sync(ref_key))
         return std::make_optional(std::move(ref_key));
@@ -172,7 +177,8 @@ inline std::optional<RefKey> get_symbol_ref_key(
     return std::make_optional(std::move(ref_key));
 }
 
-inline void read_symbol_ref(std::shared_ptr<StreamSource> store, const StreamId& stream_id, VersionMapEntry& entry) {
+inline void read_symbol_ref(std::shared_ptr<StreamSource> store, const StreamId& stream_id, VersionMapEntry& entry)
+{
     auto maybe_ref_key = get_symbol_ref_key(store, stream_id);
     if (!maybe_ref_key)
         return;
@@ -182,13 +188,16 @@ inline void read_symbol_ref(std::shared_ptr<StreamSource> store, const StreamId&
     std::tie(entry.head_, version_id) = read_segment_with_keys(seg, entry);
 }
 
-inline void write_symbol_ref(std::shared_ptr<StreamSink> store, const AtomKey &latest_index, const AtomKey &journal_key) {
+inline void write_symbol_ref(std::shared_ptr<StreamSink> store, const AtomKey& latest_index, const AtomKey& journal_key)
+{
     check_is_index_or_tombstone(latest_index);
     check_is_version(journal_key);
-    ARCTICDB_DEBUG(log::version(), "Version map writing symbol ref for latest index: {} journal key {}", latest_index,
-                         journal_key);
+    ARCTICDB_DEBUG(log::version(),
+        "Version map writing symbol ref for latest index: {} journal key {}",
+        latest_index,
+        journal_key);
 
-    IndexAggregator<RowCountIndex> ref_agg(latest_index.id(), [&store, &latest_index](auto &&s) {
+    IndexAggregator<RowCountIndex> ref_agg(latest_index.id(), [&store, &latest_index](auto&& s) {
         auto segment = std::forward<SegmentInMemory>(s);
         store->write_sync(KeyType::VERSION_REF, latest_index.id(), std::move(segment));
     });
@@ -200,33 +209,38 @@ inline void write_symbol_ref(std::shared_ptr<StreamSink> store, const AtomKey &l
 
 std::unordered_map<StreamId, size_t> get_num_version_entries(const std::shared_ptr<Store>& store, size_t batch_size);
 
-inline bool need_to_load_further(const LoadParameter& load_params, VersionId loaded_until) {
-    if(!load_params.load_until_|| loaded_until > load_params.load_until_.value())
+inline bool need_to_load_further(const LoadParameter& load_params, VersionId loaded_until)
+{
+    if (!load_params.load_until_ || loaded_until > load_params.load_until_.value())
         return true;
 
-    ARCTICDB_DEBUG(log::version(), "Exiting load downto because request {} <= {}", load_params.load_until_.value(), loaded_until);
+    ARCTICDB_DEBUG(log::version(),
+        "Exiting load downto because request {} <= {}",
+        load_params.load_until_.value(),
+        loaded_until);
     return false;
 }
 
-inline bool load_latest_ongoing(const LoadParameter& load_params, const std::shared_ptr<VersionMapEntry>& entry) {
-    if(!(load_params.load_type_ == LoadType::LOAD_LATEST_UNDELETED && entry->get_first_index(false)) &&
-    !(load_params.load_type_ == LoadType::LOAD_LATEST && entry->get_first_index(true)))
+inline bool load_latest_ongoing(const LoadParameter& load_params, const std::shared_ptr<VersionMapEntry>& entry)
+{
+    if (!(load_params.load_type_ == LoadType::LOAD_LATEST_UNDELETED && entry->get_first_index(false)) &&
+        !(load_params.load_type_ == LoadType::LOAD_LATEST && entry->get_first_index(true)))
         return true;
 
     ARCTICDB_DEBUG(log::version(), "Exiting because we found a non-deleted index in load latest");
     return false;
 }
 
-inline bool looking_for_undeleted(const LoadParameter& load_params, const std::shared_ptr<VersionMapEntry>& entry) {
-    if(!(load_params.load_type_ == LoadType::LOAD_UNDELETED && entry->tombstone_all_))
+inline bool looking_for_undeleted(const LoadParameter& load_params, const std::shared_ptr<VersionMapEntry>& entry)
+{
+    if (!(load_params.load_type_ == LoadType::LOAD_UNDELETED && entry->tombstone_all_))
         return true;
 
     ARCTICDB_DEBUG(log::version(), "Exiting because we have found an undeleted version");
     return false;
 }
 
-void fix_stream_ids_of_index_keys(
-    const std::shared_ptr<Store> &store,
-    const StreamId &stream_id,
-    const std::shared_ptr<VersionMapEntry> &entry);
-}
+void fix_stream_ids_of_index_keys(const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
+    const std::shared_ptr<VersionMapEntry>& entry);
+} // namespace arcticdb

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -26,102 +26,72 @@ using namespace arcticdb::pipelines;
 class VersionedEngine {
 
 public:
-    virtual VersionedItem update_internal(
-        const StreamId& stream_id,
-        const UpdateQuery & query,
+    virtual VersionedItem update_internal(const StreamId& stream_id,
+        const UpdateQuery& query,
         InputTensorFrame&& frame,
         bool upsert,
         bool dynamic_schema,
         bool prune_previous_versions) = 0;
 
-    virtual VersionedItem append_internal(
-        const StreamId& stream_id,
+    virtual VersionedItem append_internal(const StreamId& stream_id,
         InputTensorFrame&& frame,
         bool upsert,
         bool prune_previous_versions,
         bool validate_index) = 0;
 
-    virtual VersionedItem delete_range_internal(
-        const StreamId& stream_id,
-        const UpdateQuery& query,
-        bool dynamic_schema)= 0;
+    virtual VersionedItem
+    delete_range_internal(const StreamId& stream_id, const UpdateQuery& query, bool dynamic_schema) = 0;
 
-    virtual VersionedItem sort_index(
-        const StreamId& stream_id, bool dynamic_schema) = 0;
+    virtual VersionedItem sort_index(const StreamId& stream_id, bool dynamic_schema) = 0;
 
-    virtual void append_incomplete_frame(
-        const StreamId& stream_id,
-        InputTensorFrame&& frame) const = 0;
+    virtual void append_incomplete_frame(const StreamId& stream_id, InputTensorFrame&& frame) const = 0;
 
-    virtual void append_incomplete_segment(
-        const StreamId& stream_id,
-        SegmentInMemory &&seg) = 0;
+    virtual void append_incomplete_segment(const StreamId& stream_id, SegmentInMemory&& seg) = 0;
 
-    virtual void remove_incomplete(
-        const StreamId& stream_id
-    ) = 0;
+    virtual void remove_incomplete(const StreamId& stream_id) = 0;
 
-    virtual void write_parallel_frame(
-        const StreamId& stream_id,
-        InputTensorFrame&& frame) const = 0;
+    virtual void write_parallel_frame(const StreamId& stream_id, InputTensorFrame&& frame) const = 0;
 
-    virtual bool has_stream(
-        const StreamId & stream_id,
+    virtual bool has_stream(const StreamId& stream_id,
         const std::optional<bool>& skip_compat,
-        const std::optional<bool>& iterate_on_failure
-    ) = 0;
+        const std::optional<bool>& iterate_on_failure) = 0;
 
     /**
      * Delete the given index keys, and their associated data excluding those shared with keys not in the argument.
      *
      * @param checks Checks to perform on each key to find shared data
      */
-    virtual void delete_tree(
-        const std::vector<IndexTypeKey>& idx_to_be_deleted,
-        const PreDeleteChecks& checks = default_pre_delete_checks
-    ) = 0;
+    virtual void delete_tree(const std::vector<IndexTypeKey>& idx_to_be_deleted,
+        const PreDeleteChecks& checks = default_pre_delete_checks) = 0;
 
-    virtual std::pair<VersionedItem,   arcticdb::proto::descriptors::TimeSeriesDescriptor> restore_version(
-        const StreamId& id,
-        const VersionQuery& version_query
-        ) = 0;
+    virtual std::pair<VersionedItem, arcticdb::proto::descriptors::TimeSeriesDescriptor>
+    restore_version(const StreamId& id, const VersionQuery& version_query) = 0;
 
-    virtual FrameAndDescriptor read_dataframe_internal(
-        const std::variant<VersionedItem, StreamId>& identifier,
+    virtual FrameAndDescriptor read_dataframe_internal(const std::variant<VersionedItem, StreamId>& identifier,
         ReadQuery& read_query,
         const ReadOptions& read_options) = 0;
 
-    virtual std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(
-        const StreamId &stream_id,
+    virtual std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(const StreamId& stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,
         const ReadOptions& read_options) = 0;
 
-    virtual VersionedItem write_versioned_dataframe_internal(
-        const StreamId& stream_id,
+    virtual VersionedItem write_versioned_dataframe_internal(const StreamId& stream_id,
         InputTensorFrame&& frame,
         bool prune_previous_versions,
         bool allow_sparse,
-        bool validate_index
-    ) = 0;
+        bool validate_index) = 0;
 
-    virtual std::pair<VersionedItem, std::vector<AtomKey>> write_individual_segment(
-        const StreamId& stream_id,
-        SegmentInMemory&& segment,
-        bool prune_previous_versions
-    ) = 0;
+    virtual std::pair<VersionedItem, std::vector<AtomKey>>
+    write_individual_segment(const StreamId& stream_id, SegmentInMemory&& segment, bool prune_previous_versions) = 0;
 
-    virtual std::set<StreamId> list_streams_internal(
-        std::optional<SnapshotId> snap_name,
+    virtual std::set<StreamId> list_streams_internal(std::optional<SnapshotId> snap_name,
         const std::optional<std::string>& regex,
         const std::optional<std::string>& prefix,
         const std::optional<bool>& opt_use_symbol_list,
-        const std::optional<bool>& opt_all_symbols
-    ) = 0;
+        const std::optional<bool>& opt_all_symbols) = 0;
 
-    virtual IndexRange get_index_range(
-        const StreamId &stream_id,
-        const VersionQuery& version_query) = 0;
+    virtual IndexRange get_index_range(const StreamId& stream_id, const VersionQuery& version_query) = 0;
 
     virtual std::set<StreamId> get_incomplete_symbols() = 0;
 
@@ -131,28 +101,23 @@ public:
 
     virtual void push_incompletes_to_symbol_list(const std::set<StreamId>& incompletes) = 0;
 
-    virtual void move_storage(
-        KeyType key_type,
-        timestamp horizon,
-        size_t storage_index) = 0;
+    virtual void move_storage(KeyType key_type, timestamp horizon, size_t storage_index) = 0;
 
-    virtual StorageLockWrapper get_storage_lock(
-        const StreamId& stream_id) = 0;
+    virtual StorageLockWrapper get_storage_lock(const StreamId& stream_id) = 0;
 
     virtual void delete_storage() = 0;
 
-    virtual void configure(
-        const storage::LibraryDescriptor::VariantStoreConfig & cfg) = 0;
+    virtual void configure(const storage::LibraryDescriptor::VariantStoreConfig& cfg) = 0;
 
     virtual WriteOptions get_write_options() const = 0;
 
     virtual std::shared_ptr<Store>& store() = 0;
-    virtual const arcticdb::proto::storage::VersionStoreConfig& cfg() const  = 0;
+    virtual const arcticdb::proto::storage::VersionStoreConfig& cfg() const = 0;
     virtual std::shared_ptr<VersionMap>& version_map() = 0;
     virtual SymbolList& symbol_list() = 0;
-    virtual void set_store(std::shared_ptr<Store> store)= 0;
+    virtual void set_store(std::shared_ptr<Store> store) = 0;
     virtual timestamp latest_timestamp(const std::string& symbol) = 0;
     virtual void flush_version_map() = 0;
 };
 
-} // arcticdb::version_store
+} // namespace arcticdb::version_store


### PR DESCRIPTION
The style is based on LLVM. With the following differences:
* AccessModifierOffset: -2 -> -4
* AlignAfterOpenBracket: Align -> DontAlign
* AllowAllArgumentsOnNextLine: true -> false
* AllowAllParametersOfDeclarationOnNextLine: true -> false
* AllowShortEnumsOnASingleLine: true -> false
* AllowShortFunctionsOnASingleLine: All -> None
* AlwaysBreakTemplateDeclarations: MultiLine -> Yes
* BinPackArguments: true -> false
* BinPackParameters: true -> false
* AllowAllConstructorInitializersOnNextLine: true -> false
* IndentWidth: 2 -> 4
* ObjCBlockIndentWidth: 2 -> 4
* ReflowComments true -> false
* SpaceAfterTemplateKeyword: true -> false
* SortIncludes: true -> false // Sorting the includes makes the build to
  fail
* ColumnLimit: 80 -> 120
* PackConstructorInitializers: BinPack -> Never
* PointerAlignment: Right -> Left
* AfterControlStatement: false -> MultiLine
*  AfterFunction: false -> true
* BreakBeforeBraces: Attach -> Custom