### PR TITLE
Remove SemVer version validation as it doesnt support version strings such as 1.6.1rc0

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -5,10 +5,6 @@ on:
       version:
         type: string
         required: true
-      bump:
-        description: Bump branch to the next version
-        type: choice
-        options: ["No", minor, patch, prerelease, build] # Major must be changed by hand
       overwrite:
         description: Force push tag
         type: boolean
@@ -48,10 +44,3 @@ jobs:
           # Remove the build status badge from a version tag
           sed -i 's#<img src="https://github.com/man-group/ArcticDB/actions/workflows/build.yml/badge.svg"/>##' README.md || true
           tag_and_push "Tagging" ${{inputs.version}} refs/tags/v${{inputs.version}} ${{inputs.overwrite && '-f' || ''}}
-
-      - name: Bump ${{github.ref_name}} to the next version
-        if: inputs.bump != 'No'
-        run: |
-          git switch -C bumping ${{github.ref}}
-          new_ver=`python3 -m semver bump ${{inputs.bump}} '${{inputs.version}}'`
-          tag_and_push "Bumping to" $new_ver ${{github.ref}}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -35,11 +35,6 @@ jobs:
           git push origin HEAD:$3 $4
         }
     steps:
-      - name: Validate
-        run: |
-          pip3 install semver>=3
-          python3 -m semver check '${{inputs.version}}'
-
       - name: Checkout
         uses: actions/checkout@v3.3.0
         with:


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

#### Any other comments?

We could replace this with conda version validation (from the `conda` package) or packaging version validation (from the `packaging` package) but both are a little fiddly.

To be honest this has to be approved before having an irreversible effect, so I think human validation is fine here. 

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
