### PR TITLE
Fix hardcoded Mongo database path to arcticc

### DIFF
--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -37,7 +37,7 @@ MongoStorage::MongoStorage(
     instance_.reset(); //Just want to ensure singleton here, not hang onto it
     auto key_rg = lib.as_range();
     auto it = key_rg.begin();
-    db_ = fmt::format("arcticdb_{}", *it++);
+    db_ = fmt::format("arcticc_{}", *it++);
     std::ostringstream strm;
     for (; it != key_rg.end(); ++it) {
         strm << *it->get() << "__";


### PR DESCRIPTION
Fix hardcoded Mongo database path to arcticc

We rely on this internally and it got broken in the move to Github.

We should make this configurable properly instead, but for another day.
If we ever make Mongo storage publicly available we should revisit.
