### PR TITLE
Enhancement 702: Add option to create library if it does not exist when calling get_library

### DIFF
--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-from arcticdb.options import LibraryOptions
+from arcticdb.options import DEFAULT_ENCODING_VERSION, LibraryOptions
 from arcticc.pb2.storage_pb2 import LibraryConfig
 from arcticdb_ext.storage import Library, StorageOverride
 from arcticdb.encoding_version import EncodingVersion
@@ -32,7 +32,9 @@ def set_library_options(lib_desc: "LibraryConfig", options: LibraryOptions):
     write_options.segment_row_size = options.rows_per_segment
     write_options.column_group_size = options.columns_per_segment
 
-    lib_desc.version.encoding_version = options.encoding_version
+    lib_desc.version.encoding_version = (
+        options.encoding_version if options.encoding_version is not None else DEFAULT_ENCODING_VERSION
+    )
 
 
 class ArcticLibraryAdapter(ABC):

--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -38,7 +38,7 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
     def supports_uri(uri: str) -> bool:
         return uri.startswith("azure://")
 
-    def __init__(self, uri: str, *args, **kwargs):
+    def __init__(self, uri: str, encoding_version: EncodingVersion, *args, **kwargs):
         self._uri = uri
         match = re.match(self.REGEX, uri)
 
@@ -56,8 +56,9 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
         )
         self._container = self._query_params.Container
         self._ca_cert_path = self._query_params.CA_cert_path
+        self._encoding_version = encoding_version
 
-        super().__init__(uri, EncodingVersion.V1)
+        super().__init__(uri, self._encoding_version)
 
     def __repr__(self):
         return "azure(endpoint=%s, container=%s)" % (self._endpoint, self._container)
@@ -79,7 +80,9 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
             ca_cert_path=self._ca_cert_path,
         )
 
-        lib = NativeVersionStore.create_store_from_config(env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME)
+        lib = NativeVersionStore.create_store_from_config(
+            env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version
+        )
 
         return lib._library
 
@@ -119,9 +122,14 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
             ca_cert_path=self._ca_cert_path,
         )
 
+        library_options.encoding_version = (
+            library_options.encoding_version if library_options.encoding_version is not None else self._encoding_version
+        )
         set_library_options(env_cfg.env_by_id[_DEFAULT_ENV].lib_by_path[name], library_options)
 
-        lib = NativeVersionStore.create_store_from_config(env_cfg, _DEFAULT_ENV, name)
+        lib = NativeVersionStore.create_store_from_config(
+            env_cfg, _DEFAULT_ENV, name, encoding_version=library_options.encoding_version
+        )
 
         return lib
 

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -68,10 +68,13 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
 
         add_lmdb_library_to_env(env_cfg, lib_name=name, env_name=_DEFAULT_ENV, db_dir=self._path)
 
+        library_options.encoding_version = (
+            library_options.encoding_version if library_options.encoding_version is not None else self._encoding_version
+        )
         set_library_options(env_cfg.env_by_id[_DEFAULT_ENV].lib_by_path[name], library_options)
 
         lib = NativeVersionStore.create_store_from_config(
-            env_cfg, _DEFAULT_ENV, name, encoding_version=self._encoding_version
+            env_cfg, _DEFAULT_ENV, name, encoding_version=library_options.encoding_version
         )
 
         return lib

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -176,10 +176,13 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             use_virtual_addressing=self._query_params.use_virtual_addressing,
         )
 
+        library_options.encoding_version = (
+            library_options.encoding_version if library_options.encoding_version is not None else self._encoding_version
+        )
         set_library_options(env_cfg.env_by_id[_DEFAULT_ENV].lib_by_path[name], library_options)
 
         lib = NativeVersionStore.create_store_from_config(
-            env_cfg, _DEFAULT_ENV, name, encoding_version=self._encoding_version
+            env_cfg, _DEFAULT_ENV, name, encoding_version=library_options.encoding_version
         )
 
         return lib

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -7,10 +7,10 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 from typing import List, Optional
 
-from arcticdb.options import LibraryOptions
+from arcticdb.options import DEFAULT_ENCODING_VERSION, LibraryOptions
 from arcticdb_ext.storage import LibraryManager, StorageOverride
