### PR TITLE
Use RFC 3986 URL encoding for S3 interactions

### DIFF
--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -21,6 +21,10 @@ namespace arcticdb::storage::s3 {
 S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level) :
     log_level_(log_level),
     options_() {
+    // Use correct URI encoding rather than legacy compat one in AWS SDK. PURE S3 needs this to handle symbol names
+    // that have special characters (eg ':').
+    options_.httpOptions.compliantRfc3986Encoding = true;
+
     if(log_level_ > Aws::Utils::Logging::LogLevel::Off) {
       Aws::Utils::Logging::InitializeAWSLogging(
           Aws::MakeShared<Aws::Utils::Logging::DefaultLogSystem>(

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -74,6 +74,16 @@ def test_simple_flow(lmdb_version_store_no_symbol_list, symbol):
     assert lmdb_version_store_no_symbol_list.list_symbols() == lmdb_version_store_no_symbol_list.list_versions() == []
 
 
+@pytest.mark.parametrize("special_char", ["$", ",", ":", "=", "@", "-", "_", ".", "~"])
+def test_special_chars(s3_version_store, special_char):
+    """Test chars with special URI encoding under RFC 3986"""
+    sym = f"prefix{special_char}postfix"
+    df = sample_dataframe()
+    s3_version_store.write(sym, df)
+    vitem = s3_version_store.read(sym)
+    assert_frame_equal(vitem.data, df)
+
+
 @pytest.mark.parametrize("version_store", SMOKE_TEST_VERSION_STORES)
 def test_with_prune(request, version_store, symbol):
     version_store = request.getfixturevalue(version_store)


### PR DESCRIPTION

Internal ref: AN-984

#### What does this implement/fix? Explain your changes.

This helps to support symbols with special characters in their names on some storages, by using correct URI encoding for S3 interactions rather than legacy compat one in AWS SDK (built for compat with legacy internal Amazon services).

Concretely, symbols containing `:` characters were not working correctly on PURE storage.

At a code level, the impact of the flag is to make us enter this if-condition https://github.com/aws/aws-sdk-cpp/blob/0d214e8330bc1981917a764f5dff45dcfdf382fe/src/aws-cpp-sdk-core/source/http/URI.cpp#L33 and use standard URI encoding.

#### Any other comments?

The test I have added expresses the purpose of the change but actually passed anyway as moto s3 can cope with the bad URI encoding.

