### PR TITLE
maint: Rename protocol buffer `VariantStorage` to `StorageConfig` 

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -70,19 +70,19 @@ class AzureStorage final : public Storage<AzureStorage> {
     Azure::Storage::Blobs::BlobClientOptions get_client_options(const Config &conf);
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &container_name) {
-    arcticdb::proto::storage::VariantStorage output;
+inline arcticdb::proto::storage::StorageConfig pack_config(const std::string &container_name) {
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::azure_storage::Config cfg;
     cfg.set_container_name(container_name);
     util::pack_to_any(cfg, *output.mutable_config());
     return output;
 }
 
-inline arcticdb::proto::storage::VariantStorage pack_config(
+inline arcticdb::proto::storage::StorageConfig pack_config(
         const std::string &container_name,
         const std::string &endpoint
         ) {
-    arcticdb::proto::storage::VariantStorage output;
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::azure_storage::Config cfg;
     cfg.set_container_name(container_name);
     cfg.set_endpoint(endpoint);

--- a/cpp/arcticdb/storage/config_cache.hpp
+++ b/cpp/arcticdb/storage/config_cache.hpp
@@ -53,8 +53,8 @@ class ConfigCache {
         descriptor_map_.emplace(path, desc);
     }
 
-    void add_storage(const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage storage) {
-        config_resolver_->add_storage(environment_name_, storage_name, storage);
+    void add_storage(const StorageName& storage_name, const arcticdb::proto::storage::StorageConfig storage_config) {
+        config_resolver_->add_storage(environment_name_, storage_name, storage_config);
     }
 
     std::vector<LibraryPath> list_libraries(const std::string_view &prefix) {
@@ -81,7 +81,7 @@ class ConfigCache {
         std::vector<std::unique_ptr<VariantStorage>> variants;
         for (const auto& storage_name : descriptor.storage_ids_) {
             // Otherwise see if we have the storage config.
-            arcticdb::proto::storage::VariantStorage storage_conf;
+            arcticdb::proto::storage::StorageConfig storage_conf;
             auto storage_conf_pos = storage_configs_.find(storage_name);
             if(storage_conf_pos != storage_configs_.end())
                 storage_conf = storage_conf_pos->second;
@@ -122,7 +122,7 @@ class ConfigCache {
 
     EnvironmentName environment_name_;
     std::unordered_map<LibraryPath, LibraryDescriptor> descriptor_map_;
-    std::unordered_map<StorageName, arcticdb::proto::storage::VariantStorage> storage_configs_;
+    std::unordered_map<StorageName, arcticdb::proto::storage::StorageConfig> storage_configs_;
     std::shared_ptr<ConfigResolver> config_resolver_;
     mutable std::mutex mutex_;
 };

--- a/cpp/arcticdb/storage/config_resolvers.cpp
+++ b/cpp/arcticdb/storage/config_resolvers.cpp
@@ -48,13 +48,13 @@ std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>>
     return output;
 }
 
-std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> InMemoryConfigResolver::get_storages(const EnvironmentName &environment_name) const {
+std::vector<std::pair<StorageName, arcticdb::proto::storage::StorageConfig>> InMemoryConfigResolver::get_storages(const EnvironmentName &environment_name) const {
     auto config = get_environment(environment_name);
-    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> output;
+    std::vector<std::pair<StorageName, arcticdb::proto::storage::StorageConfig>> output;
     if(!config.has_value())
         return output;
 
-    for(auto& pair : config.value().storages_)
+    for(auto& pair : config.value().storage_configs_)
         output.emplace_back(pair);
 
     return output;
@@ -65,9 +65,9 @@ void InMemoryConfigResolver::add_library(const EnvironmentName& environment_name
     config.libraries_.insert(std::make_pair(LibraryPath::from_delim_path(library_descriptor.name()), library_descriptor));
 }
 
-void InMemoryConfigResolver::add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) {
+void InMemoryConfigResolver::add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::StorageConfig& storage_config) {
     auto& config = get_or_add_environment(environment_name);
-    config.storages_.insert(std::make_pair(StorageName(storage_name), storage));
+    config.storage_configs_.insert(std::make_pair(StorageName(storage_name), storage_config));
 }
 
 }

--- a/cpp/arcticdb/storage/config_resolvers.hpp
+++ b/cpp/arcticdb/storage/config_resolvers.hpp
@@ -23,11 +23,11 @@ class ConfigResolver {
     //TODO nothing especially wrong with this method but what's the expected use case?
     //virtual std::vector<EnvironmentName> list_environments() const = 0;
     virtual std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> get_libraries(const EnvironmentName &environment_name) const = 0;
-    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_storages(const EnvironmentName &environment_name) const = 0;
+    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::StorageConfig>> get_storages(const EnvironmentName &environment_name) const = 0;
     virtual void add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) = 0;
-    virtual void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) = 0;
+    virtual void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::StorageConfig& storage_config) = 0;
     virtual void initialize_environment(const EnvironmentName& environment_name) = 0;
-    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(const EnvironmentName& environment_name) const = 0;
+    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::StorageConfig>> get_default_storages(const EnvironmentName& environment_name) const = 0;
     virtual std::string_view resolver_type() const = 0;
 };
 
@@ -39,11 +39,11 @@ namespace arcticdb::storage::details {
 
 class InMemoryConfigResolver final : public ConfigResolver {
   public:
-    typedef std::unordered_map<StorageName, arcticdb::proto::storage::VariantStorage> StorageMap;
+    typedef std::unordered_map<StorageName, arcticdb::proto::storage::StorageConfig> StorageConfigMap;
     typedef std::unordered_map<LibraryPath, arcticdb::proto::storage::LibraryDescriptor> LibraryMap;
 
     struct MemoryConfig {
-        StorageMap storages_;
+        StorageConfigMap storage_configs_;
         LibraryMap libraries_;
     };
 
@@ -58,12 +58,12 @@ class InMemoryConfigResolver final : public ConfigResolver {
     }
 
     std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>> get_libraries(const EnvironmentName &environment_name) const override;
-    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_storages(const EnvironmentName &environment_name) const override;
+    std::vector<std::pair<StorageName, arcticdb::proto::storage::StorageConfig>> get_storages(const EnvironmentName &environment_name) const override;
 
     void add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) override;
-    void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) override;
-    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(const EnvironmentName&) const override {
-        return std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>>();
+    void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::StorageConfig& storage_config) override;
+    std::vector<std::pair<StorageName, arcticdb::proto::storage::StorageConfig>> get_default_storages(const EnvironmentName&) const override {
+        return std::vector<std::pair<StorageName, arcticdb::proto::storage::StorageConfig>>();
     }
 
     void initialize_environment(const EnvironmentName&) override { }

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -155,7 +155,7 @@ class Library {
     bool storage_fallthrough_ = false;
 };
 
-inline Library create_library(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::VariantStorage>& storage_configs) {
+inline Library create_library(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::StorageConfig>& storage_configs) {
     return Library{library_path, create_storages(library_path, mode, storage_configs)};
 }
 

--- a/cpp/arcticdb/storage/library_index.hpp
+++ b/cpp/arcticdb/storage/library_index.hpp
@@ -50,8 +50,8 @@ class LibraryIndex {
         return get_library_internal(path, mode);
     }
 
-    void add_storage(const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) {
-        config_cache_.add_storage(storage_name, storage);
+    void add_storage(const StorageName& storage_name, const arcticdb::proto::storage::StorageConfig& storage_config) {
+        config_cache_.add_storage(storage_name, storage_config);
     }
 
   private:

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -66,11 +66,11 @@ namespace arcticdb::storage {
         [[nodiscard]] std::shared_ptr<Library> get_library(const LibraryPath& path, const StorageOverride& storage_override = StorageOverride{}) const {
             arcticdb::proto::storage::LibraryConfig config = get_config_internal(path, storage_override);
 
-            std::vector<arcticdb::proto::storage::VariantStorage> st;
+            std::vector<arcticdb::proto::storage::StorageConfig> storage_configs;
             for(const auto& storage: config.storage_by_id()){
-                st.emplace_back(storage.second);
+                storage_configs.emplace_back(storage.second);
             }
-            auto storages = create_storages(path, OpenMode::DELETE, st);
+            auto storages = create_storages(path, OpenMode::DELETE, storage_configs);
 
             return std::make_shared<Library>(path, std::move(storages), config.lib_desc().version());
         }

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -69,8 +69,8 @@ private:
     std::unordered_map<std::string, ::lmdb::dbi> dbi_by_key_type_;
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(const std::string& path) {
-    arcticdb::proto::storage::VariantStorage output;
+inline arcticdb::proto::storage::StorageConfig pack_config(const std::string& path) {
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::lmdb_storage::Config cfg;
     cfg.set_path(path);
     util::pack_to_any(cfg, *output.mutable_config());

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -54,8 +54,8 @@ namespace arcticdb::storage::memory {
         std::unique_ptr<MutexType> mutex_;  // Methods taking functions pointers may call back into the storage
     };
 
-    inline arcticdb::proto::storage::VariantStorage pack_config(uint64_t cache_size) {
-        arcticdb::proto::storage::VariantStorage output;
+    inline arcticdb::proto::storage::StorageConfig pack_config(uint64_t cache_size) {
+        arcticdb::proto::storage::StorageConfig output;
         arcticdb::proto::memory_storage::Config cfg;
         cfg.set_cache_size(cache_size);
         util::pack_to_any(cfg, *output.mutable_config());

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -56,8 +56,8 @@ class MongoStorage final : public Storage<MongoStorage> {
     std::string prefix_;
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(InstanceUri uri) {
-    arcticdb::proto::storage::VariantStorage output;
+inline arcticdb::proto::storage::StorageConfig pack_config(InstanceUri uri) {
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::mongo_storage::Config cfg;
     cfg.set_uri(uri.value);
     util::pack_to_any(cfg, *output.mutable_config());

--- a/cpp/arcticdb/storage/protobuf_mappings.hpp
+++ b/cpp/arcticdb/storage/protobuf_mappings.hpp
@@ -77,7 +77,7 @@ inline std::vector<std::pair<std::string, MemConfig>> convert_environment_config
     for (auto&[env_key, env_config] : envs.env_by_id()) {
         MemConfig current;
         for (auto &[storage_key, storage_value] : env_config.storage_by_id())
-            current.storages_.insert(std::make_pair(storage::StorageName(storage_key), storage_value));
+            current.storage_configs_.insert(std::make_pair(storage::StorageName(storage_key), storage_value));
 
         for (auto &[library_key, library_value] : env_config.lib_by_path())
             current.libraries_.insert(std::make_pair(LibraryPath::from_delim_path(library_key), library_value));

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -62,21 +62,21 @@ private:
     std::string bucket_name_;
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &bucket_name) {
-    arcticdb::proto::storage::VariantStorage output;
+inline arcticdb::proto::storage::StorageConfig pack_config(const std::string &bucket_name) {
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::nfs_backed_storage::Config cfg;
     cfg.set_bucket_name(bucket_name);
     util::pack_to_any(cfg, *output.mutable_config());
     return output;
 }
 
-inline arcticdb::proto::storage::VariantStorage pack_config(
+inline arcticdb::proto::storage::StorageConfig pack_config(
     const std::string &bucket_name,
     const std::string &credential_name,
     const std::string &credential_key,
     const std::string &endpoint
 ) {
-    arcticdb::proto::storage::VariantStorage output;
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::nfs_backed_storage::Config cfg;
     cfg.set_bucket_name(bucket_name);
     cfg.set_credential_name(credential_name);

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -75,21 +75,21 @@ class S3Storage final : public Storage<S3Storage> {
     std::string bucket_name_;
 };
 
-inline arcticdb::proto::storage::VariantStorage pack_config(const std::string &bucket_name) {
-    arcticdb::proto::storage::VariantStorage output;
+inline arcticdb::proto::storage::StorageConfig pack_config(const std::string &bucket_name) {
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::s3_storage::Config cfg;
     cfg.set_bucket_name(bucket_name);
     util::pack_to_any(cfg, *output.mutable_config());
     return output;
 }
 
-inline arcticdb::proto::storage::VariantStorage pack_config(
+inline arcticdb::proto::storage::StorageConfig pack_config(
         const std::string &bucket_name,
         const std::string &credential_name,
         const std::string &credential_key,
         const std::string &endpoint
         ) {
-    arcticdb::proto::storage::VariantStorage output;
+    arcticdb::proto::storage::StorageConfig output;
     arcticdb::proto::s3_storage::Config cfg;
     cfg.set_bucket_name(bucket_name);
     cfg.set_credential_name(credential_name);

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -25,45 +25,45 @@ namespace arcticdb::storage {
 std::unique_ptr<VariantStorage> create_storage(
     const LibraryPath &library_path,
     OpenMode mode,
-    const arcticdb::proto::storage::VariantStorage &storage_descriptor) {
+    const arcticdb::proto::storage::StorageConfig &storage_config) {
 
     std::unique_ptr<VariantStorage> storage;
-    auto type_name = util::get_arcticdb_pb_type_name(storage_descriptor.config());
+    auto type_name = util::get_arcticdb_pb_type_name(storage_config.config());
 
     if (type_name == s3::S3Storage::Config::descriptor()->full_name()) {
         s3::S3Storage::Config s3_config;
-        storage_descriptor.config().UnpackTo(&s3_config);
+        storage_config.config().UnpackTo(&s3_config);
         storage = std::make_unique<VariantStorage>(
                 s3::S3Storage(library_path, mode, s3_config)
         );
     } else if (type_name == lmdb::LmdbStorage::Config::descriptor()->full_name()) {
         lmdb::LmdbStorage::Config lmbd_config;
-        storage_descriptor.config().UnpackTo(&lmbd_config);
+        storage_config.config().UnpackTo(&lmbd_config);
         storage = std::make_unique<VariantStorage>(
                 lmdb::LmdbStorage(library_path, mode, lmbd_config)
         );
     } else if (type_name == mongo::MongoStorage::Config::descriptor()->full_name()) {
         mongo::MongoStorage::Config mongo_config;
-        storage_descriptor.config().UnpackTo(&mongo_config);
+        storage_config.config().UnpackTo(&mongo_config);
         storage = std::make_unique<VariantStorage>(
                 mongo::MongoStorage(library_path, mode, mongo_config)
         );
     } else if (type_name == memory::MemoryStorage::Config::descriptor()->full_name()) {
         memory::MemoryStorage::Config memory_config;
-        storage_descriptor.config().UnpackTo(&memory_config);
+        storage_config.config().UnpackTo(&memory_config);
         storage = std::make_unique<VariantStorage>(
                 memory::MemoryStorage(library_path, mode, memory_config)
         );
     } else if (type_name == nfs_backed::NfsBackedStorage::Config::descriptor()->full_name()) {
         nfs_backed::NfsBackedStorage::Config nfs_backed_config;
-        storage_descriptor.config().UnpackTo(&nfs_backed_config);
+        storage_config.config().UnpackTo(&nfs_backed_config);
         storage = std::make_unique<VariantStorage>(
                 nfs_backed::NfsBackedStorage(library_path, mode, nfs_backed_config)
         );
 #ifndef ARCTICDB_USING_CONDA //Awaiting Azure sdk support in conda https://github.com/man-group/ArcticDB/issues/519
         } else if (type_name == azure::AzureStorage::Config::descriptor()->full_name()) {
         azure::AzureStorage::Config azure_config;
-        storage_descriptor.config().UnpackTo(&azure_config);
+        storage_config.config().UnpackTo(&azure_config);
         storage = std::make_unique<VariantStorage>(
             azure::AzureStorage(library_path, mode, azure_config)
         );

--- a/cpp/arcticdb/storage/storage_override.hpp
+++ b/cpp/arcticdb/storage/storage_override.hpp
@@ -55,7 +55,7 @@ public:
         region_ = region;
     }
 
-    void modify_storage_credentials(arcticdb::proto::storage::VariantStorage& storage) const {
+    void modify_storage_credentials(arcticdb::proto::storage::StorageConfig& storage) const {
         if(storage.config().Is<arcticdb::proto::s3_storage::Config>()) {
             arcticdb::proto::s3_storage::Config s3_storage;
             storage.config().UnpackTo(&s3_storage);

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -134,7 +134,7 @@ class Storages {
     OpenMode mode_;
 };
 
-inline std::shared_ptr<Storages> create_storages(const LibraryPath& library_path, OpenMode mode, const arcticdb::proto::storage::VariantStorage &storage_config) {
+inline std::shared_ptr<Storages> create_storages(const LibraryPath& library_path, OpenMode mode, const arcticdb::proto::storage::StorageConfig &storage_config) {
     using VariantVec = std::vector<std::unique_ptr<VariantStorage>>;
     VariantVec variants;
     variants.push_back(create_storage(library_path, mode, storage_config));
@@ -142,7 +142,7 @@ inline std::shared_ptr<Storages> create_storages(const LibraryPath& library_path
     return std::make_shared<Storages>(std::move(variants), mode);
 }
 
-inline std::shared_ptr<Storages> create_storages(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::VariantStorage> &storage_configs) {
+inline std::shared_ptr<Storages> create_storages(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::StorageConfig> &storage_configs) {
     using VariantVec = std::vector<std::unique_ptr<VariantStorage>>;
     VariantVec variants;
     for (const auto& storage_config: storage_configs) {

--- a/cpp/arcticdb/storage/variant_storage_factory.hpp
+++ b/cpp/arcticdb/storage/variant_storage_factory.hpp
@@ -45,7 +45,7 @@ using VariantStorage = variant::VariantStorage<VariantStorageTypes>;
 std::unique_ptr<VariantStorage> create_storage(
     const LibraryPath& library_path,
     OpenMode mode,
-    const arcticdb::proto::storage::VariantStorage &storage_config);
+    const arcticdb::proto::storage::StorageConfig &storage_config);
 
 } // namespace storage
 } // namespace arcticdb

--- a/cpp/arcticdb/util/test/config_common.hpp
+++ b/cpp/arcticdb/util/test/config_common.hpp
@@ -28,7 +28,7 @@ inline auto get_test_environment_config(
     cfg.set_path("./"); //TODO local path is a bit annoying. TMPDIR?
     cfg.set_recreate_if_exists(true);
     util::pack_to_any(cfg, *storage_conf.mutable_config());
-    mem_config.storages_.insert(std::make_pair(storage_name, storage_conf));
+    mem_config.storage_configs_.insert(std::make_pair(storage_name, storage_conf));
 
     arcticdb::proto::storage::LibraryDescriptor library_descriptor;
     library_descriptor.add_storage_ids(storage_name.value);

--- a/cpp/arcticdb/util/test/config_common.hpp
+++ b/cpp/arcticdb/util/test/config_common.hpp
@@ -23,7 +23,7 @@ inline auto get_test_environment_config(
     using MemoryConfig = storage::details::InMemoryConfigResolver::MemoryConfig;
     MemoryConfig mem_config = {};
 
-    arcticdb::proto::storage::VariantStorage storage_conf;
+    arcticdb::proto::storage::StorageConfig storage_conf;
     arcticdb::proto::lmdb_storage::Config cfg;
     cfg.set_path("./"); //TODO local path is a bit annoying. TMPDIR?
     cfg.set_recreate_if_exists(true);

--- a/cpp/proto/arcticc/pb2/storage.proto
+++ b/cpp/proto/arcticc/pb2/storage.proto
@@ -19,11 +19,11 @@ message EnvironmentConfigsMap {
 // TODO Add Task scheduler configuration
 
 message EnvironmentConfig {
-    map<string, VariantStorage> storage_by_id = 1;
+    map<string, StorageConfig> storage_by_id = 1;
     map<string, LibraryDescriptor> lib_by_path = 2;
 }
 
-message VariantStorage {
+message StorageConfig {
     google.protobuf.Any config = 2;
     string storage = 3;
 }
@@ -184,7 +184,7 @@ message LibraryConfig {
     Portable library configuration which is sufficient to recreate a library
     */
     LibraryDescriptor lib_desc = 1;
-    map<string, VariantStorage> storage_by_id = 2;
+    map<string, StorageConfig> storage_by_id = 2;
 }
 
 

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -21,7 +21,7 @@ from arcticc.pb2.storage_pb2 import (
     EnvironmentConfig,
     LibraryConfig,
     LibraryDescriptor,
-    VariantStorage,
+    StorageConfig,
     Permissions,
     NoCredentialsStore,
 )
@@ -137,13 +137,13 @@ def add_library_config_to_env(cfg, lib_cfg, env_name):
 
 
 def get_storage_for_lib_name(lib_name, env):
-    # type: (LibName, EnvironmentConfigsMap)->(StorageId, VariantStorage)
+    # type: (LibName, EnvironmentConfigsMap)->(StorageId, StorageConfig)
     sid = "{}_store".format(lib_name)
     return sid, env.storage_by_id[sid]
 
 
 def get_secondary_storage_for_lib_name(lib_name, env):
-    # type: (LibName, EnvironmentConfigsMap)->(StorageId, VariantStorage)
+    # type: (LibName, EnvironmentConfigsMap)->(StorageId, StorageConfig)
     sid = "{}_store_2".format(lib_name)
     return sid, env.storage_by_id[sid]
 


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #633.

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

In addition to #696, this removes the last mention of `VariantStorage`, `arcticdb::proto::storage::VariantStorage` which encapsulates one configuration opaquely via `google.protobuf.Any`.

I chose `StorageConfig` as a name to be consistent with the names of the actual Storage configuration protocol buffers (i.e. `arcticdb::proto::*_storage::Config`).

#### Any other comments?

Do we need to maintain a Python alias for backward compatibility?

:warning: In any case, I think we must perform checks (such as the ones mentioned in #592) for this renaming.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
