### PR TITLE
write batch to catch all the exceptions

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -375,7 +375,7 @@ public:
         const std::vector<UpdateInfo>& stream_update_info_vector,
         bool prune_previous_versions);
 
-    std::vector<VersionedItem> batch_write_versioned_dataframe_internal(
+    std::vector<std::variant<VersionedItem, DataError>> batch_write_versioned_dataframe_internal(
         const std::vector<StreamId>& stream_ids,
         std::vector<InputTensorFrame>&& frames,
         bool prune_previous_versions,

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -101,7 +101,7 @@ std::vector<VersionedItem> PythonVersionStore::batch_write_index_keys_to_version
     return output;
 }
 
-std::vector<VersionedItem> PythonVersionStore::batch_write(
+std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_write(
     const std::vector<StreamId>& stream_ids,
     const std::vector<py::tuple> &items,
     const std::vector<py::object> &norms,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -263,7 +263,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::optional<bool>& skip_snapshots);
 
     // Batch methods
-    std::vector<VersionedItem> batch_write(
+    std::vector<std::variant<VersionedItem, DataError>> batch_write(
         const std::vector<StreamId> &stream_ids,
         const std::vector<py::tuple> &items,
         const std::vector<py::object> &norms,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1205,7 +1205,13 @@ class NativeVersionStore:
         cxx_versioned_items = self.version_store.batch_write(
             symbols, items, norm_metas, udms, prune_previous_version, validate_index
         )
-        return [self._convert_thin_cxx_item_to_python(v) for v in cxx_versioned_items]
+        write_results = []
+        for result in cxx_versioned_items:
+            if isinstance(result, DataError):
+                write_results.append(result)
+            else:
+                write_results.append(self._convert_thin_cxx_item_to_python(result))
+        return write_results
 
     def _batch_write_metadata_to_versioned_items(
         self, symbols: List[str], metadata_vector: List[Any], prune_previous_version

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -490,7 +490,7 @@ class Library:
 
     def write_batch(
         self, payloads: List[WritePayload], prune_previous_versions: bool = False, staged=False, validate_index=True
-    ) -> List[VersionedItem]:
+    ) -> List[Union[VersionedItem, DataError]]:
         """
         Write a batch of multiple symbols.
 
@@ -509,9 +509,13 @@ class Library:
 
         Returns
         -------
-        List[VersionedItem]
-            Structure containing metadata and version number of the written symbols in the store, in the
+        List[Union[VersionedItem, DataError]]
+            List of versioned items. The data attribute will be None for each versioned item.
+            i-th entry corresponds to i-th element of `payloads`. Each result correspond to
+            a structure containing metadata and version number of the written symbols in the store, in the
             same order as `payload`.
+            If a key error or any other internal exception is raised, a DataError object is returned, with symbol,
+            error_code, error_category, and exception_string properties.
 
         Raises
         ------
@@ -519,8 +523,6 @@ class Library:
             When duplicate symbols appear in payload.
         ArcticUnsupportedDataTypeException
             If data that is not of NormalizableType appears in any of the payloads.
-        UnsortedDataException
-            If data is unsorted, when validate_index is set to True.
 
         See Also
         --------
@@ -713,7 +715,7 @@ class Library:
         List[Union[VersionedItem, DataError]]
             List of versioned items. i-th entry corresponds to i-th element of `append_payloads`.
             Each result correspond to a structure containing metadata and version number of the affected
-            symbol in the store. If any internal exception is raised, a DataError object is returned, with symbol,
+            symbol in the store. If a key error or any other internal exception is raised, a DataError object is returned, with symbol,
             error_code, error_category, and exception_string properties.
 
         Raises

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -317,7 +317,7 @@ def test_write_batch(library_factory):
     lib = library_factory(LibraryOptions(rows_per_segment=10))
     assert lib._nvs._lib_cfg.lib_desc.version.write_options.segment_row_size == 10
     num_days = 40
-    num_symbols = 40
+    num_symbols = 2
     dt = datetime(2019, 4, 8, 0, 0, 0)
     column_length = 4
     num_columns = 5
@@ -343,12 +343,12 @@ def test_write_batch(library_factory):
 
 
 def test_write_batch_dedup(library_factory):
-    """Should be able to write different size of batch of data."""
+    """Should be able to write different size of batch of data reusing deduplicated data from previous versions."""
     lib = library_factory(LibraryOptions(rows_per_segment=10, dedup=True))
     assert lib._nvs._lib_cfg.lib_desc.version.write_options.segment_row_size == 10
     assert lib._nvs._lib_cfg.lib_desc.version.write_options.de_duplication == True
     num_days = 40
-    num_symbols = 10
+    num_symbols = 2
     num_versions = 4
     dt = datetime(2019, 4, 8, 0, 0, 0)
     column_length = 4
@@ -380,6 +380,48 @@ def test_write_batch_dedup(library_factory):
         data_key_version = lib._nvs.read_index("symbol_" + str(sym))["version_id"]
         for s in range(num_segments):
             assert data_key_version[s] == 0
+
+
+def test_write_batch_missing_keys_dedup(library_factory):
+    """When there is duplicate data to reuse for the current write, we need to access the index key of the previous
+    versions in order to refer to the corresponding keys for the deduplicated data."""
+    lib = library_factory(LibraryOptions(dedup=True))
+    assert lib._nvs._lib_cfg.lib_desc.version.write_options.de_duplication == True
+
+    num_days = 2
+    num_rows_per_day = 1
+
+    # Given
+    dt = datetime(2019, 4, 8, 0, 0, 0)
+    df1 = generate_dataframe(["a", "b", "c"], dt, num_days, num_rows_per_day)
+    df2 = generate_dataframe(["a", "b", "c"], dt, num_days, num_rows_per_day)
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+
+    lib_tool = lib._nvs.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    lib_tool.remove(s1_index_key)
+
+    # When
+    batch = lib.write_batch(
+        [
+            WritePayload("s1", df1, metadata="great_metadata_s1"),
+            WritePayload("s2", df2, metadata="great_metadata_s2"),
+        ]
+    )
+
+    # Then
+    assert isinstance(batch[0], DataError)
+    assert batch[0].symbol == "s1"
+    assert batch[0].version_request_type is None
+    assert batch[0].version_request_data is None
+    assert batch[0].error_code == ErrorCode.E_KEY_NOT_FOUND
+    assert batch[0].error_category == ErrorCategory.STORAGE
+
+    assert not isinstance(batch[1], DataError)
+    read_dataframe = lib.read("s2")
+    assert read_dataframe.metadata == "great_metadata_s2"
+    assert_frame_equal(read_dataframe.data, df2)
 
 
 def test_append_batch(library_factory):


### PR DESCRIPTION
Closes #652

The previous behaviour of Library.write_batch and NativeVersionStore.batch_write was to throw an exception if there was an issue when trying to write the data. For backwards compatibility reasons, this behaviour has been maintained for NativeVersionStore.batch_write.

For Library.write_batch, this has been changed. A DataError object will now be returned in the position in the list returned corresponding to the symbol there was an issue writing. This contains the symbol and version requested, and the exception string thrown. For a well-defined category of error, the error category and specific error code are also included:

`ErrorCategory.STORAGE - ErrorCode.E_KEY_NOT_FOUND: The index (in case of dedup) key required for the write method does not exist in the storage.`

Otherwise these fields of the DataError object are left as None.
