### PR TITLE
Print a warning if the user should expect `list_symbols` to be slow

### DIFF
--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -91,8 +91,8 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
             }, std::get<std::string>(compaction_id));
     }
 
-    SYMBOL_LIST_RUNTIME_LOG("found_last=", found_last);
-    SYMBOL_LIST_RUNTIME_LOG("has_newer=", has_newer);
+    SYMBOL_LIST_RUNTIME_LOG_VAL("found_last={}", found_last);
+    SYMBOL_LIST_RUNTIME_LOG_VAL("has_newer={}", has_newer);
     return (!maybe_last_compaction || found_last) && !has_newer;
 }
 
@@ -119,7 +119,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
             stream_ids.push_back(id);
 
             if (stream_ids.size() == this->max_delta_ * 2 && !warned_expected_slowdown_) {
-                log::storage().warn(
+                log::version().warn(
                         "Warning - no compacted symbol list cache found. "
                         "`list_symbols` may take longer than expected. \n\n"
                         "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
@@ -145,7 +145,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
         const StreamId& stream_id,
         timestamp creation_ts)  {
 
-        SYMBOL_LIST_RUNTIME_LOG("Writing following number of symbols to symbol list cache: ", symbols.size());
+        SYMBOL_LIST_RUNTIME_LOG_VAL("Writing following number of symbols to symbol list cache: {}", symbols.size());
         SegmentInMemory list_segment{symbol_stream_descriptor(stream_id)};
 
         for(const auto& symbol : symbols) {
@@ -177,7 +177,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
             const folly::Range<KeyVectorItr>& keys) {
         SYMBOL_LIST_RUNTIME_LOG("Loading symbols from symbol list keys");
         bool read_compaction = false;
-        int uncompacted_keys_found = 0;
+        uint64_t uncompacted_keys_found = 0;
         CollectionType symbols{};
         for(const auto& key : keys) {
             if(key.id() == compaction_id) {
@@ -187,7 +187,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
             else {
                 uncompacted_keys_found++;
                 if (uncompacted_keys_found == this->max_delta_ * 2 && !warned_expected_slowdown_) {
-                    log::storage().warn(
+                    log::version().warn(
                             "Warning - symbol list cache is significantly out of date. "
                             "`list_symbols` may take longer than expected. \n\n"
                             "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
@@ -207,9 +207,9 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
                 }
             }
         }
-        SYMBOL_LIST_RUNTIME_LOG("Post load, got following number of symbols: ", symbols.size());
+        SYMBOL_LIST_RUNTIME_LOG_VAL("Post load, got following number of symbols: {}", symbols.size());
         if(!read_compaction) {
-            SYMBOL_LIST_RUNTIME_LOG("Read no compacted segment from symbol list of size:", keys.size());
+            SYMBOL_LIST_RUNTIME_LOG_VAL("Read no compacted segment from symbol list of size: {}", keys.size());
         }
         return symbols;
     }

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -91,7 +91,8 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
             }, std::get<std::string>(compaction_id));
     }
 
-    SYMBOL_LIST_RUNTIME_LOG("found_last={}, has_newer={}", found_last, has_newer);
+    SYMBOL_LIST_RUNTIME_LOG("found_last=", found_last);
+    SYMBOL_LIST_RUNTIME_LOG("has_newer=", has_newer);
     return (!maybe_last_compaction || found_last) && !has_newer;
 }
 
@@ -116,6 +117,16 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
         store->iterate_type(KeyType::VERSION_REF, [&] (const auto& key) {
             auto id = variant_key_id(key);
             stream_ids.push_back(id);
+
+            if (stream_ids.size() == this->max_delta_ * 2 && !warned_expected_slowdown_) {
+                log::storage().warn(
+                        "Warning - no compacted symbol list cache found. "
+                        "`list_symbols` may take longer than expected. \n\n"
+                        "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
+                        "To resolve, run `list_symbols` through to completion to compact the symbol list cache.");
+
+                warned_expected_slowdown_ = true;
+            }
         });
         auto res = batch_get_latest_version(store, version_map_, stream_ids, false);
 
@@ -134,7 +145,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
         const StreamId& stream_id,
         timestamp creation_ts)  {
 
-        SYMBOL_LIST_RUNTIME_LOG("Writing {} symbols to symbol list cache", symbols.size());
+        SYMBOL_LIST_RUNTIME_LOG("Writing following number of symbols to symbol list cache: ", symbols.size());
         SegmentInMemory list_segment{symbol_stream_descriptor(stream_id)};
 
         for(const auto& symbol : symbols) {
@@ -166,6 +177,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
             const folly::Range<KeyVectorItr>& keys) {
         SYMBOL_LIST_RUNTIME_LOG("Loading symbols from symbol list keys");
         bool read_compaction = false;
+        int uncompacted_keys_found = 0;
         CollectionType symbols{};
         for(const auto& key : keys) {
             if(key.id() == compaction_id) {
@@ -173,6 +185,16 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
                 read_compaction = true;
             }
             else {
+                uncompacted_keys_found++;
+                if (uncompacted_keys_found == this->max_delta_ * 2 && !warned_expected_slowdown_) {
+                    log::storage().warn(
+                            "Warning - symbol list cache is significantly out of date. "
+                            "`list_symbols` may take longer than expected. \n\n"
+                            "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
+                            "To resolve, run `list_symbols` through to completion frequently.");
+
+                    warned_expected_slowdown_ = true;
+                }
                 const auto& action = key.id();
                 const auto& symbol = key.start_index();
                 if(action == StreamId{DeleteSymbol}) {
@@ -185,9 +207,9 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
                 }
             }
         }
-        SYMBOL_LIST_RUNTIME_LOG("Post load, got {} symbols", symbols.size());
+        SYMBOL_LIST_RUNTIME_LOG("Post load, got following number of symbols: ", symbols.size());
         if(!read_compaction) {
-            SYMBOL_LIST_RUNTIME_LOG("Read no compacted segment from symbol list of size {}", keys.size());
+            SYMBOL_LIST_RUNTIME_LOG("Read no compacted segment from symbol list of size:", keys.size());
         }
         return symbols;
     }

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -30,7 +30,10 @@
 #include <mutex>
 
 // FUTURE(GitHub #297)
-#define SYMBOL_LIST_RUNTIME_LOG(...) ARCTICDB_RUNTIME_DEBUG(log::version(), "Symbol List: {}: ", __func__, __VA_ARGS__)
+#define SYMBOL_LIST_RUNTIME_LOG(message, ...) SYMBOL_LIST_RUNTIME_LOG_IMPL(message, ##__VA_ARGS__, DEFAULT_VAL)
+#define SYMBOL_LIST_RUNTIME_LOG_IMPL(message, value, ...) ARCTICDB_RUNTIME_DEBUG(log::version(), "Symbol List: {}: {} {}", __func__, message, value)
+
+#define DEFAULT_VAL ""
 
 namespace arcticdb {
 
@@ -50,6 +53,7 @@ class SymbolList {
     StreamId type_holder_;
     uint64_t max_delta_ = 0;
     std::shared_ptr<VersionMap> version_map_;
+    bool warned_expected_slowdown_ = false;
 
   public:
     explicit SymbolList(std::shared_ptr<VersionMap> version_map, StreamId type_indicator = StringId()) :

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -30,10 +30,8 @@
 #include <mutex>
 
 // FUTURE(GitHub #297)
-#define SYMBOL_LIST_RUNTIME_LOG(message, ...) SYMBOL_LIST_RUNTIME_LOG_IMPL(message, ##__VA_ARGS__, DEFAULT_VAL)
-#define SYMBOL_LIST_RUNTIME_LOG_IMPL(message, value, ...) ARCTICDB_RUNTIME_DEBUG(log::version(), "Symbol List: {}: {} {}", __func__, message, value)
-
-#define DEFAULT_VAL ""
+#define SYMBOL_LIST_RUNTIME_LOG(message) ARCTICDB_RUNTIME_DEBUG(log::version(), "Symbol List: {}: " message, __func__)
+#define SYMBOL_LIST_RUNTIME_LOG_VAL(message, value) ARCTICDB_RUNTIME_DEBUG(log::version(), "Symbol List: {}: " message, __func__, value)
 
 namespace arcticdb {
 
@@ -53,7 +51,7 @@ class SymbolList {
     StreamId type_holder_;
     uint64_t max_delta_ = 0;
     std::shared_ptr<VersionMap> version_map_;
-    bool warned_expected_slowdown_ = false;
+    std::atomic<bool> warned_expected_slowdown_ = false;
 
   public:
     explicit SymbolList(std::shared_ptr<VersionMap> version_map, StreamId type_indicator = StringId()) :
@@ -65,7 +63,7 @@ class SymbolList {
     CollectionType load(const std::shared_ptr<Store>& store, bool no_compaction);
 
     std::vector<StreamId> get_symbols(const std::shared_ptr<Store>& store, bool no_compaction=false) {
-        SYMBOL_LIST_RUNTIME_LOG("no_compaction={}", no_compaction); // function name logged in macro
+        SYMBOL_LIST_RUNTIME_LOG_VAL("no_compaction={}", no_compaction); // function name logged in macro
         auto symbols = load(store, no_compaction);
         return {std::make_move_iterator(symbols.begin()), std::make_move_iterator(symbols.end())};
     }
@@ -76,12 +74,12 @@ class SymbolList {
     }
 
     void add_symbol(const std::shared_ptr<Store>& store, const StreamId& symbol) {
-        SYMBOL_LIST_RUNTIME_LOG("{}", symbol);
+        SYMBOL_LIST_RUNTIME_LOG_VAL("{}", symbol);
         write_symbol(store, symbol);
     }
 
     void remove_symbol(const std::shared_ptr<Store>& store, const StreamId& symbol) {
-        SYMBOL_LIST_RUNTIME_LOG("{}", symbol);
+        SYMBOL_LIST_RUNTIME_LOG_VAL("{}", symbol);
         delete_symbol(store, symbol);
     }
 

--- a/docs/mkdocs/docs/technical/on_disk_storage.md
+++ b/docs/mkdocs/docs/technical/on_disk_storage.md
@@ -99,6 +99,16 @@ We will soon be adding an API to perform exactly this operation, re-slicing data
 
 ### Symbol List Caching
 
+
+!!! Speeding up listing symbols
+
+    The below documentation details the architecture for the symbol list cache.
+    
+    It explains that to speed up `list_symbols`, **simply run `list_symbols` through to completion frequently**. 
+    The cache is built on first run and _compacted_ afterwards. 
+    This will speed up `list_symbols` for **all accessors of the library - not just the user that runs **`list_symbols`. 
+
+
 `list_symbols` is a common operation to perform on an ArcticDB library. As this returns a list of "live" symbols (those for which at least one version has not been deleted), using the data structures described above, this involves:
 
 * Loading a list of [version reference keys](#key-types) in the library.
@@ -130,4 +140,4 @@ Without any housekeeping, this process could lead to unbounded growth in the num
 
 They would be compacted into a single object stating that "symbol1" and "symbol2" were both alive at time t3. The key for this object is of the form `<library prefix>/sl/*sSt*__symbols__*0*t3*<content hash>*0*0`.
 
-Astute observers will correctly take issue with basing logical decisions on timestamps in a purely client-side database with no synchronisation between clocks of different clients enforced. As such, this cache can diverge from reality, if two different clients create and delete the same symbol at about the same time, and this is the most likely cause of odd behaviour such as `lib.read(symbol)` working, but `symbol in lib.list_symols()` returning `False`. If this happens, `lib.reload_symbol_list()` should resolve the issue.
+Astute observers will correctly take issue with basing logical decisions on timestamps in a purely client-side database with no synchronisation between clocks of different clients enforced. As such, this cache can diverge from reality, if two different clients create and delete the same symbol at about the same time, and this is the most likely cause of odd behaviour such as `lib.read(symbol)` working, but `symbol in lib.list_symbols()` returning `False`. If this happens, `lib.reload_symbol_list()` should resolve the issue.

--- a/docs/mkdocs/docs/technical/on_disk_storage.md
+++ b/docs/mkdocs/docs/technical/on_disk_storage.md
@@ -72,7 +72,7 @@ Note that where this documentation refers to a _Key Type_ key (for example a _ve
 
 Note that **Atom** keys are immutable. **Reference** keys are not immutable and therefore the associated value can be updated. 
 
-!!! Version Ref
+!!! info "Version Ref"
 
     In this documentation, `Version Reference key` is sometimes shortened to `Version Ref key`. 
 
@@ -100,7 +100,7 @@ We will soon be adding an API to perform exactly this operation, re-slicing data
 ### Symbol List Caching
 
 
-!!! Speeding up listing symbols
+!!! info "Speeding up listing symbols"
 
     The below documentation details the architecture for the symbol list cache.
     


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR:

* Prints a warning if the user should expect `list_symbols` to be slow, linking to the documentation.
* Fixes the symbol list logging - previously it wouldn't render.
* Fixes a typo in the documentation

### Any other comments?

There are no tests in this PR as all changes are either logging changes or documentation changes and neither are easy to test. 

The two warnings are:

```
[arcticdb] [warning] Warning - symbol list cache is significantly out of date. `list_symbols` may take longer than expected. 

See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching

To resolve, run `list_symbols` through to completion frequently.
```

and:

```
[2023-06-15 15:17:40.863] [arcticdb] [warning] Warning - no compacted symbol list cache found. `list_symbols` may take longer than expected. 

See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching

To resolve, run `list_symbols` through to completion to compact the symbol list cache.
```

This also adds the following to our documentation:

![image](https://github.com/man-group/ArcticDB/assets/3106180/3194aa2a-fc03-4ede-a0e9-dcc5161dd4c0)

