### PR TITLE
Higher utility GitHub Actions changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,36 @@ on:
         type: choice
         options: ["-", debug, release]
 run-name: Building ${{github.ref_name}} on ${{github.event_name}} by ${{github.actor}}
+concurrency:
+  group: ${{github.ref}}
+  cancel-in-progress: true
 jobs:
   common_config:
-    # Hacky way to supply common variables (as the env context is not available in jobs.*.with)
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Use a matrix to build the common hierarchical structure used by multiple matrix jobs in build_steps.yaml
+          # Please declare any key you added below in build_steps.yaml's dummy matrix as well to aid the linting tools
+          - linux_matrix:
+              - os: linux
+                distro: ubuntu-latest
+                cmake_preset_prefix: linux
+                cibw_build_suffix: manylinux_x86_64
+                build_dir: /tmp/cpp_build
+                symbols: "*.gz" # Please update publish.yml when changing this!!
+                do_not_archive: ["*.so", "*.[ao]", "vcpkg_installed"]
+                test_services:
+                  mongodb: { image: "mongo:4.4" }
+            windows_matrix:
+              - os: windows
+                distro: windows-latest
+                cmake_preset_prefix: windows-cl
+                cibw_build_suffix: win_amd64
+                build_dir: C:\cpp_build
+                symbols: "*.pdb" # Please update publish.yml when changing this!!
+                do_not_archive: ["*.lib", "*.ilk", "*.pyd", "*.dll", "CMakeFiles/*.dir", "vcpkg_installed"]
+                test_services: {}
     steps:
       - run: |
           if ${{startsWith(github.ref, 'refs/tags/v')}}; then
@@ -43,22 +69,8 @@ jobs:
       publish_env: ${{inputs.publish_env || env.PUBLISH_ENV || ''}}
       pypi_publish: ${{inputs.pypi_publish || env.PYPI_PUBLISH}}
       cmake_preset_type_resolved: ${{inputs.cmake_preset_type != '-' && inputs.cmake_preset_type || env.CMAKE_PRESET_TYPE}}
-      linux_python_versions: ${{vars.LINUX_PYTHON_VERSIONS || '[6, 7, 8, 9, 10, 11]'}}
-      windows_python_versions: ${{vars.WINDOWS_PYTHON_VERSIONS || '[7, 8, 9, 10, 11]'}}
-      # Please declare any key you added below in build_steps.yaml:jobs.compile.strategy.matrix to aid the linting tools
-      # Please update publish.yml if changing the symbols value!!
-      linux_matrix: >-
-        {"os":"linux", "distro":"\"ubuntu-latest\"",
-          "cmake_preset_prefix":"linux", "build_dir": "/tmp/cpp_build", "symbols": "*.gz",
-          "do_not_archive": ["*.so", "*.[ao]", "vcpkg_installed"],
-          "test_services": "{\"mongodb\": {\"image\": \"mongo:4.4\"}}"
-        }
-      windows_matrix: >-
-        {"os":"windows", "distro":"\"windows-latest\"",
-          "cmake_preset_prefix":"windows-cl", "build_dir": "C:\\cpp_build", "symbols": "*.pdb",
-          "do_not_archive": ["*.lib", "*.ilk", "*.pyd", "*.dll", "CMakeFiles/*.dir", "vcpkg_installed"],
-          "test_services": "{}"
-        }
+      linux_matrix: ${{toJson(matrix.linux_matrix)}}
+      windows_matrix: ${{toJson(matrix.windows_matrix)}}
 
   cibw_docker_image:
     needs: [common_config]
@@ -99,26 +111,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python3: ${{fromJson(needs.common_config.outputs.linux_python_versions)}}
-        python_deps: [""]
+        python3: ${{fromJson(vars.LINUX_PYTHON_VERSIONS || '[6, 7, 8, 9, 10, 11]')}}
         include:
+          - python_deps_ids: [""]
+            matrix_override: ${{fromJson(needs.common_config.outputs.linux_matrix)}}
           - python3: 6
-            python_deps: "requirements-compatibility-py36.txt"
+            python_deps_ids: ["", -compat36]
+            matrix_override:
+              - ${{fromJson(needs.common_config.outputs.linux_matrix)[0]}}
+              - python_deps_id: -compat36
+                python_deps: requirements-compatibility-py36.txt
           - python3: 8
-            python_deps: "requirements-compatibility-py38.txt"
-    name: 3.${{matrix.python3}} Linux ${{matrix.python_deps}}
+            python_deps_ids: ["", -compat38]
+            matrix_override:
+              - ${{fromJson(needs.common_config.outputs.linux_matrix)[0]}}
+              - python_deps_id: -compat38
+                python_deps: requirements-compatibility-py38.txt
+    name: 3.${{matrix.python3}} Linux
     uses: ./.github/workflows/build_steps.yml
     secrets: inherit
     permissions: {packages: write}
     with:
       job_type: follower
       python3: ${{matrix.python3}}
