### PR TITLE
Parallel version write batch  metadata method

### DIFF
--- a/cpp/arcticdb/entity/data_error.hpp
+++ b/cpp/arcticdb/entity/data_error.hpp
@@ -25,30 +25,32 @@ enum class VersionRequestType: uint32_t {
 class DataError {
 public:
     DataError(const StreamId& symbol,
-              const pipelines::VersionQueryType& version_query_type,
               std::string&& exception_string,
+              const std::optional<pipelines::VersionQueryType>& version_query_type=std::nullopt,
               std::optional<ErrorCode> error_code=std::nullopt) :
         symbol_(symbol),
         exception_string_(exception_string),
         error_code_(error_code){
-        util::variant_match(
-                version_query_type,
-                [this] (const pipelines::SnapshotVersionQuery& query) {
-                    version_request_type_ = VersionRequestType::SNAPSHOT;
-                    version_request_data_ = query.name_;
-                },
-                [this] (const pipelines::TimestampVersionQuery& query) {
-                    version_request_type_ = VersionRequestType::TIMESTAMP;
-                    version_request_data_ = query.timestamp_;
-                },
-                [this] (const pipelines::SpecificVersionQuery& query) {
-                    version_request_type_ = VersionRequestType::SPECIFIC;
-                    version_request_data_ = query.version_id_;
-                },
-                [this] (const std::monostate&) {
-                    version_request_type_ = VersionRequestType::LATEST;
-                }
-        );
+        if (version_query_type.has_value()){
+            util::variant_match(
+                    *version_query_type,
+                    [this] (const pipelines::SnapshotVersionQuery& query) {
+                        version_request_type_ = VersionRequestType::SNAPSHOT;
+                        version_request_data_ = query.name_;
+                    },
+                    [this] (const pipelines::TimestampVersionQuery& query) {
+                        version_request_type_ = VersionRequestType::TIMESTAMP;
+                        version_request_data_ = query.timestamp_;
+                    },
+                    [this] (const pipelines::SpecificVersionQuery& query) {
+                        version_request_type_ = VersionRequestType::SPECIFIC;
+                        version_request_data_ = query.version_id_;
+                    },
+                    [this] (const std::monostate&) {
+                        version_request_type_ = VersionRequestType::LATEST;
+                    }
+            );
+        }
     }
 
     DataError() = delete;
@@ -63,11 +65,11 @@ public:
         return fmt::format("{}", symbol_);
     }
 
-    VersionRequestType version_request_type() const {
+    std::optional<VersionRequestType>  version_request_type() const {
         return version_request_type_;
     }
 
-    std::variant<std::monostate, int64_t, std::string> version_request_data() const {
+    std::optional<std::variant<std::monostate, int64_t, std::string>> version_request_data() const {
         return version_request_data_;
     }
 
@@ -84,24 +86,26 @@ public:
     }
 
     std::string to_string() const {
-        std::string version_request_explanation;
-        switch (version_request_type_) {
-            case VersionRequestType::SNAPSHOT:
-                version_request_explanation = fmt::format("in snapshot '{}'", std::get<std::string>(version_request_data_));
-                break;
-            case VersionRequestType::TIMESTAMP:
-                version_request_explanation = fmt::format("at time '{}'", std::get<int64_t>(version_request_data_));
-                break;
-            case VersionRequestType::SPECIFIC:
-                version_request_explanation = fmt::format("with specified version '{}'", std::get<int64_t>(version_request_data_));
-                break;
-            case VersionRequestType::LATEST:
-                version_request_explanation = fmt::format("with specified version 'latest'");
-                break;
-            default:
-                internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
-                        "Unexpected enum value in DataError::to_string: {}",
-                        static_cast<uint32_t>(version_request_type_));
+        std::string version_request_explanation = "UNKNOWN";
+        if (version_request_type_.has_value()) {
+            switch (*version_request_type_) {
+                case VersionRequestType::SNAPSHOT:
+                    version_request_explanation = fmt::format("in snapshot '{}'", std::get<std::string>(*version_request_data_));
+                    break;
+                case VersionRequestType::TIMESTAMP:
+                    version_request_explanation = fmt::format("at time '{}'", std::get<int64_t>(*version_request_data_));
+                    break;
+                case VersionRequestType::SPECIFIC:
+                    version_request_explanation = fmt::format("with specified version '{}'", std::get<int64_t>(*version_request_data_));
+                    break;
+                case VersionRequestType::LATEST:
+                    version_request_explanation = fmt::format("with specified version 'latest'");
+                    break;
+                default:
+                    internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
+                            "Unexpected enum value in DataError::to_string: {}",
+                            static_cast<uint32_t>(*version_request_type_));
+            }
         }
         return fmt::format(
                 "Version {} of symbol '{}' unable to be retrieved: Error Category: '{}' Exception String: '{}'",
@@ -112,9 +116,9 @@ public:
     }
 private:
     StreamId symbol_;
-    VersionRequestType version_request_type_{VersionRequestType::LATEST};
+    std::optional<VersionRequestType> version_request_type_;
     // int64_t for timestamp and SignedVersionId
-    std::variant<std::monostate, int64_t, std::string> version_request_data_;
+    std::optional<std::variant<std::monostate, int64_t, std::string>> version_request_data_;
     std::string exception_string_;
     std::optional<ErrorCode> error_code_;
 };

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -16,6 +16,7 @@
 #include <pybind11/numpy.h>
 
 namespace arcticdb::convert {
+const char none_char[8] = {'\300', '\000', '\000', '\000', '\000', '\000', '\000', '\000'};
 
 using namespace arcticdb::pipelines;
 
@@ -149,6 +150,39 @@ InputTensorFrame py_ndf_to_frame(
         res.desc.add_field(scalar_field(tensor.data_type(), col_names[i]));
         res.field_tensors.push_back(std::move(tensor));
     }
+
+    ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res.desc);
+    res.set_index_range();
+    return res;
+}
+
+InputTensorFrame py_none_to_frame() {
+    ARCTICDB_SUBSAMPLE_DEFAULT(NormalizeNoneFrame)
+    InputTensorFrame res;
+    res.num_rows = 0u;
+
+    arcticdb::proto::descriptors::NormalizationMetadata::MsgPackFrame msg;
+    msg.set_size_bytes(1);
+    msg.set_version(1);
+    res.norm_meta.mutable_msg_pack_frame()->CopyFrom(msg);
+
+    // Fill index
+    res.index = stream::RowCountIndex();
+    res.desc.set_index_type(IndexDescriptor::ROWCOUNT);
+
+    // Fill tensors
+    auto col_name = "bytes";
+    auto sorted = SortedValue::UNKNOWN;
+
+    res.set_sorted(sorted);
+
+    ssize_t strides = 8;
+    ssize_t shapes = 1;
+
+    auto tensor = NativeTensor{8, 1, &strides, &shapes, DataType::UINT64, 8, none_char};
+    res.num_rows = std::max(res.num_rows, tensor.shape(0));
+    res.desc.add_field(scalar_field(tensor.data_type(), col_name));
+    res.field_tensors.push_back(std::move(tensor));
 
     ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res.desc);
     res.set_index_range();

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -48,4 +48,6 @@ pipelines::InputTensorFrame py_ndf_to_frame(
     const py::object &norm_meta,
     const py::object &user_meta);
 
