### PR TITLE
Add uri support for mongodb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,10 @@ jobs:
                 symbols: "*.gz" # Please update publish.yml when changing this!!
                 do_not_archive: ["*.so", "*.[ao]", "vcpkg_installed"]
                 test_services:
-                  mongodb: { image: "mongo:4.4" }
+                  mongodb:
+                    image: "mongo:4.4"
+                  mongodb_2:
+                    image: "mongo:4.4"
             windows_matrix:
               - os: windows
                 distro: windows-latest

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -278,13 +278,14 @@ jobs:
           echo "ARCTICDB_REAL_S3_CLEAR=${{ inputs.clear }}" >> $GITHUB_ENV
           echo "ARCTICDB_REAL_S3_ACCESS_KEY=${{ secrets.AWS_S3_ACCESS_KEY }}" >> $GITHUB_ENV
           echo "ARCTICDB_REAL_S3_SECRET_KEY=${{ secrets.AWS_S3_SECRET_KEY }}" >> $GITHUB_ENV
-          
+  
       - name: Run test
         run: build_tooling/parallel_test.sh tests/${{matrix.type}}
         env:
           TEST_OUTPUT_DIR: ${{runner.temp}}
           # Use the Mongo created in the service container above to test against
           CI_MONGO_HOST: mongodb
