### PR TITLE
Issue #517 Delete relevant part of LMDB tree upon library delete

### DIFF
--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -29,6 +29,7 @@ function worker() {
     $catch python -m pytest -v --show-capture=no --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --splits $splits --group $group --durations-path="$duration_file" --store-durations \
+        --basetemp="$new_root/temp-pytest-output" \
         "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#$group: \2#"
 }
 

--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -60,9 +60,6 @@ class ArcticLibraryAdapter(ABC):
     def create_library(self, name: str, library_options: LibraryOptions) -> NativeVersionStore:
         raise NotImplementedError
 
-    def delete_library(self, library: Library, library_config: LibraryConfig):
-        return library._nvs.version_store.clear()
-
     def cleanup_library(self, library_name: str, library_config: LibraryConfig):
         pass
 

--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -63,5 +63,8 @@ class ArcticLibraryAdapter(ABC):
     def delete_library(self, library: Library, library_config: LibraryConfig):
         return library._nvs.version_store.clear()
 
+    def cleanup_library(self, library_name: str, library_config: LibraryConfig):
+        pass
+
     def get_storage_override(self) -> StorageOverride:
         return StorageOverride()

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -17,7 +17,7 @@ from arcticdb.version_store.helper import add_lmdb_library_to_env
 from arcticdb.config import _DEFAULT_ENV
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter, set_library_options
-from arcticdb_ext.storage import Library, StorageOverride
+from arcticdb_ext.storage import StorageOverride
 from arcticdb.encoding_version import EncodingVersion
 
 

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -7,17 +7,22 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 import re
 import os
-
-from typing import Optional
+import shutil
+from arcticdb.log import storage as log
 
 from arcticdb.options import LibraryOptions
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
+from arcticc.pb2.lmdb_storage_pb2 import Config as LmdbConfig
 from arcticdb.version_store.helper import add_lmdb_library_to_env
 from arcticdb.config import _DEFAULT_ENV
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter, set_library_options
 from arcticdb_ext.storage import Library, StorageOverride
 from arcticdb.encoding_version import EncodingVersion
+
+
+def _rmtree_errorhandler(func, path, exc_info):
+    log.warn("Error removing LMDB tree at path=[{}]", path, exc_info=exc_info)
 
 
 class LMDBLibraryAdapter(ArcticLibraryAdapter):
@@ -58,9 +63,6 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
 
         return lib._library
 
-    def get_storage_override(self) -> StorageOverride:
-        return StorageOverride()
-
     def create_library(self, name, library_options: LibraryOptions):
         env_cfg = EnvironmentConfigsMap()
 
@@ -73,3 +75,13 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
         )
 
         return lib
+
+    def delete_library(self, library: Library, library_config: LibraryConfig):
+        super().delete_library(library, library_config)
+        for k, v in library_config.storage_by_id.items():
+            lmdb_config = LmdbConfig()
+            v.config.Unpack(lmdb_config)
+            shutil.rmtree(os.path.join(lmdb_config.path, library.name), onerror=_rmtree_errorhandler)
+
+    def get_storage_override(self) -> StorageOverride:
+        return StorageOverride()

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -76,12 +76,11 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
 
         return lib
 
-    def delete_library(self, library: Library, library_config: LibraryConfig):
-        super().delete_library(library, library_config)
+    def cleanup_library(self, library_name: str, library_config: LibraryConfig):
         for k, v in library_config.storage_by_id.items():
             lmdb_config = LmdbConfig()
             v.config.Unpack(lmdb_config)
-            shutil.rmtree(os.path.join(lmdb_config.path, library.name), onerror=_rmtree_errorhandler)
+            shutil.rmtree(os.path.join(lmdb_config.path, library_name), onerror=_rmtree_errorhandler)
 
     def get_storage_override(self) -> StorageOverride:
         return StorageOverride()

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -239,9 +239,10 @@ class Arctic:
         already_open = self._open_libraries.pop(name, None)
         if not already_open and not self._library_manager.has_library(name):
             return
-        self._library_adapter.delete_library(
-            self[name], self._library_manager.get_library_config(name, StorageOverride())
-        )
+        config = self._library_manager.get_library_config(name, StorageOverride())
+        self._library_adapter.delete_library(already_open or self[name], config)
+        del already_open  # essential to free resources held by the library
+        self._library_adapter.cleanup_library(name, config)
         self._library_manager.remove_library_config(name)
 
     def list_libraries(self) -> List[str]:

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -240,10 +240,12 @@ class Arctic:
         if not already_open and not self._library_manager.has_library(name):
             return
         config = self._library_manager.get_library_config(name, StorageOverride())
-        self._library_adapter.delete_library(already_open or self[name], config)
+        (already_open or self[name])._nvs.version_store.clear()
         del already_open  # essential to free resources held by the library
-        self._library_adapter.cleanup_library(name, config)
-        self._library_manager.remove_library_config(name)
+        try:
+            self._library_adapter.cleanup_library(name, config)
+        finally:
+            self._library_manager.remove_library_config(name)
 
     def list_libraries(self) -> List[str]:
         """

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -1,5 +1,6 @@
 from arcticdb import Arctic
 import pandas as pd
+import os
 
 from arcticdb.util.test import assert_frame_equal
 
@@ -19,3 +20,21 @@ def test_batch_read_only_segfault_regression(tmpdir):
     vis = fresh_lib.read_batch([str(i) for i in range(100)])  # used to crash
     assert len(vis) == 100
     assert_frame_equal(vis[0].data, df)
+
+
+def test_library_deletion(tmpdir):
+    # See Github issue #517
+    # Given
+    ac = Arctic(f"lmdb://{tmpdir}/lmdb_instance")
+    path = os.path.join(tmpdir, "lmdb_instance", "test_lib")
+    ac.create_library("test_lib")
+    assert os.path.exists(path)
+
+    ac.create_library("test_lib2")
+
+    # When
+    ac.delete_library("test_lib")
+
+    # Then
+    assert not os.path.exists(path)
+    assert ac.list_libraries() == ["test_lib2"]


### PR DESCRIPTION
## Motivation

See issue #517 for the motivation for this. We want to clean up the LMDB files when we delete a library.

## Implementation

There are three parts to this.

### parallel_test.sh change

 Use a unique fixture directory for tmpfiles like LMDB databases. This is actually unrelated to the fix but reduces test flakiness.

Otherwise they can clash. See the docs https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html

Especially the note on pytest-xdist indicating that some coordination is
necessary.

### Delete in memory handles to Library objects before cleanup

Since we use lmdb++ the lifecyle of the LMDB resources is the same as the lifecycle of the Library object itself. Therefore we need to free it before we delete any files. This is mostly for Windows - otherwise the file would be locked for the delete.

### Use shutil to clean up

Finally we simply use shutil to clean up the library upon delete.

## Subtlety

The "root" LMDB path that holds the config library `_arctic_cfg` is not cleaned up automatically for the user. I think this is a reasonable limitation.