### PR TITLE
Fix negative as_of for batch methods

### DIFF
--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -441,6 +441,28 @@ def test_read_batch_as_of(arctic_library):
     assert type(batch[1]) == PythonVersionedItem
 
 
+def test_batch_methods_with_negative_as_of(arctic_library):
+    lib = arctic_library
+    sym = "test_batch_methods_with_negative_as_of"
+    data_0 = 0
+    data_1 = 1
+    metadata_0 = {"some": "metadata"}
+    metadata_1 = {"more": "metadata"}
+    lib.write_pickle(sym, data_0, metadata=metadata_0)
+    lib.write_pickle(sym, data_1, metadata=metadata_1)
+    res = lib.read_batch([ReadRequest(sym, as_of=-1), ReadRequest(sym, as_of=-2)])
+    assert res[0].data == data_1
+    assert res[1].data == data_0
+
+    res = lib.read_metadata_batch([ReadInfoRequest(sym, as_of=-1), ReadInfoRequest(sym, as_of=-2)])
+    assert res[0].metadata == metadata_1
+    assert res[1].metadata == metadata_0
+
+    res = lib.get_description_batch([ReadInfoRequest(sym, as_of=-1), ReadInfoRequest(sym, as_of=-2)])
+    assert res[0] == lib.get_description(sym)
+    assert res[1] == lib.get_description(sym, as_of=0)
+
+
 def test_read_batch_date_ranges(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))


### PR DESCRIPTION
#### What does this implement/fix?

Fixes batch methods (read, read metadata, get description) when a negative integer is provided in the `as_of` argument.

For non-batch methods, logic was added to `get_specific_version` in `version_functions.hpp` to handle signed integers. The same logic needed to be applied to `get_key_for_version_query` in `version_map_batch_methods.hpp`.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
