### PR TITLE
build: Add missing inclusions of `cstdint`

### DIFF
--- a/cpp/arcticdb/util/decimal.hpp
+++ b/cpp/arcticdb/util/decimal.hpp
@@ -8,6 +8,7 @@
 #pragma once
 #include <array>
 #include <string_view>
+#include <cstdint>
 #include <arcticdb/util/constructors.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/util/string_utils.hpp
+++ b/cpp/arcticdb/util/string_utils.hpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 namespace arcticdb::util {
 


### PR DESCRIPTION
Including `cstdint` is necessary to resolve `uint64_t`.

Required by: gcc (GCC) 13.1.1 20230426 (Red Hat 13.1.1-1)