### PR TITLE
conda-build: Pin pybind11 to < 2.11

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -18,7 +18,8 @@ dependencies:
   - libevent
   - libmongocxx
   - zstd
-  # TODO: remove once the regression is fixed in pybind 2.11.X
+  # TODO: pybind 2.11.X became stricter regarding the handling of reference counts
+  # See: https://github.com/pybind/pybind11/issues/4748#issuecomment-1639445403
   - pybind11 < 2.11
   - pcre
   - cyrus-sasl

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -18,7 +18,8 @@ dependencies:
   - libevent
   - libmongocxx
   - zstd
-  - pybind11
+  # TODO: remove once the regression is fixed in pybind 2.11.X
+  - pybind11 < 2.11
   - pcre
   - cyrus-sasl
   - aws-sdk-cpp


### PR DESCRIPTION
#### Reference Issues/PRs

The problem is similar to the one reported in https://github.com/pybind/pybind11/issues/4748.

We might want to use what is describe here: https://github.com/pybind/pybind11/issues/4748#issuecomment-1639445403.

#### What does this implement/fix? Explain your changes.

Due to regression.

See:
https://github.com/man-group/ArcticDB/actions/runs/5643036492/job/15284070097

#### Any other comments?


