### PR TITLE
Try removing enum-compat

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ install_requires =
     pandas <2
     attrs
     dataclasses ; python_version < '3.7'
-    enum-compat
     grpcio-tools
     protobuf >=3.5.0.post1 # Per https://github.com/grpc/grpc/blob/v1.45.3/requirements.txt
     xxhash


### PR DESCRIPTION
It shouldn't be necessary on Python > 3.4, which is all that we support anyway.