-      python_deps: ${{matrix.python_deps}}
-      cibw_build: ${{format('cp3{0}-manylinux_x86_64', matrix.python3)}}
       cibw_image_tag: ${{needs.cibw_docker_image.outputs.tag}}
       cibw_version: ${{needs.common_config.outputs.cibuildwheel_ver}}
       cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
-      matrix: ${{needs.common_config.outputs.linux_matrix}}
+      matrix: ${{toJson(matrix.matrix_override)}}
+      python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
 
   leader-compile-windows:
     needs: [common_config]
@@ -146,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python3: ${{fromJson(needs.common_config.outputs.windows_python_versions)}}
+        python3: ${{fromJson(vars.WINDOWS_PYTHON_VERSIONS || '[7, 8, 9, 10, 11]')}}
     name: 3.${{matrix.python3}} Windows
     uses: ./.github/workflows/build_steps.yml
     secrets: inherit
@@ -154,7 +174,6 @@ jobs:
     with:
       job_type: follower
       python3: ${{matrix.python3}}
-      cibw_build: ${{format('cp3{0}-win_amd64', matrix.python3)}}
       cibw_version: ${{needs.common_config.outputs.cibuildwheel_ver}}
       cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
       matrix: ${{needs.common_config.outputs.windows_matrix}}

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -7,11 +7,8 @@ on:
       matrix:            {required: true, type: string, description: JSON string to feed into the matrix}
       cibw_image_tag:    {required: false, type: string, description: Linux only. As built by cibw_docker_image.yml workflow}
       cibw_version:      {required: false, type: string, description: Follower only. Must match the cibw_image_tag}
-      cibw_build:        {required: false, type: string, description: Follower only.}
+      python_deps_ids:   {default: '[""]', type: string, description: Follower test matrix parameter. JSON string.}
       python3:           {default: -1, type: number, description: Python 3 minor version}
-      python_deps:       {required: false, type: string, description: Python requirements.txt in build_tooling to test against}
-env:
-  python_impl_name: ${{inputs.python3 > 0 && format('cp3{0}', inputs.python3) || 'default'}}
 jobs:
   compile:
     strategy:
@@ -20,6 +17,7 @@ jobs:
         os: [0] # Decouples the steps from any distro version changes
         distro: [0]
         cmake_preset_prefix: [0]
+        cibw_build_suffix: [0]
         envs: [0]
         build_dir: [0] # Must be an absolute path
         symbols: [0] # Glob for symbol symbol files. Used for including in follower builds and exclusion on others.
@@ -28,9 +26,9 @@ jobs:
         exclude:
             - os: 0
         include:
-            - ${{fromJSON(inputs.matrix)}}
+            - ${{fromJSON(inputs.matrix)[0]}} # The items after 0 are for tests only
 
-    runs-on: ${{fromJson(matrix.distro)}}
+    runs-on: ${{matrix.distro}}
     container: ${{ (matrix.os == 'linux' && inputs.job_type != 'follower') && inputs.cibw_image_tag || null}}
     env:
       SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
@@ -47,6 +45,8 @@ jobs:
         CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_BUILD_PARALLEL_LEVEL ARCTIC_CMAKE_PRESET
         ARCTICDB_BUILD_DIR TEST_OUTPUT_DIR
       ARCTICDB_DEBUG_FIND_PYTHON: ${{vars.ARCTICDB_DEBUG_FIND_PYTHON}}
+      python_impl_name: ${{inputs.python3 > 0 && format('cp3{0}', inputs.python3) || 'default'}}
+      CIBW_BUILD: ${{format('cp3{0}-{1}', inputs.python3, matrix.cibw_build_suffix)}}
     defaults:
       run: {shell: bash}
     steps:
@@ -128,14 +128,13 @@ jobs:
         if: inputs.job_type == 'follower'
         run: pipx run cibuildwheel==${{inputs.cibw_version}}
         env:
-          CIBW_BUILD: ${{inputs.cibw_build}}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{inputs.cibw_image_tag}}
 
       - name: Store wheel artifact
         if: inputs.job_type == 'follower'
         uses: actions/upload-artifact@v3
         with:
-          name: wheel-${{inputs.python_deps || inputs.cibw_build}}
+          name: wheel-${{env.CIBW_BUILD}}
           path: wheelhouse/*.whl
 
       - name: Discover test directory names
@@ -160,7 +159,7 @@ jobs:
         env:
           _exclusion: "\n!${{matrix.build_dir}}/**/"
         with:
