### PR TITLE
Ensure that `bucket_name` can also be taken from the URI

### DIFF
--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -106,7 +106,8 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
         .def(py::init<>())
         .def_property("credential_name", &S3CredentialsOverride::credential_name,  &S3CredentialsOverride::set_credential_name)
         .def_property("credential_key", &S3CredentialsOverride::credential_key, &S3CredentialsOverride::set_credential_key)
-        .def_property("endpoint", &S3CredentialsOverride::endpoint, &S3CredentialsOverride::set_endpoint);
+        .def_property("endpoint", &S3CredentialsOverride::endpoint, &S3CredentialsOverride::set_endpoint)
+        .def_property("bucket_name", &S3CredentialsOverride::bucket_name, &S3CredentialsOverride::set_bucket_name);
 
     py::class_<StorageOverride>(storage, "StorageOverride")
         .def(py::init<>())

--- a/cpp/arcticdb/storage/storage_override.hpp
+++ b/cpp/arcticdb/storage/storage_override.hpp
@@ -11,6 +11,7 @@ class S3CredentialsOverride {
     std::string credential_name_;
     std::string credential_key_;
     std::string endpoint_;
+    std::string bucket_;
 
 public:
     std::string credential_name() const {
@@ -37,6 +38,14 @@ public:
         endpoint_ = endpoint;
     }
 
+    std::string bucket_name_() const {
+        return bucket_;
+    }
+
+    void set_bucket_name(std::string_view bucket_name){
+        bucket_name_ = bucket_name;
+    }
+
     void modify_storage_credentials(arcticdb::proto::storage::VariantStorage& storage) const {
         if(storage.config().Is<arcticdb::proto::s3_storage::Config>()) {
             arcticdb::proto::s3_storage::Config s3_storage;
@@ -49,6 +58,9 @@ public:
 
             if(!endpoint_.empty())
                 s3_storage.set_endpoint(endpoint_);
+
+            if (!bucket_name_).empty())
+                s3_storage.set_bucket_name(bucket_name_);
 
             util::pack_to_any(s3_storage, *storage.mutable_config());
         }

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -134,6 +134,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             s3_override.credential_name = self._query_params.access
             s3_override.credential_key = self._query_params.secret
             s3_override.endpoint = self._endpoint
+            s3_override.bucket_name = self._bucket
             storage_override = StorageOverride()
             storage_override.set_override(s3_override)
 


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### What does this implement/fix? Explain your changes.

When using AWS regional replication to replicate data, you may replicate one bucket to another bucket with a different name.

If so, replicated bucket libraries will be inaccessible when accessed via the target bucket as the bucket name will be copied from the library manager config stored in the source region. 

This ensures that the bucket name is overriden by the bucket stored in the Arctic URI. 