+          CI_MONGO_HOST_2: mongodb_2
           ARCTICDB_PERSISTENT_STORAGE_LIB_NAME: 'test_${{ github.ref_name }}_${{matrix.os}}_${{env.python_impl_name}}${{matrix.python_deps_id}}'
   
 

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -13,11 +13,8 @@ catch=`{ which catchsegv 2>/dev/null || echo ; } | tail -n 1`
 function worker() {
     group=${1:?Must pass the group id argument}
     shift
-    duration_file="$TEST_OUTPUT_DIR/pytest-durations.$group.json"
     new_root=$PARALLEL_TEST_ROOT/$group
     set -o xtrace -o pipefail
-
-    cp "$tooling_dir/pytest-durations.json" "$duration_file"
 
     # Build a directory that's just the test assets, so can't access other Python source not in the wheel
     # Each test also get a separate directory since there's a mystery lock somewhere preventing concurrent runs (even)
@@ -28,7 +25,7 @@ function worker() {
 
     $catch python -m pytest -v --show-capture=no --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
-        --splits $splits --group $group --durations-path="$duration_file" --store-durations \
+        --splits $splits --group $group \
         --basetemp="$new_root/temp-pytest-output" \
         "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#$group: \2#"
 }

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -164,8 +164,14 @@ class MongoClientImpl {
         uint64_t min_pool_size,
         uint64_t max_pool_size,
         uint64_t selection_timeout_ms) {
-        return fmt::format("{}&minPoolSize={}&maxPoolSize={}&serverSelectionTimeoutMS={}",
-            uri, min_pool_size, max_pool_size, selection_timeout_ms);
+        const auto uri_options = mongocxx::uri(uri).options();
+        if (uri_options.find("minPoolSize") == uri_options.end())
+            uri += fmt::format("&minPoolSize={}", min_pool_size);
+        if (uri_options.find("maxPoolSize") == uri_options.end())
+            uri += fmt::format("&maxPoolSize={}", max_pool_size);
+        if (uri_options.find("serverSelectionTimeoutMS") == uri_options.end())
+            uri += fmt::format("&serverSelectionTimeoutMS={}", selection_timeout_ms);
+        return uri;
     }
 
   public:

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -65,4 +65,5 @@ dependencies:
   # See: https://github.com/man-group/ArcticDB/pull/291
   - hypothesis < 6.73
   - pytest-sugar
+  - pymongo
 

--- a/python/arcticdb/adapters/__init__.py
+++ b/python/arcticdb/adapters/__init__.py
@@ -1,3 +1,4 @@
 from arcticdb.adapters.lmdb_library_adapter import LMDBLibraryAdapter
 from arcticdb.adapters.s3_library_adapter import S3LibraryAdapter
 from arcticdb.adapters.azure_library_adapter import AzureLibraryAdapter
+from arcticdb.adapters.mongo_library_adapter import MongoLibraryAdapter

--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -86,9 +86,7 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
         return lib._library
 
     def _parse_query(self, query: str) -> ParsedQuery:
-        if query and query.startswith("?"):
-            query = query.strip("?")
-        elif not query:
+        if not query:
             raise ValueError(f"Invalid Azure URI. Missing query parameter")
 
         parsed_query = re.split("[;]", query)

--- a/python/arcticdb/adapters/mongo_library_adapter.py
+++ b/python/arcticdb/adapters/mongo_library_adapter.py
@@ -1,0 +1,70 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+from arcticdb.options import LibraryOptions
+from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
+from arcticdb.version_store.helper import add_mongo_library_to_env
+from arcticdb.config import _DEFAULT_ENV
+from arcticdb.version_store._store import NativeVersionStore
+from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter, set_library_options
+from arcticdb_ext.storage import Library
+from arcticdb.encoding_version import EncodingVersion
+from arcticdb.exceptions import UserInputException
+from collections import namedtuple
+from dataclasses import dataclass, fields
+import pymongo
+
+PARSED_QUERY = namedtuple("PARSED_QUERY", ["region"])
+
+
+class MongoLibraryAdapter(ArcticLibraryAdapter):
+    @staticmethod
+    def supports_uri(uri: str) -> bool:
+        return uri.startswith("mongodb://")
+
+    def __init__(self, uri: str, encoding_version: EncodingVersion, *args, **kwargs):
+        try:
+            parameters = pymongo.uri_parser.parse_uri(uri)
+            self._endpoint = f"{parameters['nodelist'][0][0]}:{parameters['nodelist'][0][1]}"
+        except Exception as e:
+            raise UserInputException(
+                f"Invalid connection string format. {e} Correct format: mongodb://[HOST]/[DATABASE][?OPTIONS]"
+            )
+        self._uri = uri
+        self._encoding_version = encoding_version
+
+        super().__init__(uri, self._encoding_version)
+
+    def __repr__(self):
+        return f"mongodb(endpoint={self._endpoint})"
+
+    @property
+    def config_library(self):
+        env_cfg = EnvironmentConfigsMap()
+
+        add_mongo_library_to_env(cfg=env_cfg, lib_name=self.CONFIG_LIBRARY_NAME, env_name=_DEFAULT_ENV, uri=self._uri)
+
+        lib = NativeVersionStore.create_store_from_config(
+            env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version
+        )
+
+        return lib._library
+
+    def create_library(self, name, library_options: LibraryOptions):
+        env_cfg = EnvironmentConfigsMap()
+
+        add_mongo_library_to_env(cfg=env_cfg, lib_name=name, env_name=_DEFAULT_ENV, uri=self._uri)
+        library_options.encoding_version = (
+            library_options.encoding_version if library_options.encoding_version is not None else self._encoding_version
+        )
+        set_library_options(env_cfg.env_by_id[_DEFAULT_ENV].lib_by_path[name], library_options)
+
+        lib = NativeVersionStore.create_store_from_config(
+            env_cfg, _DEFAULT_ENV, name, encoding_version=library_options.encoding_version
+        )
+
+        return lib

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -14,8 +14,9 @@ from arcticdb.version_store.library import ArcticInvalidApiUsageException, Libra
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.adapters.s3_library_adapter import S3LibraryAdapter
 from arcticdb.adapters.lmdb_library_adapter import LMDBLibraryAdapter
-from arcticdb.encoding_version import EncodingVersion
 from arcticdb.adapters.azure_library_adapter import AzureLibraryAdapter
+from arcticdb.adapters.mongo_library_adapter import MongoLibraryAdapter
+from arcticdb.encoding_version import EncodingVersion
 
 
 class Arctic:
@@ -24,7 +25,7 @@ class Arctic:
     creation, deletion and retrieval of Arctic libraries.
     """
 
-    _LIBRARY_ADAPTERS = [S3LibraryAdapter, LMDBLibraryAdapter, AzureLibraryAdapter]
+    _LIBRARY_ADAPTERS = [S3LibraryAdapter, LMDBLibraryAdapter, AzureLibraryAdapter, MongoLibraryAdapter]
 
     def __init__(self, uri: str, encoding_version: EncodingVersion = DEFAULT_ENCODING_VERSION):
         """

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -35,7 +35,7 @@ from arcticdb_ext import set_config_int, get_config_int, unset_config_int
 # leave out Mongo as spinning up a Mongo instance in Windows CI is fiddly, and Mongo support is only
 # currently required for Linux for internal use.
 # We also skip it on Mac as github actions containers don't work with macos
-RUN_MONGO_TEST = True if sys.platform == "linux" else False
+RUN_MONGO_TEST = sys.platform == "linux"
 
 
 def maybe_not_check_freq(f):

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -18,6 +18,7 @@ import attr
 from six import PY3
 from copy import deepcopy
 from functools import wraps
+import sys
 
 from arcticdb.config import Defaults
 from arcticdb.log import configure, logger_by_name
@@ -30,6 +31,11 @@ from arcticc.pb2.storage_pb2 import LibraryDescriptor, VersionStoreConfig
 from arcticdb.version_store.helper import ArcticFileConfig
 from arcticdb.config import _DEFAULT_ENVS_PATH
 from arcticdb_ext import set_config_int, get_config_int, unset_config_int
+
+# leave out Mongo as spinning up a Mongo instance in Windows CI is fiddly, and Mongo support is only
+# currently required for Linux for internal use.
+# We also skip it on Mac as github actions containers don't work with macos
+RUN_MONGO_TEST = True if sys.platform == "linux" else False
 
 
 def maybe_not_check_freq(f):

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -190,7 +190,7 @@ def add_memory_library_to_env(cfg, lib_name, env_name, description=None):
     _add_lib_desc_to_env(env, lib_name, sid, description)
 
 
-def add_mongo_library_to_env(cfg, lib_name, env_name, uri=None, description=None):
+def get_mongo_proto(cfg, lib_name, env_name, uri):
     env = cfg.env_by_id[env_name]
     mongo = MongoConfig()
     if uri is not None:
@@ -198,6 +198,18 @@ def add_mongo_library_to_env(cfg, lib_name, env_name, uri=None, description=None
 
     sid, storage = get_storage_for_lib_name(lib_name, env)
     storage.config.Pack(mongo, type_url_prefix="cxx.arctic.org")
+    return sid, storage
+
+
+def add_mongo_library_to_env(cfg, lib_name, env_name, uri=None, description=None):
+    env = cfg.env_by_id[env_name]
+    sid, storage = get_mongo_proto(
+        cfg=cfg,
+        lib_name=lib_name,
+        env_name=env_name,
+        uri=uri,
+    )
+
     _add_lib_desc_to_env(env, lib_name, sid, description)
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -162,7 +162,7 @@ def moto_s3_uri_incl_bucket(moto_s3_endpoint_and_credentials):
         ),
     ],
 )
