### PR TITLE
Generic parallel get version for batch description

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -693,12 +693,14 @@ if(${TEST})
             version/test/test_append.cpp
             version/test/test_merge.cpp
             version/test/test_sparse.cpp
+            version/test/test_stream_version_data.cpp
             version/test/test_symbol_list.cpp
             version/test/test_version_map.cpp
+            version/test/test_version_map_batch.cpp
             version/test/test_version_store.cpp
             version/test/test_sorting_info_state_machine.cpp
             version/test/version_map_model.hpp
-            version/test/test_stream_version_data.cpp version/test/test_version_map_batch.cpp)
+            )
 
     set(EXECUTABLE_PERMS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE) # 755
 

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -698,7 +698,7 @@ if(${TEST})
             version/test/test_version_store.cpp
             version/test/test_sorting_info_state_machine.cpp
             version/test/version_map_model.hpp
-            )
+            version/test/test_stream_version_data.cpp version/test/test_version_map_batch.cpp)
 
     set(EXECUTABLE_PERMS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE) # 755
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1160,31 +1160,29 @@ SpecificAndLatestVersionKeys LocalVersionedEngine::get_stream_index_map(
     return std::make_pair(specific_versions, latest_versions);
 }
 
+folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata_future_impl(std::optional<AtomKey> key){
+    if (key.has_value()){
+        return store()->read_metadata(key.value());
+    }else{
+        return folly::makeFuture(std::make_pair(std::nullopt, std::nullopt));
+    }
+}
+
+folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata_future(folly::Future<std::optional<AtomKey>>&& version_fut){
+    return  std::move(version_fut)
+    .thenValue([that = this](std::optional<AtomKey> key){
+        return that->get_metadata_future_impl(key);
+    });
+}
+
 std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::batch_read_metadata_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries
     ) {
-    auto [specific_versions_index_map, latest_versions_index_map] = get_stream_index_map(stream_ids, version_queries);
-    auto version_queries_is_empty = version_queries.empty();
+    auto versions_fut = batch_get_versions(store(), version_map(), stream_ids, version_queries);
     std::vector<folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>> fut_vec;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
-        if(!version_queries_is_empty && std::holds_alternative<SpecificVersionQuery>(version_queries[stream_id.index].content_)){
-            const auto& query = version_queries[stream_id.index].content_;
-            auto specific_version_map_key = std::make_pair(*stream_id, std::get<SpecificVersionQuery>(query).version_id_);
-            auto specific_version_it = specific_versions_index_map->find(specific_version_map_key);
-            if (specific_version_it != specific_versions_index_map->end()){
-                fut_vec.push_back(store()->read_metadata(specific_version_it->second));
-            }else{
-                fut_vec.push_back(std::make_pair(std::nullopt, std::nullopt));
-            }
-        }else{
-            auto last_version_it = latest_versions_index_map->find(*stream_id);
-            if(last_version_it != latest_versions_index_map->end()) {
-                fut_vec.push_back(store()->read_metadata(last_version_it->second));
-            }else{
-                fut_vec.push_back(std::make_pair(std::nullopt, std::nullopt));   
-            }
-        }
+    for (auto& version: versions_fut){
+        fut_vec.push_back(get_metadata_future(std::move(version)));
     }
     return folly::collect(fut_vec).get();
 }

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -731,7 +731,7 @@ void LocalVersionedEngine::delete_trees_responsibly(
                     [&check, &not_to_delete](auto& prev) { if (check.prev_version) not_to_delete.insert(prev);},
                     [&check, &not_to_delete](auto& next) { if (check.next_version) not_to_delete.insert(next);},
                     [v=key.version_id()](const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry) {
-                        // Can't use is_indexish_and_not_tombstoned() because the target version's index key might have
+                        // Can't use is_live_index_type_key() because the target version's index key might have
                         // already been tombstoned, so will miss it and thus not able to find the prev/next key.
                         return is_index_key_type(key.type()) && (key.version_id() == v || !entry->is_tombstoned(key));
                     });

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -175,6 +175,12 @@ public:
         arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
     );
 
