### PR TITLE
fix(docs): central docs URL from API docs homepage

### DIFF
--- a/docs/sphinxdocs/source/index.rst
+++ b/docs/sphinxdocs/source/index.rst
@@ -6,7 +6,7 @@ Introduction
 
 This site documents the Python API of ArcticDB.
 
-Tutorials, guides and team contact details are available `here <http://arcticdb.io/docs>`_.
+Tutorials, guides and team contact details are available `here <https://docs.arcticdb.io>`_.
 
 The API is structured into the following components:
 


### PR DESCRIPTION
`https://arcticdb.io/docs` has been replaced by `https://docs.arcticdb.io` as far as I can tell; this seems annoying.