### PR TITLE
fix: Remove uneeded `FMT_COMPILE`

### DIFF
--- a/cpp/arcticdb/storage/lmdb/lmdb_storage-inl.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage-inl.hpp
@@ -102,7 +102,7 @@ template<class Visitor>
     std::vector<VariantKey> failed_reads;
 
     (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
-        auto db_name = fmt::format(FMT_COMPILE("{}"), group.key());
+        auto db_name = fmt::format("{}", group.key());
         ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
         auto dbi = ::lmdb::dbi::open(txn, db_name.data());
         for (auto &k : group.values()) {


### PR DESCRIPTION
#### Reference Issues/PRs

Bug first observed in https://github.com/conda-forge/arcticdb-feedstock/pull/22.

#### What does this implement/fix? Explain your changes.

This occurrence of `FMT_COMPILE` causes a ICE Segfault with gxx-12.

#### Any other comments?

@willdealtry: Do we need `FMT_COMPILE`, here?

cc @mehertz