### PR TITLE
Support negative integers in `as_of`

### DIFF
--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -71,6 +71,7 @@ using VariantId = std::variant<NumericId, StringId>;
 using StreamId = VariantId;
 using SnapshotId = VariantId;
 using VersionId = uint64_t;
+using SignedVersionId = int64_t;
 using GenerationId = VersionId;
 using timestamp = int64_t;
 using shape_t = ssize_t;

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -107,7 +107,7 @@ struct TimestampVersionQuery {
 };
 
 struct SpecificVersionQuery {
-    VersionId version_id_;
+    SignedVersionId version_id_;
 };
 
 struct VersionQuery {
@@ -123,7 +123,7 @@ struct VersionQuery {
         content_ = TimestampVersionQuery{ts};
     }
 
-    void set_version(VersionId version) {
+    void set_version(SignedVersionId version) {
         content_ = SpecificVersionQuery{version};
     }
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -93,7 +93,7 @@ public:
 
     std::optional<VersionedItem> get_specific_version(
         const StreamId &stream_id,
-        VersionId version_id,
+        SignedVersionId signed_version_id,
         const VersionQuery& version_query);
 
     std::optional<VersionedItem> get_version_at_time(

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -54,7 +54,7 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{j}, false, false});
+            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
         }
     }
 
@@ -74,13 +74,11 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
 
 TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     SKIP_WIN("Exceeds LMDB map size");
-    ScopedConfig cpu_threads("VersionStore.NumCPUThreads", 1);
-    ScopedConfig io_threads("VersionStore.NumIOThreads", 1);
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
 
-    uint64_t num_streams = 1000;
-    uint64_t num_versions_per_stream = 500;
+    uint64_t num_streams = 25;
+    uint64_t num_versions_per_stream = 50;
 
     for(uint64_t i = 0; i < num_streams; ++i) {
         auto stream = fmt::format("stream_{}", i);
@@ -98,7 +96,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{j}, false, false});
+            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
         }
     }
 
@@ -148,7 +146,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.push_back(StreamId{"stream_0"});
-        version_queries.push_back(VersionQuery{SpecificVersionQuery{i}, false, false});
+        version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
     }
 
     // Do query
@@ -181,7 +179,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.push_back(StreamId{"stream_0"});
-        version_queries.push_back(VersionQuery{SpecificVersionQuery{i}, false, false});
+        version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
     }
 
     // Do query
@@ -228,7 +226,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{j}, false, false});
+            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
         }
     }
 
@@ -243,7 +241,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
             stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{j}, false, false});
+            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
             stream_ids.push_back(StreamId{stream});
             version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false, false});
             stream_ids.push_back(StreamId{stream});

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -148,6 +148,7 @@ public:
         entry->head_ = ref_entry.head_;
         auto loaded_until = std::numeric_limits<VersionId>::max();
         VersionId oldest_loaded_index_version = std::numeric_limits<VersionId>::max();
+        std::optional<VersionId> latest_version;
 
         if ((load_params.load_type_ == LoadType::LOAD_LATEST || load_params.load_type_ == LoadType::LOAD_LATEST_UNDELETED)
             && is_index_key_type(ref_entry.keys_[0].type()))
@@ -156,10 +157,16 @@ public:
         } else {
             do {
                 auto [key, seg] = store->read_sync(next_key.value());
-                std::tie(next_key, loaded_until) = read_segment_with_keys(seg, entry);
+                next_key = read_segment_with_keys(seg, entry, loaded_until);
                 oldest_loaded_index_version = std::min(oldest_loaded_index_version, loaded_until);
+                if (!latest_version.has_value()) {
+                    auto latest = entry->get_first_index(true);
+                    if (latest.has_value()) {
+                        latest_version = latest->version_id();
+                    }
+                }
             } while (next_key
-            && need_to_load_further(load_params, loaded_until)
+            && need_to_load_further(load_params, loaded_until, latest_version)
             && load_latest_ongoing(load_params, entry)
             && looking_for_undeleted(load_params, entry, oldest_loaded_index_version));
 
@@ -579,16 +586,36 @@ private:
             return false;
         }
 
+        // TODO: Fix #587
         if (entry->second->load_type_ < load_param.load_type_) {
             ARCTICDB_DEBUG(log::version(), "Required load type {} exceeds existing load type {}, will reload", load_param.load_type_, entry->second->load_type_);
             return false;
         }
 