-          name: build-metadata-${{inputs.job_type}}-${{matrix.os}}-${{env.python_impl_name}}-${{inputs.python_deps || ''}}
+          name: build-metadata-${{inputs.job_type}}-${{matrix.os}}-${{env.python_impl_name}}
           retention-days: ${{inputs.job_type == 'cpp-tests' && 7 || 90}}
           # On Windows, exclusions like "!**/*.ext" are prefixed with a drive letter (D:\) of the current working dir
           # before matching. This breaks since we moved the build_dir to C:. Work around by templating exclusions:
@@ -170,7 +169,9 @@ jobs:
 
     outputs:
       manylinux_image: ${{env.manylinux_image}}
+      python_impl_name: ${{env.python_impl_name}}
       test_dirs: ${{env.test_dirs}}
+      cibw_build: ${{env.CIBW_BUILD}}
 
   python_tests:
     if: inputs.job_type == 'follower'
@@ -179,14 +180,18 @@ jobs:
       fail-fast: false
       matrix:
         type: ${{fromJSON(vars.TEST_DIRS_OVERRIDE || needs.compile.outputs.test_dirs)}}
+        python_deps_id: ${{fromJson(inputs.python_deps_ids)}}
         include:
-          - ${{fromJSON(inputs.matrix)}}
-    name: ${{matrix.type}}
-    runs-on: ${{fromJson(matrix.distro)}}
+          ${{fromJSON(inputs.matrix)}}
+    name: ${{matrix.type}}${{matrix.python_deps_id}}
+    runs-on: ${{matrix.distro}}
     container: ${{matrix.os == 'linux' && needs.compile.outputs.manylinux_image || null}}
     defaults:
       run: {shell: bash}
