### PR TITLE
Fix to ensure batch prune previous methods clean up index and data keys as well as version keys

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -253,6 +253,13 @@ public:
                async::submit_io_task(RemoveBatchTask{keys, library_, opts});
     }
 
+    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(std::vector<entity::VariantKey> &&keys,
+                                                                storage::RemoveOpts opts) override {
+        return keys.empty() ?
+               std::vector<RemoveKeyResultType>() :
+               async::submit_io_task(RemoveBatchTask{std::move(keys), library_, opts});
+    }
+
     void copy_to_results(
         std::vector<folly::Future<storage::KeySegmentPair>> &batch,
         std::vector<storage::KeySegmentPair> &res

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -304,6 +304,16 @@ namespace arcticdb {
             return output;
         }
 
+        folly::Future<std::vector<RemoveKeyResultType>>
+        remove_keys(std::vector<entity::VariantKey> &&keys, storage::RemoveOpts opts) override {
+            std::vector<RemoveKeyResultType> output;
+            for (const auto &key: keys) {
+                output.emplace_back(remove_key_sync(key, opts));
+            }
+
+            return output;
+        }
+
         void insert_atom_key(const AtomKey &key) {
             seg_by_atom_key_.insert(std::make_pair(key, std::make_unique<SegmentInMemory>()));
         }

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -121,6 +121,9 @@ struct StreamSink {
     [[nodiscard]] virtual folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
         const std::vector<entity::VariantKey> &keys, storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
 
+    [[nodiscard]] virtual folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
+        std::vector<entity::VariantKey> &&keys, storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
+
     virtual timestamp current_timestamp() = 0;
 };
 

--- a/cpp/arcticdb/stream/test/mock_stores.hpp
+++ b/cpp/arcticdb/stream/test/mock_stores.hpp
@@ -112,6 +112,10 @@ class NullStore :
         util::raise_rte("Not implemented");
     }
 
+    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(std::vector<entity::VariantKey>&&) override {
+        util::raise_rte("Not implemented");
+    }
+
     folly::Future<std::vector<AtomKey>> batch_write(
         std::vector<std::pair<PartialKey, SegmentInMemory>> &&,
         const std::unordered_map<ContentHash, AtomKey>&,

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -146,7 +146,7 @@ public:
         const PreDeleteChecks& checks = default_pre_delete_checks
     ) override {
         auto snapshot_map = get_master_snapshots_map(store());
-        delete_trees_responsibly(idx_to_be_deleted, snapshot_map, std::nullopt, checks);
+        delete_trees_responsibly(idx_to_be_deleted, snapshot_map, std::nullopt, checks).get();
     };
 
     /**
@@ -157,7 +157,7 @@ public:
      * to exclude it from shared data check
      * @param dry_run Only do the check, but don't actually delete anything.
      */
