### PR TITLE
Fix in folly future chain for write batch with dedup

### DIFF
--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -126,7 +126,7 @@ std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteratio
                                 read_keys.push_back(key);
                                 ARCTICDB_DEBUG(log::storage(), "Version map iterating key {}", key);
                                 if (perform_read_segment_with_keys) {
-                                    auto [kv, seg] = store->read(to_atom(key)).get();
+                                    auto [kv, seg] = store->read_sync(to_atom(key));
                                     read_segment_with_keys(seg, output);
                                 }
                             },


### PR DESCRIPTION
If we currently use the deduplication library option for write batching, the chain of folly::Futures may be broken due to deep get() calls within the generate_segments_from_keys and generate_keys_from_segments functions. These get() calls are unnecessary since they don't collect any set of futures and are called immediately after the asynchronous read method is executed. In these cases, the most suitable function to use is read_sync() instead of read_async() to ensure that the chain of futures is not broken.

By looking at this, I also observed that might be other potential deadlocks when trying to delete old data (because the call todo_backwards_compat_check, which is not completely sync and we still incur some get()/s there). This part has also been addressed by creating pure sync functions for this particular niche case.


closes #593 
