### PR TITLE
top-k initial cpp implementation

### DIFF
--- a/cpp/arcticdb/entity/data_error.hpp
+++ b/cpp/arcticdb/entity/data_error.hpp
@@ -25,30 +25,32 @@ enum class VersionRequestType: uint32_t {
 class DataError {
 public:
     DataError(const StreamId& symbol,
-              const pipelines::VersionQueryType& version_query_type,
               std::string&& exception_string,
+              const std::optional<pipelines::VersionQueryType>& version_query_type=std::nullopt,
               std::optional<ErrorCode> error_code=std::nullopt) :
         symbol_(symbol),
         exception_string_(exception_string),
         error_code_(error_code){
-        util::variant_match(
-                version_query_type,
-                [this] (const pipelines::SnapshotVersionQuery& query) {
-                    version_request_type_ = VersionRequestType::SNAPSHOT;
-                    version_request_data_ = query.name_;
-                },
-                [this] (const pipelines::TimestampVersionQuery& query) {
-                    version_request_type_ = VersionRequestType::TIMESTAMP;
-                    version_request_data_ = query.timestamp_;
-                },
-                [this] (const pipelines::SpecificVersionQuery& query) {
-                    version_request_type_ = VersionRequestType::SPECIFIC;
-                    version_request_data_ = query.version_id_;
-                },
-                [this] (const std::monostate&) {
-                    version_request_type_ = VersionRequestType::LATEST;
-                }
-        );
+        if (version_query_type.has_value()){
+            util::variant_match(
+                    *version_query_type,
+                    [this] (const pipelines::SnapshotVersionQuery& query) {
+                        version_request_type_ = VersionRequestType::SNAPSHOT;
+                        version_request_data_ = query.name_;
+                    },
+                    [this] (const pipelines::TimestampVersionQuery& query) {
+                        version_request_type_ = VersionRequestType::TIMESTAMP;
+                        version_request_data_ = query.timestamp_;
+                    },
+                    [this] (const pipelines::SpecificVersionQuery& query) {
+                        version_request_type_ = VersionRequestType::SPECIFIC;
+                        version_request_data_ = query.version_id_;
+                    },
+                    [this] (const std::monostate&) {
+                        version_request_type_ = VersionRequestType::LATEST;
+                    }
+            );
+        }
     }
 
     DataError() = delete;
@@ -63,11 +65,11 @@ public:
         return fmt::format("{}", symbol_);
     }
 
-    VersionRequestType version_request_type() const {
+    std::optional<VersionRequestType>  version_request_type() const {
         return version_request_type_;
     }
 
-    std::variant<std::monostate, int64_t, std::string> version_request_data() const {
+    std::optional<std::variant<std::monostate, int64_t, std::string>> version_request_data() const {
         return version_request_data_;
     }
 
@@ -84,24 +86,26 @@ public:
     }
 
     std::string to_string() const {
-        std::string version_request_explanation;
-        switch (version_request_type_) {
-            case VersionRequestType::SNAPSHOT:
-                version_request_explanation = fmt::format("in snapshot '{}'", std::get<std::string>(version_request_data_));
-                break;
-            case VersionRequestType::TIMESTAMP:
-                version_request_explanation = fmt::format("at time '{}'", std::get<int64_t>(version_request_data_));
-                break;
-            case VersionRequestType::SPECIFIC:
-                version_request_explanation = fmt::format("with specified version '{}'", std::get<int64_t>(version_request_data_));
-                break;
-            case VersionRequestType::LATEST:
-                version_request_explanation = fmt::format("with specified version 'latest'");
-                break;
-            default:
-                internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
-                        "Unexpected enum value in DataError::to_string: {}",
-                        static_cast<uint32_t>(version_request_type_));
+        std::string version_request_explanation = "UNKNOWN";
+        if (version_request_type_.has_value()) {
+            switch (*version_request_type_) {
+                case VersionRequestType::SNAPSHOT:
+                    version_request_explanation = fmt::format("in snapshot '{}'", std::get<std::string>(*version_request_data_));
+                    break;
+                case VersionRequestType::TIMESTAMP:
+                    version_request_explanation = fmt::format("at time '{}'", std::get<int64_t>(*version_request_data_));
+                    break;
+                case VersionRequestType::SPECIFIC:
+                    version_request_explanation = fmt::format("with specified version '{}'", std::get<int64_t>(*version_request_data_));
+                    break;
+                case VersionRequestType::LATEST:
+                    version_request_explanation = fmt::format("with specified version 'latest'");
+                    break;
+                default:
+                    internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
+                            "Unexpected enum value in DataError::to_string: {}",
+                            static_cast<uint32_t>(*version_request_type_));
+            }
         }
         return fmt::format(
                 "Version {} of symbol '{}' unable to be retrieved: Error Category: '{}' Exception String: '{}'",
@@ -112,9 +116,9 @@ public:
     }
 private:
     StreamId symbol_;
-    VersionRequestType version_request_type_{VersionRequestType::LATEST};
+    std::optional<VersionRequestType> version_request_type_;
     // int64_t for timestamp and SignedVersionId
-    std::variant<std::monostate, int64_t, std::string> version_request_data_;
+    std::optional<std::variant<std::monostate, int64_t, std::string>> version_request_data_;
     std::string exception_string_;
     std::optional<ErrorCode> error_code_;
 };

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -16,6 +16,7 @@
 #include <pybind11/numpy.h>
 
 namespace arcticdb::convert {
+const char none_char[8] = {'\300', '\000', '\000', '\000', '\000', '\000', '\000', '\000'};
 
 using namespace arcticdb::pipelines;
 
@@ -149,6 +150,39 @@ InputTensorFrame py_ndf_to_frame(
         res.desc.add_field(scalar_field(tensor.data_type(), col_names[i]));
         res.field_tensors.push_back(std::move(tensor));
     }
+
+    ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res.desc);
+    res.set_index_range();
+    return res;
+}
+
+InputTensorFrame py_none_to_frame() {
+    ARCTICDB_SUBSAMPLE_DEFAULT(NormalizeNoneFrame)
+    InputTensorFrame res;
+    res.num_rows = 0u;
+
+    arcticdb::proto::descriptors::NormalizationMetadata::MsgPackFrame msg;
+    msg.set_size_bytes(1);
+    msg.set_version(1);
+    res.norm_meta.mutable_msg_pack_frame()->CopyFrom(msg);
+
+    // Fill index
+    res.index = stream::RowCountIndex();
+    res.desc.set_index_type(IndexDescriptor::ROWCOUNT);
+
+    // Fill tensors
+    auto col_name = "bytes";
+    auto sorted = SortedValue::UNKNOWN;
+
+    res.set_sorted(sorted);
+
+    ssize_t strides = 8;
+    ssize_t shapes = 1;
+
+    auto tensor = NativeTensor{8, 1, &strides, &shapes, DataType::UINT64, 8, none_char};
+    res.num_rows = std::max(res.num_rows, tensor.shape(0));
+    res.desc.add_field(scalar_field(tensor.data_type(), col_name));
+    res.field_tensors.push_back(std::move(tensor));
 
     ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res.desc);
     res.set_index_range();

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -48,4 +48,6 @@ pipelines::InputTensorFrame py_ndf_to_frame(
     const py::object &norm_meta,
     const py::object &user_meta);
 
