### PR TITLE
Set prune_previous_versions as False by default

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -275,7 +275,7 @@ class Library:
         symbol: str,
         data: NormalizableType,
         metadata: Any = None,
-        prune_previous_versions: bool = True,
+        prune_previous_versions: bool = False,
         staged=False,
         validate_index=True,
     ) -> VersionedItem:
@@ -314,7 +314,7 @@ class Library:
             Data to be written. To write non-normalizable data, use `write_pickle`.
         metadata : Any, default=None
             Optional metadata to persist along with the symbol.
-        prune_previous_versions : bool, default=True
+        prune_previous_versions : bool, default=False
             Removes previous (non-snapshotted) versions from the database.
         staged : bool, default=False
             Whether to write to a staging area rather than immediately to the library.
@@ -382,7 +382,7 @@ class Library:
         )
 
     def write_pickle(
-        self, symbol: str, data: Any, metadata: Any = None, prune_previous_versions: bool = True, staged=False
+        self, symbol: str, data: Any, metadata: Any = None, prune_previous_versions: bool = False, staged=False
     ) -> VersionedItem:
         """
         See `write`. This method differs from `write` only in that ``data`` can be of any type that is serialisable via
@@ -455,7 +455,7 @@ class Library:
         raise ArcticUnsupportedDataTypeException(error_message)
 
     def write_batch(
-        self, payloads: List[WritePayload], prune_previous_versions: bool = True, staged=False, validate_index=True
+        self, payloads: List[WritePayload], prune_previous_versions: bool = False, staged=False, validate_index=True
     ) -> List[VersionedItem]:
         """
         Write a batch of multiple symbols.
@@ -464,7 +464,7 @@ class Library:
         ----------
         payloads : `List[WritePayload]`
             Symbols and their corresponding data. There must not be any duplicate symbols in `payload`.
-        prune_previous_versions: `bool`, default=True
+        prune_previous_versions: `bool`, default=False
             See `write`.
         staged: `bool`, default=False
             See `write`.
@@ -529,7 +529,7 @@ class Library:
         )
 
     def write_batch_pickle(
-        self, payloads: List[WritePayload], prune_previous_versions: bool = True, staged=False
+        self, payloads: List[WritePayload], prune_previous_versions: bool = False, staged=False
     ) -> List[VersionedItem]:
         """
         Write a batch of multiple symbols, pickling their data if necessary.
@@ -538,7 +538,7 @@ class Library:
         ----------
         payloads : `List[WritePayload]`
             Symbols and their corresponding data. There must not be any duplicate symbols in `payload`.
-        prune_previous_versions: `bool`, default=True
+        prune_previous_versions: `bool`, default=False
             See `write`.
         staged: `bool`, default=False
             See `write`.

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -421,6 +421,17 @@ def test_prune_previous_versions(arctic_library):
     assert lib["symbol"].metadata == {"tres": "interessant"}
 
 
+def test_non_prune_previous_versions_by_default(arctic_library):
+    lib = arctic_library
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    lib.write("symbol", df)
+    lib.write("symbol", df)
+    lib.write("symbol", df)
+    lib.write("symbol", df)
+    lib.write("symbol", df)
+    assert len(lib.list_versions("symbol")) == 5
+
+
 def test_delete_version(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -676,8 +687,8 @@ def test_write_with_unpacking(arctic_library):
 def test_prune_previous_versions_with_write(arctic_library):
     lib = arctic_library
     # When
-    lib.write("sym", pd.DataFrame())
-    lib.write("sym", pd.DataFrame({"col": [1, 2, 3]}), prune_previous_versions=False)
+    lib.write("sym", pd.DataFrame(), prune_previous_versions=True)
+    lib.write("sym", pd.DataFrame({"col": [1, 2, 3]}))
 
     # Then
     v0 = lib.read("sym", as_of=0).data
@@ -687,7 +698,7 @@ def test_prune_previous_versions_with_write(arctic_library):
     assert not v1.empty
 
     # We prune by default
-    lib.write("sym", pd.DataFrame())
+    lib.write("sym", pd.DataFrame(), prune_previous_versions=True)
     with pytest.raises(NoDataFoundException):
         lib.read("sym", as_of=0)
     with pytest.raises(NoDataFoundException):


### PR DESCRIPTION
prune_previous_versions=True is a usability concern. If you intend to keep history but forget to call this argument once, you lose all your history. Best to set to None (for potential future library level option), or False if we want to require users to manually clean up versions from now onwards. This PR, set this value as False by default.

