### PR TITLE
build: Pin dependencies for the conda environment specification

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -2,36 +2,46 @@ name: arcticdb
 channels:
   - conda-forge
 dependencies:
-  - lmdb
+  # Build tools
+  - cmake
+  - gtest
+  - gflags
+  - doxygen
   - boost-cpp
-  - fmt
-  - spdlog
-  # This is the last version published on vcpkg the usual
-  # installation setup depends on.
-  - folly==2022.10.31
+  # Build dependencies
+  - krb5
   - lz4-c
-  - prometheus-cpp
   - double-conversion
   - libevent
-  - libprotobuf < 4
   - libmongocxx
   - zstd
   - pybind11
   - pcre
-  - gflags
   - cyrus-sasl
-  - python
-  - msgpack-c
-  - doxygen
   - aws-sdk-cpp
-  - gtest
-  - cmake
-  - bitmagic
+  - prometheus-cpp
+  - libprotobuf < 4
+  - bitmagic==7.12.3
+  - spdlog=1.11.0
+  - fmt==9.1.0
+  - folly==2022.10.31 # latest version published on vcpkg
+  # Vendored build dependencies (see `cpp/thirdparty`)
+  # Versions must be kept in sync
+  - xxhash==0.8.1  # assuming the vendored copy is the latest version
+  - semimap==1.0.0
+  - robin_hood==3.11.5
+  - rapidcheck==2023.4.13 # assuming the vendored copy is the latest version
+  - lmdb==0.9.22
+  - lmdbxx==0.9.14
+  - msgpack-c=6.0.0  # taking the latest on conda-forge based on the vendored CHANGELOG's
+  - recycle==6.0.0  # greatest smallest version based on the submodule commit
+  - remotery==1.2.1
+  # Python dependences
+  - python
   - numpy
   - pandas
   - pytest
   - boto3
-  - krb5
   - werkzeug
   - moto
   - pytest-server-fixtures
@@ -39,10 +49,3 @@ dependencies:
   # See: https://github.com/man-group/ArcticDB/pull/291
   - hypothesis < 6.73
   - pytest-sugar
-  - xxhash
-  - semimap
-  - recycle
-  - rapidcheck
-  - remotery
-  - robin_hood
-  - lmdbxx

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -21,21 +21,23 @@ dependencies:
   - aws-sdk-cpp
   - prometheus-cpp
   - libprotobuf < 4
-  - bitmagic==7.12.3
-  - spdlog=1.11.0
-  - fmt==9.1.0
+  - bitmagic
+  - spdlog
+  - fmt
   - folly==2022.10.31 # latest version published on vcpkg
   # Vendored build dependencies (see `cpp/thirdparty`)
   # Versions must be kept in sync
-  - xxhash==0.8.1  # assuming the vendored copy is the latest version
-  - semimap==1.0.0
-  - robin_hood==3.11.5
-  - rapidcheck==2023.4.13 # assuming the vendored copy is the latest version
+  - xxhash
+  - semimap
+  - robin_hood
+  - rapidcheck
+  - msgpack-c
+  - recycle
+  - remotery
+  # Matches the version of lmdb and lmdbxx as vendored
+  # via submodules.
   - lmdb==0.9.22
   - lmdbxx==0.9.14
-  - msgpack-c=6.0.0  # taking the latest on conda-forge based on the vendored CHANGELOG's
-  - recycle==6.0.0  # greatest smallest version based on the submodule commit
-  - remotery==1.2.1
   # Python dependences
   - python
   - numpy


### PR DESCRIPTION
Builds must use the same versions of the build dependencies to be sure ArcticDB has the exact same behavior. 

This is still WIP; in particular, we need to find the exact version of the vendored dependencies. 

cc @DerThorsten