### PR TITLE
Warn on invalid creds/server/bucket (#473)

### DIFF
--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -57,6 +57,11 @@ class Library {
     Library& operator=(const Library&) = delete;
     Library& operator=(Library&&) = delete;
 
+    /** Calls check_accessibility() on the primary Storage. */
+    CheckAccessibilityResult check_accessibility_of_primary_storage() {
+        return storages_->check_accessibility_of_primary_storage();
+    }
+
     /**
      * Tries to get every key of the given type (and prefix if not empty). Please assume this can skip keys sometimes
      * and code defensively.
@@ -122,7 +127,7 @@ class Library {
         return res;
     }
 
-    /** Calls VariantStorage::do_key_path on the primary storage */
+    /** Calls Storage::do_key_path on the primary storage */
     std::string key_path(const VariantKey& key) const {
         return storages_->key_path(key);
     }

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -34,6 +34,10 @@ class LmdbStorage final : public Storage {
 
     LmdbStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
 
+    CheckAccessibilityResult check_accessibility() override {
+        return {spdlog::level::trace, "No storage access check necessary"}; // The constructor throws on invalid path
+    }
+
   private:
     void do_write(Composite<KeySegmentPair>&& kvs) final;
 

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -22,6 +22,10 @@ namespace arcticdb::storage::memory {
 
         MemoryStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
 
+        CheckAccessibilityResult check_accessibility() override {
+            return {spdlog::level::trace, "No storage access check necessary"};
+        }
+
     private:
         void do_write(Composite<KeySegmentPair>&& kvs) final;
 

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -24,6 +24,9 @@ class MongoStorage final : public Storage {
 
     MongoStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
 
+    CheckAccessibilityResult check_accessibility() override {
+        return {spdlog::level::debug, "Storage access check not yet implemented for MongoDB"};
+    }
   private:
     void do_write(Composite<KeySegmentPair>&& kvs) final;
 

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -100,6 +100,19 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
                                             return none.cast<py::object>();
                                        });
         })
+        .def("check_accessibility_of_primary_storage", &Library::check_accessibility_of_primary_storage)
+        ;
+
+    py::class_<CheckAccessibilityResult, std::shared_ptr<CheckAccessibilityResult>>(storage, "CheckAccessibilityResult")
+        .def_readonly("log_level", &CheckAccessibilityResult::log_level_)
+        .def_readonly("user_friendly_description", &CheckAccessibilityResult::user_friendly_description_)
+        .def_readonly("technical_details", &CheckAccessibilityResult::technical_details_)
+        .def("__str__", [](CheckAccessibilityResult self) {
+            return fmt::format("CheckAccessibilityResult({}, {}, {})",
+                    self.log_level_,
+                    self.user_friendly_description_,
+                    self.technical_details_);
+        })
         ;
 
     py::class_<S3CredentialsOverride>(storage, "S3CredentialsOverride")

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -33,6 +33,10 @@ public:
 
     NfsBackedStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
 
+    CheckAccessibilityResult check_accessibility() override {
+        return arcticdb::storage::s3::do_check_accessibility(s3_client_, bucket_name_);
+    }
+
 private:
     void do_write(Composite<KeySegmentPair>&& kvs) final;
 

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -42,6 +42,7 @@ S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level) :
         return;
     ARCTICDB_RUNTIME_DEBUG(log::Loggers::instance()->storage(),
         "Does not appear to be using AWS. Will set AWS_EC2_METADATA_DISABLED");
+    ec2_metadata_disabled_by_us_ = true;
 #ifdef WIN32
     _putenv_s("AWS_EC2_METADATA_DISABLED", "true");
 #else

--- a/cpp/arcticdb/storage/s3/s3_api.hpp
+++ b/cpp/arcticdb/storage/s3/s3_api.hpp
@@ -25,9 +25,13 @@ public:
     static std::shared_ptr<S3ApiInstance> instance();
     static void destroy_instance();
 
+    bool is_ec2_metadata_disabled_by_us() const {
+        return ec2_metadata_disabled_by_us_;
+    }
 private:
   Aws::Utils::Logging::LogLevel log_level_;
   Aws::SDKOptions options_;
