### PR TITLE
build: Use the same version of folly for vcpkg and conda

### DIFF
--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -158,7 +158,7 @@
     { "name": "double-conversion", "version": "3.2.1" },
     { "name": "fizz", "version-string": "2022.10.31.00" },
     { "name": "fmt", "version": "9.1.0#1" },
-    { "name": "folly", "version-string": "2022.10.31.00#3" },
+    { "name": "folly", "version-string": "2023.05.22.00" },
     { "name": "gflags", "version": "2.2.2#5" },
     { "name": "glog", "version": "0.6.0#2" },
     { "name": "gtest", "version": "1.12.1" },

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -60,6 +60,11 @@
   ],
   "overrides": [
     {
+      "name": "folly",
+      "version-string": "2023.05.22.00",
+      "$comments": "folly has no ABI compatibility from one commit to another. Hence we have to use the exact same version of folly on both build setup. This is the common oldest version of folly on vcpkg and conda-forge."
+    },
+    {
       "name": "openssl",
       "version-string": "1.1.1l"
     },
@@ -158,7 +163,6 @@
     { "name": "double-conversion", "version": "3.2.1" },
     { "name": "fizz", "version-string": "2022.10.31.00" },
     { "name": "fmt", "version": "9.1.0#1" },
-    { "name": "folly", "version-string": "2023.05.22.00" },
     { "name": "gflags", "version": "2.2.2#5" },
     { "name": "glog", "version": "0.6.0#2" },
     { "name": "gtest", "version": "1.12.1" },

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -28,7 +28,10 @@ dependencies:
   - spdlog
   # Incompatibility with fmt last version
   - fmt < 10
-  - folly >2022.10.31 # latest version published on vcpkg
+  # folly has no ABI compatibility from one commit to another.
+  # Hence we have to use the exact same version of folly on both build setup.
+  # This is the common oldest version of folly on vcpkg and conda-forge
+  - folly==2023.05.22.00
   # Vendored build dependencies (see `cpp/thirdparty`)
   # Versions must be kept in sync
   - xxhash


### PR DESCRIPTION
#### Reference Issues/PRs

Relates to https://github.com/man-group/ArcticDB/pull/449.

#### What does this implement/fix? Explain your changes.

[folly does not guarantee ABI compatibility](https://github.com/facebook/folly/#build-notes). This currently manifests with missing symbols when linking against folly without specifying a specific version (see [those logs](https://github.com/man-group/ArcticDB/actions/runs/5253659204/jobs/9491264135#step:6:405)).

We need to find a common version of folly on both vcpkg and conda-forge.

#### Any other comments?