+    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata_future_impl(
+        std::optional<AtomKey> key);
+
+    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata_future(
+        folly::Future<std::optional<AtomKey>>&& version_fut);
+
     void create_column_stats_internal(
         const VersionedItem& versioned_item,
         ColumnStats& column_stats,

--- a/cpp/arcticdb/version/test/test_stream_version_data.cpp
+++ b/cpp/arcticdb/version/test/test_stream_version_data.cpp
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+
+#include <arcticdb/version/version_map_batch_methods.hpp>
+
+TEST(StreamVersionData, SpecificVersion) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    StreamVersionData stream_version_data;
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false, false};
+    stream_version_data.react(query_1);
+    VersionQuery query_2{SpecificVersionQuery{VersionId(4)}, false, false};
+    stream_version_data.react(query_2);
+    ASSERT_EQ(stream_version_data.count_, 2);
+    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_DOWNTO);
+    ASSERT_EQ(stream_version_data.load_param_.load_until_, 4);
+}
+
+TEST(StreamVersionData, SpecificVersionReversed) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    StreamVersionData stream_version_data(VersionQuery{SpecificVersionQuery{VersionId(4)}, false, false});
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false, false};
+    stream_version_data.react(query_2);
+    ASSERT_EQ(stream_version_data.count_, 2);
+    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_DOWNTO);
+    ASSERT_EQ(stream_version_data.load_param_.load_until_, 4);
+}
+
+TEST(StreamVersionData, Timestamp) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    StreamVersionData stream_version_data;
+    VersionQuery query_1{TimestampVersionQuery{timestamp(12)}, false, false};
+    stream_version_data.react(query_1);
+    VersionQuery query_2{TimestampVersionQuery{timestamp(4)}, false, false};
+    stream_version_data.react(query_2);
+    ASSERT_EQ(stream_version_data.count_, 2);
+    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_param_.load_from_time_, 4);
+}
+
+TEST(StreamVersionData, TimestampUnordered) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    StreamVersionData stream_version_data;
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false, false};
+    stream_version_data.react(query_1);
+    VersionQuery query_2{TimestampVersionQuery{timestamp(7)}, false, false};
+    stream_version_data.react(query_2);
+    VersionQuery query_3{TimestampVersionQuery{timestamp(4)}, false, false};
+    stream_version_data.react(query_3);
+    ASSERT_EQ(stream_version_data.count_, 3);
+    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_param_.load_from_time_, 3);
+}
+
+TEST(StreamVersionData, Latest) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    StreamVersionData stream_version_data;
+    VersionQuery query_1{std::monostate{}, false, false};
+    stream_version_data.react(query_1);
+    ASSERT_EQ(stream_version_data.count_, 1);
+    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_LATEST_UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_until_.has_value(), false);
+}
+
+TEST(StreamVersionData, SpecificToTimestamp) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    StreamVersionData stream_version_data;
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false, false};
+    stream_version_data.react(query_1);
+    VersionQuery query_2{TimestampVersionQuery{timestamp(3)}, false, false};
+    stream_version_data.react(query_2);
+    ASSERT_EQ(stream_version_data.count_, 2);
+    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_until_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_param_.load_from_time_.has_value(), false);
+}
+
+TEST(StreamVersionData, TimestampToSpecific) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    StreamVersionData stream_version_data;
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false, false};
+    stream_version_data.react(query_1);
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false, false};
+    stream_version_data.react(query_2);
+    ASSERT_EQ(stream_version_data.count_, 2);
+    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_until_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_param_.load_from_time_.has_value(), false);
+}

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -41,6 +41,11 @@ TEST_F(VersionMapBatchStore, Simple) {
         add_versions_for_stream(version_map, store, stream, 5);
     }
 
