### PR TITLE
Ensure content hash is copied during restore version + fixing timestamp-uniqueness-related flaky tests

### DIFF
--- a/cpp/arcticdb/util/clock.hpp
+++ b/cpp/arcticdb/util/clock.hpp
@@ -50,15 +50,12 @@ struct ManualClock {
     inline static std::atomic<entity::timestamp> time_{0};
 
     static entity::timestamp nanos_since_epoch() {
-        return LinearClock::time_.load();
+        return time_.load();
     }
     static entity::timestamp coarse_nanos_since_epoch() {
-        return LinearClock::time_.load();
+        return time_.load();
     }
 };
 
 
 } // namespace arcticdb::util
-
-
-

--- a/cpp/arcticdb/util/clock.hpp
+++ b/cpp/arcticdb/util/clock.hpp
@@ -46,6 +46,17 @@ struct LinearClock {
     }
 };
 
+struct ManualClock {
+    inline static std::atomic<entity::timestamp> time_{0};
+
+    static entity::timestamp nanos_since_epoch() {
+        return LinearClock::time_.load();
+    }
+    static entity::timestamp coarse_nanos_since_epoch() {
+        return LinearClock::time_.load();
+    }
+};
+
 
 } // namespace arcticdb::util
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -24,11 +24,11 @@
 #include <arcticdb/python/gil_lock.hpp>
 
 namespace arcticdb::version_store {
-
+template<class ClockType>
 LocalVersionedEngine::LocalVersionedEngine(
         const std::shared_ptr<storage::Library>& library,
-        const std::optional<std::string>& license_key ARCTICDB_UNUSED) :
-    store_(std::make_shared<async::AsyncStore<util::SysClock>>(library, codec::default_lz4_codec(), encoding_version(library->config()))),
+        const ClockType&) :
+    store_(std::make_shared<async::AsyncStore<ClockType>>(library, codec::default_lz4_codec(), encoding_version(library->config()))),
     symbol_list_(std::make_shared<SymbolList>(version_map_)){
     configure(library->config());
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Created versioned engine at {} for library path {}  with config {}", uintptr_t(this),
@@ -43,6 +43,9 @@ LocalVersionedEngine::LocalVersionedEngine(
         async::TaskScheduler::reattach_instance();
     }
 }
