### PR TITLE
Fix a backwards incompatible change to exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dist/
 cmake-build-*/
 dist_release/
 CMakeUserPresets.json
+
+*_pb2.py
+*.mdb

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -9,6 +9,7 @@
 #include <arcticdb/codec/python_bindings.hpp>
 #include <arcticdb/column_store/python_bindings.hpp>
 #include <arcticdb/storage/python_bindings.hpp>
+#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/stream/python_bindings.hpp>
 #include <arcticdb/toolbox/python_bindings.hpp>
 #include <arcticdb/version/python_bindings.hpp>
@@ -16,10 +17,10 @@
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/trace.hpp>
 #include <arcticdb/python/python_utils.hpp>
+#include <arcticdb/python/arctic_version.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/entity/metrics.hpp>
 #include <arcticdb/entity/protobufs.hpp>
-#include <folly/init/Init.h>
 #include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/util/global_lifetimes.hpp>
 #include <arcticdb/util/configs_map.hpp>
@@ -271,10 +272,27 @@ PYBIND11_MODULE(arcticdb_ext, m) {
     arcticdb::async::register_bindings(m);
     arcticdb::codec::register_bindings(m);
     arcticdb::column_store::register_bindings(m);
-    arcticdb::storage::apy::register_bindings(m, base_exception);
+
+    auto storage_submodule = m.def_submodule("storage", "Segment storage implementation apis");
+    auto no_data_found_exception = py::register_exception<arcticdb::storage::NoDataFoundException>(
+            storage_submodule, "NoDataFoundException", base_exception.ptr());
+    arcticdb::storage::apy::register_bindings(storage_submodule, base_exception);
+
     arcticdb::stream::register_bindings(m);
     arcticdb::toolbox::apy::register_bindings(m);
-    arcticdb::version_store::register_bindings(m, base_exception);
+
+    m.def("get_version_string", &arcticdb::get_arcticdb_version_string);
+    m.def("read_runtime_config", [](const py::object object) {
+        auto config = arcticc::pb2::config_pb2::RuntimeConfig{};
+        arcticdb::python_util::pb_from_python(object, config);
+        arcticdb::read_runtime_config(config);
+    });
+
+    auto version_submodule = m.def_submodule("version_store", "Versioned storage implementation apis");
+    arcticdb::version_store::register_bindings(version_submodule, base_exception);
+    py::register_exception<arcticdb::NoSuchVersionException>(
+            version_submodule, "NoSuchVersionException", no_data_found_exception.ptr());
+
     register_configs_map_api(m);
     register_log(m.def_submodule("log"));
     register_instrumentation(m.def_submodule("instrumentation"));

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -32,9 +32,7 @@ std::shared_ptr<LibraryIndex> create_library_index(const std::string &environmen
     return std::make_shared<LibraryIndex>(EnvironmentName{environment_name}, mem_resolver);
 }
 
-void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception) {
-    auto storage = m.def_submodule("storage", "Segment storage implementation apis");
-
+void register_bindings(py::module& storage, py::exception<arcticdb::ArcticException>& base_exception) {
     py::enum_<KeyType>(storage, "KeyType")
         .value("STREAM_GROUP", KeyType::STREAM_GROUP)
         .value("VERSION", KeyType::VERSION)
@@ -154,7 +152,6 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
         ;
 
     py::register_exception<DuplicateKeyException>(storage, "DuplicateKeyException", base_exception.ptr());
-    py::register_exception<NoDataFoundException>(storage, "NoDataFoundException", base_exception.ptr());
     py::register_exception<PermissionException>(storage, "PermissionException", base_exception.ptr());
 }
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -24,10 +24,8 @@
 
 namespace arcticdb::version_store {
 
-void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& base_exception) {
-    auto version = m.def_submodule("version_store", "Versioned storage implementation apis");
+void register_bindings(py::module &version, py::exception<arcticdb::ArcticException>& base_exception) {
 
-    py::register_exception<NoSuchVersionException>(version, "NoSuchVersionException", base_exception.ptr());
     py::register_exception<StreamDescriptorMismatch>(version, "StreamDescriptorMismatch", base_exception.ptr());
 
     py::class_<AtomKey, std::shared_ptr<AtomKey>>(version, "AtomKey")
@@ -575,14 +573,6 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
              &PythonVersionStore::latest_timestamp,
              "Returns latest timestamp of a symbol")
         ;
-
-    m.def("get_version_string", &get_arcticdb_version_string);
-
-    m.def("read_runtime_config", [](const py::object object) {
-        auto config = RuntimeConfig{};
-         python_util::pb_from_python(object, config);
-         read_runtime_config(config);
-    });
 
     py::class_<LocalVersionedEngine>(version, "VersionedEngine")
       .def(py::init<std::shared_ptr<storage::Library>>())

--- a/python/tests/unit/arcticdb/test_errors.py
+++ b/python/tests/unit/arcticdb/test_errors.py
@@ -81,4 +81,5 @@ def test_no_such_version_exception(lmdb_version_store):
     with pytest.raises(NoSuchVersionException) as e:
         lmdb_version_store.restore_version("sym", as_of=999)
     assert not issubclass(e.type, _ArcticLegacyCompatibilityException)
+    assert issubclass(e.type, NoDataFoundException)
     assert issubclass(e.type, ArcticException)

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -10,7 +10,7 @@ import time
 from pandas import Timestamp
 import pytest
 
-from arcticdb.exceptions import NoSuchVersionException
+from arcticdb.exceptions import NoSuchVersionException, NoDataFoundException
 
 
 def test_read_descriptor(lmdb_version_store, one_col_df):
@@ -63,8 +63,9 @@ def test_column_names_by_timestamp(lmdb_version_store, one_col_df, two_col_df):
     after_two_col_write = Timestamp.now(tz="UTC")
 
     # Assert querying with a time before the first write raises an exception
-    with pytest.raises(NoSuchVersionException):
+    with pytest.raises(NoDataFoundException) as excinfo:
         lmdb_version_store.column_names(symbol, as_of=Timestamp("1970-01-01", tz="UTC"))
+    assert issubclass(excinfo.type, NoSuchVersionException)
 
     # Assert query with the timestamp after the one col write returns only a single column
     assert lmdb_version_store.column_names(symbol, as_of=after_one_col_write) == ["x"]


### PR DESCRIPTION
The NoSuchVersionException needs to be a NoDataFoundException, since read_descriptor used to throw a NoDataFoundException but now it throws a NoSuchVersionException, and we need to be compatible with earlier consumers who may be catching a NoSuchVersionException.

I implement this by lifting the affected exceptions up to the top level `python_module.cpp`. I think this makes the configuration the most declarative and clear for this slightly fiddly interaction across submodules.

Internal ref: AN-976