+pipelines::InputTensorFrame py_none_to_frame();
+
 } // namespace arcticdb::convert

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -271,6 +271,11 @@ public:
         bool validate_index
     );
 
+    std::vector<std::variant<VersionedItem, DataError>> batch_write_versioned_metadata_internal(
+        const std::vector<StreamId>& stream_ids,
+        bool prune_previous_versions,
+        std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>&& user_meta_protos);
+
     std::vector<AtomKey> batch_append_internal(
         std::vector<VersionId> version_ids,
         const std::vector<StreamId>& stream_ids,
@@ -355,9 +360,10 @@ public:
 
     folly::Future<VersionedItem> write_index_key_to_version_map_async(
         const std::shared_ptr<VersionMap> &version_map,
-        const AtomKey&& index_key,
-        const UpdateInfo& stream_update_info,
-        bool prune_previous_versions);
+        AtomKey&& index_key,
+        UpdateInfo&& stream_update_info,
+        bool prune_previous_versions,
+        bool add_new_symbol);
 
     std::vector<folly::Future<folly::Unit>> batch_write_version_and_prune_if_needed(
         const std::vector<AtomKey>& index_keys,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -298,6 +298,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def(py::init<std::string, std::unordered_map<std::string, std::string>>())
             .def("__str__", &AggregationClause::to_string);
 
+    py::class_<TopKClause, std::shared_ptr<TopKClause>>(version, "TopKClause")
+            .def(py::init<std::vector<float_t>, uint8_t>());
+
     py::class_<ReadQuery>(version, "PythonVersionStoreReadQuery")
             .def(py::init())
             .def_readwrite("columns",&ReadQuery::columns)
@@ -309,7 +312,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
                     std::vector<std::variant<std::shared_ptr<FilterClause>,
                                 std::shared_ptr<ProjectClause>,
                                 std::shared_ptr<GroupByClause>,
-                                std::shared_ptr<AggregationClause>>> clauses) {
+                                std::shared_ptr<AggregationClause>,
+                                std::shared_ptr<TopKClause>>> clauses) {
                 std::vector<std::shared_ptr<Clause>> _clauses;
                 for (auto&& clause: clauses) {
                     util::variant_match(

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -237,8 +237,6 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def_property_readonly("end", &pipelines::ColRange::end)
         .def_property_readonly("diff", &pipelines::ColRange::diff);
 
-
-
     auto adapt_read_dfs = [](std::vector<std::variant<ReadResult, DataError>> && ret) -> py::list {
         py::list lst;
         for (auto &res: ret) {

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -45,8 +45,7 @@ struct LoadParameter {
     }
 
     LoadParameter(LoadType load_type, int64_t load_from_time_or_until) :
-        load_type_(load_type),
-        load_from_time_(load_from_time_or_until) {
+        load_type_(load_type) {
         switch(load_type_) {
             case LoadType::LOAD_FROM_TIME:
                 load_from_time_ = load_from_time_or_until;
@@ -68,8 +67,10 @@ struct LoadParameter {
     bool iterate_on_failure_ = false;
 
     void validate() const {
-        util::check(load_type_ == LoadType::LOAD_DOWNTO ? static_cast<bool>(load_until_) : !static_cast<bool>(load_until_),
+        util::check((load_type_ == LoadType::LOAD_DOWNTO) == load_until_.has_value(),
                     "Invalid load parameter: load_type {} with load_util {}", int(load_type_), load_until_.value_or(VersionId{}));
+        util::check((load_type_ == LoadType::LOAD_FROM_TIME) == load_from_time_.has_value(),
+            "Invalid load parameter: load_type {} with load_from_time_ {}", int(load_type_), load_from_time_.value_or(timestamp{}));
     }
 };
 
@@ -296,7 +297,7 @@ struct VersionMapEntry {
     void check_stream_id() const {
         if (empty())
             return;
-        
+
         std::unordered_map<StreamId, std::vector<VersionId>> id_to_version_id;
         if (head_)
             id_to_version_id[head_.value().id()].push_back(head_.value().version_id());

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -269,8 +269,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         bool prune_previous_versions,
         bool validate_index);
 
-    std::vector<VersionedItem> batch_write_metadata(
-        std::vector<StreamId> stream_ids,
+    std::vector<std::variant<VersionedItem, DataError>> batch_write_metadata(
+        const std::vector<StreamId>& stream_ids,
         const std::vector<py::object>& user_meta,
         bool prune_previous_versions);
 

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -109,7 +109,10 @@ if PY3:
     def _accept_array_string(v):
         # TODO remove this once arctic keeps the string type under the hood
         # and does not transform string into bytes
-        return isinstance(v, string_types) or isinstance(v, binary_type)
+        # string_types and binary_type can be a single type or a tuple
+        supported_string_types = string_types if isinstance(string_types, tuple) else (string_types,)
+        supported_binary_types = binary_type if isinstance(binary_type, tuple) else (binary_type,)
+        return type(v) in supported_string_types or type(v) in supported_binary_types
 
 else:
 

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -32,6 +32,8 @@ from arcticdb.exceptions import ArcticNativeException, LibraryNotFound
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.authorization.permissions import OpenMode
 
+from numpy.linalg import norm
+
 
 def create_lib_from_config(cfg, env=Defaults.ENV, lib_name=Defaults.LIB):
     return NativeVersionStore.create_lib_from_config(cfg, env, lib_name)
@@ -402,3 +404,6 @@ def get_arctic_native_lib(lib_fqn):
         raise LibraryNotFound(lib_fqn)
     lib, path = m.group(1), m.group(2)
     return ArcticFileConfig(config_path=path)[lib]
+
+def euclidean(x, y):
+    return norm(x-y)

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -11,10 +11,11 @@ from enum import Enum, auto
 from typing import Optional, Any, Tuple, Dict, AnyStr, Union, List, Iterable, NamedTuple
 from numpy import datetime64
 
-from arcticdb.supported_types import Timestamp
+from arcticdb.supported_types import Timestamp, numeric_types
 
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.version_store._store import NativeVersionStore, VersionedItem, VersionQueryInput
+from arcticdb.version_store.helper import euclidean
 from arcticdb_ext.exceptions import ArcticException
 from arcticdb_ext.version_store import DataError
 import pandas as pd
@@ -29,6 +30,7 @@ AsOf = Union[int, str, datetime.datetime]
 
 NORMALIZABLE_TYPES = (pd.DataFrame, pd.Series, np.ndarray)
 
+VECTOR_DATABASE = "VECTOR_DATABASE" # this will have to be made better distinguished somehow.
 
 NormalizableType = Union[NORMALIZABLE_TYPES]
 """Types that can be normalised into Arctic's internal storage structure.
@@ -51,6 +53,8 @@ class ArcticDuplicateSymbolsInBatchException(ArcticInvalidApiUsageException):
 class ArcticUnsupportedDataTypeException(ArcticInvalidApiUsageException):
     """Exception indicating that a method does not support the type of data provided."""
 
+class ArcticWriteToDistinguishedSymbolException(ArcticInvalidApiUsageException):
+    """Exception indicating that the symbol provided has a distinguished name and may not be written to."""
 
 class SymbolVersion(NamedTuple):
     """A named tuple. A symbol name - version pair.
@@ -227,6 +231,7 @@ class StagedDataFinalizeMethod(Enum):
     APPEND = auto()
 
 
+
 class Library:
     """
     The main interface exposing read/write functionality within a given Arctic instance.
@@ -257,6 +262,7 @@ class Library:
         self.arctic_instance_desc = arctic_instance_description
         self._nvs = nvs
         self._nvs._normalizer.df._skip_df_consolidation = True
+        self._vector_dimension = None
 
     def __repr__(self):
         return "Library(%s, path=%s, storage=%s)" % (
@@ -270,6 +276,146 @@ class Library:
 
     def __contains__(self, symbol: str):
         return self.has_symbol(symbol)
+
+    def insert_vectors(
+        self,
+        df: pd.DataFrame,
+        metadata: Any = None,
+        prune_previous_versions: bool = False,
+        staged=False,
+        validate_index=True,
+    ) -> None:
+        """
+        Writes vectors to a library. Takes `pandas.DataFrame`s. Once the first
+        vectors are inserted, their shape is fixed. Note that we use the column
+        names effectively as keys.
+
+        Parameters
+        ==========
+
+        df : pandas.DataFrame
+            The `pandas.DataFrame` containing the vectors to be written to the library.
+        metadata : Any, default=None
+        prune_previous_versions : bool, default=False
+        staged : bool, default=False
+        validate_index: bool, default=False
+            See write.
+
+        Returns
+        =======
+
+        None
+
+        Raises
+        ======
+
+        ArcticUnsupportedDataTypeException
+            if df is not a `pandas.dataFrame`, or  any of its columns have
+            non-numeric type.
+        ArcticException
+            if an attempt is made to insert vectors of a different shape from
+            those previously inserted.
+        """
+        if not isinstance(df, pd.DataFrame):
+            raise ArcticUnsupportedDataTypeException(
+                "To insert vectors into a library, they must be in a pandas"
+                "DataFrame with a column labelled 'vectors' containing the vectors"
+                "in numpy arrays of fixed size."
+            )
+        if any([type not in numeric_types for type in df.dtypes.unique()]):
+            raise ArcticUnsupportedDataTypeException(
+                "Vectors must comprise numeric types. You attempted to insert "
+                f"{df.dtypes.unique()}, one of which does not count."
+            )
+        if not self._vector_dimension:
+            self._vector_dimension = df.shape[0]
+        if self._vector_dimension != df.shape[0]:
+            raise ArcticException(
+                f"Library {self.name} has been initialised with vectors"
+                f"of {self._vector_dimension} dimensions, but you attempted to"
+                f"vectors of size {df.shape[0]}."
+            )
+        return self._nvs.write(
+            symbol=VECTOR_DATABASE,
+            data=df,
+            metadata=metadata,
+            prune_previous_version=prune_previous_versions,
+            pickle_on_failure=False,
+            parallel=staged,
+            validate_index=validate_index,
+        )
+
+    def top_k(
+        self,
+        k: int,
+        query: np.ndarray,
+        method: str = "euclidean",
+        show_similarity: bool = "false",
+        show_vectors: bool = "false"
+    ) -> pd.DataFrame:
+        """
+        Returns the top k most similar vectors in a library by `method`.
+
+        Parameters
+        ==========
+
+        k : int
+            The number of vectors to return.
+        query : np.ndarray
+            A numpy array representing the query.
+        method : str
+            Choice of method for computing distance. Must be "euclidean" presently.
+        show_similarity : bool
+            Choice of whether to show similarity in the output dataframe.
+        show_vectors : bool
+            Choice of whether to show the vectors themselves or merely their keys.
+
+        Returns
+        =======
+
+        pandas.DataFrame
+
+        Examples
+        ========
+
+        >>> df = pd.DataFrame(np.random.rand(10, 10))
+        >>> query = np.zeros(10)
+        >>> lib.insert_vectors(df, columns = np.arange(10))  # default made explicit here.
+        >>> lib.top_k(
+        >>>     k=5,
+        >>>     query=query,
+        >>>     method="euclidean",
+        >>>     show_similarity="True"
+        >>>     show_vectors="True"
+        >>> )
+        >>>            8    2    4    7    9
+        >>>          0 .001 .003 .004 .008 .009
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>>          0 .000 .000 .000 .000 .000
+        >>> similarity .001 .003 .004 .008 .009
+        """
+        if method == "euclidean":
+            def compare(x):
+                return euclidean(query,x)
+        else:
+            raise NotImplementedError(
+                "Distance methods other than 'euclidean' are unsupported."
+            )
+        df = self.read(VECTOR_DATABASE).data
+        klargest = df.apply(compare).nlargest(k).rename("similarity")
+        result = pd.DataFrame(columns=klargest.index)
+        if show_vectors:
+             result = df[klargest.index]
+        if show_similarity:
+            result = result.append(klargest)
+        return result
 
     def write(
         self,
@@ -370,6 +516,12 @@ class Library:
             raise ArcticUnsupportedDataTypeException(
                 "data is of a type that cannot be normalized. Consider using "
                 f"write_pickle instead. type(data)=[{type(data)}]"
+            )
+
+        if symbol == VECTOR_DATABASE:
+            raise ArcticWriteToDistinguishedSymbolException(
+                f"The symbol {VECTOR_DATABASE} is reserved for internal use "
+                "and may not be written to by users."
             )
 
         return self._nvs.write(

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -24,7 +24,6 @@ from arcticdb_ext.version_store import FilterClause as _FilterClause
 from arcticdb_ext.version_store import ProjectClause as _ProjectClause
 from arcticdb_ext.version_store import GroupByClause as _GroupByClause
 from arcticdb_ext.version_store import AggregationClause as _AggregationClause
-from arcticdb_ext.version_store import TopKClause as _TopKClause
 from arcticdb_ext.version_store import ExpressionName as _ExpressionName
 from arcticdb_ext.version_store import ColumnName as _ColumnName
 from arcticdb_ext.version_store import ValueName as _ValueName
@@ -468,11 +467,6 @@ class QueryBuilder:
         """
         self.clauses.append(_GroupByClause(name))
         self._python_clauses.append(PythonGroupByClause(name))
-        return self
-
-    def top_k(self, vector: List[float], k: int):
-        self.clauses.append(_TopKClause(vector, k))
-        self._python_clauses.append(PythonTopKClause(vector, k))
         return self
 
     def agg(self, aggregations: Dict[str, str]):

--- a/python/arcticdb/version_store/vector_db.py
+++ b/python/arcticdb/version_store/vector_db.py
@@ -1,0 +1,188 @@
+import warnings
+from typing import Union, Dict, Optional, Iterable
+
+
+import pandas as pd
+import numpy as np
+
+from collections.abc import Mapping
+from collections import namedtuple
+
+from arcticdb.supported_types import Timestamp, numeric_types
+from arcticdb.version_store.library import Library, ArcticUnsupportedDataTypeException
+
+from arcticdb.version_store.processing import QueryBuilder
+from arcticdb_ext.version_store import TopKClause as _TopKClause
+
+VECTOR_DB_DISTINGUISHED_PREFIX = "vector_db_"
+
+VECTOR_VALUE_ERROR = "Vectors uploaded as dictionaries must be " \
+                     "in the form of dictionaries with keys that are " \
+                     "string identifiers and values that are " \
+                     "dictionaries containing in turn " \
+                     "at least an entry under 'values' containing " \
+                     "something that can be coerced to an `np.ndarray` " \
+                     "of floats of one dimension."
+
+PythonTopKClause = namedtuple("TopKClause", ["vector", "k"])
+
+
+class VectorDB:
+    """
+    The main interface exposing vector database functionality in a given Arctic instance.
+
+    VectorDBs contain namespaces which are the atomic unit of vector storage. Namespaces
+    support upsertion and top-k queries.
+    """
+
+    def __init__(self, library: Library):
+        """
+        Parameters
+        ----------
+        library
+            The library in which vectors will be stored. See `Arctic.create_library`.
+        dimensions
+            The number of dimensions those vectors should have.
+        """
+        self._lib = library
+        self._dimensions = dict()  # dimensionality of vectors in each sym
+
+    def __repr__(self):
+        return f"VectorDB({str(self._lib)})"
+
+    def __contains__(self, namespace: str):
+        return f"{VECTOR_DB_DISTINGUISHED_PREFIX}{namespace}" in self._lib
+
+    def upsert(
+            self,
+            namespace: str,
+            vectors: Union[Dict[str, Dict[str, any]], pd.DataFrame, np.ndarray],
+            identifiers: Optional[Iterable[str]] = None,
+            metadata: Optional[Dict[str, Dict]] = None
+    ) -> None:
+        """
+        Parameters
+        ----------
+        namespace
+            The namespace to which `vectors` should be upserted.
+        vectors
+            In the case of a dictionary, we expect a dictionary whose keys are strings
+            (taken as identifiers of vectors), and whose values are in turn dictionaries
+            minimally containing a key-value pair 'value' pointing to something that
+            yields a one-dimensional `np.ndarray` of numeric types corresponding to a
+            vector. Each vector must have the same dimensionality.
+
+            In the case of a pandas DataFrame, we expect string columns and the entries to
+            all be of a numeric type.
+
+            In the case of an ndarray, we expect a list of `identifiers` corresponding to
+            the number of vectors. We also expect an `np.ndarray` of `np.ndarray`s
+            (i.e. two dimensions) populated by numeric types. Note that upserting an
+            `np.ndarray` corresponds to upserting the transpose of the equivalent
+            `pd.DataFrame`. For example:
+
+            >>> vdb.upsert("vdb", np.array([[0,1],[2,3]]), identifiers=["a", "b"])
+
+            inserts vectors <0,1> and <2,3>, but
+
+            >>> vdb.upsert("vdb", pd.DataFrame(np.array([0,1],[2,3])))
+
+            inserts vectors <0,2> and <1,3>.
+        """
+        if metadata:
+            warnings.warn("Metadata are presently ignored.")
+        data_frame_to_upsert = None
+        symbol_name = f"{VECTOR_DB_DISTINGUISHED_PREFIX}{namespace}"
+        dimensions = self._dimensions.get(namespace)
+        if symbol_name in self._lib:
+            raise NotImplementedError
+        else:  # namespace not in self.lib
+            if isinstance(vectors, Mapping):
+                data_frame_to_upsert = pd.DataFrame()
+                for k, v in vectors.items():
+                    if type(k) is not str:
+                        raise ArcticUnsupportedDataTypeException(VECTOR_VALUE_ERROR)
+                    if "vectors" not in v.keys():
+                        raise ValueError()
+                    column = np.array(v)
+                    if column.ndim != 1:
+                        raise ValueError(VECTOR_VALUE_ERROR)
+                    if column.dtype not in numeric_types:
+                        raise ArcticUnsupportedDataTypeException(
+                            "Vectors inserted must all have a numeric type. You attempted to "
+                            f"insert a vector that as an np.array has dtype {column.dtype}, "
+                            "which does count."
+                        )
+                    if not dimensions:
+                        self._dimensions[namespace] = column.shape[0]
+                        dimensions = column.shape[0]
+                    elif column.shape[0] != dimensions:
+                        raise ValueError("The vectors must all have the same number "
+                                         "of dimensions.")
+                    data_frame_to_upsert[k] = column.astype(np.float32)
+            elif isinstance(vectors, pd.DataFrame):
+                if any([t not in numeric_types for t in vectors.dtypes.unique()]):
+                    raise ArcticUnsupportedDataTypeException(
+                        "Vectors inserted must all have a numeric type. You attempted to "
+                        f"insert {vectors.dtypes.unique()}, at least one of which does "
+                        "count."
+                    )
+                self._dimensions[namespace] = vectors.shape[0]
+                data_frame_to_upsert = vectors.astype(np.float32)
+            elif isinstance(vectors, np.ndarray):
+                if vectors.ndim != 2:
+                    raise ValueError("Upsertion of vectors in an `np.ndarray` takes "
+                                     "two-dimensional arrays; the parameter `vector` had "
+                                     f"{vectors.ndim} instead.")
+                if any([type not in numeric_types for type in vectors.dtypes.unique()]):
+                    raise ArcticUnsupportedDataTypeException(
+                        "Vectors inserted must all have a numeric type. You attempted to "
+                        f"insert {vectors.dtypes.unique()}, at least one of which does "
+                        "count."
+                    )
+                if not identifiers:
+                    raise ValueError("Upsertion of vectors in an `np.ndarray` requires "
+                                     "a list of identifiers.")
+                if len(identifiers) != len(vectors):
+                    raise ValueError(f"You gave {len(identifiers)} identifiers but "
+                                     f"{len(vectors)} vectors.")
+                if any([type(identifier) is not str for identifier in identifiers]):
+                    raise ValueError(f"All identifiers must be strings.")
+                self._dimensions[namespace] = vectors.shape[1]
+                data_frame_to_upsert = pd.DataFrame(vectors.T, columns=identifiers)
+            else:
+                raise ArcticUnsupportedDataTypeException(
+                    f"Upsertion of vectors of type {type(vectors)} is unsupported."
+                )
+        self._lib.write(
+            symbol_name,
+            data_frame_to_upsert)
+
+    def top_k(
+            self,
+            namespace: str,
+            k: int,
+            query_vector: Iterable[float],
+            norm: Optional[str] = None,
+            index: Optional[str] = None
+    ) -> pd.DataFrame:
+        if k < 1:
+            raise ValueError("top-k makes sense only for integer k>0.")
+        if norm:
+            warnings.warn("Norms are presently ignored; we just use the Euclidean.")
+        if index:
+            warnings.warn("Indexing is presently unsupported.")
+        qv = np.array(query_vector)
+        if qv.ndim != 1:
+            raise ValueError("Query vectors must be one-dimensional.")
+        if qv.shape[0] != self._dimensions[namespace]:
+            raise ValueError("Query vectors must have the same number of components "
+                             f"({self._dimensions[namespace]}) "
+                             "as the vectors in the VectorDB. The vector given had "
+                             f"{qv.shape[0]} components.")
+        q = QueryBuilder()
+        q.clauses.append(_TopKClause(qv, k))
+        q._python_clauses.append(PythonTopKClause(qv, k))
+        result = self._lib.read(f"{VECTOR_DB_DISTINGUISHED_PREFIX}{namespace}", query_builder=q).data
+        result.index = list(result.index[:-1]) + ["similarity"]
+        return result

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -12,6 +12,7 @@ import string
 import pytz
 from arcticdb_ext.exceptions import InternalException, ErrorCode, ErrorCategory
 from arcticdb.exceptions import ArcticNativeNotYetImplemented, LibraryNotFound
+from arcticdb_ext.version_store import NoSuchVersionException
 from pandas import Timestamp
 
 try:
@@ -67,58 +68,6 @@ except ImportError:
         StagedDataFinalizeMethod,
     )
 
-
-# def test_top_k(arctic_client):
-#     ac = arctic_client
-#     ac.create_library("pytest_test_top_k_lib")
-#     lib = ac["pytest_test_top_k_lib"]
-#     lib.insert_vectors(pd.DataFrame(np.random.rand(100,100)))
-#     meilleurs = lib.top_k(
-#         k=5,
-#         query=np.zeros(100),
-#         show_vectors=True,
-#         show_similarity=True
-#     )
-#     pass
-
-def test_top_k(arctic_client):
-    np.random.seed(0)
-    random.seed(0)
-    ac = arctic_client
-
-    dimensions, number_of_vectors, k = 15, 20, 5
-    string_column_names = [''.join(random.choices(
-            string.ascii_uppercase + string.digits,
-            k=10))
-        for _ in range(number_of_vectors)]
-
-    ac.create_library("pytest_test_top_k")
-    vector_db = VectorDB(ac["pytest_test_top_k"])
-
-    df = pd.DataFrame(np.random.rand(dimensions,number_of_vectors),columns=string_column_names)
-    qv = np.array([0]*dimensions)
-    distances = df.apply(lambda x: np.linalg.norm(x-qv))
-    top_k_distances = distances[distances.argsort()[:k]]
-    python_result = df[top_k_distances.index].append(pd.DataFrame(top_k_distances).T)
-    python_result.index = list(range(dimensions)) + ["similarity"]
-
-    vector_db.upsert(f"df{dimensions}", df)
-    cpp_result = vector_db.top_k(f"df{dimensions}", 5, qv)
-
-    assert_frame_equal(python_result, cpp_result)
-
-def test_new(arctic_client):
-    np.random.seed(100)
-    ac = arctic_client
-    ac.create_library("pytest_test_new")
-    lib = ac["pytest_test_new"]
-    df = pd.DataFrame([[0] + [i]*99 for i in range(100)])
-    lib.write("df", df)
-
-    q = QueryBuilder()
-    q = q.groupby("0").agg({"3": "mean"})
-    result = lib.read("df", query_builder=q).data
-    pass
 
 def test_library_creation_deletion(arctic_client):
     ac = arctic_client

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -359,6 +359,25 @@ def test_basic_write_read_update_and_append(arctic_library):
     assert read_metadata.version == 1
 
 
+def test_write_metadata_with_none(arctic_library):
+    lib = arctic_library
+    symbol = "symbol"
+    meta = {"meta_" + str(symbol): 0}
+
+    result_write = lib.write_metadata(symbol, meta)
+    assert result_write.version == 0
+
+    read_meta_symbol = lib.read_metadata(symbol)
+    assert read_meta_symbol.data is None
+    assert read_meta_symbol.metadata == meta
+    assert read_meta_symbol.version == 0
+
+    read_symbol = lib.read(symbol)
+    assert read_symbol.data is None
+    assert read_symbol.metadata == meta
+    assert read_symbol.version == 0
+
+
 def staged_write(sym, arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})

--- a/python/tests/integration/arcticdb/test_vector_db.py
+++ b/python/tests/integration/arcticdb/test_vector_db.py
@@ -1,0 +1,231 @@
+import string
+
+from hypothesis import example, given, strategies as st
+from hypothesis.extra.pandas import column, data_frames, range_indexes
+from arcticdb_ext.version_store import NoSuchVersionException
+from arcticdb.util.hypothesis import (
+    numeric_type_strategies,
+    string_strategy,
+    use_of_function_scoped_fixtures_in_hypothesis_checked
+)
+
+try:
+    from arcticdb.version_store import VersionedItem as PythonVersionedItem
+except ImportError:
+    # arcticdb squashes the packages
+    from arcticdb._store import VersionedItem as PythonVersionedItem
+from arcticdb.version_store.vector_db import VectorDB
+
+import pytest
+import pandas as pd
+import numpy as np
+from arcticdb_ext.tools import AZURE_SUPPORT
+from arcticdb.util.test import assert_frame_equal
+import random
+
+if AZURE_SUPPORT:
+    pass
+
+try:
+    from arcticdb.version_store.library import (
+        WritePayload,
+        ArcticUnsupportedDataTypeException,
+        ReadRequest,
+        ReadInfoRequest,
+        ArcticInvalidApiUsageException,
+        StagedDataFinalizeMethod,
+    )
+except ImportError:
+    # arcticdb squashes the packages
+    from arcticdb.library import (
+        WritePayload,
+        ArcticUnsupportedDataTypeException,
+        ReadRequest,
+        ReadInfoRequest,
+        ArcticInvalidApiUsageException,
+        StagedDataFinalizeMethod,
+    )
+
+def test_top_k(arctic_client):
+    np.random.seed(0)
+    random.seed(0)
+    ac = arctic_client
+
+    dimensions, number_of_vectors, k = 15, 20, 5
+    string_column_names = [''.join(random.choices(
+        string.ascii_uppercase + string.digits,
+        k=10))
+        for _ in range(number_of_vectors)]
+
+    ac.create_library("pytest_test_top_k")
+    vector_db = VectorDB(ac["pytest_test_top_k"])
+
+    df = pd.DataFrame(
+        np.random.rand(dimensions,number_of_vectors),
+        columns=string_column_names
+    )
+    qv = np.array([0]*dimensions)
+    distances = df.apply(lambda x: np.linalg.norm(x-qv))
+    top_k_distances = distances[distances.argsort()[:k]]
+    python_result = df[top_k_distances.index].append(
+        pd.DataFrame(top_k_distances).T
+    )
+    python_result.index = list(range(dimensions)) + ["similarity"]
+
+    vector_db.upsert(f"df{dimensions}", df)
+    cpp_result = vector_db.top_k(f"df{dimensions}", k, qv)
+
+    assert_frame_equal(python_result, cpp_result)
+
+def test_validation(arctic_client):
+    ac = arctic_client
+    ac.create_library("pytest_test_validation")
+    vector_db = VectorDB(ac["pytest_test_validation"])
+
+    # Three-dimensional arrays can't be ingested..
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[[0]]]), identifiers=["test"])
+
+    # The number of vectors should be the same as the number of identifiers.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[0]]), identifiers=[])
+
+    # The identifiers must be strings.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[0]]), identifiers=[0])
+
+    # ndarrays must be supplied with identifiers.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[1]]))
+
+    # Subsequent insertion of differently-dimensioned vectors
+    # makes top-k meaningless and therefore is prohibited.
+    with pytest.raises(ValueError):
+        vector_db["differently_dimensioned_array_case"].upsert(np.array([[1]]), identifiers=["a"])
+        vector_db["differently_dimensioned_array_case"].upsert(np.array([[1,2]]), identifiers=["b"])
+    with pytest.raises(ValueError):
+        vector_db["differently_dimensioned_df_case"].upsert(pd.DataFrame(np.random.rand(100,100)))
+        vector_db["differently_dimensioned_df_case"].upsert(pd.DataFrame(np.random.rand(200,200)))
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert({"1": {"vector": [0]}, "2": {"vector": [1, 2]}})
+
+    # Vectors in mappings must be one-dimensional.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert({"1": {"vector": [[0]]}})
+
+    # Keys to vectors in mappings must be strings.
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert({0: {"vector": [0]}})
+
+    # top-k with k !> 0 doesn't make sense.
+    with pytest.raises(ValueError):
+        vector_db["empty"].top_k(0, [])
+
+    # Non-numeric "vectors" (soi-disants) are unsupported.
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert(pd.DataFrame([""]))
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert({"vector": {"vector": [""]}})
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert(
+            np.array([[""]]),
+            identifiers=["test"]
+        )
+
+    # Upsertion takes mappings, DFs, and ndarrays.
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert(True)
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert([])
+
+
+def test_inextant_namespace(arctic_client):
+    ac = arctic_client
+    ac.create_library("pytest_test_inextant_namespace")
+    vector_db = VectorDB(ac["pytest_test_inextant_namespace"])
+    with pytest.raises(NoSuchVersionException):
+        vector_db.read("DOES_NOT_EXIST")
+    with pytest.raises(NoSuchVersionException):
+        vector_db["DOES_NOT_EXIST"].read()
+
+def test_vector_db_requires_library(arctic_client):
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        VectorDB(3)
+
+def test_vector_db_empty_upsertions(arctic_client):
+    np.random.seed(0)
+    random.seed(0)
+
+    ac = arctic_client
+    ac.create_library("pytest_test_vector_db_empty_upsertions")
+
+    vector_db = VectorDB(ac["pytest_test_vector_db_empty_upsertions"])
+
+    with pytest.raises(ValueError):
+        vector_db.upsert("empty1", np.array([[]]))
+
+    vector_db.upsert("empty2", {})
+    assert_frame_equal(
+        vector_db.read("empty2"),
+        pd.DataFrame(),
+        check_index_type=False
+    )
+
+    vector_db.upsert("empty3", pd.DataFrame())
+    assert_frame_equal(
+        vector_db.read("empty3"),
+        pd.DataFrame(),
+        check_index_type=False
+    )
+
+def test_vector_db_upsertion(arctic_client):
+    np.random.seed(0)
+    random.seed(0)
+
+    ac = arctic_client
+    ac.create_library("pytest_test_vector_db_upsertion")
+
+    vector_db = VectorDB(ac["pytest_test_vector_db_upsertion"])
+
+    dimensions, number_of_vectors, k = 15, 20, 5
+    first_string_column_names = [''.join(random.choices(
+        string.ascii_uppercase + string.digits,
+        k=10))
+        for _ in range(number_of_vectors)]
+    second_string_column_names = [''.join(random.choices(
+        string.ascii_uppercase + string.digits,
+        k=15))
+        for _ in range(number_of_vectors)]
+    first_df = pd.DataFrame(
+        np.random.rand(dimensions,number_of_vectors),
+        columns=first_string_column_names
+    )
+    second_df = pd.DataFrame(
+        np.random.rand(dimensions,number_of_vectors),
+        columns=second_string_column_names
+    )
+
+    vector_db.upsert("first_is_first", first_df)
+    vector_db.upsert("first_is_first", second_df)
+    vector_db.upsert("second_is_first", second_df)
+    vector_db.upsert("second_is_first", first_df)
+
+    assert_frame_equal(
+        vector_db.read("first_is_first"),
+        vector_db.read("second_is_first"),
+        check_like=True
+    )
+
+    vector_db.upsert("first_is_first", first_df)
+    vector_db.upsert("first_is_first", first_df)
+    vector_db.upsert("first_is_first", first_df)
+
+    assert_frame_equal(
+        vector_db.read("first_is_first"),
+        vector_db.read("second_is_first"),
+        check_like=True
+    )
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@given(df=data_frames([column("a", elements=numeric_type_strategies())], index=range_indexes()))
+def test_upsertion_idempotent(arctic_client, df):
+    assert True


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #674, #650.

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

A `VectorDB` wraps round a library (it takes the library when initialised). It supports

1. upsertion of vectors (for fresh identifiers, insertion; for used identifiers, updating); and
2. top-_k_ queries (presently Euclidean-only).

In Python, the API itself is otherwise completely unchanged. There are new methods in cpp that are accessible only through a `VectorDB` in Python.

#### Any other comments?

This is very much a draft and probably shouldn't be merged into the integration branch yet until I've properly documented it.

This is not very fast and limited to datasets that fit in memory; see #668 for further details.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
