### PR TITLE
Fix for read batch when as of is TimeStamp

### DIFF
--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -196,7 +196,7 @@ inline std::optional<AtomKey> get_key_for_version_query(
             auto version_key = get_version_key_from_time_for_versions(timestamp_version.timestamp_, version_map_entry->get_indexes(false));
             if(version_key.has_value()){
                 auto version_id = version_key.value().version_id();
-                return find_index_key_for_version_id(version_id, version_map_entry);
+                return find_index_key_for_version_id(version_id, version_map_entry, false);
             }else{
                 return std::nullopt;
             }

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -828,7 +828,6 @@ def test_read_batch_time_stamp(arctic_library):
     sym = "sym_"
     num_versions = 3
     num_symbols = 3
-    original_dataframes = []
     for v_num in range(num_versions):
         write_requests = []
         for sym_num in range(num_symbols):


### PR DESCRIPTION
This PR fix a bug in the batch_get_versions_async function trying to get the version of specific timestamps. batch read method is affected by this issue.

close #606

