### PR TITLE
Resolve merge conflict issues with third_part/CMakeLists.txt

### DIFF
--- a/cpp/third_party/CMakeLists.txt
+++ b/cpp/third_party/CMakeLists.txt
@@ -8,10 +8,6 @@ if(NOT ${ARCTICDB_USING_CONDA})
     add_subdirectory(rapidcheck/extras/gtest)
     add_subdirectory(Remotery)
 endif()
+
 add_subdirectory(lmdbcxx)
-add_subdirectory(Remotery)
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Remotery/lib)
-
-add_subdirectory(rapidcheck EXCLUDE_FROM_ALL)
-add_subdirectory(rapidcheck/extras/gtest EXCLUDE_FROM_ALL)

--- a/cpp/third_party/CMakeLists.txt
+++ b/cpp/third_party/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT ${ARCTICDB_USING_CONDA})
     add_subdirectory(rapidcheck)
     add_subdirectory(rapidcheck/extras/gtest)
     add_subdirectory(Remotery)
+
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Remotery/lib)
 endif()
 
-add_subdirectory(lmdbcxx)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Remotery/lib)

--- a/cpp/third_party/CMakeLists.txt
+++ b/cpp/third_party/CMakeLists.txt
@@ -7,8 +7,6 @@ if(NOT ${ARCTICDB_USING_CONDA})
     add_subdirectory(rapidcheck)
     add_subdirectory(rapidcheck/extras/gtest)
     add_subdirectory(Remotery)
-    add_subdirectory(lmdbcxx)
-
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Remotery/lib)
 endif()
-
+add_subdirectory(lmdbcxx)

--- a/cpp/third_party/CMakeLists.txt
+++ b/cpp/third_party/CMakeLists.txt
@@ -7,6 +7,7 @@ if(NOT ${ARCTICDB_USING_CONDA})
     add_subdirectory(rapidcheck)
     add_subdirectory(rapidcheck/extras/gtest)
     add_subdirectory(Remotery)
+    add_subdirectory(lmdbcxx)
 
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Remotery/lib)
 endif()


### PR DESCRIPTION
When merging:

https://github.com/man-group/ArcticDB/pull/333 
https://github.com/man-group/ArcticDB/pull/337
https://github.com/man-group/ArcticDB/pull/323
https://github.com/man-group/ArcticDB/pull/331

I incorrectly manually fixed the merge conflicts. This PR resolves the merge conflict. 

Believe only lmdbcxx requires `add_subdirectory` when not using Conda.