### PR TITLE
Add Azurite in Github Action's Linux testing environment

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -215,6 +215,12 @@ jobs:
           disk-root: "D:"  # This is also the checkout directory. Total size 12GB.
         continue-on-error: true
 
+      - name: Install azurite
+        if: matrix.os == 'linux'
+        run: |
+          yum install -y npm
+          npm install -g azurite
+
       - name: Install the wheel and dependencies
         run: |
           cmake -P cpp/CMake/CpuCount.cmake | sed 's/^-- //' | tee -a $GITHUB_ENV


### PR DESCRIPTION
Azurite is the official enumerator for Azure Storage.
This PR is for adding Azurite in the testing environment to allow pytest cases to be able to test against it in Linux.


For closes https://github.com/man-group/ArcticDB/issues/428