### PR TITLE
Remove tests skips in test_storage_lock.cpp for Windows

### DIFF
--- a/cpp/arcticdb/util/test/test_storage_lock.cpp
+++ b/cpp/arcticdb/util/test/test_storage_lock.cpp
@@ -16,7 +16,6 @@ using namespace arcticdb;
 using namespace folly;
 
 TEST(StorageLock, SingleThreaded) {
-    SKIP_WIN("StorageLock is not supported");
     auto store = std::make_shared<InMemoryStore>();
     StorageLock lock1{StringId{"test_lock"}};
     StorageLock lock2{StringId{"test_lock"}};
@@ -32,7 +31,6 @@ TEST(StorageLock, SingleThreaded) {
 }
 
 TEST(StorageLock, Timeout) {
-    SKIP_WIN("StorageLock is not supported");
     auto store = std::make_shared<InMemoryStore>();
     StorageLock lock{"test_lock"};
     StorageLock lock2{"test_lock"};
@@ -184,7 +182,6 @@ struct ForceReleaseLockTask {
 };
 
 TEST(StorageLock, Wait) {
-    SKIP_WIN("StorageLock is not supported");
     using namespace arcticdb;
 
     auto lock_data = std::make_shared<LockData>(4);
@@ -201,7 +198,6 @@ TEST(StorageLock, Wait) {
 }
 
 TEST(StorageLock, Timeouts) {
-    SKIP_WIN("StorageLock is not supported");
     using namespace arcticdb;
     std::unordered_map<std::string, spdlog::level::level_enum> log_levels{ {"lock", spdlog::level::debug}};
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

We are currently skipping the storage lock tests when testing the Windows build.

The storage lock code is used so we need the tests to work.


