### PR TITLE
Enhancement/531/modify batch read behaviour if a version doesnt exist

### DIFF
--- a/cpp/arcticdb/pipeline/read_options.hpp
+++ b/cpp/arcticdb/pipeline/read_options.hpp
@@ -19,6 +19,7 @@ struct ReadOptions {
     std::optional<bool> allow_sparse_;
     std::optional<bool> set_tz_;
     std::optional<bool> optimise_string_memory_;
+    std::optional<bool> batch_throw_on_missing_version_;
 
     void set_force_strings_to_fixed(const std::optional<bool>& force_strings_to_fixed) {
         force_strings_to_fixed_ = force_strings_to_fixed;
@@ -50,6 +51,10 @@ struct ReadOptions {
 
     void set_optimise_string_memory(const std::optional<bool>& optimise_string_memory) {
         optimise_string_memory_ = optimise_string_memory;
+    }
+
+    void set_batch_throw_on_missing_version(bool batch_throw_on_missing_version) {
+        batch_throw_on_missing_version_ = batch_throw_on_missing_version;
     }
 };
 } //namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -120,7 +120,7 @@ FrameAndDescriptor LocalVersionedEngine::read_column_stats_internal(
     return read_column_stats_impl(store(), versioned_item);
 }
 
-std::pair<VersionedItem, FrameAndDescriptor> LocalVersionedEngine::read_column_stats_version_internal(
+ReadVersionOutput LocalVersionedEngine::read_column_stats_version_internal(
     const StreamId& stream_id,
     const VersionQuery& version_query) {
     auto versioned_item = get_version_to_read(stream_id, version_query);
@@ -130,7 +130,7 @@ std::pair<VersionedItem, FrameAndDescriptor> LocalVersionedEngine::read_column_s
             stream_id
             );
     auto frame_and_descriptor = read_column_stats_internal(versioned_item.value());
-    return std::make_pair(versioned_item.value(), std::move(frame_and_descriptor));
+    return ReadVersionOutput{std::move(versioned_item.value()), std::move(frame_and_descriptor)};
 }
 
 ColumnStats LocalVersionedEngine::get_column_stats_info_internal(
@@ -315,7 +315,7 @@ IndexRange LocalVersionedEngine::get_index_range(
     return index::get_index_segment_range(version.value().key_, store());
 }
 
-std::pair<VersionedItem, FrameAndDescriptor> LocalVersionedEngine::read_dataframe_version_internal(
+std::optional<ReadVersionOutput> LocalVersionedEngine::read_dataframe_version_internal(
     const StreamId &stream_id,
     const VersionQuery& version_query,
     ReadQuery& read_query,
@@ -327,15 +327,22 @@ std::pair<VersionedItem, FrameAndDescriptor> LocalVersionedEngine::read_datafram
             log::version().warn("No index:  Key not found for {}, will attempt to use incomplete segments.", stream_id);
             identifier = stream_id;
         }
-        else
-            throw storage::NoDataFoundException(fmt::format("read_dataframe_version: version not found for symbol '{}'", stream_id));
+        else {
+            if (read_options.batch_throw_on_missing_version_.value_or(true)) {
+                throw storage::NoDataFoundException(
+                        fmt::format("read_dataframe_version: version query '{}' not found for symbol '{}'", version_query, stream_id));
+            } else {
+                log::version().warn("read_dataframe_version: version query '{}' not found for symbol '{}'", version_query, stream_id);
+                return std::nullopt;
+            }
+        }
     }
     else  {
         identifier = version.value();
     }
 
     auto frame_and_descriptor = read_dataframe_internal(identifier, read_query, read_options);
-    return std::make_pair(version.value_or(VersionedItem{}), std::move(frame_and_descriptor));
+    return ReadVersionOutput{version.value_or(VersionedItem{}), std::move(frame_and_descriptor)};
 }
 
 folly::Future<DescriptorItem> LocalVersionedEngine::get_descriptor(
@@ -948,7 +955,7 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& strea
     return versioned_item;
 }
 
