### PR TITLE
Support update with daterange for generic non-Pandas timeseries structures

### DIFF
--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -185,7 +185,7 @@ def param_dict(fields, cases=None, xfail=None, py2only=None, py3only=None):
 
 
 def configure_test_logger(level="INFO"):
-    level = os.getenv("ARCTICC_TEST_LOG_LEVEL", "INFO")
+    level = os.getenv("ARCTICC_TEST_LOG_LEVEL", level)
     if os.getenv("ARCTICC_TEST_FILE_LOGGING"):
         outputs = ["file", "console"]
     else:

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1257,7 +1257,7 @@ def restrict_data_to_date_range_only(data: T, *, start: Timestamp, end: Timestam
             start, end = _strip_tz(start, end)
         data = data.loc[pd.to_datetime(start) : pd.to_datetime(end)]
     else:  # non-Pandas, try to slice it anyway
-        if not data.timezone:
+        if not hasattr(data, "timezone") or not data.timezone:
             start, end = _strip_tz(start, end)
         data = data[start.to_pydatetime() - timedelta(microseconds=1) : end.to_pydatetime() + timedelta(microseconds=1)]
     return data

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1257,7 +1257,7 @@ def restrict_data_to_date_range_only(data: T, *, start: Timestamp, end: Timestam
             start, end = _strip_tz(start, end)
         data = data.loc[pd.to_datetime(start) : pd.to_datetime(end)]
     else:  # non-Pandas, try to slice it anyway
-        if not hasattr(data, "timezone") or not data.timezone:
+        if not getattr(data, "timezone", None):
             start, end = _strip_tz(start, end)
         data = data[start.to_pydatetime() - timedelta(microseconds=1) : end.to_pydatetime() + timedelta(microseconds=1)]
     return data

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -7,6 +7,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 import copy
 import datetime
+from datetime import timedelta
 import math
 
 import numpy as np
@@ -1255,6 +1256,10 @@ def restrict_data_to_date_range_only(data: T, *, start: Timestamp, end: Timestam
         if not data.index.get_level_values(0).tz:
             start, end = _strip_tz(start, end)
         data = data.loc[pd.to_datetime(start) : pd.to_datetime(end)]
+    else:  # non-Pandas, try to slice it anyway
+        if not data.timezone:
+            start, end = _strip_tz(start, end)
+        data = data[start.to_pydatetime() - timedelta(microseconds=1) : end.to_pydatetime() + timedelta(microseconds=1)]
     return data
 
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -362,25 +362,6 @@ def test_update_times(lmdb_version_store):
     assert update_times_versioned[0] < update_times_versioned[1] < update_times_versioned[2]
 
 
-def test_update_date_range_dataframe(lmdb_version_store):
-    """Restrictive update - when date_range is specified ensure that we only touch values in that range."""
-    # given
-    dtidx = pd.date_range("2022-06-01", "2022-06-05")
-    df = pd.DataFrame(index=dtidx, data={"a": [1, 2, 3, 4, 5]}, dtype=np.int64)
-    lmdb_version_store.write("sym_1", df)
-
-    dtidx = pd.date_range("2022-05-01", "2022-06-10")
-    a = np.arange(dtidx.shape[0])
-    update_df = pd.DataFrame(index=dtidx, data={"a": a}, dtype=np.int64)
-
-    # when
-    lmdb_version_store.update("sym_1", update_df, date_range=(datetime(2022, 6, 2), datetime(2022, 6, 4)))
-
-    # then
-    result = lmdb_version_store.read("sym_1").data
-    np.testing.assert_array_equal(result["a"].values, [1, 32, 33, 34, 5])
-
-
 def test_get_info_multi_index(lmdb_version_store):
     dtidx = pd.date_range(pd.Timestamp("2016-01-01"), periods=3)
     vals = np.arange(3, dtype=np.uint32)

--- a/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
+++ b/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
@@ -1,0 +1,114 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from datetime import datetime, timedelta
+from numpy.testing import assert_array_equal
+
+from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer, \
+    clear_registered_normalizers
+from arcticc.pb2.descriptors_pb2 import NormalizationMetadata
+
+
+def test_update_date_range_dataframe(lmdb_version_store):
+    """Restrictive update - when date_range is specified ensure that we only touch values in that range."""
+    # given
+    dtidx = pd.date_range("2022-06-01", "2022-06-05")
+    df = pd.DataFrame(index=dtidx, data={"a": [1, 2, 3, 4, 5]}, dtype=np.int64)
+    lmdb_version_store.write("sym_1", df)
+
+    dtidx = pd.date_range("2022-05-01", "2022-06-10")
+    a = np.arange(dtidx.shape[0])
+    update_df = pd.DataFrame(index=dtidx, data={"a": a}, dtype=np.int64)
+
+    # when
+    lmdb_version_store.update("sym_1", update_df, date_range=(datetime(2022, 6, 2), datetime(2022, 6, 4)))
+
+    # then
+    result = lmdb_version_store.read("sym_1").data
+    np.testing.assert_array_equal(result["a"].values, [1, 32, 33, 34, 5])
+
+
+class CustomTimeseries:
+    """Simulation of a non-Pandas DataFrame-like object, with some behaviour similar to a legacy one used in Man."""
+    def __init__(self, wrapped: pd.DataFrame):
+        self.timezone = None
+        self.wrapped = wrapped
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            open_ended = slice(item.start + timedelta(microseconds=1), item.stop - timedelta(microseconds=1), item.step)
+            return self.wrapped[open_ended]
+        else:
+            return self.wrapped[item]
+
+
+class CustomTimeseriesNormalizer(CustomNormalizer):
+    def normalize(self, item, **kwargs):
+        if isinstance(item, CustomTimeseries):
+            return item.wrapped, NormalizationMetadata.CustomNormalizerMeta()
+
+    def denormalize(self, item, norm_meta):
+        return CustomTimeseries(item)
+
+
+@pytest.fixture
+def lmdb_version_store_custom_norm(version_store_factory):
+    try:
+        register_normalizer(CustomTimeseriesNormalizer())
+        yield version_store_factory()
+    finally:
+        clear_registered_normalizers()
+
+
+def test_update_date_range_non_pandas_dataframe(lmdb_version_store_custom_norm):
+    """Check that updates with a daterange work for a simple non-Pandas timeseries.
+
+    This simulates a legacy DataFrame equivalent still used occasionally in Man.
+    """
+    version_store = lmdb_version_store_custom_norm
+
+    # given
+    dtidx = pd.date_range("2022-06-01", "2022-06-05")
+    df = pd.DataFrame(index=dtidx, data={"a": [1, 2, 3, 4, 5]}, dtype=np.int64)
+    version_store.write("sym_1", CustomTimeseries(df))
+
+    dtidx = pd.date_range("2022-05-01", "2022-06-10")
+    a = np.arange(dtidx.shape[0])
+    update_df = pd.DataFrame(index=dtidx, data={"a": a}, dtype=np.int64)
+
+    # when
+    version_store.update("sym_1", CustomTimeseries(update_df), date_range=(datetime(2022, 6, 2), datetime(2022, 6, 4)))
+
+    # then
+    result = version_store.read("sym_1").data
+    np.testing.assert_array_equal(result["a"].values, [1, 32, 33, 34, 5])
+
+
+def test_update_date_range_dataframe_multiindex(lmdb_version_store):
+    """Similar to the test_update_date_range_dataframe, but with a multiindex."""
+    # given
+    dtidx = pd.date_range("2022-06-01", "2022-06-05")
+    second_level = np.arange(7, 12)
+    a = np.arange(1, 6)
+    multi_df = pd.DataFrame({"a": a}, index=pd.MultiIndex.from_arrays([dtidx, second_level]))
+    sym = "update_date_range_dataframe_multiindex"
+    lmdb_version_store.write(sym, multi_df)
+
+    dtidx = pd.date_range("2022-05-01", "2022-06-10")
+    second_level = np.arange(dtidx.shape[0])
+    a = np.arange(dtidx.shape[0])
+    update_df = pd.DataFrame(index=pd.MultiIndex.from_arrays([dtidx, second_level]), data={"a": a}, dtype=np.int64)
+
+    # when
+    lmdb_version_store.update(sym, update_df, date_range=(datetime(2022, 6, 2), datetime(2022, 6, 4)))
+
+    # then
+    result = lmdb_version_store.read(sym).data
+    np.testing.assert_array_equal(result["a"].values, [1, 32, 33, 34, 5])

--- a/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
+++ b/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
@@ -8,11 +8,16 @@ As of the Change Date specified in that file, in accordance with the Business So
 import numpy as np
 import pandas as pd
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+from arcticdb.version_store import TimeFrame
 from numpy.testing import assert_array_equal
 
-from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer, \
-    clear_registered_normalizers
+from arcticdb.version_store._custom_normalizers import (
+    CustomNormalizer,
+    register_normalizer,
+    clear_registered_normalizers,
+)
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata
 
 
@@ -35,27 +40,72 @@ def test_update_date_range_dataframe(lmdb_version_store):
     np.testing.assert_array_equal(result["a"].values, [1, 32, 33, 34, 5])
 
 
+class CustomIndex:
+    def __init__(self, index: pd.Index):
+        self.wrapped = index
+
+    def __len__(self):
+        return len(self.wrapped)
+
+    def __getitem__(self, item):
+        return self.wrapped[item]
+
+    def __getattr__(self, name):
+        if name in ("is_monotonic_increasing", "is_monotonic_decreasing"):
+            raise AttributeError("These Pandas settings are not implemented on this non-Pandas timeseries index")
+        return getattr(self.wrapped, name)
+
+
 class CustomTimeseries:
     """Simulation of a non-Pandas DataFrame-like object, with some behaviour similar to a legacy one used in Man."""
-    def __init__(self, wrapped: pd.DataFrame):
-        self.timezone = None
+
+    def __init__(self, wrapped: pd.DataFrame, *args, custom_index: bool, with_timezone_attr: bool, timezone):
+        if timezone and not with_timezone_attr:
+            raise RuntimeError("Meaningless test case - set with_timezone_attr=True")
+        if with_timezone_attr:
+            self.timezone = timezone
+        if custom_index:
+            self.index = CustomIndex(wrapped.index)
         self.wrapped = wrapped
+        self.with_timezone_attr = with_timezone_attr
+        self.custom_index = custom_index
 
     def __getitem__(self, item):
         if isinstance(item, slice):
             open_ended = slice(item.start + timedelta(microseconds=1), item.stop - timedelta(microseconds=1), item.step)
-            return self.wrapped[open_ended]
+            return CustomTimeseries(
+                self.wrapped[open_ended],
+                custom_index=self.custom_index,
+                with_timezone_attr=self.with_timezone_attr,
+                timezone=self.timezone,
+            )
         else:
-            return self.wrapped[item]
+            return CustomTimeseries(
+                self.wrapped[item],
+                custom_index=self.custom_index,
+                with_timezone_attr=self.with_timezone_attr,
+                timezone=self.timezone,
+            )
+
+    def __getattr__(self, name):
+        if name == "loc":
+            raise AttributeError("loc is not implemented on this non-Pandas timeseries")
+        return getattr(self.wrapped, name)
 
 
 class CustomTimeseriesNormalizer(CustomNormalizer):
     def normalize(self, item, **kwargs):
         if isinstance(item, CustomTimeseries):
-            return item.wrapped, NormalizationMetadata.CustomNormalizerMeta()
+            df = TimeFrame(
+                times=item.wrapped.index.values,
+                columns_names=list(item.wrapped.columns),
+                columns_values=[item.wrapped[c].values for c in item.columns],
+            )
+            return df, NormalizationMetadata.CustomNormalizerMeta()
 
     def denormalize(self, item, norm_meta):
-        return CustomTimeseries(item)
+        df = pd.DataFrame(index=item.times, data=dict(zip(item.columns_names, item.columns_values)))
+        return CustomTimeseries(df, custom_index=False, with_timezone_attr=True, timezone=None)
 
 
 @pytest.fixture
@@ -67,7 +117,11 @@ def lmdb_version_store_custom_norm(version_store_factory):
         clear_registered_normalizers()
 
 
-def test_update_date_range_non_pandas_dataframe(lmdb_version_store_custom_norm):
+@pytest.mark.parametrize(
+    "with_timezone_attr,timezone_", [(True, None), (True, None), (True, timezone.utc), (False, None)]
+)
+@pytest.mark.skip("These fail due to too strict unsorted data checks, PR #388 should resolve")
+def test_update_date_range_non_pandas_dataframe(lmdb_version_store_custom_norm, with_timezone_attr, timezone_):
     """Check that updates with a daterange work for a simple non-Pandas timeseries.
 
     This simulates a legacy DataFrame equivalent still used occasionally in Man.
@@ -77,14 +131,18 @@ def test_update_date_range_non_pandas_dataframe(lmdb_version_store_custom_norm):
     # given
     dtidx = pd.date_range("2022-06-01", "2022-06-05")
     df = pd.DataFrame(index=dtidx, data={"a": [1, 2, 3, 4, 5]}, dtype=np.int64)
-    version_store.write("sym_1", CustomTimeseries(df))
+    version_store.write("sym_1", CustomTimeseries(df, with_timezone_attr=with_timezone_attr, timezone=timezone_))
 
     dtidx = pd.date_range("2022-05-01", "2022-06-10")
     a = np.arange(dtidx.shape[0])
     update_df = pd.DataFrame(index=dtidx, data={"a": a}, dtype=np.int64)
 
     # when
-    version_store.update("sym_1", CustomTimeseries(update_df), date_range=(datetime(2022, 6, 2), datetime(2022, 6, 4)))
+    version_store.update(
+        "sym_1",
+        CustomTimeseries(update_df, with_timezone_attr=with_timezone_attr, timezone=timezone_),
+        date_range=(datetime(2022, 6, 2), datetime(2022, 6, 4)),
+    )
 
     # then
     result = version_store.read("sym_1").data


### PR DESCRIPTION
Support update with daterange for generic non-Pandas timeseries structures, such as one occasionally used in Man.

I've moved `test_update_date_range_dataframe` unchanged to a new file as `test_basic_version_store.py` is huge.

The checks will fail on this until something like https://github.com/man-group/ArcticDB/pull/388 is merged.