-        if(entry->second->load_type_ == LoadType::LOAD_DOWNTO && ((
-            load_param.load_type_ == LoadType::LOAD_DOWNTO && entry->second->loaded_until_ > load_param.load_until_.value())
-            || load_param.load_type_ == LoadType::LOAD_UNDELETED)) {
-            ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {}", load_param.load_until_.value(), entry->second->loaded_until_);
-            return false;
+        if(entry->second->load_type_ == LoadType::LOAD_DOWNTO) {
+            if (load_param.load_type_ == LoadType::LOAD_UNDELETED) {
+                return false;
+            }
+            if (load_param.load_type_ == LoadType::LOAD_DOWNTO ) {
+                if (load_param.load_until_.value() >= 0) {
+                    if (entry->second->loaded_until_ > static_cast<VersionId>(load_param.load_until_.value())) {
+                        ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {}",
+                                       load_param.load_until_.value(), entry->second->loaded_until_);
+                        return false;
+                    }
+                } else {
+                    auto opt_latest = entry->second->get_first_index(true);
+                    if (opt_latest.has_value()) {
+                        auto opt_version_id = get_version_id_negative_index(opt_latest->version_id(), *load_param.load_until_);
+                        if (opt_version_id.has_value() && entry->second->loaded_until_ > *opt_version_id) {
+                            ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {} and there are {} total versions",
+                                           load_param.load_until_.value(), entry->second->loaded_until_, opt_latest->version_id());
+                            return false;
+                        }
+                    }
+                }
+
+            }
         }
 
         if(load_param.load_type_ == LoadType::LOAD_UNDELETED && !entry->second->tombstone_all_ &&

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -28,6 +28,7 @@ from arcticdb.exceptions import (
     NoSuchVersionException,
     StreamDescriptorMismatch,
 )
+from arcticdb_ext.storage import NoDataFoundException
 from arcticdb.flattener import Flattener
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer
@@ -1203,19 +1204,56 @@ def test_coercion_to_str_with_dynamic_strings(lmdb_version_store_string_coercion
         sample_mock.assert_not_called()
 
 
-def test_find_version(lmdb_version_store):
-    lmdb_version_store.write("first", 1)
-    lmdb_version_store.write("second", 1)
-    lmdb_version_store.snapshot("a")
-    lmdb_version_store.write("first", 2)
-    lmdb_version_store.snapshot("b")
+def test_find_version(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    # def test_find_version(lmdb_version_store):
+    #     lib = lmdb_version_store
+    sym = "test_find_version"
 
-    assert lmdb_version_store._find_version("first", as_of=1).version == 1
-    assert lmdb_version_store._find_version("second", as_of=0).version == 0
-    # assert lmdb_version_store._find_version("second", as_of=2) is None
-    assert lmdb_version_store._find_version("first", as_of="a").version == 0
-    assert lmdb_version_store._find_version("first", as_of=datetime.utcnow()).version == 1  # Latest
-    assert lmdb_version_store._find_version("second").version == 0  # Latest
+    # Version 0 is alive and in a snapshot
+    lib.write(sym, 0)
+    lib.snapshot("snap_0")
+    time_0 = datetime.utcnow()
+
+    # Version 1 is only available in snap_1
+    lib.write(sym, 1)
+    lib.snapshot("snap_1")
+    time_1 = datetime.utcnow()
+    lib.delete_version(sym, 1)
+
+    # Version 2 is fully deleted
+    lib.write(sym, 2)
+    time_2 = datetime.utcnow()
+    lib.delete_version(sym, 2)
+
+    # Version 3 is not in any snapshots
+    lib.write(sym, 3)
+    time_3 = datetime.utcnow()
+
+    # Latest
+    assert lib._find_version(sym).version == 3
+    # By version number
+    assert lib._find_version(sym, as_of=0).version == 0
+    assert lib._find_version(sym, as_of=1).version == 1
+    assert lib._find_version(sym, as_of=2) is None
+    assert lib._find_version(sym, as_of=3).version == 3
+    assert lib._find_version(sym, as_of=1000) is None
+    # By negative version number
+    assert lib._find_version(sym, as_of=-1).version == 3
+    assert lib._find_version(sym, as_of=-2) is None
+    assert lib._find_version(sym, as_of=-3).version == 1
+    assert lib._find_version(sym, as_of=-4).version == 0
+    assert lib._find_version(sym, as_of=-1000) is None
+    # By snapshot
+    assert lib._find_version(sym, as_of="snap_0").version == 0
+    assert lib._find_version(sym, as_of="snap_1").version == 1
+    with pytest.raises(NoDataFoundException):
+        lib._find_version(sym, as_of="snap_1000")
+    # By timestamp
+    assert lib._find_version(sym, as_of=time_0).version == 0
+    assert lib._find_version(sym, as_of=time_1).version == 0
+    assert lib._find_version(sym, as_of=time_2).version == 0
+    assert lib._find_version(sym, as_of=time_3).version == 3
 
 
 def test_library_deletion_lmdb(lmdb_version_store):


### PR DESCRIPTION
**What does this PR do?**

This PR enables negative indexing to select "the last-but-nth version". This is equivalent to [negative indexing in Python](https://www.tutorialspoint.com/what-is-a-negative-indexing-in-python).

For example, following this PR:

```
read(...as_of=0...) will select the first version
read(...as_of=-1...) will select the most recent version
read(...as_of=-2...) will select the version prior to the most recent version
```

**Engineering considerations**

This PR modifies `LocalVersionedEngine::get_specific_version` to do most of the heavy lifting. As a result, this change should take effect across the board for all read methods.