### PR TITLE
Only open library once in the interpreter lifetime

### DIFF
--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -9,8 +9,8 @@ from arcticdb.options import LibraryOptions
 from arcticc.pb2.storage_pb2 import LibraryConfig
 from arcticdb_ext.storage import Library, StorageOverride
 from arcticdb.encoding_version import EncodingVersion
+from arcticdb.version_store._store import NativeVersionStore
 from abc import ABC, abstractmethod
-from typing import Optional
 
 
 def set_library_options(lib_desc: "LibraryConfig", options: LibraryOptions):
@@ -57,11 +57,7 @@ class ArcticLibraryAdapter(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def create_library_config(self, name: str, library_options: LibraryOptions) -> LibraryConfig:
-        raise NotImplementedError
-
-    @abstractmethod
-    def initialize_library(self, name: str, config: LibraryConfig):
+    def create_library(self, name: str, library_options: LibraryOptions) -> NativeVersionStore:
         raise NotImplementedError
 
     def delete_library(self, library: Library, library_config: LibraryConfig):

--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -63,7 +63,7 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
         return "azure(endpoint=%s, container=%s)" % (self._endpoint, self._container)
 
     @property
-    def config_library(self) -> Library:
+    def config_library(self):
         env_cfg = EnvironmentConfigsMap()
         with_prefix = (
             f"{self._query_params.Path_prefix}/{self.CONFIG_LIBRARY_NAME}" if self._query_params.Path_prefix else False
@@ -79,9 +79,9 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
             ca_cert_path=self._ca_cert_path,
         )
 
-        lib = NativeVersionStore.create_store_from_config(env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME)._library
+        lib = NativeVersionStore.create_store_from_config(env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME)
 
-        return lib
+        return lib._library
 
     def _parse_query(self, query: str) -> ParsedQuery:
         if query and query.startswith("?"):
@@ -100,7 +100,7 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
         _kwargs = {k: v for k, v in parsed_query.items() if k in field_dict.keys()}
         return _kwargs
 
-    def create_library_config(self, name, library_options: LibraryOptions) -> LibraryConfig:
+    def create_library(self, name, library_options: LibraryOptions):
         env_cfg = EnvironmentConfigsMap()
 
         if self._query_params.Path_prefix:
@@ -123,10 +123,7 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
 
         lib = NativeVersionStore.create_store_from_config(env_cfg, _DEFAULT_ENV, name)
 
-        return lib._lib_cfg
-
-    def initialize_library(self, name: str, config: LibraryConfig):
-        pass
+        return lib
 
     @property
     def path_prefix(self):

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -47,21 +47,21 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
         return "LMDB(path=%s)" % self._path
 
     @property
-    def config_library(self) -> Library:
+    def config_library(self):
         env_cfg = EnvironmentConfigsMap()
 
         add_lmdb_library_to_env(env_cfg, lib_name=self.CONFIG_LIBRARY_NAME, env_name=_DEFAULT_ENV, db_dir=self._path)
 
         lib = NativeVersionStore.create_store_from_config(
             env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version
-        )._library
+        )
 
-        return lib
+        return lib._library
 
     def get_storage_override(self) -> StorageOverride:
         return StorageOverride()
 
-    def create_library_config(self, name, library_options: LibraryOptions) -> LibraryConfig:
+    def create_library(self, name, library_options: LibraryOptions):
         env_cfg = EnvironmentConfigsMap()
 
         add_lmdb_library_to_env(env_cfg, lib_name=name, env_name=_DEFAULT_ENV, db_dir=self._path)
@@ -72,7 +72,4 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
             env_cfg, _DEFAULT_ENV, name, encoding_version=self._encoding_version
         )
 
-        return lib._lib_cfg
-
-    def initialize_library(self, name: str, config: LibraryConfig):
-        pass
+        return lib

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -72,7 +72,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         return "S3(endpoint=%s, bucket=%s)" % (self._endpoint, self._bucket)
 
     @property
-    def config_library(self) -> Library:
+    def config_library(self):
         env_cfg = EnvironmentConfigsMap()
         _name = self._query_params.access if not self._query_params.aws_auth else USE_AWS_CRED_PROVIDERS_TOKEN
         _key = self._query_params.secret if not self._query_params.aws_auth else USE_AWS_CRED_PROVIDERS_TOKEN
@@ -96,9 +96,9 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
 
         lib = NativeVersionStore.create_store_from_config(
             env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version
-        )._library
+        )
 
-        return lib
+        return lib._library
 
     def _parse_query(self, query: str) -> ParsedQuery:
         if query and query.startswith("?"):
@@ -150,7 +150,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
 
         return storage_override
 
-    def create_library_config(self, name, library_options: LibraryOptions) -> LibraryConfig:
+    def create_library(self, name, library_options: LibraryOptions):
         env_cfg = EnvironmentConfigsMap()
 
         _name = self._query_params.access if not self._query_params.aws_auth else USE_AWS_CRED_PROVIDERS_TOKEN
