### PR TITLE
Parallel version append batch method

### DIFF
--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -195,23 +195,22 @@ folly::Future<entity::AtomKey> append_frame(
 
     auto existing_slices = unfiltered_index(index_segment_reader);
     auto keys_fut = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store);
-
-    auto slice_and_keys_to_append = keys_fut.wait().value();
-
-    auto slices_to_write = std::move(existing_slices);
-    slices_to_write.insert(std::end(slices_to_write), std::begin(slice_and_keys_to_append), std::end(slice_and_keys_to_append));
-    std::sort(std::begin(slices_to_write), std::end(slices_to_write));
-    if(dynamic_schema) {
-        auto merged_descriptor =
-            merge_descriptors(frame.desc, std::vector< std::shared_ptr<FieldCollection>>{ index_segment_reader.tsd().fields_ptr()}, {});
-        merged_descriptor.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame.desc.get_sorted()));
-        auto tsd =
-            make_timeseries_descriptor(frame.num_rows + frame.offset, std::move(merged_descriptor), std::move(frame.norm_meta), std::move(frame.user_meta), std::nullopt, std::nullopt, frame.bucketize_dynamic);
-        return index::write_index(stream::index_type_from_descriptor(frame.desc), std::move(tsd), std::move(slices_to_write), key, store);
-    } else {
-        frame.desc.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame.desc.get_sorted()));
-        return index::write_index(std::move(frame), std::move(slices_to_write), key, store);
-    }
+    return std::move(keys_fut)
+    .thenValue([dynamic_schema, slices_to_write = std::move(existing_slices), frame = std::move(frame), index_segment_reader = std::move(index_segment_reader), key = std::move(key), &store](auto&& slice_and_keys_to_append) mutable {
+        slices_to_write.insert(std::end(slices_to_write), std::make_move_iterator(std::begin(slice_and_keys_to_append)), std::make_move_iterator(std::end(slice_and_keys_to_append)));
+        std::sort(std::begin(slices_to_write), std::end(slices_to_write));
+        if(dynamic_schema) {
+            auto merged_descriptor =
+                merge_descriptors(frame.desc, std::vector< std::shared_ptr<FieldCollection>>{ index_segment_reader.tsd().fields_ptr()}, {});
+            merged_descriptor.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame.desc.get_sorted()));
+            auto tsd =
+                make_timeseries_descriptor(frame.num_rows + frame.offset, std::move(merged_descriptor), std::move(frame.norm_meta), std::move(frame.user_meta), std::nullopt, std::nullopt, frame.bucketize_dynamic);
+            return index::write_index(stream::index_type_from_descriptor(frame.desc), std::move(tsd), std::move(slices_to_write), key, store);
+        } else {
+            frame.desc.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame.desc.get_sorted()));
+            return index::write_index(std::move(frame), std::move(slices_to_write), key, store);
+        }
+    });
 }
 
 void update_string_columns(const SegmentInMemory& original, SegmentInMemory output) {

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -276,13 +276,13 @@ public:
         bool prune_previous_versions,
         std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>&& user_meta_protos);
 
-    std::vector<AtomKey> batch_append_internal(
-        std::vector<VersionId> version_ids,
+    std::vector<std::variant<VersionedItem, DataError>> batch_append_internal(
         const std::vector<StreamId>& stream_ids,
-        std::vector<AtomKey> prevs,
-        std::vector<InputTensorFrame> frames,
-        const WriteOptions& write_options,
-        bool validate_index);
+        std::vector<InputTensorFrame>&& frames,
+        bool prune_previous_versions,
+        bool validate_index,
+        bool upsert,
+        bool throw_on_missing_version);
 
     std::vector<ReadVersionOutput> batch_read_keys(
         const std::vector<AtomKey> &keys,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -276,13 +276,15 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::vector<py::object>& user_meta,
         bool prune_previous_versions);
 
-    std::vector<VersionedItem> batch_append(
+    std::vector<std::variant<VersionedItem, DataError>> batch_append(
         const std::vector<StreamId> &stream_ids,
         const std::vector<py::tuple> &items,
         const std::vector<py::object> &norms,
         const std::vector<py::object> &user_metas,
         bool prune_previous_versions,
-        bool ensre_sorted);
+        bool validate_index,
+        bool upsert,
+        bool throw_on_missing_version);
 
     std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> batch_restore_version(
         const std::vector<StreamId>& id,

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1914,6 +1914,16 @@ def test_batch_append(lmdb_version_store_tombstone, three_col_df):
         assert vit.metadata == append_metadata[sym]
 
 
+def test_batch_append_with_throw_exception(lmdb_version_store, three_col_df):
+    multi_data = {"sym1": three_col_df(), "sym2": three_col_df(1)}
+    with pytest.raises(NoSuchVersionException):
+        lmdb_version_store.batch_append(
+            list(multi_data.keys()),
+            list(multi_data.values()),
+            write_if_missing=False,
+        )
+
+
 @pytest.mark.parametrize("use_date_range_clause", [True, False])
 def test_batch_read_date_range(lmdb_version_store_tombstone_and_sync_passive, use_date_range_clause):
     lmdb_version_store = lmdb_version_store_tombstone_and_sync_passive


### PR DESCRIPTION
- This pull request introduces per-symbol parallelism for the append_batch method, which requires significant implementation changes using the Folly Futures API.
- The way Folly Futures work requires creating a chain of futures for each independent append, which ultimately converges into a single future containing all the individual appends. This can be visualized as a tree with each individual append representing a branch that has its own independent per-slice write append, which are also futures.
- To ensure proper functioning for all append flows, it's important to avoid intermediate .get() calls from the futures of all these flows. Instead, we must call a SINGLE .get() at the end of the entire futures chain, when they converge; otherwise, the system will deadlock.
- This changes also reuses the async method write_index_key_to_version_map_async, which is also used by write_batch.
- In our local environment, we observed an approximate 10-fold improvement by appending data for 2000 symbols using the changes in this PR compared to appending the same data by the non-batch version of this method (append). The results with these changes showed 15.2S by using the batch append method, while the results by using the non-batch version of the method were approximately 165s. These experiments were conducted on an 8-core CPU with the number of IO threads incremented to 50 (VersionStore.NumIOThreads = 50).