-from arcticdb.exceptions import LibraryNotFound
-from arcticdb.version_store.library import Library
+from arcticdb.exceptions import LibraryNotFound, MismatchingLibraryOptions
+from arcticdb.version_store.library import ArcticInvalidApiUsageException, Library
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.adapters.s3_library_adapter import S3LibraryAdapter
 from arcticdb.adapters.lmdb_library_adapter import LMDBLibraryAdapter
@@ -26,7 +26,7 @@ class Arctic:
 
     _LIBRARY_ADAPTERS = [S3LibraryAdapter, LMDBLibraryAdapter, AzureLibraryAdapter]
 
-    def __init__(self, uri: str, encoding_version: EncodingVersion = EncodingVersion.V1):
+    def __init__(self, uri: str, encoding_version: EncodingVersion = DEFAULT_ENCODING_VERSION):
         """
         Initializes a top-level Arctic library management instance.
 
@@ -123,6 +123,10 @@ class Arctic:
                 The LMDB URI connection scheme has the form ``lmdb:///<path to store LMDB files>``. There are no options
                 available for the LMDB URI connection scheme.
 
+        encoding_version: EncodingVersion, default DEFAULT_ENCODING_VERSION
+            When creating new libraries with this Arctic instance, the defaul encoding version to use.
+            Can be overridden by specifying the encoding version in the LibraryOptions argument to create_library.
+
         Examples
         --------
 
@@ -170,12 +174,29 @@ class Arctic:
     def __repr__(self):
         return "Arctic(config=%r)" % self._library_adapter
 
-    def get_library(self, library: str) -> Library:
+    def get_library(
+        self, name: str, create_if_missing: Optional[bool] = False, library_options: Optional[LibraryOptions] = None
+    ) -> Library:
         """
-        Returns the library named `library`.
+        Returns the library named `name`.
 
         This method can also be invoked through subscripting. ``Arctic('bucket').get_library("test")`` is equivalent to
         ``Arctic('bucket')["test"]``.
+
+        Parameters
+        ----------
+        name: str
+            The name of the library that you wish to retrieve.
+
+        create_if_missing: Optional[bool], default = False
+            If True, and the library does not exist, then create it.
+
+        library_options: Optional[LibraryOptions], default = None
+            If create_if_missing is True, and the library does not already exist, then it will be created with these
+            options, or the defaults if not provided.
+            If create_if_missing is True, and the library already exists, ensures that the existing library options
+            match these.
+            Unused if create_if_missing is False.
 
         Examples
         --------
@@ -188,9 +209,25 @@ class Arctic:
         -------
         Library
         """
-        return self[library]
+        if library_options and not create_if_missing:
+            raise ArcticInvalidApiUsageException(
+                "In get_library, library_options must be falsey if create_if_missing is falsey"
+            )
+        try:
+            lib = self[name]
+            if create_if_missing and library_options:
+                if library_options.encoding_version is None:
+                    library_options.encoding_version = self._encoding_version
+                if lib.options() != library_options:
+                    raise MismatchingLibraryOptions(f"{name}: {lib.options()} != {library_options}")
+            return lib
+        except LibraryNotFound as e:
+            if create_if_missing:
+                return self.create_library(name, library_options)
+            else:
+                raise e
 
-    def create_library(self, name: str, library_options: Optional[LibraryOptions] = None) -> None:
+    def create_library(self, name: str, library_options: Optional[LibraryOptions] = None) -> Library:
         """
         Creates the library named ``name``.
 
@@ -215,8 +252,12 @@ class Arctic:
         >>> arctic = Arctic('s3://MY_ENDPOINT:MY_BUCKET')
         >>> arctic.create_library('test.library')
         >>> my_library = arctic['test.library']
+
+        Returns
+        -------
+        Library that was just created
         """
-        if name in self._open_libraries or self._library_manager.has_library(name):
+        if self.has_library(name):
             raise ValueError(f"Library [{name}] already exists.")
 
         if library_options is None:
@@ -227,6 +268,7 @@ class Arctic:
         lib = Library(repr(self), library)
         self._open_libraries[name] = lib
         self._library_manager.write_library_config(library._lib_cfg, name)
+        return self.get_library(name)
 
     def delete_library(self, name: str) -> None:
         """
@@ -250,6 +292,21 @@ class Arctic:
             self._library_adapter.cleanup_library(name, config)
         finally:
             self._library_manager.remove_library_config(name)
