### PR TITLE
Add branch of `read_batch` that improves parallelism if there is no `QueryBuilder` query

### DIFF
--- a/cpp/arcticdb/pipeline/index_segment_reader.hpp
+++ b/cpp/arcticdb/pipeline/index_segment_reader.hpp
@@ -17,7 +17,11 @@
 #include <cstdint>
 
 namespace arcticdb {
-    class Store;
+class Store;
+}
+
+namespace arcticdb::pipelines {
+struct ReadQuery;
 }
 
 namespace arcticdb::pipelines::index {
@@ -133,5 +137,8 @@ index::IndexSegmentReader get_index_reader(
 IndexRange get_index_segment_range(
     const AtomKey &prev_index,
     const std::shared_ptr<Store> &store);
+
+
+void check_column_and_date_range_filterable(const IndexSegmentReader& index_segment_reader, const ReadQuery& read_query);
 
 } // namespace arcticdb::pipelines::index

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -214,7 +214,7 @@ void decode_into_frame_static(
     SegmentInMemory &frame,
     PipelineContextRow &context,
     Segment &&s,
-    const std::shared_ptr<BufferHolder>& buffers) {
+    const std::shared_ptr<BufferHolder> buffers) {
     auto seg = std::move(s);
     ARCTICDB_SAMPLE_DEFAULT(DecodeIntoFrame)
     const uint8_t *data = seg.buffer().data();
@@ -1019,12 +1019,12 @@ folly::Future<std::vector<VariantKey>> fetch_data(
     {
         ARCTICDB_SUBSAMPLE_DEFAULT(QueueReadContinuations)
         for ( auto& row : *context) {
-            keys.emplace_back(row.slice_and_key().key());
+            keys.push_back(row.slice_and_key().key());
             continuations.emplace_back([
                 row = row,
                 frame = frame,
                 dynamic_schema=dynamic_schema,
-                &buffers](auto &&ks) mutable {
+                buffers](auto &&ks) mutable {
                 auto key_seg = std::forward<storage::KeySegmentPair>(ks);
                 if(dynamic_schema)
                     decode_into_frame_dynamic(frame, row, std::move(key_seg.segment()), buffers);

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -78,7 +78,7 @@ void decode_into_frame_static(
     SegmentInMemory &frame,
     PipelineContextRow &context,
     Segment &&seg,
-    const std::shared_ptr<BufferHolder>& buffers
+    const std::shared_ptr<BufferHolder> buffers
     );
 
 void decode_into_frame_dynamic(

--- a/cpp/arcticdb/python/gil_lock.hpp
+++ b/cpp/arcticdb/python/gil_lock.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+namespace arcticdb {
+
+struct GILLock {
+    PyGILState_STATE gstate;
+
+    void lock() {
+        gstate = PyGILState_Ensure();
+    }
+
+    void unlock() {
+        PyGILState_Release(gstate);
+    }
+};
+
+class ScopedGILLock {
+public:
+    ScopedGILLock() : acquired_gil_(false) { acquire(); }
+
+    ~ScopedGILLock() { release(); }
+
+    void acquire() {
+        if (!acquired_gil_) {
+            state_ = PyGILState_Ensure();
+            acquired_gil_ = true;
+        }
+    }
+
+    void release() {
+        if (acquired_gil_) {
+            PyGILState_Release(state_);
+            acquired_gil_ = false;
+        }
+    }
+
+private:
+    bool acquired_gil_;
+    PyGILState_STATE state_;
+};
+
+} //namespace arcticdb

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -280,9 +280,9 @@ namespace arcticdb {
             throw std::runtime_error("Not implemented");
         }
 
-        std::vector<VariantKey> batch_read_compressed(
-                std::vector<entity::VariantKey> &&keys,
-                std::vector<ReadContinuation> &&,
+        folly::Future<std::vector<VariantKey>> batch_read_compressed(
+                std::vector<entity::VariantKey>&& keys,
+                std::vector<ReadContinuation>&&,
                 const BatchReadArgs &
         ) override {
             std::lock_guard lock{mutex_};

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -54,9 +54,9 @@ struct StreamSource {
 
     using ReadContinuation = folly::Function<entity::VariantKey(storage::KeySegmentPair &&)>;
 
-    virtual std::vector<entity::VariantKey> batch_read_compressed(
-        std::vector<entity::VariantKey> &&keys,
-        std::vector<ReadContinuation> &&continuations,
+    virtual folly::Future<std::vector<entity::VariantKey>> batch_read_compressed(
+        std::vector<entity::VariantKey>&& keys,
+        std::vector<ReadContinuation>&& continuations,
         const BatchReadArgs &args) = 0;
 
     /**

--- a/cpp/arcticdb/stream/test/mock_stores.hpp
+++ b/cpp/arcticdb/stream/test/mock_stores.hpp
@@ -129,9 +129,10 @@ class NullStore :
         throw std::runtime_error("Not implemented for tests");
     }
 
-        std::vector<folly::Future<VariantKey>>
+    folly::Future<std::vector<VariantKey>>
     batch_read_compressed(
-        std::vector<entity::VariantKey> &&, std::vector<ReadContinuation> &&,
+        std::vector<entity::VariantKey>&&,
+        std::vector<ReadContinuation>&&,
         const BatchReadArgs &
     ) override {
         throw std::runtime_error("Not implemented for tests");

--- a/cpp/arcticdb/util/random.h
+++ b/cpp/arcticdb/util/random.h
@@ -42,7 +42,7 @@ inline double random_double() {
 }
 
 inline double random_probability() {
-    return double(random_int()) / std::numeric_limits< uint64_t >::max();
+    return double(random_int()) / static_cast<double>(std::numeric_limits< uint64_t >::max());
 }
 
 inline char random_char() {

--- a/cpp/arcticdb/util/test/rapidcheck_generators.hpp
+++ b/cpp/arcticdb/util/test/rapidcheck_generators.hpp
@@ -172,7 +172,7 @@ bool check_read_frame(const TestDataFrame &data_frame, ReaderType &reader, std::
     bool success = true;
     auto timestamp = data_frame.start_ts_;
     auto row = 0u;
-    reader.foreach_row([&](auto &&row_ref) {
+    reader.foreach_row([&row, &timestamp, &success, &data_frame, &reader, &errors](auto &&row_ref) {
         timestamp += data_frame.timestamp_increments_[row];
         for (size_t col = 0; col < data_frame.num_columns_; ++col) {
             data_frame.types_[col].visit_tag([&](auto type_desc_tag) {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -21,6 +21,7 @@
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/util/container_filter_wrapper.hpp>
+#include <arcticdb/python/gil_lock.hpp>
 
 namespace arcticdb::version_store {
 
@@ -881,13 +882,15 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& strea
     return versioned_item;
 }
 
-folly::Future<FrameAndDescriptor> async_read_direct(
+folly::Future<std::pair<VersionedItem, FrameAndDescriptor>> async_read_direct(
     const std::shared_ptr<Store>& store,
+    const VariantKey& index_key,
     SegmentInMemory&& index_segment,
     const ReadQuery& read_query,
     std::shared_ptr<BufferHolder> buffers,
     const ReadOptions& read_options) {
     auto index_segment_reader = std::make_shared<index::IndexSegmentReader>(std::move(index_segment));
+    check_column_and_date_range_filterable(*index_segment_reader, read_query);
     auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor{*index_segment_reader->mutable_tsd().mutable_stream_descriptor()});
     pipeline_context->set_selected_columns(read_query.columns);
     const bool dynamic_schema = opt_false(read_options.dynamic_schema_);
@@ -905,34 +908,63 @@ folly::Future<FrameAndDescriptor> async_read_direct(
     mark_index_slices(pipeline_context, dynamic_schema, bucketize_dynamic);
     auto frame = allocate_frame(pipeline_context);
 
-    return fetch_data(frame, pipeline_context, store, dynamic_schema, buffers).then(
-        [pipeline_context, frame, &read_options] (auto&&) mutable {
+    return fetch_data(frame, pipeline_context, store, dynamic_schema, buffers).thenValue(
+        [pipeline_context, frame, read_options](auto &&) mutable {
+            ScopedGILLock gil_lock;
             reduce_and_fix_columns(pipeline_context, frame, read_options);
-        }).then(
-            [index_segment_reader, frame] (auto&&) {
-                return FrameAndDescriptor{frame, std::move(index_segment_reader->mutable_tsd()), {}, {}};
-            });
+        }).thenValue(
+        [index_segment_reader, frame, index_key, buffers](auto &&) {
+            return std::make_pair(VersionedItem{to_atom(index_key)},
+                                  FrameAndDescriptor{frame, std::move(index_segment_reader->mutable_tsd()), {}, buffers});
+        });
 }
 
-std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>> LocalVersionedEngine::batch_read_keys(
+std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::batch_read_keys(
     const std::vector<AtomKey> &keys,
     const std::vector<ReadQuery> &read_queries,
     const ReadOptions& read_options) {
-
+    py::gil_scoped_release release_gil;
     std::vector<folly::Future<std::pair<entity::VariantKey, SegmentInMemory>>> index_futures;
     for (auto &index_key: keys) {
         index_futures.push_back(store()->read(index_key));
     }
     auto indexes = folly::collect(index_futures).get();
 
-    std::vector<folly::Future<FrameAndDescriptor>> results_fut;
+    std::vector<folly::Future<std::pair<VersionedItem, FrameAndDescriptor>>> results_fut;
     auto i = 0u;
     util::check(read_queries.empty() || read_queries.size() == keys.size(), "Expected read queries to either be empty or equal to size of keys");
-    for (auto&& [index_key, index_segment]: indexes) {
-        results_fut.push_back(async_read_direct(store(), std::move(index_segment), read_queries.empty() ? ReadQuery{} : read_queries[i++], std::make_shared<BufferHolder>(), read_options));
+    for (auto&& [index_key, index_segment] : indexes) {
+        results_fut.push_back(async_read_direct(store(), keys[i], std::move(index_segment), read_queries.empty() ? ReadQuery{} : read_queries[i], std::make_shared<BufferHolder>(), read_options));
+        ++i;
     }
     Allocator::instance()->trim();
-    return std::make_pair(keys, folly::collect(results_fut).get());
+    return folly::collect(results_fut).get();
+}
+
+std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::temp_batch_read_internal_direct(
+    const std::vector<StreamId> &stream_ids,
+    const std::vector<VersionQuery> &version_queries,
+    std::vector<ReadQuery> &read_queries,
+    const ReadOptions &read_options) {
+    py::gil_scoped_release release_gil;
+    auto versions = batch_get_versions(store(), version_map(), stream_ids, version_queries);
+    std::vector<folly::Future<std::pair<VersionedItem, FrameAndDescriptor>>> output;
+    for (auto &&version : folly::enumerate(versions)) {
+        auto read_query = read_queries.empty() ? ReadQuery{} : read_queries[version.index];
+        output.emplace_back(std::move(*version).thenValue([store = store()](auto maybe_index_key) -> ReadKeyOutput {
+            util::check(static_cast<bool>(maybe_index_key), "Version not found for stream");
+            return store->read_sync(maybe_index_key.value());
+        }).thenValue([store = store(), read_query = std::move(read_query), read_options](auto &&key_segment_pair) {
+            auto [index_key, index_segment] = std::move(key_segment_pair);
+            return async_read_direct(store,
+                                     std::move(index_key),
+                                     std::move(index_segment),
+                                     read_query,
+                                     std::make_shared<BufferHolder>(),
+                                     read_options);
+        }));
+    }
+    return folly::collect(output).get();
 }
 
 std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::batch_read_internal(
@@ -940,6 +972,12 @@ std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::
     const std::vector<VersionQuery>& version_queries,
     std::vector<ReadQuery>& read_queries,
     const ReadOptions& read_options) {
+
+    if(std::none_of(std::begin(read_queries), std::end(read_queries), [] (const auto& read_query) {
+        return !read_query.query_->empty();
+    })) {
+        return temp_batch_read_internal_direct(stream_ids, version_queries, read_queries, read_options);
+    }
 
     std::vector<folly::Future<std::pair<VersionedItem, FrameAndDescriptor>>> results_fut;
     for (size_t idx=0; idx < stream_ids.size(); idx++) {
@@ -1160,34 +1198,44 @@ SpecificAndLatestVersionKeys LocalVersionedEngine::get_stream_index_map(
     return std::make_pair(specific_versions, latest_versions);
 }
 
+folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata(
+    std::optional<AtomKey> key){
+    if (key.has_value()){
+        return store()->read_metadata(key.value());
+    }else{
+        return folly::makeFuture(std::make_pair(std::nullopt, std::nullopt));
+    }
+}
+
+folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata_async(
+    folly::Future<std::optional<AtomKey>>&& version_fut){
+    return  std::move(version_fut)
+    .thenValue([this](std::optional<AtomKey> key){
+        return get_metadata(key);
+    });
+}
+
 std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::batch_read_metadata_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries
     ) {
-    auto [specific_versions_index_map, latest_versions_index_map] = get_stream_index_map(stream_ids, version_queries);
-    auto version_queries_is_empty = version_queries.empty();
+    auto versions_fut = batch_get_versions(store(), version_map(), stream_ids, version_queries);
     std::vector<folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>> fut_vec;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
-        if(!version_queries_is_empty && std::holds_alternative<SpecificVersionQuery>(version_queries[stream_id.index].content_)){
-            const auto& query = version_queries[stream_id.index].content_;
-            auto specific_version_map_key = std::make_pair(*stream_id, std::get<SpecificVersionQuery>(query).version_id_);
-            auto specific_version_it = specific_versions_index_map->find(specific_version_map_key);
-            if (specific_version_it != specific_versions_index_map->end()){
-                fut_vec.push_back(store()->read_metadata(specific_version_it->second));
-            }else{
-                fut_vec.push_back(std::make_pair(std::nullopt, std::nullopt));
-            }
-        }else{
-            auto last_version_it = latest_versions_index_map->find(*stream_id);
-            if(last_version_it != latest_versions_index_map->end()) {
-                fut_vec.push_back(store()->read_metadata(last_version_it->second));
-            }else{
-                fut_vec.push_back(std::make_pair(std::nullopt, std::nullopt));   
-            }
-        }
+    for (auto&& version: versions_fut){
+        fut_vec.push_back(get_metadata_async(std::move(version)));
     }
     return folly::collect(fut_vec).get();
 }
+
+std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> LocalVersionedEngine::read_metadata_internal(
+    const StreamId& stream_id,
+    const VersionQuery& version_query
+    ) {
+    auto version = get_version_to_read(stream_id, version_query);
+    std::optional<AtomKey> key = version.has_value() ? std::make_optional<AtomKey>(version->key_) : std::nullopt;
+    return get_metadata(key).get();
+}
+
 
 VersionedItem LocalVersionedEngine::sort_merge_internal(
     const StreamId& stream_id,
@@ -1264,16 +1312,15 @@ std::unordered_map<KeyType, std::pair<size_t, size_t>> LocalVersionedEngine::sca
         auto& pair = sizes[key_type];
         pair.first = keys.size();
         std::vector<stream::StreamSource::ReadContinuation> continuations;
-        continuations.reserve(keys.size());
         std::atomic<size_t> key_size{0};
-        for(auto i = 0u; i < keys.size(); ++i) {
+        for(auto&& key : keys) {
             continuations.emplace_back([&key_size] (auto&& ks) {
                 auto key_seg = std::move(ks);
                 key_size += key_seg.segment().total_segment_size();
                 return key_seg.variant_key();
             });
         }
-        store->batch_read_compressed(std::move(keys), std::move(continuations), BatchReadArgs{});
+        store->batch_read_compressed(std::move(keys), std::move(continuations),BatchReadArgs{});
         pair.second = key_size;
     });
     return sizes;

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -175,6 +175,12 @@ public:
         arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
     );
 
+    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata(
+        std::optional<AtomKey> key);
+
+    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata_async(
+        folly::Future<std::optional<AtomKey>>&& version_fut);
+
     void create_column_stats_internal(
         const VersionedItem& versioned_item,
         ColumnStats& column_stats,
@@ -248,12 +254,18 @@ public:
         const WriteOptions& write_options,
         bool validate_index);
 
-    std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>> batch_read_keys(
+    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> batch_read_keys(
         const std::vector<AtomKey> &keys,
         const std::vector<ReadQuery> &read_queries,
         const ReadOptions& read_options);
 
     std::vector<std::pair<VersionedItem, FrameAndDescriptor>> batch_read_internal(
+        const std::vector<StreamId>& stream_ids,
+        const std::vector<VersionQuery>& version_queries,
+        std::vector<ReadQuery>& read_queries,
+        const ReadOptions& read_options);
+
+    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> temp_batch_read_internal_direct(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,
@@ -276,6 +288,10 @@ public:
     std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> batch_read_metadata_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
+
+    std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> read_metadata_internal(
+        const StreamId& stream_id,
+        const VersionQuery& version_query);
 
     bool is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) override;
 

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -2,6 +2,7 @@
 
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
+#include <arcticdb/util/test/gtest_utils.hpp>
 
 using namespace arcticdb;
 using namespace arcticdb::pipelines;
@@ -33,6 +34,7 @@ void add_versions_for_stream(
 }
 
 TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
+    SKIP_WIN("Exceeds LMDB map size");
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
 
@@ -71,11 +73,14 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
 }
 
 TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
+    SKIP_WIN("Exceeds LMDB map size");
+    ScopedConfig cpu_threads("VersionStore.NumCPUThreads", 1);
+    ScopedConfig io_threads("VersionStore.NumIOThreads", 1);
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
 
-    uint64_t num_streams = 10;
-    uint64_t num_versions_per_stream = 5;
+    uint64_t num_streams = 1000;
+    uint64_t num_versions_per_stream = 500;
 
     for(uint64_t i = 0; i < num_streams; ++i) {
         auto stream = fmt::format("stream_{}", i);
@@ -126,6 +131,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
 
 
 TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
+    SKIP_WIN("Exceeds LMDB map size");
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
 
@@ -137,6 +143,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
 
     std::vector<StreamId> stream_ids;
     std::vector<VersionQuery> version_queries;
+
 
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
@@ -156,6 +163,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
 
 
 TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
+    SKIP_WIN("Exceeds LMDB map size");
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
 
@@ -197,6 +205,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
 }
 
 TEST_F(VersionMapBatchStore, CombinedQueries) {
+    SKIP_WIN("Exceeds LMDB map size");
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
 

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -345,7 +345,7 @@ TEST_F(VersionStoreTest, StressBatchReadUncompressed) {
     }
 
     std::vector<ReadQuery> read_queries;
-    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>{}, read_queries, ReadOptions{});
+    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, ReadOptions{});
     for(auto version : folly::enumerate(latest_versions)) {
         auto expected = get_test_simple_frame(version->item.symbol(), 10, version.index);
         bool equal = expected.segment_ == version->frame_data.frame();

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -559,17 +559,6 @@ void ensure_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_
         norm_meta.mutable_df()->mutable_common()->mutable_index()->set_tz("UTC");
 }
 
-void check_column_and_date_range_filterable(const pipelines::index::IndexSegmentReader& index_segment_reader, const ReadQuery& read_query) {
-    util::check(!index_segment_reader.is_pickled()
-    || (read_query.columns.empty() && std::holds_alternative<std::monostate>(read_query.row_filter)),
-    "The data for this symbol is pickled and does not support column stats, date_range, row_range, or column queries");
-    util::check(index_segment_reader.has_timestamp_index() || !std::holds_alternative<IndexRange>(read_query.row_filter),
-            "Cannot apply date range filter to symbol with non-timestamp index");
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(index_segment_reader.tsd().stream_descriptor().sorted() == arcticdb::proto::descriptors::SortedValue::UNKNOWN ||
-        index_segment_reader.tsd().stream_descriptor().sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING ||
-        !std::holds_alternative<IndexRange>(read_query.row_filter),
-            "When filtering data using date_range, the symbol must be sorted in ascending order. ArcticDB believes it is not sorted in ascending order and cannot therefore filter the data using date_range.");
-}
 }
 
 std::optional<pipelines::index::IndexSegmentReader> get_index_segment_reader(

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -231,8 +231,8 @@ inline std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions(
         } else {
             auto fut = shared_futures.find(*symbol);
             if(fut == shared_futures.end()) {
-                auto check_reload_task_fut = async::submit_io_task(CheckReloadTask{store, version_map, *symbol, it->second.load_param_});
-                auto [splitter, inserted] = shared_futures.emplace(*symbol, folly::FutureSplitter(std::move(check_reload_task_fut)));
+                auto [splitter, inserted] = shared_futures.emplace(*symbol, folly::FutureSplitter(async::submit_io_task(CheckReloadTask{store, version_map, *symbol, it->second.load_param_})));
+
                 version_entry_fut = splitter->second.getFuture();
             } else {
                 version_entry_fut = fut->second.getFuture();

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1006,13 +1006,14 @@ std::pair<VersionedItem, py::object> PythonVersionStore::read_metadata(
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: read_metadata");
     ARCTICDB_SAMPLE(ReadMetadata, 0)
 
-    auto version = get_version_to_read(stream_id, version_query);
-    if(!version)
+    auto metadata = read_metadata_internal(stream_id, version_query);
+    if(!metadata.first.has_value())
         throw NoDataFoundException(fmt::format("read_metadata: version not found for symbol", stream_id));
 
-    auto metadata_proto = store()->read_metadata(version.value().key_).get().second;
+    auto metadata_proto = metadata.second;
     py::object pyobj = metadata_protobuf_to_pyobject(metadata_proto);
-    return std::pair{version.value(), pyobj};
+    VersionedItem version{std::move(to_atom(*metadata.first))};
+    return std::pair{version, pyobj};
 }
 
 std::vector<VersionedItem> PythonVersionStore::batch_write_metadata(

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -324,19 +324,16 @@ private:
     void delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key);
 };
 
-inline std::vector<ReadResult> frame_to_read_result(std::pair<std::vector<AtomKey>, std::vector<FrameAndDescriptor>>&& keys_frame_and_descriptors) {
-    auto& keys = keys_frame_and_descriptors.first;
-    auto& frame_and_descriptors = keys_frame_and_descriptors.second;
-
+inline std::vector<ReadResult> frame_to_read_result(std::vector<std::pair<VersionedItem, FrameAndDescriptor>>&& keys_frame_and_descriptors) {
     std::vector<ReadResult> read_results;
-    read_results.reserve(keys.size());
-    for (auto fd : folly::enumerate(frame_and_descriptors)) {
+    read_results.reserve(keys_frame_and_descriptors.size());
+    for (auto [item, fd] : keys_frame_and_descriptors) {
         read_results.emplace_back(ReadResult(
-            VersionedItem{std::move(keys[fd.index])},
-            PythonOutputFrame{fd->frame_, fd->buffers_},
-            fd->desc_.normalization(),
-            fd->desc_.user_meta(),
-            fd->desc_.multi_key_meta(),
+            item,
+            PythonOutputFrame{fd.frame_, fd.buffers_},
+            fd.desc_.normalization(),
+            fd.desc_.user_meta(),
+            fd.desc_.multi_key_meta(),
             std::vector<AtomKey>{}));
     }
     return read_results;

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -271,6 +271,33 @@ def test_read_meta_batch_with_as_ofs(arctic_library):
     assert results_list[4].metadata == {"meta2": 8}
 
 
+def test_read_meta_batch_with_as_ofs_stress(arctic_library):
+    lib = arctic_library
+    num_symbols = 10
+    num_versions = 20
+    for sym in range(num_symbols):
+        for version in range(num_versions):
+            lib.write_pickle(
+                "sym_" + str(sym), version, metadata={"meta_" + str(sym): version}, prune_previous_versions=False
+            )
+
+    requests = [
+        ReadInfoRequest("sym_" + str(sym), as_of=version)
+        for sym in range(num_symbols)
+        for version in range(num_versions)
+    ]
+    results_list = lib.read_metadata_batch(requests)
+    for sym in range(num_symbols):
+        for version in range(num_versions):
+            idx = sym * num_versions + version
+            assert results_list[idx].metadata == {"meta_" + str(sym): version}
+
+    requests = ["sym_" + str(sym) for sym in range(num_symbols)]
+    results_list = lib.read_metadata_batch(requests)
+    for sym in range(num_symbols):
+        assert results_list[sym].metadata == {"meta_" + str(sym): num_versions - 1}
+
+
 def test_basic_write_read_update_and_append(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})


### PR DESCRIPTION
### What does this PR resolve?

Prior to this PR, `batch_read` parallelises over the slices of symbols, not over individual symbols. Large symbols are by default split (or sliced) per 100k rows or 127 columns and as a result, reading large symbols acheives a degree of parallelism as each slices will be retrieved and decompressed in parallel.

However if you are reading many small symbols, **there will be no effective parallelism**. Each symbol will be wholy retrieved and decompressed before processing the next symbol.

This PR provides a temporary resolution to this problem. As described in the next section, as long as there is no QueryBuilder query, this PR will parallelise across symbols as well as slices.

### How does this PR achieve this?

* Adds `temp_batch_read_internal_direct`. This is a special method that is only called if there is no processing required (read: no `QueryBuilder` query). This paralellises across both slices and symbols.
* Modifies `batch_read_compressed` to return `folly::Future`s enabling the scheduling of many futures to be managed higher up in the stack.
* Adds `gil_lock.hpp`. This adds a scoped means of taking and releasing the GIL. This is used to globally take the GIL when preparing the output frame. 
* Moves `read_options` one level lower to ensure that the lifetime management of objects is correct as we can no longer rely on them being maintained by the enclosing scope

### What is required after this?

#273 completes the work and enables symbol-leel parallelism even if a QueryBuilder query has been added. 