### PR TITLE
Implement per symbol parallelisation for write batch method

### DIFF
--- a/cpp/arcticdb/pipeline/slicing.hpp
+++ b/cpp/arcticdb/pipeline/slicing.hpp
@@ -67,15 +67,6 @@ SlicingPolicy get_slicing_policy(
 
 std::vector<FrameSlice> slice(InputTensorFrame &frame, const SlicingPolicy& slicer);
 
-std::vector<folly::Future<SliceAndKey>> write_slices(
-    const InputTensorFrame &frame,
-    const std::vector<FrameSlice> &slices,
-    const SlicingPolicy& slicing,
-    folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
-    const std::shared_ptr<stream::StreamSink>& sink,
-    const std::shared_ptr<DeDupMap>& de_dup_map);
-
-
 inline auto slice_begin_pos(const FrameSlice& slice, const InputTensorFrame& frame) {
     return slice.row_range.first - frame.offset;
 }

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -24,6 +24,7 @@
 #include <arcticdb/stream/append_map.hpp>
 #include <arcticdb/version/version_utils.hpp>
 #include <arcticdb/entity/merge_descriptors.hpp>
+#include <arcticdb/async/task_scheduler.hpp>
 
 #include <pybind11/pybind11.h>
 
@@ -32,9 +33,9 @@ namespace arcticdb::pipelines {
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;
 
-std::vector<folly::Future<SliceAndKey>> write_slices(
+folly::Future<std::vector<SliceAndKey>> write_slices(
         const InputTensorFrame &frame,
-        const std::vector<FrameSlice> &slices,
+        std::vector<FrameSlice>&& slices,
         const SlicingPolicy &slicing,
         folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
         const std::shared_ptr<stream::StreamSink>& sink,
@@ -107,14 +108,14 @@ std::vector<folly::Future<SliceAndKey>> write_slices(
     auto fut_writes = sink->batch_write(std::move(key_segs), de_dup_map);
 
     ARCTICDB_SUBSAMPLE_DEFAULT(WriteSlicesWait)
-    return std::move(fut_writes).thenValue([&](auto &&keys) {
-        std::vector<folly::Future<SliceAndKey>> res;
+    return std::move(fut_writes).thenValue([slices = std::move(slices)](auto &&keys) mutable {
+        std::vector<SliceAndKey> res;
         res.reserve(keys.size());
         for (std::size_t i = 0; i < res.capacity(); ++i) {
             res.emplace_back(SliceAndKey{slices[i], std::move(to_atom(keys[i]))});
         }
         return res;
-    }).get();
+    });
 }
 
 folly::Future<entity::VariantKey> write_multi_index(
@@ -131,7 +132,7 @@ folly::Future<entity::VariantKey> write_multi_index(
     return writer.commit();
 }
 
-std::vector<folly::Future<SliceAndKey>> slice_and_write(
+folly::Future<std::vector<SliceAndKey>> slice_and_write(
         InputTensorFrame &frame,
         const SlicingPolicy &slicing,
         folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
@@ -140,15 +141,13 @@ std::vector<folly::Future<SliceAndKey>> slice_and_write(
         bool sparsify_floats) {
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceFrame)
     auto slices = slice(frame, slicing);
-
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
-    auto fut_slice_keys = write_slices(frame, slices, slicing, std::move(partial_key_gen), sink, de_dup_map, sparsify_floats);
-    return fut_slice_keys;
+    return write_slices(frame, std::move(slices), slicing, std::move(partial_key_gen), sink, de_dup_map, sparsify_floats);
 }
 
 folly::Future<entity::AtomKey>
 write_frame(
-        const IndexPartialKey& key,
+        IndexPartialKey&& key,
         InputTensorFrame&& frame,
         const SlicingPolicy &slicing,
         const std::shared_ptr<Store>& store,
@@ -158,7 +157,9 @@ write_frame(
     auto fut_slice_keys = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store, de_dup_map, sparsify_floats);
     // Write the keys of the slices into an index segment
     ARCTICDB_SUBSAMPLE_DEFAULT(WriteIndex)
-    return index::write_index(std::move(frame), std::move(fut_slice_keys), key, store);
+    return std::move(fut_slice_keys).thenValue([frame = std::move(frame), key = std::move(key), &store](auto&& slice_keys) mutable {
+        return index::write_index(std::move(frame), std::move(slice_keys), key, store);
+    });
 }
 
 folly::Future<entity::AtomKey> append_frame(
@@ -193,8 +194,7 @@ folly::Future<entity::AtomKey> append_frame(
     );
 
     auto existing_slices = unfiltered_index(index_segment_reader);
-    auto fut_slice_keys = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store);
-    auto keys_fut = folly::collect(fut_slice_keys);
+    auto keys_fut = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store);
 
     auto slice_and_keys_to_append = keys_fut.wait().value();
 

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -26,7 +26,7 @@ namespace arcticdb::pipelines {
 
 using namespace arcticdb::stream;
 
-std::vector<folly::Future<SliceAndKey>> slice_and_write(
+folly::Future<std::vector<SliceAndKey>> slice_and_write(
         InputTensorFrame &frame,
         const SlicingPolicy &slicing,
         folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)> &&partial_key_gen,
@@ -35,16 +35,17 @@ std::vector<folly::Future<SliceAndKey>> slice_and_write(
         bool allow_sparse = false
 );
 
-std::vector<folly::Future<SliceAndKey>> write_slices(
-    const InputTensorFrame &frame,
-    const std::vector<FrameSlice> &slices,
-    const SlicingPolicy& slicing,
-    folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
-    const std::shared_ptr<stream::StreamSink>& sink,
-    const std::shared_ptr<DeDupMap>& de_dup_map);
+folly::Future<std::vector<SliceAndKey>> write_slices(
+        const InputTensorFrame &frame,
+        std::vector<FrameSlice>&& slices,
+        const SlicingPolicy &slicing,
+        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
+        const std::shared_ptr<stream::StreamSink>& sink,
+        const std::shared_ptr<DeDupMap>& de_dup_map,
+        bool sparsify_floats);
 
 folly::Future<entity::AtomKey> write_frame(
-    const IndexPartialKey &key,
+    IndexPartialKey &&key,
     InputTensorFrame&& frame,
     const SlicingPolicy &slicing,
     const std::shared_ptr<Store> &store,

--- a/cpp/arcticdb/version/test/test_snapshot.cpp
+++ b/cpp/arcticdb/version/test/test_snapshot.cpp
@@ -81,7 +81,7 @@ TEST(SnapshotCreate, Basic) {
     frame.index_range = IndexRange{0, num_rows};
     frame.num_rows = num_rows;
 
-    auto fut = write::write_frame(pk, std::move(frame), slicing, store);
+    auto fut = write::write_frame(std::move(pk), std::move(frame), slicing, store);
 
 
     auto version_key = std::move(fut.wait().value());

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -59,7 +59,7 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
     
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){
@@ -103,7 +103,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -115,7 +115,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     }
 
     // Now we can perform the actual batch query per timestamps
-    auto versions_querying_with_timestamp = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){
@@ -152,7 +152,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
     }
 
     // Do query
-    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
     
     // Check results
     for(uint64_t i = 0; i < num_versions; i++){
@@ -185,7 +185,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     }
 
     // Do query
-    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -194,7 +194,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     }
 
     // Now we can perform the actual batch query per timestamps
-    auto versions_querying_with_timestamp = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_versions; i++){
@@ -233,7 +233,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -251,7 +251,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         }
     }
 
-    auto versions_querying_with_mix_types = folly::collect(batch_get_versions(store, version_map, stream_ids, version_queries)).get();
+    auto versions_querying_with_mix_types = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -49,7 +49,7 @@ auto write_version_frame(
     auto wrapper = get_test_simple_frame(stream_id, rows, start_val);
     auto& frame = wrapper.frame_;
     auto store = pvs._test_get_store();
-    auto var_key = write_frame(pk, std::move(frame), slicing, store, de_dup_map).get();
+    auto var_key = write_frame(std::move(pk), std::move(frame), slicing, store, de_dup_map).get();
     auto key = to_atom(var_key); // Moves
     if (update_version_map) {
         pvs._test_get_version_map()->write_version(store, key);
@@ -320,7 +320,7 @@ TEST_F(VersionStoreTest, StressBatchWrite) {
         frames.push_back(wrapper.frame_);
     }
 
-    test_store_->batch_write_internal(version_ids, symbols, frames, dedup_maps, false);
+    folly::collect(test_store_->batch_write_internal(version_ids, symbols, std::move(frames), dedup_maps, false)).get();
 }
 
 TEST_F(VersionStoreTest, StressBatchReadUncompressed) {

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -99,7 +99,7 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
     auto partial_key = IndexPartialKey{frame.desc.id(), version_id};
     sorting::check<ErrorCode::E_UNSORTED_DATA>(!validate_index || frame.desc.get_sorted() == SortedValue::ASCENDING || !std::holds_alternative<stream::TimeseriesIndex>(frame.index),
                 "When calling write with validate_index enabled, input data must be sorted.");
-    return write_frame(partial_key, std::move(frame), slicing_arg, store, de_dup_map, sparsify_floats);
+    return write_frame(std::move(partial_key), std::move(frame), slicing_arg, store, de_dup_map, sparsify_floats);
 }
 
 namespace {
@@ -332,8 +332,7 @@ VersionedItem update_impl(
     frame.set_bucketize_dynamic(bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, frame);
 
-    auto fut_slice_keys = slice_and_write(frame, slicing_arg, get_partial_key_gen(frame, IndexPartialKey{stream_id, update_info.next_version_id_}), store);
-    auto new_slice_and_keys = folly::collect(fut_slice_keys).wait().value();
+    auto new_slice_and_keys = slice_and_write(frame, slicing_arg, get_partial_key_gen(frame, IndexPartialKey{stream_id, update_info.next_version_id_}), store).wait().value();
     std::sort(std::begin(new_slice_and_keys), std::end(new_slice_and_keys));
 
     IndexRange orig_filter_range;

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -40,28 +40,25 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_latest_v
 }
 
 // The logic here is the same as get_latest_undeleted_version_and_next_version_id
-inline std::unordered_map<StreamId, version_store::UpdateInfo> batch_get_latest_undeleted_version_and_next_version_id(
+inline std::vector<folly::Future<version_store::UpdateInfo>> batch_get_latest_undeleted_version_and_next_version_id_async(
         const std::shared_ptr<Store> &store,
         const std::shared_ptr<VersionMap> &version_map,
         const std::vector<StreamId> &stream_ids) {
     ARCTICDB_SAMPLE(BatchGetLatestUndeletedVersionAndNextVersionId, 0)
-    std::unordered_map<StreamId, version_store::UpdateInfo> output;
-
-    async::submit_tasks_for_range(stream_ids,
-                                  [store, version_map](auto& stream_id) {
-        return async::submit_io_task(CheckReloadTask{store,
+    std::vector<folly::Future<version_store::UpdateInfo>> vector_fut;
+    for (auto& stream_id: stream_ids){
+        vector_fut.push_back(async::submit_io_task(CheckReloadTask{store,
                                                      version_map,
                                                      stream_id,
-                                                     LoadParameter{LoadType::LOAD_LATEST_UNDELETED}});
-        },
-        [&output](auto& id, auto&& entry) {
-        auto latest_version = entry->get_first_index(true);
-        auto latest_undeleted_version = entry->get_first_index(false);
-        VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
-        output[id] =  {latest_undeleted_version, next_version_id};
-    });
-
-    return output;
+                                                     LoadParameter{LoadType::LOAD_LATEST_UNDELETED}})
+        .thenValue([](auto&& entry){
+            auto latest_version = entry->get_first_index(true);
+            auto latest_undeleted_version = entry->get_first_index(false);
+            VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
+            return version_store::UpdateInfo{latest_undeleted_version, next_version_id};
+        }));
+    }
+    return vector_fut;
 }
 
 inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_specific_version(
@@ -201,7 +198,7 @@ inline std::optional<AtomKey> get_key_for_version_query(
         });
 }
 
-inline std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions(
+inline std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions_async(
     const std::shared_ptr<Store>& store,
     const std::shared_ptr<VersionMap>& version_map,
     const std::vector<StreamId>& symbols,
@@ -264,12 +261,12 @@ inline void batch_write_and_prune_previous(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const std::vector<AtomKey> &keys,
-    const std::unordered_map<StreamId, version_store::UpdateInfo>& stream_update_info_map) {
+    const std::vector<version_store::UpdateInfo>& stream_update_info_vector) {
     std::vector<folly::Future<folly::Unit>> results;
     results.reserve(keys.size());
-    for (const auto &key : keys) {
-        auto previous_index_key = stream_update_info_map.at(key.id()).previous_index_key_;
-        results.emplace_back(async::submit_io_task(WriteAndPrunePreviousTask{store, version_map, key, previous_index_key}));
+    for(auto key : folly::enumerate(keys)){
+        auto previous_index_key = stream_update_info_vector[key.index].previous_index_key_;
+        results.emplace_back(async::submit_io_task(WriteAndPrunePreviousTask{store, version_map, *key, previous_index_key}));
     }
 
     folly::collect(results).wait();

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -87,11 +87,11 @@ std::vector<InputTensorFrame> create_input_tensor_frames(
 
 std::vector<VersionedItem> PythonVersionStore::batch_write_index_keys_to_version_map(
     const std::vector<AtomKey>& index_keys,
-    const std::unordered_map<StreamId, UpdateInfo>& stream_update_info_map,
+    const std::vector<UpdateInfo>& stream_update_info_vector,
     bool prune_previous_versions) {
 
     if(prune_previous_versions)
-        batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_map);
+        batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_vector);
     else
         batch_write_version(store(), version_map(), index_keys);
 
@@ -116,25 +116,8 @@ std::vector<VersionedItem> PythonVersionStore::batch_write(
     bool prune_previous_versions,
     bool validate_index) {
 
-    std::vector<VersionId> version_ids;
-    auto write_options = get_write_options();
-    auto stream_update_info_map = batch_get_latest_undeleted_version_and_next_version_id(store(),
-                                                                                         version_map(),
-                                                                                         stream_ids);
-    std::vector<std::shared_ptr<DeDupMap>> de_dup_maps;
-    for (const auto &stream_id: stream_ids) {
-        const auto& update_info = stream_update_info_map.at(stream_id);
-        version_ids.push_back(update_info.next_version_id_);
-        if(cfg().write_options().de_duplication()) {
-            auto de_dup_map = get_de_dup_map(stream_id, update_info.previous_index_key_, write_options);
-            de_dup_maps.push_back(de_dup_map);
-        } else {
-            de_dup_maps.emplace_back(std::make_shared<DeDupMap>());
-        }
-    }
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
-    auto index_keys = batch_write_internal(std::move(version_ids), stream_ids, std::move(frames), std::move(de_dup_maps), validate_index);
-    return batch_write_index_keys_to_version_map(index_keys, stream_update_info_map, prune_previous_versions);
+    return batch_write_versioned_dataframe_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index);
 }
 
 std::vector<VersionedItem> PythonVersionStore::batch_append(
@@ -145,20 +128,20 @@ std::vector<VersionedItem> PythonVersionStore::batch_append(
     bool prune_previous_versions,
     bool validate_index) {
     auto write_options = get_write_options();
-    auto stream_update_info_map = batch_get_latest_undeleted_version_and_next_version_id(store(),
-                                                                                         version_map(),
-                                                                                         stream_ids);
+    auto stream_update_info_vector_fut = batch_get_latest_undeleted_version_and_next_version_id_async(store(),
+                                                                                                      version_map(),
+                                                                                                      stream_ids);
+    
+    auto stream_update_info_vector = folly::collect(stream_update_info_vector_fut).via(&async::io_executor()).get();
     std::vector<VersionId> version_ids;
     std::vector<AtomKey> existing_keys;
-    for (const auto &stream_id: stream_ids) {
-        auto update_info = stream_update_info_map.at(stream_id);
-        util::check(update_info.previous_index_key_.has_value(), "Can't batch append to nonexistent symbol {}", stream_id);
+    for (const auto& update_info: stream_update_info_vector) {
         version_ids.push_back(update_info.next_version_id_);
         existing_keys.push_back(*(update_info.previous_index_key_));
     }
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
     auto index_keys = batch_append_internal(std::move(version_ids), stream_ids, std::move(existing_keys), std::move(frames), write_options, validate_index);
-    return batch_write_index_keys_to_version_map(index_keys, stream_update_info_map, prune_previous_versions);
+    return batch_write_index_keys_to_version_map(index_keys, stream_update_info_vector, prune_previous_versions);
 }
 
 void PythonVersionStore::_clear_symbol_list_keys() {
@@ -580,7 +563,7 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     }
 
     auto frames = create_input_tensor_frames(sub_keys, items, norm_metas, user_metas);
-    auto index_keys = batch_write_internal(std::move(version_ids), sub_keys, std::move(frames), std::move(de_dup_maps), false);
+    auto index_keys = folly::collect(batch_write_internal(std::move(version_ids), sub_keys, std::move(frames), std::move(de_dup_maps), false)).get();
     auto multi_key = write_multi_index_entry(store(), index_keys, stream_id, metastruct, user_meta, version_id);
     auto versioned_item = VersionedItem(to_atom(multi_key));
     version_map()->write_version(store(), versioned_item.key_);
@@ -1023,14 +1006,15 @@ std::vector<VersionedItem> PythonVersionStore::batch_write_metadata(
     bool prune_previous_versions) {
     std::vector<std::pair<VersionedItem, py::object>> results;
     std::vector<AtomKey> keys_to_read;
-    auto stream_update_info_map = batch_get_latest_undeleted_version_and_next_version_id(store(),
-                                                                                         version_map(),
-                                                                                         stream_ids);
+    auto stream_update_info_vector_fut = batch_get_latest_undeleted_version_and_next_version_id_async(store(),
+                                                                                                      version_map(),
+                                                                                                      stream_ids);
+    auto stream_update_info_vector = folly::collect(stream_update_info_vector_fut).via(&async::io_executor()).get();
     std::vector<folly::Future<AtomKey>> fut_vec;
     for(const auto& stream_id : folly::enumerate(stream_ids)) {
         arcticdb::proto::descriptors::UserDefinedMetadata user_meta_proto;
         python_util::pb_from_python(user_meta[stream_id.index], user_meta_proto);
-        const auto& update_info = stream_update_info_map.at(*stream_id);
+        const auto& update_info = stream_update_info_vector[stream_id.index];
         util::check(update_info.previous_index_key_.has_value(),
                     "Failed to find latest version to write metadata to for symbol {}",
                     *stream_id);
@@ -1040,7 +1024,7 @@ std::vector<VersionedItem> PythonVersionStore::batch_write_metadata(
     }
     auto index_keys = folly::collect(fut_vec).get();
     if(prune_previous_versions) {
-        batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_map);
+        batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_vector);
     } else {
         batch_write_version(store(), version_map(), index_keys);
     }

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -328,7 +328,7 @@ private:
 
     std::vector<VersionedItem> batch_write_index_keys_to_version_map(
         const std::vector<AtomKey>& index_keys,
-        const std::unordered_map<StreamId, UpdateInfo>& stream_update_info_map,
+        const std::vector<UpdateInfo>& stream_update_info_vector,
         bool prune_previous_versions);
 
     void delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key);

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -40,7 +40,8 @@ from arcticdb.util.test import configure_test_logger, apply_lib_cfg
 from arcticdb.version_store.helper import ArcticMemoryConfig
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._normalization import MsgPackNormalizer
-
+from arcticdb.options import LibraryOptions
+from arcticdb_ext.storage import Library
 
 configure_test_logger()
 
@@ -229,6 +230,30 @@ def version_store_factory(lib_name, tmpdir):
             result._library = None
 
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _arctic_library_factory_impl(used, name, arctic_client, library_options) -> Library:
+    """Common logic behind all the factory fixtures"""
+    name = name or default_name
+    if name == "_unique_":
+        name = name + str(len(used))
+    assert name not in used, f"{name} is already in use"
+    arctic_client.create_library(name, library_options)
+    out = arctic_client[name]
+    used[name] = out
+    return out
+
+
+@pytest.fixture(scope="function")
+def library_factory(arctic_client, lib_name):
+    used: Dict[str, Library] = {}
+
+    def create_library(
+        library_options: Optional[LibraryOptions] = None,
+    ) -> Library:
+        return _arctic_library_factory_impl(used, lib_name, arctic_client, library_options)
+
+    return create_library
 
 
 @pytest.fixture


### PR DESCRIPTION
- This pull request introduces per-symbol parallelism for the write_batch method, which requires significant implementation changes using the Folly Futures API. 
- The way Folly Futures work requires creating a chain of futures for each independent read, which ultimately converges into a single future containing all the individual writes. This can be visualized as a tree with each individual read representing a branch that has its own independent per-slice read operations, which are also futures. 
- To ensure proper functioning for all write flows, it's important to avoid intermediate .get() calls from the futures of all these flows. Instead, we must call a SINGLE .get() at the end of the entire futures chain, when they converge; otherwise, the system will deadlock. 
- This changes also requires the implementation of the async version of the method `async_batch_get_latest_undeleted_version_and_next_version_id`.
- In our local environment, we observed an approximate 12-fold improvement by writing 2000 symbols occupying a single segment using the changes in this PR compared to the current master. The results with these changes showed 12.37 +- 1.27S, while the results in master were approximately 145s. These experiments were conducted on an 8-core CPU with the number of IO threads incremented to 50 (VersionStore.NumIOThreads = 50).