### PR TITLE
Fix for read batch when filtering by column

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -965,6 +965,8 @@ folly::Future<ReadVersionOutput> async_read_direct(
     auto index_segment_reader = std::make_shared<index::IndexSegmentReader>(std::move(index_segment));
 
     check_column_and_date_range_filterable(*index_segment_reader, read_query);
+    add_index_columns_to_query(read_query, index_segment_reader->tsd());
+
     auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor{index_segment_reader->tsd().as_stream_descriptor()});
     pipeline_context->set_selected_columns(read_query.columns);
     const bool dynamic_schema = opt_false(read_options.dynamic_schema_);

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -170,6 +170,10 @@ void read_indexed_keys_to_pipeline(
     ReadQuery& read_query,
     const ReadOptions& read_options);
 
+void add_index_columns_to_query(
+    const ReadQuery& read_query, 
+    const TimeseriesDescriptor& desc);
+
 } //namespace arcticdb::version_store
 
 #define ARCTICDB_VERSION_CORE_H_

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -76,7 +76,7 @@ class Arctic:
             Azure
             -----
 
-                The Azure URI connection scheme has the form ``azure://[options]``. 
+                The Azure URI connection scheme has the form ``azure://[options]``.
                 It is based on the Azure Connection String, with additional options for configuring ArcticDB.
                 Please refer to https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string for more details.
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -71,6 +71,12 @@ def symbol():
     return "sym" + str(random.randint(0, 10000))
 
 
+def assert_equal_value(data, expected):
+    received = data.reindex(sorted(data.columns), axis=1)
+    expected = expected.reindex(sorted(expected.columns), axis=1)
+    assert_frame_equal(received, expected)
+
+
 def test_simple_flow(lmdb_version_store_no_symbol_list, symbol):
     df = sample_dataframe()
     modified_df = pd.DataFrame({"col": [1, 2, 3, 4]})
@@ -1650,6 +1656,30 @@ def test_batch_read_date_range(lmdb_version_store_tombstone_and_sync_passive):
         start = date_range[0]
         end = date_range[-1]
         assert_frame_equal(vit.data, dfs[x].loc[start:end])
+
+
+def test_batch_read_columns(lmdb_version_store_tombstone_and_sync_passive):
+    lmdb_version_store = lmdb_version_store_tombstone_and_sync_passive
+    columns_of_interest = ["strings", "uint8"]
+    number_of_requests = 5
+    symbols = []
+    for i in range(number_of_requests):
+        symbols.append("sym_{}".format(i))
+
+    base_date = pd.Timestamp("2019-06-01")
+    dfs = []
+    for j in range(number_of_requests):
+        df = get_sample_dataframe(1000, j)
+        df.index = pd.date_range(base_date + pd.DateOffset(j), periods=len(df))
+        dfs.append(df)
+
+    for x, symbol in enumerate(symbols):
+        lmdb_version_store.write(symbol, dfs[x])
+
+    result_dict = lmdb_version_store.batch_read(symbols, columns=[columns_of_interest] * number_of_requests)
+    for x, sym in enumerate(result_dict.keys()):
+        vit = result_dict[sym]
+        assert_equal_value(vit.data, dfs[x][columns_of_interest])
 
 
 def test_batch_read_symbol_doesnt_exist(lmdb_version_store):


### PR DESCRIPTION
async_read_direct need to add the index column as part of the set of columns requested by the read. It only applies when we specify a set of columns for the read operation