-def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):
+def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version, lib_name):
     if request.param == "S3":
         ac = Arctic(moto_s3_uri_incl_bucket, encoding_version)
     elif request.param == "Azure":
@@ -201,12 +201,12 @@ def azurite_azure_uri_incl_bucket(azurite_azure_uri, azure_client_and_create_con
 
 
 @pytest.fixture(scope="function")
-def arctic_library(request, arctic_client, lib_name):
+def arctic_library(request, arctic_client):
     if AZURE_SUPPORT:
         request.getfixturevalue("azure_client_and_create_container")
 
-    arctic_client.create_library(lib_name)
-    return arctic_client[lib_name]
+    arctic_client.create_library("pytest_test_lib")
+    return arctic_client["pytest_test_lib"]
 
 
 @pytest.fixture()
@@ -438,8 +438,14 @@ def mongo_test_uri(request):
     # Use MongoDB if it's running (useful in CI), otherwise spin one up with pytest-server-fixtures.
     # mongodb does not support prefix to differentiate different tests and the server is session-scoped
     # therefore lib_name is needed to be used to avoid reusing library name or list_versions check will fail
-    mongo_host = os.getenv("CI_MONGO_HOST", "localhost")
-    mongo_port = os.getenv("CI_MONGO_PORT", 27017)
+    if (
+        "--group" not in sys.argv or sys.argv[sys.argv.index("--group") + 1] == "1"
+    ):  # To detect pytest-split parallelization group in use
+        mongo_host = os.getenv("CI_MONGO_HOST", "localhost")
+        mongo_port = 27017
+    else:
+        mongo_host = os.getenv("CI_MONGO_HOST_2", "localhost")
+        mongo_port = 27017
     mongo_path = f"{mongo_host}:{mongo_port}"
     try:
         res = requests.get(f"http://{mongo_path}")
@@ -450,10 +456,16 @@ def mongo_test_uri(request):
     if have_running_mongo:
         uri = f"mongodb://{mongo_path}"
     else:
-        mongo_server_sess = request.getfixturevalue("mongo_server")
-        uri = f"mongodb://{mongo_server_sess.hostname}:{mongo_server_sess.port}"
+        mongo_server = request.getfixturevalue("mongo_server")
+        uri = f"mongodb://{mongo_server.hostname}:{mongo_server.port}"
 
-    return uri
+    yield uri
+
+    # mongodb does not support prefix to differentiate different tests and the server is session-scoped
+    mongo_client = pymongo.MongoClient(uri)
+    for db_name in mongo_client.list_database_names():
+        if db_name not in ["local", "admin", "apiomat", "config"]:
+            mongo_client.drop_database(db_name)
 
 
 @pytest.fixture

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -33,6 +33,7 @@ import subprocess
 from pathlib import Path
 import socket
 import tempfile
+import pymongo
 
 import requests
 from pytest_server_fixtures.base import get_ephemeral_port
@@ -45,7 +46,7 @@ from arcticdb.version_store.helper import (
     create_test_azure_cfg,
 )
 from arcticdb.config import Defaults
-from arcticdb.util.test import configure_test_logger, apply_lib_cfg
+from arcticdb.util.test import configure_test_logger, apply_lib_cfg, RUN_MONGO_TEST
 from arcticdb.version_store.helper import ArcticMemoryConfig
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._normalization import MsgPackNormalizer
@@ -146,7 +147,21 @@ def moto_s3_uri_incl_bucket(moto_s3_endpoint_and_credentials):
     ] + ":" + bucket + "?access=" + aws_access_key + "&secret=" + aws_secret_key + "&port=" + port
 
 