+
+    def has_library(self, name: str) -> bool:
+        """
+        Query if the given library exists
+
+        Parameters
+        ----------
+        name: `str`
+            Name of the library to check the existence of.
+
+        Returns
+        -------
+        True if the library exists, False otherwise.
+        """
+        return name in self._open_libraries or self._library_manager.has_library(name)
 
     def list_libraries(self) -> List[str]:
         """

--- a/python/arcticdb/exceptions.py
+++ b/python/arcticdb/exceptions.py
@@ -17,3 +17,7 @@ class ArcticNativeNotYetImplemented(ArcticException):
 
 class LibraryNotFound(ArcticException):
     pass
+
+
+class MismatchingLibraryOptions(ArcticException):
+    pass

--- a/python/arcticdb/options.py
+++ b/python/arcticdb/options.py
@@ -6,7 +6,12 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
+from typing import Optional
+
 from arcticdb.encoding_version import EncodingVersion
+
+
+DEFAULT_ENCODING_VERSION = EncodingVersion.V1
 
 
 class LibraryOptions:
@@ -31,9 +36,9 @@ class LibraryOptions:
         *,
         dynamic_schema: bool = False,
         dedup: bool = False,
-        rows_per_segment=100_000,
-        columns_per_segment=127,
-        encoding_version: EncodingVersion = EncodingVersion.V1,
+        rows_per_segment: int = 100_000,
+        columns_per_segment: int = 127,
+        encoding_version: Optional[EncodingVersion] = None,
     ):
         """
         Parameters
@@ -111,6 +116,10 @@ class LibraryOptions:
 
         columns_per_segment: int, default 127
             See rows_per_segment
+
+        encoding_version: Optional[EncodingVersion], default None
+            The encoding version to use when writing data to storage.
+            v2 is faster, but still experimental, so use with caution.
         """
         self.dynamic_schema = dynamic_schema
         self.dedup = dedup
@@ -118,8 +127,18 @@ class LibraryOptions:
         self.columns_per_segment = columns_per_segment
         self.encoding_version = encoding_version
 
+    def __eq__(self, right):
+        return (
+            self.dynamic_schema == right.dynamic_schema
+            and self.dedup == right.dedup
+            and self.rows_per_segment == right.rows_per_segment
+            and self.columns_per_segment == right.columns_per_segment
+            and self.encoding_version == right.encoding_version
+        )
+
     def __repr__(self):
         return (
             f"LibraryOptions(dynamic_schema={self.dynamic_schema}, dedup={self.dedup},"
-            f" rows_per_segment={self.rows_per_segment}, columns_per_segment={self.columns_per_segment})"
+            f" rows_per_segment={self.rows_per_segment}, columns_per_segment={self.columns_per_segment},"
+            f" encoding_version={self.encoding_version if self.encoding_version is not None else 'Default'})"
         )

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -11,6 +11,7 @@ from enum import Enum, auto
 from typing import Optional, Any, Tuple, Dict, AnyStr, Union, List, Iterable, NamedTuple
 from numpy import datetime64
 
+from arcticdb.options import LibraryOptions
 from arcticdb.supported_types import Timestamp
 
 from arcticdb.version_store.processing import QueryBuilder
@@ -303,6 +304,16 @@ class Library:
 
     def __contains__(self, symbol: str):
         return self.has_symbol(symbol)
+
+    def options(self) -> LibraryOptions:
+        write_options = self._nvs.lib_cfg().lib_desc.version.write_options
+        return LibraryOptions(
+            dynamic_schema=write_options.dynamic_schema,
+            dedup=write_options.de_duplication,
+            rows_per_segment=write_options.segment_row_size,
+            columns_per_segment=write_options.column_group_size,
+            encoding_version=self._nvs.lib_cfg().lib_desc.version.encoding_version,
+        )
 
     def write(
         self,


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #702 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

- Makes the `AzureLibraryAdapter` behave in the same way as the others with regards to default encoding
- Allow the user to override the encoding specified on the `Arctic` instance being used to create a library by specifying the encoding in the `LibraryOptions` (arguably previously a bug, since `LibraryOptions.encoding_version` was unused)
- Documented the `encoding_version` argument to both the `Arctic` and `LibraryOptions` `__init__` methods
- Added the `encoding_version` to the `LibraryOptions` `__repr__`
- Add an `options()` method to the `Library` class to retrieve the `LibraryOptions` object this library was created with
- Add a `has_library` method to the `Arctic` class
- Add optional arguments to `Arctic.create_library` to allow the library to be created if it does not exist

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