+
+template LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<storage::Library>& library, const util::SysClock&);
+template LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<storage::Library>& library, const util::ManualClock&);
 
 folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_indexes(
         const std::vector<AtomKey> &pruned_indexes,
@@ -839,7 +842,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
     log::version().debug("Forbidden: {} total of data keys", data_keys_not_to_be_deleted.size());
     RemoveOpts remove_opts;
     remove_opts.ignores_missing_key_ = true;
-    
+
     std::vector<entity::VariantKey> vks_column_stats;
     std::transform(keys_to_delete->begin(),
                     keys_to_delete->end(),

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -379,6 +379,12 @@ public:
     void _test_set_store(std::shared_ptr<Store> store);
     std::shared_ptr<VersionMap> _test_get_version_map();
 
+    /** Get the time used by the Store (e.g. that would be used in the AtomKey).
+        For testing purposes only. */
+    entity::timestamp get_store_current_timestamp_for_tests() {
+        return store()->current_timestamp();
+    }
+
 protected:
     VersionedItem compact_incomplete_dynamic(
             const StreamId& stream_id,

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -45,9 +45,11 @@ struct IndexKeyAndUpdateInfo{
 class LocalVersionedEngine : public VersionedEngine {
 
 public:
+    template<class ClockType = util::SysClock>
     explicit LocalVersionedEngine(
         const std::shared_ptr<storage::Library>& library,
-        const std::optional<std::string>& license_key = std::nullopt);
+        const ClockType& = util::SysClock{} // Only used to allow the template variable to be inferred
+        );
 
     virtual ~LocalVersionedEngine() = default;
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -651,13 +651,16 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("latest_timestamp",
              &PythonVersionStore::latest_timestamp,
              "Returns latest timestamp of a symbol")
+        .def("get_store_current_timestamp_for_tests",
+             &PythonVersionStore::get_store_current_timestamp_for_tests,
+             "For testing purposes only")
         ;
 
     py::class_<ManualClockVersionStore, PythonVersionStore>(version, "ManualClockVersionStore")
         .def(py::init<const std::shared_ptr<storage::Library>&>())
         .def_property_static("time",
             []() { return util::ManualClock::time_.load(); },
-            [](entity::timestamp ts) { util::ManualClock::time_ = ts; })
+            [](const py::class_<ManualClockVersionStore>&, entity::timestamp ts) { util::ManualClock::time_ = ts; })
          ;
 
     py::class_<LocalVersionedEngine>(version, "VersionedEngine")

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -361,7 +361,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def_readwrite("row_filter",&UpdateQuery::row_filter);
 
     py::class_<PythonVersionStore>(version, "PythonVersionStore")
-        .def(py::init<std::shared_ptr<storage::Library>, std::optional<std::string>>(),
+        .def(py::init([](const std::shared_ptr<storage::Library>& library, std::optional<std::string>) {
+                return PythonVersionStore(library);
+             }),
              py::arg("library"),
              py::arg("license_key") = std::nullopt)
         .def("write_partitioned_dataframe",
@@ -650,6 +652,13 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              &PythonVersionStore::latest_timestamp,
              "Returns latest timestamp of a symbol")
         ;
+
+    py::class_<ManualClockVersionStore, PythonVersionStore>(version, "ManualClockVersionStore")
+        .def(py::init<const std::shared_ptr<storage::Library>&>())
+        .def_property_static("time",
+            []() { return util::ManualClock::time_.load(); },
+            [](entity::timestamp ts) { util::ManualClock::time_ = ts; })
+         ;
 
     py::class_<LocalVersionedEngine>(version, "VersionedEngine")
       .def(py::init<std::shared_ptr<storage::Library>>())

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -38,9 +38,8 @@ using namespace arcticdb::entity;
 namespace as = arcticdb::stream;
 using namespace arcticdb::storage;
 
-PythonVersionStore::PythonVersionStore(const std::shared_ptr<storage::Library>& library, const std::optional<std::string>& license_key) :
-    LocalVersionedEngine(library, license_key) {
-}
+template PythonVersionStore::PythonVersionStore(const std::shared_ptr<storage::Library>& library, const util::SysClock& ct);
+template PythonVersionStore::PythonVersionStore(const std::shared_ptr<storage::Library>& library, const util::ManualClock& ct);
 
 VersionedItem PythonVersionStore::write_dataframe_specific_version(
     const StreamId& stream_id,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -51,9 +51,10 @@ namespace as = arcticdb::stream;
 class PythonVersionStore : public LocalVersionedEngine {
 
   public:
-    explicit PythonVersionStore(
-        const std::shared_ptr<storage::Library>& library,
-        const std::optional<std::string>& license_key = std::nullopt);
+    template<class ClockType = util::SysClock>
+    explicit PythonVersionStore(const std::shared_ptr<storage::Library>& library, const ClockType& ct = util::SysClock{}) :
+        LocalVersionedEngine(library, ct) {
+    }
 
     VersionedItem write_dataframe_specific_version(
         const StreamId& stream_id,
@@ -333,6 +334,11 @@ private:
         bool prune_previous_versions);
 
     void delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key);
+};
+
+struct ManualClockVersionStore : PythonVersionStore {
+    ManualClockVersionStore(const std::shared_ptr<storage::Library>& library) :
+            PythonVersionStore(library, util::ManualClock{}) {}
 };
 
 inline std::vector<std::variant<ReadResult, DataError>> frame_to_read_result(std::vector<ReadVersionOutput>&& keys_frame_and_descriptors) {

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -13,6 +13,8 @@ import pandas as pd
 import pytest
 import string
 import random
+import time
+import attr
 from six import PY3
 from copy import deepcopy
 from functools import wraps
@@ -20,6 +22,7 @@ from packaging import version
 
 from arcticdb.config import Defaults
 from arcticdb.log import configure, logger_by_name
+from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._custom_normalizers import CustomNormalizer
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata
 from arcticc.pb2.logger_pb2 import LoggerConfig, LoggersConfig
@@ -490,3 +493,31 @@ def regularize_dataframe(df):
     output = output.reset_index(drop=True)
     output = output.astype("float", errors="ignore")
     return output
+
+
+@attr.s(slots=True, auto_attribs=True)
+class BeforeAfterTimestamp:
+    before: pd.Timestamp
+    after: Optional[pd.Timestamp]
+
+
+@contextmanager
+def distinct_timestamps(lib: NativeVersionStore):
+    """Ensures the timestamp used by ArcticDB operations before, during and leaving the context are all different.
+
+    Yields
+    ------
+    BeforeAfterTimestamp
+    """
+    get_ts = lib.version_store.get_store_current_timestamp_for_tests
+    before = get_ts()
+    while get_ts() == before:
+        time.sleep(0.000001)  # 1us - The worst resolution in our clock implementations
+    out = BeforeAfterTimestamp(pd.Timestamp(before, unit="ns"), None)
+    try:
+        yield out
+    finally:
+        right_after = get_ts()
+        while get_ts() == right_after:
+            time.sleep(0.000001)
+        out.after = pd.Timestamp(get_ts(), unit="ns")

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -36,7 +36,7 @@ from arcticdb.version_store._custom_normalizers import CustomNormalizer, registe
 from arcticdb.version_store._store import UNSUPPORTED_S3_CHARS, MAX_SYMBOL_SIZE, VersionedItem
 from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
-from arcticdb_ext.version_store import NoSuchVersionException, StreamDescriptorMismatch
+from arcticdb_ext.version_store import NoSuchVersionException, StreamDescriptorMismatch, ManualClockVersionStore
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata  # Importing from arcticdb dynamically loads arcticc.pb2
 from arcticdb.util.test import (
     sample_dataframe,
@@ -1738,6 +1738,8 @@ def test_dynamic_schema_similar_index_column_dataframe_multiple_col(lmdb_version
 
 def test_restore_version(version_store_factory):
     lmdb_version_store = version_store_factory(col_per_group=2, row_per_segment=2)
+    # Triggers bug https://github.com/man-group/ArcticDB/issues/469 by freezing time
+    lmdb_version_store.version_store = ManualClockVersionStore(lmdb_version_store._library)
     symbol = "test_restore_version"
     df1 = get_sample_dataframe(20, 4)
     df1.index = pd.DatetimeIndex([pd.Timestamp.now()] * len(df1))

--- a/python/tests/integration/arcticdb/version_store/test_metadata_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_metadata_support.py
@@ -5,16 +5,14 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-import time
 import numpy as np
 from pandas import DataFrame, Timestamp
 import pytest
-import sys
 
 from arcticdb.version_store import NativeVersionStore, VersionedItem
 from arcticdb.exceptions import ArcticNativeNotYetImplemented
 from arcticdb_ext.storage import NoDataFoundException
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, distinct_timestamps
 
 
 # In the following lines, the naming convention is
@@ -85,22 +83,21 @@ def test_read_metadata_by_timestamp(lmdb_version_store):
     symbol = "test_symbol"
 
     metadata_v0 = {"something": 1}
-    lmdb_version_store.write(symbol, 1, metadata=metadata_v0)  # v0
-    time_after_first_write = Timestamp.utcnow()
-    time.sleep(0.1)
+    with distinct_timestamps(lmdb_version_store) as first_write_timestamps:
+        lmdb_version_store.write(symbol, 1, metadata=metadata_v0)  # v0
 
     with pytest.raises(NoDataFoundException):
         lmdb_version_store.read(symbol, as_of=Timestamp(0))
 
-    assert lmdb_version_store.read_metadata(symbol, as_of=time_after_first_write).metadata == metadata_v0
+    assert lmdb_version_store.read_metadata(symbol, as_of=first_write_timestamps.after).metadata == metadata_v0
 
     metadata_v1 = {"something more": 2}
-    lmdb_version_store.write(symbol, 2, metadata=metadata_v1)  # v1
-    time.sleep(0.11)
+    with distinct_timestamps(lmdb_version_store):
+        lmdb_version_store.write(symbol, 2, metadata=metadata_v1)  # v1
 
     metadata_v2 = {"something else": 3}
-    lmdb_version_store.write(symbol, 3, metadata=metadata_v2)  # v2
-    time.sleep(0.1)
+    with distinct_timestamps(lmdb_version_store):
+        lmdb_version_store.write(symbol, 3, metadata=metadata_v2)  # v2
 
     metadata_v3 = {"nothing": 4}
     lmdb_version_store.write(symbol, 4, metadata=metadata_v3)  # v3
@@ -109,7 +106,7 @@ def test_read_metadata_by_timestamp(lmdb_version_store):
     assert len(versions) == 4
     sorted_versions_for_a = sorted([v for v in versions if v["symbol"] == symbol], key=lambda x: x["version"])
 
-    assert lmdb_version_store.read_metadata(symbol, as_of=time_after_first_write).metadata == metadata_v0
+    assert lmdb_version_store.read_metadata(symbol, as_of=first_write_timestamps.after).metadata == metadata_v0
 
     ts_for_v1 = sorted_versions_for_a[1]["date"]
     assert lmdb_version_store.read_metadata(symbol, as_of=ts_for_v1).metadata == metadata_v1


### PR DESCRIPTION
Fixes #469

`restore_ version` doesn't copy the content hash in data keys. `restore_version` will create new versions of the data keys but as all the data keys will have a content hash of `0`, it's possible for there to be collisions if the timestamp happens to be the same. 

This change ensures that the content hash is copied over ensuring that there is no possibility of duplicated/colliding key names. As a result, this fixes the restore_version test being flaky. 

The first commit introduces a reliably failing test and the second commit fixes it