-folly::Future<std::pair<VersionedItem, FrameAndDescriptor>> async_read_direct(
+folly::Future<ReadVersionOutput> async_read_direct(
     const std::shared_ptr<Store>& store,
     const VariantKey& index_key,
     SegmentInMemory&& index_segment,
@@ -981,12 +988,12 @@ folly::Future<std::pair<VersionedItem, FrameAndDescriptor>> async_read_direct(
             reduce_and_fix_columns(pipeline_context, frame, read_options);
         }).thenValue(
         [index_segment_reader, frame, index_key, buffers](auto &&) {
-            return std::make_pair(VersionedItem{to_atom(index_key)},
-                                  FrameAndDescriptor{frame, std::move(index_segment_reader->mutable_tsd()), {}, buffers});
+            return ReadVersionOutput{VersionedItem{to_atom(index_key)},
+                                  FrameAndDescriptor{frame, std::move(index_segment_reader->mutable_tsd()), {}, buffers}};
         });
 }
 
-std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::batch_read_keys(
+std::vector<ReadVersionOutput> LocalVersionedEngine::batch_read_keys(
     const std::vector<AtomKey> &keys,
     const std::vector<ReadQuery> &read_queries,
     const ReadOptions& read_options) {
@@ -997,7 +1004,7 @@ std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::
     }
     auto indexes = folly::collect(index_futures).get();
 
-    std::vector<folly::Future<std::pair<VersionedItem, FrameAndDescriptor>>> results_fut;
+    std::vector<folly::Future<ReadVersionOutput>> results_fut;
     auto i = 0u;
     util::check(read_queries.empty() || read_queries.size() == keys.size(), "Expected read queries to either be empty or equal to size of keys");
     for (auto&& [index_key, index_segment] : indexes) {
@@ -1008,33 +1015,46 @@ std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::
     return folly::collect(results_fut).get();
 }
 
-std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::temp_batch_read_internal_direct(
+std::vector<std::optional<ReadVersionOutput>> LocalVersionedEngine::temp_batch_read_internal_direct(
     const std::vector<StreamId> &stream_ids,
     const std::vector<VersionQuery> &version_queries,
     std::vector<ReadQuery> &read_queries,
     const ReadOptions &read_options) {
     py::gil_scoped_release release_gil;
+    // This read option should always be set when calling batch_read
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_missing_version_.has_value(),
+                                                    "ReadOptions::batch_throw_on_missing_version_ should always be set here");
     auto versions = batch_get_versions_async(store(), version_map(), stream_ids, version_queries);
-    std::vector<folly::Future<std::pair<VersionedItem, FrameAndDescriptor>>> output;
-    for (auto &&version : folly::enumerate(versions)) {
-        auto read_query = read_queries.empty() ? ReadQuery{} : read_queries[version.index];
-        output.emplace_back(std::move(*version).thenValue([store = store()](auto maybe_index_key) -> ReadKeyOutput {
-            util::check(static_cast<bool>(maybe_index_key), "Version not found for stream");
-            return store->read_sync(maybe_index_key.value());
-        }).thenValue([store = store(), read_query = std::move(read_query), read_options](auto &&key_segment_pair) {
-            auto [index_key, index_segment] = std::move(key_segment_pair);
-            return async_read_direct(store,
-                                     std::move(index_key),
-                                     std::move(index_segment),
-                                     read_query,
-                                     std::make_shared<BufferHolder>(),
-                                     read_options);
+    std::vector<folly::Future<std::optional<ReadVersionOutput>>> output;
+    for (auto&& [idx, version] : folly::enumerate(versions)) {
+        auto read_query = read_queries.empty() ? ReadQuery{} : read_queries[idx];
+        output.emplace_back(std::move(version).thenValue([store = store(), read_options, read_query](auto&& maybe_index_key){
+            missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
+                    !(*read_options.batch_throw_on_missing_version_) || maybe_index_key.has_value(),
+                    "Version not found for symbol");
+            if (maybe_index_key.has_value()) {
+                return std::move(store->read(*maybe_index_key))
+                .thenValue([store, read_query, read_options](auto&& key_segment_pair) {
+                    auto [index_key, index_segment] = std::move(key_segment_pair);
+                    return async_read_direct(store,
+                                             std::move(index_key),
+                                             std::move(index_segment),
+                                             read_query,
+                                             std::make_shared<BufferHolder>(),
+                                             read_options);
+                })
+                .thenValue([](auto&& read_version_output) {
+                    return folly::makeFuture(std::make_optional<ReadVersionOutput>(std::move(read_version_output)));
+                });
+            } else {
+                return folly::makeFuture(std::optional<ReadVersionOutput>());
+            }
         }));
     }
     return folly::collect(output).get();
 }
 
-std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::batch_read_internal(
+std::vector<std::optional<ReadVersionOutput>> LocalVersionedEngine::batch_read_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     std::vector<ReadQuery>& read_queries,
@@ -1046,7 +1066,7 @@ std::vector<std::pair<VersionedItem, FrameAndDescriptor>> LocalVersionedEngine::
         return temp_batch_read_internal_direct(stream_ids, version_queries, read_queries, read_options);
     }
 
-    std::vector<folly::Future<std::pair<VersionedItem, FrameAndDescriptor>>> results_fut;
+    std::vector<folly::Future<std::optional<ReadVersionOutput>>> results_fut;
     for (size_t idx=0; idx < stream_ids.size(); idx++) {
         auto version_query = version_queries.size() > idx ? version_queries[idx] : VersionQuery{};
         auto read_query = read_queries.size() > idx ? read_queries[idx] : ReadQuery{};

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -120,7 +120,7 @@ public:
         ReadQuery& read_query,
         const ReadOptions& read_options) override;
 
-    std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(
+    std::optional<ReadVersionOutput> read_dataframe_version_internal(
         const StreamId &stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,
@@ -223,7 +223,7 @@ public:
     FrameAndDescriptor read_column_stats_internal(
         const VersionedItem& versioned_item);
 
-    std::pair<VersionedItem, FrameAndDescriptor> read_column_stats_version_internal(
+    ReadVersionOutput read_column_stats_version_internal(
         const StreamId& stream_id,
         const VersionQuery& version_query);
 
@@ -273,18 +273,18 @@ public:
         const WriteOptions& write_options,
         bool validate_index);
 
-    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> batch_read_keys(
+    std::vector<ReadVersionOutput> batch_read_keys(
         const std::vector<AtomKey> &keys,
         const std::vector<ReadQuery> &read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> batch_read_internal(
+    std::vector<std::optional<ReadVersionOutput>> batch_read_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> temp_batch_read_internal_direct(
+    std::vector<std::optional<ReadVersionOutput>> temp_batch_read_internal_direct(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -108,6 +108,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("set_incompletes", &ReadOptions::set_incompletes)
         .def("set_set_tz", &ReadOptions::set_set_tz)
         .def("set_optimise_string_memory", &ReadOptions::set_optimise_string_memory)
+        .def("set_batch_throw_on_missing_version", &ReadOptions::set_batch_throw_on_missing_version)
         .def_property_readonly("incompletes", &ReadOptions::get_incompletes);
 
     using FrameDataWrapper = arcticdb::pipelines::FrameDataWrapper;
@@ -189,13 +190,18 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
 
 
 
-    auto adapt_read_dfs = [](std::vector<ReadResult> && ret) -> py::list {
+    auto adapt_read_dfs = [](std::vector<std::optional<ReadResult>> && ret) -> py::list {
         py::list lst;
         for (auto &res: ret) {
-            auto pynorm = python_util::pb_to_python(res.norm_meta);
-            auto pyuser_meta = python_util::pb_to_python(res.user_meta);
-            auto multi_key_meta = python_util::pb_to_python(res.multi_key_meta);
-            lst.append(py::make_tuple(res.item, std::move(res.frame_data), pynorm, pyuser_meta, multi_key_meta, res.multi_keys));
+            if (res.has_value()) {
+                auto pynorm = python_util::pb_to_python(res->norm_meta);
+                auto pyuser_meta = python_util::pb_to_python(res->user_meta);
+                auto multi_key_meta = python_util::pb_to_python(res->multi_key_meta);
+                lst.append(py::make_tuple(res->item, std::move(res->frame_data), pynorm, pyuser_meta, multi_key_meta,
+                                          res->multi_keys));
+            } else {
+                lst.append(py::none());
+            }
         }
         return lst;
     };

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -345,10 +345,12 @@ TEST_F(VersionStoreTest, StressBatchReadUncompressed) {
     }
 
     std::vector<ReadQuery> read_queries;
-    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, ReadOptions{});
+    ReadOptions read_options;
+    read_options.set_batch_throw_on_missing_version(true);
+    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, read_options);
     for(auto version : folly::enumerate(latest_versions)) {
-        auto expected = get_test_simple_frame(version->item.symbol(), 10, version.index);
-        bool equal = expected.segment_ == version->frame_data.frame();
+        auto expected = get_test_simple_frame((*version)->item.symbol(), 10, version.index);
+        bool equal = expected.segment_ == (*version)->frame_data.frame();
         ASSERT_EQ(equal, true);
     }
 }
@@ -445,8 +447,8 @@ TEST(VersionStore, UpdateWithin) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto& seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).value();
+    const auto& seg = read_result.frame_and_descriptor_.frame_;
 
     for(auto i = 0u; i < num_rows; ++i) {
         auto expected = i;
@@ -487,8 +489,8 @@ TEST(VersionStore, UpdateBefore) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto& seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).value();
+    const auto& seg = read_result.frame_and_descriptor_.frame_;
 
     for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
         auto expected = i;
@@ -529,8 +531,8 @@ TEST(VersionStore, UpdateAfter) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto& seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).value();
+    const auto& seg = read_result.frame_and_descriptor_.frame_;
 
     for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
         auto expected = i;
@@ -572,9 +574,8 @@ TEST(VersionStore, UpdateIntersectBefore) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).value();
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
         auto expected = i;
@@ -616,9 +617,8 @@ TEST(VersionStore, UpdateIntersectAfter) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}).value();
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
         auto expected = i;
@@ -670,8 +670,8 @@ TEST(VersionStore, UpdateWithinSchemaChange) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options).value();
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u;i < num_rows; ++i) {
         auto expected = i;
@@ -731,8 +731,8 @@ TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
-    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options).value();
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u;i < num_rows; ++i) {
         auto expected = i;

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -281,7 +281,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::vector<StreamId>& id,
         const std::vector<VersionQuery>& version_query);
 
-    std::vector<ReadResult> batch_read(
+    std::vector<std::optional<ReadResult>> batch_read(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,
@@ -334,16 +334,16 @@ private:
     void delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key);
 };
 
-inline std::vector<ReadResult> frame_to_read_result(std::vector<std::pair<VersionedItem, FrameAndDescriptor>>&& keys_frame_and_descriptors) {
-    std::vector<ReadResult> read_results;
+inline std::vector<std::optional<ReadResult>> frame_to_read_result(std::vector<ReadVersionOutput>&& keys_frame_and_descriptors) {
+    std::vector<std::optional<ReadResult>> read_results;
     read_results.reserve(keys_frame_and_descriptors.size());
-    for (auto [item, fd] : keys_frame_and_descriptors) {
+    for (auto& read_version_output : keys_frame_and_descriptors) {
         read_results.emplace_back(ReadResult(
-            item,
-            PythonOutputFrame{fd.frame_, fd.buffers_},
-            fd.desc_.proto().normalization(),
-            fd.desc_.proto().user_meta(),
-            fd.desc_.proto().multi_key_meta(),
+            read_version_output.versioned_item_,
+            PythonOutputFrame{read_version_output.frame_and_descriptor_.frame_, read_version_output.frame_and_descriptor_.buffers_},
+            read_version_output.frame_and_descriptor_.desc_.proto().normalization(),
+            read_version_output.frame_and_descriptor_.desc_.proto().user_meta(),
+            read_version_output.frame_and_descriptor_.desc_.proto().multi_key_meta(),
             std::vector<AtomKey>{}));
     }
     return read_results;

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -23,6 +23,18 @@ namespace arcticdb::version_store {
 using namespace arcticdb::entity;
 using namespace arcticdb::pipelines;
 
+struct ReadVersionOutput {
+    ReadVersionOutput() = delete;
+    ReadVersionOutput(VersionedItem&& versioned_item, FrameAndDescriptor&& frame_and_descriptor):
+            versioned_item_(std::move(versioned_item)),
+            frame_and_descriptor_(std::move(frame_and_descriptor)) {}
+
+    ARCTICDB_MOVE_ONLY_DEFAULT(ReadVersionOutput)
+
+    VersionedItem versioned_item_;
+    FrameAndDescriptor frame_and_descriptor_;
+};
+
 /**
  * The VersionedEngine interface contains methods that are portable between languages.
  *
@@ -97,7 +109,7 @@ public:
         ReadQuery& read_query,
         const ReadOptions& read_options) = 0;
 
-    virtual std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(
+    virtual std::optional<ReadVersionOutput> read_dataframe_version_internal(
         const StreamId &stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -935,9 +935,9 @@ class Library:
                     f"Unsupported item in the symbols argument s=[{s}] type(s)=[{type(s)}]. Only [str] and"
                     " [ReadRequest] are supported."
                 )
-
+        throw_on_missing_version = False
         return self._nvs._batch_read_to_versioned_items(
-            symbol_strings, as_ofs, date_ranges, columns, query_builder or query_builders
+            symbol_strings, as_ofs, date_ranges, columns, query_builder or query_builders, throw_on_missing_version
         )
 
     def read_metadata(self, symbol: str, as_of: Optional[AsOf] = None) -> VersionedItem:

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1159,6 +1159,67 @@ def test_read_batch_unhandled_type(arctic_library):
         lib.read_batch([1])
 
 
+def test_read_batch_symbol_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df = pd.DataFrame({"a": [3, 5, 7]})
+    lib.write("s1", df)
+    # When
+    batch = lib.read_batch(["s1", "s2"])
+    # Then
+    assert_frame_equal(batch[0].data, df)
+    assert batch[1] is None
+
+
+def test_read_batch_version_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+    # When
+    batch = lib.read_batch([ReadRequest("s1", as_of=0), ReadRequest("s1", as_of=1), ReadRequest("s2", as_of=1)])
+    # Then
+    assert_frame_equal(batch[0].data, df1)
+    assert batch[1] is None
+    assert batch[2] is None
+
+
+def test_read_batch_query_builder_symbol_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    q = QueryBuilder()
+    q = q[q["a"] < 5]
+    lib.write("s1", pd.DataFrame({"a": [3, 5, 7]}))
+    # When
+    batch = lib.read_batch(["s1", "s2"], query_builder=q)
+    # Then
+    assert_frame_equal(batch[0].data, pd.DataFrame({"a": [3]}))
+    assert batch[1] is None
+
+
+def test_read_batch_query_builder_version_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    q = QueryBuilder()
+    q = q[q["a"] < 5]
+    lib.write("s1", pd.DataFrame({"a": [3, 5, 7]}))
+    lib.write("s2", pd.DataFrame({"a": [4, 6, 8]}))
+    # When
+    batch = lib.read_batch(
+        [ReadRequest("s1", as_of=0), ReadRequest("s1", as_of=1), ReadRequest("s2", as_of=1)], query_builder=q
+    )
+    # Then
+    assert_frame_equal(batch[0].data, pd.DataFrame({"a": [3]}))
+    assert batch[1] is None
+    assert batch[2] is None
+
+
 def test_has_symbol(arctic_library):
     lib = arctic_library
     lib.write("symbol", pd.DataFrame())

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1652,6 +1652,23 @@ def test_batch_read_date_range(lmdb_version_store_tombstone_and_sync_passive):
         assert_frame_equal(vit.data, dfs[x].loc[start:end])
 
 
+def test_batch_read_symbol_doesnt_exist(lmdb_version_store):
+    sym1 = "sym1"
+    sym2 = "sym2"
+    lmdb_version_store.write(sym1, 1)
+    with pytest.raises(NoDataFoundException):
+        _ = lmdb_version_store.batch_read([sym1, sym2])
+
+
+def test_batch_read_version_doesnt_exist(lmdb_version_store):
+    sym1 = "sym1"
+    sym2 = "sym2"
+    lmdb_version_store.write(sym1, 1)
+    lmdb_version_store.write(sym2, 2)
+    with pytest.raises(NoDataFoundException):
+        _ = lmdb_version_store.batch_read([sym1, sym2], as_ofs=[0, 1])
+
+
 def test_index_keys_start_end_index(lmdb_version_store, sym):
     idx = pd.date_range("2022-01-01", periods=100, freq="D")
     df = pd.DataFrame({"a": range(len(idx))}, index=idx)


### PR DESCRIPTION
Closes #531 

The previous behaviour was to throw a `NoDataFoundException` if any of the requested symbols/versions did not exist. The new behaviour is to return a `None` in the list for any symbols/versions that do not exist.

The existing behaviour is maintained on `NativeVersionStore` for backwards compatibility.