### PR TITLE
Fix flaky test in newer pandas version

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -70,6 +70,9 @@ def test_hypothesis_sum_agg(lmdb_version_store, df):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"a": "sum"})
     expected = df.groupby("grouping_column").agg({"a": "sum"})
+    expected.replace(
+        np.nan, np.inf, inplace=True
+    )  # New version of pandas treats values which exceeds limits as np.nan rather than np.inf, as in old version and arcticdb
 
     symbol = "sum_agg"
     lib.write(symbol, df)

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -41,6 +41,9 @@ def test_hypothesis_mean_agg(lmdb_version_store, df):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"a": "mean"})
     expected = df.groupby("grouping_column").agg({"a": "mean"})
+    expected.replace(
+        np.nan, np.inf, inplace=True
+    )  # New version of pandas treats values which exceeds limits as np.nan rather than np.inf, as in old version and arcticdb
 
     symbol = "mean_agg"
     lib.write(symbol, df)


### PR DESCRIPTION
In newer pandas version, values that exceed limit will be output as `np.nan` rather than `np.inf`, as in old pandas version and ArcticDB. This may lead to assertion failure in the hypothesis test.
This pull request will treat `np.nan` and `np.inf` as the same in  `test_hypothesis_mean_agg` to prevent the test from being flaky. 