### PR TITLE
fix: Fully qualify `arcticdb::storage::DuplicateKeyException`

### DIFF
--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -110,7 +110,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
         try {
             store->write_sync(KeyType::SYMBOL_LIST, 0, StreamId{ action }, IndexValue{ symbol }, IndexValue{ symbol },
                 std::move(seg));
-        } catch (const DuplicateKeyException& e [[unused]]) {
+        } catch ([[maybe_unused]] const DuplicateKeyException& e)  {
             // Both version and content hash are fixed, so collision is possible
             ARCTICDB_DEBUG(log::storage(), "Symbol list DuplicateKeyException: {}", e.what());
         }

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -110,7 +110,7 @@ bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
         try {
             store->write_sync(KeyType::SYMBOL_LIST, 0, StreamId{ action }, IndexValue{ symbol }, IndexValue{ symbol },
                 std::move(seg));
-        } catch ([[maybe_unused]] const DuplicateKeyException& e)  {
+        } catch ([[maybe_unused]] const arcticdb::storage::DuplicateKeyException& e)  {
             // Both version and content hash are fixed, so collision is possible
             ARCTICDB_DEBUG(log::storage(), "Symbol list DuplicateKeyException: {}", e.what());
         }


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up of #600.

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

`DuplicateKeyException` is not fully qualified, creating compilation errors. This fully qualifies `DuplicateKeyException` with its full namespace.

This should fix recent compilations errors observed on the CI for conda-forge builds.

#### Any other comments?

Also, `[[unused]]` is not standardized as an attribute and this makes the compilation fails using some compilers. `[[maybe_unused]]` is a portable, standardized replacement.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