-    void delete_trees_responsibly(
+    folly::Future<folly::Unit> delete_trees_responsibly(
         const std::vector<IndexTypeKey>& idx_to_be_deleted,
         const arcticdb::MasterSnapshotMap& snapshot_map,
         const std::optional<SnapshotId>& snapshot_being_deleted = std::nullopt,
@@ -351,6 +351,11 @@ public:
         const UpdateInfo& stream_update_info,
         bool prune_previous_versions);
 
+    std::vector<folly::Future<folly::Unit>> batch_write_version_and_prune_if_needed(
+        const std::vector<AtomKey>& index_keys,
+        const std::vector<UpdateInfo>& stream_update_info_vector,
+        bool prune_previous_versions);
+
     std::vector<VersionedItem> batch_write_versioned_dataframe_internal(
         const std::vector<StreamId>& stream_ids,
         std::vector<InputTensorFrame>&& frames,
@@ -387,7 +392,7 @@ protected:
      *
      * @param pruned_indexes Must all share the same id() and should be tombstoned.
      */
-    void delete_unreferenced_pruned_indexes(
+    folly::Future<folly::Unit> delete_unreferenced_pruned_indexes(
             const std::vector<AtomKey> &pruned_indexes,
             const AtomKey& key_to_keep
     );

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -598,7 +598,7 @@ TEST_F(VersionMapStore, StressTestBatchSameSymbol) {
 
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
-    batch_write_version(store, version_map, keys);
+    folly::collect(batch_write_version(store, version_map, keys)).get();
 }
 
 TEST_F(VersionMapStore, StressTestBatchWrite) {
@@ -616,6 +616,6 @@ TEST_F(VersionMapStore, StressTestBatchWrite) {
 
     auto store = test_store_->_test_get_store();
     auto version_map = std::make_shared<VersionMap>();
-    batch_write_version(store, version_map, keys);
+    folly::collect(batch_write_version(store, version_map, keys)).get();
 }
 } // namespace arcticdb

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -90,11 +90,7 @@ std::vector<VersionedItem> PythonVersionStore::batch_write_index_keys_to_version
     const std::vector<UpdateInfo>& stream_update_info_vector,
     bool prune_previous_versions) {
 
-    if(prune_previous_versions)
-        batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_vector);
-    else
-        batch_write_version(store(), version_map(), index_keys);
-
+    folly::collect(batch_write_version_and_prune_if_needed(index_keys, stream_update_info_vector, prune_previous_versions)).get();
     std::vector<VersionedItem> output(index_keys.size());
     for(auto key : folly::enumerate(index_keys))
         output[key.index] = *key;
@@ -377,7 +373,7 @@ void PythonVersionStore::add_to_snapshot(
     if(variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
         tombstone_snapshot(store(), to_ref(snap_key), std::move(snap_segment), version_map()->log_changes());
     } else {
-        delete_trees_responsibly(deleted_keys, get_master_snapshots_map(store()), snap_name);
+        delete_trees_responsibly(deleted_keys, get_master_snapshots_map(store()), snap_name).get();
         if (version_map()->log_changes()) {
             log_delete_snapshot(store(), snap_name);
         }
@@ -418,7 +414,7 @@ void PythonVersionStore::remove_from_snapshot(
     if(variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
         tombstone_snapshot(store(), to_ref(snap_key), std::move(snap_segment), version_map()->log_changes());
     } else {
-        delete_trees_responsibly(deleted_keys, get_master_snapshots_map(store()), snap_name);
+        delete_trees_responsibly(deleted_keys, get_master_snapshots_map(store()), snap_name).get();
         if (version_map()->log_changes()) {
             log_delete_snapshot(store(), snap_name);
         }
@@ -842,7 +838,7 @@ void PythonVersionStore::delete_snapshot_sync(const SnapshotId& snap_name, const
         delete_trees_responsibly(
             index_keys_in_current_snapshot,
             snap_map,
-            snap_name);
+            snap_name).get();
         ARCTICDB_DEBUG(log::version(), "Deleted orphaned index keys in snapshot {}", snap_name);
     } catch(const std::exception &ex) {
         log::version().warn("Garbage collection of unreachable deleted index keys failed due to: {}", ex.what());
@@ -940,7 +936,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
 
     auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, prev_id.value(), true, false);
     auto pruned_indexes = version_map()->tombstone_from_key_or_all(store(), stream_id, previous);
-    delete_unreferenced_pruned_indexes(pruned_indexes, latest.value());
+    delete_unreferenced_pruned_indexes(pruned_indexes, latest.value()).get();
 }
 
 void PythonVersionStore::delete_all_versions(const StreamId& stream_id) {
@@ -1032,12 +1028,7 @@ std::vector<VersionedItem> PythonVersionStore::batch_write_metadata(
                                                                    std::move(user_meta_proto)}));
     }
     auto index_keys = folly::collect(fut_vec).get();
-    if(prune_previous_versions) {
-        batch_write_and_prune_previous(store(), version_map(), index_keys, stream_update_info_vector);
-    } else {
-        batch_write_version(store(), version_map(), index_keys);
-    }
-
+    folly::collect(batch_write_version_and_prune_if_needed(index_keys, stream_update_info_vector, prune_previous_versions)).get();
     std::vector<VersionedItem> output(index_keys.size());
     for(auto key : folly::enumerate(index_keys))
         output[key.index] = std::move(*key);

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -166,10 +166,9 @@ struct WriteAndPrunePreviousTask : async::BaseTask {
         maybe_prev_(std::move(maybe_prev)) {
     }
 
-    folly::Unit operator()() {
+    folly::Future<std::vector<AtomKey>> operator()() {
         ScopedLock lock(version_map_->get_lock_object(key_.id()));
-        version_map_->write_and_prune_previous(store_, key_, maybe_prev_);
-        return folly::Unit{};
+        return version_map_->write_and_prune_previous(store_, key_, maybe_prev_);
     }
 };
 


### PR DESCRIPTION
So far, in the "prune previous version" option for batch methods, the version map is updated correctly, but the index and data keys are never deleted. This pull request addresses this issue by calling the corresponding delete_unreferenced_pruned_indexes method after updating the version map. This is not a trivial task since delete_unreferenced_pruned_indexes is currently not designed to be asynchronous, so it had to be converted to a purely synchronous method.

closes #230