### PR TITLE
read metadata batch to catch all the exceptions

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -316,7 +316,7 @@ public:
             const std::vector<StreamId>& stream_ids,
             const std::vector<VersionQuery>& version_queries);
 
-    std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> batch_read_metadata_internal(
+    std::vector<std::variant<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>, DataError>> batch_read_metadata_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -296,7 +296,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, py::object>> batch_read_metadata(
+    std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> batch_read_metadata(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1074,7 +1074,9 @@ class Library:
         """
         return self._nvs.read_metadata(symbol, as_of)
 
-    def read_metadata_batch(self, symbols: List[Union[str, ReadInfoRequest]]) -> List[VersionedItem]:
+    def read_metadata_batch(
+        self, symbols: List[Union[str, ReadInfoRequest]]
+    ) -> List[Union[SymbolDescription, DataError]]:
         """
         Reads the metadata of multiple symbols.
 
@@ -1085,11 +1087,13 @@ class Library:
 
         Returns
         -------
-        List[VersionedItem]
+        List[Union[SymbolDescription, DataError]]
             A list of the read results, whose i-th element corresponds to the i-th element of the ``symbols`` parameter.
             A VersionedItem object with the metadata field set as None will be returned if the requested version of the
-                symbol exists but there is no metadata
+            symbol exists but there is no metadata
             A None object will be returned if the requested version of the symbol does not exist
+            If a key error or any other internal exception occurs, a DataError object is returned, with symbol, version_request_type,
+            version_request_data properties, error_code, error_category, and exception_string properties.
 
         See Also
         --------


### PR DESCRIPTION
Closes #613

The previous behaviour of Library.read_metadata_batch and NativeVersionStore.batch_read_metadata was to throw an exception if there was an issue related to a missing key. For backwards compatibility reasons, this behaviour has been maintained for NativeVersionStore.batch_read_metadata.

For Library.read_metadata_batch, this has been changed. A DataError object will now be returned in the position in the list returned corresponding to the symbol/version pair there was an issue retrieving. This contains the symbol and version requested, and the exception string thrown. For one well-defined category of error, the error category and specific error code are also included:

ErrorCategory.STORAGE - ErrorCode.E_KEY_NOT_FOUND: The index key required to read the specified version does not exist in the storage.
Otherwise these fields of the DataError object are left as None.