### PR TITLE
Refactor underlying segment write scheduling 

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -344,6 +344,7 @@ set(arcticdb_srcs
         version/version_store_objects.hpp
         version/version_utils.hpp
         # CPP files
+        async/async_store.cpp
         async/task_scheduler.cpp
         async/tasks.cpp
         codec/codec.cpp
@@ -422,7 +423,7 @@ set(arcticdb_srcs
         version/version_core.cpp
         version/version_store_api.cpp
         version/version_utils.cpp
-        version/symbol_list.cpp)
+        version/symbol_list.cpp )
 
 # Exclude vendored sources when using conda.
 if(NOT ${ARCTICDB_USING_CONDA}) #Awaiting Azure sdk support in conda https://github.com/man-group/ArcticDB/issues/519

--- a/cpp/arcticdb/async/async_store.cpp
+++ b/cpp/arcticdb/async/async_store.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/async/async_store.hpp>
+#include <arcticdb/entity/variant_key.hpp>
+#include <arcticdb/codec/segment.hpp>
+#include <arcticdb/storage/key_segment_pair.hpp>
+#include <arcticdb/version/de_dup_map.hpp>
+
+namespace arcticdb::async {
+std::pair<entity::VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
+    const std::shared_ptr<DeDupMap> &de_dup_map,
+    storage::KeySegmentPair&& key_seg) {
+    if (auto de_dup_key = de_dup_map->get_key_if_present(key_seg.atom_key())) {
+        ARCTICDB_DEBUG(log::version(),
+                       "Found existing key with same contents: using existing object {}",
+                       de_dup_key.value());
+        return std::make_pair(de_dup_key.value(), std::nullopt);
+    } else {
+        ARCTICDB_DEBUG(log::version(),
+                       "No existing key with same contents: writing new object {}",
+                       key_seg.atom_key());
+        return std::make_pair(std::move(key_seg.atom_key()), std::make_optional(std::move(key_seg.segment())));
+    }
+}
+}

--- a/cpp/arcticdb/async/async_store.cpp
+++ b/cpp/arcticdb/async/async_store.cpp
@@ -15,16 +15,18 @@ namespace arcticdb::async {
 std::pair<entity::VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
     const std::shared_ptr<DeDupMap> &de_dup_map,
     storage::KeySegmentPair&& key_seg) {
-    if (auto de_dup_key = de_dup_map->get_key_if_present(key_seg.atom_key())) {
-        ARCTICDB_DEBUG(log::version(),
-                       "Found existing key with same contents: using existing object {}",
-                       de_dup_key.value());
-        return std::make_pair(de_dup_key.value(), std::nullopt);
-    } else {
+    std::optional<AtomKey> de_dup_key;
+    if (!de_dup_map || !(de_dup_key = de_dup_map->get_key_if_present(key_seg.atom_key()))) {
         ARCTICDB_DEBUG(log::version(),
                        "No existing key with same contents: writing new object {}",
                        key_seg.atom_key());
         return std::make_pair(std::move(key_seg.atom_key()), std::make_optional(std::move(key_seg.segment())));
+
+    } else {
+        ARCTICDB_DEBUG(log::version(),
+                       "Found existing key with same contents: using existing object {}",
+                       de_dup_key.value());
+        return std::make_pair(de_dup_key.value(), std::nullopt);
     }
 }
 }

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <arcticdb/async/task_scheduler.hpp>
-#include <arcticdb/util/clock.hpp>#
+#include <arcticdb/util/clock.hpp>
 #include <arcticdb/storage/store.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/storage/library.hpp>

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <arcticdb/async/task_scheduler.hpp>
-#include <arcticdb/util/clock.hpp>
+#include <arcticdb/util/clock.hpp>#
 #include <arcticdb/storage/store.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/storage/library.hpp>
