### PR TITLE
Read metadata batch to catch all exceptions

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1606,25 +1606,52 @@ folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobu
     }
 }
 
-folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata_async(
-    folly::Future<std::optional<AtomKey>>&& version_fut){
+folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata_async(
+    folly::Future<std::optional<AtomKey>>&& version_fut,
+    const StreamId& stream_id,
+    const VersionQuery& version_query
+    ) {
     return  std::move(version_fut)
-    .thenValue([this](std::optional<AtomKey>&& key){
+    .thenValue([this, &stream_id, &version_query](std::optional<AtomKey>&& key){
+        missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(key.has_value(),
+        "Unable to retrieve  metadata. {}@{}: version not found", stream_id, version_query);
         return get_metadata(std::move(key));
+    })
+    .thenValue([](auto&& metadata){
+        auto&& [opt_key, meta_proto] = metadata;
+        return std::make_pair(std::move(*opt_key), std::move(meta_proto));
     });
 }
-
-std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::batch_read_metadata_internal(
+ 
+std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::Any>>, DataError>> LocalVersionedEngine::batch_read_metadata_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     const ReadOptions& read_options
     ) {
-    auto versions_fut = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
-    std::vector<folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>> fut_vec;
-    for (auto&& version: versions_fut){
-        fut_vec.push_back(get_metadata_async(std::move(version)));
+    auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
+    std::vector<folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>>> metadata_futures;
+    for (auto&& [idx, version]: folly::enumerate(version_futures)) {
+        metadata_futures.push_back(get_metadata_async(std::move(version), stream_ids[idx], version_queries[idx]));
     }
-    return folly::collect(fut_vec).get();
+
+    auto metadatas = folly::collectAll(metadata_futures).get();
+    std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::Any>>, DataError>> metadatas_or_errors;
+    metadatas_or_errors.reserve(metadatas.size());
+    for (auto&& [idx, metadata]: folly::enumerate(metadatas)) {
+        if (metadata.hasValue()) {
+            metadatas_or_errors.emplace_back(std::move(metadata.value()));
+        } else {
+            auto exception = metadata.exception();
+            DataError data_error(stream_ids[idx], exception.what().toStdString(), version_queries[idx].content_);
+            if (exception.is_compatible_with<NoSuchVersionException>()) {
+                data_error.set_error_code(ErrorCode::E_NO_SUCH_VERSION);
+            } else if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
+                data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+            }
+            metadatas_or_errors.emplace_back(std::move(data_error));
+        }
+    }
+    return metadatas_or_errors;
 }
 
 std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> LocalVersionedEngine::read_metadata_internal(

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -195,8 +195,10 @@ public:
     folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata(
         std::optional<AtomKey>&& key);
 
-    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata_async(
-        folly::Future<std::optional<AtomKey>>&& version_fut);
+    folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>> get_metadata_async(
+        folly::Future<std::optional<AtomKey>>&& version_fut,
+        const StreamId& stream_id,
+        const VersionQuery& version_query);
 
     folly::Future<DescriptorItem> get_descriptor(
         AtomKey&& key);
@@ -316,7 +318,7 @@ public:
             const std::vector<StreamId>& stream_ids,
             const std::vector<VersionQuery>& version_queries);
 
-    std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> batch_read_metadata_internal(
+    std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::Any>>, DataError>> batch_read_metadata_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1014,23 +1014,28 @@ std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> PythonVersionStore::
     return batch_restore_version_internal(stream_ids, version_queries);
 }
 
-std::vector<std::pair<VersionedItem, py::object>> PythonVersionStore::batch_read_metadata(
+std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> PythonVersionStore::batch_read_metadata(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     const ReadOptions& read_options) {
     ARCTICDB_SAMPLE(BatchReadMetadata, 0)
-    auto metadata = batch_read_metadata_internal(stream_ids, version_queries, read_options);
+    auto metadatas_or_errors = batch_read_metadata_internal(stream_ids, version_queries, read_options);
 
-    std::vector<std::pair<VersionedItem, py::object>> results;
-    for (auto [key, meta_proto]: metadata) {
+    std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> results;
+    for (auto&& metadata_or_error: metadatas_or_errors) {
+        if (std::holds_alternative<std::pair<VariantKey, std::optional<google::protobuf::Any>>>(metadata_or_error)) {
+            auto&& [key, meta_proto] = std::get<std::pair<VariantKey, std::optional<google::protobuf::Any>>>(metadata_or_error);
+            VersionedItem version{std::move(to_atom(key))};
             if(meta_proto.has_value()) {
-                VersionedItem version{std::move(to_atom(*key))};
-                auto res = std::make_pair(version, metadata_protobuf_to_pyobject(meta_proto));
-                results.push_back(res);
+                auto res = std::make_pair(std::move(version), metadata_protobuf_to_pyobject(std::move(meta_proto)));
+                results.push_back(std::move(res));
             }else{
-                auto res = std::make_pair(VersionedItem(), py::none());
-                results.push_back(res);   
+                auto res = std::make_pair(std::move(version), py::none());
+                results.push_back(std::move(res));   
             }
+        } else {
+            results.push_back(std::get<DataError>(std::move(metadata_or_error)));   
+        }
     }
     return results;
 }

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -296,7 +296,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, py::object>> batch_read_metadata(
+    std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> batch_read_metadata(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1015,34 +1015,35 @@ class NativeVersionStore:
             Dictionary of symbol mapping with the versioned items. The data attribute will be None.
         """
         _check_batch_kwargs(NativeVersionStore.batch_read_metadata, NativeVersionStore.read_metadata, kwargs)
-        meta_items = self._batch_read_meta_to_versioned_items(symbols, as_ofs, kwargs)
-        return {v.symbol: v for v in meta_items if v is not None}
+        include_errors_and_none_meta = False
+        meta_items = self._batch_read_metadata_to_versioned_items(
+            symbols, as_ofs, include_errors_and_none_meta, **kwargs
+        )
+        return {v.symbol: v for v in meta_items}
 
-    def _batch_read_meta_to_versioned_items(self, symbols, as_ofs, kwargs=None):
-        if kwargs is None:
-            kwargs = dict()
-        meta_data_list = []
+    def _batch_read_metadata_to_versioned_items(self, symbols, as_ofs, include_errors_and_none_meta, **kwargs):
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         read_options = self._get_read_options(**kwargs)
-        result = self.version_store.batch_read_metadata(symbols, version_queries, read_options)
-        result_list = list(zip(symbols, result))
-        for original_symbol, result in result_list:
-            vitem, udm = result
-            if original_symbol != vitem.symbol:
-                meta_data_list.append(None)
-            else:
-                meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
-                meta_data_list.append(
-                    VersionedItem(
-                        symbol=vitem.symbol,
-                        library=self._library.library_path,
-                        data=None,
-                        version=vitem.version,
-                        metadata=meta,
-                        host=self.env,
+        metadatas_or_errors = self.version_store.batch_read_metadata(symbols, version_queries, read_options)
+        meta_items = []
+        for metadata in metadatas_or_errors:
+            if isinstance(metadata, DataError) and include_errors_and_none_meta:
+                meta_items.append(metadata)
+            if not isinstance(metadata, DataError):
+                vitem, udm = metadata
+                if udm is not None or include_errors_and_none_meta:
+                    meta = denormalize_user_metadata(udm, self._normalizer) if udm is not None else None
+                    meta_items.append(
+                        VersionedItem(
+                            symbol=vitem.symbol,
+                            library=self._library.library_path,
+                            data=None,
+                            version=vitem.version,
+                            metadata=meta,
+                            host=self.env,
+                        )
                     )
-                )
-        return meta_data_list
+        return meta_items
 
     def batch_read_metadata_multi(
         self, symbols: List[str], as_ofs: Optional[List[VersionQueryInput]] = None, **kwargs

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -15,6 +15,7 @@ from arcticdb.supported_types import Timestamp
 
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.version_store._store import NativeVersionStore, VersionedItem, VersionQueryInput
+from arcticdb.version_store._normalization import denormalize_user_metadata
 from arcticdb_ext.exceptions import ArcticException
 from arcticdb_ext.version_store import DataError
 import pandas as pd
@@ -1075,22 +1076,24 @@ class Library:
         """
         return self._nvs.read_metadata(symbol, as_of)
 
-    def read_metadata_batch(self, symbols: List[Union[str, ReadInfoRequest]]) -> List[VersionedItem]:
+    def read_metadata_batch(self, symbols: List[Union[str, ReadInfoRequest]]) -> List[Union[VersionedItem, DataError]]:
         """
         Reads the metadata of multiple symbols.
 
         Parameters
         ----------
         symbols : List[Union[str, ReadInfoRequest]]
-            List of symbols to read.
+            List of symbols to read metadata.
 
         Returns
         -------
-        List[VersionedItem]
-            A list of the read results, whose i-th element corresponds to the i-th element of the ``symbols`` parameter.
+        List[Union[VersionedItem, DataError]]
+            A list of the read metadata results, whose i-th element corresponds to the i-th element of the ``symbols`` parameter.
             A VersionedItem object with the metadata field set as None will be returned if the requested version of the
-                symbol exists but there is no metadata
-            A None object will be returned if the requested version of the symbol does not exist
+            symbol exists but there is no metadata
+            If the specified version does not exist, a DataError object is returned, with symbol, version_request_type,
+            version_request_data properties, error_code, error_category, and exception_string properties. If a key error or
+            any other internal exception occurs, the same DataError object is also returned.
 
         See Also
         --------
@@ -1116,7 +1119,9 @@ class Library:
                 raise ArcticInvalidApiUsageException(
                     f"Invalid symbol type s=[{s}] type(s)=[{type(s)}]. Only [str] and [ReadInfoRequest] are supported."
                 )
-        return self._nvs._batch_read_meta_to_versioned_items(symbol_strings, as_ofs)
+
+        include_errors_and_none_meta = True
+        return self._nvs._batch_read_metadata_to_versioned_items(symbol_strings, as_ofs, include_errors_and_none_meta)
 
     def write_metadata(self, symbol: str, metadata: Any) -> VersionedItem:
         """


### PR DESCRIPTION
Closes https://github.com/man-group/ArcticDB/issues/613

The previous behaviour of Library.read_metadata_batch and NativeVersionStore.batch_read_metadata was to throw an exception if there was an issue related to a missing key. For backwards compatibility reasons, this behaviour has been maintained for NativeVersionStore.batch_read_metadata.

For Library.read_metadata_batch, this has been changed. A DataError object will now be returned in the position in the list returned corresponding to the symbol/version pair there was an issue retrieving. This contains the symbol and version requested, and the exception string thrown. For one well-defined category of error, the error category and specific error code are also included:

- ErrorCategory.STORAGE - ErrorCode.E_KEY_NOT_FOUND: The index key required to read the specified version does not exist in the storage.

- ErrorCategory.MISSING_DATA - ErrorCode.E_NO_SUCH_VERSION: The version requested by the user does not exist

Otherwise these fields of the DataError object are left as None.