### PR TITLE
Optimisations for get_description_batch

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -185,6 +185,7 @@ set(arcticdb_srcs
         entity/types-inl.hpp
         entity/variant_key.hpp
         entity/versioned_item.hpp
+        entity/descriptor_item.hpp
         log/log.hpp
         log/trace.hpp
         pipeline/column_mapping.hpp

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -314,6 +314,10 @@ public:
         impl_->set_metadata(std::move(meta));
     }
 
+    bool has_metadata() {
+        return impl_->has_metadata();
+    }
+
     void override_metadata(google::protobuf::Any &&meta) {
         impl_->override_metadata(std::move(meta));
     }

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -771,6 +771,10 @@ public:
             metadata_ = std::make_unique<google::protobuf::Any>(std::move(meta));
     }
 
+    bool has_metadata() {
+        return static_cast<bool>(metadata_);
+    }
+
     const google::protobuf::Any *metadata() const {
         return metadata_.get();
     }

--- a/cpp/arcticdb/entity/descriptor_item.hpp
+++ b/cpp/arcticdb/entity/descriptor_item.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/entity/atom_key.hpp>
+#include <fmt/format.h>
+#include <string>
+
+
+namespace arcticdb {
+struct DescriptorItem {
+    DescriptorItem(
+        entity::AtomKey &&key, 
+        std::optional<IndexValue> start_index, 
+        std::optional<IndexValue> end_index,
+        std::optional<google::protobuf::Any> timeseries_descriptor) :
+        key_(std::move(key)),
+        start_index_(start_index),
+        end_index_(end_index),
+        timeseries_descriptor_(timeseries_descriptor) {
+    }
+
+    DescriptorItem() = delete;
+
+    entity::AtomKey key_;
+    std::optional<IndexValue> start_index_;
+    std::optional<IndexValue> end_index_;
+    std::optional<google::protobuf::Any> timeseries_descriptor_;
+    
+    std::string symbol() const { return fmt::format("{}", key_.id()); }
+    uint64_t version() const { return key_.version_id(); }
+    timestamp creation_ts() const { return key_.creation_ts(); }
+    std::optional<IndexValue> start_index() const { return start_index_; }
+    std::optional<IndexValue> end_index() const { return end_index_; }
+    std::optional<google::protobuf::Any> timeseries_descriptor() const { return timeseries_descriptor_; }
+};
+}

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -19,6 +19,7 @@
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/version/versioned_engine.hpp>
+#include <arcticdb/entity/descriptor_item.hpp>
 
 #include <sstream>
 
@@ -115,7 +116,7 @@ public:
         ReadQuery& read_query,
         const ReadOptions& read_options) override;
 
-    std::pair<VersionedItem, std::optional<google::protobuf::Any>> read_descriptor_version_internal(
+    DescriptorItem read_descriptor_internal(
             const StreamId& stream_id,
             const VersionQuery& version_query);
 
@@ -176,10 +177,18 @@ public:
     );
 
     folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata(
-        std::optional<AtomKey> key);
+        std::optional<AtomKey>&& key);
 
     folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata_async(
         folly::Future<std::optional<AtomKey>>&& version_fut);