@@ -18,6 +18,10 @@
 #include <arcticdb/processing/clause.hpp>
 
 namespace arcticdb::async {
+
+std::pair<VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
+    const std::shared_ptr<DeDupMap> &de_dup_map,
+    storage::KeySegmentPair&& key_seg);
 
 template<class ClockType = util::SysClock>
 class AsyncStore : public Store {
@@ -47,7 +51,7 @@ public:
 
         return async::submit_cpu_task(EncodeAtomTask{
             key_type, version_id, stream_id, start_index, end_index, current_timestamp(),
-            std::move(segment), codec_, size_t(0), encoding_version_
+            std::move(segment), codec_, encoding_version_
         })
             .via(&async::io_executor())
             .thenValue(WriteSegmentTask{library_});
@@ -69,7 +73,7 @@ public:
 
         return async::submit_cpu_task(EncodeAtomTask{
             key_type, version_id, stream_id, start_index, end_index, creation_ts,
-            std::move(segment), codec_, size_t(0), encoding_version_
+            std::move(segment), codec_, encoding_version_
         })
             .via(&async::io_executor())
             .thenValue(WriteSegmentTask{library_});
@@ -106,7 +110,7 @@ public:
 
         auto encoded = EncodeAtomTask{
             key_type, version_id, stream_id, start_index, end_index, current_timestamp(),
-            std::move(segment), codec_, size_t(0), encoding_version_
+            std::move(segment), codec_, encoding_version_
         }();
         return WriteSegmentTask{library_}(std::move(encoded));
     }
@@ -142,7 +146,7 @@ public:
                     segment.descriptor().id());
 
         return async::submit_cpu_task(EncodeSegmentTask{
-            key, std::move(segment), codec_, size_t(0), encoding_version_
+            key, std::move(segment), codec_, encoding_version_
         })
             .via(&async::io_executor())
             .thenValue(UpdateSegmentTask{library_, opts});
