### PR TITLE
Fix logging not being configurable from env var

### DIFF
--- a/python/arcticdb/log.py
+++ b/python/arcticdb/log.py
@@ -39,17 +39,17 @@ class _Logger(object):
         _log(self._id, _Lvl.ERROR, msg.format(*args, **kwargs) + "\n" + exc)
 
 
-codec = _Logger(_LoggerId.CODEC)
-inmem = _Logger(_LoggerId.IN_MEM)
-root = _Logger(_LoggerId.ROOT)
-storage = _Logger(_LoggerId.STORAGE)
-version = _Logger(_LoggerId.VERSION)
-memory = _Logger(_LoggerId.MEMORY)
-timings = _Logger(_LoggerId.TIMINGS)
-lock = _Logger(_LoggerId.LOCK)
-schedule = _Logger(_LoggerId.SCHEDULE)
+logger_by_name = {
+    "codec": _Logger(_LoggerId.CODEC),
+    "inmem": _Logger(_LoggerId.IN_MEM),
+    "root": _Logger(_LoggerId.ROOT),
+    "storage": _Logger(_LoggerId.STORAGE),
+    "version": _Logger(_LoggerId.VERSION),
+    "memory": _Logger(_LoggerId.MEMORY),
+    "timings": _Logger(_LoggerId.TIMINGS),
+    "lock": _Logger(_LoggerId.LOCK),
+    "schedule": _Logger(_LoggerId.SCHEDULE),
+}
 
-
-logger_by_name = dict(
-    codec=codec, inmem=inmem, root=root, storage=storage, version=version, memory=memory, timings=timings, lock=lock
-)
+for key, value in logger_by_name.items():
+    globals()[key] = value

--- a/python/arcticdb/tools.py
+++ b/python/arcticdb/tools.py
@@ -57,7 +57,7 @@ def set_config_from_env_vars(env_vars: Dict[str, str]):
                     if config_name.upper() == "ALL":
                         default_log_level = v.upper()
                     else:
-                        log_level_changes[config_name] = v.upper()
+                        log_level_changes[config_name.lower()] = v.upper()
                 else:
                     logging.error("Invalid type for env var %s (value %s), type used %s", k, v, var_type)
             except Exception as e:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Previously setting the logging level via an env var would have no impact. Now setting an env var such as the below works:

```
ARCTICDB_schedule_loglevel=WARN 
```

Also the `schedule` track wasn't even configurable from the Python.


