### PR TITLE
Enhancement 558+529+556: Add option to treat date_range as a clause to reduce memory usage, and so that it works with other QueryBuilder clauses

### DIFF
--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -851,6 +851,63 @@ public:
         return data_.buffer().blocks();
     }
 
+    // Only works if column is of numeric type and is monotonically increasing
+    // Returns the index such that if val were inserted before that index, the order would be preserved
+    // By default returns the lowest index satisfying this property. If from_right=true, returns the highest such index
+    template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
+    size_t search_sorted(T val, bool from_right=false) const {
+        // There will not necessarily be a unique answer for sparse columns
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(!is_sparse(),
+                                                        "Column::search_sorted not supported with sparse columns");
+        std::optional<size_t> res;
+        type().visit_tag([this, &res, val, from_right](auto type_desc_tag){
+            using TDT = decltype(type_desc_tag);
+            using RawType = typename TDT::DataTypeTag::raw_type;
+            if constexpr(std::is_same_v<T, RawType>) {
+                int64_t low{0};
+                int64_t high{row_count() -1};
+                while (!res.has_value()) {
+                    auto mid{low + (high - low) / 2};
+                    auto mid_value = *scalar_at<RawType>(mid);
+                    if (val == mid_value) {
+                        // At least one value in the column exactly matches the input val
+                        // Search to the right/left for the last/first such value
+                        if (from_right) {
+                            while (++mid <= high && val == *scalar_at<RawType>(mid)) {}
+                            res = mid;
+                        } else {
+                            while (--mid >= low && val == *scalar_at<RawType>(mid)) {}
+                            res = mid + 1;
+                        }
+                    } else if (val > mid_value) {
+                        if (mid + 1 <= high && val >= *scalar_at<RawType>(mid + 1)) {
+                            // Narrow the search interval
+                            low = mid + 1;
+                        } else {
+                            // val is less than the next value, so we have found the right interval
+                            res = mid + 1;
+                        }
+                    } else { // val < mid_value
+                        if (mid - 1 >= low && val <= *scalar_at<RawType>(mid + 1)) {
+                            // Narrow the search interval
+                            high = mid - 1;
+                        } else {
+                            // val is greater than the previous value, so we have found the right interval
+                            res = mid;
+                        }
+                    }
+                }
+            } else {
+                // TODO: Could relax this requirement using something like has_valid_common_type
+                internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
+                        "Column::search_sorted requires input value to be of same type as column");
+            }
+        });
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                res.has_value(), "Column::search_sorted should always find an index");
+        return *res;
+    }
+
     static std::vector<std::shared_ptr<Column>> split(const std::shared_ptr<Column>& column, size_t num_rows);
 
     static std::shared_ptr<Column> truncate(const std::shared_ptr<Column>& column, size_t start_row, size_t end_row);

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -484,4 +484,46 @@ struct RowRangeClause {
     [[nodiscard]] std::string to_string() const;
 };
 
+struct DateRangeClause {
+
+    ClauseInfo clause_info_;
+    // Time range to keep, inclusive of start and end
+    timestamp start_;
+    timestamp end_;
+
+    explicit DateRangeClause(timestamp start, timestamp end):
+            start_(start),
+            end_(end) {
+    }
+
+    DateRangeClause() = delete;
+
+    ARCTICDB_MOVE_COPY_DEFAULT(DateRangeClause)
+
+    [[nodiscard]] Composite<ProcessingSegment> process(std::shared_ptr<Store> store,
+                                                       Composite<ProcessingSegment> &&p) const;
+
+    [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingSegment>> &&) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] const ClauseInfo& clause_info() const {
+        return clause_info_;
+    }
+
+    void set_processing_config(ARCTICDB_UNUSED const ProcessingConfig& processing_config) {
+    }
+
+    [[nodiscard]] timestamp start() const {
+        return start_;
+    }
+
+    [[nodiscard]] timestamp end() const {
+        return end_;
+    }
+
+    [[nodiscard]] std::string to_string() const;
+};
+
 }//namespace arcticdb

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -304,6 +304,12 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def(py::init<RowRangeClause::RowRangeType, int64_t>())
             .def("__str__", &RowRangeClause::to_string);
 