-@pytest.fixture(scope="function", params=["S3", "LMDB", "Azure"] if AZURE_SUPPORT else ["S3", "LMDB"])
+@pytest.fixture(
+    scope="function",
+    params=[
+        "S3",
+        "LMDB",
+        pytest.param(
+            "Azure",
+            marks=pytest.mark.skipif(not AZURE_SUPPORT, reason="Pending Azure Storge Conda support"),
+        ),
+        pytest.param(
+            "Mongo",
+            marks=pytest.mark.skipif(not RUN_MONGO_TEST, reason="Mongo test on windows is fiddly"),
+        ),
+    ],
+)
 def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):
     if request.param == "S3":
         ac = Arctic(moto_s3_uri_incl_bucket, encoding_version)
@@ -154,6 +169,8 @@ def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):
         ac = Arctic(request.getfixturevalue("azurite_azure_uri_incl_bucket"), encoding_version)
     elif request.param == "LMDB":
         ac = Arctic(f"lmdb://{tmpdir}", encoding_version)
+    elif request.param == "Mongo":
+        ac = Arctic(request.getfixturevalue("mongo_test_uri"), encoding_version)
     else:
         raise NotImplementedError()
 
@@ -184,12 +201,12 @@ def azurite_azure_uri_incl_bucket(azurite_azure_uri, azure_client_and_create_con
 
 
 @pytest.fixture(scope="function")
-def arctic_library(request, arctic_client):
+def arctic_library(request, arctic_client, lib_name):
     if AZURE_SUPPORT:
         request.getfixturevalue("azure_client_and_create_container")
 
-    arctic_client.create_library("pytest_test_lib")
-    return arctic_client["pytest_test_lib"]
+    arctic_client.create_library(lib_name)
+    return arctic_client[lib_name]
 
 
 @pytest.fixture()
@@ -416,9 +433,11 @@ def azure_store_factory(lib_name, arcticdb_test_azure_config, azure_client_and_c
 
 
 @pytest.fixture
-def mongo_store_factory(request, lib_name):
+def mongo_test_uri(request):
     """Similar capability to `s3_store_factory`, but uses a mongo store."""
     # Use MongoDB if it's running (useful in CI), otherwise spin one up with pytest-server-fixtures.
+    # mongodb does not support prefix to differentiate different tests and the server is session-scoped
+    # therefore lib_name is needed to be used to avoid reusing library name or list_versions check will fail
     mongo_host = os.getenv("CI_MONGO_HOST", "localhost")
     mongo_port = os.getenv("CI_MONGO_PORT", 27017)
     mongo_path = f"{mongo_host}:{mongo_port}"
@@ -431,10 +450,15 @@ def mongo_store_factory(request, lib_name):
     if have_running_mongo:
         uri = f"mongodb://{mongo_path}"
     else:
-        mongo_server_sess = request.getfixturevalue("mongo_server_sess")
+        mongo_server_sess = request.getfixturevalue("mongo_server")
         uri = f"mongodb://{mongo_server_sess.hostname}:{mongo_server_sess.port}"
 
-    cfg_maker = functools.partial(create_test_mongo_cfg, uri=uri)
+    return uri
+
+
+@pytest.fixture
+def mongo_store_factory(request, lib_name, mongo_test_uri):
+    cfg_maker = functools.partial(create_test_mongo_cfg, uri=mongo_test_uri)
     used = {}
     try:
         yield functools.partial(_version_store_factory_impl, used, cfg_maker, lib_name)
@@ -723,7 +747,17 @@ def spawn_azurite(azurite_port):
 @pytest.fixture(
     scope="function",
     params=(
-        ["moto_s3_uri_incl_bucket", "azurite_azure_uri_incl_bucket"] if AZURE_SUPPORT else ["moto_s3_uri_incl_bucket"]
+        [
+            "moto_s3_uri_incl_bucket",
+            pytest.param(
+                "mongo_test_uri",
+                marks=pytest.mark.skipif(not RUN_MONGO_TEST, reason="Mongo test on windows is fiddly"),
+            ),
+            pytest.param(
+                "azurite_azure_uri_incl_bucket",
+                marks=pytest.mark.skipif(not AZURE_SUPPORT, reason="Pending Azure Storge Conda support"),
+            ),
+        ]
     ),
 )
 def object_storage_uri_incl_bucket(request):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -172,22 +172,20 @@ def test_library_options(arctic_client):
     assert lib._nvs._lib_cfg.lib_desc.version.encoding_version == EncodingVersion.V2
 
 
-def test_separation_between_libraries(object_storage_uri_incl_bucket, lib_name):
+def test_separation_between_libraries(object_storage_uri_incl_bucket):
     """Validate that symbols in one library are not exposed in another."""
     ac = Arctic(object_storage_uri_incl_bucket)
     assert ac.list_libraries() == []
 
-    lib = lib_name
-    lib2 = f"{lib_name}2"
-    ac.create_library(lib)
-    ac.create_library(lib2)
+    ac.create_library("pytest_test_lib")
+    ac.create_library("pytest_test_lib_2")
 
-    assert ac.list_libraries() == [lib, lib2]
+    assert ac.list_libraries() == ["pytest_test_lib", "pytest_test_lib_2"]
 
-    ac[lib].write("test_1", pd.DataFrame())
-    ac[lib2].write("test_2", pd.DataFrame())
-    assert ac[lib].list_symbols() == ["test_1"]
-    assert ac[lib2].list_symbols() == ["test_2"]
+    ac["pytest_test_lib"].write("test_1", pd.DataFrame())
+    ac["pytest_test_lib_2"].write("test_2", pd.DataFrame())
+    assert ac["pytest_test_lib"].list_symbols() == ["test_1"]
+    assert ac["pytest_test_lib_2"].list_symbols() == ["test_2"]
 
 
 def get_path_prefix_option(uri):
@@ -957,11 +955,11 @@ def test_tail(arctic_library):
 
 
 @pytest.mark.parametrize("dedup", [True, False])
-def test_dedup(object_storage_uri_incl_bucket, dedup, lib_name):
+def test_dedup(object_storage_uri_incl_bucket, dedup):
     ac = Arctic(object_storage_uri_incl_bucket)
     assert ac.list_libraries() == []
-    ac.create_library(lib_name, LibraryOptions(dedup=dedup))
-    lib = ac[lib_name]
+    ac.create_library("pytest_test_library", LibraryOptions(dedup=dedup))
+    lib = ac["pytest_test_library"]
     symbol = "test_dedup"
     lib.write_pickle(symbol, 1)
     lib.write_pickle(symbol, 1, prune_previous_versions=False)
@@ -969,16 +967,16 @@ def test_dedup(object_storage_uri_incl_bucket, dedup, lib_name):
     assert data_key_version == 0 if dedup else 1
 
 
-def test_segment_slicing(object_storage_uri_incl_bucket, lib_name):
+def test_segment_slicing(object_storage_uri_incl_bucket):
     ac = Arctic(object_storage_uri_incl_bucket)
     assert ac.list_libraries() == []
     rows_per_segment = 5
     columns_per_segment = 2
     ac.create_library(
-        lib_name,
+        "pytest_test_library",
         LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=columns_per_segment),
     )
-    lib = ac[lib_name]
+    lib = ac["pytest_test_library"]
     symbol = "test_segment_slicing"
     rows = 12
     columns = 3

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -27,7 +27,7 @@ import pandas as pd
 from datetime import datetime, timezone
 import numpy as np
 from arcticdb_ext.tools import AZURE_SUPPORT
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, RUN_MONGO_TEST
 
 if AZURE_SUPPORT:
     from azure.storage.blob import BlobServiceClient
@@ -172,20 +172,22 @@ def test_library_options(arctic_client):
     assert lib._nvs._lib_cfg.lib_desc.version.encoding_version == EncodingVersion.V2
 
 
-def test_separation_between_libraries(object_storage_uri_incl_bucket):
+def test_separation_between_libraries(object_storage_uri_incl_bucket, lib_name):
     """Validate that symbols in one library are not exposed in another."""
     ac = Arctic(object_storage_uri_incl_bucket)
     assert ac.list_libraries() == []
 
-    ac.create_library("pytest_test_lib")
-    ac.create_library("pytest_test_lib_2")
+    lib = lib_name
+    lib2 = f"{lib_name}2"
+    ac.create_library(lib)
+    ac.create_library(lib2)
 
-    assert ac.list_libraries() == ["pytest_test_lib", "pytest_test_lib_2"]
+    assert ac.list_libraries() == [lib, lib2]
 
-    ac["pytest_test_lib"].write("test_1", pd.DataFrame())
-    ac["pytest_test_lib_2"].write("test_2", pd.DataFrame())
-    assert ac["pytest_test_lib"].list_symbols() == ["test_1"]
-    assert ac["pytest_test_lib_2"].list_symbols() == ["test_2"]
+    ac[lib].write("test_1", pd.DataFrame())
+    ac[lib2].write("test_2", pd.DataFrame())
+    assert ac[lib].list_symbols() == ["test_1"]
+    assert ac[lib2].list_symbols() == ["test_2"]
 
 
 def get_path_prefix_option(uri):
@@ -195,18 +197,28 @@ def get_path_prefix_option(uri):
         return "&path_prefix"
 
 
-def test_separation_between_libraries_with_prefixes(object_storage_uri_incl_bucket):
+@pytest.mark.parametrize(
+    "lib_type",
+    [
+        "moto_s3_uri_incl_bucket",
+        pytest.param(
+            "azurite_azure_uri_incl_bucket",
+            marks=pytest.mark.skipif(not AZURE_SUPPORT, reason="Pending Azure Storge Conda support"),
+        ),
+    ],
+)
+def test_separation_between_libraries_with_prefixes(lib_type, request):
     """The motivation for the prefix feature is that separate users want to be able to create libraries
     with the same name in the same bucket without over-writing each other's work. This can be useful when
     creating a new bucket is time-consuming, for example due to organisational issues.
     """
-
-    option = get_path_prefix_option(object_storage_uri_incl_bucket)
-    mercury_uri = f"{object_storage_uri_incl_bucket}{option}=/planet/mercury"
+    lib = request.getfixturevalue(lib_type)
+    option = get_path_prefix_option(lib)
+    mercury_uri = f"{lib}{option}=/planet/mercury"
     ac_mercury = Arctic(mercury_uri)
     assert ac_mercury.list_libraries() == []
 
-    mars_uri = f"{object_storage_uri_incl_bucket}{option}=/planet/mars"
+    mars_uri = f"{lib}{option}=/planet/mars"
     ac_mars = Arctic(mars_uri)
     assert ac_mars.list_libraries() == []
 
@@ -511,6 +523,16 @@ def test_delete_date_range(arctic_library):
         lib["symbol"].data, pd.DataFrame({"column": [7, 8]}, index=pd.date_range(start="1/3/2018", end="1/4/2018"))
     )
     assert lib["symbol"].version == 1