+
+    folly::Future<DescriptorItem> get_descriptor(
+        AtomKey&& key);
+
+    folly::Future<DescriptorItem> get_descriptor_async(
+        folly::Future<std::optional<AtomKey>>&& version_fut,
+        const StreamId& stream_id,
+        const VersionQuery& version_query);
 
     void create_column_stats_internal(
         const VersionedItem& versioned_item,
@@ -271,7 +280,7 @@ public:
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, std::optional<google::protobuf::Any>>> batch_read_descriptor_internal(
+    std::vector<DescriptorItem> batch_read_descriptor_internal(
             const std::vector<StreamId>& stream_ids,
             const std::vector<VersionQuery>& version_queries);
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -136,6 +136,25 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def_property_readonly("symbol", &VersionedItem::symbol)
         .def_property_readonly("version", &VersionedItem::version);
 
+    py::class_<DescriptorItem>(version, "DescriptorItem")
+        .def_property_readonly("symbol", &DescriptorItem::symbol)
+        .def_property_readonly("version", &DescriptorItem::version)
+        .def_property_readonly("start_index", &DescriptorItem::start_index)
+        .def_property_readonly("end_index", &DescriptorItem::end_index)
+        .def_property_readonly("creation_ts", &DescriptorItem::creation_ts)
+        .def_property_readonly("timeseries_descriptor", [](const DescriptorItem& self) {
+          py::object pyobj;
+          auto timeseries_descriptor = self.timeseries_descriptor();
+          if (timeseries_descriptor.has_value()) {
+               arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
+               timeseries_descriptor->UnpackTo(&tsd);
+               pyobj = python_util::pb_to_python(tsd);
+          } else {
+               pyobj = pybind11::none();
+          }
+          return pyobj;
+        });
+
     py::class_<pipelines::FrameSlice, std::shared_ptr<pipelines::FrameSlice>>(version, "FrameSlice")
         .def_property_readonly("col_range", &pipelines::FrameSlice::columns)
         .def_property_readonly("row_range", &pipelines::FrameSlice::rows);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -27,6 +27,7 @@
 #include <arcticdb/util/ranges_from_future.hpp>
 
 #include <arcticdb/entity/versioned_item.hpp>
+#include <arcticdb/entity/descriptor_item.hpp>
 #include <arcticdb/pipeline/query.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 
@@ -1082,40 +1083,18 @@ std::vector<std::pair<VersionedItem, py::object>> PythonVersionStore::batch_read
     return results;
 }
 
-std::pair<VersionedItem, py::object> PythonVersionStore::read_descriptor(
+DescriptorItem PythonVersionStore::read_descriptor(
     const StreamId& stream_id,
     const VersionQuery& version_query
     ) {
-    auto [version, metadata_proto] = read_descriptor_version_internal(stream_id, version_query);
-    py::object pyobj;
-    if (metadata_proto.has_value()) {
-        arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
-        metadata_proto->UnpackTo(&tsd);
-        pyobj = python_util::pb_to_python(tsd);
-    } else {
-        pyobj = pybind11::none();
-    }
-    return std::make_pair(version, pyobj);
+    return read_descriptor_internal(stream_id, version_query);
 }
 
-std::vector<std::pair<VersionedItem, py::object>> PythonVersionStore::batch_read_descriptor(
+std::vector<DescriptorItem> PythonVersionStore::batch_read_descriptor(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries){
     
-    auto vector_descriptors = batch_read_descriptor_internal(stream_ids, version_queries);
-    std::vector<std::pair<VersionedItem, py::object>> output_vector;
-    for (auto [version, metadata_proto] : vector_descriptors) {
-        py::object pyobj;
-        if (metadata_proto.has_value()) {
-            arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
-            metadata_proto->UnpackTo(&tsd);
-            pyobj = python_util::pb_to_python(tsd);
-        } else {
-            pyobj = pybind11::none();
-        }
-        output_vector.push_back(std::make_pair(version, pyobj));
-    }
-    return output_vector;
+    return batch_read_descriptor_internal(stream_ids, version_queries);
 }
 
 ReadResult PythonVersionStore::read_index(

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -182,11 +182,11 @@ class PythonVersionStore : public LocalVersionedEngine {
         const VersionQuery& version_query
     );
 
-    std::vector<std::pair<VersionedItem, py::object>> batch_read_descriptor(
+    std::vector<DescriptorItem> batch_read_descriptor(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
-    std::pair<VersionedItem, py::object> read_descriptor(
+    DescriptorItem read_descriptor(
         const StreamId& stream_id,
         const VersionQuery& version_query);
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2233,8 +2233,26 @@ class NativeVersionStore:
             True if the symbol is pickled, False otherwise.
         """
         version_query = self._get_version_query(as_of, **kwargs)
-        _, desc = self.version_store.read_descriptor(symbol, version_query)
-        return self.is_pickled_descriptor(desc)
+        dit = self.version_store.read_descriptor(symbol, version_query)
+        return self.is_pickled_descriptor(dit.timeseries_descriptor)
+
+    def _get_time_range_from_ts(self, desc, min_ts, max_ts):
+        if min_ts == None or max_ts == None:
+            return datetime64("nat"), datetime64("nat")
+        input_type = desc.normalization.WhichOneof("input_type")
+        tz = None
+        if input_type == "df":
+            index_metadata = desc.normalization.df.common
+            tz = get_timezone_from_metadata(index_metadata)
+        if tz:
+            # If tz is provided, it is stored in UTC - hence needs to be localized to UTC before
+            # converting to the given tz
+            return (
+                _from_tz_timestamp(min_ts, "UTC").astimezone(pytz.timezone(tz)),
+                _from_tz_timestamp(max_ts, "UTC").astimezone(pytz.timezone(tz)),
+            )
+        else:
+            return _from_tz_timestamp(min_ts, None), _from_tz_timestamp(max_ts, None)
 
     def get_timerange_for_symbol(
         self, symbol: str, version: Optional[VersionQueryInput] = None
@@ -2265,23 +2283,9 @@ class NativeVersionStore:
 
         start_indices, end_indices = index_data[0], index_data[1]
         min_ts, max_ts = min(start_indices), max(end_indices)
-
         # to get timezone info
-        _, desc = self.version_store.read_descriptor(symbol, version_query)
-        input_type = desc.normalization.WhichOneof("input_type")
-        tz = None
-        if input_type == "df":
-            index_metadata = desc.normalization.df.common
-            tz = get_timezone_from_metadata(index_metadata)
-        if tz:
-            # If tz is provided, it is stored in UTC - hence needs to be localized to UTC before
-            # converting to the given tz
-            return (
-                _from_tz_timestamp(min_ts, "UTC").astimezone(pytz.timezone(tz)),
-                _from_tz_timestamp(max_ts, "UTC").astimezone(pytz.timezone(tz)),
-            )
-        else:
-            return _from_tz_timestamp(min_ts, None), _from_tz_timestamp(max_ts, None)
+        dit = self.version_store.read_descriptor(symbol, version_query)
+        return self._get_time_range_from_ts(dit.timeseries_descriptor, min_ts, max_ts)
 
     def name(self):
         return self._lib_cfg.lib_desc.name
@@ -2303,8 +2307,8 @@ class NativeVersionStore:
             The number of rows in the specified revision of the symbol.
         """
         version_query = self._get_version_query(as_of)
-        vit, desc = self.version_store.read_descriptor(symbol, version_query)
-        return desc.total_rows
+        dit = self.version_store.read_descriptor(symbol, version_query)
+        return dit.timeseries_descriptor.total_rows
 
     def lib_cfg(self):
         return self._lib_cfg
@@ -2312,19 +2316,20 @@ class NativeVersionStore:
     def open_mode(self):
         return self._open_mode
 
-    def _process_info(self, symbol: str, vit, desc, as_of: Optional[VersionQueryInput] = None) -> Dict[str, Any]:
-        columns = [f.name for f in desc.stream_descriptor.fields]
-        dtypes = [f.type_desc for f in desc.stream_descriptor.fields]
+    def _process_info(self, symbol: str, dit, as_of: Optional[VersionQueryInput] = None) -> Dict[str, Any]:
+        timeseries_descriptor = dit.timeseries_descriptor
+        columns = [f.name for f in timeseries_descriptor.stream_descriptor.fields]
+        dtypes = [f.type_desc for f in timeseries_descriptor.stream_descriptor.fields]
         index = []
         index_dtype = []
-        input_type = desc.normalization.WhichOneof("input_type")
+        input_type = timeseries_descriptor.normalization.WhichOneof("input_type")
         index_type = "NA"
         if input_type == "df":
-            index_type = desc.normalization.df.common.WhichOneof("index_type")
+            index_type = timeseries_descriptor.normalization.df.common.WhichOneof("index_type")
             if index_type == "index":
-                index_metadata = desc.normalization.df.common.index
+                index_metadata = timeseries_descriptor.normalization.df.common.index
             else:
-                index_metadata = desc.normalization.df.common.multi_index
+                index_metadata = timeseries_descriptor.normalization.df.common.multi_index
 
             if index_type == "multi_index" or (index_type == "index" and index_metadata.is_not_range_index):
                 index_name_from_store = columns.pop(0)
@@ -2356,20 +2361,22 @@ class NativeVersionStore:
                         index_name = index_name[_IDX_PREFIX_LEN:]
                     index.append(index_name)
                     index_dtype.append(dtypes.pop(0))
-            if desc.normalization.df.has_synthetic_columns:
+            if timeseries_descriptor.normalization.df.has_synthetic_columns:
                 columns = pd.RangeIndex(0, len(columns))
 
+        date_range = self._get_time_range_from_ts(timeseries_descriptor, dit.start_index, dit.end_index)
+        last_update = datetime64(dit.creation_ts, "ns")
         return {
             "col_names": {"columns": columns, "index": index, "index_dtype": index_dtype},
             "dtype": dtypes,
-            "rows": desc.total_rows,
-            "last_update": self.update_time(symbol, as_of),
+            "rows": timeseries_descriptor.total_rows,
+            "last_update": last_update,
             "input_type": input_type,
             "index_type": index_type,
-            "normalization_metadata": desc.normalization,
-            "type": self.get_arctic_style_type_info_for_norm(desc),
-            "date_range": self.get_timerange_for_symbol(symbol, vit.version),
-            "sorted": SortedValue.Name(desc.stream_descriptor.sorted),
+            "normalization_metadata": timeseries_descriptor.normalization,
+            "type": self.get_arctic_style_type_info_for_norm(timeseries_descriptor),
+            "date_range": date_range,
+            "sorted": SortedValue.Name(timeseries_descriptor.stream_descriptor.sorted),
         }
 
     def get_info(self, symbol: str, version: Optional[VersionQueryInput] = None) -> Dict[str, Any]:
@@ -2399,8 +2406,8 @@ class NativeVersionStore:
             - date_range, `tuple`
         """
         version_query = self._get_version_query(version)
-        vit, desc = self.version_store.read_descriptor(symbol, version_query)
-        return self._process_info(symbol, vit, desc, version)
+        dit = self.version_store.read_descriptor(symbol, version_query)
+        return self._process_info(symbol, dit, version)
 
     def batch_get_info(
         self, symbols: List[str], as_ofs: Optional[List[VersionQueryInput]] = None
@@ -2444,10 +2451,8 @@ class NativeVersionStore:
         list_descriptors = self.version_store.batch_read_descriptor(symbols, version_queries)
         args_list = list(zip(list_descriptors, symbols, version_queries, as_ofs_lists))
         list_infos = []
-        for descriptor, symbol, version_query, as_of in args_list:
-            vit = descriptor[0]
-            desc = descriptor[1]
-            list_infos.append(self._process_info(symbol, vit, desc, as_of))
+        for dit, symbol, version_query, as_of in args_list:
+            list_infos.append(self._process_info(symbol, dit, as_of))
         return list_infos
 
     def write_metadata(

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1341,8 +1341,12 @@ class Library:
         last_update_time = pd.to_datetime(info["last_update"], utc=True)
         columns = tuple(NameWithDType(n, t) for n, t in zip(info["col_names"]["columns"], info["dtype"]))
         index = NameWithDType(info["col_names"]["index"], info["col_names"]["index_dtype"])
-        date_range = tuple(map(lambda x: x.replace(tzinfo=datetime.timezone.utc), info["date_range"]))
-
+        date_range = tuple(
+            map(
+                lambda x: x.replace(tzinfo=datetime.timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+                info["date_range"],
+            )
+        )
         return SymbolDescription(
             columns=columns,
             index=index,
@@ -1397,10 +1401,15 @@ class Library:
         infos = self._nvs.batch_get_info(symbol_strings, as_ofs)
         list_descriptions = []
         for info in infos:
-            last_update_time = pd.to_datetime(info["last_update"])
+            last_update_time = pd.to_datetime(info["last_update"], utc=True)
             columns = tuple(NameWithDType(n, t) for n, t in zip(info["col_names"]["columns"], info["dtype"]))
             index = NameWithDType(info["col_names"]["index"], info["col_names"]["index_dtype"])
-
+            date_range = tuple(
+                map(
+                    lambda x: x.replace(tzinfo=datetime.timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+                    info["date_range"],
+                )
+            )
             list_descriptions.append(
                 SymbolDescription(
                     columns=columns,
@@ -1408,7 +1417,7 @@ class Library:
                     row_count=info["rows"],
                     last_update_time=last_update_time,
                     index_type=info["index_type"],
-                    date_range=info["date_range"],
+                    date_range=date_range,
                 )
             )
         return list_descriptions

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -6,10 +6,12 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 import sys
+import os
 
 import pytz
 from arcticdb_ext.exceptions import InternalException
 from arcticdb.exceptions import ArcticNativeNotYetImplemented
+from pandas import Timestamp
 
 try:
     from arcticdb.version_store import VersionedItem as PythonVersionedItem
@@ -31,7 +33,7 @@ import pandas as pd
 from datetime import datetime, date, timezone
 import numpy as np
 from arcticdb.util.test import assert_frame_equal
-
+from numpy import datetime64
 
 try:
     from arcticdb.version_store.library import (
@@ -1207,13 +1209,43 @@ def test_get_description_batch(arctic_library):
         [ReadInfoRequest("symbol1", as_of=0), ReadInfoRequest("symbol2", as_of=0), ReadInfoRequest("symbol3", as_of=0)]
     )
 
-    assert infos[0].date_range == (datetime(2018, 1, 1), datetime(2018, 1, 6))
-    assert infos[1].date_range == (datetime(2019, 1, 1), datetime(2019, 1, 6))
-    assert infos[2].date_range == (datetime(2020, 1, 1), datetime(2020, 1, 6))
+    assert infos[0].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2018, 1, 1), datetime(2018, 1, 6)),
+        )
+    )
+    assert infos[1].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2019, 1, 1), datetime(2019, 1, 6)),
+        )
+    )
+    assert infos[2].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2020, 1, 1), datetime(2020, 1, 6)),
+        )
+    )
 
-    assert original_infos[0].date_range == (datetime(2018, 1, 1), datetime(2018, 1, 4))
-    assert original_infos[1].date_range == (datetime(2019, 1, 1), datetime(2019, 1, 4))
-    assert original_infos[2].date_range == (datetime(2020, 1, 1), datetime(2020, 1, 4))
+    assert original_infos[0].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
+        )
+    )
+    assert original_infos[1].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2019, 1, 1), datetime(2019, 1, 4)),
+        )
+    )
+    assert original_infos[2].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2020, 1, 1), datetime(2020, 1, 4)),
+        )
+    )
 
     list_infos = list(zip(infos, original_infos))
     # then
@@ -1265,13 +1297,43 @@ def test_get_description_batch_multiple_versions(arctic_library):
     infos = infos_multiple_version[3:6]
     original_infos = infos_multiple_version[0:3]
 
-    assert infos[0].date_range == (datetime(2018, 1, 1), datetime(2018, 1, 6))
-    assert infos[1].date_range == (datetime(2019, 1, 1), datetime(2019, 1, 6))
-    assert infos[2].date_range == (datetime(2020, 1, 1), datetime(2020, 1, 6))
+    assert infos[0].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2018, 1, 1), datetime(2018, 1, 6)),
+        )
+    )
+    assert infos[1].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2019, 1, 1), datetime(2019, 1, 6)),
+        )
+    )
+    assert infos[2].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2020, 1, 1), datetime(2020, 1, 6)),
+        )
+    )
 
-    assert original_infos[0].date_range == (datetime(2018, 1, 1), datetime(2018, 1, 4))
-    assert original_infos[1].date_range == (datetime(2019, 1, 1), datetime(2019, 1, 4))
-    assert original_infos[2].date_range == (datetime(2020, 1, 1), datetime(2020, 1, 4))
+    assert original_infos[0].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
+        )
+    )
+    assert original_infos[1].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2019, 1, 1), datetime(2019, 1, 4)),
+        )
+    )
+    assert original_infos[2].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2020, 1, 1), datetime(2020, 1, 4)),
+        )
+    )
 
     list_infos = list(zip(infos, original_infos))
     # then
@@ -1282,6 +1344,52 @@ def test_get_description_batch_multiple_versions(arctic_library):
         assert info.row_count == 6
         assert original_info.row_count == 4
         assert info.last_update_time > original_info.last_update_time
+
+
+def test_read_description_batch_high_amount(arctic_library):
+    lib = arctic_library
+    num_symbols = 10
+    num_versions = 10
+    start_year = 2000
+    start_day = 1
+    for sym in range(num_symbols):
+        for version in range(num_versions):
+            start_date = pd.Timestamp(str("{}/1/{}".format(start_year + sym, start_day + version)))
+            end_date = pd.Timestamp(str("{}/1/{}".format(start_year + sym, start_day + version + 3)))
+            df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start=start_date, end=end_date))
+            lib.write("sym_" + str(sym), df, prune_previous_versions=False)
+    requests = [
+        ReadInfoRequest("sym_" + str(sym), as_of=version)
+        for sym in range(num_symbols)
+        for version in range(num_versions)
+    ]
+    results_list = lib.get_description_batch(requests)
+    for sym in range(num_symbols):
+        for version in range(num_versions):
+            idx = sym * num_versions + version
+            date_ramge_comp = (
+                datetime(start_year + sym, 1, start_day + version),
+                datetime(start_year + sym, 1, start_day + version + 3),
+            )
+            date_range_comp_with_utc = tuple(
+                map(lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x, date_ramge_comp)
+            )
+            assert results_list[idx].date_range == date_range_comp_with_utc
+            if version > 0:
+                assert results_list[idx].last_update_time > results_list[idx - 1].last_update_time
+                assert results_list[idx].last_update_time.tz == pytz.UTC
+
+
+def test_read_description_batch_empty_nat(arctic_library):
+    lib = arctic_library
+    num_symbols = 10
+    for sym in range(num_symbols):
+        lib.write("sym_" + str(sym), pd.DataFrame())
+    requests = [ReadInfoRequest("sym_" + str(sym)) for sym in range(num_symbols)]
+    results_list = lib.get_description_batch(requests)
+    for sym in range(num_symbols):
+        assert np.isnat(results_list[sym].date_range[0]) == True
+        assert np.isnat(results_list[sym].date_range[1]) == True
 
 
 def test_tail(arctic_library):


### PR DESCRIPTION
In this PR, we provide per-symbol parallelism for the read_batch_metadata method. This provides significant performance over the existing implementation. 

This PR also moves `_get_process_info`, a Python method which constructs much of the return structure, into C++. This has been done for performance reasons.

Initial benchmarking shows a significant performance increase. Exact numbers will follow prior to publishing the PR out of draft.

Addresses issue created by https://github.com/man-group/ArcticDB/issues/197


Performance improvement for reading the descriptor data of 1000 symbols, using a 8-CPU processor (8 cpu threads/12 IO threads) is almost **40x!**