### PR TITLE
Bugfix 554: Remove unused  argument from write_batch

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -489,7 +489,7 @@ class Library:
         raise ArcticUnsupportedDataTypeException(error_message)
 
     def write_batch(
-        self, payloads: List[WritePayload], prune_previous_versions: bool = False, staged=False, validate_index=True
+        self, payloads: List[WritePayload], prune_previous_versions: bool = False, validate_index=True
     ) -> List[VersionedItem]:
         """
         Write a batch of multiple symbols.
@@ -499,8 +499,6 @@ class Library:
         payloads : `List[WritePayload]`
             Symbols and their corresponding data. There must not be any duplicate symbols in `payload`.
         prune_previous_versions: `bool`, default=False
-            See `write`.
-        staged: `bool`, default=False
             See `write`.
         validate_index: bool, default=False
             If set to True, it will verify for each entry in the batch whether the index of the data supports date range searches and update operations.
@@ -558,7 +556,6 @@ class Library:
             [p.metadata for p in payloads],
             prune_previous_version=prune_previous_versions,
             pickle_on_failure=False,
-            parallel=staged,
             validate_index=validate_index,
         )
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #554 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Staged writes are not currently supported by the batch methods, and it's inclusion as an argument in `write_batch` was an error.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
