### PR TITLE
top-k initial cpp implementation

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -422,7 +422,10 @@ set(arcticdb_srcs
         version/version_core.cpp
         version/version_store_api.cpp
         version/version_utils.cpp
-        version/symbol_list.cpp )
+        version/symbol_list.cpp
+        vector_db/vector_db.hpp
+        vector_db/vector_db.cpp
+        )
 
 # Exclude vendored sources when using conda.
 if(NOT ${ARCTICDB_USING_CONDA}) #Awaiting Azure sdk support in conda https://github.com/man-group/ArcticDB/issues/519

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -49,6 +49,8 @@ struct ClauseInfo {
     std::optional<std::string> new_index_{std::nullopt};
     // Whether this clause modifies the output descriptor
     bool modifies_output_descriptor_{false};
+    // Whether to reorder columns as in the original DF.
+    bool follows_original_columns_order_{true};
 };
 
 // Changes how the clause behaves based on information only available after it is constructed

--- a/cpp/arcticdb/vector_db/vector_db.cpp
+++ b/cpp/arcticdb/vector_db/vector_db.cpp
@@ -1,0 +1,102 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/processing/clause.hpp>
+#include <arcticdb/vector_db/vector_db.hpp>
+
+namespace arcticdb {
+    TopKClause::TopKClause(std::vector<double> query_vector, uint8_t k) :
+            query_vector_(std::move(query_vector)),
+            k_(k) {
+        clause_info_.modifies_output_descriptor_ = true;
+        clause_info_.follows_original_columns_order_ = false;
+        clause_info_.can_combine_with_column_selection_ = false;
+    }
+
+    Composite<ProcessingSegment> TopKClause::process(std::shared_ptr<Store> store,
+                                                     Composite<ProcessingSegment> &&p) const {
+        auto procs = std::move(p);
+        TopK top_k(k_);
+        // We expect a vector in each column.
+        // top_k_ is updated as we read more vectors. We want to efficiently remove
+        // the 'worst' (least similar) vector as we go along to ensure we have the
+        // top k, not the top k+1.
+        auto lp = 2;
+        // Let's pretend that only the lp-norms exist. We'll use p=2 for now as a default.
+
+        procs.broadcast(
+                [&store, &top_k, lp, this](const ProcessingSegment &proc) {
+                    for (const auto& slice_and_key: proc.data()) {
+                        std::vector <std::shared_ptr<Column>> columns = slice_and_key.segment(store).columns();
+                        for (auto&& [idx, col]: folly::enumerate(columns)) {
+                            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                                    static_cast<long unsigned>(col->row_count()) == this->query_vector_.size(),
+                                    "Expected vector of length {}, got vector of length {}.",
+                                    col->row_count(),
+                                    this->query_vector_.size());
+                            col->type().visit_tag([&top_k, &slice_and_key, &store, &col=col, idx=idx, lp, this](auto type_desc_tag) {
+                                using TypeDescriptorTag = decltype(type_desc_tag);
+                                using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
+
+                                if constexpr (is_floating_point_type(TypeDescriptorTag::DataTypeTag::data_type)) {
+
+                                    ColumnData col_data = col->data();
+                                    double sum_differences_exponentiated = 0;
+                                    auto j = 0u;
+
+                                    while (auto block = col_data.next<TypeDescriptorTag>()) {
+                                        auto ptr = reinterpret_cast<const RawType *>(block.value().data());
+                                        for (auto progress_in_block = 0u; progress_in_block <
+                                                                          block.value().row_count(); ++progress_in_block, ++j, ++ptr) {
+                                            sum_differences_exponentiated += pow(
+                                                    abs(*ptr - this->query_vector_[j]), lp);
+                                        }
+                                    }
+
+                                    top_k.try_insert(NamedColumnSortedByDistance(
+                                            sum_differences_exponentiated,
+                                            col,
+                                            slice_and_key.segment(store).field(idx).name()));
+                                }
+                            });
+                        }
+                    }
+                }
+        );
+        // By this time we should have iterated through each block of each SegmentInMemory of each ProcessingSegment;
+        // and in each case read a vector and inserted it if more similar than the running top_k_. Now we write to a new
+        // segment.
+        SegmentInMemory seg;
+        seg.descriptor().set_index(IndexDescriptor(0, IndexDescriptor::ROWCOUNT));
+        seg.set_row_id(query_vector_.size() - 1 + 1);
+        // -1 because of zero-indexing, +1 because we want to add the distance on at the end.
+            for (const auto &column: top_k.top_k_) {
+            // todo: replace (mem)cpying of columns' contents with holding of pointers in top_k_ and addition of pointers to seg
+            // this doesn't work presently because the columns can have >1 block.
+            column.column_->type().visit_tag([&column, &seg, lp, this](auto type_desc_tag) {
+                using TypeDescriptorTag = decltype(type_desc_tag);
+                using RawType = typename TypeDescriptorTag::DataTypeTag::raw_type;
+
+                if constexpr (is_floating_point_type(TypeDescriptorTag::DataTypeTag::data_type)) {
+                    auto write_col = std::make_shared<Column>(column.column_->type(), this->query_vector_.size() + 1, true, false);
+
+                    auto col_data = column.column_->data();
+                    auto write_ptr = reinterpret_cast<RawType *>(write_col->ptr());
+                    while (auto block = col_data.next<TypeDescriptorTag>()) {
+                        auto ptr = reinterpret_cast<const RawType *>(block.value().data());
+                        std::memcpy(write_ptr, ptr, block.value().row_count() * sizeof(RawType));
+                        write_ptr += block.value().row_count();
+                    }
+                    *write_ptr = RawType(pow(column.distance_, 1 / static_cast<double>(lp)));
+                    write_col->set_row_data(this->query_vector_.size());
+                    seg.add_column(scalar_field(DataType::FLOAT64, column.name_), write_col);
+                    }
+            });
+        }
+        return Composite{ProcessingSegment{std::move(seg)}};
+    }
+}

--- a/cpp/arcticdb/vector_db/vector_db.cpp
+++ b/cpp/arcticdb/vector_db/vector_db.cpp
@@ -62,6 +62,11 @@ namespace arcticdb {
                                             col,
                                             slice_and_key.segment(store).field(idx).name()));
                                 }
+                                else {
+                                    internal::raise<ErrorCode::E_INVALID_ARGUMENT>(
+                                            "Vectors should exclusively comprise floats; the Python layer should otherwise raise an error and prevent upsertion of vectors containing non-float components."
+                                            );
+                                }
                             });
                         }
                     }
@@ -94,6 +99,11 @@ namespace arcticdb {
                     write_col->set_row_data(this->query_vector_.size());
                     seg.add_column(scalar_field(DataType::FLOAT64, column.name_), write_col);
                     }
+                else {
+                    internal::raise<ErrorCode::E_INVALID_ARGUMENT>(
+                            "Vectors should exclusively comprise floats; the Python layer should otherwise raise an error and prevent upsertion of vectors containing non-float components."
+                    );
+                }
             });
         }
         return Composite{ProcessingSegment{std::move(seg)}};