@@ -182,10 +182,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             env_cfg, _DEFAULT_ENV, name, encoding_version=self._encoding_version
         )
 
-        return lib._lib_cfg
-
-    def initialize_library(self, name: str, config: LibraryConfig):
-        pass
+        return lib
 
     def _configure_aws(self):
         if not self._query_params.region:

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -212,8 +212,7 @@ class Arctic:
         >>> arctic.create_library('test.library')
         >>> my_library = arctic['test.library']
         """
-        already_open = self._open_libraries.get(name)
-        if already_open or self._library_manager.has_library(name):
+        if name in self._open_libraries or self._library_manager.has_library(name):
             raise ValueError(f"Library [{name}] already exists.")
 
         if library_options is None:

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -5,7 +5,6 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-import enum
 from typing import List, Optional
 
 from arcticdb.options import LibraryOptions
@@ -149,8 +148,13 @@ class Arctic:
         self._library_adapter = _cls(uri, self._encoding_version)
         self._library_manager = LibraryManager(self._library_adapter.config_library)
         self._uri = uri
+        self._open_libraries = dict()
 
     def __getitem__(self, name: str) -> Library:
+        already_open = self._open_libraries.get(name)
+        if already_open:
+            return already_open
+
         storage_override = self._library_adapter.get_storage_override()
         lib = NativeVersionStore(
             self._library_manager.get_library(name, storage_override),
@@ -208,15 +212,18 @@ class Arctic:
         >>> arctic.create_library('test.library')
         >>> my_library = arctic['test.library']
         """
-        if self._library_manager.has_library(name):
-            raise ValueError(f"{name} already exists as a library. Please delete prior to re-creating.")
+        already_open = self._open_libraries.get(name)
+        if already_open or self._library_manager.has_library(name):
+            raise ValueError(f"Library [{name}] already exists.")
 
         if library_options is None:
             library_options = LibraryOptions()
 
-        library_config = self._library_adapter.create_library_config(name, library_options)
-        self._library_adapter.initialize_library(name, library_config)
-        self._library_manager.write_library_config(library_config, name)
+        library = self._library_adapter.create_library(name, library_options)
+        library.env = repr(self._library_adapter)
+        lib = Library(repr(self), library)
+        self._open_libraries[name] = lib
+        self._library_manager.write_library_config(library._lib_cfg, name)
 
     def delete_library(self, name: str) -> None:
         """
@@ -230,7 +237,8 @@ class Arctic:
         name: `str`
             Name of the library to delete.
         """
-        if not self._library_manager.has_library(name):
+        already_open = self._open_libraries.pop(name, None)
+        if not already_open and not self._library_manager.has_library(name):
             return
         self._library_adapter.delete_library(
             self[name], self._library_manager.get_library_config(name, StorageOverride())

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1583,3 +1583,20 @@ def test_reload_symbol_list(connection_string, client, request):
 def test_get_uri(object_storage_uri_incl_bucket):
     ac = Arctic(object_storage_uri_incl_bucket)
     assert ac.get_uri() == object_storage_uri_incl_bucket
+
+
+def test_lmdb(tmpdir):
+    # Github Issue #520 - this used to segfault
+    d = {
+        "test1": pd.Timestamp("1979-01-18 00:00:00"),
+        "test2": pd.Timestamp("1979-01-19 00:00:00"),
+    }
+
+    arc = Arctic(f"lmdb://{tmpdir}")
+    arc.create_library("model")
+    lib = arc.get_library("model")
+
+    for i in range(50):
+        lib.write_pickle("test", d)
+        lib = arc.get_library("model")
+        lib.read("test").data


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

This addresses the issue reported here https://github.com/man-group/ArcticDB/issues/520#issuecomment-1611455485 in issue #520, but doesn't solve the OP's issue.


#### What does this implement/fix? Explain your changes.

An LMDB env should never be opened twice in the same process. I posted some LMDB usage guidelines on issue #520. However we had many issues with our use of it.

- At library creation, a `LibraryIndex` object creates the storages, which creates LMDB envs for both the config library and the actual library, and holds those envs open.
- On calling `Arctic#get_library` a `LibraryManager` object then recreates the storages, regardless of whether they were already open or not. This is why the `get_library` call affected whether the user saw issues or not.

These break the rule of LMDB:

    _Do not have open an LMDB database twice in the same process at the same time. Not even from a plain open() call - close()ing it breaks flock() advisory locking._

and presumably leading to corruption in the memory-mapped file that LMDB holds open.

#### Alternatives

I also tried making the LMDB env global - https://github.com/man-group/ArcticDB/pull/579 - which I think would work too. However this approach seems cleaner and simpler and lets us manage the env with the RAII idioms that LMDB++ is designed for.
