### PR TITLE
Enhancement/612/read batch to catch all exceptions

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -186,6 +186,7 @@ set(arcticdb_srcs
         entity/key.hpp
         entity/key-inl.hpp
         entity/metrics.hpp
+        entity/data_error.hpp
         entity/native_tensor.hpp
         entity/performance_tracing.hpp
         entity/protobuf_mappings.hpp

--- a/cpp/arcticdb/entity/data_error.hpp
+++ b/cpp/arcticdb/entity/data_error.hpp
@@ -1,0 +1,121 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <fmt/format.h>
+
+#include <arcticdb/pipeline/query.hpp>
+
+namespace arcticdb::entity {
+
+enum class VersionRequestType: uint32_t {
+    SNAPSHOT,
+    TIMESTAMP,
+    SPECIFIC,
+    LATEST
+};
+
+class DataError {
+public:
+    DataError(const StreamId& symbol,
+              const pipelines::VersionQueryType& version_query_type,
+              std::string&& exception_string,
+              std::optional<ErrorCode> error_code=std::nullopt) :
+        symbol_(symbol),
+        exception_string_(exception_string),
+        error_code_(error_code){
+        util::variant_match(
+                version_query_type,
+                [this] (const pipelines::SnapshotVersionQuery& query) {
+                    version_request_type_ = VersionRequestType::SNAPSHOT;
+                    version_request_data_ = query.name_;
+                },
+                [this] (const pipelines::TimestampVersionQuery& query) {
+                    version_request_type_ = VersionRequestType::TIMESTAMP;
+                    version_request_data_ = query.timestamp_;
+                },
+                [this] (const pipelines::SpecificVersionQuery& query) {
+                    version_request_type_ = VersionRequestType::SPECIFIC;
+                    version_request_data_ = query.version_id_;
+                },
+                [this] (const std::monostate&) {
+                    version_request_type_ = VersionRequestType::LATEST;
+                }
+        );
+    }
+
+    DataError() = delete;
+
+    ARCTICDB_MOVE_COPY_DEFAULT(DataError);
+
+    void set_error_code(ErrorCode error_code) {
+        error_code_ = error_code;
+    }
+
+    std::string symbol() const {
+        return fmt::format("{}", symbol_);
+    }
+
+    VersionRequestType version_request_type() const {
+        return version_request_type_;
+    }
+
+    std::variant<std::monostate, int64_t, std::string> version_request_data() const {
+        return version_request_data_;
+    }
+
+    std::optional<ErrorCode> error_code() const {
+        return error_code_;
+    }
+
+    std::optional<ErrorCategory> error_category() const {
+        return error_code_.has_value() ? std::make_optional<ErrorCategory>(get_error_category(*error_code_)) : std::nullopt;
+    }
+
+    std::string exception_string() const {
+        return exception_string_;
+    }
+
+    std::string to_string() const {
+        std::string version_request_explanation;
+        switch (version_request_type_) {
+            case VersionRequestType::SNAPSHOT:
+                version_request_explanation = fmt::format("in snapshot '{}'", std::get<std::string>(version_request_data_));
+                break;
+            case VersionRequestType::TIMESTAMP:
+                version_request_explanation = fmt::format("at time '{}'", std::get<int64_t>(version_request_data_));
+                break;
+            case VersionRequestType::SPECIFIC:
+                version_request_explanation = fmt::format("with specified version '{}'", std::get<int64_t>(version_request_data_));
+                break;
+            case VersionRequestType::LATEST:
+                version_request_explanation = fmt::format("with specified version 'latest'");
+                break;
+            default:
+                internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
+                        "Unexpected enum value in DataError::to_string: {}",
+                        static_cast<uint32_t>(version_request_type_));
+        }
+        return fmt::format(
+                "Version {} of symbol '{}' unable to be retrieved: Error Category: '{}' Exception String: '{}'",
+                version_request_explanation,
+                symbol_,
+                error_category().has_value() ? get_error_category_names().at(*error_category()) : "UNKNOWN",
+                exception_string_);
+    }
+private:
+    StreamId symbol_;
+    VersionRequestType version_request_type_{VersionRequestType::LATEST};
+    // int64_t for timestamp and SignedVersionId
+    std::variant<std::monostate, int64_t, std::string> version_request_data_;
+    std::string exception_string_;
+    std::optional<ErrorCode> error_code_;
+};
+}

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -110,8 +110,15 @@ struct SpecificVersionQuery {
     SignedVersionId version_id_;
 };
 
