### PR TITLE
Enable importing `DataError` from `arcticdb`

### DIFF
--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -8,6 +8,7 @@ from arcticdb.version_store.processing import QueryBuilder
 import arcticdb.version_store.library as library
 from arcticdb.options import LibraryOptions
 from arcticdb.tools import set_config_from_env_vars
+from arcticdb_ext.version_store import DataError
 
 set_config_from_env_vars(_os.environ)
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -902,6 +902,9 @@ class Library:
         True
         >>> batch[3].symbol
         "s2"
+        >>> from arcticdb import DataError
+        >>> isinstance(batch[3], DataError)
+        True
         >>> batch[3].version_request_type
         VersionRequestType.SPECIFIC
         >>> batch[3].version_request_data

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -19,13 +19,13 @@ except ImportError:
     # arcticdb squashes the packages
     from arcticdb._store import VersionedItem as PythonVersionedItem
 from arcticdb_ext.storage import NoDataFoundException, KeyType
-from arcticdb_ext.version_store import DataError, VersionRequestType
+from arcticdb_ext.version_store import VersionRequestType
 
 from arcticdb.arctic import Arctic
 from arcticdb.adapters.s3_library_adapter import S3LibraryAdapter
 from arcticdb.options import LibraryOptions
 from arcticdb.encoding_version import EncodingVersion
-from arcticdb import QueryBuilder
+from arcticdb import QueryBuilder, DataError
 from arcticc.pb2.s3_storage_pb2 import Config as S3Config
 
 import math

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -13,11 +13,11 @@ from arcticdb_ext.exceptions import ErrorCode, ErrorCategory
 
 from arcticdb.version_store import VersionedItem as PythonVersionedItem
 from arcticdb_ext.storage import KeyType
-from arcticdb_ext.version_store import DataError, VersionRequestType
+from arcticdb_ext.version_store import VersionRequestType
 
 from arcticdb.arctic import Arctic
 from arcticdb.options import LibraryOptions
-from arcticdb import QueryBuilder
+from arcticdb import QueryBuilder, DataError
 
 import pytest
 import pandas as pd


### PR DESCRIPTION
#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

`DataError` can now be imported from `arcticdb`. Previously, you would have to import from `arcticdb_ext.version_store` which exposes internal implementation details.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