+  bool ec2_metadata_disabled_by_us_;
 };
 
 } //namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -60,9 +60,7 @@ std::unique_ptr<Storage> create_storage(
         } else if (type_name == azure::AzureStorage::Config::descriptor()->full_name()) {
         azure::AzureStorage::Config azure_config;
         storage_descriptor.config().UnpackTo(&azure_config);
-        storage = std::make_unique<azure::AzureStorage  >(
-            azure::AzureStorage(library_path, mode, azure_config)
-        );
+        storage = std::make_unique<azure::AzureStorage>(library_path, mode, std::move(azure_config));
 #endif
     } else
         throw std::runtime_error(fmt::format("Unknown config type {}", type_name));

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -31,6 +31,10 @@ class Storages {
         storages_(std::move(storages)), mode_(mode) {
     }
 
+    CheckAccessibilityResult check_accessibility_of_primary_storage() {
+        return primary().check_accessibility();
+    }
+
     void write(Composite<KeySegmentPair>&& kvs) {
         ARCTICDB_SAMPLE(StoragesWrite, 0)
         primary().write(std::move(kvs));

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -53,6 +53,19 @@ The [symbol list cache](/technical/on_disk_storage#symbol-list-caching) is compa
 
 The default is 500.
 
+### S3Storage.CheckBucketMaxWait
+
+The `Arctic` constructor will check the given S3 bucket is accessible.
+It will wait at most this amount of time in milliseconds.
+
+The default is 1000ms.
+
+### S3Storage.ConnectTimeoutMs and S3Storage.RequestTimeoutMs
+
+Refer to [AWS documentation](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/client-config.html).
+
+The defaults are 30000 and 200000 respectively.
+
 ### S3Storage.DeleteBatchSize
 
 The S3 API supports the `DeleteObjects` method, whereby a single HTTP request can be used to delete multiple objects. This parameter can be used to control how many objects are requested to be deleted at a time.
@@ -84,7 +97,7 @@ If only `NumCPUThreads` is set, `NumIOThreads` will still default to x1.5 `NumCP
 
 ArcticDB has multiple log streams, and the verbosity of each can be configured independently. 
 The available streams are visible in the [source code](https://github.com/man-group/ArcticDB/blob/master/python/arcticdb/log.py), although the most commonly useful logs are in:
- 
+
 * `version` - contains information about versions being read, created, or destroyed, and traversal of the [version layer](/technical/on_disk_storage#version-layer) linked list
 * `storage` - contains information about individual operations that interact with the storage device (read object, write object, delete object, etc)
 

--- a/python/arcticdb/adapters/azure_storage_fixture.py
+++ b/python/arcticdb/adapters/azure_storage_fixture.py
@@ -1,0 +1,132 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import re
+import shutil
+from typing import Optional
+from tempfile import mkdtemp
+
+from azure.storage.blob import (
+    ContainerClient,
+    AccessPolicy,
+    ContainerSasPermissions,
+    generate_container_sas,
+    LinearRetry,
+)
+
+from arcticdb.version_store.helper import add_azure_library_to_env
+from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
+
+from .storage_fixture_api import *
+
+
+class AzureContainer(StorageFixture):
+    _FIELD_REGEX = {
+        ArcticUriFields.HOST: re.compile("[/;](BlobEndpoint=https?://)([^;:/]+)"),
+        ArcticUriFields.USER: re.compile("[/;](AccountName=)([^;]+);"),
+        ArcticUriFields.PASSWORD: re.compile("[/;](AccountKey=)([^;]+);"),
+        ArcticUriFields.BUCKET: re.compile("[/;](Container=)([^;]+);"),
+    }
+    _POLICY = {"connection_timeout": 1, "read_timeout": 2, "retry_policy": LinearRetry(retry_total=3, backoff=1)}
+    _bucket_id = 0
+
+    container: str
+    client: Optional[ContainerClient]
+    _admin_client: Optional[ContainerClient] = None
+
+    def _set_uri_and_client(self, auth: str):
+        f = self.factory
+        self.arctic_uri = (
+            f"azure://DefaultEndpointsProtocol=http;{auth};BlobEndpoint={f.endpoint_root}/{f.account_name};"
+            f"Container={self.container};CA_cert_path={f.ca_cert_path}"
+        )
+
+        self.client = ContainerClient.from_connection_string(self.arctic_uri, self.container, **self._POLICY)
+        # add connection_verify=False to bypass ssl checking
+
+    def __init__(self, factory: "AzuriteStorageFixtureFactory") -> None:
+        self.factory = factory
+        self.container = f"container{self._bucket_id}"
+        AzureContainer._bucket_id += 1
+        self._set_uri_and_client(f"AccountName={factory.account_name};AccountKey={factory.account_key}")
+
+        # __exit__() assumes this object owns the container, so always create and bail if exists:
+        self.client.create_container()
+
+        if factory.enforcing_permissions:
+            self._admin_client = self.client
+            self.set_permission(read=False, write=False)
+            sas = generate_container_sas(
+                account_name=factory.account_name,
+                account_key=factory.account_key,
+                container_name=self.container,
+                policy_id="main",
+            )
+            self._set_uri_and_client("SharedAccessSignature=" + sas)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.client:
+            if self._admin_client:
+                self._admin_client.delete_container(timeout=3)
+                self._admin_client.close()
+            else:
+                self.client.delete_container(timeout=3)
+            self.client.close()
+            self.client = None
+
+    def create_test_cfg(self, lib_name: str) -> EnvironmentConfigsMap:
+        cfg = EnvironmentConfigsMap()
+        add_azure_library_to_env(
+            cfg=cfg,
+            lib_name=lib_name,
+            env_name=Defaults.ENV,
+            container_name=self.container,
+            endpoint=self.arctic_uri,
+            ca_cert_path=self.factory.ca_cert_path,
+        )
+        return cfg
+
+    def set_permission(self, *, read: bool, write: bool):
+        client = self._admin_client
+        assert client, "This instance was not created with a enforcing_permissions Factory"
+        perm = ContainerSasPermissions(read=read, list=read, write=write, delete=write)
+        client.set_container_access_policy({"main": AccessPolicy(permission=perm)})
+
+
+class AzuriteStorageFixtureFactory(StorageFixtureFactory):
+    host = "127.0.0.1"
+
+    # Per https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-azurite
+    account_name = "devstoreaccount1"
+    account_key = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+
+    # Default cert path is used; May run into problem on Linux's non RHEL distribution
+    # See more on https://github.com/man-group/ArcticDB/issues/514
+    ca_cert_path = ""
+
+    enforcing_permissions = False
+    """Set to True to create AzureContainer with SAS authentication"""
+
+    def __init__(self, port=0, working_dir: Optional[str] = None):
+        self.port = port or get_ephemeral_port()
+        self.endpoint_root = f"http://{self.host}:{self.port}"
+        self.working_dir = str(working_dir) if working_dir else mkdtemp(suffix="AzuriteStorageFixtureFactory")
+
+    def __enter__(self):
+        exe = shutil.which("azurite")
+        cmd = f"{exe} --blobPort {self.port} --blobHost {self.host} --queuePort 0 --tablePort 0"
+        self._p = start_process_that_can_be_gracefully_killed(cmd, cwd=self.working_dir)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            gracefully_kill_process(self._p)
+        finally:
+            shutil.rmtree(self.working_dir, ignore_errors=True)
+
+    def create_fixture(self) -> AzureContainer:
+        return AzureContainer(self)

--- a/python/arcticdb/adapters/lmdb_storage_adapter.py
+++ b/python/arcticdb/adapters/lmdb_storage_adapter.py
@@ -1,0 +1,52 @@
+import shutil
+from typing import Optional, Any
+from tempfile import mkdtemp
+
+from arcticdb.version_store.helper import add_lmdb_library_to_env
+from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
+
+from .storage_fixture_api import *
+
+
+class LmdbStorageFixture(StorageFixture):
+    def __init__(self, db_dir: Optional[str]):
+        self.db_dir = str(db_dir) or mkdtemp(suffix="LmdbStorageFixtureFactory")
+        self.arctic_uri = "lmdb://" + self.db_dir  # TODO: extra config?
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        for result in self.generated_libs.values():
+            #  pytest holds a member variable `cached_result` equal to `result` above which keeps the storage alive and
+            #  locked. See https://github.com/pytest-dev/pytest/issues/5642 . So we need to decref the C++ objects
+            #  keeping the LMDB env open before they will release the lock and allow Windows to delete the LMDB files.
+            result.version_store = None
+            result._library = None
+
+        shutil.rmtree(self.db_dir, ignore_errors=True)
+
+    def create_test_cfg(self, lib_name: str, *, lmdb_config: Dict[str, Any] = {}) -> EnvironmentConfigsMap:
+        cfg = EnvironmentConfigsMap()
+        add_lmdb_library_to_env(
+            cfg, lib_name=lib_name, env_name=Defaults.ENV, db_dir=self.db_dir, lmdb_config=lmdb_config
+        )
+        return cfg
+
+    def create_version_store_factory(self, default_lib_name: str):
+        def create_version_store(
+            col_per_group: Optional[int] = None,  # Legacy option names
+            row_per_segment: Optional[int] = None,
+            lmdb_config: Dict[str, Any] = {},  # Mainly to allow setting map_size
+            **kwargs,
+        ) -> NativeVersionStore:
+            if col_per_group is not None and "column_group_size" not in kwargs:
+                kwargs["column_group_size"] = col_per_group
+            if row_per_segment is not None and "segment_row_size" not in kwargs:
+                kwargs["segment_row_size"] = row_per_segment
+            cfg_factory = self.create_test_cfg
+            if lmdb_config:
+                cfg_factory = functools.partial(cfg_factory, lmdb_config=lmdb_config)
+            return _version_store_factory_impl(self.generated_libs, cfg_factory, default_lib_name, **kwargs)
+
+        return create_version_store
+
+    def set_permission(self, *, read: bool, write: bool):
+        raise NotImplementedError("LmdbStorageFixture don't support permissions")

--- a/python/arcticdb/adapters/s3_storage_fixture.py
+++ b/python/arcticdb/adapters/s3_storage_fixture.py
@@ -1,0 +1,187 @@
+import re
+import time
+import json
+import requests
+from typing import Any, NamedTuple, List
+
+import boto3
+import werkzeug
+from moto.server import DomainDispatcherApplication, create_backend_app
+
+from arcticdb.version_store.helper import add_s3_library_to_env
+from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
+
+from .storage_fixture_api import *
+
+
+Key = NamedTuple("Key", [("id", str), ("secret", str), ("user_name", str)])
+
+
+class S3Bucket(StorageFixture):
+    _FIELD_REGEX = {
+        ArcticUriFields.HOST: re.compile("^s3://()([^:/]+)"),
+        ArcticUriFields.BUCKET: re.compile("^s3://[^:]+(:)([^?]+)"),
+        ArcticUriFields.USER: re.compile("[?&](access=)([^&]+)&?"),
+        ArcticUriFields.PASSWORD: re.compile("[?&](secret=)([^&]+)&?"),
+    }
+
+    _bucket_id = 0
+    bucket: str
+    key: Key
+
+    def __init__(self, factory: "MotoS3StorageFixtureFactory"):
+        self.factory = factory
+        factory._live_buckets.append(self)
+
+        bucket = self.bucket = f"test_bucket_{self._bucket_id}"
+        factory._s3_admin.create_bucket(Bucket=bucket)
+        S3Bucket._bucket_id = S3Bucket._bucket_id + 1
+
+        if factory.enforcing_permissions:
+            self.key = factory._create_user_get_key(bucket + "_user")
+        else:
+            self.key = factory._DUMMY_KEY
+
+        s3 = factory
+        self.arctic_uri = f"s3://{s3.host}:{self.bucket}?access={self.key.id}&secret={self.key.secret}&port={s3.port}"
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.factory.cleanup_bucket(self)
+
+    def make_boto_client(self):
+        return self.factory._boto("s3", self.key)
+
+    def create_test_cfg(self, lib_name: str) -> EnvironmentConfigsMap:
+        cfg = EnvironmentConfigsMap()
+        add_s3_library_to_env(
+            cfg,
+            lib_name=lib_name,
+            env_name=Defaults.ENV,
+            credential_name=self.key.id,
+            credential_key=self.key.secret,
+            bucket_name=self.bucket,
+            endpoint=self.factory.endpoint,
+            with_prefix=False,  # to allow s3_store_factory reuse_name to work correctly
+        )
+        return cfg
+
+    def set_permission(self, *, read: bool, write: bool):
+        f = self.factory
+        assert f.enforcing_permissions and self.key is not f._DUMMY_KEY
+        if read:
+            f._iam_admin.put_user_policy(
+                UserName=self.key.user_name, PolicyName="bucket", PolicyDocument=f._RW_POLICY if write else f._RO_POLICY
+            )
+        else:
+            f._iam_admin.delete_user_policy(UserName=self.key.user_name, PolicyName="bucket")
+
+
+class _HostDispatcherApplication(DomainDispatcherApplication):
+    """The stand-alone server needs a way to distinguish between S3 and IAM. We use the host for that"""
+
+    _MAP = {"localhost": "s3", "127.0.0.1": "iam"}
+
+    def get_backend_for_host(self, host):
+        return self._MAP.get(host, host)
+
+
+class MotoS3StorageFixtureFactory(StorageFixtureFactory):
+    _DUMMY_KEY = Key("awd", "awd", "dummy")
+    _RO_POLICY: str
+    _RW_POLICY: str
+    host = "localhost"
+    port: int
+    endpoint: str
+    _enforcing_permissions = False
+    _iam_endpoint: str
+    _p: multiprocessing.Process
+    _s3_admin: Any
+    _iam_admin: Any = None
+    _live_buckets: List[S3Bucket] = []
+
+    @staticmethod
+    def run_server(port):
+        werkzeug.run_simple(
+            "0.0.0.0",
+            port,
+            _HostDispatcherApplication(create_backend_app),
+            threaded=True,
+            ssl_context=None,
+        )
+
+    def _boto(self, service: str, key: Key):
+        return boto3.client(
+            service_name=service,
+            endpoint_url=self.endpoint if service == "s3" else self._iam_endpoint,
+            region_name="us-east-1",
+            aws_access_key_id=key.id,
+            aws_secret_access_key=key.secret,
+        )
+
+    def __enter__(self):
+        port = self.port = get_ephemeral_port()
+        self.endpoint = f"http://{self.host}:{port}"
+        self._iam_endpoint = f"http://127.0.0.1:{port}"
+
+        p = self._p = multiprocessing.Process(target=self.run_server, args=(port,))
+        p.start()
+        time.sleep(0.5)
+
+        self._s3_admin = self._boto("s3", self._DUMMY_KEY)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        gracefully_kill_process(self._p)
+
+    def _create_user_get_key(self, user: str, iam=None):
+        iam = iam or self._iam_admin
+        user_id = iam.create_user(UserName=user)["User"]["UserId"]
+        response = iam.create_access_key(UserName=user)["AccessKey"]
+        return Key(response["AccessKeyId"], response["SecretAccessKey"], user)
+
+    @property
+    def enforcing_permissions(self):
+        return self._enforcing_permissions
+
+    @enforcing_permissions.setter
+    def enforcing_permissions(self, enforcing: bool):
+        # Inspired by https://github.com/getmoto/moto/blob/master/tests/test_s3/test_s3_auth.py
+        if enforcing == self._enforcing_permissions:
+            return
+        if enforcing and not self._iam_admin:
+            iam = self._boto("iam", self._DUMMY_KEY)
+
+            def _policy(*statements):
+                return json.dumps({"Version": "2012-10-17", "Statement": statements})
+
+            policy = _policy(
+                {"Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+                {"Effect": "Allow", "Action": "iam:*", "Resource": "*"},
+            )
+            policy_arn = iam.create_policy(PolicyName="admin", PolicyDocument=policy)["Policy"]["Arn"]
+
+            self._RO_POLICY = _policy({"Effect": "Allow", "Action": ["s3:List*", "s3:Get*"], "Resource": "*"})
+            self._RW_POLICY = _policy({"Effect": "Allow", "Action": "s3:*", "Resource": "*"})
+
+            key = self._create_user_get_key("admin", iam)
+            iam.attach_user_policy(UserName="admin", PolicyArn=policy_arn)
+            self._iam_admin = self._boto("iam", key)
+            self._s3_admin = self._boto("s3", key)
+
+        # The number is the remaining requests before permission checks kick in
+        requests.post(self._iam_endpoint + "/moto-api/reset-auth", "0" if enforcing else "inf")
+        self._enforcing_permissions = enforcing
+
+    def create_fixture(self) -> S3Bucket:
+        return S3Bucket(self)
+
+    def cleanup_bucket(self, b: S3Bucket):
+        self._live_buckets.remove(b)
+        if not len(self._live_buckets):
+            requests.post(self._iam_endpoint + "/moto-api/reset")
+            self._iam_admin = None
+        else:
+            for lib in b.generated_libs.values():
+                lib.version_store.clear()
+
+            self._s3_admin.delete_bucket(Bucket=b.bucket)

--- a/python/arcticdb/adapters/storage_fixture_api.py
+++ b/python/arcticdb/adapters/storage_fixture_api.py
@@ -1,0 +1,155 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import multiprocessing
+import subprocess
+import os
+import platform
+import signal
+import functools
+import socketserver
+from typing import Dict, Union, Pattern
+from contextlib import AbstractContextManager, contextmanager
+from abc import abstractmethod
+from enum import Enum
+
+from arcticdb.config import Defaults
+from arcticdb.version_store import NativeVersionStore
+from arcticdb.version_store.helper import ArcticMemoryConfig
+from arcticdb.util.test import apply_lib_cfg
+from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
+
+_WINDOWS = platform.system() == "Windows"
+
+
+def get_ephemeral_port():  # https://stackoverflow.com/a/61685162/
+    with socketserver.TCPServer(("localhost", 0), None) as s:
+        return s.server_address[1]
+
+
+def start_process_that_can_be_gracefully_killed(cmd, **kwargs):
+    if isinstance(cmd, str) and not kwargs.get("shell"):
+        cmd = cmd.split()
+    print("Running", cmd)
+    creation_flags = subprocess.CREATE_NEW_PROCESS_GROUP if _WINDOWS else 0
+    return subprocess.Popen(cmd, creationflags=creation_flags, **kwargs)
+
+
+def gracefully_kill_process(p: Union[multiprocessing.Process, subprocess.Popen]):
+    if _WINDOWS:
+        # On windows p.terminate() == p.kill(), so close the console first to give the process a chance to clean up
+        # https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent
+        os.kill(p.pid, signal.CTRL_BREAK_EVENT)
+    p.terminate()
+    if not _WINDOWS:
+        try:
+            if isinstance(p, multiprocessing.Process):
+                p.join(timeout=2)
+                exitcode = p.exitcode
+            else:
+                exitcode = p.wait(timeout=2)
+        except:
+            exitcode = None
+        if exitcode is None:
+            os.kill(p.pid, signal.SIGKILL)  # TODO (python37): use Process.kill()
+
+
+def _version_store_factory_impl(
+    used, make_cfg, default_name, *, name: str = None, reuse_name=False, **kwargs
+) -> NativeVersionStore:
+    """Common logic behind all the factory fixtures"""
+    name = name or default_name
+    if name == "_unique_":
+        name = name + str(len(used))
+    assert (name not in used) or reuse_name, f"{name} is already in use"
+    cfg = make_cfg(name)
+    lib = cfg.env_by_id[Defaults.ENV].lib_by_path[name]
+    # Use symbol list by default (can still be overridden by kwargs)
+    lib.version.symbol_list = True
+    apply_lib_cfg(lib, kwargs)
+    out = ArcticMemoryConfig(cfg, Defaults.ENV)[name]
+    used[name] = out
+    return out
+
+
+class ArcticUriFields(Enum):
+    """For use with ``replace_uri_field()`` below"""
+    HOST = "HOST"
+    USER = "USER"
+    PASSWORD = "PASSWORD"
+    BUCKET = "BUCKET"
+
+    def __str__(self):
+        return self.value
+
+
+class StorageFixture(AbstractContextManager):
+    """Manages the life-cycle of a piece of storage and provides test facing methods:"""
+
+    _FIELD_REGEX: Dict[ArcticUriFields, Pattern]
+    """Used by ``replace_uri_field()``."""
+
+    arctic_uri: str
+    """The URI of this Storage for use with the ``Arctic`` constructor"""
+
+    generated_libs: Dict[str, NativeVersionStore] = {}
+
+    def __enter__(self):
+        """Fixtures are typically set up in __init__, so this just returns self"""
+        return self
+
+    @abstractmethod
+    def create_test_cfg(self, lib_name: str) -> EnvironmentConfigsMap:
+        """Creates a new storage config instance.
+        If ``lib_name`` is the same as a previous call on this instance, then that storage should be reused."""
+
+    def create_version_store_factory(self, default_lib_name: str):
+        """Returns a function that takes optional library options and produces ``NativeVersionStore``s"""
+        return functools.partial(
+            _version_store_factory_impl, self.generated_libs, self.create_test_cfg, default_lib_name
+        )
+
+    @abstractmethod
+    def set_permission(self, *, read: bool, write: bool):
+        """Makes the connection to the storage have the given permissions. If unsupported, call ``pytest.skip()``.
+        See ``set_enforcing_permissions`` below."""
+
+    @classmethod
+    def replace_uri_field(cls, uri: str, field: ArcticUriFields, replacement: str):
+        regex = cls._FIELD_REGEX[field]
+        match = regex.search(uri)
+        assert match, f"{uri} does not have {field}"
+        return f"{uri[:match.start(2)]}{replacement}{uri[match.end(2):]}"
+
+
+class StorageFixtureFactory(AbstractContextManager):
+    """For ``StorageFixture``s backed by shared/expensive resources, implement this class to manage those."""
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Properly clean up the fixture. This should be safe to be called multiple times."""
+
+    @property
+    def enforcing_permissions(self):
+        """Indicates whether the Factory will create Fixtures that enforces permissions.
+
+        If supported (settable), the new value should affect subsequent calls to ``create_fixture()``
+        and possibly existing fixtures."""
+        return False
+
+    @contextmanager
+    def enforcing_permissions_context(self, set_to=True):
+        saved = self.enforcing_permissions
+        try:
+            self.enforcing_permissions = set_to
+            yield
+        finally:
+            self.enforcing_permissions = saved
+
+    @abstractmethod
+    def create_fixture(self) -> StorageFixture:
+        ...

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -26,7 +26,7 @@ class Arctic:
 
     _LIBRARY_ADAPTERS = [S3LibraryAdapter, LMDBLibraryAdapter, AzureLibraryAdapter]
 
-    def __init__(self, uri: str, encoding_version: EncodingVersion = EncodingVersion.V1):
+    def __init__(self, uri: str, encoding_version=EncodingVersion.V1, check_storage_access=True):
         """
         Initializes a top-level Arctic library management instance.
 
@@ -122,6 +122,9 @@ class Arctic:
 
                 The LMDB URI connection scheme has the form ``lmdb:///<path to store LMDB files>``. There are no options
                 available for the LMDB URI connection scheme.
+        check_storage_access: bool
+            Where supported by the storage, check if the storage is accessible.
+            See :py:meth:`arcticdb.adapters.arctic_library_adapter.ArcticLibraryAdapter.check_storage_access`
 
         Examples
         --------
@@ -150,6 +153,9 @@ class Arctic:
         self._library_manager = LibraryManager(self._library_adapter.config_library)
         self._uri = uri
         self._open_libraries = dict()
+
+        if check_storage_access:
+            self._library_adapter.check_storage_access()
 
     def __getitem__(self, name: str) -> Library:
         already_open = self._open_libraries.get(name)

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -272,52 +272,6 @@ def add_s3_library_to_env(
     _add_lib_desc_to_env(env, lib_name, sid, description)
 
 
-def create_test_lmdb_cfg(lib_name: str, db_dir: str, lmdb_config: Dict[str, Any] = {}):
-    cfg = EnvironmentConfigsMap()
-    add_lmdb_library_to_env(cfg, lib_name=lib_name, env_name=Defaults.ENV, db_dir=db_dir, lmdb_config=lmdb_config)
-    return cfg
-
-
-def create_test_s3_cfg(
-    lib_name: str,
-    credential_name: str,
-    credential_key: str,
-    bucket_name: str,
-    endpoint: str,
-    *,
-    is_https: bool = False,
-    with_prefix: Union[str, bool, None] = True,
-    region: str = None,
-) -> EnvironmentConfigsMap:
-    cfg = EnvironmentConfigsMap()
-    add_s3_library_to_env(
-        cfg,
-        lib_name=lib_name,
-        env_name=Defaults.ENV,
-        credential_name=credential_name,
-        credential_key=credential_key,
-        bucket_name=bucket_name,
-        endpoint=endpoint,
-        with_prefix=with_prefix,
-        is_https=is_https,
-        region=region,
-    )
-    return cfg
-
-
-def create_test_azure_cfg(lib_name, credential_name, credential_key, container_name, endpoint, ca_cert_path):
-    cfg = EnvironmentConfigsMap()
-    add_azure_library_to_env(
-        cfg=cfg,
-        lib_name=lib_name,
-        env_name=Defaults.ENV,
-        container_name=container_name,
-        endpoint=endpoint,
-        ca_cert_path=ca_cert_path,
-    )
-    return cfg
-
-
 def create_test_memory_cfg(lib_name=Defaults.LIB, description=None):
     cfg = EnvironmentConfigsMap()
     add_memory_library_to_env(cfg, lib_name=lib_name, env_name=Defaults.ENV, description=description)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -6,190 +6,86 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 import functools
-import multiprocessing
-import shutil
-
-import boto3
-import werkzeug
-from moto.server import DomainDispatcherApplication, create_backend_app
-
-import sys
-import signal
 import enum
-
-if sys.platform == "win32":
-    # Hack to define signal.SIGKILL as some deps eg pytest-test-fixtures hardcode SIGKILL terminations.
-    signal.SIGKILL = signal.SIGINT
-
-import time
 import os
 import pytest
+import requests
 import numpy as np
 import pandas as pd
 import random
 from datetime import datetime
-from typing import Optional, Any, Dict
-import subprocess
-from pathlib import Path
-import socket
-import tempfile
+from typing import Optional
 
-import requests
-from pytest_server_fixtures.base import get_ephemeral_port
-
+from arcticdb.adapters.storage_fixture_api import _version_store_factory_impl
+from arcticdb.adapters.azure_storage_fixture import AzuriteStorageFixtureFactory
+from arcticdb.adapters.lmdb_storage_adapter import LmdbStorageFixture
+from arcticdb.adapters.s3_storage_fixture import MotoS3StorageFixtureFactory
 from arcticdb.arctic import Arctic
-from arcticdb.version_store.helper import (
-    create_test_lmdb_cfg,
-    create_test_s3_cfg,
-    create_test_mongo_cfg,
-    create_test_azure_cfg,
-)
-from arcticdb.config import Defaults
-from arcticdb.util.test import configure_test_logger, apply_lib_cfg
-from arcticdb.version_store.helper import ArcticMemoryConfig
-from arcticdb.version_store import NativeVersionStore
+from arcticdb.version_store.helper import create_test_mongo_cfg
+from arcticdb.version_store.library import Library
 from arcticdb.version_store._normalization import MsgPackNormalizer
+from arcticdb.util.test import configure_test_logger
 from arcticdb.options import LibraryOptions
-from arcticdb_ext.storage import Library
 from arcticdb_ext.tools import AZURE_SUPPORT
 
-if AZURE_SUPPORT:
-    from azure.storage.blob import BlobServiceClient
 
 configure_test_logger()
 
-bucket_id = 0
 # Use a smaller memory mapped limit for all tests
 MsgPackNormalizer.MMAP_DEFAULT_SIZE = 20 * (1 << 20)
 
 
-def run_server(port):
-    werkzeug.run_simple(
-        "0.0.0.0", port, DomainDispatcherApplication(create_backend_app, service="s3"), threaded=True, ssl_context=None
-    )
+@pytest.fixture
+def _lmdb_storage(tmpdir):
+    with LmdbStorageFixture(tmpdir) as f:
+        yield f
 
 
-@pytest.fixture(scope="module")
-def _moto_s3_uri_module():
-    port = get_ephemeral_port()
-    p = multiprocessing.Process(target=run_server, args=(port,))
-    p.start()
-
-    time.sleep(0.5)
-
-    yield f"http://localhost:{port}"
-
-    try:
-        # terminate sends SIGTERM - no need to be polite here so...
-        os.kill(p.pid, signal.SIGKILL)
-
-        p.terminate()
-        p.join()
-    except Exception:
-        pass
-
-
-@pytest.fixture(scope="function")
-def azure_client_and_create_container(azurite_container, azurite_azure_uri):
-    client = BlobServiceClient.from_connection_string(
-        conn_str=azurite_azure_uri, container_name=azurite_container
-    )  # add connection_verify=False to bypass ssl checking
-
-    container_client = client.get_container_client(container=azurite_container)
-    if not container_client.exists():
-        client.create_container(name=azurite_container)
-
-    return client
-
-
-@pytest.fixture(scope="function")
-def boto_client(_moto_s3_uri_module):
-    endpoint = _moto_s3_uri_module
-    client = boto3.client(
-        service_name="s3", endpoint_url=endpoint, aws_access_key_id="awd", aws_secret_access_key="awd"
-    )
-
-    yield client
+@pytest.fixture(scope="session")
+def s3_storage_factory():
+    with MotoS3StorageFixtureFactory() as f:
+        yield f
 
 
 @pytest.fixture
-def aws_access_key():
-    return "awd"
+def s3_bucket(s3_storage_factory):
+    with s3_storage_factory.create_fixture() as f:
+        yield f
+
+
+@pytest.fixture(scope="session")
+def azurite_storage_factory():
+    if AZURE_SUPPORT:
+        with AzuriteStorageFixtureFactory() as f:
+            yield f
+    else:
+        yield
 
 
 @pytest.fixture
-def aws_secret_key():
-    return "awd"
-
-
-@pytest.fixture(scope="function")
-def moto_s3_endpoint_and_credentials(_moto_s3_uri_module, aws_access_key, aws_secret_key):
-    global bucket_id
-
-    endpoint = _moto_s3_uri_module
-    port = endpoint.rsplit(":", 1)[1]
-    client = boto3.client(
-        service_name="s3", endpoint_url=endpoint, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key
-    )
-
-    bucket = f"test_bucket_{bucket_id}"
-    client.create_bucket(Bucket=bucket)
-    bucket_id = bucket_id + 1
-    yield endpoint, port, bucket, aws_access_key, aws_secret_key
-
-
-@pytest.fixture(scope="function")
-def moto_s3_uri_incl_bucket(moto_s3_endpoint_and_credentials):
-    endpoint, port, bucket, aws_access_key, aws_secret_key = moto_s3_endpoint_and_credentials
-    yield endpoint.replace("http://", "s3://").rsplit(":", 1)[
-        0
-    ] + ":" + bucket + "?access=" + aws_access_key + "&secret=" + aws_secret_key + "&port=" + port
+def azurite_container(azurite_storage_factory: AzuriteStorageFixtureFactory):
+    with azurite_storage_factory.create_fixture() as f:
+        yield f
 
 
 @pytest.fixture(scope="function", params=["S3", "LMDB", "Azure"] if AZURE_SUPPORT else ["S3", "LMDB"])
-def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):
-    if request.param == "S3":
-        ac = Arctic(moto_s3_uri_incl_bucket, encoding_version)
-    elif request.param == "Azure":
-        ac = Arctic(request.getfixturevalue("azurite_azure_uri_incl_bucket"), encoding_version)
-    elif request.param == "LMDB":
-        ac = Arctic(f"lmdb://{tmpdir}", encoding_version)
-    else:
-        raise NotImplementedError()
-
+def arctic_client(request, encoding_version):
+    fixture_name = {"S3": "s3_bucket", "LMDB": "_lmdb_storage", "Azure": "azurite_container"}[request.param]
+    storage_fixture = request.getfixturevalue(fixture_name)
+    ac = Arctic(storage_fixture.arctic_uri, encoding_version)
     assert not ac.list_libraries()
-    yield ac
+    return ac
 
 
-@pytest.fixture
-def azurite_azure_test_connection_setting(azurite_port, azurite_container, spawn_azurite):
-    credential_name = "devstoreaccount1"
-    credential_key = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
-    endpoint = f"http://127.0.0.1:{azurite_port}"
-    # Default cert path is used; May run into problem on Linux's non RHEL distribution; See more on https://github.com/man-group/ArcticDB/issues/514
-    ca_cert_path = ""
-
-    return endpoint, azurite_container, credential_name, credential_key, ca_cert_path
-
-
-@pytest.fixture
-def azurite_azure_uri(azurite_azure_test_connection_setting):
-    (endpoint, container, credential_name, credential_key, ca_cert_path) = azurite_azure_test_connection_setting
-    return f"azure://DefaultEndpointsProtocol=http;AccountName={credential_name};AccountKey={credential_key};BlobEndpoint={endpoint}/{credential_name};Container={container};CA_cert_path={ca_cert_path}"  # semi-colon at the end is not accepted by the sdk
-
-
-@pytest.fixture
-def azurite_azure_uri_incl_bucket(azurite_azure_uri, azure_client_and_create_container):
-    return azurite_azure_uri
+@pytest.fixture(params=(["s3_bucket", "azurite_container"] if AZURE_SUPPORT else ["s3_bucket"]))
+def object_storage_fixture(request):
+    """``StorageFixture`` instances backed by an object store, i.e. not LMDB."""
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="function")
-def arctic_library(request, arctic_client):
-    if AZURE_SUPPORT:
-        request.getfixturevalue("azure_client_and_create_container")
-
-    arctic_client.create_library("pytest_test_lib")
-    return arctic_client["pytest_test_lib"]
+def arctic_library(request, library_factory):
+    return library_factory()
 
 
 @pytest.fixture()
@@ -200,51 +96,6 @@ def sym():
 @pytest.fixture()
 def lib_name():
     return f"local.test_{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}"
-
-
-@pytest.fixture
-def arcticdb_test_s3_config(moto_s3_endpoint_and_credentials):
-    endpoint, port, bucket, aws_access_key, aws_secret_key = moto_s3_endpoint_and_credentials
-
-    def create(lib_name):
-        return create_test_s3_cfg(lib_name, aws_access_key, aws_secret_key, bucket, endpoint)
-
-    return create
-
-
-@pytest.fixture
-def arcticdb_test_azure_config(azurite_azure_test_connection_setting, azurite_azure_uri):
-    def create(lib_name):
-        (endpoint, container, credential_name, credential_key, ca_cert_path) = azurite_azure_test_connection_setting
-        return create_test_azure_cfg(
-            lib_name=lib_name,
-            credential_name=credential_name,
-            credential_key=credential_key,
-            container_name=container,
-            endpoint=azurite_azure_uri,
-            ca_cert_path=ca_cert_path,
-        )
-
-    return create
-
-
-def _version_store_factory_impl(
-    used, make_cfg, default_name, *, name: str = None, reuse_name=False, **kwargs
-) -> NativeVersionStore:
-    """Common logic behind all the factory fixtures"""
-    name = name or default_name
-    if name == "_unique_":
-        name = name + str(len(used))
-
-    assert (name not in used) or reuse_name, f"{name} is already in use"
-    cfg = make_cfg(name)
-    lib = cfg.env_by_id[Defaults.ENV].lib_by_path[name]
-    # Use symbol list by default (can still be overridden by kwargs)
-    lib.version.symbol_list = True
-    apply_lib_cfg(lib, kwargs)
-    out = ArcticMemoryConfig(cfg, Defaults.ENV)[name]
-    used[name] = out
-    return out
 
 
 @enum.unique
@@ -265,7 +116,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def version_store_factory(lib_name, tmpdir):
+def version_store_factory(lib_name, _lmdb_storage):
     """Factory to create any number of distinct LMDB libs with the given WriteOptions or VersionStoreConfig.
 
     Accepts legacy options col_per_group and row_per_segment.
@@ -273,94 +124,31 @@ def version_store_factory(lib_name, tmpdir):
     The values in `lmdb_config` populates the `LmdbConfig` Protobuf that creates the `Library` in C++. On Windows, it
     can be used to override the `map_size`.
     """
-    used: Dict[str, NativeVersionStore] = {}
-
-    def create_version_store(
-        col_per_group: Optional[int] = None,
-        row_per_segment: Optional[int] = None,
-        lmdb_config: Dict[str, Any] = {},
-        override_name: str = None,
-        **kwargs,
-    ) -> NativeVersionStore:
-        if col_per_group is not None and "column_group_size" not in kwargs:
-            kwargs["column_group_size"] = col_per_group
-        if row_per_segment is not None and "segment_row_size" not in kwargs:
-            kwargs["segment_row_size"] = row_per_segment
-
-        if override_name is not None:
-            library_name = override_name
-        else:
-            library_name = lib_name
-
-        cfg_factory = functools.partial(create_test_lmdb_cfg, db_dir=str(tmpdir), lmdb_config=lmdb_config)
-        return _version_store_factory_impl(used, cfg_factory, library_name, **kwargs)
-
-    try:
-        yield create_version_store
-    except RuntimeError as e:
-        if "mdb_" in str(e):  # Dump keys when we get uncaught exception from LMDB:
-            for store in used.values():
-                print(store)
-                lt = store.library_tool()
-                for kt in lt.key_types():
-                    for key in lt.find_keys(kt):
-                        print(key)
-        raise
-    finally:
-        for result in used.values():
-            #  pytest holds a member variable `cached_result` equal to `result` above which keeps the storage alive and
-            #  locked. See https://github.com/pytest-dev/pytest/issues/5642 . So we need to decref the C++ objects keeping
-            #  the LMDB env open before they will release the lock and allow Windows to delete the LMDB files.
-            result.version_store = None
-            result._library = None
-
-        shutil.rmtree(tmpdir, ignore_errors=True)
-
-
-def _arctic_library_factory_impl(used, name, arctic_client, library_options) -> Library:
-    """Common logic behind all the factory fixtures"""
-    name = name or default_name
-    if name == "_unique_":
-        name = name + str(len(used))
-    assert name not in used, f"{name} is already in use"
-    arctic_client.create_library(name, library_options)
-    out = arctic_client[name]
-    used[name] = out
-    return out
+    return _lmdb_storage.create_version_store_factory(lib_name)
 
 
 @pytest.fixture(scope="function")
 def library_factory(arctic_client, lib_name):
-    used: Dict[str, Library] = {}
+    """Useful if a test wants to create libraries without manually supplying names for them."""
 
-    def create_library(
-        library_options: Optional[LibraryOptions] = None,
-    ) -> Library:
-        return _arctic_library_factory_impl(used, lib_name, arctic_client, library_options)
+    def create_library(library_options: Optional[LibraryOptions] = None, name: str = lib_name) -> Library:
+        if name == "_unique_":
+            name = name + str(len(arctic_client.list_libraries()))
+        arctic_client.create_library(name, library_options)
+        out = arctic_client[name]
+        return out
 
     return create_library
 
 
 @pytest.fixture
-def s3_store_factory(lib_name, moto_s3_endpoint_and_credentials):
+def s3_store_factory(lib_name, s3_bucket):
     """Factory to create any number of S3 libs with the given WriteOptions or VersionStoreConfig.
 
     `name` can be a magical value "_unique_" which will create libs with unique names.
     This factory will clean up any libraries requested
     """
-    endpoint, port, bucket, aws_access_key, aws_secret_key = moto_s3_endpoint_and_credentials
-
-    # Not exposing the config factory to discourage people from creating libs that won't get cleaned up
-    def make_cfg(name):
-        # with_prefix=False to allow reuse_name to work correctly
-        return create_test_s3_cfg(name, aws_access_key, aws_secret_key, bucket, endpoint, with_prefix=False)
-
-    used = {}
-    try:
-        yield functools.partial(_version_store_factory_impl, used, make_cfg, lib_name)
-    finally:
-        for lib in used.values():
-            lib.version_store.clear()
+    return s3_bucket.create_version_store_factory(lib_name)
 
 
 @pytest.fixture(scope="function")
@@ -401,18 +189,13 @@ def real_s3_version_store(real_s3_store_factory):
 
 
 @pytest.fixture
-def azure_store_factory(lib_name, arcticdb_test_azure_config, azure_client_and_create_container):
+def azure_store_factory(lib_name, azurite_container):
     """Factory to create any number of Azure libs with the given WriteOptions or VersionStoreConfig.
 
     `name` can be a magical value "_unique_" which will create libs with unique names.
     This factory will clean up any libraries requested
     """
-    used = {}
-    try:
-        yield functools.partial(_version_store_factory_impl, used, arcticdb_test_azure_config, lib_name)
-    finally:
-        for lib in used.values():
-            lib.version_store.clear()
+    return azurite_container.create_version_store_factory()
 
 
 @pytest.fixture
@@ -488,6 +271,11 @@ def mongo_version_store(mongo_store_factory):
 def object_store_factory(request):
     store_factory = request.getfixturevalue(request.param)
     return store_factory
+
+
+@pytest.fixture
+def object_version_store(object_store_factory):
+    return object_store_factory()
 
 
 @pytest.fixture
@@ -681,58 +469,6 @@ def get_wide_df():
         return pd.DataFrame(index=[pd.Timestamp(ts)], data={str(col): get_val(col) for col in cols})
 
     return get_df
-
-
-@pytest.fixture(scope="module")
-def azurite_port():
-    return get_ephemeral_port()
-
-
-@pytest.fixture
-def azurite_container():
-    global bucket_id
-    container = f"testbucket{bucket_id}"
-    bucket_id = bucket_id + 1
-    return container
-
-
-@pytest.fixture(scope="module")
-def spawn_azurite(azurite_port):
-    if AZURE_SUPPORT:
-        temp_folder = tempfile.TemporaryDirectory()
-        try:  # Awaiting fix for cleanup in windows file-in-use problem
-            p = subprocess.Popen(
-                f"azurite --silent --blobPort {azurite_port} --blobHost 127.0.0.1 --queuePort 0 --tablePort 0",
-                cwd=temp_folder.name,
-                shell=True,
-            )
-            time.sleep(2)  # Wait for Azurite to start up
-            yield
-        finally:
-            print("Killing Azurite")
-            if sys.platform == "win32":  # different way of killing process on Windows
-                os.system(f"taskkill /F /PID {p.pid}")
-            else:
-                p.kill()
-            temp_folder = None  # For cleanup; For an unknown reason somehow using with syntax causes error
-
-    else:
-        yield
-
-
-@pytest.fixture(
-    scope="function",
-    params=(
-        ["moto_s3_uri_incl_bucket", "azurite_azure_uri_incl_bucket"] if AZURE_SUPPORT else ["moto_s3_uri_incl_bucket"]
-    ),
-)
-def object_storage_uri_incl_bucket(request):
-    yield request.getfixturevalue(request.param)
-
-
-@pytest.fixture
-def object_version_store(object_store_factory):
-    return object_store_factory()
 
 
 @pytest.fixture(

--- a/python/tests/integration/arcticdb/test_arctic_logging.py
+++ b/python/tests/integration/arcticdb/test_arctic_logging.py
@@ -1,0 +1,72 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import pytest
+import os
+import sys
+from subprocess import run, PIPE
+
+from arcticdb.adapters.storage_fixture_api import ArcticUriFields
+
+# Tests in this file forks another process in order to capture the logging output
+
+
+_DEFAULT_ENV = {
+    **os.environ,
+    "ARCTICDB_S3STORAGE_CHECKBUCKETMAXWAIT_INT": "3000",  # Moto is too slow and always time out on the default 1s
+    "ARCTICDB_AZURESTORAGE_CHECKCONTAINERMAXWAITMS_INT": "1000",
+}
+
+
+def _check_storage_is_accessible_logging(uri, *expected_strs, env=_DEFAULT_ENV):
+    code = f"""import logging; logging.basicConfig(); logging.getLogger("arcticdb.adapters").setLevel(logging.INFO)
+from arcticdb import Arctic; Arctic("{uri}")"""
+    p = run([sys.executable], universal_newlines=True, input=code, stderr=PIPE, timeout=15, env=env)
+    print(p.stderr, flush=True)
+    for expected in expected_strs:
+        assert str(expected) in p.stderr
+
+
+@pytest.mark.parametrize("field", [ArcticUriFields.USER, ArcticUriFields.PASSWORD])
+def test_check_storage_is_accessible_invalid_access_key(field, object_storage_fixture):
+    storage = object_storage_fixture
+    uri = storage.replace_uri_field(storage.arctic_uri, field, "YmFk")  # "bad" in Base64 for Azure
+    with storage.factory.enforcing_permissions_context():
+        _check_storage_is_accessible_logging(uri, "WARN", "No permission", 403)
+
+
+def test_check_storage_is_accessible_permission(object_storage_fixture):
+    factory = object_storage_fixture.factory
+    with factory.enforcing_permissions_context():
+        with factory.create_fixture() as bucket:
+            _check_storage_is_accessible_logging(bucket.arctic_uri, "WARNING", "No permission", 403)
+
+
+def test_check_storage_is_accessible_no_bucket(object_storage_fixture):
+    storage = object_storage_fixture
+    uri = storage.replace_uri_field(storage.arctic_uri, ArcticUriFields.BUCKET, "bad")
+    _check_storage_is_accessible_logging(uri, "Error", 404)
+
+
+def test_check_storage_is_accessible_network_error_s3(s3_bucket):
+    storage = s3_bucket
+    uri = storage.replace_uri_field(storage.arctic_uri, ArcticUriFields.HOST, "256.0.0.0")
+    env = {
+        **_DEFAULT_ENV,
+        "ARCTICDB_S3STORAGE_CONNECTTIMEOUTMS_INT": "500",
+        "ARCTICDB_S3STORAGE_REQUESTTIMEOUTMS_INT": "500",
+        "AWS_RETRY_MODE": "standard",
+        "AWS_MAX_ATTEMPTS": "1",  # Otherwise it takes minutes before the AWS SDK will shut down
+    }
+    _check_storage_is_accessible_logging(uri, "WARN", "Cannot connect", env=env)
+
+def test_check_storage_is_accessible_network_error_azure(azurite_container):
+    # Azure's implementation is broken in that it will repeatedly try an invalid address until timeout
+    storage = azurite_container
+    uri = storage.replace_uri_field(storage.arctic_uri, ArcticUriFields.HOST, "256.0.0.0")
+    _check_storage_is_accessible_logging(uri, "Unable to determine")
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,6 @@ Testing =
     pytest-timeout
     packaging
     future
-    pytest-server-fixtures
     mock
     boto3
     moto


### PR DESCRIPTION
This PR has two separate commits:

## 1: Introduce StorageFixtures

* standard, non-pytest-coupled API for storage fixture life cycles
* methods for setting permissions and closing the fixtures independent of pytest for error handling testing

## 2: Logic and tests for the warning

This replaces #551 

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
