### PR TITLE
Pass `ReadOptions` rather than individual options; Fix `as_of` with timestamp reading entire version chain

### DIFF
--- a/cpp/arcticdb/pipeline/read_options.hpp
+++ b/cpp/arcticdb/pipeline/read_options.hpp
@@ -20,6 +20,7 @@ struct ReadOptions {
     std::optional<bool> set_tz_;
     std::optional<bool> optimise_string_memory_;
     std::optional<bool> batch_throw_on_missing_version_;
+    std::optional<bool> read_previous_on_failure_;
 
     void set_force_strings_to_fixed(const std::optional<bool>& force_strings_to_fixed) {
         force_strings_to_fixed_ = force_strings_to_fixed;

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -202,7 +202,7 @@ namespace arcticdb {
             util::raise_rte("Not implemented");
         }
 
-        RemoveKeyResultType remove_key_sync(const entity::VariantKey &key, RemoveOpts opts) override {
+        RemoveKeyResultType remove_key_sync(const entity::VariantKey &key, storage::RemoveOpts opts) override {
             StorageFailureSimulator::instance()->go(FailureType::DELETE);
             std::lock_guard lock{mutex_};
             size_t removed = util::variant_match(key,

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -316,7 +316,7 @@ inline std::pair<storage::LibraryPath, arcticdb::proto::storage::LibraryConfig> 
 inline std::shared_ptr<storage::Library> test_library_from_config(const storage::LibraryPath& lib_path,  const arcticdb::proto::storage::LibraryConfig& lib_cfg) {
     auto storage_cfg = lib_cfg.storage_by_id().at(lib_cfg.lib_desc().storage_ids(0));
     auto vs_cfg = lib_cfg.lib_desc().has_version()
-            ? LibraryDescriptor::VariantStoreConfig{lib_cfg.lib_desc().version()}
+            ? storage::LibraryDescriptor::VariantStoreConfig{lib_cfg.lib_desc().version()}
             : std::monostate{};
     return std::make_shared<storage::Library>(
             lib_path,

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -177,7 +177,7 @@ inline auto get_test_config_data() {
  * See also python_version_store_in_memory() and stream_test_common.hpp for alternatives using LMDB.
  */
 template<typename VerStoreType = version_store::LocalVersionedEngine>
-inline VerStoreType get_test_engine(LibraryDescriptor::VariantStoreConfig cfg = {}) {
+inline VerStoreType get_test_engine(storage::LibraryDescriptor::VariantStoreConfig cfg = {}) {
     auto [path, storages] = get_test_config_data();
     auto library = std::make_shared<arcticdb::storage::Library>(path, std::move(storages), std::move(cfg));
     return VerStoreType(library);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -82,7 +82,7 @@ void LocalVersionedEngine::create_column_stats_version_internal(
     ColumnStats& column_stats,
     const VersionQuery& version_query,
     const ReadOptions& read_options) {
-    auto versioned_item = get_version_to_read(stream_id, version_query);
+    auto versioned_item = get_version_to_read(stream_id, version_query, read_options);
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
             versioned_item.has_value(),
             "create_column_stats_version_internal: version not found for stream '{}'",
@@ -107,7 +107,7 @@ void LocalVersionedEngine::drop_column_stats_version_internal(
     const StreamId& stream_id,
     const std::optional<ColumnStats>& column_stats_to_drop,
     const VersionQuery& version_query) {
-    auto versioned_item = get_version_to_read(stream_id, version_query);
+    auto versioned_item = get_version_to_read(stream_id, version_query, ReadOptions{});
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
             versioned_item.has_value(),
             "drop_column_stats_version_internal: version not found for stream '{}'",
@@ -124,7 +124,7 @@ FrameAndDescriptor LocalVersionedEngine::read_column_stats_internal(
 ReadVersionOutput LocalVersionedEngine::read_column_stats_version_internal(
     const StreamId& stream_id,
     const VersionQuery& version_query) {
-    auto versioned_item = get_version_to_read(stream_id, version_query);
+    auto versioned_item = get_version_to_read(stream_id, version_query, ReadOptions{});
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
             versioned_item.has_value(),
             "read_column_stats_version_internal: version not found for stream '{}'",
@@ -142,7 +142,7 @@ ColumnStats LocalVersionedEngine::get_column_stats_info_internal(
 ColumnStats LocalVersionedEngine::get_column_stats_info_version_internal(
     const StreamId& stream_id,
     const VersionQuery& version_query) {
-    auto versioned_item = get_version_to_read(stream_id, version_query);
+    auto versioned_item = get_version_to_read(stream_id, version_query, ReadOptions{});
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
             versioned_item.has_value(),
             "get_column_stats_info_version_internal: version not found for stream '{}'",
@@ -198,8 +198,9 @@ std::string LocalVersionedEngine::dump_versions(const StreamId& stream_id) {
 
 std::optional<VersionedItem> LocalVersionedEngine::get_latest_version(
     const StreamId &stream_id,
-    const VersionQuery& version_query) {
-    auto key = get_latest_undeleted_version(store(), version_map(), stream_id,  opt_true(version_query.skip_compat_), opt_false(version_query.iterate_on_failure_));
+    const VersionQuery& version_query,
+    const ReadOptions& read_options) {
+    auto key = get_latest_undeleted_version(store(), version_map(), stream_id,  version_query, read_options);
     if (!key) {
         ARCTICDB_DEBUG(log::version(), "get_latest_version didn't find version for stream_id: {}", stream_id);
         return std::nullopt;
@@ -210,17 +211,16 @@ std::optional<VersionedItem> LocalVersionedEngine::get_latest_version(
 std::optional<VersionedItem> LocalVersionedEngine::get_specific_version(
     const StreamId &stream_id,
     SignedVersionId signed_version_id,
-    const VersionQuery& version_query) {
+    const VersionQuery& version_query,
+    const ReadOptions& read_options) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: get_specific_version");
-    auto key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, signed_version_id, opt_true(version_query.skip_compat_),
-                                                   opt_true(version_query.iterate_on_failure_));
+    auto key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, signed_version_id, version_query, read_options);
     if (!key) {
         VersionId version_id;
         if (signed_version_id >= 0) {
             version_id = static_cast<VersionId>(signed_version_id);
         } else {
-            auto opt_latest_key = ::arcticdb::get_latest_version(store(), version_map(), stream_id, opt_true(version_query.skip_compat_),
-                                                 opt_true(version_query.iterate_on_failure_));
+            auto opt_latest_key = ::arcticdb::get_latest_version(store(), version_map(), stream_id, version_query, read_options);
             if (opt_latest_key.has_value()) {
                 auto opt_version_id = get_version_id_negative_index(opt_latest_key->version_id(), signed_version_id);
                 if (opt_version_id.has_value()) {
@@ -253,33 +253,25 @@ std::optional<VersionedItem> LocalVersionedEngine::get_specific_version(
 std::optional<VersionedItem> LocalVersionedEngine::get_version_at_time(
     const StreamId& stream_id,
     timestamp as_of,
-    const VersionQuery& version_query
+    const VersionQuery& version_query,
+    const ReadOptions& read_options
     ) {
 
-    auto version_key =
-        get_version_key_from_time(store(), version_map(), stream_id, as_of, false, opt_true(version_query.iterate_on_failure_));
-    std::optional<AtomKey> key;
-    if (!version_key) {
+    auto index_key = load_index_key_from_time(store(), version_map(), stream_id, as_of, version_query, read_options);
+    if (!index_key) {
         auto index_keys = get_index_keys_in_snapshots(store(), stream_id);
         auto vector_index_keys = std::vector<AtomKey>(index_keys.begin(), index_keys.end());
         std::sort(std::begin(vector_index_keys), std::end(vector_index_keys),
                   [](auto& k1, auto& k2) {return k1.creation_ts() > k2.creation_ts();});
-        key = get_version_key_from_time_for_versions(as_of, vector_index_keys);
-    } else {
-        auto version_id = version_key.value().version_id();
-        key = ::arcticdb::get_specific_version(store(), version_map(),
-            stream_id,
-            version_id,
-            opt_true(version_query.skip_compat_),
-            opt_true(version_query.iterate_on_failure_));
+        index_key = get_index_key_from_time(as_of, vector_index_keys);
     }
 
-    if (!key) {
+    if (!index_key) {
         log::version().warn("read_dataframe_timestamp: version id not found for stream {} timestamp {}", stream_id, as_of);
         return std::nullopt;
     }
 
-    return VersionedItem(std::move(key.value()));
+    return VersionedItem(std::move(index_key.value()));
 }
 
 std::optional<VersionedItem> LocalVersionedEngine::get_version_from_snapshot(
@@ -306,20 +298,21 @@ std::optional<VersionedItem> LocalVersionedEngine::get_version_from_snapshot(
 
 std::optional<VersionedItem> LocalVersionedEngine::get_version_to_read(
     const StreamId &stream_id,
-    const VersionQuery &version_query
+    const VersionQuery &version_query,
+    const ReadOptions& read_options
     ) {
     return util::variant_match(version_query.content_,
-       [&stream_id, &version_query, that=this](const SpecificVersionQuery &specific) {
-            return that->get_specific_version(stream_id, specific.version_id_, version_query);
+       [&stream_id, &version_query, &read_options, this](const SpecificVersionQuery &specific) {
+            return get_specific_version(stream_id, specific.version_id_, version_query, read_options);
         },
-        [&stream_id, that=this](const SnapshotVersionQuery &snapshot) {
-            return that->get_version_from_snapshot(stream_id, snapshot.name_);
+        [&stream_id, this](const SnapshotVersionQuery &snapshot) {
+            return get_version_from_snapshot(stream_id, snapshot.name_);
         },
-        [&stream_id, &version_query, that=this](const TimestampVersionQuery &timestamp) {
-            return that->get_version_at_time(stream_id, timestamp.timestamp_, version_query);
+        [&stream_id, &version_query, &read_options, this](const TimestampVersionQuery &timestamp) {
+            return get_version_at_time(stream_id, timestamp.timestamp_, version_query, read_options);
         },
-        [&stream_id, &version_query, that=this](const std::monostate &) {
-            return that->get_latest_version(stream_id, version_query);
+        [&stream_id, &version_query, &read_options, this](const std::monostate &) {
+            return get_latest_version(stream_id, version_query, read_options);
     }
     );
 }
@@ -327,7 +320,7 @@ std::optional<VersionedItem> LocalVersionedEngine::get_version_to_read(
 IndexRange LocalVersionedEngine::get_index_range(
     const StreamId &stream_id,
     const VersionQuery& version_query) {
-    auto version = get_version_to_read(stream_id, version_query);
+    auto version = get_version_to_read(stream_id, version_query, ReadOptions{});
     if(!version)
         return unspecified_range();
 
@@ -339,7 +332,7 @@ ReadVersionOutput LocalVersionedEngine::read_dataframe_version_internal(
     const VersionQuery& version_query,
     ReadQuery& read_query,
     const ReadOptions& read_options) {
-    auto version = get_version_to_read(stream_id, version_query);
+    auto version = get_version_to_read(stream_id, version_query, ReadOptions{});
     std::variant<VersionedItem, StreamId> identifier;
     if(!version) {
         if(opt_false(read_options.incompletes_)) {
@@ -426,10 +419,11 @@ folly::Future<DescriptorItem> LocalVersionedEngine::get_descriptor_async(
 
 DescriptorItem LocalVersionedEngine::read_descriptor_internal(
     const StreamId& stream_id,
-    const VersionQuery& version_query
+    const VersionQuery& version_query,
+    const ReadOptions& read_options
     ) {
     ARCTICDB_SAMPLE(ReadDescriptor, 0)
-    auto version = get_version_to_read(stream_id, version_query);
+    auto version = get_version_to_read(stream_id, version_query, read_options);
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(version.has_value(),
         "Unable to retrieve descriptor data. {}@{}: version not found", stream_id, version_query);
     return get_descriptor(std::move(version->key_)).get();
@@ -437,8 +431,9 @@ DescriptorItem LocalVersionedEngine::read_descriptor_internal(
 
 std::vector<DescriptorItem> LocalVersionedEngine::batch_read_descriptor_internal(
     const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries) {
-    auto versions_fut = batch_get_versions_async(store(), version_map(), stream_ids, version_queries);
+    const std::vector<VersionQuery>& version_queries,
+    const ReadOptions& read_options) {
+    auto versions_fut = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
     std::vector<folly::Future<DescriptorItem>> fut_vec;
     for(const auto& stream_id : folly::enumerate(stream_ids)) {
         fut_vec.push_back(
@@ -458,7 +453,7 @@ std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
     ){
     auto de_dup_map = std::make_shared<DeDupMap>();
     if (write_options.de_duplication) {
-        auto maybe_undeleted_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
+        auto maybe_undeleted_prev = get_latest_undeleted_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
         if (maybe_undeleted_prev) {
             // maybe_undeleted_prev is index key
             auto data_keys = get_data_keys(store(), {maybe_undeleted_prev.value()}, storage::ReadKeyOpts{});
@@ -483,7 +478,7 @@ std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
 
 
 VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool dynamic_schema) {
-    auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
+    auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto version_id = get_next_version_from_key(maybe_prev.value());
     auto [index_segment_reader, slice_and_keys] = index::read_index_to_vector(store(), maybe_prev.value());
@@ -522,7 +517,7 @@ VersionedItem LocalVersionedEngine::delete_range_internal(
     const StreamId& stream_id,
     const UpdateQuery & query,
     bool dynamic_schema) {
-    auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, true, false);
+    auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto versioned_item = delete_range_impl(store(),
                                             maybe_prev.value(),
@@ -545,8 +540,8 @@ VersionedItem LocalVersionedEngine::update_internal(
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
                                                                         version_map(),
                                                                         stream_id,
-                                                                        true,
-                                                                        false);
+                                                                        VersionQuery{},
+                                                                        ReadOptions{});
     if (update_info.previous_index_key_.has_value()) {
         auto versioned_item = update_impl(store(),
                                           update_info,
@@ -592,8 +587,8 @@ VersionedItem LocalVersionedEngine::write_versioned_metadata_internal(
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
                                                                         version_map(),
                                                                         stream_id,
-                                                                        true,
-                                                                        false);
+                                                                        VersionQuery{},
+                                                                        ReadOptions{});
     util::check(update_info.previous_index_key_.has_value(), "No previous version exists for write metadata");
     ARCTICDB_DEBUG(log::version(), "write_versioned_dataframe for stream_id: {}", stream_id);
     auto index_key = UpdateMetadataTask{store(),
@@ -622,7 +617,7 @@ VersionedItem LocalVersionedEngine::write_versioned_dataframe_internal(
     ARCTICDB_SAMPLE(WriteVersionedDataFrame, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_dataframe");
-    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
+    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     auto version_id = get_next_version_from_key(maybe_prev);
     ARCTICDB_DEBUG(log::version(), "write_versioned_dataframe for stream_id: {} , version_id = {}", stream_id, version_id);
     auto write_options = get_write_options();
@@ -653,10 +648,10 @@ std::pair<VersionedItem, TimeseriesDescriptor> LocalVersionedEngine::restore_ver
     const VersionQuery& version_query
     ) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: restore_version");
-    auto version_to_restore = get_version_to_read(stream_id, version_query);
+    auto version_to_restore = get_version_to_read(stream_id, version_query, ReadOptions{});
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(static_cast<bool>(version_to_restore),
                                                  "Unable to restore {}@{}: version not found", stream_id, version_query);
-    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
+    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     ARCTICDB_DEBUG(log::version(), "restore for stream_id: {} , version_id = {}", stream_id, version_to_restore->key_.version_id());
     return AsyncRestoreVersionTask{store(), version_map(), stream_id, version_to_restore->key_, maybe_prev}().get();
 }
@@ -669,7 +664,7 @@ std::pair<VersionedItem, std::vector<AtomKey>> LocalVersionedEngine::write_indiv
     ARCTICDB_SAMPLE(WriteVersionedDataFrame, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_dataframe");
-    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, true, false);
+    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     auto version_id = get_next_version_from_key(maybe_prev);
     ARCTICDB_DEBUG(log::version(), "write_versioned_dataframe for stream_id: {} , version_id = {}", stream_id, version_id);
     auto index = index_type_from_descriptor(segment.descriptor());
@@ -796,7 +791,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
                 auto load_param = load_type == LoadType::LOAD_DOWNTO
                         ? LoadParameter{load_type, static_cast<SignedVersionId>(min.second)}
                         : LoadParameter{load_type};
-                const auto entry = version_map()->check_reload(store(), min.first, load_param, true, false, __FUNCTION__);
+                const auto entry = version_map()->check_reload(store(), min.first, load_param, __FUNCTION__);
                 entry_map.emplace(std::move(min.first), entry);
             }
         }
@@ -828,7 +823,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
         not_to_delete.erase(key);
     }
 
-    ReadKeyOpts read_opts;
+    storage::ReadKeyOpts read_opts;
     read_opts.ignores_missing_key_ = true;
     auto data_keys_to_be_deleted = get_data_keys_set(store(), *keys_to_delete, read_opts);
     log::version().debug("Candidate: {} total of data keys", data_keys_to_be_deleted.size());
@@ -837,7 +832,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
     auto data_keys_not_to_be_deleted = get_data_keys_set(store(), *not_to_delete, read_opts);
     not_to_delete.clear();
     log::version().debug("Forbidden: {} total of data keys", data_keys_not_to_be_deleted.size());
-    RemoveOpts remove_opts;
+    storage::RemoveOpts remove_opts;
     remove_opts.ignores_missing_key_ = true;
     
     std::vector<entity::VariantKey> vks_column_stats;
@@ -936,7 +931,7 @@ VersionedItem LocalVersionedEngine::compact_incomplete_dynamic(
     bool sparsify) {
     log::version().info("Compacting incomplete symbol {}", stream_id);
 
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, true, false);
+    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     auto versioned_item =  compact_incomplete_impl(
             store_, stream_id, user_meta, update_info,
             append, convert_int_to_float, via_iteration, sparsify, get_write_options());
@@ -951,7 +946,7 @@ VersionedItem LocalVersionedEngine::compact_incomplete_dynamic(
 
 bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) {
     auto update_info = get_latest_undeleted_version_and_next_version_id(
-            store(), version_map(), stream_id, true, false);
+            store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     auto pre_defragmentation_info = get_pre_defragmentation_info(
         store(), stream_id, update_info, get_write_options(), segment_size.value_or(cfg_.write_options().segment_row_size()));
     return is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction);
@@ -962,7 +957,7 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& strea
 
     // Currently defragmentation only for latest version - is there a use-case to allow compaction for older data?
     auto update_info = get_latest_undeleted_version_and_next_version_id(
-        store(), version_map(), stream_id, true, false);
+        store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
 
     auto versioned_item = defragment_symbol_data_impl(
             store(), stream_id, update_info, get_write_options(),
@@ -1044,7 +1039,8 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::te
     std::vector<ReadQuery> &read_queries,
     const ReadOptions &read_options) {
     py::gil_scoped_release release_gil;
-    auto versions = batch_get_versions_async(store(), version_map(), stream_ids, version_queries);
+
+    auto versions = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
     std::vector<folly::Future<ReadVersionOutput>> read_versions_futs;
     for (auto&& [idx, version] : folly::enumerate(versions)) {
         auto read_query = read_queries.empty() ? ReadQuery{} : read_queries[idx];
@@ -1295,8 +1291,8 @@ VersionedItem LocalVersionedEngine::append_internal(
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
                                                                         version_map(),
                                                                         stream_id,
-                                                                        true,
-                                                                        false);
+                                                                        VersionQuery{},
+                                                                        ReadOptions{});
 
     if(update_info.previous_index_key_.has_value()) {
         auto versioned_item = append_impl(store(),
@@ -1426,9 +1422,9 @@ timestamp LocalVersionedEngine::get_update_time_internal(
         const StreamId& stream_id,
         const VersionQuery& version_query
         ) {
-    auto version = get_version_to_read(stream_id, version_query);
+    auto version = get_version_to_read(stream_id, version_query, ReadOptions{});
     if(!version)
-        throw NoDataFoundException(fmt::format("get_update_time: version not found for symbol", stream_id));
+        throw storage::NoDataFoundException(fmt::format("get_update_time: version not found for symbol", stream_id));
     return version->key_.creation_ts();
 }
 
@@ -1485,9 +1481,10 @@ folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobu
 
 std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::batch_read_metadata_internal(
     const std::vector<StreamId>& stream_ids,
-    const std::vector<VersionQuery>& version_queries
+    const std::vector<VersionQuery>& version_queries,
+    const ReadOptions& read_options
     ) {
-    auto versions_fut = batch_get_versions_async(store(), version_map(), stream_ids, version_queries);
+    auto versions_fut = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
     std::vector<folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>> fut_vec;
     for (auto&& version: versions_fut){
         fut_vec.push_back(get_metadata_async(std::move(version)));
@@ -1497,9 +1494,10 @@ std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf:
 
 std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> LocalVersionedEngine::read_metadata_internal(
     const StreamId& stream_id,
-    const VersionQuery& version_query
+    const VersionQuery& version_query,
+    const ReadOptions& read_options
     ) {
-    auto version = get_version_to_read(stream_id, version_query);
+    auto version = get_version_to_read(stream_id, version_query, read_options);
     std::optional<AtomKey> key = version.has_value() ? std::make_optional<AtomKey>(version->key_) : std::nullopt;
     return get_metadata(std::move(key)).get();
 }
@@ -1513,15 +1511,14 @@ VersionedItem LocalVersionedEngine::sort_merge_internal(
     bool via_iteration,
     bool sparsify
     ) {
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, true, false);
+    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     auto versioned_item = sort_merge_impl(store_, stream_id, user_meta, update_info, append, convert_int_to_float, via_iteration, sparsify);
     version_map()->write_version(store(), versioned_item.key_);
     return versioned_item;
 }
 
-bool LocalVersionedEngine::has_stream(const StreamId & stream_id, const std::optional<bool>& skip_compat, const std::optional<bool>& iterate_on_failure){
-
-    auto opt = get_latest_undeleted_version(store(), version_map(),  stream_id, opt_true(skip_compat), opt_false(iterate_on_failure));
+bool LocalVersionedEngine::has_stream(const StreamId & stream_id){
+    auto opt = get_latest_undeleted_version(store(), version_map(),  stream_id, VersionQuery{}, ReadOptions{});
     return opt.has_value();
 }
 
@@ -1561,7 +1558,7 @@ timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
     if(auto latest_incomplete = latest_incomplete_timestamp(store(), symbol); latest_incomplete)
         return latest_incomplete.value();
 
-    if(auto latest_key = get_latest_version(symbol, VersionQuery{}); latest_key)
+    if(auto latest_key = get_latest_version(symbol, VersionQuery{}, ReadOptions{}); latest_key)
         return latest_key.value().key_.end_time();
 
     return -1;
@@ -1601,27 +1598,6 @@ void LocalVersionedEngine::force_release_lock(const StreamId& name) {
 
 WriteOptions LocalVersionedEngine::get_write_options() const  {
     return  WriteOptions::from_proto(cfg().write_options());
-}
-
-AtomKey LocalVersionedEngine::_test_write_segment(const std::string& symbol) {
-    auto wrapper = SinkWrapper(symbol, {
-        scalar_field(DataType::UINT64, "thing1"),
-        scalar_field(DataType::UINT64, "thing2"),
-        scalar_field(DataType::UINT64, "thing3"),
-        scalar_field(DataType::UINT64, "thing4")
-    });
-
-    for(size_t j = 0; j < 20; ++j ) {
-        wrapper.aggregator_.start_row(timestamp(j))([&](auto& rb) {
-            rb.set_scalar(1, j);
-            rb.set_scalar(2, j + 1);
-            rb.set_scalar(3, j + j);
-            rb.set_scalar(4, j * j);
-        });
-    }
-
-    wrapper.aggregator_.commit();
-    return to_atom(store()->write(KeyType::TABLE_DATA, VersionId{}, StreamId{symbol}, 0, 0, std::move(wrapper.segment())).get());
 }
 
 std::shared_ptr<VersionMap> LocalVersionedEngine::_test_get_version_map() {

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -90,17 +90,20 @@ public:
 
     std::optional<VersionedItem> get_latest_version(
         const StreamId &stream_id,
-        const VersionQuery& version_query);
+        const VersionQuery& version_query,
+        const ReadOptions& read_options);
 
     std::optional<VersionedItem> get_specific_version(
         const StreamId &stream_id,
         SignedVersionId signed_version_id,
-        const VersionQuery& version_query);
+        const VersionQuery& version_query,
+        const ReadOptions& read_options);
 
     std::optional<VersionedItem> get_version_at_time(
         const StreamId& stream_id,
         timestamp as_of,
-        const VersionQuery& version_query);
+        const VersionQuery& version_query,
+        const ReadOptions& read_options);
 
     std::optional<VersionedItem> get_version_from_snapshot(
         const StreamId& stream_id,
@@ -113,7 +116,8 @@ public:
 
     std::optional<VersionedItem> get_version_to_read(
         const StreamId& stream_id,
-        const VersionQuery& version_query
+        const VersionQuery& version_query,
+        const ReadOptions& read_options
     );
 
     FrameAndDescriptor read_dataframe_internal(
@@ -129,16 +133,15 @@ public:
 
     DescriptorItem read_descriptor_internal(
             const StreamId& stream_id,
-            const VersionQuery& version_query);
+            const VersionQuery& version_query,
+            const ReadOptions& read_options);
 
     void write_parallel_frame(
         const StreamId& stream_id,
         InputTensorFrame&& frame) const override;
 
     bool has_stream(
-        const StreamId & stream_id,
-        const std::optional<bool>& skip_compat,
-        const std::optional<bool>& iterate_on_failure
+        const StreamId & stream_id
     ) override;
 
     void delete_tree(
@@ -293,7 +296,8 @@ public:
 
     std::vector<DescriptorItem> batch_read_descriptor_internal(
             const std::vector<StreamId>& stream_ids,
-            const std::vector<VersionQuery>& version_queries);
+            const std::vector<VersionQuery>& version_queries,
+            const ReadOptions& read_options);
 
     std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> batch_restore_version_internal(
         const std::vector<StreamId>& stream_ids,
@@ -307,11 +311,13 @@ public:
 
     std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> batch_read_metadata_internal(
         const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries);
+        const std::vector<VersionQuery>& version_queries,
+        const ReadOptions& read_options);
 
     std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> read_metadata_internal(
         const StreamId& stream_id,
-        const VersionQuery& version_query);
+        const VersionQuery& version_query,
+        const ReadOptions& read_options);
 
     bool is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) override;
 
@@ -370,7 +376,6 @@ public:
 
     std::unordered_map<KeyType, std::pair<size_t, size_t>> scan_object_sizes();
     std::shared_ptr<Store>& _test_get_store() { return store_; }
-    AtomKey _test_write_segment(const std::string& symbol);
     void _test_set_validate_version_map() {
         version_map()->set_validate(true);
     }

--- a/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
+++ b/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
@@ -23,7 +23,7 @@
 template <typename Model>
 void check_latest_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
     using namespace arcticdb;
-    auto prev = get_latest_version(sut.store_,sut.map_, symbol, true, true);
+    auto prev = get_latest_version(sut.store_,sut.map_, symbol, pipelines::VersionQuery{}, ReadOptions{});
     auto sut_version_id = prev ? prev.value().version_id() : 0;
     auto model_prev = s0.get_latest_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
@@ -33,7 +33,10 @@ void check_latest_versions(const Model&  s0, MapStorePair &sut, std::string symb
 template <typename Model>
 void check_latest_undeleted_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
     using namespace arcticdb;
-    auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, true, true);
+    pipelines::VersionQuery version_query;
+    version_query.set_skip_compat(true),
+    version_query.set_iterate_on_failure(true);
+    auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, version_query, ReadOptions{});
     auto sut_version_id = prev ? prev.value().version_id() : 0;
     auto model_prev = s0.get_latest_undeleted_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
@@ -222,7 +225,7 @@ struct GetAllVersions : rc::state::Command<Model, MapStorePair> {
     void run(const Model& s0, MapStorePair &sut) const override {
         auto model_versions = s0.get_all_versions(symbol_);
         using namespace arcticdb;
-        auto sut_version = get_all_versions(sut.store_, sut.map_, symbol_, true, true);
+        auto sut_version = get_all_versions(sut.store_, sut.map_, symbol_, pipelines::VersionQuery{}, ReadOptions{});
         RC_ASSERT(model_versions.size() == sut_version.size());
 
         for(auto i = size_t{0}; i < model_versions.size(); ++i)

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -59,7 +59,7 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
     
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){
@@ -101,7 +101,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -113,7 +113,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     }
 
     // Now we can perform the actual batch query per timestamps
-    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){
@@ -150,7 +150,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
     }
 
     // Do query
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
     
     // Check results
     for(uint64_t i = 0; i < num_versions; i++){
@@ -183,7 +183,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     }
 
     // Do query
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -192,7 +192,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     }
 
     // Now we can perform the actual batch query per timestamps
-    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_versions; i++){
@@ -231,7 +231,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -249,7 +249,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         }
     }
 
-    auto versions_querying_with_mix_types = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
+    auto versions_querying_with_mix_types = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -379,21 +379,21 @@ TEST(VersionStore, TestReadTimestampAt) {
 
   auto version_map = version_store._test_get_version_map();
   version_map->write_version(mock_store, key1);
-  auto key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
+  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{}, ReadOptions{});
   ASSERT_EQ(key.value().content_hash(), 3);
 
   version_map->write_version(mock_store, key2);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{}, ReadOptions{});
   ASSERT_EQ(key.value().content_hash(), 3);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{}, ReadOptions{});
   ASSERT_EQ(key.value().content_hash(), 4);
 
   version_map->write_version(mock_store, key3);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(0), true, false);
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{}, ReadOptions{});
   ASSERT_EQ(key.value().content_hash(), 3);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{}, ReadOptions{});
   ASSERT_EQ(key.value().content_hash(), 4);
-  key = get_version_key_from_time(mock_store, version_map, id, timestamp(2), true, false);
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(2), pipelines::VersionQuery{}, ReadOptions{});
   ASSERT_EQ(key.value().content_hash(), 5);
 }
 
@@ -411,7 +411,7 @@ TEST(VersionStore, TestReadTimestampAtInequality) {
 
   auto version_map = version_store._test_get_version_map();
   version_map->write_version(mock_store, key1);
-  auto key = get_version_key_from_time(mock_store, version_map, id, timestamp(1), true, false);
+  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{}, ReadOptions{});
   ASSERT_EQ(static_cast<bool>(key), true);
   ASSERT_EQ(key.value().content_hash(), 3);
 }

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -10,12 +10,12 @@
 namespace arcticdb {
 
 std::deque<AtomKey> backwards_compat_delete_all_versions(
-    const std::shared_ptr<Store> store,
+    const std::shared_ptr<Store>& store,
     std::shared_ptr<VersionMap>& version_map,
     const StreamId& stream_id
     ) {
     std::deque<AtomKey> output;
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
+    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
     output.assign(std::begin(indexes), std::end(indexes));
 
@@ -27,11 +27,11 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
     return output;
 }
 
-std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<Store> store, std::shared_ptr<VersionMap>& version_map, const AtomKey &key) {
+std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<Store>& store, std::shared_ptr<VersionMap>& version_map, const AtomKey &key) {
     log::version().debug("Version map pruning previous versions for stream {}", key.id());
 
     std::vector<AtomKey> output;
-    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL}, true, false, __FUNCTION__);
+    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL},  __FUNCTION__);
 
     auto old_entry = *entry;
     entry->clear();

--- a/cpp/arcticdb/version/test/version_map_model.hpp
+++ b/cpp/arcticdb/version/test/version_map_model.hpp
@@ -36,7 +36,7 @@ struct MapStorePair {
 
     void write_version(const std::string &id) {
         log::version().info("MapStorePair, write version {}", id);
-        auto prev = get_latest_version(store_, map_, id, true, true);
+        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{}, ReadOptions{});
         auto version_id = prev ? prev.value().version_id() + 1 : 0;
         map_->write_version(store_, make_test_index_key(id, version_id, KeyType::TABLE_INDEX));
     }
@@ -51,7 +51,7 @@ struct MapStorePair {
 
     void write_and_prune_previous(const std::string &id) {
         log::version().info("MapStorePair, write_and_prune_previous version {}", id);
-        auto prev = get_latest_version(store_, map_, id, true, true);
+        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{}, ReadOptions{});
         auto version_id = prev ? prev.value().version_id() + 1 : 0;
 
         if(tombstones_)

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -9,19 +9,27 @@
 
 #include <arcticdb/version/version_map.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
-
+#include <arcticdb/pipeline/read_options.hpp>
+#include <arcticdb/pipeline/query.hpp>
 
 namespace arcticdb {
+
+inline void set_load_param_options(LoadParameter& load_param, const pipelines::VersionQuery& version_query, const ReadOptions& read_options) {
+    load_param.use_previous_ = read_options.read_previous_on_failure_.value_or(false);
+    load_param.skip_compat_ = version_query.skip_compat_.value_or(true);
+    load_param.iterate_on_failure_ = version_query.iterate_on_failure_.value_or(false);
+}
 
 inline std::optional<AtomKey> get_latest_undeleted_version(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    bool skip_compat,
-    bool iterate_on_failure) {
+    const pipelines::VersionQuery& version_query,
+    const ReadOptions& read_options) {
     ARCTICDB_RUNTIME_SAMPLE(GetLatestUndeletedVersion, 0)
-    const auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED},
-                                                 skip_compat, iterate_on_failure, __FUNCTION__);
+    LoadParameter load_param{LoadType::LOAD_LATEST_UNDELETED};
+    set_load_param_options(load_param, version_query, read_options);
+    const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(false);
 }
 
@@ -29,11 +37,12 @@ inline std::optional<AtomKey> get_latest_version(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    bool skip_compat,
-    bool iterate_on_failure) {
+    const pipelines::VersionQuery& version_query,
+    const ReadOptions& read_options) {
     ARCTICDB_SAMPLE(GetLatestVersion, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_LATEST}, skip_compat,
-                                           iterate_on_failure, __FUNCTION__);
+    LoadParameter load_param{LoadType::LOAD_LATEST};
+    set_load_param_options(load_param, version_query, read_options);
+    auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(true);
 }
 
@@ -42,11 +51,12 @@ inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_i
         const std::shared_ptr<Store> &store,
         const std::shared_ptr<VersionMap> &version_map,
         const StreamId &stream_id,
-        bool skip_compat,
-        bool iterate_on_failure) {
+        const pipelines::VersionQuery& version_query,
+        const ReadOptions& read_options) {
     ARCTICDB_SAMPLE(GetLatestUndeletedVersionAndHighestVersionId, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED},
-                                           skip_compat, iterate_on_failure, __FUNCTION__);
+    LoadParameter load_param{LoadType::LOAD_LATEST_UNDELETED};
+    set_load_param_options(load_param, version_query, read_options);
+    auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     auto latest_version = entry->get_first_index(true);
     auto latest_undeleted_version = entry->get_first_index(false);
     VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
@@ -57,17 +67,13 @@ inline std::vector<AtomKey> get_all_versions(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    bool skip_compat,
-    bool iterate_on_failure) {
+    const pipelines::VersionQuery& version_query,
+    const ReadOptions& read_option
+    ) {
     ARCTICDB_SAMPLE(GetAllVersions, 0)
-    const LoadParameter load_parameter(LoadType::LOAD_UNDELETED);
-    auto entry = version_map->check_reload(
-        store,
-        stream_id,
-        load_parameter,
-        skip_compat,
-        iterate_on_failure,
-        __FUNCTION__);
+    LoadParameter load_param{LoadType::LOAD_UNDELETED};
+    set_load_param_options(load_param, version_query, read_option);
+    auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_indexes(false);
 }
 
@@ -76,12 +82,12 @@ inline std::optional<AtomKey> get_specific_version(
         const std::shared_ptr<VersionMap> &version_map,
         const StreamId &stream_id,
         SignedVersionId signed_version_id,
-        bool skip_compat,
-        bool iterate_on_failure,
+        const pipelines::VersionQuery& version_query,
+        const ReadOptions& read_option,
         bool include_deleted = false) {
-    ARCTICDB_SAMPLE(GetSpecificVersion, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_DOWNTO, signed_version_id},
-                                           skip_compat, iterate_on_failure, __FUNCTION__);
+    LoadParameter load_param{LoadType::LOAD_DOWNTO, signed_version_id};
+    auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
+    set_load_param_options(load_param, version_query, read_option);
     VersionId version_id;
     if (signed_version_id >= 0) {
         version_id = static_cast<VersionId>(signed_version_id);
@@ -135,7 +141,10 @@ inline bool has_undeleted_version(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &id) {
-    return static_cast<bool>(get_latest_undeleted_version(store, version_map, id, true, false));
+    pipelines::VersionQuery version_query;
+    version_query.set_skip_compat(true),
+    version_query.set_iterate_on_failure(false);
+    return static_cast<bool>(get_latest_undeleted_version(store, version_map, id, version_query, ReadOptions{}));
 }
 
 inline void insert_if_undeleted(
@@ -151,9 +160,12 @@ inline void insert_if_undeleted(
 inline std::unordered_map<VersionId, bool> get_all_tombstoned_versions(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id) {
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, false,
-                                           __FUNCTION__);
+    const StreamId &stream_id,
+    const pipelines::VersionQuery& version_query,
+    const ReadOptions& read_option) {
+    LoadParameter load_param{LoadType::LOAD_ALL};
+    set_load_param_options(load_param, version_query, read_option);
+    auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::unordered_map<VersionId, bool> result;
     for (auto key: entry->get_tombstoned_indexes())
             result[key.version_id()] = store->key_exists(key).get();
@@ -166,11 +178,14 @@ inline version_store::TombstoneVersionResult tombstone_version(
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
     VersionId version_id,
+    const pipelines::VersionQuery& version_query,
+    const ReadOptions& read_options,
     bool allow_tombstoning_beyond_latest_version=false,
     const std::optional<timestamp>& creation_ts=std::nullopt) {
     ARCTICDB_DEBUG(log::version(), "Tombstoning version {} for stream {}", version_id, stream_id);
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_UNDELETED}, true, false,
-                                           __FUNCTION__);
+    LoadParameter load_param{LoadType::LOAD_UNDELETED};
+    set_load_param_options(load_param, version_query, read_options);
+    auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     // Might as well do the previous/next version check while we find the required version_id.
     // But if entry is empty, it's possible the load failed (since iterate_on_failure=false above), so set the flag
     // to defer the check to delete_tree() (instead of reloading in case eager delete is disabled).
@@ -190,7 +205,7 @@ inline version_store::TombstoneVersionResult tombstone_version(
             util::raise_rte("Version {} for symbol {} is already deleted", version_id, stream_id);
         } else {
             if (!allow_tombstoning_beyond_latest_version) {
-                auto latest_key = get_latest_version(store, version_map, stream_id, true, false);
+                auto latest_key = get_latest_version(store, version_map, stream_id, version_query, read_options);
                 if (!latest_key || latest_key.value().version_id() < version_id)
                     util::raise_rte("Can't delete version {} for symbol {} - it's higher than the latest version",
                             stream_id, version_id);
@@ -210,40 +225,46 @@ inline version_store::TombstoneVersionResult tombstone_version(
     return res;
 }
 
-inline std::optional<AtomKey> get_version_key_from_time_for_versions(
+inline std::optional<AtomKey> get_index_key_from_time(
     timestamp from_time,
-    const std::vector<AtomKey> &version_keys) {
-    // get_all_versions will hold the lock
-    // Version keys are sorted in reverse order
-    auto at_or_after = std::lower_bound(version_keys.begin(), version_keys.end(), from_time,
-                                        [](const AtomKey &v_key, timestamp cmp) {
-                                            return v_key.creation_ts() > cmp;
-                                        });
-    // If iterator points to the last element, we didn't have any versions before that or empty
-    if (at_or_after == version_keys.end()) {
+    const std::vector<AtomKey> &keys) {
+    auto at_or_after = std::lower_bound(
+        std::begin(keys),
+        std::end(keys),
+        from_time,
+        [](const AtomKey &v_key, timestamp cmp) {
+            return v_key.creation_ts() > cmp;
+        });
+    // If iterator points to the last element, we didn't have any versions before that
+    if (at_or_after == keys.end()) {
         return std::nullopt;
     }
     return *at_or_after;
 }
 
-inline std::optional<AtomKey> get_version_key_from_time(
+inline std::optional<AtomKey> load_index_key_from_time(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
     timestamp from_time,
-    bool skip_compat,
-    bool iterate_on_failure) {
-    // get_all_versions will hold the lock
-    auto all_versions = get_all_versions(store, version_map, stream_id, skip_compat, iterate_on_failure);
-    return get_version_key_from_time_for_versions(from_time, all_versions);
+    const pipelines::VersionQuery& version_query,
+    const ReadOptions& read_options) {
+    LoadParameter load_param{LoadType::LOAD_FROM_TIME, from_time};
+    set_load_param_options(load_param, version_query, read_options);
+    auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
+    auto indexes = entry->get_indexes(false);
+    return get_index_key_from_time(from_time, indexes);
 }
 
 inline std::vector<AtomKey> get_index_and_tombstone_keys(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
-    const StreamId &stream_id) {
-    const auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, true, true,
-                                                 __FUNCTION__);
+    const StreamId &stream_id,
+    const pipelines::VersionQuery& version_query,
+    const ReadOptions& read_options) {
+    LoadParameter load_param{LoadType::LOAD_ALL};
+    set_load_param_options(load_param, version_query, read_options);
+    const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::vector<AtomKey> res;
     std::copy_if(std::begin(entry->keys_), std::end(entry->keys_), std::back_inserter(res),
                  [&](const auto &key) { return is_index_or_tombstone(key); });
@@ -262,7 +283,7 @@ inline std::set<StreamId> list_streams(
     if (prefix && store->supports_prefix_matching()) {
         ARCTICDB_DEBUG(log::version(), "Storage backend supports prefix matching");
         store->iterate_type(KeyType::VERSION_REF, [&store, &res, &version_map, all_symbols](auto &&vk) {
-                                auto key = std::forward<VariantKey>(vk);
+                                auto key = std::forward<VariantKey&&>(vk);
                                 util::check(!variant_key_id_empty(key), "Unexpected empty id in key {}", key);
                                 if(all_symbols)
                                     res.insert(variant_key_id(key));

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -31,6 +31,14 @@ enum class LoadType :
     LOAD_ALL = 6
 };
 
+inline constexpr bool is_latest_load_type(LoadType load_type) {
+    return load_type == LoadType::LOAD_LATEST || load_type == LoadType::LOAD_LATEST_UNDELETED;
+}
+
+inline constexpr bool is_partial_load_type(LoadType load_type) {
+    return load_type == LoadType::LOAD_DOWNTO || load_type == LoadType::LOAD_FROM_TIME;
+}
+
 struct LoadParameter {
     explicit LoadParameter(LoadType load_type) :
         load_type_(load_type) {
@@ -55,6 +63,9 @@ struct LoadParameter {
     LoadType load_type_ = LoadType::NOT_LOADED;
     std::optional<SignedVersionId> load_until_ = std::nullopt;
     std::optional<timestamp> load_from_time_ = std::nullopt;
+    bool use_previous_ = false;
+    bool skip_compat_ = true;
+    bool iterate_on_failure_ = false;
 
     void validate() const {
         util::check(load_type_ == LoadType::LOAD_DOWNTO ? static_cast<bool>(load_until_) : !static_cast<bool>(load_until_),

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -181,16 +181,19 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     std::pair<VersionedItem, py::object> read_metadata(
         const StreamId& stream_id,
-        const VersionQuery& version_query
+        const VersionQuery& version_query,
+        const ReadOptions& read_options
     );
 
     std::vector<DescriptorItem> batch_read_descriptor(
         const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries);
+        const std::vector<VersionQuery>& version_queries,
+        const ReadOptions& read_options);
 
     DescriptorItem read_descriptor(
         const StreamId& stream_id,
-        const VersionQuery& version_query);
+        const VersionQuery& version_query,
+        const ReadOptions& read_options);
 
     ReadResult read_index(
         const StreamId& stream_id,
@@ -290,7 +293,8 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     std::vector<std::pair<VersionedItem, py::object>> batch_read_metadata(
         const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries);
+        const std::vector<VersionQuery>& version_queries,
+        const ReadOptions& read_options);
 
     std::set<StreamId> list_streams(
         const std::optional<SnapshotId>& snap_name = std::nullopt,

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -109,23 +109,20 @@ struct CheckReloadTask : async::BaseTask {
     const std::shared_ptr<VersionMap> version_map_;
     const StreamId stream_id_;
     const LoadParameter load_param_;
-    const bool iterate_on_failure_;
 
     CheckReloadTask(
         std::shared_ptr<Store> store,
         std::shared_ptr<VersionMap> version_map,
         StreamId stream_id,
-        LoadParameter load_param,
-        bool iterate_on_failure = false) :
+        LoadParameter load_param) :
         store_(std::move(store)),
         version_map_(std::move(version_map)),
         stream_id_(std::move(stream_id)),
-        load_param_(load_param),
-        iterate_on_failure_(iterate_on_failure){
+        load_param_(load_param) {
     }
 
     std::shared_ptr<VersionMapEntry> operator()() const {
-        return version_map_->check_reload(store_, stream_id_, load_param_, true, iterate_on_failure_, __FUNCTION__);
+        return version_map_->check_reload(store_, stream_id_, load_param_, __FUNCTION__);
     }
 };
 

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -20,9 +20,6 @@
 #include <optional>
 
 namespace arcticdb {
-using namespace arcticdb::storage;
-using namespace arcticdb::entity;
-using namespace arcticdb::stream;
 
 inline entity::VariantKey write_multi_index_entry(
     std::shared_ptr<StreamSink> store,
@@ -36,13 +33,13 @@ inline entity::VariantKey write_multi_index_entry(
     ARCTICDB_DEBUG(log::version(), "Version map writing multi key");
     folly::Future<VariantKey> multi_key_fut = folly::Future<VariantKey>::makeEmpty();
 
-    IndexAggregator<RowCountIndex> multi_index_agg(stream_id, [&](auto &&segment) {
+    IndexAggregator<RowCountIndex> multi_index_agg(stream_id, [&multi_key_fut, &store, version_id, stream_id](auto &&segment) {
         multi_key_fut = store->write(KeyType::MULTI_KEY,
                                      version_id,  // version_id
                                      stream_id,
                                      0,  // start_index
                                      0,  // end_index
-                                     std::forward<SegmentInMemory>(segment)).wait();
+                                     std::forward<decltype(segment)>(segment)).wait();
     });
 
     for (auto &key : keys) {
@@ -68,18 +65,35 @@ inline entity::VariantKey write_multi_index_entry(
     return multi_key_fut.wait().value();
 }
 
+struct LoadProgress {
+    VersionId loaded_until_ = std::numeric_limits<VersionId>::max();
+    VersionId oldest_loaded_index_version_ = std::numeric_limits<VersionId>::max();
+    timestamp earliest_loaded_timestamp_ = std::numeric_limits<timestamp>::max();
+};
+
 inline std::optional<AtomKey> read_segment_with_keys(
     const SegmentInMemory &seg,
     VersionMapEntry &entry,
-    VersionId& oldest_loaded_index) {
+    LoadProgress& load_progress) {
     ssize_t row = 0;
     std::optional<AtomKey> next;
+    VersionId oldest_loaded_index = std::numeric_limits<VersionId>::max();
+    timestamp earliest_loaded_timestamp = std::numeric_limits<timestamp>::max();
+
     for (; row < ssize_t(seg.row_count()); ++row) {
         auto key = read_key_row(seg, row);
         ARCTICDB_TRACE(log::version(), "Reading key {}", key);
+
         if (is_index_key_type(key.type())) {
             entry.keys_.push_back(key);
             oldest_loaded_index = std::min(oldest_loaded_index, key.version_id());
+
+            // Note that LOAD_FROM_TIME is implicitly loading undeleted. If there was a requirement
+            // to load from a particular time disregarding whether symbols are deleted or not, there would
+            // need to be an additional termination condition
+            if(!entry.is_tombstoned(key))
+                earliest_loaded_timestamp = std::min(earliest_loaded_timestamp, key.creation_ts());
+
         } else if (key.type() == KeyType::TOMBSTONE) {
             entry.tombstones_.try_emplace(key.version_id(), key);
             entry.keys_.push_back(key);
@@ -96,14 +110,17 @@ inline std::optional<AtomKey> read_segment_with_keys(
         }
     }
     util::check(row == ssize_t(seg.row_count()), "Unexpected ordering in journal segment");
+    load_progress.loaded_until_ = oldest_loaded_index;
+    load_progress.oldest_loaded_index_version_ = std::min(load_progress.oldest_loaded_index_version_, load_progress.loaded_until_);
+    load_progress.earliest_loaded_timestamp_ = std::min(load_progress.earliest_loaded_timestamp_, earliest_loaded_timestamp);
     return next;
 }
 
 inline std::optional<AtomKey> read_segment_with_keys(
     const SegmentInMemory &seg,
     const std::shared_ptr<VersionMapEntry> &entry,
-    VersionId& oldest_loaded_index) {
-    return read_segment_with_keys(seg, *entry, oldest_loaded_index);
+    LoadProgress& load_progress) {
+    return read_segment_with_keys(seg, *entry, load_progress);
 }
 
 template<class Predicate>
@@ -111,7 +128,7 @@ std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteratio
     const std::shared_ptr<StreamSource> &store,
     Predicate &&predicate,
     const StreamId &stream_id,
-    std::vector<KeyType> key_types,
+    const std::vector<KeyType>& key_types,
     bool perform_read_segment_with_keys = true) {
 
     auto prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
@@ -128,8 +145,8 @@ std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteratio
                                 ARCTICDB_DEBUG(log::storage(), "Version map iterating key {}", key);
                                 if (perform_read_segment_with_keys) {
                                     auto [kv, seg] = store->read_sync(to_atom(key));
-                                    VersionId version_id{};
-                                    read_segment_with_keys(seg, output, version_id);
+                                    LoadProgress load_progress;
+                                    (void)read_segment_with_keys(seg, output, load_progress);
                                 }
                             },
                             prefix);
@@ -204,29 +221,33 @@ inline std::optional<RefKey> get_symbol_ref_key(
     return std::make_optional(std::move(ref_key));
 }
 
-inline void read_symbol_ref(std::shared_ptr<StreamSource> store, const StreamId &stream_id, VersionMapEntry &entry) {
+inline void read_symbol_ref(const std::shared_ptr<StreamSource>& store, const StreamId &stream_id, VersionMapEntry &entry) {
     auto maybe_ref_key = get_symbol_ref_key(store, stream_id);
     if (!maybe_ref_key)
         return;
 
     auto [key, seg] = store->read_sync(maybe_ref_key.value());
-    VersionId version_id{};
-    entry.head_ = read_segment_with_keys(seg, entry, version_id);
+
+    LoadProgress load_progress;
+    entry.head_ = read_segment_with_keys(seg, entry, load_progress);
 }
 
 inline void write_symbol_ref(std::shared_ptr<StreamSink> store,
                              const AtomKey &latest_index,
+                             const std::optional<AtomKey>&,
                              const AtomKey &journal_key) {
     check_is_index_or_tombstone(latest_index);
     check_is_version(journal_key);
+
     ARCTICDB_DEBUG(log::version(), "Version map writing symbol ref for latest index: {} journal key {}", latest_index,
                    journal_key);
 
     IndexAggregator<RowCountIndex> ref_agg(latest_index.id(), [&store, &latest_index](auto &&s) {
-        auto segment = std::forward<SegmentInMemory>(s);
+        auto segment = std::forward<decltype(s)>(s);
         store->write_sync(KeyType::VERSION_REF, latest_index.id(), std::move(segment));
     });
     ref_agg.add_key(latest_index);
+
     ref_agg.add_key(journal_key);
     ref_agg.commit();
     ARCTICDB_DEBUG(log::version(), "Done writing symbol ref for key: {}", journal_key);
@@ -242,34 +263,58 @@ inline std::optional<VersionId> get_version_id_negative_index(VersionId latest, 
 
 std::unordered_map<StreamId, size_t> get_num_version_entries(const std::shared_ptr<Store> &store, size_t batch_size);
 
-inline bool need_to_load_further(const LoadParameter &load_params,
-                                 VersionId loaded_until,
-                                 const std::optional<VersionId>& latest_version) {
-    if (!load_params.load_until_)
-        return true;
+inline bool is_positive_version_query(const LoadParameter& load_params) {
+    return load_params.load_until_.value() >= 0;
+}
 
-    if (load_params.load_until_.value() >= 0) {
-        if (loaded_until > static_cast<VersionId>(load_params.load_until_.value())) {
-            return true;
+inline bool loaded_until_version_id(const LoadParameter &load_params, const LoadProgress& load_progress, const std::optional<VersionId>& latest_version) {
+    if (!load_params.load_until_)
+        return false;
+
+    if (is_positive_version_query(load_params)) {
+        if (load_progress.loaded_until_ > static_cast<VersionId>(load_params.load_until_.value())) {
+            return false;
         }
     } else {
         if (latest_version.has_value()) {
-            auto opt_version_id = get_version_id_negative_index(latest_version.value(), *load_params.load_until_);
-            if (opt_version_id.has_value()) {
-                if (loaded_until > *opt_version_id) {
-                    return true;
-                }
+            if (auto opt_version_id = get_version_id_negative_index(latest_version.value(), *load_params.load_until_);
+                opt_version_id && load_progress.loaded_until_ > *opt_version_id) {
+                    return false;
             }
         } else {
-            return true;
+            return false;
         }
     }
     ARCTICDB_DEBUG(log::version(),
                    "Exiting load downto because loaded to version {} for request {} with {} total versions",
-                   loaded_until,
-                   *load_params.load_until_,
-                   latest_version.value());
-    return false;
+                   load_progress.loaded_until_,
+                   load_params.load_until_.value(),
+                   latest_version.value()
+                  );
+    return true;
+}
+
+inline void set_latest_version(const std::shared_ptr<VersionMapEntry>& entry, std::optional<VersionId>& latest_version) {
+    if (!latest_version) {
+        auto latest = entry->get_first_index(true);
+        if(latest)
+            latest_version = latest->version_id();
+    }
+}
+
+static constexpr timestamp nanos_to_seconds(timestamp nanos) {
+    return nanos / timestamp(10000000000);
+}
+
+inline bool loaded_until_timestamp(const LoadParameter &load_params, const LoadProgress& load_progress) {
+    if (!load_params.load_from_time_ || load_progress.earliest_loaded_timestamp_ > load_params.load_from_time_.value())
+        return false;
+
+    ARCTICDB_DEBUG(log::version(),
+                   "Exiting load from timestamp because request {} <= {}",
+                   load_params.load_from_time_.value(),
+                   load_progress.earliest_loaded_timestamp_);
+    return true;
 }
 
 inline bool load_latest_ongoing(const LoadParameter &load_params, const std::shared_ptr<VersionMapEntry> &entry) {
@@ -281,19 +326,19 @@ inline bool load_latest_ongoing(const LoadParameter &load_params, const std::sha
     return false;
 }
 
-inline bool looking_for_undeleted(const LoadParameter& load_params, const std::shared_ptr<VersionMapEntry>& entry, const VersionId& oldest_loaded_index) {
+inline bool looking_for_undeleted(const LoadParameter& load_params, const std::shared_ptr<VersionMapEntry>& entry, const LoadProgress& load_progress) {
     if(load_params.load_type_ != LoadType::LOAD_UNDELETED) {
         return true;
     }
 
     if(entry->tombstone_all_) {
-        const bool is_deleted_by_tombstone_all = entry->tombstone_all_->version_id() >= oldest_loaded_index;
+        const bool is_deleted_by_tombstone_all = entry->tombstone_all_->version_id() >= load_progress.oldest_loaded_index_version_;
         if(is_deleted_by_tombstone_all) {
             ARCTICDB_DEBUG(
                 log::version(),
                 "Exiting because tombstone all key deletes all versions beyond: {} and the oldest loaded index has version: {}",
                 entry->tombstone_all_->version_id(),
-                oldest_loaded_index);
+                load_progress.oldest_loaded_index_version_);
             return false;
         } else {
             return true;
@@ -302,6 +347,18 @@ inline bool looking_for_undeleted(const LoadParameter& load_params, const std::s
         return true;
     }
 }
+
+inline bool key_exists_in_ref_entry(const LoadParameter& load_params, const VersionMapEntry& ref_entry, const std::optional<AtomKey>&, LoadProgress&) {
+    if (is_latest_load_type(load_params.load_type_) && is_index_key_type(ref_entry.keys_[0].type()))
+        return true;
+
+    return false;
+}
+
+inline void set_loaded_until(const LoadProgress& load_progress, const std::shared_ptr<VersionMapEntry>& entry) {
+    entry->loaded_until_ = load_progress.loaded_until_;
+}
+
 
 void fix_stream_ids_of_index_keys(
     const std::shared_ptr<Store> &store,
@@ -315,7 +372,7 @@ inline SortedValue deduce_sorted(SortedValue existing_frame, SortedValue input_f
     constexpr auto DESCENDING = SortedValue::DESCENDING;
     constexpr auto UNSORTED = SortedValue::UNSORTED;
 
-    auto final_state = UNSORTED;
+    SortedValue final_state;
     switch (existing_frame) {
     case UNKNOWN:
         if (input_frame != UNSORTED) {

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -84,9 +84,7 @@ public:
         InputTensorFrame&& frame) const = 0;
 
     virtual bool has_stream(
-        const StreamId & stream_id,
-        const std::optional<bool>& skip_compat,
-        const std::optional<bool>& iterate_on_failure
+        const StreamId & stream_id
     ) = 0;
 
     /**

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1023,7 +1023,8 @@ class NativeVersionStore:
             kwargs = dict()
         meta_data_list = []
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
-        result = self.version_store.batch_read_metadata(symbols, version_queries)
+        read_options = self._get_read_options(**kwargs)
+        result = self.version_store.batch_read_metadata(symbols, version_queries, read_options)
         result_list = list(zip(symbols, result))
         for original_symbol, result in result_list:
             vitem, udm = result
@@ -1079,7 +1080,8 @@ class NativeVersionStore:
         _check_batch_kwargs(NativeVersionStore.batch_read_metadata, NativeVersionStore.read_metadata, kwargs)
         results_dict = {}
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
-        for result in self.version_store.batch_read_metadata(symbols, version_queries):
+        read_options = self._get_read_options(**kwargs)
+        for result in self.version_store.batch_read_metadata(symbols, version_queries, read_options):
             vitem, udm = result
             meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
             if vitem.symbol not in results_dict:
@@ -1466,7 +1468,6 @@ class NativeVersionStore:
         read_options.set_set_tz(self.resolve_defaults("set_tz", proto_cfg, global_default=False, **kwargs))
         read_options.set_allow_sparse(self.resolve_defaults("allow_sparse", proto_cfg, global_default=False, **kwargs))
         read_options.set_incompletes(self.resolve_defaults("incomplete", proto_cfg, global_default=False, **kwargs))
-
         return read_options
 
     def _get_queries(self, as_of, date_range, row_range, columns, query_builder, **kwargs):
@@ -1634,8 +1635,8 @@ class NativeVersionStore:
         self, symbol: str, as_of: Optional[VersionQueryInput] = None, raise_on_missing: Optional[bool] = False, **kwargs
     ) -> Optional[VersionedItem]:
         version_query = self._get_version_query(as_of, **kwargs)
-
-        version_handle = self.version_store.find_version(symbol, version_query)
+        read_options = self._get_read_options(**kwargs)
+        version_handle = self.version_store.find_version(symbol, version_query, read_options)
 
         if version_handle is None and raise_on_missing:
             raise KeyError(f"Cannot find version for symbol={symbol},as_of={as_of}")
@@ -2162,7 +2163,8 @@ class NativeVersionStore:
             The data attribute will not be populated.
         """
         version_query = self._get_version_query(as_of, **kwargs)
-        version_item, udm = self.version_store.read_metadata(symbol, version_query)
+        read_options = self._get_read_options(**kwargs)
+        version_item, udm = self.version_store.read_metadata(symbol, version_query, read_options)
         meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
 
         return VersionedItem(
@@ -2239,7 +2241,8 @@ class NativeVersionStore:
             True if the symbol is pickled, False otherwise.
         """
         version_query = self._get_version_query(as_of, **kwargs)
-        dit = self.version_store.read_descriptor(symbol, version_query)
+        read_options = self._get_read_options(**kwargs)
+        dit = self.version_store.read_descriptor(symbol, version_query, read_options)
         return self.is_pickled_descriptor(dit.timeseries_descriptor)
 
     def _get_time_range_from_ts(self, desc, min_ts, max_ts):
@@ -2261,7 +2264,7 @@ class NativeVersionStore:
             return _from_tz_timestamp(min_ts, None), _from_tz_timestamp(max_ts, None)
 
     def get_timerange_for_symbol(
-        self, symbol: str, version: Optional[VersionQueryInput] = None
+        self, symbol: str, version: Optional[VersionQueryInput] = None, **kwargs
     ) -> Tuple[datetime, datetime]:
         """
         Query the earliest and latest timestamp in the index of the specified revision of the symbol.
@@ -2280,6 +2283,7 @@ class NativeVersionStore:
         """
         given_version = max([v["version"] for v in self.list_versions(symbol)]) if version is None else version
         version_query = self._get_version_query(given_version)
+        read_options = self._get_read_options(**kwargs)
 
         i = self.version_store.read_index(symbol, version_query)
         frame_data = ReadResult(*i).frame_data
@@ -2290,7 +2294,7 @@ class NativeVersionStore:
         start_indices, end_indices = index_data[0], index_data[1]
         min_ts, max_ts = min(start_indices), max(end_indices)
         # to get timezone info
-        dit = self.version_store.read_descriptor(symbol, version_query)
+        dit = self.version_store.read_descriptor(symbol, version_query, read_options)
         return self._get_time_range_from_ts(dit.timeseries_descriptor, min_ts, max_ts)
 
     def name(self):
@@ -2412,7 +2416,8 @@ class NativeVersionStore:
             - date_range, `tuple`
         """
         version_query = self._get_version_query(version)
-        dit = self.version_store.read_descriptor(symbol, version_query)
+        read_options = _PythonVersionStoreReadOptions()
+        dit = self.version_store.read_descriptor(symbol, version_query, read_options)
         return self._process_info(symbol, dit, version)
 
     def batch_get_info(
@@ -2454,7 +2459,9 @@ class NativeVersionStore:
         version_queries = []
         for as_of in as_ofs_lists:
             version_queries.append(self._get_version_query(as_of))
-        list_descriptors = self.version_store.batch_read_descriptor(symbols, version_queries)
+
+        read_options = _PythonVersionStoreReadOptions()
+        list_descriptors = self.version_store.batch_read_descriptor(symbols, version_queries, read_options)
         args_list = list(zip(list_descriptors, symbols, version_queries, as_ofs_lists))
         list_infos = []
         for dit, symbol, version_query, as_of in args_list:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -685,9 +685,9 @@ def spawn_azurite(azurite_port):
 
 @pytest.fixture(
     scope="function",
-    params=["moto_s3_uri_incl_bucket", "azurite_azure_uri_incl_bucket"]
-    if AZURE_SUPPORT
-    else ["moto_s3_uri_incl_bucket"],
+    params=(
+        ["moto_s3_uri_incl_bucket", "azurite_azure_uri_incl_bucket"] if AZURE_SUPPORT else ["moto_s3_uri_incl_bucket"]
+    ),
 )
 def object_storage_uri_incl_bucket(request):
     yield request.getfixturevalue(request.param)

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -36,13 +36,8 @@ from datetime import datetime, date, timezone, timedelta
 import numpy as np
 from arcticdb_ext.tools import AZURE_SUPPORT
 from numpy import datetime64
-from arcticdb.util.test import (
-    assert_frame_equal,
-    random_strings_of_length,
-    random_floats,
-)
+from arcticdb.util.test import assert_frame_equal, random_strings_of_length, random_floats
 import random
-
 
 if AZURE_SUPPORT:
     from azure.storage.blob import BlobServiceClient

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -111,7 +111,8 @@ def test_special_chars(s3_version_store, special_char):
 
 @pytest.mark.parametrize("breaking_char", [chr(0), "\0", "&", "*", "<", ">"])
 def test_s3_breaking_chars(s3_version_store, breaking_char):
-    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db"""
+    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db
+    """
     sym = f"prefix{breaking_char}postfix"
     df = sample_dataframe()
     with pytest.raises(ArcticNativeNotYetImplemented):
@@ -302,7 +303,8 @@ def test_prune_previous_versions_multiple_times(lmdb_version_store, symbol):
 
 
 def test_prune_previous_versions_write_batch(lmdb_version_store):
-    """Verify that the batch write method correctly prunes previous versions when the corresponding option is specified."""
+    """Verify that the batch write method correctly prunes previous versions when the corresponding option is specified.
+    """
     # Given
     lib = lmdb_version_store
     lib_tool = lib.library_tool()
@@ -332,7 +334,8 @@ def test_prune_previous_versions_write_batch(lmdb_version_store):
 
 
 def test_prune_previous_versions_batch_write_metadata(lmdb_version_store):
-    """Verify that the batch write metadata method correctly prunes previous versions when the corresponding option is specified."""
+    """Verify that the batch write metadata method correctly prunes previous versions when the corresponding option is specified.
+    """
     # Given
     lib = lmdb_version_store
     lib_tool = lib.library_tool()
@@ -362,7 +365,8 @@ def test_prune_previous_versions_batch_write_metadata(lmdb_version_store):
 
 
 def test_prune_previous_versions_append_batch(lmdb_version_store):
-    """Verify that the batch append method correctly prunes previous versions when the corresponding option is specified."""
+    """Verify that the batch append method correctly prunes previous versions when the corresponding option is specified.
+    """
     # Given
     lib = lmdb_version_store
     lib_tool = lib.library_tool()

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -111,8 +111,7 @@ def test_special_chars(s3_version_store, special_char):
 
 @pytest.mark.parametrize("breaking_char", [chr(0), "\0", "&", "*", "<", ">"])
 def test_s3_breaking_chars(s3_version_store, breaking_char):
-    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db
-    """
+    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db"""
     sym = f"prefix{breaking_char}postfix"
     df = sample_dataframe()
     with pytest.raises(ArcticNativeNotYetImplemented):

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1391,8 +1391,6 @@ def test_coercion_to_str_with_dynamic_strings(lmdb_version_store_string_coercion
 
 def test_find_version(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
-    # def test_find_version(lmdb_version_store):
-    #     lib = lmdb_version_store
     sym = "test_find_version"
 
     # Version 0 is alive and in a snapshot
@@ -1435,7 +1433,7 @@ def test_find_version(lmdb_version_store_v1):
     with pytest.raises(NoDataFoundException):
         lib._find_version(sym, as_of="snap_1000")
     # By timestamp
-    # assert lib._find_version(sym, as_of=time_0).version == 0
+    assert lib._find_version(sym, as_of=time_0).version == 0
     assert lib._find_version(sym, as_of=time_1).version == 0
     assert lib._find_version(sym, as_of=time_2).version == 0
     assert lib._find_version(sym, as_of=time_3).version == 3

--- a/python/tests/stress/arcticdb/version_store/test_stress_version_map_compact.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_version_map_compact.py
@@ -35,6 +35,7 @@ def write_data(lib, sym, done, error):
                 assert lib.has_symbol(sym, vid)
             for d_id in range(delete_version_id):
                 assert d_id not in vs
+
     except Exception as e:
         print(e)
         error.value = 1

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -26,12 +26,7 @@ from hypothesis.extra.pandas import column, data_frames, range_indexes
 def test_group_on_float_column_with_nans(lmdb_version_store):
     lib = lmdb_version_store
     sym = "test_group_on_float_column_with_nans"
-    df = pd.DataFrame(
-        {
-            "grouping_column": [1.0, 2.0, np.nan, 1.0, 2.0, 2.0],
-            "agg_column": [1, 2, 3, 4, 5, 6],
-        }
-    )
+    df = pd.DataFrame({"grouping_column": [1.0, 2.0, np.nan, 1.0, 2.0, 2.0], "agg_column": [1, 2, 3, 4, 5, 6]})
     lib.write(sym, df)
     expected = df.groupby("grouping_column").agg({"agg_column": "sum"})
     q = QueryBuilder()

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1045,12 +1045,7 @@ def test_filter_numeric_isnotin_empty_set(lmdb_version_store, df):
 def test_filter_nones_and_nans_retained_in_string_column(lmdb_version_store):
     lib = lmdb_version_store
     sym = "test_filter_nones_and_nans_retained_in_string_column"
-    df = pd.DataFrame(
-        {
-            "filter_column": [1, 2, 1, 2, 1, 2],
-            "string_column": ["1", "2", np.nan, "4", None, "6"],
-        },
-    )
+    df = pd.DataFrame({"filter_column": [1, 2, 1, 2, 1, 2], "string_column": ["1", "2", np.nan, "4", None, "6"]})
     lib.write(sym, df)
     q = QueryBuilder()
     q = q[q["filter_column"] == 1]

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -71,10 +71,7 @@ def test_querybuilder_filter_then_groupby(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     symbol = "test_querybuilder_filter_then_groupby"
     df = pd.DataFrame(
-        {
-            "col1": ["a", "b", "c", "a", "b", "c", "a", "b", "c", "d"],
-            "col2": [1, 2, 3, 2, 1, 3, 1, 1, 3, 4],
-        },
+        {"col1": ["a", "b", "c", "a", "b", "c", "a", "b", "c", "d"], "col2": [1, 2, 3, 2, 1, 3, 1, 1, 3, 4]},
         index=np.arange(10),
     )
     lib.write(symbol, df)
@@ -129,11 +126,7 @@ def test_querybuilder_project_then_groupby(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     symbol = "test_querybuilder_project_then_groupby"
     df = pd.DataFrame(
-        {
-            "col1": [1, 2, 2, 3, 3, 3, 4, 4, 4, 4],
-            "col2": np.arange(0, 1, 0.1, dtype=np.float64),
-        },
-        index=np.arange(10),
+        {"col1": [1, 2, 2, 3, 3, 3, 4, 4, 4, 4], "col2": np.arange(0, 1, 0.1, dtype=np.float64)}, index=np.arange(10)
     )
     lib.write(symbol, df)
     q = QueryBuilder()
@@ -153,10 +146,7 @@ def test_querybuilder_groupby_then_filter(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     symbol = "test_querybuilder_groupby_then_filter"
     df = pd.DataFrame(
-        {
-            "col1": ["a", "b", "c", "a", "b", "c", "a", "b", "c", "d"],
-            "col2": [1, 2, 3, 2, 1, 3, 1, 1, 3, 4],
-        },
+        {"col1": ["a", "b", "c", "a", "b", "c", "a", "b", "c", "d"], "col2": [1, 2, 3, 2, 1, 3, 1, 1, 3, 4]},
         index=np.arange(10),
     )
     lib.write(symbol, df)
@@ -173,11 +163,7 @@ def test_querybuilder_groupby_then_project(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     symbol = "test_querybuilder_groupby_then_project"
     df = pd.DataFrame(
-        {
-            "col1": [5, 23, 42, 5, 23, 42, 5, 23, 42, 0],
-            "col2": [1, 2, 3, 2, 1, 3, 1, 1, 3, 4],
-        },
-        index=np.arange(10),
+        {"col1": [5, 23, 42, 5, 23, 42, 5, 23, 42, 0], "col2": [1, 2, 3, 2, 1, 3, 1, 1, 3, 4]}, index=np.arange(10)
     )
     lib.write(symbol, df)
     q = QueryBuilder()

--- a/python/tests/util/date.py
+++ b/python/tests/util/date.py
@@ -137,7 +137,9 @@ class DateRange(GeneralSlice):
                 else (
                     other.startopen
                     if self.start < other.start
-                    else self.startopen if self.start > other.start else (self.startopen or other.startopen)
+                    else self.startopen
+                    if self.start > other.start
+                    else (self.startopen or other.startopen)
                 )
             )
         )
@@ -150,7 +152,9 @@ class DateRange(GeneralSlice):
                 else (
                     other.endopen
                     if self.end > other.end
-                    else self.endopen if self.end < other.end else (self.endopen or other.endopen)
+                    else self.endopen
+                    if self.end < other.end
+                    else (self.endopen or other.endopen)
                 )
             )
         )

--- a/python/tests/util/date.py
+++ b/python/tests/util/date.py
@@ -131,24 +131,28 @@ class DateRange(GeneralSlice):
         startopen = (
             other.startopen
             if self.start is None
-            else self.startopen
-            if other.start is None
-            else other.startopen
-            if self.start < other.start
-            else self.startopen
-            if self.start > other.start
-            else (self.startopen or other.startopen)
+            else (
+                self.startopen
+                if other.start is None
+                else (
+                    other.startopen
+                    if self.start < other.start
+                    else self.startopen if self.start > other.start else (self.startopen or other.startopen)
+                )
+            )
         )
         endopen = (
             other.endopen
             if self.end is None
-            else self.endopen
-            if other.end is None
-            else other.endopen
-            if self.end > other.end
-            else self.endopen
-            if self.end < other.end
-            else (self.endopen or other.endopen)
+            else (
+                self.endopen
+                if other.end is None
+                else (
+                    other.endopen
+                    if self.end > other.end
+                    else self.endopen if self.end < other.end else (self.endopen or other.endopen)
+                )
+            )
         )
 
         new_start = (


### PR DESCRIPTION
Using AWS replication it's possible that the version key associated with the most recent reference key update might not yet be available. In order to mitigate this, we store both the first- and second-most-recent version keys in the reference key structure, and in the event that the first one is not readable use the second to iterate the version chain.

NOTE: In the process of making this change it became clear that loading the version map as_of a particular time loads the whole map without early termination. This is problematic for the above change because the assumption that only a load of the latest version should terminate the version chain following after the reference key is broken, therefore it's necessary to have correct early termination when searching the version list by timestamp.

This is now the major change in this PR. The promotion of the penultimate key to the reference segment in the version list is still in the code, but is currently disabled to mitigate technical risk (as it changes the stored format and might be difficult to back out), and whilst we decide whether the API is optimal. 

This has been done because correct early termination of the version list traversal by timestamp needs to be fixed sooner rather than later, and disentangling the changes would be difficult and slow