### PR TITLE
Extra update checks

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -429,7 +429,7 @@ public:
                                encoding_version_));
         }, write_count);
 
-        for (folly::Future<VariantKey>&& encode_fut : encode_futs) {
+        for (folly::Future<storage::KeySegmentPair>& encode_fut : encode_futs) {
             futs.emplace_back(
                 std::move(encode_fut).thenValue([de_dup_map](auto &&ks) -> std::pair<VariantKey,
                                                                                      std::optional<Segment>> {

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -429,7 +429,7 @@ public:
                                encoding_version_));
         }, write_count);
 
-        for (auto &&encode_fut : encode_futs) {
+        for (folly::Future<VariantKey>&& encode_fut : encode_futs) {
             futs.emplace_back(
                 std::move(encode_fut).thenValue([de_dup_map](auto &&ks) -> std::pair<VariantKey,
                                                                                      std::optional<Segment>> {


### PR DESCRIPTION
Add some extra checks to the update method to catch strange things happening due to out-of-order data. Unaffected + affected keys should equal the number of keys in the index segment reader. Also, the maximum number of output keys should be less than the unaffected keys + 2 times the affected keys (because they may be overlapping at both their beginning and end) + the number of new keys.