### PR TITLE
Add handling of unspecified ca path in azure uri

### DIFF
--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -27,7 +27,7 @@ PARSED_QUERY = namedtuple("PARSED_QUERY", ["region"])
 @dataclass
 class ParsedQuery:
     Path_prefix: Optional[str] = None
-    CA_cert_path: Optional[str] = None
+    CA_cert_path: Optional[str] = ""
     Container: Optional[str] = None
 
 

--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -27,7 +27,7 @@ PARSED_QUERY = namedtuple("PARSED_QUERY", ["region"])
 @dataclass
 class ParsedQuery:
     Path_prefix: Optional[str] = None
-    CA_cert_path: Optional[str] = ""
+    CA_cert_path: str = ""
     Container: Optional[str] = None
 
 

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -337,7 +337,7 @@ def get_azure_proto(
     container_name,
     endpoint,
     with_prefix: Optional[bool] = True,
-    ca_cert_path: Optional[str] = "",
+    ca_cert_path: str = "",
 ):
     env = cfg.env_by_id[env_name]
     azure = AzureConfig()
@@ -367,7 +367,7 @@ def add_azure_library_to_env(
     endpoint,
     description: Optional[bool] = None,
     with_prefix: Optional[bool] = True,
-    ca_cert_path: Optional[str] = None,
+    ca_cert_path: str = "",
 ):
     env = cfg.env_by_id[env_name]
     sid, storage = get_azure_proto(

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -28,7 +28,7 @@ from arcticc.pb2.storage_pb2 import (
 
 from arcticdb.config import *  # for backward compat after moving to config
 from arcticdb.config import _expand_path
-from arcticdb.exceptions import ArcticNativeException, LibraryNotFound
+from arcticdb.exceptions import ArcticNativeException, LibraryNotFound, UserInputException
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.authorization.permissions import OpenMode
 
@@ -337,10 +337,12 @@ def get_azure_proto(
     container_name,
     endpoint,
     with_prefix: Optional[bool] = True,
-    ca_cert_path: Optional[str] = None,
+    ca_cert_path: Optional[str] = "",
 ):
     env = cfg.env_by_id[env_name]
     azure = AzureConfig()
+    if not container_name:
+        raise UserInputException("Container needs to be specified")
     azure.container_name = container_name
     azure.endpoint = endpoint
     if with_prefix:

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1066,6 +1066,7 @@ def test_lmdb(tmpdir):
         lib.read("test").data
 
 
+@pytest.mark.skipif(not AZURE_SUPPORT, reason="Pending Azure Storge Conda support")
 def test_azure_no_ca_path(azurite_azure_test_connection_setting):
     (endpoint, container, credential_name, credential_key, ca_cert_path) = azurite_azure_test_connection_setting
     ac = Arctic(

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1064,3 +1064,10 @@ def test_lmdb(tmpdir):
         lib.write_pickle("test", d)
         lib = arc.get_library("model")
         lib.read("test").data
+
+
+def test_azure_no_ca_path(azurite_azure_test_connection_setting):
+    (endpoint, container, credential_name, credential_key, ca_cert_path) = azurite_azure_test_connection_setting
+    ac = Arctic(
+        f"azure://DefaultEndpointsProtocol=http;AccountName={credential_name};AccountKey={credential_key};BlobEndpoint={endpoint}/{credential_name};Container={container}"
+    )


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

https://github.com/man-group/ArcticDB/issues/756

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

It fixes the bug which prevents ArcticDB support Azure uri without specifying ca certificate path. It also slightly improve the error handling of docstring.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
