### PR TITLE
Skip test_diff_long_stream_descriptor_mismatch on MacOS

### DIFF
--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2063,6 +2063,7 @@ def test_modification_methods_dont_return_input_data(lmdb_version_store, batch, 
             pytest.skip(str(e))
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Test broken on MacOS (issue #692)")
 @pytest.mark.parametrize("method", ("append", "update"))
 @pytest.mark.parametrize("num", (5, 50, 1001))
 def test_diff_long_stream_descriptor_mismatch(lmdb_version_store, method, num):

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2063,7 +2063,7 @@ def test_modification_methods_dont_return_input_data(lmdb_version_store, batch, 
             pytest.skip(str(e))
 
 
-@pytest.mark.skipif(sys.platform == 'darwin', reason="Test broken on MacOS (issue #692)")
+@pytest.mark.skipif(sys.platform == "darwin", reason="Test broken on MacOS (issue #692)")
 @pytest.mark.parametrize("method", ("append", "update"))
 @pytest.mark.parametrize("num", (5, 50, 1001))
 def test_diff_long_stream_descriptor_mismatch(lmdb_version_store, method, num):


### PR DESCRIPTION
Does not fix the issue obviously - skip to unblock further merges whilst fix is applied.

Relates to #692 