@@ -315,14 +319,14 @@ public:
     }
 
     folly::Future<std::vector<VariantKey>> batch_read_compressed(
-        std::vector<entity::VariantKey> &&keys,
+        std::vector<entity::VariantKey> &&ks,
         std::vector<ReadContinuation> &&continuations,
         const BatchReadArgs &args) override {
-
+        auto keys = std::move(ks);
         util::check(!keys.empty(), "Unexpected empty keys in batch_read_compressed");
 
         auto key_seg_futs = folly::window(keys, [*this](auto &&key) {
-            return async::submit_io_task(ReadCompressedTask(std::move(key), library_, storage::ReadKeyOpts{}));
+            return async::submit_io_task(ReadCompressedTask(std::forward<decltype(key)>(key), library_, storage::ReadKeyOpts{}));
         }, args.batch_size_);
 
         util::check(key_seg_futs.size() == keys.size(),
@@ -334,7 +338,7 @@ public:
         for (auto &&key_seg_fut : folly::enumerate(key_seg_futs)) {
             result.emplace_back(std::move(*key_seg_fut).thenValue([continuation =
             std::move(continuations[key_seg_fut.index])](auto &&key_seg) mutable {
-                return continuation(std::move(key_seg));
+                return continuation(std::forward<decltype(key_seg)>(key_seg));
             }));
         }
 
@@ -411,68 +415,38 @@ public:
         const std::shared_ptr<DeDupMap> &de_dup_map,
         const BatchWriteArgs &args) override {
         auto key_segments = std::move(key_seg_pairs);
+        std::vector<folly::Future<VariantKey>> futs;
+        futs.reserve(key_seg_pairs.size());
         std::size_t write_count = args.lib_write_count == 0 ? 16ULL : args.lib_write_count;
 
-        auto res = std::make_shared<std::vector<VariantKey>>(key_segments.size());
-        auto count = 0ULL;
-        std::vector<folly::Future<folly::Unit>> write_futures;
-        for (std::size_t start = 0ULL, nxt; start < key_segments.size(); start = nxt) {
-            nxt = std::min(start + write_count, key_segments.size());
-            auto range = folly::Range(key_segments.begin() + start, key_segments.begin() + nxt);
-            auto key_segs = std::make_shared<std::vector<storage::KeySegmentPair>>();
-            auto key_seg_mutex = std::make_shared<std::mutex>();
-            std::vector<folly::Future<folly::Unit>> futs;
-            futs.reserve(range.size());
+        auto encode_futs = folly::window(key_segments, [*this](auto &&ks) {
+            auto [key, seg] = std::forward<decltype(ks)>(ks);
+            return async::submit_cpu_task(
+                EncodeAtomTask(std::move(key),
+                               ClockType::nanos_since_epoch(),
+                               std::move(seg),
+                               codec_,
+                               encoding_version_));
+        }, write_count);
 
-            for (auto &[key, seg] : range) {
-                futs.emplace_back(async::submit_cpu_task(
-                    EncodeAtomTask(std::move(key),
-                                   ClockType::nanos_since_epoch(),
-                                   std::move(seg),
-                                   codec_,
-                                   count++,
-                                   encoding_version_))
-                                      .thenValue([de_dup_map, res](auto &&ks) {
-                                          auto key_seg = std::forward<decltype(ks)>(ks);
-                                          auto de_dup_key =
-                                              de_dup_map ? de_dup_map->get_key_if_present(key_seg.atom_key())
-                                                         : std::nullopt;
+        for (auto &&encode_fut : encode_futs) {
+            futs.emplace_back(
+                std::move(encode_fut).thenValue([de_dup_map](auto &&ks) -> std::pair<VariantKey,
+                                                                                     std::optional<Segment>> {
+                        auto key_seg = std::forward<decltype(ks)>(ks);
+                        return lookup_match_in_dedup_map(de_dup_map, std::move(key_seg));
+                    })
+                    .via(&async::io_executor()).thenValue([lib = library_](auto &&item) {
+                        auto key_opt_segment = std::forward<decltype(item)>(item);
+                        if (key_opt_segment.second)
+                            lib->write(Composite<storage::KeySegmentPair>({VariantKey{key_opt_segment.first},
+                                                                           std::move(*key_opt_segment.second)}));
 
-                                          if (de_dup_key) {
-                                              ARCTICDB_DEBUG(log::version(),
-                                                             "Found existing key with same contents: using existing object {}",
-                                                             de_dup_key.value());
-                                              (*res)[key_seg.id()] = (de_dup_key.value());
-                                              return std::make_pair(storage::KeySegmentPair{}, false);
-                                          } else {
-                                              ARCTICDB_DEBUG(log::version(),
-                                                             "No existing key with same contents: writing new object {}",
-                                                             key_seg.atom_key());
-                                              (*res)[key_seg.id()] = (key_seg.atom_key());
-                                              return std::make_pair(std::move(key_seg), true);
-                                          }
-                                      }).thenValue([key_segs = key_segs, key_seg_mutex = key_seg_mutex](auto &&pk) {
-                    auto pair_key_write = std::forward<decltype(pk)>(pk);
-                    if (pair_key_write.second) {
-                        std::lock_guard kl{*key_seg_mutex};
-                        ARCTICDB_DEBUG(log::version(), "Enqueuing {} for write", pair_key_write.first.atom_key());
-                        key_segs->emplace_back(std::move(pair_key_write.first));
-                    }
-                }));
-            }
-
-            auto write_fut = folly::collect(std::move(futs)).via(&async::io_executor()).then([lib = library_,
-                                                                                                 key_segs =
-                                                                                                 key_segs](auto &&) {
-                if (!key_segs->empty())
-                    lib->write(Composite<storage::KeySegmentPair>(std::move(*key_segs)));
-            });
-            write_futures.push_back(std::move(write_fut));
+                        return key_opt_segment.first;
+                    }));
         }
 
-        return folly::collect(std::move(write_futures)).via(&async::io_executor()).then([res](auto &&){
-            return std::move(*res);
-        });
+        return folly::collect(futs).via(&async::io_executor());
     }
 
     void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &cfg)

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -36,20 +36,17 @@ struct EncodeAtomTask : BaseTask {
     timestamp creation_ts_;
     SegmentInMemory segment_;
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta_;
-    size_t id_;
     EncodingVersion encoding_version_;
 
     EncodeAtomTask(PartialKey &&pk,
                    timestamp creation_ts,
                    SegmentInMemory &&segment,
                    std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
-                   size_t id,
                    EncodingVersion encoding_version)
         : partial_key_(std::move(pk)),
           creation_ts_(creation_ts),
           segment_(std::move(segment)),
           codec_meta_(std::move(codec_meta)),
-          id_(id),
           encoding_version_(encoding_version){}
 
     EncodeAtomTask(
@@ -61,12 +58,11 @@ struct EncodeAtomTask : BaseTask {
         timestamp creation_ts,
         SegmentInMemory &&segment,
         const std::shared_ptr<arcticdb::proto::encoding::VariantCodec> &codec_meta,
-        size_t id,
         EncodingVersion encoding_version
     )
         : EncodeAtomTask(PartialKey{key_type, gen_id, std::move(stream_id), std::move(start_index),
                                     std::move(end_index)}, creation_ts,
-                         std::move(segment), codec_meta, id, encoding_version) {
+                         std::move(segment), codec_meta, encoding_version) {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(EncodeAtomTask)
@@ -77,7 +73,7 @@ struct EncodeAtomTask : BaseTask {
         auto content_hash = hash_segment_header(enc_seg.header());
 
         AtomKey k = partial_key_.build_key(creation_ts_, content_hash);
-        return {std::move(k), std::move(enc_seg), id_};
+        return {std::move(k), std::move(enc_seg)};
     }
 
     storage::KeySegmentPair operator()() {
@@ -90,18 +86,15 @@ struct EncodeSegmentTask : BaseTask {
     VariantKey key_;
     SegmentInMemory segment_;
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta_;
-    size_t id_;
     EncodingVersion encoding_version_;
 
     EncodeSegmentTask(entity::VariantKey key,
                       SegmentInMemory &&segment,
                       std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
-                      size_t id,
                       EncodingVersion encoding_version)
             : key_(std::move(key)),
               segment_(std::move(segment)),
               codec_meta_(std::move(codec_meta)),
-              id_(id),
               encoding_version_(encoding_version){}
 
 
@@ -109,7 +102,7 @@ struct EncodeSegmentTask : BaseTask {
 
     storage::KeySegmentPair encode() {
         auto enc_seg = ::arcticdb::encode_dispatch(std::move(segment_), *codec_meta_, encoding_version_);
-        return {std::move(key_), std::move(enc_seg), size_t(id_)};
+        return {std::move(key_), std::move(enc_seg)};
     }
 
     storage::KeySegmentPair operator()() {
@@ -144,7 +137,7 @@ struct EncodeRefTask : BaseTask {
     [[nodiscard]] storage::KeySegmentPair encode() {
         auto enc_seg = ::arcticdb::encode_dispatch(std::move(segment_), *codec_meta_, encoding_version_);
         auto k = RefKey{id_, key_type_};
-        return {std::move(k), std::move(enc_seg), size_t(0)};
+        return {std::move(k), std::move(enc_seg)};
     }
 
     storage::KeySegmentPair operator()() {
@@ -251,12 +244,12 @@ struct CopyCompressedTask : BaseTask {
 
     CopyCompressedTask(entity::VariantKey source_key,
                        KeyType key_type,
-                       const StreamId& stream_id,
+                       StreamId stream_id,
                        VersionId version_id,
                        std::shared_ptr<storage::Library> lib) :
         source_key_(std::move(source_key)),
         key_type_(key_type),
-        stream_id_(stream_id),
+        stream_id_(std::move(stream_id)),
         version_id_(version_id),
         lib_(std::move(lib)) {
         ARCTICDB_DEBUG(log::storage(), "Creating copy compressed task for key {} -> {} {} {}",
@@ -304,7 +297,7 @@ struct DecodeSlicesTask : BaseTask {
 
     std::shared_ptr<std::unordered_set<std::string>> filter_columns_;
 
-    DecodeSlicesTask(
+    explicit DecodeSlicesTask(
             const std::shared_ptr<std::unordered_set<std::string>>& filter_columns)  :
                 filter_columns_(filter_columns) {
             }
@@ -312,7 +305,8 @@ struct DecodeSlicesTask : BaseTask {
     Composite<pipelines::SliceAndKey> operator()(Composite<std::pair<Segment, pipelines::SliceAndKey>> && skp) const {
         ARCTICDB_SAMPLE(DecodeAtomTask, 0)
         auto sk_pairs = std::move(skp);
-        return sk_pairs.transform([that=this] (auto&& seg_slice_pair){
+        return sk_pairs.transform([that=this] (auto&& ssp){
+            auto seg_slice_pair = std::forward<decltype(ssp)>(ssp);
             ARCTICDB_DEBUG(log::version(), "Decoding slice {}", seg_slice_pair.second.key());
             return that->decode_into_slice(std::move(seg_slice_pair));
         });
@@ -344,7 +338,7 @@ struct MemSegmentProcessingTask : BaseTask {
     std::optional<Composite<ProcessingSegment>> procs_;
 
     explicit MemSegmentProcessingTask(
-           const std::shared_ptr<Store> store,
+           const std::shared_ptr<Store>& store,
            std::vector<std::shared_ptr<Clause>> clauses,
            std::optional<Composite<ProcessingSegment>>&& procs = std::nullopt) :
         store_(store),
@@ -352,7 +346,7 @@ struct MemSegmentProcessingTask : BaseTask {
         procs_(std::move(procs)) {
     }
 
-    ProcessingSegment slice_to_segment(Composite<pipelines::SliceAndKey>&& is) {
+   static ProcessingSegment slice_to_segment(Composite<pipelines::SliceAndKey>&& is) {
         auto inputs = std::move(is);
         return ProcessingSegment(inputs.as_range());
     }

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -43,7 +43,7 @@ TEST(Async, SinkBasic) {
 
     auto seg = ac::SegmentInMemory();
     aa::EncodeAtomTask enc{
-        ac::entity::KeyType::GENERATION, 6, 123, 456, 457, 999, std::move(seg), codec_opt, size_t(0), ac::EncodingVersion::V2
+        ac::entity::KeyType::GENERATION, 6, 123, 456, 457, 999, std::move(seg), codec_opt, ac::EncodingVersion::V2
     };
 
     auto v = sched.submit_cpu_task(enc).via(&aa::io_executor()).thenValue(aa::WriteSegmentTask{lib}).get();

--- a/cpp/arcticdb/storage/key_segment_pair.hpp
+++ b/cpp/arcticdb/storage/key_segment_pair.hpp
@@ -18,15 +18,13 @@ namespace arcticdb::storage {
      * not contain any positioning information for the contained data.
      */
     class KeySegmentPair {
-
         struct KeySegmentData {
             VariantKey key_;
             Segment segment_;
-            size_t id_;
 
             KeySegmentData() = default;
-            explicit KeySegmentData(VariantKey &&key) : key_(std::move(key)), segment_(), id_(0) {}
-            KeySegmentData(VariantKey &&key, Segment &&segment, size_t id) : key_(std::move(key)), segment_(std::move(segment)), id_(id) {}
+            explicit KeySegmentData(VariantKey &&key) : key_(std::move(key)), segment_() {}
+            KeySegmentData(VariantKey &&key, Segment &&segment) : key_(std::move(key)), segment_(std::move(segment)) {}
 
             ARCTICDB_NO_MOVE_OR_COPY(KeySegmentData)
         };
@@ -35,9 +33,7 @@ namespace arcticdb::storage {
         KeySegmentPair() : data_(std::make_shared<KeySegmentData>()) {}
         explicit KeySegmentPair(VariantKey &&key) : data_(std::make_shared<KeySegmentData>(std::move(key))) {}
         KeySegmentPair(VariantKey &&key, Segment&& segment) :
-            data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment), 0)) {}
-        KeySegmentPair(VariantKey &&key, Segment&& segment, size_t id) :
-            data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment), id)) {}
+            data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment))) {}
 
         ARCTICDB_MOVE_COPY_DEFAULT(KeySegmentPair)
 
@@ -54,7 +50,7 @@ namespace arcticdb::storage {
             return std::get<AtomKey >(variant_key());
         }
 
-        const AtomKey &atom_key() const {
+        [[nodiscard]] const AtomKey &atom_key() const {
             util::check(std::holds_alternative<AtomKey>(variant_key()), "Expected atom key access");
             return std::get<AtomKey >(variant_key());
         }
@@ -64,7 +60,7 @@ namespace arcticdb::storage {
             return std::get<RefKey >(variant_key());
         }
 
-        const RefKey &ref_key() const {
+        [[nodiscard]] const RefKey &ref_key() const {
             util::check(std::holds_alternative<RefKey>(variant_key()), "Expected ref key access");
             return std::get<RefKey >(variant_key());
         }
@@ -73,29 +69,26 @@ namespace arcticdb::storage {
             return data_->key_;
         }
 
-        const VariantKey& variant_key() const {
+        [[nodiscard]] const VariantKey& variant_key() const {
             return data_->key_;
         }
 
-        const Segment &segment() const {
+        [[nodiscard]] const Segment &segment() const {
             return data_->segment_;
         }
 
-        bool has_segment() const {
+        [[nodiscard]] bool has_segment() const {
             return !segment().is_empty();
         }
 
-        std::string_view key_view() const {
+        [[nodiscard]] std::string_view key_view() const {
             return variant_key_view(variant_key());
         }
 
-        KeyType key_type() const {
+        [[nodiscard]] KeyType key_type() const {
             return variant_key_type(variant_key());
         }
 
-        size_t id() {
-            return data_->id_;
-        }
     private:
         std::shared_ptr<KeySegmentData> data_;
     };


### PR DESCRIPTION
The current version of batch_write which is called by a normal lib.write() to write the data segments collects on the encoded segments so that it can compare them to the dedup map. This in unecessary as the items in the dedup map already exist, and the by-hand batching functionality can be replaced with a folly::window to reduce tail latency. 

Enqueuing the (possible) writes to storage immediately after the compress and check for duplicates results in a 7x speedup in the high_entropy (i.e bandwidth-constrained) test case in test_stress_generated, which is a public benchmark from Wes McKinney's blog. 