### PR TITLE
Add a means of caching data for each symbol such as start time for qu…

### DIFF
--- a/cpp/arcticdb/stream/protobuf_mappings.hpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.hpp
@@ -29,6 +29,16 @@ inline arcticdb::proto::descriptors::NormalizationMetadata make_timeseries_norm_
     return norm_meta;
 }
 
+inline arcticdb::proto::descriptors::NormalizationMetadata make_rowcount_norm_meta(const entity::StreamId& stream_id) {
+    using namespace arcticdb::proto::descriptors;
+    NormalizationMetadata norm_meta;
+    NormalizationMetadata_PandasDataFrame pandas;
+    auto id = std::get<entity::StringId>(stream_id);
+    pandas.mutable_common()->set_name(std::move(id));
+    norm_meta.mutable_df()->CopyFrom(pandas);
+    return norm_meta;
+}
+
 /**
  * Set the minimum defaults into norm_meta. Originally created to synthesize norm_meta for incomplete compaction.
  */

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1066,7 +1066,7 @@ VersionedItem LocalVersionedEngine::append_internal(
     }
 }
 
-VersionedItem LocalVersionedEngine::refresh_symbol_cache() {
+VersionedItem LocalVersionedEngine::refresh_symbol_stats_cache() {
     struct SymbolData {
         StreamId stream_id_;
         timestamp first_index_;
@@ -1410,7 +1410,7 @@ std::unordered_map<KeyType, std::pair<size_t, size_t>> LocalVersionedEngine::sca
         pair.first = keys.size();
         std::vector<stream::StreamSource::ReadContinuation> continuations;
         std::atomic<size_t> key_size{0};
-        for(auto&& key : keys) {
+        for(auto&& key ARCTICDB_UNUSED : keys) {
             continuations.emplace_back([&key_size] (auto&& ks) {
                 auto key_seg = std::move(ks);
                 key_size += key_seg.segment().total_segment_size();

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -281,7 +281,7 @@ public:
 
     timestamp get_update_time_internal(const StreamId &stream_id, const VersionQuery &version_query);
 
-    VersionedItem refresh_symbol_cache();
+    VersionedItem refresh_symbol_stats_cache();
 
     std::vector<timestamp> batch_get_update_times(
             const std::vector<StreamId>& stream_ids,

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -281,6 +281,8 @@ public:
 
     timestamp get_update_time_internal(const StreamId &stream_id, const VersionQuery &version_query);
 
+    VersionedItem refresh_symbol_cache();
+
     std::vector<timestamp> batch_get_update_times(
             const std::vector<StreamId>& stream_ids,
             const std::vector<VersionQuery>& version_queries);
@@ -324,6 +326,10 @@ public:
         const std::optional<AtomKey>& maybe_prev,
         const WriteOptions& write_options
     );
+
+    StreamId symbol_cache_id() {
+        return "__symbol_cache__";
+    }
 
     std::unordered_map<KeyType, std::pair<size_t, size_t>> scan_object_sizes();
     std::shared_ptr<Store>& _test_get_store() { return store_; }
@@ -375,7 +381,6 @@ protected:
     SpecificAndLatestVersionKeys get_stream_index_map(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
-
 
 private:
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -577,8 +577,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("latest_timestamp",
              &PythonVersionStore::latest_timestamp,
              "Returns latest timestamp of a symbol")
-        .def("refresh_symbol_cache",
-            &PythonVersionStore::refresh_symbol_cache,
+        .def("refresh_symbol_stats_cache",
+            &PythonVersionStore::refresh_symbol_stats_cache,
             "Refresh the cache of symbol start and end times and sizes")
         .def("symbol_cache_name",
              &PythonVersionStore::symbol_cache_id,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -577,6 +577,12 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("latest_timestamp",
              &PythonVersionStore::latest_timestamp,
              "Returns latest timestamp of a symbol")
+        .def("refresh_symbol_cache",
+            &PythonVersionStore::refresh_symbol_cache,
+            "Refresh the cache of symbol start and end times and sizes")
+        .def("symbol_cache_name",
+             &PythonVersionStore::symbol_cache_id,
+             "Get the name of the symbol data cache")
         ;
 
     py::class_<LocalVersionedEngine>(version, "VersionedEngine")

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2605,17 +2605,15 @@ class NativeVersionStore:
     def library_tool(self) -> LibraryTool:
         return LibraryTool(self.library())
 
-    def generate_symbol_stats(self):
-        self.version_store.refresh_symbol_cache()
+    def refresh_symbol_stats_cache(self):
+        self.version_store.refresh_symbol_stats_cache()
 
     def get_symbol_stats(
         self,
         as_of: Optional[VersionQueryInput] = None,
         columns: Optional[List[str]] = None,
-        query_builder: Optional[QueryBuilder] = None):
+        query_builder: Optional[QueryBuilder] = None,
+    ):
         return self.read(
-            self.version_store.symbol_cache_name(),
-            as_of=as_of,
-            columns=columns,
-            query_builder=query_builder
+            self.version_store.symbol_cache_name(), as_of=as_of, columns=columns, query_builder=query_builder
         )

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2604,3 +2604,18 @@ class NativeVersionStore:
 
     def library_tool(self) -> LibraryTool:
         return LibraryTool(self.library())
+
+    def generate_symbol_stats(self):
+        self.version_store.refresh_symbol_cache()
+
+    def get_symbol_stats(
+        self,
+        as_of: Optional[VersionQueryInput] = None,
+        columns: Optional[List[str]] = None,
+        query_builder: Optional[QueryBuilder] = None):
+        return self.read(
+            self.version_store.symbol_cache_name(),
+            as_of=as_of,
+            columns=columns,
+            query_builder=query_builder
+        )

--- a/python/tests/unit/arcticdb/test_symbol_stats.py
+++ b/python/tests/unit/arcticdb/test_symbol_stats.py
@@ -1,0 +1,34 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import pandas as pd
+import numpy as np
+import random
+
+
+def test_symbol_stats(lmdb_version_store):
+    num_symbols = 10;
+    symbol_to_df={}
+    initial_timestamp = pd.Timestamp("2019-01-01")
+    for i in range(num_symbols):
+        symbol = "symbol_{}".format(i)
+        num_rows = random.randint(1, 50)
+        date_range = pd.date_range(initial_timestamp, periods=num_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=date_range)
+        symbol_to_df[symbol] = df
+        lmdb_version_store.write(symbol, df)
+
+    lmdb_version_store.generate_symbol_stats()
+    vit = lmdb_version_store.get_symbol_stats()
+
+    for sym in vit.data.index:
+        df = symbol_to_df[sym]
+        assert(vit.data["start_time"][sym] == df.index[0])
+        end_time = vit.data["end_time"][sym].floor('ms')
+        assert(end_time == df.index[-1])
+        assert(vit.data["num_rows"][sym] == len(df))

--- a/python/tests/unit/arcticdb/test_symbol_stats.py
+++ b/python/tests/unit/arcticdb/test_symbol_stats.py
@@ -12,8 +12,8 @@ import random
 
 
 def test_symbol_stats(lmdb_version_store):
-    num_symbols = 10;
-    symbol_to_df={}
+    num_symbols = 10
+    symbol_to_df = {}
     initial_timestamp = pd.Timestamp("2019-01-01")
     for i in range(num_symbols):
         symbol = "symbol_{}".format(i)
@@ -23,12 +23,12 @@ def test_symbol_stats(lmdb_version_store):
         symbol_to_df[symbol] = df
         lmdb_version_store.write(symbol, df)
 
-    lmdb_version_store.generate_symbol_stats()
+    lmdb_version_store.refresh_symbol_stats_cache()
     vit = lmdb_version_store.get_symbol_stats()
 
     for sym in vit.data.index:
         df = symbol_to_df[sym]
-        assert(vit.data["start_time"][sym] == df.index[0])
-        end_time = vit.data["end_time"][sym].floor('ms')
-        assert(end_time == df.index[-1])
-        assert(vit.data["num_rows"][sym] == len(df))
+        assert vit.data["start_time"][sym] == df.index[0]
+        end_time = vit.data["end_time"][sym].floor("ms")
+        assert end_time == df.index[-1]
+        assert vit.data["num_rows"][sym] == len(df)


### PR DESCRIPTION
In the medium term, we plan to add data to the symbol list to add some constantly-collected statistics about the start and end time-ranges for a symbol, the number of rows etc. However, whilst this is not a particularly difficult task, it is non-trivial to get correct as at the moment the symbol list assumes that data is time-independent, a symbol either exists or doesn't. Ensuring the data is correct would mean correctly selecting the latest symbol list entry on compaction.

In the meantime, this PR provides a method to generate a symbol containing the statistics for all other symbols in the library. This should be relatively quick to generate as it works in parallel, and unlike batch_read_descriptor will involve at most a handful of IO operations, so should be extremely fast to retrieve.

Written in one day, feel free to take a look but I wll tidy a bit on Monday, specifically I intend to split the statistics generation and write into two non-class functions in the cpp file, and pass in the class members such as store and version map from the now-trivial existing function