### PR TITLE
Use Man's compatibility layer in the arcticc namespace package

### DIFF
--- a/python/arcticc/__init__.py
+++ b/python/arcticc/__init__.py
@@ -1,1 +1,9 @@
+# file from ArcticDB
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
+# Use Man's API backwards compatibility layer if it is installed.
+# This will not do anything outside of Man Group systems.
+try:
+    from man.arcticdb.arcticdb_renamer import *
+except ImportError:
+    pass


### PR DESCRIPTION
This will only have an effect within Man Group systems.

In those systems, it installs a handler to redirect Python imports from our old internal structure,
where `arcticdb` was called `arcticc`, to the new structure that this project uses.

#### Reference Issues/PRs

Internal ref AN-994

#### What does this implement/fix? Explain your changes.


#### Any other comments?


