### PR TITLE
conda-build: Use fmt < 10

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -26,7 +26,8 @@ dependencies:
   - libprotobuf < 4
   - bitmagic
   - spdlog
-  - fmt
+  # Incompatibility with fmt last version
+  - fmt < 10
   - folly >2022.10.31 # latest version published on vcpkg
   # Vendored build dependencies (see `cpp/thirdparty`)
   # Versions must be kept in sync


### PR DESCRIPTION
#### Reference Issues/PRs

Resolves recent failures on the CI as first observed for #478 (see [those logs](https://github.com/man-group/ArcticDB/actions/runs/5245199328)).

#### What does this implement/fix? Explain your changes.

ArcticDB does not support fmt 10 and above for now

#### Any other comments?

cc @mehertz 

