### PR TITLE
Bugfix 703: Restrict supported string types to type equality rather than has isinstance

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -109,7 +109,10 @@ if PY3:
     def _accept_array_string(v):
         # TODO remove this once arctic keeps the string type under the hood
         # and does not transform string into bytes
-        return isinstance(v, string_types) or isinstance(v, binary_type)
+        # string_types and binary_type can be a single type or a tuple
+        supported_string_types = string_types if isinstance(string_types, tuple) else (string_types,)
+        supported_binary_types = binary_type if isinstance(binary_type, tuple) else (binary_type,)
+        return type(v) in supported_string_types or type(v) in supported_binary_types
 
 else:
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #703 

When normalising columns of `dtype` `object`, all of the contained objects **must** be of a Python string type.

The existing implementation used `isinstance` to check for this condition, but this also picks up classes that have inherited from `str`. Instead, we must check that the `type` of the column elements is an exact match for `str` in order for lower level code to work correctly.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