+    py::class_<DateRangeClause, std::shared_ptr<DateRangeClause>>(version, "DateRangeClause")
+            .def(py::init<timestamp, timestamp>())
+            .def_property_readonly("start", &DateRangeClause::start)
+            .def_property_readonly("end", &DateRangeClause::end)
+            .def("__str__", &DateRangeClause::to_string);
+
     py::class_<ReadQuery>(version, "PythonVersionStoreReadQuery")
             .def(py::init())
             .def_readwrite("columns",&ReadQuery::columns)
@@ -316,7 +322,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
                                 std::shared_ptr<ProjectClause>,
                                 std::shared_ptr<GroupByClause>,
                                 std::shared_ptr<AggregationClause>,
-                                std::shared_ptr<RowRangeClause>>> clauses) {
+                                std::shared_ptr<RowRangeClause>,
+                                std::shared_ptr<DateRangeClause>>> clauses) {
                 std::vector<std::shared_ptr<Clause>> _clauses;
                 for (auto&& clause: clauses) {
                     util::variant_match(

--- a/python/arcticdb/supported_types.py
+++ b/python/arcticdb/supported_types.py
@@ -6,7 +6,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 import datetime
-from typing import Union
+from typing import Sequence, Union, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -20,6 +20,18 @@ float_types = [np.float32, np.float64]
 numeric_types = int_types + float_types
 time_types = (pd.Timestamp, datetime.datetime, datetime.date)
 Timestamp = Union[time_types]
+
+_ExtDateRangeTypes = pd.core.indexes.datetimelike.DatetimeIndexOpsMixin
+if TYPE_CHECKING:
+    try:
+        import arctic.date
+
+        _ExtDateRangeTypes = Union[_ExtDateRangeTypes, arctic.date.DateRange]
+    except ModuleNotFoundError:
+        pass
+
+ExplicitlySupportedDates = Union[time_types]
+DateRangeInput = Union[Sequence[ExplicitlySupportedDates], _ExtDateRangeTypes]
 
 Shape = np.uint64
 

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -24,7 +24,7 @@ from arcticc.pb2.storage_pb2 import VersionStoreConfig
 from mmap import mmap
 from collections import Counter
 from arcticdb.exceptions import ArcticNativeException, ArcticNativeNotYetImplemented
-from arcticdb.supported_types import time_types as supported_time_types
+from arcticdb.supported_types import DateRangeInput, time_types as supported_time_types
 from arcticdb.version_store.read_result import ReadResult
 from arcticdb_ext.version_store import SortedValue as _SortedValue
 from pandas.core.internals import make_block
@@ -1271,7 +1271,7 @@ def restrict_data_to_date_range_only(data: T, *, start: Timestamp, end: Timestam
     return data
 
 
-def normalize_dt_range_to_ts(dtr: "DateRangeInput") -> Tuple[Timestamp, Timestamp]:
+def normalize_dt_range_to_ts(dtr: DateRangeInput) -> Tuple[Timestamp, Timestamp]:
     def _to_utc_ts(v: "ExplicitlySupportedDates", bound_name: str) -> Timestamp:
         if not isinstance(v, supported_time_types):
             raise TypeError(

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -868,6 +868,9 @@ class Library:
             part of the data that falls withing the given range (inclusive). None on either end leaves that part of the
             range open-ended. Hence specifying ``(None, datetime(2025, 1, 1)`` declares that you wish to read all data up
             to and including 20250101.
+            The same effect can be achieved by using the date_range clause of the QueryBuilder class, which will be
+            slower, but return data with a smaller memory footprint. See the QueryBuilder.date_range docstring for more
+            details.
 
         columns: List[str], default=None
             Applicable only for Pandas data. Determines which columns to return data for.

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -15,8 +15,9 @@ import pandas as pd
 from typing import Dict
 
 from arcticdb.exceptions import ArcticNativeException, UserInputException
+from arcticdb.version_store._normalization import normalize_dt_range_to_ts
 from arcticdb.preconditions import check
-from arcticdb.supported_types import time_types as supported_time_types
+from arcticdb.supported_types import DateRangeInput, time_types as supported_time_types
 
 from arcticdb_ext.version_store import PipelineOptimisation as _Optimisation
 from arcticdb_ext.version_store import ExpressionContext as _ExpressionContext
@@ -25,6 +26,7 @@ from arcticdb_ext.version_store import ProjectClause as _ProjectClause
 from arcticdb_ext.version_store import GroupByClause as _GroupByClause
 from arcticdb_ext.version_store import AggregationClause as _AggregationClause
 from arcticdb_ext.version_store import RowRangeClause as _RowRangeClause
+from arcticdb_ext.version_store import DateRangeClause as _DateRangeClause
 from arcticdb_ext.version_store import RowRangeType as _RowRangeType
 from arcticdb_ext.version_store import ExpressionName as _ExpressionName
 from arcticdb_ext.version_store import ColumnName as _ColumnName
@@ -265,6 +267,7 @@ PythonProjectionClause = namedtuple("PythonProjectionClause", ["name", "expr"])
 PythonGroupByClause = namedtuple("PythonGroupByClause", ["name"])
 PythonAggregationClause = namedtuple("PythonAggregationClause", ["aggregations"])
 PythonRowRangeClause = namedtuple("PythonRowRangeClause", ["row_range_type", "n"])
+PythonDateRangeClause = namedtuple("PythonDateRangeClause", ["start", "end"])
 
 
 class QueryBuilder:
@@ -483,6 +486,30 @@ class QueryBuilder:
         self._python_clauses.append(PythonAggregationClause(aggregations))
         return self
 
+    # TODO: specify type of other must be QueryBuilder with from __future__ import annotations once only Python 3.7+
+    # supported
+    def then(self, other):
+        """
+        Applies processing specified in other after any processing already defined for this QueryBuilder.
+
+        Parameters
+        ----------
+        other: `QueryBuilder`
+            QueryBuilder to apply after this one in the processing pipeline.
+
+        Returns
+        -------
+        QueryBuilder
+            Modified QueryBuilder object.
+        """
+        check(
+            not len(other.clauses) or not isinstance(other.clauses[0], _DateRangeClause),
+            "In QueryBuilder.then: Date range only supported as first clause in the pipeline",
+        )
+        self.clauses.extend(other.clauses)
+        self._python_clauses.extend(other._python_clauses)
+        return self
+
     def _head(self, n: int):
         check(not len(self.clauses), "Head only supported as first clause in the pipeline")
         self.clauses.append(_RowRangeClause(_RowRangeType.HEAD, n))
@@ -493,6 +520,35 @@ class QueryBuilder:
         check(not len(self.clauses), "Tail only supported as first clause in the pipeline")
         self.clauses.append(_RowRangeClause(_RowRangeType.TAIL, n))
         self._python_clauses.append(PythonRowRangeClause(_RowRangeType.TAIL, n))
+        return self
+
+    def date_range(self, date_range: DateRangeInput):
+        """
+        DateRange to read data for.  Applicable only for Pandas data with a DateTime index. Returns only the part
+        of the data that falls within the given range. The returned data object will use less memory than passing
+        date_range directly as an argument to the read method, at the cost of being slightly slower.
+        Must be the first clause in the QueryBuilder object.
+
+        Parameters
+        ----------
+        date_range: `DateRangeInput`
+            A date range in the same format as accepted by the read method.
+
+        Examples
+        --------
+
+        >>> q = QueryBuilder()
+        >>> q = q.date_range((pd.Timestamp("2000-01-01"), pd.Timestamp("2001-01-01")))
+
+        Returns
+        -------
+        QueryBuilder
+            Modified QueryBuilder object.
+        """
+        check(not len(self.clauses), "Date range only supported as first clause in the pipeline")
+        start, end = normalize_dt_range_to_ts(date_range)
+        self.clauses.append(_DateRangeClause(start.value, end.value))
+        self._python_clauses.append(PythonDateRangeClause(start.value, end.value))
         return self
 
     def __eq__(self, right):
@@ -568,7 +624,14 @@ class QueryBuilder:
                 clause.set_pipeline_optimisation(_Optimisation.MEMORY)
 
     def needs_post_processing(self):
-        return not any(isinstance(clause, _RowRangeClause) for clause in self.clauses)
+        return not any(isinstance(clause, (_RowRangeClause, _DateRangeClause)) for clause in self.clauses)
+
+    def has_date_range_clause(self):
+        return len(self.clauses) and isinstance(self.clauses[0], _DateRangeClause)
+
+    def date_range_boundaries(self):
+        check(self.has_date_range_clause(), "QueryBuilder has no date_range clause")
+        return self.clauses[0].start, self.clauses[0].end
 
 
 CONSTRUCTOR_MAP = {

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -29,6 +29,7 @@ from arcticdb.exceptions import (
     StreamDescriptorMismatch,
     UserInputException,
 )
+from arcticdb import QueryBuilder
 from arcticdb.flattener import Flattener
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer
@@ -489,45 +490,73 @@ def test_range_index(lmdb_version_store, sym):
     assert_frame_equal(expected, vit.data)
 
 
-def test_date_range(lmdb_version_store):
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_date_range(lmdb_version_store, use_date_range_clause):
     initial_timestamp = pd.Timestamp("2019-01-01")
     df = pd.DataFrame(data=np.arange(100), index=pd.date_range(initial_timestamp, periods=100))
     sym = "date_test"
     lmdb_version_store.write(sym, df)
     start_offset = 2
     end_offset = 5
+
     query_start_ts = initial_timestamp + pd.DateOffset(start_offset)
     query_end_ts = initial_timestamp + pd.DateOffset(end_offset)
 
     # Should return everything from given start to end of the index
-    data_start = lmdb_version_store.read(sym, date_range=(query_start_ts, None)).data
+    date_range = (query_start_ts, None)
+    if use_date_range_clause:
+        q = QueryBuilder()
+        q = q.date_range(date_range)
+        data_start = lmdb_version_store.read(sym, query_builder=q).data
+    else:
+        data_start = lmdb_version_store.read(sym, date_range=date_range).data
     assert query_start_ts == data_start.index[0]
     assert data_start[data_start.columns[0]][0] == start_offset
 
     # Should return everything from start of index to the given end.
-    data_end = lmdb_version_store.read(sym, date_range=(None, query_end_ts)).data
+    date_range = (None, query_end_ts)
+    if use_date_range_clause:
+        q = QueryBuilder()
+        q = q.date_range(date_range)
+        data_end = lmdb_version_store.read(sym, query_builder=q).data
+    else:
+        data_end = lmdb_version_store.read(sym, date_range=date_range).data
     assert query_end_ts == data_end.index[-1]
     assert data_end[data_end.columns[0]][-1] == end_offset
 
-    data_closed = lmdb_version_store.read(sym, date_range=(query_start_ts, query_end_ts)).data
+    date_range = (query_start_ts, query_end_ts)
+    if use_date_range_clause:
+        q = QueryBuilder()
+        q = q.date_range(date_range)
+        data_closed = lmdb_version_store.read(sym, query_builder=q).data
+    else:
+        data_closed = lmdb_version_store.read(sym, date_range=date_range).data
     assert query_start_ts == data_closed.index[0]
     assert query_end_ts == data_closed.index[-1]
     assert data_closed[data_closed.columns[0]][0] == start_offset
     assert data_closed[data_closed.columns[0]][-1] == end_offset
 
 
-def test_date_range_none(lmdb_version_store):
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_date_range_none(lmdb_version_store, use_date_range_clause):
     sym = "date_test2"
     rows = 100
     initial_timestamp = pd.Timestamp("2019-01-01")
     df = pd.DataFrame(data=np.arange(rows), index=pd.date_range(initial_timestamp, periods=100))
     lmdb_version_store.write(sym, df)
+    date_range = (None, None)
     # Should just return everything
-    data = lmdb_version_store.read(sym, date_range=(None, None)).data
+    if use_date_range_clause:
+        q = QueryBuilder()
+        q = q.date_range(date_range)
+        data = lmdb_version_store.read(sym, query_builder=q).data
+    else:
+        data = lmdb_version_store.read(sym, date_range=(None, None)).data
     assert len(data) == rows
 
 
-def test_date_range_start_equals_end(lmdb_version_store):
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_date_range_start_equals_end(lmdb_version_store, use_date_range_clause):
     sym = "date_test2"
     rows = 100
     initial_timestamp = pd.Timestamp("2019-01-01")
@@ -535,10 +564,45 @@ def test_date_range_start_equals_end(lmdb_version_store):
     lmdb_version_store.write(sym, df)
     start_offset = 2
     query_start_ts = initial_timestamp + pd.DateOffset(start_offset)
+    date_range = (query_start_ts, query_start_ts)
     # Should just return everything
-    data = lmdb_version_store.read(sym, date_range=(query_start_ts, query_start_ts)).data
+    if use_date_range_clause:
+        q = QueryBuilder()
+        q = q.date_range(date_range)
+        data = lmdb_version_store.read(sym, query_builder=q).data
+    else:
+        data = lmdb_version_store.read(sym, date_range=date_range).data
     assert len(data) == 1
     assert data[data.columns[0]][0] == start_offset
+
+
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_date_range_row_sliced(lmdb_version_store_tiny_segment, use_date_range_clause):
+    lib = lmdb_version_store_tiny_segment
+    sym = "test_date_range_row_sliced"
+    # lmdb_version_store_tiny_segment produces 2x2 segments
+    num_rows = 6
+    index = pd.date_range("2000-01-01", periods=num_rows, freq="D")
+    df = pd.DataFrame({"col": np.arange(num_rows)}, index=index)
+    lib.write(sym, df)
+
+    expected = df.iloc[1:-1]
+
+    date_range = (index[1], index[-2])
+    if use_date_range_clause:
+        q = QueryBuilder()
+        q = q.date_range(date_range)
+        received = lib.read(sym, query_builder=q).data
+    else:
+        received = lib.read(sym, date_range=date_range).data
+    assert_frame_equal(expected, received)
+
+    date_range = (index[0] + pd.Timedelta(12, unit="h"), index[-1] - pd.Timedelta(12, unit="h"))
+    if use_date_range_clause:
+        received = lib.read(sym, query_builder=q).data
+    else:
+        received = lib.read(sym, date_range=date_range).data
+    assert_frame_equal(expected, received)
 
 
 def test_get_info(lmdb_version_store):
@@ -1850,7 +1914,8 @@ def test_batch_append(lmdb_version_store_tombstone, three_col_df):
         assert vit.metadata == append_metadata[sym]
 
 
-def test_batch_read_date_range(lmdb_version_store_tombstone_and_sync_passive):
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_batch_read_date_range(lmdb_version_store_tombstone_and_sync_passive, use_date_range_clause):
     lmdb_version_store = lmdb_version_store_tombstone_and_sync_passive
     symbols = []
     for i in range(5):
@@ -1872,7 +1937,15 @@ def test_batch_read_date_range(lmdb_version_store_tombstone_and_sync_passive):
         date_range = pd.date_range(base_date + pd.DateOffset(j + 100), periods=500)
         date_ranges.append(date_range)
 
-    result_dict = lmdb_version_store.batch_read(symbols, date_ranges=date_ranges)
+    if use_date_range_clause:
+        qbs = []
+        for date_range in date_ranges:
+            q = QueryBuilder()
+            q = q.date_range(date_range)
+            qbs.append(q)
+        result_dict = lmdb_version_store.batch_read(symbols, query_builder=qbs)
+    else:
+        result_dict = lmdb_version_store.batch_read(symbols, date_ranges=date_ranges)
     for x, sym in enumerate(result_dict.keys()):
         vit = result_dict[sym]
         date_range = date_ranges[x]

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -7,6 +7,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 import numpy as np
 import pandas as pd
+import pytest
 
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.util.test import assert_frame_equal
@@ -31,6 +32,87 @@ def test_reuse_querybuilder(lmdb_version_store_tiny_segment):
     received = lib.read(symbol, query_builder=q).data
 
     expected["new_col"] = (expected["col1"] * expected["col2"]) + 13
+    assert_frame_equal(expected, received)
+
+
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_querybuilder_date_range_then_filter(lmdb_version_store_tiny_segment, use_date_range_clause):
+    lib = lmdb_version_store_tiny_segment
+    symbol = "test_querybuilder_date_range_then_filter"
+    df = pd.DataFrame(
+        {"col1": np.arange(10), "col2": np.arange(100, 110)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(symbol, df)
+
+    date_range = (pd.Timestamp("2000-01-04"), pd.Timestamp("2000-01-07"))
+
+    q = QueryBuilder()
+    if use_date_range_clause:
+        q = q.date_range(date_range)
+    q = q[q["col1"].isin(0, 3, 6, 9)]
+
+    if use_date_range_clause:
+        received = lib.read(symbol, query_builder=q).data
+    else:
+        received = lib.read(symbol, date_range=date_range, query_builder=q).data
+    expected = df.query("col1 in [3, 6]")
+    assert_frame_equal(expected, received)
+
+
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_querybuilder_date_range_then_project(lmdb_version_store_tiny_segment, use_date_range_clause):
+    lib = lmdb_version_store_tiny_segment
+    symbol = "test_querybuilder_date_range_then_project"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)},
+        index=pd.date_range("2000-01-01", periods=10),
+    )
+    lib.write(symbol, df)
+
+    date_range = (pd.Timestamp("2000-01-04"), pd.Timestamp("2000-01-07"))
+
+    q = QueryBuilder()
+    if use_date_range_clause:
+        q = q.date_range(date_range)
+    q = q.apply("new_col", (q["col1"] * q["col2"]) + 13)
+
+    if use_date_range_clause:
+        received = lib.read(symbol, query_builder=q).data
+    else:
+        received = lib.read(symbol, date_range=date_range, query_builder=q).data
+    expected = df.iloc[3:-3]
+    expected["new_col"] = expected["col1"] * expected["col2"] + 13
+    assert_frame_equal(expected, received)
+
+
+@pytest.mark.parametrize("use_date_range_clause", [True, False])
+def test_querybuilder_date_range_then_groupby(lmdb_version_store_tiny_segment, use_date_range_clause):
+    lib = lmdb_version_store_tiny_segment
+    symbol = "test_querybuilder_date_range_then_groupby"
+    df = pd.DataFrame(
+        {
+            "col1": ["a", "b", "c", "a", "b", "c", "a", "b", "c", "d"],
+            "col2": [1, 2, 3, 2, 1, 3, 1, 1, 3, 4],
+        },
+        index=pd.date_range("2000-01-01", periods=10),
+    )
+    lib.write(symbol, df)
+
+    date_range = (pd.Timestamp("2000-01-04"), pd.Timestamp("2000-01-07"))
+
+    q = QueryBuilder()
+    if use_date_range_clause:
+        q = q.date_range(date_range)
+    q = q.groupby("col1").agg({"col2": "sum"})
+
+    if use_date_range_clause:
+        received = lib.read(symbol, query_builder=q).data
+    else:
+        received = lib.read(symbol, date_range=date_range, query_builder=q).data
+    received.sort_index(inplace=True)
+
+    expected = df.iloc[3:-3]
+    expected = expected.groupby("col1").agg({"col2": "sum"})
     assert_frame_equal(expected, received)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #558 
Closes #529
Closes #556 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

This PR adds a `date_range` clause to the `QueryBuilder` class. This can be used in place of the `date_range` arg to `read`-like methods. In this case, the output data will be the same, but there are more `memcpy`s involved, so it will be slightly slower, but with the advantage that the memory footprint of the returned dataframe will be smaller.

In addition, this means that filtering, projections, groupbys and aggregations now all work with the `date_range` parameter.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