+
+
+@pytest.mark.skipif(not RUN_MONGO_TEST, reason="Mongo test on windows is fiddly")
+def test_mongo_repr(mongo_test_uri):
+    max_pool_size = 10
+    min_pool_size = 100
+    selection_timeout_ms = 1000
+    uri = f"{mongo_test_uri}/?maxPoolSize={max_pool_size}&minPoolSize={min_pool_size}&serverSelectionTimeoutMS={selection_timeout_ms}"
+    ac = Arctic(uri)
+    assert repr(ac) == f"Arctic(config=mongodb(endpoint={mongo_test_uri[len('mongodb://'):]}))"
 
 
 def test_s3_repr(moto_s3_uri_incl_bucket):
@@ -935,11 +957,11 @@ def test_tail(arctic_library):
 
 
 @pytest.mark.parametrize("dedup", [True, False])
-def test_dedup(object_storage_uri_incl_bucket, dedup):
+def test_dedup(object_storage_uri_incl_bucket, dedup, lib_name):
     ac = Arctic(object_storage_uri_incl_bucket)
     assert ac.list_libraries() == []
-    ac.create_library("pytest_test_library", LibraryOptions(dedup=dedup))
-    lib = ac["pytest_test_library"]
+    ac.create_library(lib_name, LibraryOptions(dedup=dedup))
+    lib = ac[lib_name]
     symbol = "test_dedup"
     lib.write_pickle(symbol, 1)
     lib.write_pickle(symbol, 1, prune_previous_versions=False)
