### PR TITLE
Only log ErrorCategory::INTERNAL errors

### DIFF
--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -25,7 +25,8 @@ struct Raise {
     [[noreturn]] void operator()(fmt::format_string<Args...> format, Args&&...args) const {
         std::string combo_format = fmt::format(FMT_COMPILE("{} {}"), error_code_data<code>.name_, format);
         std::string msg = fmt::format(combo_format, std::forward<Args>(args)...);
-        log::root().error(msg);
+        if (error_category == ErrorCategory::INTERNAL)
+            log::root().error(msg);
         throw_error<code>(msg);
     }
 
@@ -33,7 +34,8 @@ struct Raise {
     [[noreturn]] void operator()(FormatString format, Args&&...args) const {
         std::string combo_format = fmt::format(FMT_COMPILE("{} {}"), error_code_data<code>.name_, format);
         std::string msg = fmt::format(combo_format, std::forward<Args>(args)...);
-        log::root().error(msg);
+        if (error_category == ErrorCategory::INTERNAL)
+            log::root().error(msg);
         throw_error<code>(msg);
     }
 };

--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -25,7 +25,7 @@ struct Raise {
     [[noreturn]] void operator()(fmt::format_string<Args...> format, Args&&...args) const {
         std::string combo_format = fmt::format(FMT_COMPILE("{} {}"), error_code_data<code>.name_, format);
         std::string msg = fmt::format(combo_format, std::forward<Args>(args)...);
-        if (error_category == ErrorCategory::INTERNAL)
+        if constexpr(error_category == ErrorCategory::INTERNAL)
             log::root().error(msg);
         throw_error<code>(msg);
     }
@@ -34,7 +34,7 @@ struct Raise {
     [[noreturn]] void operator()(FormatString format, Args&&...args) const {
         std::string combo_format = fmt::format(FMT_COMPILE("{} {}"), error_code_data<code>.name_, format);
         std::string msg = fmt::format(combo_format, std::forward<Args>(args)...);
-        if (error_category == ErrorCategory::INTERNAL)
+        if constexpr(error_category == ErrorCategory::INTERNAL)
             log::root().error(msg);
         throw_error<code>(msg);
     }


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fixes #675 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Only `ErrorCode::INTERNAL` will be logged to standard error.

Otherwise exceptions will be raised to be dealt with by the caller. 

#### Any other comments?

I'm unsure if this will cause some messages to be lost if the exception is not percolated upwards. 

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