--- a/cpp/arcticdb/vector_db/vector_db.hpp
+++ b/cpp/arcticdb/vector_db/vector_db.hpp
@@ -39,11 +39,11 @@ namespace arcticdb {
     };
 
     struct TopK {
-        uint64_t _k;
+        uint64_t k_;
         std::set<NamedColumnSortedByDistance> top_k_;
-        double _furthest_distance{std::numeric_limits<double>::infinity()};
+        double furthest_distance_{std::numeric_limits<double>::infinity()};
 
-        explicit TopK(int k) : _k(k) {}
+        explicit TopK(int k) : k_(k) {}
 
         TopK() = delete;
 
@@ -64,27 +64,27 @@ namespace arcticdb {
             // NB We require <= so that the vector name acts as the tiebreaker when the distance is the same.
             // This is not guaranteed to the user but is useful for testing.
             bool inserted = false;
-            if (col.distance_ < _furthest_distance || (col.distance_ == _furthest_distance && col < *top_k_.rbegin())) {
+            if (col.distance_ < furthest_distance_ || (col.distance_ == furthest_distance_ && col < *top_k_.rbegin())) {
                 top_k_.insert(col);
                 inserted = true;
             }
-            // Obviously if col.distance_ < _furthest_distance then we've got a closer vector so we insert it.
-            // Where col.distance_ == _furthest_distance, the latter cannot be infinity, since in Python we require that
+            // Obviously if col.distance_ < furthest_distance_ then we've got a closer vector so we insert it.
+            // Where col.distance_ == furthest_distance_, the latter cannot be infinity, since in Python we require that
             // all vectors should be within the n-cube centred about the origin whose long diagonal has length
-            // std::numeric_limits<double>::max(). Therefore, _furthest_distance is finite. Therefore, it's been
+            // std::numeric_limits<double>::max(). Therefore, furthest_distance_ is finite. Therefore, it's been
             // altered, and so we have at least member of top_k_. So top_k_ is nonempty and we can compare
             // col < *top_k_.rbegin().
-            if (top_k_.size() > _k) {
+            if (top_k_.size() > k_) {
                 top_k_.erase(*top_k_.rbegin());
-                _furthest_distance = top_k_.rbegin()->distance_;
-            } else if (inserted && top_k_.size() == _k) {
-                _furthest_distance = top_k_.rbegin()->distance_;
+                furthest_distance_ = top_k_.rbegin()->distance_;
+            } else if (inserted && top_k_.size() == k_) {
+                furthest_distance_ = top_k_.rbegin()->distance_;
             }
             // There are three cases here.
             // - top_k.size() < k. Then we don't need to erase anything or refresh the furthest distance. When there are
             //   fewer than k elements in top_k_, we want to add any new vector we see; we may remove it later of course.
             // - top_k_.size() is exactly k. Then we don't need to erase anything. But we might have just inserted
-            //   something so we need to reload the _furthest_distance if we inserted something.
+            //   something so we need to reload the furthest_distance_ if we inserted something.
             // - top_k.size() = k+1. Then we do need to erase the furthest element. We also need to refresh the largest
             //   element.
             return inserted;

--- a/cpp/arcticdb/vector_db/vector_db.hpp
+++ b/cpp/arcticdb/vector_db/vector_db.hpp
@@ -1,0 +1,126 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/processing/clause.hpp>
+
+namespace arcticdb {
+
+    struct NamedColumnSortedByDistance {
+        double distance_;
+        std::shared_ptr<Column> column_;
+        std::string_view name_;
+
+        explicit NamedColumnSortedByDistance(double distance,
+                                             std::shared_ptr<Column> column,
+                                             std::string_view name) :
+                distance_(distance),
+                column_(column),
+                name_(name) {}
+
+        NamedColumnSortedByDistance() = delete;
+
+        ARCTICDB_MOVE_COPY_DEFAULT(NamedColumnSortedByDistance);
+
+        bool operator<(const NamedColumnSortedByDistance &that) const {
+            return distance_ < that.distance_ || (distance_ == that.distance_ && name_ < that.name_);
+            // name is a tiebreaker.
+        };
+
+        bool operator==(const NamedColumnSortedByDistance &that) const {
+            return distance_ == that.distance_ && column_ == that.column_ && name_ == that.name_;
+        };
+
+    };
+
+    struct TopK {
+        uint64_t _k;
+        std::set<NamedColumnSortedByDistance> top_k_;
+        double _furthest_distance{std::numeric_limits<double>::infinity()};
+
+        explicit TopK(int k) : _k(k) {}
+
+        TopK() = delete;
+
+        ARCTICDB_MOVE_COPY_DEFAULT(TopK);
+
+        bool try_insert(
+                double distance,
+                std::shared_ptr<Column> column,
+                std::string_view name
+        ) {
+            return try_insert(NamedColumnSortedByDistance(
+                    distance,
+                    column,
+                    name));
+        }
+
+        bool try_insert(const NamedColumnSortedByDistance &col) {
+            // NB We require <= so that the vector name acts as the tiebreaker when the distance is the same.
+            // This is not guaranteed to the user but is useful for testing.
+            bool inserted = false;
+            if (col.distance_ < _furthest_distance || (col.distance_ == _furthest_distance && col < *top_k_.rbegin())) {
+                top_k_.insert(col);
+                inserted = true;
+            }
+            // Obviously if col.distance_ < _furthest_distance then we've got a closer vector so we insert it.
+            // Where col.distance_ == _furthest_distance, the latter cannot be infinity, since in Python we require that
+            // all vectors should be within the n-cube centred about the origin whose long diagonal has length
+            // std::numeric_limits<double>::max(). Therefore, _furthest_distance is finite. Therefore, it's been
+            // altered, and so we have at least member of top_k_. So top_k_ is nonempty and we can compare
+            // col < *top_k_.rbegin().
+            if (top_k_.size() > _k) {
+                top_k_.erase(*top_k_.rbegin());
+                _furthest_distance = top_k_.rbegin()->distance_;
+            } else if (inserted && top_k_.size() == _k) {
+                _furthest_distance = top_k_.rbegin()->distance_;
+            }
+            // There are three cases here.
+            // - top_k.size() < k. Then we don't need to erase anything or refresh the furthest distance. When there are
+            //   fewer than k elements in top_k_, we want to add any new vector we see; we may remove it later of course.
+            // - top_k_.size() is exactly k. Then we don't need to erase anything. But we might have just inserted
+            //   something so we need to reload the _furthest_distance if we inserted something.
+            // - top_k.size() = k+1. Then we do need to erase the furthest element. We also need to refresh the largest
+            //   element.
+            return inserted;
+        }
+    };
+
+
+    struct TopKClause {
+        ClauseInfo clause_info_;
+        std::vector<double> query_vector_;
+        uint64_t k_;
+
+        TopKClause() = delete;
+
+        ARCTICDB_MOVE_COPY_DEFAULT(TopKClause);
+
+        TopKClause(std::vector<double> query_vector, uint8_t k);
+
+        [[nodiscard]] Composite<ProcessingSegment> process(
+                std::shared_ptr<Store> store,
+                Composite<ProcessingSegment> &&p
+        ) const;
+
+        [[nodiscard]] std::optional<std::vector<Composite<ProcessingSegment>>> repartition(
+                ARCTICDB_UNUSED std::vector<Composite<ProcessingSegment>> &&) const {
+            return std::nullopt;
+        }
+
+        [[nodiscard]] const ClauseInfo &clause_info() const {
+            return clause_info_;
+        }
+
+        void set_processing_config(ARCTICDB_UNUSED const ProcessingConfig &processing_config) {}
+
+
+        [[nodiscard]] std::string to_string() const;
+    };
+
+}

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -23,6 +23,7 @@
 #include <arcticdb/pipeline/value_set.hpp>
 #include <arcticdb/python/adapt_read_dataframe.hpp>
 #include <arcticdb/version/schema_checks.hpp>
+#include <arcticdb/vector_db/vector_db.hpp>
 
 namespace arcticdb::version_store {
 
@@ -296,6 +297,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def(py::init<std::string, std::unordered_map<std::string, std::string>>())
             .def("__str__", &AggregationClause::to_string);
 
+    py::class_<TopKClause, std::shared_ptr<TopKClause>>(version, "TopKClause")
+            .def(py::init<std::vector<double>, uint8_t>());
+
     py::enum_<RowRangeClause::RowRangeType>(version, "RowRangeType")
             .value("HEAD", RowRangeClause::RowRangeType::HEAD)
             .value("TAIL", RowRangeClause::RowRangeType::TAIL);
@@ -323,7 +327,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
                                 std::shared_ptr<GroupByClause>,
                                 std::shared_ptr<AggregationClause>,
                                 std::shared_ptr<RowRangeClause>,
-                                std::shared_ptr<DateRangeClause>>> clauses) {
+                                std::shared_ptr<DateRangeClause>,
+                                std::shared_ptr<TopKClause>>> clauses) {
                 std::vector<std::shared_ptr<Clause>> _clauses;
                 for (auto&& clause: clauses) {
                     util::variant_match(

--- a/python/arcticdb/vector_db/vector_db.py
+++ b/python/arcticdb/vector_db/vector_db.py
@@ -1,0 +1,521 @@
+import warnings
+import pandas as pd
+import numpy as np
+
+from collections import namedtuple
+from typing import Union, Optional, Collection, List, Mapping
+
+from arcticdb import Arctic
+from arcticdb.options import LibraryOptions
+from arcticdb.version_store.library import Library, ArcticUnsupportedDataTypeException
+from arcticdb.version_store.processing import QueryBuilder
+from arcticdb_ext.version_store import TopKClause as _TopKClause, NoSuchVersionException
+from arcticdb_ext.storage import NoDataFoundException
+
+VECTOR_DB_DISTINGUISHED_SUFFIX = "_vector_db"
+
+VECTOR_VALUE_ERROR = """
+Vectors uploaded as mappings must have the following form.
+- The key should be an identifier that is a string.
+- The value should be another mapping.
+    - The keys of these mappings should be strings.
+    - They should include a value under "vector".
+    - The value under "vector" should be something that can be turned into a one-dimensional ndarray of floats.
+    - That array should have the right number of values (i.e. correspond to the number of dimensions of the other
+    vectors in the namespace.)
+Attempts to upsert mappings not in this form should cause errors.
+"""
+
+PythonTopKClause = namedtuple("TopKClause", ["vector", "k"])
+
+SENSIBLE_SEGMENT_SIZE = 100000000
+
+
+def _generate_dataframe_from_ndarray(
+    vectors: np.ndarray,
+    identifiers: Collection[str],
+    expected_dimensions: Optional[int] = None,
+    metadata: Optional[Mapping[str, Mapping[str, any]]] = None,
+) -> pd.DataFrame:
+    """
+    Generates a normalised `pd.DataFrame` for writing to an Arctic symbol from an `np.ndarray`.
+
+    Parameters
+    ----------
+    vectors
+        The array from which the dataframe is generated.
+    identifiers
+        A collection of strings that serve as identifiers of the vectors. These will be used as column headers.
+    expected_dimensions
+        An optional int parameter; if specified, the array will be checked for the correct dimensionality.
+    metadata
+        An optional dictionary of metadata to associate with the dataframe; presently ignored.
+
+    Returns
+    -------
+    A `pd.DataFrame` suitable for writing to an Arctic symbol internally.
+
+    Raises
+    ------
+    ArcticUnsupportedDataTypeException
+        if the array given contains non-numeric types.
+    ValueError
+        if no identifiers are given, the wrong number of identifiers is given, a non-string identifier is given, or a
+        vector of the wrong dimensionality is given.
+    """
+    if vectors.ndim != 2:
+        raise ValueError(
+            "Upsertion of vectors in an `np.ndarray` takes two-dimensional arrays; "
+            f"the vector given had {vectors.ndim} instead."
+        )
+    if not np.issubdtype(vectors.dtype, float):
+        if np.issubdtype(vectors.dtype, int):
+            vectors = vectors.astype(np.float64)
+        else:
+            raise ArcticUnsupportedDataTypeException(
+                "Vectors inserted must all exclusively contain floats. "
+                f"You attempted to insert {vectors.dtype}, which doesn't count."
+            )
+    if identifiers is None:
+        raise ValueError("Upsertion of vectors in an `np.ndarray` requires a list of identifiers.")
+    if len(identifiers) != len(vectors):
+        raise ValueError(f"You gave {len(identifiers)} identifiers but {len(vectors)} vectors.")
+    if any([type(identifier) is not str for identifier in identifiers]):
+        raise ValueError(f"All identifiers must be strings.")
+    if expected_dimensions and expected_dimensions != vectors.shape[1]:
+        raise ValueError(
+            f"Expected vectors of {expected_dimensions} dimensions; got vectors of {vectors.shape[1]} dimensions."
+        )
+    return pd.DataFrame(vectors.T, columns=identifiers)
+
+
+def _generate_dataframe_from_mapping(
+    vectors: Mapping[str, Mapping[str, any]], expected_dimensions: Optional[int] = None
+) -> pd.DataFrame:
+    """
+    Generates a normalised `pd.DataFrame` suitable for writing to an Arctic library from a mapping.
+
+    Parameters
+    ----------
+    vectors
+        The mapping should have the following form:
+
+        ```
+        {...
+            identifier :
+                { ...
+                    "vector" : vector
+                }
+        }
+        ```
+
+        where the identifier is a string, and the result of calling `np.array(vector)` is a one-dimensional array of
+        floats of the right length.
+
+        The mapping may optionally include metadata in addition to the value of the vector. Those metadata are presently
+        ignored.
+    expected_dimensions
+        An optional int parameter; if specified, the array will be checked for the correct dimensionality.
+
+    Returns
+    -------
+    A `pd.DataFrame` suitable for writing to an Arctic symbol internally.
+
+    Raises
+    ------
+    ArcticUnsupportedDataTypeException
+        if any of the values under the key `vector` have non-numeric type.
+    ValueError
+        if a vector is included that when converted to an `np.ndarray` has a shape of more than one dimension, or if
+        it is a one-dimensional `np.ndarray` of the wrong length given the expected length of each vector.
+    """
+    data_frame_to_upsert = pd.DataFrame()
+    for k, v in vectors.items():
+        if type(k) is not str:
+            raise ArcticUnsupportedDataTypeException(VECTOR_VALUE_ERROR)
+        if "vector" not in v.keys():
+            raise ValueError()
+        column = np.array(v["vector"])
+        if column.ndim != 1:
+            raise ValueError(VECTOR_VALUE_ERROR)
+        if not np.issubdtype(column.dtype, float):
+            if np.issubdtype(column.dtype, int):
+                column = column.astype(np.float64)
+            else:
+                raise ArcticUnsupportedDataTypeException(
+                    "Vectors inserted must exclusively contain floats. You attempted to insert a vector that as an "
+                    f"ndarray has dtype {column.dtype} which doesn't count."
+                )
+        if not expected_dimensions:
+            expected_dimensions = column.shape[0]
+        elif column.shape[0] != expected_dimensions:
+            raise ValueError("The vectors must all have the same number of dimensions.")
+        data_frame_to_upsert[k] = column
+    return data_frame_to_upsert
+
+
+def _generate_dataframe_from_dataframe(
+    vectors: pd.DataFrame, expected_dimensions: Optional[int] = None
+) -> pd.DataFrame:
+    """
+    Generates a normalised `pd.DataFrame` suitable for writing to an Arctic library from a `pd.DataFrame`.
+
+    vectors
+        the dataframe.
+    expected_dimensions
+        An optional int parameter; if specified, the array will be checked for the correct dimensionality.
+
+    Returns
+    -------
+    A `pd.DataFrame` suitable for writing to an Arctic symbol internally.
+
+    Raises
+    ------
+    ArcticUnsupportedDataTypeException
+        if any of the values in the frame has a non-numeric type.
+    ValueError
+        if the length of the vectors supplied is unexpected.
+    """
+    for col in vectors:
+        if np.issubdtype(vectors[col], int):
+            vectors[col] = vectors[col].astype(np.float64)
+        elif not np.issubdtype(vectors[col].dtype, float):
+            raise ArcticUnsupportedDataTypeException(
+                "Vectors inserted must all exclusively contain floats. You attempted to "
+                f"insert {vectors[col].dtype}, which does not count."
+            )
+
+    if expected_dimensions and vectors.shape[0] != expected_dimensions:
+        raise ValueError(
+            f"Expected vectors of {expected_dimensions} dimensions; got vectors of {vectors.shape[0]} dimensions."
+        )
+    else:
+        return vectors
+
+
+def _generate_dataframe(
+    vectors: Union[Mapping[str, Mapping[str, any]], np.ndarray, pd.DataFrame],
+    expected_dimensions: Optional[int] = None,
+    identifiers: Optional[Collection[str]] = None,
+    metadata: Optional[Mapping[str, Mapping]] = None,
+) -> pd.DataFrame:
+    """
+    Generates a `pd.DataFrame` from input.
+
+    Parameters
+    ----------
+    vectors
+        A `Mapping`, `np.ndarray`, or `pd.DataFrame`. See `_generate_dataframe_from_ndarray` and
+        `_generate_dataframe_from_mapping` for further details.
+    expected_dimensions
+        The number of dimensions expected from each vector; if specified, and if vectors do not match, a `ValueError`
+        will be raised.
+    identifiers
+        In the case of an `np.ndarray`, we require a separate collection of identifiers of the vectors.
+    metadata
+        Presently ignored.
+
+    Returns
+    -------
+    A `pd.DataFrame` suitable for writing to an Arctic sybmol.
+
+    Raises
+    ------
+    ArcticUnsupportedDataTypeException
+        if the input is not a `Mapping`, `np.ndarray`, or `pd.DataFrame`, or any vector given has non-numeric type.
+    ValueError
+        if a `Mapping` is provided and `metadata` are too; or if a `Mapping` or `pd.DataFrame` is provided and
+        identifiers are too.
+    """
+    if isinstance(vectors, Mapping):
+        if metadata:
+            raise ValueError(
+                "Vectors uploaded as mappings should not be accompanied by a separate metadata parameter. "
+                "Include metadata in the mapping itself."
+            )
+        if identifiers:
+            raise ValueError(
+                "Vectors uploaded as mappings should not be accompanied by a separate parameter for "
+                "identifiers. The keys of the mapping are used as identifiers instead."
+            )
+        df_to_upsert = _generate_dataframe_from_mapping(vectors, expected_dimensions)
+    elif isinstance(vectors, np.ndarray):
+        df_to_upsert = _generate_dataframe_from_ndarray(vectors, identifiers, expected_dimensions, metadata)
+    elif isinstance(vectors, pd.DataFrame):
+        if identifiers:
+            raise ValueError(
+                "Vectors uploaded as dataframes should not be accompanied by a separate parameter for "
+                "identifiers. The column headings of the dataframe are used as identifiers instead."
+            )
+        df_to_upsert = _generate_dataframe_from_dataframe(vectors, expected_dimensions)
+    else:
+        raise ArcticUnsupportedDataTypeException(f"Upsertion of vectors of type {type(vectors)} is unsupported.")
+    df_to_upsert.columns = df_to_upsert.columns.astype(str)
+    return df_to_upsert
+
+
+class VectorDB:
+    """
+    The main interface exposing vector database functionality in a given Arctic instance.
+
+    VectorDBs contain namespaces which are the atomic unit of vector storage. Namespaces
+    support upsertion and top-k queries.
+    """
+
+    def __init__(self, library: Library):
+        """
+        Parameters
+        ----------
+        library
+            The library in which vectors will be stored. See `Arctic.create_library`. In initialising the library, we
+            recommend using the `new_vector_db` method.
+        """
+        if type(library) is not Library:
+            raise ArcticUnsupportedDataTypeException(
+                f"Vector databases must be initialised on libraries. You tried to initialise from a {type(library)}."
+            )
+        self._max_vector_size = library._nvs._library.config.write_options.segment_row_size
+        self._lib = library
+
+    def __repr__(self):
+        return f"VectorDB({str(self._lib)})"
+
+    def __contains__(self, namespace: str):
+        return f"{namespace}{VECTOR_DB_DISTINGUISHED_SUFFIX}" in self._lib
+
+    def __getitem__(self, item: str):
+        return _VectorSymbol(item, self)
+
+    def upsert(
+        self,
+        namespace: str,
+        vectors: Union[Mapping[str, Mapping[str, any]], pd.DataFrame, np.ndarray],
+        identifiers: Optional[Collection[str]] = None,
+        metadata: Optional[Mapping[str, Mapping]] = None,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        namespace
+            The namespace to which `vectors` should be upserted.
+        vectors
+            In the case of a mapping, we expect a mapping whose keys are strings
+            (taken as identifiers of vectors), and whose values are in turn mapping
+            minimally containing a key-value pair 'value' pointing to something that
+            yields a one-dimensional `np.ndarray` of numeric types corresponding to a
+            vector. Each vector must have the same dimensionality.
+
+            In the case of a pandas DataFrame, we expect string columns and the entries to
+            all be of a numeric type.
+
+            In the case of an ndarray, we expect a list of `identifiers` corresponding to
+            the number of vectors. We also expect an `np.ndarray` of `np.ndarray`s
+            (i.e. two dimensions) populated by numeric types. Note that upserting an
+            `np.ndarray` corresponds to upserting the transpose of the equivalent
+            `pd.DataFrame`. For example:
+
+            >>> vdb.upsert("vdb", np.array([[0,1],[2,3]]), identifiers=["a", "b"])
+
+            inserts vectors <0,1> and <2,3>, but
+
+            >>> vdb.upsert("vdb", pd.DataFrame(np.array([0,1],[2,3])))
+
+            inserts vectors <0,2> and <1,3>.
+            identifiers
+        identifiers
+            In the case of an `np.ndarray`, we require a separate collection of identifiers of the vectors.
+        metadata
+            Presently ignored.
+        """
+        symbol_name = f"{namespace}{VECTOR_DB_DISTINGUISHED_SUFFIX}"
+        if metadata:
+            warnings.warn("Metadata are presently ignored.")
+
+        try:  # where symbol_name in self._lib
+            expected_dimensions = self._lib.read_metadata(symbol_name).metadata["dimensions"]
+        except NoDataFoundException:  # symbol_name not in self._lib
+            expected_dimensions = None
+
+        data_frame_to_upsert = _generate_dataframe(vectors, expected_dimensions, identifiers, metadata)
+        actual_dimensions = data_frame_to_upsert.shape[0]
+        if actual_dimensions > self._max_vector_size:
+            raise ValueError(
+                f"VectorDB {self} has maximum vector size {self._max_vector_size}, but you attempted to "
+                f"upsert vectors of size {data_frame_to_upsert.shape[0]}. To store vectors with more than "
+                f"{self._max_vector_size} vectors, you will have to initialise a new VectorDB on a "
+                "fresh library like so:\n\n"
+                ">>> arctic_client.create_library('nomen', LibraryOptions(rows_per_segment = k)\n\n"
+                "where k is the maximum vector size."
+            )
+        if data_frame_to_upsert.isnull().values.any():
+            raise ValueError("Vectors upserted must not contain NaNs.")
+        maximum_component = ((0.5 * np.finfo(np.float64).max) ** 0.5) / actual_dimensions
+        if (abs(data_frame_to_upsert).values > maximum_component).any():
+            raise ValueError(
+                "Vector component too large. The distance between vectors must not exceed the largest value storeable "
+                f"in an np.float64, {np.finfo(np.float64).max}.\n\n"
+                "To ensure this, the absolute value of component must not exceed\n\n"
+                "(1/d) * ((0.5 * np.finfo(np.float64).max) ** 0.5)\n\n"
+                "where d is the number of dimensions of the vector namespace. This applies to both the query vector "
+                "and the vectors stored. This bounds the vectors to a region in which the n-dimensional diagonal is "
+                "(approximately) np.finfo(np.float64).max."
+            )
+        try:  # in case where symbol_name in self._lib
+            old_df = self.read(namespace)
+            warnings.warn("This is extremely memory-inefficient!")
+            updated_df = old_df.combine_first(data_frame_to_upsert)
+            self._lib.write(symbol_name, updated_df, metadata={"dimensions": data_frame_to_upsert.shape[0]})
+        except NoSuchVersionException:  # symbol_name not in self._lib
+            self._lib.write(symbol_name, data_frame_to_upsert, metadata={"dimensions": data_frame_to_upsert.shape[0]})
+
+    def top_k(
+        self,
+        namespace: str,
+        query_vector: Collection[float],
+        k: int,
+        norm: Optional[str] = None,
+        index: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """
+        Returns the top `k` most similar vectors to `query_vector` in `namespace`. We use the vector ID as a tiebreaker.
+
+        Parameters
+        ----------
+        namespace
+            The namespace in which to perform the top-k search.
+        k
+            The number of vectors to return from the search.
+        query_vector
+            The vector from which distances are taken.
+        norm
+            The distance norm based on which the top k will be computed. This is presently ignored; the default
+            is Euclidean.
+        index
+            The index based on which to compute the top k. This is also ignored.
+        """
+        symbol_name = f"{namespace}{VECTOR_DB_DISTINGUISHED_SUFFIX}"
+        if k < 1:
+            raise ValueError("top-k makes sense only for integer k>0.")
+        if norm:
+            warnings.warn("Norms are presently ignored; we just use the Euclidean.")
+        if index:
+            warnings.warn("Indexing is presently unsupported.")
+        qv = np.array(query_vector)
+        if qv.ndim != 1:
+            raise ValueError("Query vectors must be one-dimensional.")
+        if np.isnan(np.dot(qv, qv)):  # apparently fast way of looking for nans.
+            raise ValueError("Query vectors may not contain NaNs.")
+
+        expected_dimensions = self._lib.read_metadata(symbol_name).metadata["dimensions"]
+        maximum_component = ((0.5 * np.finfo(np.float64).max) ** 0.5) / expected_dimensions
+        if (np.abs(qv) > maximum_component).any():
+            raise ValueError(
+                "Vector component too large. The distance between vectors must not exceed the largest value storeable "
+                f"in an np.float64, {np.finfo(np.float64).max}.\n\n"
+                "To ensure this, the absolute value of component must not exceed\n\n"
+                "(1/d) * ((0.5 * np.finfo(np.float64).max) ** 0.5)\n\n"
+                "where d is the number of dimensions of the vector namespace. This applies to both the query vector "
+                "and the vectors stored. This bounds the vectors to a region in which the n-dimensional diagonal is "
+                "(approximately) np.finfo(np.float64).max."
+            )
+
+        if qv.shape[0] != expected_dimensions:
+            raise ValueError(
+                "Query vectors must have the same number of components "
+                f"({expected_dimensions}) "
+                "as the vectors in the VectorDB. The vector given had "
+                f"{qv.shape[0]} components."
+            )
+        q = QueryBuilder()
+        q._top_k(qv, k)
+        result = self._lib.read(symbol_name, query_builder=q).data
+        result.index = list(result.index[:-1]) + ["similarity"]
+        return result
+
+    def read(self, namespace: str, identifiers: Optional[Collection[str]] = None) -> pd.DataFrame:
+        """
+        Reads a `namespace`.
+
+        Parameters
+        ----------
+        namespace
+            The namespace read.
+        identifiers
+            Presently ignored.
+        """
+        return self._lib.read(f"{namespace}{VECTOR_DB_DISTINGUISHED_SUFFIX}", identifiers).data
+
+
+class _VectorSymbol:
+    def __init__(self, namespace: str, vector_db: VectorDB):
+        """
+        A fairly simple wrapper to allow use of subscripts to access namespaces.
+
+        Parameters
+        ----------
+        namespace
+            The VectorDB to be subscripted.
+        vector_db
+            The namespace (the subscript).
+        """
+        self.namespace = namespace
+        self.vector_db = vector_db
+
+    def upsert(
+        self,
+        vectors: Union[Mapping[str, Mapping[str, any]], pd.DataFrame, np.ndarray],
+        identifiers: Optional[Collection[str]] = None,
+        metadata: Optional[Mapping[str, Mapping]] = None,
+    ) -> None:
+        self.vector_db.upsert(self.namespace, vectors, identifiers, metadata)
+
+    def top_k(
+        self, k: int, query_vector: Collection[float], norm: Optional[str] = None, index: Optional[str] = None
+    ) -> pd.DataFrame:
+        return self.vector_db.top_k(self.namespace, k, query_vector, norm, index)
+
+    def read(self, identifiers: Optional[List[str]] = None) -> pd.DataFrame:
+        return self.vector_db.read(self.namespace, identifiers)
+
+
+def new_vector_db(ac: Arctic, name: str, max_vector_size: int, segment_width: Optional[int] = None) -> VectorDB:
+    """
+    Returns a new VectorDB, after automatically creating an Arctic library in which to store the vectors. This is the
+    recommended method to initialise a VectorDB with the correct library parameters.
+
+    Explanation
+
+    Data in namespaces are processed in 'segments', which correspond to a row and column slice. Each vector is stored in
+    a column. For reasons of efficiency, we require that each vector should fit in one segment. The height of the
+    segment is determined in advance by `LibraryOptions`. Therefore, the maximum vector size is given by the
+    `rows_per_segment` parameter of `LibraryOptions` minus one. But we also store distances in the same column, so
+    the `rows_per_segment` parameter must be one more than the maximum vector size.
+
+    However, we also process vectors in batches given by segments, and it is more efficient to process
+    reasonably large numbers of vectors in one go. Therefore, we want `columns_per_segment` to be fairly large.
+
+    This would suggest that we should make segments as large (width- and height-wise) as possible. But for
+    reasons of efficiency, the segment size should be limited to roughly 100 million entries. Within all these
+    constraints, you should therefore work out the largest size of vector you envisage adding to the VectorDB.
+    This determines the segment row size, and therefore the recommended segment column size.
+
+    Parameters
+    ----------
+    ac
+        An `ArcticClient` in which the `VectorDB` will be stored.
+    name
+        The name of the library which the `VectorDB` will use.
+    max_vector_size
+        The maximum size of vectors that can be inserted.
+    segment_width
+        An optional parameter to specify the segment width; otherwise computed automatically.
+
+    Returns
+    -------
+    A VectorDB.
+    """
+    if max_vector_size < 1:
+        raise ValueError(f"max_vector_size must be at least 1; you attempted to set it to {max_vector_size}.")
+    column_width = segment_width if segment_width else int(SENSIBLE_SEGMENT_SIZE / max_vector_size)
+    ac.create_library(name, LibraryOptions(rows_per_segment=max_vector_size, columns_per_segment=column_width))
+    return VectorDB(ac[name])

--- a/python/arcticdb/vector_db/vector_db.py
+++ b/python/arcticdb/vector_db/vector_db.py
@@ -9,7 +9,7 @@ from arcticdb import Arctic
 from arcticdb.options import LibraryOptions
 from arcticdb.version_store.library import Library, ArcticUnsupportedDataTypeException
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.version_store import TopKClause as _TopKClause, NoSuchVersionException
+from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb_ext.storage import NoDataFoundException
 
 VECTOR_DB_DISTINGUISHED_SUFFIX = "_vector_db"
@@ -20,7 +20,8 @@ Vectors uploaded as mappings must have the following form.
 - The value should be another mapping.
     - The keys of these mappings should be strings.
     - They should include a value under "vector".
-    - The value under "vector" should be something that can be turned into a one-dimensional ndarray of floats.
+    - The value under "vector" should be something that is turned into a one-dimensional ndarray of floats by the method
+    np.array, e.g., a one-dimensional list of floats.
     - That array should have the right number of values (i.e. correspond to the number of dimensions of the other
     vectors in the namespace.)
 Attempts to upsert mappings not in this form should cause errors.
@@ -65,7 +66,7 @@ def _generate_dataframe_from_ndarray(
     """
     if vectors.ndim != 2:
         raise ValueError(
-            "Upsertion of vectors in an `np.ndarray` takes two-dimensional arrays; "
+            "Upsertion of vectors in an np.ndarray takes two-dimensional arrays; "
             f"the vector given had {vectors.ndim} instead."
         )
     if not np.issubdtype(vectors.dtype, float):
@@ -77,7 +78,7 @@ def _generate_dataframe_from_ndarray(
                 f"You attempted to insert {vectors.dtype}, which doesn't count."
             )
     if identifiers is None:
-        raise ValueError("Upsertion of vectors in an `np.ndarray` requires a list of identifiers.")
+        raise ValueError("Upsertion of vectors in an np.ndarray requires a list of identifiers.")
     if len(identifiers) != len(vectors):
         raise ValueError(f"You gave {len(identifiers)} identifiers but {len(vectors)} vectors.")
     if any([type(identifier) is not str for identifier in identifiers]):
@@ -303,7 +304,8 @@ class VectorDB:
             (taken as identifiers of vectors), and whose values are in turn mapping
             minimally containing a key-value pair 'value' pointing to something that
             yields a one-dimensional `np.ndarray` of numeric types corresponding to a
-            vector. Each vector must have the same dimensionality.
+            vector. That could, for example, be a one-dimensional list of floats.
+            Each vector must have the same dimensionality.
 
             In the case of a pandas DataFrame, we expect string columns and the entries to
             all be of a numeric type.

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -12,7 +12,7 @@ from math import inf
 import numpy as np
 import pandas as pd
 
-from typing import Dict
+from typing import Dict, Collection
 
 from arcticdb.exceptions import ArcticNativeException, UserInputException
 from arcticdb.version_store._normalization import normalize_dt_range_to_ts
@@ -28,6 +28,7 @@ from arcticdb_ext.version_store import AggregationClause as _AggregationClause
 from arcticdb_ext.version_store import RowRangeClause as _RowRangeClause
 from arcticdb_ext.version_store import DateRangeClause as _DateRangeClause
 from arcticdb_ext.version_store import RowRangeType as _RowRangeType
+from arcticdb_ext.version_store import TopKClause as _TopKClause
 from arcticdb_ext.version_store import ExpressionName as _ExpressionName
 from arcticdb_ext.version_store import ColumnName as _ColumnName
 from arcticdb_ext.version_store import ValueName as _ValueName
@@ -266,6 +267,7 @@ PythonFilterClause = namedtuple("PythonFilterClause", ["expr"])
 PythonProjectionClause = namedtuple("PythonProjectionClause", ["name", "expr"])
 PythonGroupByClause = namedtuple("PythonGroupByClause", ["name"])
 PythonAggregationClause = namedtuple("PythonAggregationClause", ["aggregations"])
+PythonTopKClause = namedtuple("TopKClause", ["vector", "k"])
 PythonRowRangeClause = namedtuple("PythonRowRangeClause", ["row_range_type", "n"])
 PythonDateRangeClause = namedtuple("PythonDateRangeClause", ["start", "end"])
 
@@ -522,6 +524,11 @@ class QueryBuilder:
         self._python_clauses.append(PythonRowRangeClause(_RowRangeType.TAIL, n))
         return self
 
+    def _top_k(self, query_vector: Collection[float], k: int):
+        self.clauses.append(_TopKClause(query_vector, k))
+        self._python_clauses.append(PythonTopKClause(query_vector, k))
+        return self
+
     def date_range(self, date_range: DateRangeInput):
         """
         DateRange to read data for.  Applicable only for Pandas data with a DateTime index. Returns only the part
@@ -592,6 +599,8 @@ class QueryBuilder:
                 self.clauses.append(_GroupByClause(python_clause.name))
             elif isinstance(python_clause, PythonAggregationClause):
                 self.clauses.append(_AggregationClause(self.clauses[-1].grouping_column, python_clause.aggregations))
+            elif isinstance(python_clause, PythonTopKClause):
+                self.clauses.append(_TopKClause(python_clause.vector, python_clause.k))
             else:
                 raise ArcticNativeException(
                     f"Unrecognised clause type {type(python_clause)} when unpickling QueryBuilder"

--- a/python/tests/integration/arcticdb/test_vector_db.py
+++ b/python/tests/integration/arcticdb/test_vector_db.py
@@ -1,0 +1,307 @@
+import string
+
+from hypothesis import HealthCheck, settings, given, strategies as st, reproduce_failure
+from hypothesis.extra.pandas import column, data_frames, range_indexes
+from hypothesis.extra.numpy import arrays
+from arcticdb.options import LibraryOptions
+from arcticdb_ext.version_store import NoSuchVersionException
+from arcticdb.util.hypothesis import (
+    numeric_type_strategies,
+    string_strategy,
+    use_of_function_scoped_fixtures_in_hypothesis_checked,
+)
+
+try:
+    from arcticdb.version_store import VersionedItem as PythonVersionedItem
+except ImportError:
+    # arcticdb squashes the packages
+    from arcticdb._store import VersionedItem as PythonVersionedItem
+from arcticdb.vector_db.vector_db import VectorDB, new_vector_db
+
+import pytest
+import pandas as pd
+import numpy as np
+from arcticdb_ext.tools import AZURE_SUPPORT
+from arcticdb.util.test import assert_frame_equal, assert_series_equal
+import random
+
+if AZURE_SUPPORT:
+    pass
+
+try:
+    from arcticdb.version_store.library import (
+        WritePayload,
+        ArcticUnsupportedDataTypeException,
+        ReadRequest,
+        ReadInfoRequest,
+        ArcticInvalidApiUsageException,
+        StagedDataFinalizeMethod,
+    )
+except ImportError:
+    # arcticdb squashes the packages
+    from arcticdb.library import (
+        WritePayload,
+        ArcticUnsupportedDataTypeException,
+        ReadRequest,
+        ReadInfoRequest,
+        ArcticInvalidApiUsageException,
+        StagedDataFinalizeMethod,
+    )
+
+
+def test_top_k_simple(arctic_client):
+    np.random.seed(0)
+    random.seed(0)
+    ac = arctic_client
+
+    dimensions, number_of_vectors, k = 15000, 200, 5
+    string_column_names = [
+        "".join(random.choices(string.ascii_uppercase + string.digits, k=10)) for _ in range(number_of_vectors)
+    ]
+
+    ac.create_library("pytest_test_top_k_simple")
+    vector_db = VectorDB(ac["pytest_test_top_k_simple"])
+
+    df = pd.DataFrame(np.random.rand(dimensions, number_of_vectors), columns=string_column_names)
+    qv = np.random.rand(dimensions)
+    distances = df.apply(lambda x: np.linalg.norm(x - qv))
+
+    combined = np.array([distances, np.array(distances.index)])
+    indices = np.core.records.fromrecords(combined.T, names=["distance", "id"]).argsort(order=["distance", "id"])[:k]
+    top_k_distances = distances[indices]
+
+    python_result = df.iloc[:, indices].append(pd.DataFrame(top_k_distances).T)
+    python_result.index = list(range(dimensions)) + ["similarity"]
+
+    vector_db.upsert(f"df{dimensions}", df)
+    cpp_result = vector_db.top_k(f"df{dimensions}", qv, k)
+
+    assert_frame_equal(python_result, cpp_result)
+
+
+def test_maximum_vector_size(arctic_client):
+    ac = arctic_client
+    ac.create_library("pytest_test_maximum_vector_size", LibraryOptions(rows_per_segment=2))
+    vdb = VectorDB(ac["pytest_test_maximum_vector_size"])
+    vdb.upsert("pytest_test_maximum_vector_size_namespace", pd.DataFrame(np.zeros((1, 1))))
+    with pytest.raises(ValueError):
+        vdb.upsert("pytest_test_maximum_vector_size_namespace", pd.DataFrame(np.zeros((2, 2))))
+
+
+def test_new_vector_db(arctic_client):
+    new_vector_db(arctic_client, "pytest_test_new_vector_db", 100)
+    new_vector_db(arctic_client, "pytest_test_new_vector_db_two", 100, 100)
+    with pytest.raises(ValueError):
+        new_vector_db(arctic_client, "pytest_test_new_vector_db", 100)
+    with pytest.raises(ValueError):
+        new_vector_db(arctic_client, "pytest_test_new_vector_db", 0)
+
+
+def test_validation(arctic_client):
+    ac = arctic_client
+    ac.create_library("pytest_test_validation")
+    vector_db = VectorDB(ac["pytest_test_validation"])
+
+    # Three-dimensional arrays can't be ingested..
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[[0]]]), identifiers=["test"])
+
+    # The number of vectors should be the same as the number of identifiers.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[0]]), identifiers=[])
+
+    # The identifiers must be strings.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[0]]), identifiers=[0])
+
+    # ndarrays must be supplied with identifiers.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert(np.array([[1]]))
+
+    # Subsequent insertion of differently-dimensioned vectors
+    # makes top-k meaningless and therefore is prohibited.
+    with pytest.raises(ValueError):
+        vector_db["differently_dimensioned_array_case"].upsert(np.array([[1]]), identifiers=["a"])
+        vector_db["differently_dimensioned_array_case"].upsert(np.array([[1, 2]]), identifiers=["b"])
+    with pytest.raises(ValueError):
+        vector_db["differently_dimensioned_df_case"].upsert(pd.DataFrame(np.random.rand(100, 100)))
+        vector_db["differently_dimensioned_df_case"].upsert(pd.DataFrame(np.random.rand(200, 200)))
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert({"1": {"vector": [0]}, "2": {"vector": [1, 2]}})
+
+    # Vectors in mappings must be one-dimensional.
+    with pytest.raises(ValueError):
+        vector_db["vdb"].upsert({"1": {"vector": [[0]]}})
+
+    # Keys to vectors in mappings must be strings.
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert({0: {"vector": [0]}})
+
+    # top-k with k !> 0 doesn't make sense.
+    with pytest.raises(ValueError):
+        vector_db["empty"].top_k([], 0)
+
+    # Non-numeric "vectors" (soi-disants) are unsupported.
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert(pd.DataFrame([""]))
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert({"vector": {"vector": [""]}})
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert(np.array([[""]]), identifiers=["test"])
+
+    # Upsertion takes mappings, DFs, and ndarrays.
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert(True)
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        vector_db["vdb"].upsert([])
+
+
+def test_inextant_namespace(arctic_client):
+    ac = arctic_client
+    ac.create_library("pytest_test_inextant_namespace")
+    vector_db = VectorDB(ac["pytest_test_inextant_namespace"])
+    with pytest.raises(NoSuchVersionException):
+        vector_db.read("DOES_NOT_EXIST")
+    with pytest.raises(NoSuchVersionException):
+        vector_db["DOES_NOT_EXIST"].read()
+
+
+def test_vector_db_requires_library(arctic_client):
+    with pytest.raises(ArcticUnsupportedDataTypeException):
+        VectorDB(3)
+
+
+def test_vector_db_empty_upsertions(arctic_client):
+    np.random.seed(0)
+    random.seed(0)
+
+    ac = arctic_client
+    ac.create_library("pytest_test_vector_db_empty_upsertions")
+
+    vector_db = VectorDB(ac["pytest_test_vector_db_empty_upsertions"])
+
+    with pytest.raises(ValueError):
+        vector_db.upsert("empty1", np.array([[]]))
+
+    vector_db.upsert("empty2", {})
+    assert_frame_equal(vector_db.read("empty2"), pd.DataFrame(), check_index_type=False)
+
+    vector_db.upsert("empty3", pd.DataFrame())
+    assert_frame_equal(vector_db.read("empty3"), pd.DataFrame(), check_index_type=False)
+
+
+def test_vector_db_upsertion(arctic_client):
+    np.random.seed(0)
+    random.seed(0)
+
+    ac = arctic_client
+    ac.create_library("pytest_test_vector_db_upsertion")
+
+    vector_db = VectorDB(ac["pytest_test_vector_db_upsertion"])
+
+    dimensions, number_of_vectors, k = 15, 20, 5
+    first_string_column_names = [
+        "".join(random.choices(string.ascii_uppercase + string.digits, k=10)) for _ in range(number_of_vectors)
+    ]
+    second_string_column_names = [
+        "".join(random.choices(string.ascii_uppercase + string.digits, k=15)) for _ in range(number_of_vectors)
+    ]
+    first_df = pd.DataFrame(np.random.rand(dimensions, number_of_vectors), columns=first_string_column_names)
+    second_df = pd.DataFrame(np.random.rand(dimensions, number_of_vectors), columns=second_string_column_names)
+
+    vector_db.upsert("first_is_first", first_df)
+    vector_db.upsert("first_is_first", second_df)
+    vector_db.upsert("second_is_first", second_df)
+    vector_db.upsert("second_is_first", first_df)
+
+    assert_frame_equal(vector_db.read("first_is_first"), vector_db.read("second_is_first"), check_like=True)
+
+    vector_db.upsert("first_is_first", first_df)
+    vector_db.upsert("first_is_first", first_df)
+    vector_db.upsert("first_is_first", first_df)
+
+    assert_frame_equal(vector_db.read("first_is_first"), vector_db.read("second_is_first"), check_like=True)
+
+
+@st.composite
+def dataframe_and_query_vector_and_k_and_repeats(draw):
+    vectors = draw(st.integers(min_value=1, max_value=10))
+    df = draw(
+        data_frames(
+            [column(i, dtype=np.float64) for i in range(vectors)],
+            index=range_indexes(min_size=1, max_size=10),
+        )
+    )
+    length = df.shape[0]
+    query_vector = draw(arrays(np.float64, shape=(length)))
+    k = draw(st.integers(min_value=1, max_value=vectors))
+    repeats = draw(st.integers(min_value=0, max_value=10))
+    return (df, query_vector, k, repeats)
+
+
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(suppress_health_check=[HealthCheck.too_slow], deadline=None, print_blob=True, max_examples=100)
+@given(dataframe_and_query_vector_and_k_and_repeats=dataframe_and_query_vector_and_k_and_repeats())
+def test_upsertion_idempotent(arctic_client, dataframe_and_query_vector_and_k_and_repeats):
+    ac = arctic_client
+    df, query_vector, k, repeats = dataframe_and_query_vector_and_k_and_repeats
+    if "pytest_test_upsertion_idempotent" in ac.list_libraries():
+        ac.delete_library("pytest_test_upsertion_idempotent")
+
+    vdb = new_vector_db(ac, "pytest_test_upsertion_idempotent", df.shape[0])
+
+    if df.isnull().values.any():
+        with pytest.raises(ValueError):
+            vdb.upsert("df", df)
+    else:
+        maximum_component = ((0.5 * np.finfo(np.float64).max) ** 0.5) / df.shape[0]
+        if (abs(df).values > maximum_component).any():
+            with pytest.raises(ValueError):
+                vdb.upsert("df", df)
+        else:
+            vdb.upsert("df", df)
+            first = vdb.read("df")
+            for _ in range(repeats):
+                vdb.upsert("df", df)
+            assert_frame_equal(first.sort_index(axis=1), vdb.read("df").sort_index(axis=1))
+
+
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(suppress_health_check=[HealthCheck.too_slow], deadline=None, print_blob=True, max_examples=100)
+@given(dataframe_and_query_vector_and_k_and_repeats=dataframe_and_query_vector_and_k_and_repeats())
+def test_top_k(arctic_client, dataframe_and_query_vector_and_k_and_repeats):
+    ac = arctic_client
+    df, qv, k, repeats = dataframe_and_query_vector_and_k_and_repeats
+    dimensions = df.shape[0]
+
+    if "pytest_test_top_k" in ac.list_libraries():
+        ac.delete_library("pytest_test_top_k")
+
+    ac.create_library("pytest_test_top_k")
+    vector_db = VectorDB(ac["pytest_test_top_k"])
+
+    if df.isnull().values.any():
+        with pytest.raises(ValueError):
+            vector_db.upsert(f"df{dimensions}", df)
+    else:
+        maximum_component = ((0.5 * np.finfo(np.float64).max) ** 0.5) / df.shape[0]
+        if (abs(df).values > maximum_component).any():
+            with pytest.raises(ValueError):
+                vector_db.upsert(f"df{dimensions}", df)
+        else:
+            vector_db.upsert(f"df{dimensions}", df)
+            if np.isnan(np.dot(qv, qv)):  # apparently fast way of looking for nans
+                with pytest.raises(ValueError):
+                    vector_db.top_k(f"df{dimensions}", qv, k)
+            elif (abs(qv) > maximum_component).any():
+                with pytest.raises(ValueError):
+                    vector_db.top_k(f"df{dimensions}", qv, k)
+            else:
+                distances = df.apply(lambda x: np.linalg.norm(x - qv))
+                indices = np.lexsort((np.array(distances.index).astype(str), distances))[:k]
+                top_k_distances = distances[indices]
+                python_result = df.iloc[:, indices].append(pd.DataFrame(top_k_distances).T)
+                python_result.index = list(range(dimensions)) + ["similarity"]
+
+                cpp_result = vector_db.top_k(f"df{dimensions}", qv, k)
+                assert_frame_equal(python_result, cpp_result)


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #674, #650.

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

A `VectorDB` wraps round a library (it takes the library when initialised). It supports

1. upsertion of vectors (for fresh identifiers, insertion; for used identifiers, updating); and
2. top-_k_ queries (presently Euclidean-only).

In Python, the API itself is otherwise completely unchanged. There are new methods in cpp that are accessible only through a `VectorDB` in Python.

#### Any other comments?

This is not very fast and limited to datasets that fit in memory; see #668 for further details.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