@@ -947,16 +969,16 @@ def test_dedup(object_storage_uri_incl_bucket, dedup):
     assert data_key_version == 0 if dedup else 1
 
 
-def test_segment_slicing(object_storage_uri_incl_bucket):
+def test_segment_slicing(object_storage_uri_incl_bucket, lib_name):
     ac = Arctic(object_storage_uri_incl_bucket)
     assert ac.list_libraries() == []
     rows_per_segment = 5
     columns_per_segment = 2
     ac.create_library(
-        "pytest_test_library",
+        lib_name,
         LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=columns_per_segment),
     )
-    lib = ac["pytest_test_library"]
+    lib = ac[lib_name]
     symbol = "test_segment_slicing"
     rows = 12
     columns = 3

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -45,12 +45,13 @@ from arcticdb.util.test import (
     assert_series_equal,
     config_context,
     distinct_timestamps,
+    RUN_MONGO_TEST,
 )
 from arcticdb_ext.tools import AZURE_SUPPORT
 from tests.util.date import DateRange
 
 
-if sys.platform == "linux":
+if RUN_MONGO_TEST:
     SMOKE_TEST_VERSION_STORES = [
         "lmdb_version_store_v1",
         "lmdb_version_store_v2",
@@ -59,9 +60,6 @@ if sys.platform == "linux":
         "mongo_version_store",
     ]
 else:
-    # leave out Mongo as spinning up a Mongo instance in Windows CI is fiddly, and Mongo support is only
-    # currently required for Linux for internal use.
-    # We also skip it on Mac as github actions containers don't work with macos
     SMOKE_TEST_VERSION_STORES = [
         "lmdb_version_store_v1",
         "lmdb_version_store_v2",


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs
https://github.com/man-group/arcticdb-man/issues/26
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.
Add uri support for mongodb-backed storage
#### Any other comments?
Due to the backward compatibility mongodb options MinPoolSize, MaxPoolSize and SelectionTimeoutMs, a relatively complicated design for connection string handling is adopted. In the old fashioned way, the three options are added by the connection string as
```
return fmt::format("{}&minPoolSize={}&maxPoolSize={}&serverSelectionTimeoutMS={}",
            uri, min_pool_size, max_pool_size, selection_timeout_ms);
```
The three options are supported by mongodb connection string so user may add them in the uri, the way supported in this PR.
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
