### PR TITLE
Fix exception when trying to get a library that doesn't exist

### DIFF
--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 from arcticdb.options import LibraryOptions
 from arcticdb_ext.storage import LibraryManager, StorageOverride
+from arcticdb.exceptions import LibraryNotFound
 from arcticdb.version_store.library import Library
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.adapters.s3_library_adapter import S3LibraryAdapter
@@ -154,6 +155,9 @@ class Arctic:
         already_open = self._open_libraries.get(name)
         if already_open:
             return already_open
+
+        if not self._library_manager.has_library(name):
+            raise LibraryNotFound(name)
 
         storage_override = self._library_adapter.get_storage_override()
         lib = NativeVersionStore(

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -10,7 +10,7 @@ import os
 
 import pytz
 from arcticdb_ext.exceptions import InternalException
-from arcticdb.exceptions import ArcticNativeNotYetImplemented
+from arcticdb.exceptions import ArcticNativeNotYetImplemented, LibraryNotFound
 from pandas import Timestamp
 
 try:
@@ -98,7 +98,7 @@ def test_library_creation_deletion(arctic_client):
     ac.delete_library("library_that_does_not_exist")
 
     assert not ac.list_libraries()
-    with pytest.raises(Exception):  # TODO: Nicely wrap?
+    with pytest.raises(LibraryNotFound):
         _lib = ac["pytest_test_lib"]
 
 
@@ -274,7 +274,7 @@ def test_library_management_path_prefix(connection_string, client, request):
     ac.delete_library("pytest_test_lib")
 
     assert not ac.list_libraries()
-    with pytest.raises(Exception):  # TODO: Nicely wrap?
+    with pytest.raises(LibraryNotFound):
         _lib = ac["pytest_test_lib"]
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Added a check when trying to get a library that doesn't exist and raising the corresponding LibraryNotFound exception.

#### Any other comments?
Also changed the tests to reflect the new exception

