### PR TITLE
get description batch to catch all the exceptions

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -301,7 +301,7 @@ public:
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<DescriptorItem> batch_read_descriptor_internal(
+    std::vector<std::variant<DescriptorItem, DataError>> batch_read_descriptor_internal(
             const std::vector<StreamId>& stream_ids,
             const std::vector<VersionQuery>& version_queries,
             const ReadOptions& read_options);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1043,7 +1043,7 @@ DescriptorItem PythonVersionStore::read_descriptor(
     return read_descriptor_internal(stream_id, version_query, read_options);
 }
 
-std::vector<DescriptorItem> PythonVersionStore::batch_read_descriptor(
+std::vector<std::variant<DescriptorItem, DataError>> PythonVersionStore::batch_read_descriptor(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options){

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -188,7 +188,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const ReadOptions& read_options
     );
 
-    std::vector<DescriptorItem> batch_read_descriptor(
+    std::vector<std::variant<DescriptorItem, DataError>> batch_read_descriptor(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2519,6 +2519,10 @@ class NativeVersionStore:
             - type, `str`
             - date_range, `tuple`
         """
+        throw_on_missing_version = True
+        return self._batch_read_descriptor(symbols, as_ofs, throw_on_missing_version)
+
+    def _batch_read_descriptor(self, symbols, as_ofs, throw_on_missing_version):
         as_ofs_lists = []
         if as_ofs == None:
             as_ofs_lists = [None] * len(symbols)
@@ -2530,12 +2534,16 @@ class NativeVersionStore:
             version_queries.append(self._get_version_query(as_of))
 
         read_options = _PythonVersionStoreReadOptions()
-        list_descriptors = self.version_store.batch_read_descriptor(symbols, version_queries, read_options)
-        args_list = list(zip(list_descriptors, symbols, version_queries, as_ofs_lists))
-        list_infos = []
+        read_options.set_batch_throw_on_missing_version(throw_on_missing_version)
+        descriptions_or_errors = self.version_store.batch_read_descriptor(symbols, version_queries, read_options)
+        args_list = list(zip(descriptions_or_errors, symbols, version_queries, as_ofs_lists))
+        description_results = []
         for dit, symbol, version_query, as_of in args_list:
-            list_infos.append(self._process_info(symbol, dit, as_of))
-        return list_infos
+            if isinstance(dit, DataError):
+                description_results.append(dit)
+            else:
+                description_results.append(self._process_info(symbol, dit, as_of))
+        return description_results
 
     def write_metadata(
         self, symbol: str, metadata: Any, prune_previous_version: Optional[bool] = None


### PR DESCRIPTION
Closes https://github.com/man-group/ArcticDB/issues/599

The previous behaviour of Library.get_description_batch and NativeVersionStore.batch_get_info was to throw an exception if there was an issue retrieving any of the requested symbol/version pairs. For backwards compatibility reasons, this behaviour has been maintained for NativeVersionStore.batch_get_info.

For Library.get_description_batch, this has been changed. A DataError object will now be returned in the position in the list returned corresponding to the symbol/version pair there was an issue retrieving. This contains the symbol and version requested, and the exception string thrown. For two well-defined categories of error, the error category and specific error code are also included:

ErrorCategory.MISSING_DATA - ErrorCode.E_NO_SUCH_VERSION: The version requested by the user does not exist
ErrorCategory.STORAGE - ErrorCode.E_KEY_NOT_FOUND: The index key required to read the specified version does not exist in the storage.
Otherwise these fields of the DataError object are left as None.