+pipelines::InputTensorFrame py_none_to_frame();
+
 } // namespace arcticdb::convert

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -271,6 +271,11 @@ public:
         bool validate_index
     );
 
+    std::vector<std::variant<VersionedItem, DataError>> batch_write_versioned_metadata_internal(
+        const std::vector<StreamId>& stream_ids,
+        bool prune_previous_versions,
+        std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>&& user_meta_protos);
+
     std::vector<AtomKey> batch_append_internal(
         std::vector<VersionId> version_ids,
         const std::vector<StreamId>& stream_ids,
@@ -355,9 +360,10 @@ public:
 
     folly::Future<VersionedItem> write_index_key_to_version_map_async(
         const std::shared_ptr<VersionMap> &version_map,
-        const AtomKey&& index_key,
-        const UpdateInfo& stream_update_info,
-        bool prune_previous_versions);
+        AtomKey&& index_key,
+        UpdateInfo&& stream_update_info,
+        bool prune_previous_versions,
+        bool add_new_symbol);
 
     std::vector<folly::Future<folly::Unit>> batch_write_version_and_prune_if_needed(
         const std::vector<AtomKey>& index_keys,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -237,8 +237,6 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def_property_readonly("end", &pipelines::ColRange::end)
         .def_property_readonly("diff", &pipelines::ColRange::diff);
 
-
-
     auto adapt_read_dfs = [](std::vector<std::variant<ReadResult, DataError>> && ret) -> py::list {
         py::list lst;
         for (auto &res: ret) {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -269,8 +269,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         bool prune_previous_versions,
         bool validate_index);
 
-    std::vector<VersionedItem> batch_write_metadata(
-        std::vector<StreamId> stream_ids,
+    std::vector<std::variant<VersionedItem, DataError>> batch_write_metadata(
+        const std::vector<StreamId>& stream_ids,
         const std::vector<py::object>& user_meta,
         bool prune_previous_versions);
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -165,13 +165,46 @@ class WritePayload:
         self.metadata = metadata
 
     def __repr__(self):
-        return f"WriteArgs(symbol={self.symbol}, data_id={id(self.data)}, metadata={self.metadata})"
+        return f"WritePayload(symbol={self.symbol}, data_id={id(self.data)}, metadata={self.metadata})"
 
     def __iter__(self):
         yield self.symbol
         yield self.data
         if self.metadata is not None:
             yield self.metadata
+
+
+class WriteMetadataPayload:
+    """
+    WriteMetadataPayload is designed to enable batching of multiple operations with an API that mirrors the singular
+    ``write_metadata`` API.
+
+    Construction of ``WriteMetadataPayload`` objects is only required for batch write metadata operations.
+
+    One instance of ``WriteMetadataPayload`` refers to one unit that can be written through to ArcticDB.
+    """
+
+    def __init__(self, symbol: str, metadata: Any):
+        """
+        Constructor.
+
+        Parameters
+        ----------
+        symbol : str
+            Symbol name. Limited to 255 characters. The following characters are not supported in symbols:
+            ``"*", "&", "<", ">"``
+        metadata : Any
+            metadata to persist along with the symbol.
+        """
+        self.symbol = symbol
+        self.metadata = metadata
+
+    def __repr__(self):
+        return f"WriteMetadataPayload(symbol={self.symbol}, metadata={self.metadata})"
+
+    def __iter__(self):
+        yield self.symbol
+        yield self.metadata
 
 
 class ReadRequest(NamedTuple):
@@ -1045,6 +1078,57 @@ class Library:
             Structure containing metadata and version number of the affected symbol in the store.
         """
         return self._nvs.write_metadata(symbol, metadata, prune_previous_version=False)
+
+    def write_metadata_batch(
+        self, write_metadata_payloads: List[WriteMetadataPayload], prune_previous_versions=None
+    ) -> List[Union[VersionedItem, DataError]]:
+        """
+        Write metadata to multiple symbols in a batch fashion. This is more efficient than making multiple `write_metadata` calls
+        in succession as some constant-time operations can be executed only once rather than once for each element of
+        `write_metadata_payloads`.
+        Note that this isn't an atomic operation - it's possible for the metadata for one symbol to be fully written and
+        readable before another symbol.
+        Parameters
+        ----------
+        write_metadata_payloads : `List[WriteMetadataPayload]`
+            Symbols and their corresponding metadata. There must not be any duplicate symbols in `payload`.
+        prune_previous_version : `Optional[bool]`, default=None
+            Remove previous versions from version list. Uses library default if left as None.
+
+        Returns
+        -------
+        List[Union[VersionedItem, DataError]]
+            List of versioned items. The data attribute will be None for each versioned item.
+            i-th entry corresponds to i-th element of `write_metadata_payloads`. Each result correspond to
+            a structure containing metadata and version number of the affected symbol in the store.
+            If any internal exception is raised, a DataError object is returned, with symbol,
+            error_code, error_category, and exception_string properties.
+
+        Raises
+        ------
+        ArcticDuplicateSymbolsInBatchException
+            When duplicate symbols appear in write_metadata_payloads.
+
+        Examples
+        --------
+
+        Writing a simple batch:
+
+        >>> payload_1 = WriteMetadataPayload("symbol_1", {'the': 'metadata_1'})
+        >>> payload_2 = WriteMetadataPayload("symbol_2", {'the': 'metadata_2'})
+        >>> items = lib.write_metadata_batch([payload_1, payload_2])
+        >>> lib.read_metadata("symbol_1")
+        {'the': 'metadata_1'}
+        >>> lib.read_metadata("symbol_2")
+        {'the': 'metadata_2'}
+        """
+
+        self._raise_if_duplicate_symbols_in_batch(write_metadata_payloads)
+        return self._nvs._batch_write_metadata_to_versioned_items(
+            [p.symbol for p in write_metadata_payloads],
+            [p.metadata for p in write_metadata_payloads],
+            prune_previous_version=prune_previous_versions,
+        )
 
     def snapshot(
         self,

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -304,6 +304,25 @@ def test_basic_write_read_update_and_append(arctic_library):
     assert read_metadata.version == 1
 
 
+def test_write_metadata_with_none(arctic_library):
+    lib = arctic_library
+    symbol = "symbol"
+    meta = {"meta_" + str(symbol): 0}
+
+    result_write = lib.write_metadata(symbol, meta)
+    assert result_write.version == 0
+
+    read_meta_symbol = lib.read_metadata(symbol)
+    assert read_meta_symbol.data is None
+    assert read_meta_symbol.metadata == meta
+    assert read_meta_symbol.version == 0
+
+    read_symbol = lib.read(symbol)
+    assert read_symbol.data is None
+    assert read_symbol.metadata == meta
+    assert read_symbol.version == 0
+
+
 def staged_write(sym, arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})


### PR DESCRIPTION
- This pull request introduces per-symbol parallelism for the ```write_batch_metadata``` method, which requires significant implementation changes using the Folly Futures API.
- The way Folly Futures work requires creating a chain of futures for each independent read, which ultimately converges into a single future containing all the individual writes. This can be visualized as a tree with each individual read representing a branch that has its own independent per-slice read operations, which are also futures.
- To ensure proper functioning for all write metadata flows, it's important to avoid intermediate .get() calls from the futures of all these flows. Instead, we must call a SINGLE .get() at the end of the entire futures chain, when they converge; otherwise, the system will deadlock.
- This changes also reuses the async method async_batch_get_latest_undeleted_version_and_next_version_id, which is also used by write_batch.
- In our local environment, we observed an approximate 37-fold improvement by writing metadata for 2000 symbols using the changes in this PR compared to writing the same metadata by the non-batch version of this method (write_metadata). The results with these changes showed 5.59S by using the write batch metadata method, while the results by using the non-batch version of the method were approximately 145s. These experiments were conducted on an 8-core CPU with the number of IO threads incremented to 50 (VersionStore.NumIOThreads = 50).