### PR TITLE
Docs 672: Add docstring for DataError class

### DIFF
--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -132,13 +132,47 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def_property_readonly("names", &PythonOutputFrame::names, py::return_value_policy::reference)
         .def_property_readonly("index_columns", &PythonOutputFrame::index_columns, py::return_value_policy::reference);
 
-    py::enum_<VersionRequestType>(version, "VersionRequestType")
-            .value("SNAPSHOT", VersionRequestType::SNAPSHOT)
-            .value("TIMESTAMP", VersionRequestType::TIMESTAMP)
-            .value("SPECIFIC", VersionRequestType::SPECIFIC)
-            .value("LATEST", VersionRequestType::LATEST);
+    py::enum_<VersionRequestType>(version, "VersionRequestType", R"pbdoc(
+        Enum of possible version request types passed to as_of.
+    )pbdoc")
+            .value("SNAPSHOT", VersionRequestType::SNAPSHOT, R"pbdoc(
+            Request the version of the symbol contained in the specified snapshot.
+    )pbdoc")
+            .value("TIMESTAMP", VersionRequestType::TIMESTAMP, R"pbdoc(
+            Request the version of the symbol as it was at the specified timestamp.
+    )pbdoc")
+            .value("SPECIFIC", VersionRequestType::SPECIFIC, R"pbdoc(
+            Request a specific version of the symbol.
+    )pbdoc")
+            .value("LATEST", VersionRequestType::LATEST, R"pbdoc(
+            Request the latest undeleted version of the symbol.
+    )pbdoc");
 