+    for(auto i = 5u; i < 10u; ++i) {
+        auto stream = fmt::format("stream_{}", i);
+        add_versions_for_stream(version_map, store, stream, 5);
+    }
+
     for(auto i = 0u; i < 5; ++i) {
         auto stream = fmt::format("stream_{}", i);
         add_versions_for_stream(version_map, store, stream, 5, 5);
@@ -60,5 +65,20 @@ TEST_F(VersionMapBatchStore, Simple) {
     stream_ids.push_back(StreamId{"stream_8"});
     version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
 
-    batch_get_versions(store, version_map, stream_ids, version_queries);
+
+    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    ASSERT_EQ(versions[0]->id(), StreamId{"stream_1"});
+    ASSERT_EQ(versions[0]->version_id(), 4);
+
+    ASSERT_EQ(versions[1]->id(), StreamId{"stream_4"});
+    ASSERT_EQ(versions[1]->version_id(), 4);
+
+    ASSERT_EQ(versions[2]->id(), StreamId{"stream_1"});
+    ASSERT_EQ(versions[2]->version_id(), 1);
+
+    ASSERT_EQ(versions[3]->id(), StreamId{"stream_3"});
+    ASSERT_EQ(versions[3]->version_id(), 7);
+
+    ASSERT_EQ(versions[4]->id(), StreamId{"stream_8"});
+    ASSERT_EQ(versions[4]->version_id(), 4);
 }

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <arcticdb/version/version_map_batch_methods.hpp>
+#include <arcticdb/stream/test/stream_test_common.hpp>
+
+struct VersionMapBatchStore : arcticdb::TestStore {
+protected:
+    std::string get_name() override {
+        return "version_map_batch";
+    }
+};
+
+namespace arcticdb {
+
+AtomKey test_index_key(StreamId id, VersionId version_id) {
+    return atom_key_builder().version_id(version_id).creation_ts(PilotedClock::nanos_since_epoch()).content_hash(3)
+        .start_index(4).end_index(5).build(id, KeyType::TABLE_INDEX);
+}
+
+void add_versions_for_stream(
+    std::shared_ptr<VersionMap> version_map,
+    std::shared_ptr<Store> store,
+    StreamId stream_id,
+    size_t num_versions,
+    size_t start = 0u) {
+    for(auto i = start; i < start + num_versions; ++i) {
+        version_map->write_version(store, test_index_key(stream_id, i));
+    }
+};
+}
+
+TEST_F(VersionMapBatchStore, Simple) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    auto store = test_store_->_test_get_store();
+    auto version_map = std::make_shared<VersionMap>();
+
+    for(auto i = 0u; i < 5; ++i) {
+        auto stream = fmt::format("stream_{}", i);
+        add_versions_for_stream(version_map, store, stream, 5);
+    }
+
+    for(auto i = 0u; i < 5; ++i) {
+        auto stream = fmt::format("stream_{}", i);
+        add_versions_for_stream(version_map, store, stream, 5, 5);
+    }
+
+    std::vector<StreamId> stream_ids;
+    std::vector<VersionQuery> version_queries;
+
+    stream_ids.push_back(StreamId{"stream_1"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    stream_ids.push_back(StreamId{"stream_4"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    stream_ids.push_back(StreamId{"stream_1"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{1}, false, false});
+    stream_ids.push_back(StreamId{"stream_3"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{7}, false, false});
+    stream_ids.push_back(StreamId{"stream_8"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+
+    batch_get_versions(store, version_map, stream_ids, version_queries);
+}

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -3,6 +3,9 @@
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
 
+using namespace arcticdb;
+using namespace arcticdb::pipelines;
+
 struct VersionMapBatchStore : arcticdb::TestStore {
 protected:
     std::string get_name() override {
@@ -29,19 +32,11 @@ void add_versions_for_stream(
 };
 }
 
-TEST_F(VersionMapBatchStore, Simple) {
-    using namespace arcticdb;
-    using namespace arcticdb::pipelines;
-
+TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
 
-    for(auto i = 0u; i < 5; ++i) {
-        auto stream = fmt::format("stream_{}", i);
-        add_versions_for_stream(version_map, store, stream, 5);
-    }
-
-    for(auto i = 5u; i < 10u; ++i) {
+    for(auto i = 0u; i < 10; ++i) {
         auto stream = fmt::format("stream_{}", i);
         add_versions_for_stream(version_map, store, stream, 5);
     }
@@ -81,4 +76,358 @@ TEST_F(VersionMapBatchStore, Simple) {
 
     ASSERT_EQ(versions[4]->id(), StreamId{"stream_8"});
     ASSERT_EQ(versions[4]->version_id(), 4);
+}
+
+TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
+    auto store = test_store_->_test_get_store();
+    auto version_map = std::make_shared<VersionMap>();
+
+    for(auto i = 0u; i < 10; ++i) {
+        auto stream = fmt::format("stream_{}", i);
+        add_versions_for_stream(version_map, store, stream, 5);
+    }
+
+    for(auto i = 0u; i < 5; ++i) {
+        auto stream = fmt::format("stream_{}", i);
+        add_versions_for_stream(version_map, store, stream, 5, 5);
+    }
+
+    std::vector<StreamId> stream_ids;
+    std::vector<VersionQuery> version_queries;
+
+    // First, for test purposes information, we retrieve the information of
+
+    stream_ids.push_back(StreamId{"stream_1"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    stream_ids.push_back(StreamId{"stream_4"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    stream_ids.push_back(StreamId{"stream_1"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{1}, false, false});
+    stream_ids.push_back(StreamId{"stream_3"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{7}, false, false});
+    stream_ids.push_back(StreamId{"stream_8"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+
+
+    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+
+
+    //Secondly, once we have the timestamps in hand, we are going to query them
+
+    version_queries.clear();
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[0]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[1]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[2]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[3]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[4]->creation_ts())}, false, false});
+
+
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+
+    ASSERT_EQ(versions_querying_with_timestamp[0]->id(), StreamId{"stream_1"});
+    ASSERT_EQ(versions_querying_with_timestamp[0]->version_id(), versions[0]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[1]->id(), StreamId{"stream_4"});
+    ASSERT_EQ(versions_querying_with_timestamp[1]->version_id(), versions[1]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[2]->id(), StreamId{"stream_1"});
+    ASSERT_EQ(versions_querying_with_timestamp[2]->version_id(), versions[2]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[3]->id(), StreamId{"stream_3"});
+    ASSERT_EQ(versions_querying_with_timestamp[3]->version_id(), versions[3]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[4]->id(), StreamId{"stream_8"});
+    ASSERT_EQ(versions_querying_with_timestamp[4]->version_id(), versions[4]->version_id());
+}
+
+
+TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
+    auto store = test_store_->_test_get_store();
+    auto version_map = std::make_shared<VersionMap>();
+
+    auto stream = fmt::format("stream_{}", 0);
+    add_versions_for_stream(version_map, store, stream, 50);
+
+    std::vector<StreamId> stream_ids;
+    std::vector<VersionQuery> version_queries;
+
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{44}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{8}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{7}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{6}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{9}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{30}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{1}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{33}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{29}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{45}, false, false});
+
+    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    ASSERT_EQ(versions[0]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[0]->version_id(), 4);
+
+    ASSERT_EQ(versions[1]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[1]->version_id(), 44);
+
+    ASSERT_EQ(versions[2]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[2]->version_id(), 8);
+
+    ASSERT_EQ(versions[3]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[3]->version_id(), 7);
+
+    ASSERT_EQ(versions[4]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[4]->version_id(), 6);
+
+    ASSERT_EQ(versions[5]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[5]->version_id(), 9);
+
+    ASSERT_EQ(versions[6]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[6]->version_id(), 30);
+
+    ASSERT_EQ(versions[7]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[7]->version_id(), 1);
+
+    ASSERT_EQ(versions[8]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[8]->version_id(),33);
+
+    ASSERT_EQ(versions[9]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[9]->version_id(), 29);
+
+    ASSERT_EQ(versions[10]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[10]->version_id(), 45);
+}
+
+
+TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
+    auto store = test_store_->_test_get_store();
+    auto version_map = std::make_shared<VersionMap>();
+
+    auto stream = fmt::format("stream_{}", 0);
+    add_versions_for_stream(version_map, store, stream, 50);
+
+    std::vector<StreamId> stream_ids;
+    std::vector<VersionQuery> version_queries;
+
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{44}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{8}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{7}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{6}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{9}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{30}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{1}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{33}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{29}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{45}, false, false});
+
+
+    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+
+
+    //Secondly, once we have the timestamps in hand, we are going to query them
+
+    version_queries.clear();
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[0]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[1]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[2]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[3]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[4]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[5]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[6]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[7]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[8]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[9]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[10]->creation_ts())}, false, false});
+
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+
+    ASSERT_EQ(versions_querying_with_timestamp[0]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[0]->version_id(), versions[0]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[1]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[1]->version_id(), versions[1]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[2]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[2]->version_id(), versions[2]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[3]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[3]->version_id(), versions[3]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[4]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[4]->version_id(), versions[4]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[5]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[5]->version_id(), versions[5]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[6]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[6]->version_id(), versions[6]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[7]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[7]->version_id(), versions[7]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[8]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[8]->version_id(), versions[8]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[9]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[9]->version_id(), versions[9]->version_id());
+
+    ASSERT_EQ(versions_querying_with_timestamp[10]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_timestamp[10]->version_id(), versions[10]->version_id());
+}
+
+TEST_F(VersionMapBatchStore, CombinedQueries) {
+    auto store = test_store_->_test_get_store();
+    auto version_map = std::make_shared<VersionMap>();
+
+    auto stream = fmt::format("stream_{}", 0);
+    add_versions_for_stream(version_map, store, stream, 50);
+
+    for(auto i = 1u; i < 5; ++i) {
+        auto stream = fmt::format("stream_{}", i);
+        add_versions_for_stream(version_map, store, stream, 10);
+    }
+
+    std::vector<StreamId> stream_ids;
+    std::vector<VersionQuery> version_queries;
+
+    //First pass we do an initial set of mixed requests but only for version if queries, to retrieve the timestamps
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{44}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{8}, false, false});
+    stream_ids.push_back(StreamId{"stream_1"});
+    version_queries.push_back(VersionQuery{std::monostate{}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{6}, false, false});
+    stream_ids.push_back(StreamId{"stream_2"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{9}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{std::monostate{}, false, false});
+    stream_ids.push_back(StreamId{"stream_4"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{1}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{33}, false, false});
+    stream_ids.push_back(StreamId{"stream_3"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{8}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{49}, false, false});
+    stream_ids.push_back(StreamId{"stream_0"});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{48}, false, false});
+
+
+    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    ASSERT_EQ(versions[0]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[0]->version_id(), 4);
+
+    ASSERT_EQ(versions[1]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[1]->version_id(), 44);
+
+    ASSERT_EQ(versions[2]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[2]->version_id(), 8);
+
+    ASSERT_EQ(versions[3]->id(), StreamId{"stream_1"});
+    ASSERT_EQ(versions[3]->version_id(), 9);
+
+    ASSERT_EQ(versions[4]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[4]->version_id(), 6);
+
+    ASSERT_EQ(versions[5]->id(), StreamId{"stream_2"});
+    ASSERT_EQ(versions[5]->version_id(), 9);
+
+    ASSERT_EQ(versions[6]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[6]->version_id(), 49);
+
+    ASSERT_EQ(versions[7]->id(), StreamId{"stream_4"});
+    ASSERT_EQ(versions[7]->version_id(), 1);
+
+    ASSERT_EQ(versions[8]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[8]->version_id(),33);
+
+    ASSERT_EQ(versions[9]->id(), StreamId{"stream_3"});
+    ASSERT_EQ(versions[9]->version_id(), 8);
+
+    ASSERT_EQ(versions[10]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[10]->version_id(), 49);
+
+    ASSERT_EQ(versions[11]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions[11]->version_id(), 48);
+
+    //Second pass we combine all the type of requests, using both version id and timestamp requests
+
+    version_queries.clear();
+
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{4}, false, false});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{44}, false, false});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{8}, false, false});
+    version_queries.push_back(VersionQuery{std::monostate{}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[4]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{9}, false, false});
+    version_queries.push_back(VersionQuery{std::monostate{}, false, false});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{1}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[8]->creation_ts())}, false, false});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{8}, false, false});
+    version_queries.push_back(VersionQuery{SpecificVersionQuery{49}, false, false});
+    version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[11]->creation_ts())}, false, false});
+
+    auto versions_querying_with_mix_types = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    ASSERT_EQ(versions_querying_with_mix_types[0]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[0]->version_id(), 4);
+
+    ASSERT_EQ(versions_querying_with_mix_types[1]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[1]->version_id(), 44);
+
+    ASSERT_EQ(versions_querying_with_mix_types[2]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[2]->version_id(), 8);
+
+    ASSERT_EQ(versions_querying_with_mix_types[3]->id(), StreamId{"stream_1"});
+    ASSERT_EQ(versions_querying_with_mix_types[3]->version_id(), 9);
+
+    ASSERT_EQ(versions_querying_with_mix_types[4]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[4]->version_id(), versions[4]->version_id());
+
+    ASSERT_EQ(versions_querying_with_mix_types[5]->id(), StreamId{"stream_2"});
+    ASSERT_EQ(versions_querying_with_mix_types[5]->version_id(), 9);
+
+    ASSERT_EQ(versions_querying_with_mix_types[6]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[6]->version_id(), 49);
+
+    ASSERT_EQ(versions_querying_with_mix_types[7]->id(), StreamId{"stream_4"});
+    ASSERT_EQ(versions_querying_with_mix_types[7]->version_id(), 1);
+
+    ASSERT_EQ(versions_querying_with_mix_types[8]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[8]->version_id(), versions[8]->version_id());
+
+    ASSERT_EQ(versions_querying_with_mix_types[9]->id(), StreamId{"stream_3"});
+    ASSERT_EQ(versions_querying_with_mix_types[9]->version_id(), 8);
+
+    ASSERT_EQ(versions_querying_with_mix_types[10]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[10]->version_id(), 49);
+
+    ASSERT_EQ(versions_querying_with_mix_types[11]->id(), StreamId{"stream_0"});
+    ASSERT_EQ(versions_querying_with_mix_types[11]->version_id(), versions[11]->version_id());
 }

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -121,7 +121,7 @@ inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKe
 }
 
 struct StreamVersionData {
-    StreamVersionData(const pipelines::VersionQuery& version_query) {
+    explicit StreamVersionData(const pipelines::VersionQuery& version_query) {
         react(version_query);
     }
 
@@ -151,6 +151,7 @@ struct StreamVersionData {
             load_param_.load_until_ = std::min(load_param_.load_until_.value(), specific_version.version_id_);
             break;
         case LoadType::LOAD_FROM_TIME:
+        case LoadType::LOAD_UNDELETED:
             load_param_ = LoadParameter{LoadType::LOAD_UNDELETED};
             break;
         default:
@@ -169,6 +170,7 @@ struct StreamVersionData {
             load_param_.load_from_time_ = std::min(load_param_.load_from_time_.value(), timestamp_query.timestamp_);
             break;
         case LoadType::LOAD_DOWNTO:
+        case LoadType::LOAD_UNDELETED:
             load_param_ = LoadParameter{LoadType::LOAD_UNDELETED};
             break;
         default:
@@ -187,7 +189,7 @@ inline std::optional<AtomKey> get_key_for_version_query(const std::shared_ptr<Ve
         return find_index_key_for_version_id(specific_version.version_id_, version_map_entry);
     },
     [&version_map_entry] (const pipelines::TimestampVersionQuery& timestamp_version) {
-       return find_index_key_for_version_id(timestamp_version.timestamp_, version_map_entry);
+       return find_index_key_for_version_timestamp(timestamp_version.timestamp_, version_map_entry);
     },
     [&version_map_entry] (const std::monostate&) {
        return version_map_entry->get_first_index(false);
@@ -221,26 +223,22 @@ inline std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions(
     for(const auto& symbol : folly::enumerate(symbols)) {
         const auto it = version_data.find(*symbol);
         util::check(it != version_data.end(), "Missing version data for symbol {}", *symbol);
+        auto version_entry_fut = folly::Future<std::shared_ptr<VersionMapEntry>>::makeEmpty();
         if(it->second.count_ == 1) {
-            output.push_back(async::submit_io_task(CheckReloadTask{store, version_map, *symbol,
-                                                                   it->second.load_param_}).thenValue([version_query =
-            version_queries[symbol.index]](auto version_map_entry) {
-                return get_key_for_version_query(version_map_entry, version_query);
-            }));
+            version_entry_fut = async::submit_io_task(CheckReloadTask{store, version_map, *symbol, it->second.load_param_});
         } else {
             auto fut = shared_futures.find(*symbol);
             if(fut == shared_futures.end()) {
-                auto [splitter, inserted] = shared_futures.emplace(*symbol, folly::FutureSplitter(async::submit_io_task(CheckReloadTask{store, version_map, *symbol,
-                                                                                                                                                                           it->second.load_param_})));
-                output.push_back(splitter->second.getFuture().thenValue([version_query = version_queries[symbol.index]](auto version_map_entry) {
-                    return get_key_for_version_query(version_map_entry, version_query);
-                }));
+                auto [splitter, inserted] = shared_futures.emplace(*symbol, folly::FutureSplitter(async::submit_io_task(CheckReloadTask{store, version_map, *symbol, it->second.load_param_})));
+                version_entry_fut = splitter->second.getFuture();
             } else {
-                output.push_back(fut->second.getFuture().thenValue([version_query = version_queries[symbol.index]](auto version_map_entry) {
-                    return get_key_for_version_query(version_map_entry, version_query);
-                }));
+                version_entry_fut = fut->second.getFuture();
             }
         }
+        output.push_back(std::move(version_entry_fut)
+        .thenValue([version_query = version_queries[symbol.index]](auto version_map_entry) {
+            return get_key_for_version_query(version_map_entry, version_query);
+        }));
     }
 
     return output;

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -378,6 +378,16 @@ inline std::optional<std::pair<AtomKey, AtomKey>> get_latest_key_pair(const std:
     return std::nullopt;
 }
 
+inline std::optional<AtomKey> find_index_key_for_version_timestamp(timestamp as_of, const std::shared_ptr<VersionMapEntry>& entry, bool included_deleted=true) {
+    auto key = std::find_if(std::begin(entry->keys_), std::end(entry->keys_), [as_of] (const auto& key) {
+        return is_index_key_type(key.type()) && key.creation_ts() == as_of;
+    });
+    if(key == std::end(entry->keys_))
+        return std::nullopt;
+
+    return included_deleted || !entry->is_tombstoned(*key) ? std::make_optional(*key) : std::nullopt;
+}
+
 inline void remove_duplicate_index_keys(const std::shared_ptr<VersionMapEntry>& entry) {
     entry->keys_.erase(std::unique(entry->keys_.begin(), entry->keys_.end()), entry->keys_.end());
 }


### PR DESCRIPTION
In this PR, we provide per-symbol parallelism for the read_batch_description method.

Considering all this and the way folly Futures work, it is required to propagate a chain of futures all the way long for each independent read description, which ultimately, they converge in a single future containing all the individual description reads. On top of these changes we need to re-use the batch_get_versions function as the start of all the future chain, where all the versions are obtained, per each symbol-version query pair.