### PR TITLE
Fix compilation errors issued by clang-16.

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -766,7 +766,6 @@ if(${TEST})
     else()
         set(COMMON_PUBLIC_TEST_LIBRARIES
                 arcticdb_core_static
-                libatomic.a  # Otherwise gtest_discover_tests cannot run the test if libatomic is not in a standard location
                 GTest::gtest
                 GTest::gmock
                 Python::Python # + pybind11::pybind11 (transitively included) = pybind11::embed, but latter is sometimes not found...

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -766,6 +766,7 @@ if(${TEST})
     else()
         set(COMMON_PUBLIC_TEST_LIBRARIES
                 arcticdb_core_static
+                atomic
                 GTest::gtest
                 GTest::gmock
                 Python::Python # + pybind11::pybind11 (transitively included) = pybind11::embed, but latter is sometimes not found...

--- a/cpp/arcticdb/codec/segment.hpp
+++ b/cpp/arcticdb/codec/segment.hpp
@@ -34,7 +34,7 @@ static constexpr uint16_t HEADER_VERSION_V1 = 1;
 
 inline EncodingVersion encoding_version(const storage::LibraryDescriptor::VariantStoreConfig cfg) {
     return util::variant_match(cfg,
-                               [&cfg](const arcticdb::proto::storage::VersionStoreConfig &version_config) {
+                               [](const arcticdb::proto::storage::VersionStoreConfig &version_config) {
                                    return EncodingVersion(version_config.encoding_version());
                                },
                                [](std::monostate) {

--- a/cpp/arcticdb/processing/aggregation.hpp
+++ b/cpp/arcticdb/processing/aggregation.hpp
@@ -165,7 +165,7 @@ struct MaxOrMinAggregatorData {
                     auto col_data = input_column->column_->data();
                     auto out_ptr = reinterpret_cast<MaybeValue<GlobalRawType>*>(that->aggregated_.data());
                     std::fill(out_ptr + prev_size, out_ptr + unique_values, MaybeValue<GlobalRawType>{});
-                    entity::details::visit_type(input_column->column_->type().data_type(), [&groups, &out_ptr, &col_data, that=that] (auto type_desc_tag) {
+                    entity::details::visit_type(input_column->column_->type().data_type(), [&groups, &out_ptr, &col_data] (auto type_desc_tag) {
                         using ColumnTagType = std::decay_t<decltype(type_desc_tag)>;
                         using ColumnType =  typename ColumnTagType::raw_type;
                         if constexpr(!is_sequence_type(ColumnTagType::data_type)) {

--- a/cpp/arcticdb/util/test/rapidcheck_generators.hpp
+++ b/cpp/arcticdb/util/test/rapidcheck_generators.hpp
@@ -174,7 +174,7 @@ bool check_read_frame(const TestDataFrame &data_frame, ReaderType &reader, std::
     auto timestamp = data_frame.start_ts_;
     auto row = 0u;
 
-    reader.foreach_row([&row, &timestamp, &success, &data_frame, &reader, &errors](auto &&row_ref) {
+    reader.foreach_row([&row, &timestamp, &success, &data_frame, &errors](auto &&row_ref) {
         timestamp += data_frame.timestamp_increments_[row];
         for (size_t col = 0; col < data_frame.num_columns_; ++col) {
             data_frame.types_[col].visit_tag([&](auto type_desc_tag) {

--- a/cpp/arcticdb/util/test/test_slab_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_slab_allocator.cpp
@@ -23,7 +23,6 @@ using pointer_set = std::unordered_set<typename MemoryChunk::pointer>;
 
 size_t num_threads = std::thread::hardware_concurrency() - 1;
 std::size_t const num_blocks_per_thread = 10000;
-std::size_t const num_loops = 10000;
 
 template <typename MemoryChunk>
 pointer_set<MemoryChunk> call_alloc_and_dealloc(MemoryChunk& mc, std::size_t n, int64_t& execution_time_ms) {


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
ArcticDB fails to build with clang-16 + lld. The changes are minor fixes for the compilation errors.
* Delete definitions of unused variables (in lambda captures and globals)
* Fix the way libatomic is linked to the tests

#### Any other comments?