-    py::class_<DataError, std::shared_ptr<DataError>>(version, "DataError")
+    py::class_<DataError, std::shared_ptr<DataError>>(version, "DataError", R"pbdoc(
+        Return value for batch methods which fail in some way.
+
+        Attributes
+        ----------
+        symbol: str
+            Read or modified symbol.
+        version_request_type: Optional[VersionRequestType]
+            For operations that support as_of, the type of version query provided. `None` otherwise.
+        version_request_data: Optional[Union[str, int]]
+            For operations that support as_of, the value provided in the version query:
+                None - Operation does not support as_of, or latest version was requested
+                str - The name of the snapshot provided to as_of
+                int - The specific version requested if version_request_type == VersionRequestType::SPECIFIC, or
+                      nanoseconds since epoch if version_request_type == VersionRequestType::TIMESTAMP
+        error_code: Optional[ErrorCode]
+            For the most common error types, the ErrorCode is included here.
+            e.g. ErrorCode.E_NO_SUCH_VERSION if the version requested has been deleted
+            Please see the Error Messages section of the docs for more detail.
+        error_category: Optional[ErrorCategory]
+            If error_code is provided, the category is also provided.
+            e.g.  ErrorCategory.MISSING_DATA if error_code is ErrorCode.E_NO_SUCH_VERSION
+        exception_string: str
+            The string associated with the exception that was originally raised.
+    )pbdoc")
             .def_property_readonly("symbol", &DataError::symbol)
             .def_property_readonly("version_request_type", &DataError::version_request_type)
             .def_property_readonly("version_request_data", &DataError::version_request_data)

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ cd ..
 ```
 
 This writes build files to `./sphinxdocs/build/html`.
+Open `./sphinxdocs/build/html/index.html` in the browser of your choice to just view the Sphinx docs.
 
 ## Uploading
 

--- a/docs/sphinxdocs/source/arcticdb/arcticdb.Arctic.rst
+++ b/docs/sphinxdocs/source/arcticdb/arcticdb.Arctic.rst
@@ -1,4 +1,4 @@
-arcticdb.Arctic
+﻿arcticdb.Arctic
 ===============
 
 .. currentmodule:: arcticdb
@@ -17,6 +17,7 @@ arcticdb.Arctic
       ~Arctic.create_library
       ~Arctic.delete_library
       ~Arctic.get_library
+      ~Arctic.get_uri
       ~Arctic.list_libraries
    
    

--- a/docs/sphinxdocs/source/conf.py
+++ b/docs/sphinxdocs/source/conf.py
@@ -27,7 +27,7 @@ print(f"Prepended root={root} to path")
 # -- Project information -----------------------------------------------------
 
 project = "ArcticDB"
-copyright = "2022, Man Group"
+copyright = "2023, Man Group"
 author = "Man Group"
 
 

--- a/docs/sphinxdocs/source/library.rst
+++ b/docs/sphinxdocs/source/library.rst
@@ -28,5 +28,11 @@ methods.
     :special-members: __init__
     :members:
 
+.. autoclass:: arcticdb.VersionedItem
+
+.. autoclass:: arcticdb.DataError
+
+.. autoclass:: arcticdb.VersionRequestType
+
 .. automodule:: arcticdb.version_store.library
     :members: arcticdb.version_store.library.NormalizableType,arcticdb.version_store.library.ArcticInvalidApiUsageException,arcticdb.version_store.library.ArcticDuplicateSymbolsInBatchException,arcticdb.version_store.library.ArcticUnsupportedDataTypeException,arcticdb.version_store.library.SymbolVersion,arcticdb.version_store.library.VersionInfo,arcticdb.version_store.library.SymbolDescription,arcticdb.version_store.library.WritePayload,arcticdb.version_store.library.ReadRequest

--- a/docs/sphinxdocs/source/library/arcticdb.version_store.library.Library.rst
+++ b/docs/sphinxdocs/source/library/arcticdb.version_store.library.Library.rst
@@ -15,14 +15,17 @@
    
       ~Library.__init__
       ~Library.append
+      ~Library.defragment_symbol_data
       ~Library.delete
       ~Library.delete_data_in_range
       ~Library.delete_snapshot
       ~Library.finalize_staged_data
       ~Library.get_description
+      ~Library.get_description_batch
       ~Library.get_staged_symbols
       ~Library.has_symbol
       ~Library.head
+      ~Library.is_symbol_fragmented
       ~Library.list_snapshots
       ~Library.list_symbols
       ~Library.list_versions
@@ -30,6 +33,7 @@
       ~Library.read
       ~Library.read_batch
       ~Library.read_metadata
+      ~Library.read_metadata_batch
       ~Library.reload_symbol_list
       ~Library.snapshot
       ~Library.sort_and_finalize_staged_data
@@ -37,9 +41,9 @@
       ~Library.update
       ~Library.write
       ~Library.write_batch
-      ~Library.write_pickle_batch
       ~Library.write_metadata
       ~Library.write_pickle
+      ~Library.write_pickle_batch
    
    
 

--- a/docs/sphinxdocs/source/library/arcticdb.version_store.library.ReadInfoRequest.rst
+++ b/docs/sphinxdocs/source/library/arcticdb.version_store.library.ReadInfoRequest.rst
@@ -1,0 +1,31 @@
+﻿arcticdb.version\_store.library.ReadInfoRequest
+===============================================
+
+.. currentmodule:: arcticdb.version_store.library
+
+.. autoclass:: ReadInfoRequest
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~ReadInfoRequest.__init__
+      ~ReadInfoRequest.count
+      ~ReadInfoRequest.index
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~ReadInfoRequest.as_of
+      ~ReadInfoRequest.symbol
+   
+   

--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -5,10 +5,12 @@ import sys as _sys
 from arcticdb.arctic import Arctic
 from arcticdb.options import LibraryOptions
 from arcticdb.version_store.processing import QueryBuilder
+from arcticdb.version_store._store import VersionedItem
 import arcticdb.version_store.library as library
 from arcticdb.options import LibraryOptions
 from arcticdb.tools import set_config_from_env_vars
-from arcticdb_ext.version_store import DataError
+from arcticdb_ext.version_store import DataError, VersionRequestType
+from arcticdb_ext.exceptions import ErrorCode, ErrorCategory
 
 set_config_from_env_vars(_os.environ)
 


### PR DESCRIPTION
Closes #672

Adds a docstring for the `DataError` class.
Makes `VersionedItem` importable directly from the `arcticdb` module

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