+using VersionQueryType = std::variant<
+        std::monostate, // Represents "latest"
+        SnapshotVersionQuery,
+        TimestampVersionQuery,
+        SpecificVersionQuery
+        >;
+
 struct VersionQuery {
-    std::variant<std::monostate, SnapshotVersionQuery, TimestampVersionQuery, SpecificVersionQuery> content_;
+    VersionQueryType content_;
     std::optional<bool> skip_compat_;
     std::optional<bool> iterate_on_failure_;
 

--- a/cpp/arcticdb/pipeline/read_options.hpp
+++ b/cpp/arcticdb/pipeline/read_options.hpp
@@ -19,6 +19,7 @@ struct ReadOptions {
     std::optional<bool> allow_sparse_;
     std::optional<bool> set_tz_;
     std::optional<bool> optimise_string_memory_;
+    std::optional<bool> batch_throw_on_missing_version_;
 
     void set_force_strings_to_fixed(const std::optional<bool>& force_strings_to_fixed) {
         force_strings_to_fixed_ = force_strings_to_fixed;
@@ -50,6 +51,10 @@ struct ReadOptions {
 
     void set_optimise_string_memory(const std::optional<bool>& optimise_string_memory) {
         optimise_string_memory_ = optimise_string_memory;
+    }
+
+    void set_batch_throw_on_missing_version(bool batch_throw_on_missing_version) {
+        batch_throw_on_missing_version_ = batch_throw_on_missing_version;
     }
 };
 } //namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -20,6 +20,7 @@
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/version/versioned_engine.hpp>
 #include <arcticdb/entity/descriptor_item.hpp>
+#include <arcticdb/entity/data_error.hpp>
 
 #include <sstream>
 namespace arcticdb::version_store {
@@ -120,7 +121,7 @@ public:
         ReadQuery& read_query,
         const ReadOptions& read_options) override;
 
-    std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(
+    ReadVersionOutput read_dataframe_version_internal(
         const StreamId &stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,
@@ -223,7 +224,7 @@ public:
     FrameAndDescriptor read_column_stats_internal(
         const VersionedItem& versioned_item);
 
-    std::pair<VersionedItem, FrameAndDescriptor> read_column_stats_version_internal(
+    ReadVersionOutput read_column_stats_version_internal(
         const StreamId& stream_id,
         const VersionQuery& version_query);
 
@@ -273,18 +274,18 @@ public:
         const WriteOptions& write_options,
         bool validate_index);
 
-    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> batch_read_keys(
+    std::vector<ReadVersionOutput> batch_read_keys(
         const std::vector<AtomKey> &keys,
         const std::vector<ReadQuery> &read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> batch_read_internal(
+    std::vector<std::variant<ReadVersionOutput, DataError>> batch_read_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, FrameAndDescriptor>> temp_batch_read_internal_direct(
+    std::vector<std::variant<ReadVersionOutput, DataError>> temp_batch_read_internal_direct(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -10,6 +10,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
+#include <arcticdb/entity/data_error.hpp>
 #include <arcticdb/version/version_store_api.hpp>
 #include <arcticdb/python/arctic_version.hpp>
 #include <arcticdb/python/python_utils.hpp>
@@ -108,6 +109,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("set_incompletes", &ReadOptions::set_incompletes)
         .def("set_set_tz", &ReadOptions::set_set_tz)
         .def("set_optimise_string_memory", &ReadOptions::set_optimise_string_memory)
+        .def("set_batch_throw_on_missing_version", &ReadOptions::set_batch_throw_on_missing_version)
         .def_property_readonly("incompletes", &ReadOptions::get_incompletes);
 
     using FrameDataWrapper = arcticdb::pipelines::FrameDataWrapper;
@@ -130,6 +132,20 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def_property_readonly("names", &PythonOutputFrame::names, py::return_value_policy::reference)
         .def_property_readonly("index_columns", &PythonOutputFrame::index_columns, py::return_value_policy::reference);
 
+    py::enum_<VersionRequestType>(version, "VersionRequestType")
+            .value("SNAPSHOT", VersionRequestType::SNAPSHOT)
+            .value("TIMESTAMP", VersionRequestType::TIMESTAMP)
+            .value("SPECIFIC", VersionRequestType::SPECIFIC)
+            .value("LATEST", VersionRequestType::LATEST);
+
+    py::class_<DataError, std::shared_ptr<DataError>>(version, "DataError")
+            .def_property_readonly("symbol", &DataError::symbol)
+            .def_property_readonly("version_request_type", &DataError::version_request_type)
+            .def_property_readonly("version_request_data", &DataError::version_request_data)
+            .def_property_readonly("error_code", &DataError::error_code)
+            .def_property_readonly("error_category", &DataError::error_category)
+            .def_property_readonly("exception_string", &DataError::exception_string)
+            .def("__str__", &DataError::to_string);
 
     // TODO: add repr.
     py::class_<VersionedItem>(version, "VersionedItem")
@@ -189,13 +205,22 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
 
 
 
-    auto adapt_read_dfs = [](std::vector<ReadResult> && ret) -> py::list {
+    auto adapt_read_dfs = [](std::vector<std::variant<ReadResult, DataError>> && ret) -> py::list {
         py::list lst;
         for (auto &res: ret) {
-            auto pynorm = python_util::pb_to_python(res.norm_meta);
-            auto pyuser_meta = python_util::pb_to_python(res.user_meta);
-            auto multi_key_meta = python_util::pb_to_python(res.multi_key_meta);
-            lst.append(py::make_tuple(res.item, std::move(res.frame_data), pynorm, pyuser_meta, multi_key_meta, res.multi_keys));
+            util::variant_match(
+                    res,
+                    [&lst] (ReadResult& res) {
+                        auto pynorm = python_util::pb_to_python(res.norm_meta);
+                        auto pyuser_meta = python_util::pb_to_python(res.user_meta);
+                        auto multi_key_meta = python_util::pb_to_python(res.multi_key_meta);
+                        lst.append(py::make_tuple(res.item, std::move(res.frame_data), pynorm, pyuser_meta, multi_key_meta,
+                                                  res.multi_keys));
+                    },
+                    [&lst] (DataError& data_error) {
+                        lst.append(data_error);
+                    }
+            );
         }
         return lst;
     };

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -345,10 +345,12 @@ TEST_F(VersionStoreTest, StressBatchReadUncompressed) {
     }
 
     std::vector<ReadQuery> read_queries;
-    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, ReadOptions{});
-    for(auto version : folly::enumerate(latest_versions)) {
-        auto expected = get_test_simple_frame(version->item.symbol(), 10, version.index);
-        bool equal = expected.segment_ == version->frame_data.frame();
+    ReadOptions read_options;
+    read_options.set_batch_throw_on_missing_version(true);
+    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, read_options);
+    for(auto&& [idx, version] : folly::enumerate(latest_versions)) {
+        auto expected = get_test_simple_frame(std::get<ReadResult>(version).item.symbol(), 10, idx);
+        bool equal = expected.segment_ == std::get<ReadResult>(version).frame_data.frame();
         ASSERT_EQ(equal, true);
     }
 }
@@ -446,7 +448,7 @@ TEST(VersionStore, UpdateWithin) {
 
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto& seg = read_result.second.frame_;
+    const auto& seg = read_result.frame_and_descriptor_.frame_;
 
     for(auto i = 0u; i < num_rows; ++i) {
         auto expected = i;
@@ -488,7 +490,7 @@ TEST(VersionStore, UpdateBefore) {
 
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto& seg = read_result.second.frame_;
+    const auto& seg = read_result.frame_and_descriptor_.frame_;
 
     for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
         auto expected = i;
@@ -530,7 +532,7 @@ TEST(VersionStore, UpdateAfter) {
 
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto& seg = read_result.second.frame_;
+    const auto& seg = read_result.frame_and_descriptor_.frame_;
 
     for(auto i = 0u; i < num_rows + update_range.diff(); ++i) {
         auto expected = i;
@@ -572,9 +574,8 @@ TEST(VersionStore, UpdateIntersectBefore) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
         auto expected = i;
@@ -616,9 +617,8 @@ TEST(VersionStore, UpdateIntersectAfter) {
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
     ReadQuery read_query;
-    auto
-        read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
-    const auto &seg = read_result.second.frame_;
+    auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{});
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u; i < num_rows + 5; ++i) {
         auto expected = i;
@@ -671,7 +671,7 @@ TEST(VersionStore, UpdateWithinSchemaChange) {
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
-    const auto &seg = read_result.second.frame_;
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u;i < num_rows; ++i) {
         auto expected = i;
@@ -732,7 +732,7 @@ TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
     read_options.set_dynamic_schema(true);
     ReadQuery read_query;
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options);
-    const auto &seg = read_result.second.frame_;
+    const auto &seg = read_result.frame_and_descriptor_.frame_;
 
     for (auto i = 0u;i < num_rows; ++i) {
         auto expected = i;

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <arcticdb/entity/data_error.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/util/timeouts.hpp>
@@ -281,7 +282,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::vector<StreamId>& id,
         const std::vector<VersionQuery>& version_query);
 
-    std::vector<ReadResult> batch_read(
+    std::vector<std::variant<ReadResult, DataError>> batch_read(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<ReadQuery>& read_queries,
@@ -334,16 +335,16 @@ private:
     void delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key);
 };
 
-inline std::vector<ReadResult> frame_to_read_result(std::vector<std::pair<VersionedItem, FrameAndDescriptor>>&& keys_frame_and_descriptors) {
-    std::vector<ReadResult> read_results;
+inline std::vector<std::variant<ReadResult, DataError>> frame_to_read_result(std::vector<ReadVersionOutput>&& keys_frame_and_descriptors) {
+    std::vector<std::variant<ReadResult, DataError>> read_results;
     read_results.reserve(keys_frame_and_descriptors.size());
-    for (auto [item, fd] : keys_frame_and_descriptors) {
+    for (auto& read_version_output : keys_frame_and_descriptors) {
         read_results.emplace_back(ReadResult(
-            item,
-            PythonOutputFrame{fd.frame_, fd.buffers_},
-            fd.desc_.proto().normalization(),
-            fd.desc_.proto().user_meta(),
-            fd.desc_.proto().multi_key_meta(),
+            read_version_output.versioned_item_,
+            PythonOutputFrame{read_version_output.frame_and_descriptor_.frame_, read_version_output.frame_and_descriptor_.buffers_},
+            read_version_output.frame_and_descriptor_.desc_.proto().normalization(),
+            read_version_output.frame_and_descriptor_.desc_.proto().user_meta(),
+            read_version_output.frame_and_descriptor_.desc_.proto().multi_key_meta(),
             std::vector<AtomKey>{}));
     }
     return read_results;

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -23,6 +23,18 @@ namespace arcticdb::version_store {
 using namespace arcticdb::entity;
 using namespace arcticdb::pipelines;
 
+struct ReadVersionOutput {
+    ReadVersionOutput() = delete;
+    ReadVersionOutput(VersionedItem&& versioned_item, FrameAndDescriptor&& frame_and_descriptor):
+            versioned_item_(std::move(versioned_item)),
+            frame_and_descriptor_(std::move(frame_and_descriptor)) {}
+
+    ARCTICDB_MOVE_ONLY_DEFAULT(ReadVersionOutput)
+
+    VersionedItem versioned_item_;
+    FrameAndDescriptor frame_and_descriptor_;
+};
+
 /**
  * The VersionedEngine interface contains methods that are portable between languages.
  *
@@ -97,7 +109,7 @@ public:
         ReadQuery& read_query,
         const ReadOptions& read_options) = 0;
 
-    virtual std::pair<VersionedItem, FrameAndDescriptor> read_dataframe_version_internal(
+    virtual ReadVersionOutput read_dataframe_version_internal(
         const StreamId &stream_id,
         const VersionQuery& version_query,
         ReadQuery& read_query,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -48,6 +48,7 @@ from arcticdb_ext.version_store import PythonVersionStoreReadOptions as _PythonV
 from arcticdb_ext.version_store import PythonVersionStoreVersionQuery as _PythonVersionStoreVersionQuery
 from arcticdb_ext.version_store import ColumnStats as _ColumnStats
 from arcticdb_ext.version_store import StreamDescriptorMismatch
+from arcticdb_ext.version_store import DataError
 from arcticdb.authorization.permissions import OpenMode
 from arcticdb.exceptions import ArcticNativeNotYetImplemented, ArcticNativeException
 from arcticdb.flattener import Flattener
@@ -962,24 +963,35 @@ class NativeVersionStore:
             Dictionary of symbol mapping with the versioned items
         """
         _check_batch_kwargs(NativeVersionStore.batch_read, NativeVersionStore.read, kwargs)
+        throw_on_missing_version = True
         versioned_items = self._batch_read_to_versioned_items(
-            symbols, as_ofs, date_ranges, columns, query_builder, kwargs
+            symbols, as_ofs, date_ranges, columns, query_builder, throw_on_missing_version, kwargs
+        )
+        check(
+            all(v is not None for v in versioned_items),
+            "Null value from _batch_read_to_versioned_items. NoDataFoundException should have been thrown instead.",
         )
         return {v.symbol: v for v in versioned_items}
 
-    def _batch_read_to_versioned_items(self, symbols, as_ofs, date_ranges, columns, query_builder, kwargs=None):
+    def _batch_read_to_versioned_items(
+        self, symbols, as_ofs, date_ranges, columns, query_builder, throw_on_missing_version, kwargs=None
+    ):
         if kwargs is None:
             kwargs = dict()
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         read_queries = self._get_read_queries(len(symbols), date_ranges, columns, query_builder)
         read_options = self._get_read_options(**kwargs)
+        read_options.set_batch_throw_on_missing_version(throw_on_missing_version)
         read_results = self.version_store.batch_read(symbols, version_queries, read_queries, read_options)
         versioned_items = []
         for i in range(len(read_results)):
-            read_result = ReadResult(*read_results[i])
-            read_query = read_queries[i]
-            vitem = self._post_process_dataframe(read_result, read_query)
-            versioned_items.append(vitem)
+            if isinstance(read_results[i], DataError):
+                versioned_items.append(read_results[i])
+            else:
+                read_result = ReadResult(*read_results[i])
+                read_query = read_queries[i]
+                vitem = self._post_process_dataframe(read_result, read_query)
+                versioned_items.append(vitem)
         return versioned_items
 
     def batch_read_metadata(

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -876,8 +876,10 @@ class Library:
 
         Returns
         -------
-        List[VersionedItem]
+        List[Union[VersionedItem, DataError]]
             A list of the read results, whose i-th element corresponds to the i-th element of the ``symbols`` parameter.
+            If the specified version does not exist, a DataError object is returned, with symbol, version_request_type,
+            version_request_data properties, error_code, error_category, and exception_string properties.
 
         Raises
         ------
@@ -891,11 +893,23 @@ class Library:
         >>> lib.write("s2", pd.DataFrame({"col": [1, 2, 3]}))
         >>> lib.write("s2", pd.DataFrame(), prune_previous_versions=False)
         >>> lib.write("s3", pd.DataFrame())
-        >>> batch = lib.read_batch(["s1", ReadRequest("s2", as_of=0), "s3"])
+        >>> batch = lib.read_batch(["s1", ReadRequest("s2", as_of=0), "s3", ReadRequest("s2", as_of=1000)])
         >>> batch[0].data.empty
         True
         >>> batch[1].data.empty
         False
+        >>> batch[2].data.empty
+        True
+        >>> batch[3].symbol
+        "s2"
+        >>> batch[3].version_request_type
+        VersionRequestType.SPECIFIC
+        >>> batch[3].version_request_data
+        1000
+        >>> batch[3].error_code
+        ErrorCode.E_NO_SUCH_VERSION
+        >>> batch[3].error_category
+        ErrorCategory.MISSING_DATA
 
         See Also
         --------
@@ -935,9 +949,9 @@ class Library:
                     f"Unsupported item in the symbols argument s=[{s}] type(s)=[{type(s)}]. Only [str] and"
                     " [ReadRequest] are supported."
                 )
-
+        throw_on_missing_version = False
         return self._nvs._batch_read_to_versioned_items(
-            symbol_strings, as_ofs, date_ranges, columns, query_builder or query_builders
+            symbol_strings, as_ofs, date_ranges, columns, query_builder or query_builders, throw_on_missing_version
         )
 
     def read_metadata(self, symbol: str, as_of: Optional[AsOf] = None) -> VersionedItem:

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1724,6 +1724,23 @@ def test_batch_read_columns(lmdb_version_store_tombstone_and_sync_passive):
         assert_equal_value(vit.data, dfs[x][columns_of_interest])
 
 
+def test_batch_read_symbol_doesnt_exist(lmdb_version_store):
+    sym1 = "sym1"
+    sym2 = "sym2"
+    lmdb_version_store.write(sym1, 1)
+    with pytest.raises(NoDataFoundException):
+        _ = lmdb_version_store.batch_read([sym1, sym2])
+
+
+def test_batch_read_version_doesnt_exist(lmdb_version_store):
+    sym1 = "sym1"
+    sym2 = "sym2"
+    lmdb_version_store.write(sym1, 1)
+    lmdb_version_store.write(sym2, 2)
+    with pytest.raises(NoDataFoundException):
+        _ = lmdb_version_store.batch_read([sym1, sym2], as_ofs=[0, 1])
+
+
 def test_index_keys_start_end_index(lmdb_version_store, sym):
     idx = pd.date_range("2022-01-01", periods=100, freq="D")
     df = pd.DataFrame({"a": range(len(idx))}, index=idx)

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -24,6 +24,7 @@ import random
 import string
 
 from arcticdb.exceptions import ArcticNativeException
+from arcticdb_ext.storage import NoDataFoundException
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb_ext.exceptions import InternalException, UserInputException
 from arcticdb.util.test import assert_frame_equal, PANDAS_VERSION
@@ -2046,6 +2047,32 @@ def test_filter_batch_incorrect_query_count(lmdb_version_store):
         batch_res = lmdb_version_store.batch_read([sym1, sym2], query_builder=[q])
     with pytest.raises(ArcticNativeException):
         batch_res = lmdb_version_store.batch_read([sym1, sym2], query_builder=[q, q, q])
+
+
+def test_filter_batch_symbol_doesnt_exist(lmdb_version_store):
+    sym1 = "sym1"
+    sym2 = "sym2"
+    df1 = DataFrame({"a": [1, 2]}, index=np.arange(2))
+    lmdb_version_store.write(sym1, df1)
+    q = QueryBuilder()
+    q = q[q["a"] == 2]
+    with pytest.raises(NoDataFoundException):
+        batch_res = lmdb_version_store.batch_read([sym1, sym2], query_builder=q)
+
+
+def test_filter_batch_version_doesnt_exist(lmdb_version_store):
+    sym1 = "sym1"
+    sym2 = "sym2"
+    df1 = DataFrame({"a": [1, 2]}, index=np.arange(2))
+    df2 = DataFrame({"a": [2, 3]}, index=np.arange(2))
+    lmdb_version_store.write(sym1, df1)
+    lmdb_version_store.write(sym2, df2)
+
+    q = QueryBuilder()
+    q = q[q["a"] == 2]
+    # pandas_query = "a == 2"
+    with pytest.raises(NoDataFoundException):
+        batch_res = lmdb_version_store.batch_read([sym1, sym2], as_ofs=[0, 1], query_builder=q)
 
 
 def test_filter_numeric_membership_equivalence():


### PR DESCRIPTION
Closes #612

The previous behaviour of `Library.read_batch` and `NativeVersionStore.batch_read` was to throw an exception if there was an issue retrieving **any** of the requested symbol/version pairs. For backwards compatibility reasons, this behaviour has been maintained for `NativeVersionStore.batch_read`.

For `Library.read_batch`, this has been changed. A `DataError` object will now be returned in the position in the list returned corresponding to the symbol/version pair there was an issue retrieving. This contains the symbol and version requested, and the exception string thrown. For two well-defined categories of error, the error category and specific error code are also included:

- ErrorCategory.MISSING_DATA - ErrorCode.E_NO_SUCH_VERSION: The version requested by the user does not exist
- ErrorCategory.STORAGE - ErrorCode.E_KEY_NOT_FOUND: At least one of the keys required to read the specified version does not exist in the storage.

Otherwise these fields of the `DataError` object are left as `None`.