### PR TITLE
Bugfix 504: handle Nones and NaNs correctly in string columns when filtering down the stringpool

### DIFF
--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -922,6 +922,9 @@ public:
         // Map from offsets in the input stringpool to offsets in the output stringpool
         // Only used if filter_down_stringpool is true
         emilib::HashMap<StringPool::offset_t, StringPool::offset_t> input_to_output_offsets;
+        // Prepopulate with None and NaN placeholder values to avoid an if statement in a tight loop later
+        input_to_output_offsets.insert(not_a_string(), not_a_string());
+        input_to_output_offsets.insert(nan_placeholder(), nan_placeholder());
 
         // Index is built to make rank queries faster
         std::unique_ptr<util::BitIndex> filter_idx;


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #504 

#### What does this implement/fix? Explain your changes.
Prior to the processing pipeline refactor, the `RowNumberLimitClause` did not filter the stringpool down during the clause. The refactor changed it so that it did (since the point of the clause is to save memory on calls to `head` when it can), exposing the fact that we did not handle `None` and `NaN` values in string columns correctly when filtering and optimising for memory.