### PR TITLE
build: Specify compilations optimizations to use for Windows

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -26,8 +26,8 @@ if(WIN32)
     # sccache needs the /Z7 format, but the linker will still produce .pdb files.
     # Guide to MSVC compilation warnings https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199?view=msvc-170
     set(CMAKE_CXX_FLAGS "/DWIN32 /D_WINDOWS /GR /EHsc /bigobj /Z7 /w /wd4244 /wd4267")
-    set(CMAKE_CXX_FLAGS_RELEASE "/MT /DNDEBUG")
-    set(CMAKE_CXX_FLAGS_DEBUG "/MTd /RTC1")
+    set(CMAKE_CXX_FLAGS_RELEASE "/MT /DNDEBUG /O2")
+    set(CMAKE_CXX_FLAGS_DEBUG "/MTd /RTC1 /Od")
 else()
     if(${ARCTICDB_USING_CONDA})
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")


### PR DESCRIPTION
#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

`/O2` optimizes for speed.
`/O1` optimizes for object files' size.
`/O1` and `/O2` are mutually exclusive.

`/Od` disables optimizations, which is useful for debugging.

#### Any other comments?

I am proposing using `/O2` for this PR, but I greatly would appreciate having other opinions.

For more information regarding MSVC's `/O` options, see:
https://learn.microsoft.com/en-us/cpp/build/reference/o-options-optimize-code
    

