### PR TITLE
Add UTC timezone info to dates returned by SymbolDescription::get_description

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -127,7 +127,7 @@ class SymbolDescription(NamedTuple):
     index: NameWithDType
     index_type: str
     row_count: int
-    last_update_time: datetime.datetime
+    last_update_time: datetime64
     date_range: Tuple[datetime.datetime, datetime.datetime]
 
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1338,10 +1338,10 @@ class Library:
             For documentation on each field.
         """
         info = self._nvs.get_info(symbol, as_of)
-
-        last_update_time = pd.to_datetime(info["last_update"])
+        last_update_time = pd.to_datetime(info["last_update"], utc=True)
         columns = tuple(NameWithDType(n, t) for n, t in zip(info["col_names"]["columns"], info["dtype"]))
         index = NameWithDType(info["col_names"]["index"], info["col_names"]["index_dtype"])
+        date_range = tuple(map(lambda x: x.replace(tzinfo=datetime.timezone.utc), info["date_range"]))
 
         return SymbolDescription(
             columns=columns,
@@ -1349,7 +1349,7 @@ class Library:
             row_count=info["rows"],
             last_update_time=last_update_time,
             index_type=info["index_type"],
-            date_range=info["date_range"],
+            date_range=date_range,
         )
 
     def get_description_batch(self, symbols: List[Union[str, ReadInfoRequest]]) -> List[SymbolDescription]:

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -6,6 +6,8 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 import sys
+
+import pytz
 from arcticdb_ext.exceptions import InternalException
 from arcticdb.exceptions import ArcticNativeNotYetImplemented
 
@@ -23,7 +25,7 @@ import math
 import re
 import pytest
 import pandas as pd
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 import numpy as np
 from arcticdb.util.test import assert_frame_equal
 
@@ -1106,12 +1108,13 @@ def test_get_description(arctic_library):
     original_info = lib.get_description("symbol", as_of=0)
     # then
     assert [c[0] for c in info.columns] == ["column"]
-    assert info.date_range == (datetime(2018, 1, 1), datetime(2018, 1, 6))
+    assert info.date_range == (datetime(2018, 1, 1, tzinfo=timezone.utc), datetime(2018, 1, 6, tzinfo=timezone.utc))
     assert info.index[0] == ["named_index"]
     assert info.index_type == "index"
     assert info.row_count == 6
     assert original_info.row_count == 4
     assert info.last_update_time > original_info.last_update_time
+    assert info.last_update_time.tz == pytz.UTC
 
 
 def test_get_description_batch(arctic_library):


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves: #197

#### What does this implement/fix? Explain your changes.
Add UTC timezone info to dates returned by SymbolDescription::get_description.
Update unit tests

#### Any other comments?


