### PR TITLE
build: Add a public version identifier

### DIFF
--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -11,3 +11,4 @@ from arcticdb.tools import set_config_from_env_vars
 
 set_config_from_env_vars(_os.environ)
 
+__version__ = "1.1.1.dev0"


### PR DESCRIPTION
Resolves #110.

The proposed identifier is based on the next version following semantic versioning and includes a development release segment as specified by PEP 440.

See: https://peps.python.org/pep-0440/#public-version-identifiers

---

If this PR gets accepted, the release process will need to adapt to follow at least those steps to:
 - commit the public version identifier not to include a development release segment
 - tag the commit of this change with the value of the public version identifier
 - create a release on GitHub
 - publish on PyPi and conda-forge
 - create a new commit bumping the version identifier with a development release segment