### PR TITLE
Issue 520 Fix for LMDB DBI Handling

### DIFF
--- a/cpp/arcticdb/storage/lmdb/lmdb_storage-inl.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage-inl.hpp
@@ -215,7 +215,7 @@ bool LmdbStorage::do_fast_delete() {
         ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
         ARCTICDB_DEBUG(log::storage(), "dropping {}", db_name);
         ::lmdb::dbi& dbi = dbi_by_key_type_.at(db_name);
-        ::lmdb::dbi_drop(dtxn, dbi, true);
+        ::lmdb::dbi_drop(dtxn, dbi);
     });
 
     dtxn.commit();

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage-inl.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage-inl.hpp
@@ -31,7 +31,7 @@ inline void LmdbStorage::do_write_internal(Composite<KeySegmentPair>&& kvs, ::lm
         auto db_name = fmt::format("{}", group.key());
 
         ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
-        auto dbi = ::lmdb::dbi::open(txn, db_name.data(), MDB_CREATE);
+        ::lmdb::dbi& dbi = dbi_by_key_type_.at(db_name);
 
         ARCTICDB_SUBSAMPLE(LmdbStorageWriteValues, 0)
         for (auto &kv : group.values()) {
@@ -104,7 +104,7 @@ template<class Visitor>
     (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
         auto db_name = fmt::format("{}", group.key());
         ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
-        auto dbi = ::lmdb::dbi::open(txn, db_name.data());
+        ::lmdb::dbi& dbi = dbi_by_key_type_.at(db_name);
         for (auto &k : group.values()) {
             auto stored_key = to_serialized_key(k);
             MDB_val mdb_key{stored_key.size(), stored_key.data()};
@@ -129,14 +129,14 @@ template<class Visitor>
 
 inline bool LmdbStorage::do_key_exists(const VariantKey&key) {
     ARCTICDB_SAMPLE(LmdbStorageKeyExists, 0)
-    auto txn = ::lmdb::txn::begin(env(), nullptr, MDB_RDONLY);  // abort()s on destruction
+    auto txn = ::lmdb::txn::begin(env(), nullptr, MDB_RDONLY);
     ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
 
     auto db_name = fmt::format("{}", variant_key_type(key));
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
 
     try {
-        auto dbi = ::lmdb::dbi::open(txn, db_name.data());
+        ::lmdb::dbi& dbi = dbi_by_key_type_.at(db_name);
         if (unsigned int tmp; ::mdb_dbi_flags(txn, dbi, &tmp) == EINVAL) {
             return false;
         }
@@ -145,7 +145,7 @@ inline bool LmdbStorage::do_key_exists(const VariantKey&key) {
         MDB_val mdb_val;
         return ::lmdb::dbi_get(txn, dbi.handle(), &mdb_key, &mdb_val);
     } catch (const ::lmdb::not_found_error &ex) {
-        ARCTICDB_DEBUG(log::storage(), "Caught lmdn not found error: {}", ex.what());
+        ARCTICDB_DEBUG(log::storage(), "Caught lmdb not found error: {}", ex.what());
         return false;
     }
 }
@@ -160,7 +160,7 @@ inline std::vector<VariantKey> LmdbStorage::do_remove_internal(Composite<Variant
         ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
         try {
             // If no key of this type has been written before, this can fail
-            auto dbi = ::lmdb::dbi::open(txn, db_name.data());
+            ::lmdb::dbi& dbi = dbi_by_key_type_.at(db_name);
             for (auto &k : group.values()) {
                 auto stored_key = to_serialized_key(k);
                 MDB_val mdb_key{stored_key.size(), stored_key.data()};
@@ -206,19 +206,16 @@ bool LmdbStorage::do_fast_delete() {
     // bool is probably not the best return type here but it does help prevent the insane boilerplate for
     // an additional function that checks whether this is supported (like the prefix matching)
     auto dtxn = ::lmdb::txn::begin(env());
-    ::lmdb::dbi default_dbi{0};
-
     foreach_key_type([&] (KeyType key_type) {
-        auto db_name = fmt::format("{}", key_type);
-        try {
-            ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
-            auto dbi = ::lmdb::dbi::open(dtxn, db_name.data());
-            ::lmdb::dbi_drop(dtxn, dbi, true);
-        }
-        catch (const ::lmdb::not_found_error &e) {
-            // Key type was not created, just skip.
+        if (key_type == KeyType::TOMBSTONE) {
+            // TOMBSTONE and LOCK both format to code 'x' - do not try to drop both
             return;
         }
+        auto db_name = fmt::format("{}", key_type);
+        ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
+        ARCTICDB_DEBUG(log::storage(), "dropping {}", db_name);
+        ::lmdb::dbi& dbi = dbi_by_key_type_.at(db_name);
+        ::lmdb::dbi_drop(dtxn, dbi, true);
     });
 
     dtxn.commit();
@@ -230,19 +227,10 @@ void LmdbStorage::do_iterate_type(KeyType key_type, Visitor &&visitor, const std
     ARCTICDB_SAMPLE(LmdbStorageItType, 0);
     auto txn = ::lmdb::txn::begin(env(), nullptr, MDB_RDONLY); // scoped abort on
     std::string type_db = fmt::format("{}", key_type);
-    ::lmdb::dbi default_dbi{0};
-    try {
-        ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
-        default_dbi = ::lmdb::dbi::open(txn, type_db.c_str());
-    }
-    catch (const ::lmdb::not_found_error &e) {
-        // this gets thrown when a storage has not yet been created among other case (we use lazy create on write)
-        // it is sufficient to return here as non existent store should result in no iteration
-        ARCTICDB_DEBUG(log::storage(), "lmdb not found error for key_type: {}", key_type);
-        return;
-    }
+    ::lmdb::dbi& dbi = dbi_by_key_type_.at(type_db);
+
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenCursor, 0)
-    auto db_cursor = ::lmdb::cursor::open(txn, default_dbi);
+    auto db_cursor = ::lmdb::cursor::open(txn, dbi);
 
     MDB_val mdb_db_key;
     ARCTICDB_SUBSAMPLE(LmdbStorageCursorFirst, 0)

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -68,6 +68,7 @@ private:
 
     std::unique_ptr<std::mutex> write_mutex_;
     std::unique_ptr<::lmdb::env> env_;
+    std::unordered_map<std::string, ::lmdb::dbi> dbi_by_key_type_;
 };
 
 class LmdbStorageFactory final : public StorageFactory<LmdbStorageFactory> {

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -1,0 +1,21 @@
+from arcticdb import Arctic
+import pandas as pd
+
+from arcticdb.util.test import assert_frame_equal
+
+
+def test_batch_read_only_segfault_regression(tmpdir):
+    # See Github issue #520
+    # This segfaults with arcticdb==1.5.0
+    ac = Arctic(f"lmdb://{tmpdir}/lmdb_instance")
+    ac.create_library("test_lib")
+    lib = ac["test_lib"]
+    df = pd.DataFrame({"a": list(range(100))}, index=list(range(100)))
+    for i in range(100):
+        lib.write(str(i), df, prune_previous_versions=True)
+
+    # New Arctic instance is essential to repro the bug
+    fresh_lib = Arctic(f"lmdb://{tmpdir}/lmdb_instance")["test_lib"]
+    vis = fresh_lib.read_batch([str(i) for i in range(100)])  # used to crash
+    assert len(vis) == 100
+    assert_frame_equal(vis[0].data, df)


### PR DESCRIPTION
**Only the HEAD and HEAD~ commits are for review here. The other two are under separate PR #585 that should be merged shortly.**

#### Reference Issues/PRs

Issue #520 this PR fixes the issue that `prophetss` reported related to parallelism in a read-only session with LMDB.

It depends on the other PR #585 and includes commits from it that will get rebased out once that is merged.

#### What does this implement/fix? Explain your changes.

As described in the comments under issue #520 this fixes an issue with our use of LMDB database handles.

There are separate notions in LMDB:

- The environment
- The databases in an environment

The environment is similar to the ArcticDB library. Within the environment we use one LMDB "database" per `KeyType`. With LMDB you open a handle called a `dbi_handle` to each database.

The LMDB programming model insists that a database handle is only opened once per process and never closed. There is no synchronization in LMDB that handles the cleanup when a handle is closed and LMDB suggest that it is almost always a mistake to close a DBI handle. Their resources are freed when the environment shuts down.

Our use of LMDB was incorrect here as we were opening new DBI handles within each transaction. We had a model where we nested,

```
LMDB environment (many long-lived)
|_ LMDB transactions (many short-lived)
    |_ LMDB database handles (many short-lived, with races in their cleanup)
```

whereas the correct model is as implemented here:

```
LMDB environment (one long-lived)
|_ LMDB database handles (few long-lived)
    |_ LMDB transactions (many short-lived)
```

