### PR TITLE
maint: Remove `VariantStorageFactory` and its implementations

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -72,26 +72,6 @@ class AzureStorage final : public Storage<AzureStorage> {
     Azure::Storage::Blobs::BlobClientOptions get_client_options(const Config &conf);
 };
 
-
-class AzureStorageFactory final : public StorageFactory<AzureStorageFactory> {
-    using Parent = StorageFactory<AzureStorageFactory>;
-    friend Parent;
-
-  public:
-    using Config = arcticdb::proto::azure_storage::Config;
-    using StorageType = AzureStorage;
-
-    AzureStorageFactory(const Config &conf) :
-        conf_(conf) {
-    }
-  private:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
-            return AzureStorage(lib, mode, conf_);
-    }
-
-    Config conf_;
-};
-
 inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &container_name) {
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::azure_storage::Config cfg;

--- a/cpp/arcticdb/storage/config_cache.hpp
+++ b/cpp/arcticdb/storage/config_cache.hpp
@@ -80,8 +80,19 @@ class ConfigCache {
         util::check(!descriptor.storage_ids_.empty(), "Can't configure library with no storage ids");
         std::vector<std::unique_ptr<VariantStorage>> variants;
         for (const auto& storage_name : descriptor.storage_ids_) {
-            auto factory = get_storage_factory(storage_name);
-            variants.emplace_back(factory->create_storage(path, mode));
+            // Otherwise see if we have the storage config.
+            arcticdb::proto::storage::VariantStorage storage_conf;
+            auto storage_conf_pos = storage_configs_.find(storage_name);
+            if(storage_conf_pos != storage_configs_.end())
+                storage_conf = storage_conf_pos->second;
+
+            // As a last resort, get the whole environment config from the resolver.
+            refresh_config();
+            storage_conf_pos = storage_configs_.find(storage_name);
+            if(storage_conf_pos != storage_configs_.end())
+                storage_conf = storage_conf_pos->second;
+
+            variants.emplace_back(create_storage(path, mode, storage_conf));
         }
         return std::make_shared<Storages>(std::move(variants), mode);
     }
@@ -109,44 +120,9 @@ class ConfigCache {
         }
     }
 
-    std::shared_ptr<VariantStorageFactory> get_storage_factory_internal(const StorageName &storage_name) {
-        //See if we have previously cached the factory
-        auto factory_it = storage_factories_.find(storage_name);
-        if (factory_it != storage_factories_.end())
-            return factory_it->second;
-
-        //Otherwise see if we have the storage config
-        auto storage_conf = storage_configs_.find(storage_name);
-        if(storage_conf != storage_configs_.end())
-            return create_storage_factory(storage_conf->second);
-
-
-        //As a last resort, get the whole environment config from the resolver
-        refresh_config();
-        storage_conf = storage_configs_.find(storage_name);
-        if(storage_conf != storage_configs_.end())
-            return create_storage_factory(storage_conf->second);
-        else
-            return std::shared_ptr<VariantStorageFactory>();
-    }
-
-
-    std::shared_ptr<VariantStorageFactory> get_storage_factory(const StorageName &storage_name) {
-        auto factory = get_storage_factory_internal(storage_name);
-        util::check(factory != nullptr,
-                    "cannot create storage factory for environment_name={}, storage_name={}",
-                    environment_name_.value, storage_name.value);
-        if (auto[it, inserted] = storage_factories_.insert(std::make_pair(storage_name, factory)); !inserted) {
-            factory = it->second;
-        }
-
-        return factory;
-    }
-
     EnvironmentName environment_name_;
     std::unordered_map<LibraryPath, LibraryDescriptor> descriptor_map_;
     std::unordered_map<StorageName, arcticdb::proto::storage::VariantStorage> storage_configs_;
-    std::unordered_map<StorageName, std::shared_ptr<VariantStorageFactory>> storage_factories_;
     std::shared_ptr<ConfigResolver> config_resolver_;
     mutable std::mutex mutex_;
 };

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -71,29 +71,6 @@ private:
     std::unordered_map<std::string, ::lmdb::dbi> dbi_by_key_type_;
 };
 
