### PR TITLE
Reduce Azure logs from warning to debug

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage-inl.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage-inl.hpp
@@ -282,7 +282,7 @@ bool do_key_exists_impl(
                 return true;
         }
         catch (const Azure::Core::RequestFailedException& e){
-            log::storage().warn("Failed to check azure key '{}' {} {}: {}",
+            log::storage().debug("Failed to check azure key '{}' {} {}: {}",
                                 key,
                                 blob_name,
                                 static_cast<int>(e.StatusCode),

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -21,10 +21,10 @@ AzureStorage::AzureStorage(const LibraryPath &library_path, OpenMode mode, const
     root_folder_(object_store_utils::get_root_folder(library_path)),
     request_timeout_(conf.request_timeout() == 0 ? 60000 : conf.request_timeout()){
         if (conf.ca_cert_path().empty())
-            log::storage().info("Using default CA cert path");
+            ARCTICDB_RUNTIME_DEBUG(log::storage(), "Using default CA cert path");
         else
-            log::storage().info("CA cert path: {}", conf.ca_cert_path());
-        log::storage().info("Connecting to Azure Blob Storage: {} Container: {}", conf.endpoint(), conf.container_name());
+            ARCTICDB_RUNTIME_DEBUG(log::storage(), "CA cert path: {}", conf.ca_cert_path());
+        ARCTICDB_RUNTIME_DEBUG(log::storage(), "Connecting to Azure Blob Storage: {} Container: {}", conf.endpoint(), conf.container_name());
 
         if (!conf.prefix().empty()) {
             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Azure prefix found, using: {}", conf.prefix());


### PR DESCRIPTION
Noise seen with current logging levels:

```
In [37]: lib.write('test', pd.DataFrame())
[2023-07-10 18:52:11.184] [arcticdb] [warning] Failed to check azure key 'r:test' test21689015021527994368/vref/*sUt*test 404: The specified blob does not exist.
[2023-07-10 18:52:11.222] [arcticdb] [warning] Failed to check azure key 'V:test' test21689015021527994368/ver/*sUt*test 404: The specified blob does not exist.
[2023-07-10 18:52:11.269] [arcticdb] [warning] Failed to check azure key 'r:test' test21689015021527994368/vref/*sUt*test 404: The specified blob does not exist.
[2023-07-10 18:52:11.309] [arcticdb] [warning] Failed to check azure key 'V:test' test21689015021527994368/ver/*sUt*test 404: The specified blob does not exist.
[2023-07-10 18:52:11.365] [arcticdb] [warning] Failed to check azure key 'r:test' test21689015021527994368/vref/*sUt*test 404: The specified blob does not exist.
[2023-07-10 18:52:11.400] [arcticdb] [warning] Failed to check azure key 'V:test' test21689015021527994368/ver/*sUt*test 404: The specified blob does not exist.
Out[37]: VersionedItem(symbol='test', library='test2', data=n/a, version=0, metadata=None, host=')
```

Note, nothing went wrong in the above example. The write succeeded exactly as expected.