### PR TITLE
Change load parameter from load all to load undeleted when reading library versions

### DIFF
--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -60,8 +60,14 @@ inline std::vector<AtomKey> get_all_versions(
     bool skip_compat,
     bool iterate_on_failure) {
     ARCTICDB_SAMPLE(GetAllVersions, 0)
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, skip_compat,
-                                           iterate_on_failure, __FUNCTION__);
+    const LoadParameter load_parameter(LoadType::LOAD_UNDELETED);
+    auto entry = version_map->check_reload(
+        store,
+        stream_id,
+        load_parameter,
+        skip_compat,
+        iterate_on_failure,
+        __FUNCTION__);
     return entry->get_indexes(false);
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs
Resolves #645
Relates to #581
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.
When listing libraries we used to load the whole version chain from disk and then filter the active versions in memory. It would be faster to use the `LOAD_UNDELETED` load parameter so that only active libraries are fetched from disk. This improves the performance in case there is one active library and a long list of deleted libraries which a re deleted with tombstone_all key.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