-class LmdbStorageFactory final : public StorageFactory<LmdbStorageFactory> {
-    using Parent = StorageFactory<LmdbStorageFactory>;
-    friend Parent;
-
-  public:
-    using Config = arcticdb::proto::lmdb_storage::Config;
-    using StorageType = LmdbStorage;
-
-    explicit LmdbStorageFactory(const Config &conf) :
-            conf_(conf), root_path_(conf.path().c_str()) {
-        if (!fs::exists(root_path_)) {
-            fs::create_directories(root_path_);
-        }
-    }
-  private:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
-        return LmdbStorage(lib, mode, conf_);
-    }
-
-    Config conf_;
-    fs::path root_path_;
-};
-
 inline arcticdb::proto::storage::VariantStorage pack_config(const std::string& path) {
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::lmdb_storage::Config cfg;

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -56,26 +56,6 @@ namespace arcticdb::storage::memory {
         std::unique_ptr<MutexType> mutex_;  // Methods taking functions pointers may call back into the storage
     };
 
-    class MemoryStorageFactory final : public StorageFactory<MemoryStorageFactory> {
-
-        using Parent = StorageFactory<MemoryStorageFactory>;
-        friend Parent;
-
-    public:
-        using Config = arcticdb::proto::memory_storage::Config;
-        using StorageType = MemoryStorage;
-
-        MemoryStorageFactory(Config conf) :
-                conf_(std::move(conf)) {}
-
-    private:
-        auto do_create_storage(LibraryPath lib, OpenMode mode) {
-            return MemoryStorage(std::move(lib), mode, conf_);
-        }
-
-        Config conf_;
-    };
-
     inline arcticdb::proto::storage::VariantStorage pack_config(uint64_t cache_size) {
         arcticdb::proto::storage::VariantStorage output;
         arcticdb::proto::memory_storage::Config cfg;

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -58,27 +58,6 @@ class MongoStorage final : public Storage<MongoStorage> {
     std::string prefix_;
 };
 
-//TODO I don't see why we need a factory at all
-class MongoStorageFactory final : public StorageFactory<MongoStorageFactory> {
-
-    using Parent = StorageFactory<MongoStorageFactory>;
-    friend Parent;
-
-  public:
-    using Config = arcticdb::proto::mongo_storage::Config;
-    using StorageType = MongoStorage;
-
-    MongoStorageFactory(Config conf) :
-        conf_(std::move(conf)) {}
-
-  private:
-    auto do_create_storage(LibraryPath lib, OpenMode mode) {
-        return MongoStorage(std::move(lib), mode, conf_);
-    }
-
-    Config conf_;
-};
-
 inline arcticdb::proto::storage::VariantStorage pack_config(InstanceUri uri) {
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::mongo_storage::Config cfg;

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -64,25 +64,6 @@ private:
     std::string bucket_name_;
 };
 
-class NfsBackedStorageFactory final : public StorageFactory<NfsBackedStorageFactory> {
-    using Parent = StorageFactory<NfsBackedStorageFactory>;
-    friend Parent;
-
-public:
-    using Config = arcticdb::proto::nfs_backed_storage::Config;
-    using StorageType = NfsBackedStorageFactory;
-
-    NfsBackedStorageFactory(const Config &conf) :
-        conf_(conf) {
-    }
-private:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
-        return NfsBackedStorage(lib, mode, conf_);
-    }
-
-    Config conf_;
-};
-
 inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &bucket_name) {
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::nfs_backed_storage::Config cfg;

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -77,26 +77,6 @@ class S3Storage final : public Storage<S3Storage> {
     std::string bucket_name_;
 };
 
-
-class S3StorageFactory final : public StorageFactory<S3StorageFactory> {
-    using Parent = StorageFactory<S3StorageFactory>;
-    friend Parent;
-
-  public:
-    using Config = arcticdb::proto::s3_storage::Config;
-    using StorageType = S3Storage;
-
-    S3StorageFactory(const Config &conf) :
-        conf_(conf) {
-    }
-  private:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
-            return S3Storage(lib, mode, conf_);
-    }
-
-    Config conf_;
-};
-
 inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &bucket_name) {
     arcticdb::proto::storage::VariantStorage output;
     arcticdb::proto::s3_storage::Config cfg;

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -22,60 +22,56 @@
 
 namespace arcticdb::storage {
 
-std::shared_ptr<VariantStorageFactory> create_storage_factory(
-    const arcticdb::proto::storage::VariantStorage &storage) {
-    std::shared_ptr<VariantStorageFactory> res;
-    auto type_name = util::get_arcticdb_pb_type_name(storage.config());
+std::unique_ptr<VariantStorage> create_storage(
+    const LibraryPath &library_path,
+    OpenMode mode,
+    const arcticdb::proto::storage::VariantStorage &storage_descriptor) {
+
+    std::unique_ptr<VariantStorage> storage;
+    auto type_name = util::get_arcticdb_pb_type_name(storage_descriptor.config());
 
     if (type_name == s3::S3Storage::Config::descriptor()->full_name()) {
         s3::S3Storage::Config s3_config;
-        storage.config().UnpackTo(&s3_config);
-        res = std::make_shared<VariantStorageFactory>(
-            s3::S3StorageFactory(s3_config)
+        storage_descriptor.config().UnpackTo(&s3_config);
+        storage = std::make_unique<VariantStorage>(
+                s3::S3Storage(library_path, mode, s3_config)
         );
     } else if (type_name == lmdb::LmdbStorage::Config::descriptor()->full_name()) {
         lmdb::LmdbStorage::Config lmbd_config;
-        storage.config().UnpackTo(&lmbd_config);
-        res = std::make_shared<VariantStorageFactory>(
-            lmdb::LmdbStorageFactory(lmbd_config)
+        storage_descriptor.config().UnpackTo(&lmbd_config);
+        storage = std::make_unique<VariantStorage>(
+                lmdb::LmdbStorage(library_path, mode, lmbd_config)
         );
     } else if (type_name == mongo::MongoStorage::Config::descriptor()->full_name()) {
         mongo::MongoStorage::Config mongo_config;
-        storage.config().UnpackTo(&mongo_config);
-        res = std::make_shared<VariantStorageFactory>(
-            mongo::MongoStorageFactory(mongo_config)
+        storage_descriptor.config().UnpackTo(&mongo_config);
+        storage = std::make_unique<VariantStorage>(
+                mongo::MongoStorage(library_path, mode, mongo_config)
         );
     } else if (type_name == memory::MemoryStorage::Config::descriptor()->full_name()) {
         memory::MemoryStorage::Config memory_config;
-        storage.config().UnpackTo(&memory_config);
-        res = std::make_shared<VariantStorageFactory>(
-            memory::MemoryStorageFactory(memory_config)
+        storage_descriptor.config().UnpackTo(&memory_config);
+        storage = std::make_unique<VariantStorage>(
+                memory::MemoryStorage(library_path, mode, memory_config)
         );
     } else if (type_name == nfs_backed::NfsBackedStorage::Config::descriptor()->full_name()) {
         nfs_backed::NfsBackedStorage::Config nfs_backed_config;
-        storage.config().UnpackTo(&nfs_backed_config);
-        res = std::make_shared<VariantStorageFactory>(
-            nfs_backed::NfsBackedStorageFactory(nfs_backed_config)
+        storage_descriptor.config().UnpackTo(&nfs_backed_config);
+        storage = std::make_unique<VariantStorage>(
+                nfs_backed::NfsBackedStorage(library_path, mode, nfs_backed_config)
         );
 #ifndef ARCTICDB_USING_CONDA //Awaiting Azure sdk support in conda https://github.com/man-group/ArcticDB/issues/519
-    } else if (type_name == azure::AzureStorage::Config::descriptor()->full_name()) {
+        } else if (type_name == azure::AzureStorage::Config::descriptor()->full_name()) {
         azure::AzureStorage::Config azure_config;
-        storage.config().UnpackTo(&azure_config);
-        res = std::make_shared<VariantStorageFactory>(
-            azure::AzureStorageFactory(azure_config)
+        storage_descriptor.config().UnpackTo(&azure_config);
+        storage = std::make_unique<VariantStorage>(
+            azure::AzureStorage(library_path, mode, azure_config)
         );
 #endif
     } else
         throw std::runtime_error(fmt::format("Unknown config type {}", type_name));
 
-    return res;
-}
-
-std::unique_ptr<VariantStorage> create_storage(
-    const LibraryPath &library_path,
-    OpenMode mode,
-    const arcticdb::proto::storage::VariantStorage &storage_config) {
-    return create_storage_factory(storage_config)->create_storage(library_path, mode);
+    return storage;
 }
 
 } // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/storage_factory.hpp
+++ b/cpp/arcticdb/storage/storage_factory.hpp
@@ -13,23 +13,3 @@
 
 #include <optional>
 #include <vector>
-
-namespace arcticdb::storage {
-
-template<class Impl>
-class StorageFactory {
-  public:
-
-    StorageFactory() = default;
-
-    auto create_storage(const LibraryPath &lib, OpenMode mode) {
-        return derived().do_create_storage(lib, mode);
-    }
-
-  private:
-    Impl &derived() {
-        return *static_cast<Impl *>(this);
-    }
-};
-
-} // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/variant_storage_factory.hpp
+++ b/cpp/arcticdb/storage/variant_storage_factory.hpp
@@ -42,34 +42,6 @@ using VariantStorageTypes = std::variant<lmdb::LmdbStorage, mongo::MongoStorage,
 #endif
 using VariantStorage = variant::VariantStorage<VariantStorageTypes>;
 
-class VariantStorageFactory final : public StorageFactory<VariantStorageFactory> {
-    using Parent = StorageFactory<VariantStorageFactory>;
-    friend Parent;
-    using StorageType = VariantStorage;
-
-public:
-    template<class T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, VariantStorageFactory>, int> = 0>
-    explicit VariantStorageFactory(T &&v) :
-        factory_variant_(std::move(v)) {}
-
-  protected:
-    auto do_create_storage(const LibraryPath &lib, OpenMode mode) {
-        return std::visit([&](auto &&impl) {
-            auto s = impl.create_storage(lib, mode);
-            return std::make_unique<VariantStorage>(std::move(s));
-        }, factory_variant_);
-    }
-  private:
-#ifdef ARCTICDB_USING_CONDA //Awaiting Azure sdk support in conda https://github.com/man-group/ArcticDB/issues/519
-    std::variant<lmdb::LmdbStorageFactory, mongo::MongoStorageFactory, s3::S3StorageFactory, memory::MemoryStorageFactory, nfs_backed::NfsBackedStorageFactory> factory_variant_;
-#else
-    std::variant<lmdb::LmdbStorageFactory, mongo::MongoStorageFactory, s3::S3StorageFactory, memory::MemoryStorageFactory, nfs_backed::NfsBackedStorageFactory, azure::AzureStorageFactory> factory_variant_;
-#endif
-};
-
-std::shared_ptr<VariantStorageFactory> create_storage_factory(
-    const arcticdb::proto::storage::VariantStorage &storage);
-
 std::unique_ptr<VariantStorage> create_storage(
     const LibraryPath& library_path,
     OpenMode mode,


### PR DESCRIPTION
#### Reference Issues/PRs

Towards https://github.com/man-group/ArcticDB/issues/624.

Discussed with @willdealtry, @alexowens90 and others.

#### What does this implement/fix? Explain your changes.

This removes unnecessary factories which are useless proxy encapsulating a convoluted logic to simply create instance of storage (i.e. instance of `VariantStorage`).

#### Any other comments?

Eventually we could remove a few file once variants are not used anymore for storages. What do you think?