### PR TITLE
Enhancement 555: Make head and tail clauses to reduce final dataframe memory footprint

### DIFF
--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -44,6 +44,7 @@ namespace arcticdb::async {
         auto &hdr = seg.header();
         auto desc = StreamDescriptor(std::make_shared<StreamDescriptor::Proto>(std::move(*hdr.mutable_stream_descriptor())), seg.fields_ptr());
         auto descriptor = async::get_filtered_descriptor(desc, filter_columns_);
+        sk.slice_.adjust_columns(descriptor.field_count() - descriptor.index().field_count());
 
         ARCTICDB_TRACE(log::codec(), "Creating segment");
         SegmentInMemory res(std::move(descriptor));

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -853,6 +853,8 @@ public:
 
     static std::vector<std::shared_ptr<Column>> split(const std::shared_ptr<Column>& column, size_t num_rows);
 
+    static std::shared_ptr<Column> truncate(const std::shared_ptr<Column>& column, size_t start_row, size_t end_row);
+
 private:
     position_t last_offset() const {
         return offsets_.empty() ? 0 : *offsets_.rbegin();
@@ -918,7 +920,7 @@ private:
 
     util::BitMagic& sparse_map() {
         if(!sparse_map_)
-            sparse_map_ = std::make_optional<util::BitMagic>();
+            sparse_map_ = std::make_optional<util::BitMagic>(0);
 
         return sparse_map_.value();
     }

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -403,6 +403,10 @@ public:
         return SegmentInMemory(impl_->filter(filter_bitset, filter_down_stringpool, validate));
     }
 
+    SegmentInMemory truncate(size_t start_row, size_t end_row) const{
+        return SegmentInMemory(impl_->truncate(start_row, end_row));
+    }
+
     std::vector<SegmentInMemory> partition(const std::vector<std::optional<uint8_t>>& row_to_segment,
                            const std::vector<uint64_t>& segment_counts) const{
         std::vector<SegmentInMemory> res;

--- a/cpp/arcticdb/pipeline/filter_segment.hpp
+++ b/cpp/arcticdb/pipeline/filter_segment.hpp
@@ -21,6 +21,12 @@ inline SegmentInMemory filter_segment(const SegmentInMemory& input,
     return input.filter(filter_bitset, filter_down_stringpool, validate);
 }
 
+inline SegmentInMemory truncate_segment(const SegmentInMemory& input,
+                                        size_t start,
+                                        size_t end) {
+    return input.truncate(start, end);
+}
+
 inline std::vector<SegmentInMemory> partition_segment(const SegmentInMemory& input,
                                       const std::vector<std::optional<uint8_t>>& row_to_segment,
                                       const std::vector<uint64_t>& segment_counts) {

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -113,6 +113,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     // Used to keep track of the total number of rows when compacting incomplete segments and
     // in sort merge
     size_t total_rows_ = 0;
+    // The number of rows according to the timeseries descriptor
+    size_t rows_ = 0;
     std::shared_ptr<arcticdb::proto::descriptors::NormalizationMetadata> norm_meta_;
     std::unique_ptr<arcticdb::proto::descriptors::UserDefinedMetadata> user_meta_;
     std::vector<SliceAndKey> slice_and_keys_;

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -70,12 +70,6 @@ struct ReadQuery {
             } else {
                 row_filter = RowRange(0, std::max(static_cast<int64_t>(0), total_rows + head_range.num_rows_));
             }
-            if (clauses_.empty() && columns.empty() && head_range.num_rows_ > 0) {
-                // TODO: columns aren't supported due to AN-334
-                clauses_.emplace_back(std::make_shared<Clause>(RowNumberLimitClause{static_cast<size_t>(head_range.num_rows_)}));
-            } else {
-                log::version().info("Arguments not compatible with head() memory usage optimisation");
-            }
             },
             [&](const TailRange &tail_range) {
             if (tail_range.num_rows_ >= 0) {

--- a/cpp/arcticdb/pipeline/read_pipeline.hpp
+++ b/cpp/arcticdb/pipeline/read_pipeline.hpp
@@ -138,7 +138,6 @@ inline std::optional<util::BitSet> clause_column_bitset(const StreamDescriptor::
             }
         }
     }
-    // If only needed because the hacky clause for head memory usage doesn't specify columns
     if (!column_set.empty()) {
         return build_column_bitset(desc, column_set);
     } else {

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -54,6 +54,7 @@ struct ClauseInfo {
 // Changes how the clause behaves based on information only available after it is constructed
 struct ProcessingConfig {
     bool dynamic_schema_{false};
+    uint64_t total_rows_;
 };
 
 
@@ -440,21 +441,31 @@ struct ColumnStatsGenerationClause {
     }
 };
 
-/**
- * Hacky short-cut to reduce memory usage for head(). Very similar to how FilterClause above works.
- * Limitations:
- * - Must be the only Clause (otherwise may return wrong results)
- * - If the n is so big that multiple RowRanges/ProcessingSegments are passed in then much more state tracking is
- * required than what is reasonable for a stop-gap, so this optimisation just disables itself.
- */
-struct RowNumberLimitClause {
+// Used by head and tail to discard rows not requested by the user
+struct RowRangeClause {
+    enum class RowRangeType: uint8_t {
+        HEAD,
+        TAIL
+    };
+
     ClauseInfo clause_info_;
-    size_t n;
-    mutable bool warning_shown = false; // folly::Poly can't deal with atomic_bool
+    RowRangeType row_range_type_;
+    // As passed into head or tail
+    int64_t n_;
 
-    explicit RowNumberLimitClause(size_t n) : n(n) {}
+    // Row range to keep. Zero-indexed, inclusive of start, exclusive of end
+    // Calculated from n, whether the RowRangeType is head or tail, and the total rows as passed in by set_processing_config
+    uint64_t start_{0};
+    uint64_t end_{0};
 
-    ARCTICDB_MOVE_COPY_DEFAULT(RowNumberLimitClause)
+    explicit RowRangeClause(RowRangeType row_range_type, int64_t n):
+            row_range_type_(row_range_type),
+            n_(n) {
+    }
+
+    RowRangeClause() = delete;
+
+    ARCTICDB_MOVE_COPY_DEFAULT(RowRangeClause)
 
     [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
                                                        Composite<ProcessingSegment> &&p) const;
@@ -468,7 +479,9 @@ struct RowNumberLimitClause {
         return clause_info_;
     }
 
-    void set_processing_config(ARCTICDB_UNUSED const ProcessingConfig& processing_config) {}
+    void set_processing_config(const ProcessingConfig& processing_config);
+
+    [[nodiscard]] std::string to_string() const;
 };
 
 }//namespace arcticdb

--- a/cpp/arcticdb/processing/processing_segment.hpp
+++ b/cpp/arcticdb/processing/processing_segment.hpp
@@ -115,6 +115,8 @@ namespace arcticdb {
 
         void apply_filter(const util::BitSet& bitset, const std::shared_ptr<Store>& store, PipelineOptimisation optimisation);
 
+        void truncate(size_t start_row, size_t end_row, const std::shared_ptr<Store>& store);
+
         void set_expression_context(const std::shared_ptr<ExpressionContext>& expression_context) {
             expression_context_ = expression_context;
         }

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -264,6 +264,14 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def(py::init<std::string, std::unordered_map<std::string, std::string>>())
             .def("__str__", &AggregationClause::to_string);
 
+    py::enum_<RowRangeClause::RowRangeType>(version, "RowRangeType")
+            .value("HEAD", RowRangeClause::RowRangeType::HEAD)
+            .value("TAIL", RowRangeClause::RowRangeType::TAIL);
+
+    py::class_<RowRangeClause, std::shared_ptr<RowRangeClause>>(version, "RowRangeClause")
+            .def(py::init<RowRangeClause::RowRangeType, int64_t>())
+            .def("__str__", &RowRangeClause::to_string);
+
     py::class_<ReadQuery>(version, "PythonVersionStoreReadQuery")
             .def(py::init())
             .def_readwrite("columns",&ReadQuery::columns)
@@ -275,7 +283,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
                     std::vector<std::variant<std::shared_ptr<FilterClause>,
                                 std::shared_ptr<ProjectClause>,
                                 std::shared_ptr<GroupByClause>,
-                                std::shared_ptr<AggregationClause>>> clauses) {
+                                std::shared_ptr<AggregationClause>,
+                                std::shared_ptr<RowRangeClause>>> clauses) {
                 std::vector<std::shared_ptr<Clause>> _clauses;
                 for (auto&& clause: clauses) {
                     util::variant_match(

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -540,7 +540,7 @@ std::vector<SliceAndKey> read_and_process(
         }
     }
 
-    ProcessingConfig processing_config{opt_false(read_options.dynamic_schema_)};
+    ProcessingConfig processing_config{opt_false(read_options.dynamic_schema_), pipeline_context->rows_};
     for (auto& clause: read_query.clauses_) {
         clause->set_processing_config(processing_config);
     }
@@ -668,6 +668,7 @@ void read_indexed_keys_to_pipeline(
 
     pipeline_context->slice_and_keys_ = filter_index(index_segment_reader, combine_filter_functions(queries));
     pipeline_context->total_rows_ = pipeline_context->calc_rows();
+    pipeline_context->rows_ = index_segment_reader.tsd().proto().total_rows();
     pipeline_context->norm_meta_ = std::make_unique<arcticdb::proto::descriptors::NormalizationMetadata>(std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_normalization()));
     pipeline_context->user_meta_ = std::make_unique<arcticdb::proto::descriptors::UserDefinedMetadata>(std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_user_meta()));
     pipeline_context->bucketize_dynamic_ = bucketize_dynamic;
@@ -774,6 +775,10 @@ void copy_segments_to_frame(const std::shared_ptr<Store>& store, const std::shar
         }
 
         auto field_count = context_row->slice_and_key().slice_.col_range.diff() + index_field_count;
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                field_count == segment.descriptor().field_count(),
+                "Column range does not match segment descriptor field count in copy_segments_to_frame: {} != {}",
+                field_count, segment.descriptor().field_count());
         for (auto field_col = index_field_count; field_col < field_count; ++field_col) {
             const auto& field_name = context_row->descriptor().fields(field_col).name();
             auto frame_loc_opt = frame.column_index(field_name);

--- a/python/tests/unit/arcticdb/version_store/test_head.py
+++ b/python/tests/unit/arcticdb/version_store/test_head.py
@@ -20,6 +20,11 @@ def generic_head_test(version_store, symbol, df, num_rows):
     assert np.array_equal(df.head(num_rows), version_store.head(symbol, num_rows).data)
 
 
+def test_head_large_segment(lmdb_version_store):
+    df = DataFrame({"x": np.arange(100_000, dtype=np.int64)})
+    generic_head_test(lmdb_version_store, "test_head_large_segment", df, 50_000)
+
+
 def test_head_zero_num_rows(lmdb_version_store, one_col_df):
     generic_head_test(lmdb_version_store, "test_head_zero_num_rows", one_col_df(), 0)
 

--- a/python/tests/unit/arcticdb/version_store/test_tail.py
+++ b/python/tests/unit/arcticdb/version_store/test_tail.py
@@ -22,6 +22,11 @@ def generic_tail_test(version_store, symbol, df, num_rows):
     assert np.array_equal(expected, actual)
 
 
+def test_tail_large_segment(lmdb_version_store):
+    df = DataFrame({"x": np.arange(100_000, dtype=np.int64)})
+    generic_tail_test(lmdb_version_store, "test_tail_large_segment", df, 50_000)
+
+
 def test_tail_zero_num_rows(lmdb_version_store, one_col_df):
     generic_tail_test(lmdb_version_store, "test_tail_zero_num_rows", one_col_df(), 0)
 


### PR DESCRIPTION
Close #555 

Originally, head and tail decoded columns from storage directly into the numpy output buffers. This resulted in all of the rows in any required segments from storage being maintained in memory even after the ArcticDB method returned, with a hacky post-processing step to ensure only the rows the user requested were visible.

This excessive memory usage caused some issues, so a workaround was added. In the case where only a single row-slice was required from storage, the `RowNumberLimitClause` was added which filtered down to only the required rows. This used the `ProcessingSegment::filter` function with a bitset of all 1s followed by all 0s, so was very inefficient.

The new implementation is not restricted to the case where only a single row-slice is required from storage. In addition, a `truncate` method has been added at the `ChunkedBuffer` level, so that selecting a contiguous range of rows from a column is now as efficient as possible. This method will also be useful for #558, #529, and #556.