### PR TITLE
Add environment variable controlling wheter AWS S3 should use SSL

### DIFF
--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -245,7 +245,9 @@ auto get_s3_config(const ConfigType& conf) {
     auto endpoint = conf.endpoint();
     util::check_arg(!endpoint.empty(), "S3 Endpoint must be specified");
     client_configuration.endpointOverride = endpoint;
-    client_configuration.verifySSL = false;
+    const bool use_ssl = ConfigsMap::instance()->get_int("S3Storage.UseSSL", conf.ssl());
+    log::storage().debug("Use ssl: {}", use_ssl);
+    client_configuration.verifySSL = use_ssl;
     client_configuration.maxConnections = conf.max_connections() == 0 ?
             ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", 16) :
             conf.max_connections();

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -245,9 +245,9 @@ auto get_s3_config(const ConfigType& conf) {
     auto endpoint = conf.endpoint();
     util::check_arg(!endpoint.empty(), "S3 Endpoint must be specified");
     client_configuration.endpointOverride = endpoint;
-    const bool use_ssl = ConfigsMap::instance()->get_int("S3Storage.UseSSL", conf.ssl());
-    log::storage().debug("Use ssl: {}", use_ssl);
-    client_configuration.verifySSL = use_ssl;
+    const bool verify_ssl = ConfigsMap::instance()->get_int("S3Storage.VerifySSL", conf.ssl());
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Verify ssl: {}", verify_ssl);
+    client_configuration.verifySSL = verify_ssl;
     client_configuration.maxConnections = conf.max_connections() == 0 ?
             ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", 16) :
             conf.max_connections();

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -59,6 +59,14 @@ The S3 API supports the `DeleteObjects` method, whereby a single HTTP request ca
 
 The default is 1000.
 
+### S3Storage.VerifySSL
+
+Control whether the client should verify the SSL certificate of the storage. If set, this will override the library option set upon library creation.
+
+Values:
+* 0: Do not perform SSL verification.
+* 1: Perform SSL verification.
+
 ### VersionStore.NumCPUThreads and VersionStore.NumIOThreads
 
 ArcticDB uses two threadpools in order to manage computational resources:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #522
#### What does this implement/fix? Explain your changes.
Add environment variable controlling wheter AWS S3 should use SSL. If the environment is not set it will use whatever is written in the config protobuf.

#### Any other comments?