-    services: ${{fromJSON(matrix.test_services)}}
+    services: ${{matrix.test_services}}
+    env:
+      python_impl_name: ${{needs.compile.outputs.python_impl_name}}
+      distinguishing_name: ${{matrix.os}}-${{needs.compile.outputs.python_impl_name}}-${{matrix.type}}${{matrix.python_deps_id}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
@@ -194,7 +199,7 @@ jobs:
       - name: Get wheel artifact
         uses: actions/download-artifact@v3
         with:
-          name: wheel-${{inputs.python_deps || inputs.cibw_build}}
+          name: wheel-${{needs.compile.outputs.cibw_build}}
           path: ${{runner.temp}}
 
       - name: Select Python (Linux)
@@ -222,9 +227,9 @@ jobs:
           python -V
           cd "$RUNNER_TEMP" # Works for Windows-style paths as well
           python -m pip install --force-reinstall *${{env.python_impl_name}}*.whl
-          if [[ -n "${{inputs.python_deps || ''}}" ]] ; then
-            echo "Using deps ${{inputs.python_deps}}"
-            python -m pip install --force-reinstall -r $GITHUB_WORKSPACE/build_tooling/${{inputs.python_deps}}
+          if [[ -n "${{matrix.python_deps || ''}}" ]] ; then
+            echo "Using deps ${{matrix.python_deps}}"
+            python -m pip install --force-reinstall -r $GITHUB_WORKSPACE/build_tooling/${{matrix.python_deps}}
           fi
           python -m pip install arcticdb[Testing] pytest-split
           python -m pip uninstall -y pytest-cpp || true # No longer works on 3.6
@@ -232,10 +237,6 @@ jobs:
           echo -e "${{matrix.envs || ''}}" | tee -a $GITHUB_ENV
           if [[ -n "$MSYSTEM" ]] ; then
             echo "LOCALAPPDATA=$LOCALAPPDATA" | tee -a $GITHUB_ENV
-            MSYS_NO_PATHCONV=1 reg.exe ADD 'HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
-            cd "/proc/registry/HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft"
-            find "Windows NT/CurrentVersion/AeDebug" "Windows/Windows Error Reporting/LocalDumps" \
-              -type f -print -exec xxd -c 64 '{}' \; || true
           fi
           ${{vars.EXTRA_TEST_PREPARE_CMD || ''}}
         env:
@@ -252,7 +253,7 @@ jobs:
         if: matrix.os == 'windows' && failure()
         uses: actions/upload-artifact@v3
         with:
-          name: crashdump-${{matrix.os}}-${{env.python_impl_name}}-${{matrix.type}}
+          name: crashdump-${{env.distinguishing_name}}
           path: ${{env.LOCALAPPDATA}}/CrashDumps/
 
       - name: Disk usage
@@ -264,6 +265,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: pytest-${{matrix.os}}-${{env.python_impl_name}}-${{matrix.type}}-${{inputs.python_deps || ''}}
+          name: pytest-${{env.distinguishing_name}}
           path: |
             ${{runner.temp}}/*test*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
       environment: { type: environment, required: false }
       api_wheel: { type: string, description: Override the wheel to generate API docs from }
 jobs:
-  docs:
+  can_merge:
     runs-on: ubuntu-latest
     environment: ${{inputs.environment}}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,8 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          configuration: build_tooling/change_log.json
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -83,7 +85,8 @@ jobs:
           body: |
             ${{steps.changelog.outputs.changelog}}
 
-            The wheels are on [Pypi](https://pypi.org/project/arcticdb/). Below are for debugging:
+            ---
+            > The wheels are on [Pypi](https://pypi.org/project/arcticdb/). Below are for debugging:
           files: ${{steps.compress.outcome == 'success' && env.SYMBOLS_ARTIFACT || ''}}
 
 

--- a/build_tooling/change_log.json
+++ b/build_tooling/change_log.json
@@ -1,0 +1,14 @@
+{
+"categories": [
+    {
+        "title": "## 🚀 Features",
+        "labels": ["enhancement"]
+    },
+    {
+        "title": "## 🐛 Fixes",
+        "labels": ["bug"]
+    }
+],
+"pr_template": "- ${{TITLE}} (#${{NUMBER}})",
+"template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>"
+}

--- a/cpp/third_party/lmdbcxx/CMakeLists.txt
+++ b/cpp/third_party/lmdbcxx/CMakeLists.txt
@@ -14,4 +14,3 @@ endif ()
 add_library(lmdb STATIC mdb.c midl.c)
 
 target_include_directories(lmdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ version = 1.0.1
 description = ArcticDB DataFrame Database
 author = Man Alpha Technology
 author_email = arcticdb@man.com
+license=Business Source License 1.1 (See LICENSE.txt)
 keywords =
 classifiers =
     Programming Language :: Python :: 3

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,6 @@ from wheel.bdist_wheel import bdist_wheel
 # the dependencies from a conda
 ARCTICDB_USING_CONDA  = os.environ.get("ARCTICDB_USING_CONDA", "0")
 ARCTICDB_USING_CONDA = ARCTICDB_USING_CONDA != "0"
-
-# numbert of cores to use for compilation
-CMAKE_BUILD_PARALLEL_LEVEL  = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "0")
-CMAKE_BUILD_PARALLEL_LEVEL = int(CMAKE_BUILD_PARALLEL_LEVEL)
-
 print(f"ARCTICDB_USING_CONDA={ARCTICDB_USING_CONDA}")
 
 def _log_and_run(*cmd, **kwargs):
@@ -154,7 +149,8 @@ class CMakeBuild(build_ext):
         candidates = glob.glob(search)
         assert len(candidates) == 1, f"Specify {env_var} or use a single build directory. {search}={candidates}"
 
-        if CMAKE_BUILD_PARALLEL_LEVEL == 0:
+        cmake_build_parallel_level = os.getenv("CMAKE_BUILD_PARALLEL_LEVEL", None)
+        if not cmake_build_parallel_level:
             try:
                 # Python API is not cgroups-aware yet, so use CMake:
                 cpu_output = subprocess.check_output([cmake, "-P", "cpp/CMake/CpuCount.cmake"], universal_newlines=True)
@@ -163,11 +159,16 @@ class CMakeBuild(build_ext):
                 print("Failed to retrieve CPU count:", e)
                 jobs = ()
         else:
-            jobs = "-j", str(CMAKE_BUILD_PARALLEL_LEVEL)
-        _log_and_run(cmake, "--build", candidates[0], *jobs, "--target", "install_" + ext.name)
+            jobs = "-j", cmake_build_parallel_level
+
+        try:
+            _log_and_run(cmake, "--build", candidates[0], *jobs, "--target", "install_" + ext.name)
+        finally:
+            launcher = os.getenv("CMAKE_CXX_COMPILER_LAUNCHER", "")
+            if "sccache" in launcher and "AUDITWHEEL_PLAT" in os.environ:
+                subprocess.run([launcher, "--show-stats"])
 
         assert os.path.exists(dest), f"No output at {dest}, but we didn't get a bad return code from CMake?"
-
 
 def readme():
     github_emoji = re.compile(r":[a-z_]+:")


### PR DESCRIPTION
* More read-able matrix reuse syntax
* Re-organised the Python pinned dependency tests
* Display sccache stats in CIBuildWheel Linux build
* Doc-only changes can be merged now
* Cancel superseded builds
* ~~Exclude LMDB compilation warnings~~ (Didn't work)
