### PR TITLE
Bugfix/nativeversionstore write metadata batch should never return dataerror objects

### DIFF
--- a/cpp/arcticdb/pipeline/read_options.hpp
+++ b/cpp/arcticdb/pipeline/read_options.hpp
@@ -19,7 +19,7 @@ struct ReadOptions {
     std::optional<bool> allow_sparse_;
     std::optional<bool> set_tz_;
     std::optional<bool> optimise_string_memory_;
-    std::optional<bool> batch_throw_on_missing_version_;
+    std::optional<bool> batch_throw_on_error_;
     std::optional<bool> read_previous_on_failure_;
 
     void set_force_strings_to_fixed(const std::optional<bool>& force_strings_to_fixed) {
@@ -54,8 +54,8 @@ struct ReadOptions {
         optimise_string_memory_ = optimise_string_memory;
     }
 
-    void set_batch_throw_on_missing_version(bool batch_throw_on_missing_version) {
-        batch_throw_on_missing_version_ = batch_throw_on_missing_version;
+    void set_batch_throw_on_error(bool batch_throw_on_error) {
+        batch_throw_on_error_ = batch_throw_on_error;
     }
 };
 } //namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -615,6 +615,7 @@ VersionedItem LocalVersionedEngine::write_versioned_metadata_internal(
 std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_write_versioned_metadata_internal(
     const std::vector<StreamId>& stream_ids,
     bool prune_previous_versions,
+    bool throw_on_error,
     std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>&& user_meta_protos) {
     auto stream_update_info_futures = batch_get_latest_undeleted_version_and_next_version_id_async(store(),
                                                                                                    version_map(),
@@ -655,12 +656,16 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         if (write_metadata_version.hasValue()) {
             write_metadata_versions_or_errors.emplace_back(std::move(write_metadata_version.value()));
         } else {
-            auto exception = write_metadata_version.exception();
-            DataError data_error(stream_ids[idx], exception.what().toStdString());
-            if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
-                data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+            if (throw_on_error) {
+                write_metadata_version.throwUnlessValue();
+            } else {
+                auto exception = write_metadata_version.exception();
+                DataError data_error(stream_ids[idx], exception.what().toStdString());
+                if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
+                    data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+                }
+                write_metadata_versions_or_errors.emplace_back(std::move(data_error));
             }
-            write_metadata_versions_or_errors.emplace_back(std::move(data_error));
         }
     }
     return write_metadata_versions_or_errors;
@@ -1119,7 +1124,7 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::te
         if (read_version.hasValue()) {
             read_versions_or_errors.emplace_back(std::move(read_version.value()));
         } else {
-            if (*read_options.batch_throw_on_missing_version_) {
+            if (*read_options.batch_throw_on_error_) {
                 read_version.throwUnlessValue();
             } else {
                 auto exception = read_version.exception();
@@ -1142,8 +1147,8 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::ba
     std::vector<ReadQuery>& read_queries,
     const ReadOptions& read_options) {
     // This read option should always be set when calling batch_read
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_missing_version_.has_value(),
-                                                    "ReadOptions::batch_throw_on_missing_version_ should always be set here");
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_error_.has_value(),
+                                                    "ReadOptions::batch_throw_on_error_ should always be set here");
 
     if(std::none_of(std::begin(read_queries), std::end(read_queries), [] (const auto& read_query) {
         return !read_query.clauses_.empty();
@@ -1165,7 +1170,7 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::ba
                                                                 read_options);
             read_versions_or_errors.emplace_back(std::move(read_version));
         } catch (const NoSuchVersionException& e) {
-            if (*read_options.batch_throw_on_missing_version_) {
+            if (*read_options.batch_throw_on_error_) {
                 throw;
             }
             read_versions_or_errors.emplace_back(DataError(stream_ids[idx],
@@ -1173,7 +1178,7 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::ba
                                                            version_query.content_,
                                                            ErrorCode::E_NO_SUCH_VERSION));
         } catch (const storage::NoDataFoundException& e) {
-            if (*read_options.batch_throw_on_missing_version_) {
+            if (*read_options.batch_throw_on_error_) {
                 throw;
             }
             read_versions_or_errors.emplace_back(DataError(stream_ids[idx],
@@ -1181,7 +1186,7 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::ba
                                                            version_query.content_,
                                                            ErrorCode::E_KEY_NOT_FOUND));
         } catch (const storage::KeyNotFoundException& e) {
-            if (*read_options.batch_throw_on_missing_version_) {
+            if (*read_options.batch_throw_on_error_) {
                 throw;
             }
             read_versions_or_errors.emplace_back(DataError(stream_ids[idx],
@@ -1189,7 +1194,7 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::ba
                                                            version_query.content_,
                                                            ErrorCode::E_KEY_NOT_FOUND));
         } catch (const std::exception& e) {
-            if (*read_options.batch_throw_on_missing_version_) {
+            if (*read_options.batch_throw_on_error_) {
                 throw;
             }
             read_versions_or_errors.emplace_back(DataError(stream_ids[idx],

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -274,6 +274,7 @@ public:
     std::vector<std::variant<VersionedItem, DataError>> batch_write_versioned_metadata_internal(
         const std::vector<StreamId>& stream_ids,
         bool prune_previous_versions,
+        bool throw_on_error,
         std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>&& user_meta_protos);
 
     std::vector<std::variant<VersionedItem, DataError>> batch_append_internal(

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -109,7 +109,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("set_incompletes", &ReadOptions::set_incompletes)
         .def("set_set_tz", &ReadOptions::set_set_tz)
         .def("set_optimise_string_memory", &ReadOptions::set_optimise_string_memory)
-        .def("set_batch_throw_on_missing_version", &ReadOptions::set_batch_throw_on_missing_version)
+        .def("set_batch_throw_on_error", &ReadOptions::set_batch_throw_on_error)
         .def_property_readonly("incompletes", &ReadOptions::get_incompletes);
 
     using FrameDataWrapper = arcticdb::pipelines::FrameDataWrapper;

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -346,7 +346,7 @@ TEST_F(VersionStoreTest, StressBatchReadUncompressed) {
 
     std::vector<ReadQuery> read_queries;
     ReadOptions read_options;
-    read_options.set_batch_throw_on_missing_version(true);
+    read_options.set_batch_throw_on_error(true);
     auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, read_options);
     for(auto&& [idx, version] : folly::enumerate(latest_versions)) {
         auto expected = get_test_simple_frame(std::get<ReadResult>(version).item.symbol(), 10, idx);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -996,7 +996,8 @@ std::pair<VersionedItem, py::object> PythonVersionStore::read_metadata(
 std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_write_metadata(
     const std::vector<StreamId>& stream_ids,
     const std::vector<py::object>& user_meta,
-    bool prune_previous_versions) {
+    bool prune_previous_versions,
+    bool throw_on_error) {
     std::vector<arcticdb::proto::descriptors::UserDefinedMetadata> user_meta_protos;
     user_meta_protos.reserve(user_meta.size());
     for(const auto& user_meta_item : user_meta) {
@@ -1004,7 +1005,7 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_wr
         python_util::pb_from_python(user_meta_item, user_meta_proto);
         user_meta_protos.emplace_back(std::move(user_meta_proto));
     }
-    return batch_write_versioned_metadata_internal(stream_ids, prune_previous_versions, std::move(user_meta_protos));
+    return batch_write_versioned_metadata_internal(stream_ids, prune_previous_versions, throw_on_error, std::move(user_meta_protos));
 }
 
 std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> PythonVersionStore::batch_restore_version(

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -274,7 +274,8 @@ class PythonVersionStore : public LocalVersionedEngine {
     std::vector<std::variant<VersionedItem, DataError>> batch_write_metadata(
         const std::vector<StreamId>& stream_ids,
         const std::vector<py::object>& user_meta,
-        bool prune_previous_versions);
+        bool prune_previous_versions,
+        bool throw_on_error);
 
     std::vector<std::variant<VersionedItem, DataError>> batch_append(
         const std::vector<StreamId> &stream_ids,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -948,9 +948,9 @@ class NativeVersionStore:
             Dictionary of symbol mapping with the versioned items
         """
         _check_batch_kwargs(NativeVersionStore.batch_read, NativeVersionStore.read, kwargs)
-        throw_on_missing_version = True
+        throw_on_error = True
         versioned_items = self._batch_read_to_versioned_items(
-            symbols, as_ofs, date_ranges, columns, query_builder, throw_on_missing_version, kwargs
+            symbols, as_ofs, date_ranges, columns, query_builder, throw_on_error, kwargs
         )
         check(
             all(v is not None for v in versioned_items),
@@ -959,14 +959,14 @@ class NativeVersionStore:
         return {v.symbol: v for v in versioned_items}
 
     def _batch_read_to_versioned_items(
-        self, symbols, as_ofs, date_ranges, columns, query_builder, throw_on_missing_version, kwargs=None
+        self, symbols, as_ofs, date_ranges, columns, query_builder, throw_on_error, kwargs=None
     ):
         if kwargs is None:
             kwargs = dict()
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         read_queries = self._get_read_queries(len(symbols), date_ranges, columns, query_builder)
         read_options = self._get_read_options(**kwargs)
-        read_options.set_batch_throw_on_missing_version(throw_on_missing_version)
+        read_options.set_batch_throw_on_error(throw_on_error)
         read_results = self.version_store.batch_read(symbols, version_queries, read_queries, read_options)
         versioned_items = []
         for i in range(len(read_results)):
@@ -1206,7 +1206,7 @@ class NativeVersionStore:
         return [self._convert_thin_cxx_item_to_python(v) for v in cxx_versioned_items]
 
     def _batch_write_metadata_to_versioned_items(
-        self, symbols: List[str], metadata_vector: List[Any], prune_previous_version
+        self, symbols: List[str], metadata_vector: List[Any], prune_previous_version, throw_on_error
     ):
         for symbol in symbols:
             self.check_symbol_validity(symbol)
@@ -1216,7 +1216,9 @@ class NativeVersionStore:
             "prune_previous_version", proto_cfg, global_default=False, existing_value=prune_previous_version
         )
         normalized_meta = [normalize_metadata(metadata_vector[idx]) for idx in range(len(symbols))]
-        cxx_versioned_items = self.version_store.batch_write_metadata(symbols, normalized_meta, prune_previous_version)
+        cxx_versioned_items = self.version_store.batch_write_metadata(
+            symbols, normalized_meta, prune_previous_version, throw_on_error
+        )
         write_metadata_results = []
         for result in cxx_versioned_items:
             if isinstance(result, DataError):
@@ -1253,7 +1255,10 @@ class NativeVersionStore:
             If any internal exception is raised, a DataError object is returned, with symbol,
             error_code, error_category, and exception_string properties.
         """
-        return self._batch_write_metadata_to_versioned_items(symbols, metadata_vector, prune_previous_version)
+        throw_on_error = True
+        return self._batch_write_metadata_to_versioned_items(
+            symbols, metadata_vector, prune_previous_version, throw_on_error
+        )
 
     def batch_append(
         self,

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1047,9 +1047,9 @@ class Library:
                     f"Unsupported item in the symbols argument s=[{s}] type(s)=[{type(s)}]. Only [str] and"
                     " [ReadRequest] are supported."
                 )
-        throw_on_missing_version = False
+        throw_on_error = False
         return self._nvs._batch_read_to_versioned_items(
-            symbol_strings, as_ofs, date_ranges, columns, query_builder or query_builders, throw_on_missing_version
+            symbol_strings, as_ofs, date_ranges, columns, query_builder or query_builders, throw_on_error
         )
 
     def read_metadata(self, symbol: str, as_of: Optional[AsOf] = None) -> VersionedItem:
@@ -1185,10 +1185,12 @@ class Library:
         """
 
         self._raise_if_duplicate_symbols_in_batch(write_metadata_payloads)
+        throw_on_error = False
         return self._nvs._batch_write_metadata_to_versioned_items(
             [p.symbol for p in write_metadata_payloads],
             [p.metadata for p in write_metadata_payloads],
             prune_previous_version=prune_previous_versions,
+            throw_on_error=throw_on_error,
         )
 
     def snapshot(

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -34,7 +34,7 @@ from arcticdb.flattener import Flattener
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer
 from arcticdb.version_store._store import UNSUPPORTED_S3_CHARS, MAX_SYMBOL_SIZE, VersionedItem
-from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException
+from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException, StorageException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb_ext.version_store import NoSuchVersionException, StreamDescriptorMismatch, ManualClockVersionStore
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata  # Importing from arcticdb dynamically loads arcticc.pb2
@@ -1365,6 +1365,23 @@ def test_batch_roundtrip_metadata(lmdb_version_store_tombstone_and_sync_passive)
         assert returned.metadata == metadatas[sym]
 
 
+def test_batch_write_metadata_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s2")[0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_index_key)
+    with pytest.raises(StorageException):
+        _ = lib.batch_write_metadata(["s1", "s2"], [{"s1_meta": 1}, {"s2_meta": 1}])
+
+
 def test_write_composite_data_with_user_meta(lmdb_version_store):
     multi_data = {"sym1": np.arange(8), "sym2": np.arange(9), "sym3": np.arange(10)}
     lmdb_version_store.write("sym", multi_data, metadata={"a": 1})
@@ -2006,6 +2023,34 @@ def test_batch_read_version_doesnt_exist(lmdb_version_store):
     lmdb_version_store.write(sym2, 2)
     with pytest.raises(NoDataFoundException):
         _ = lmdb_version_store.batch_read([sym1, sym2], as_ofs=[0, 1])
+
+
+def test_batch_read_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    df3 = pd.DataFrame({"a": [5, 7, 9]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    lib.write("s3", df3)
+    lib.write("s3", df3)
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_data_key = lib_tool.find_keys_for_id(KeyType.TABLE_DATA, "s2")[0]
+    s3_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s3")
+    s3_key_to_delete = [key for key in s3_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_data_key)
+    lib_tool.remove(s3_key_to_delete)
+
+    # The exception thrown is different for missing version keys to everything else, and so depends on which symbol is
+    # processed first
+    with pytest.raises((NoDataFoundException, StorageException)):
+        _ = lib.batch_read(["s1", "s2", "s3"], [None, None, 0])
 
 
 def test_index_keys_start_end_index(lmdb_version_store, sym):

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -24,10 +24,10 @@ import random
 import string
 
 from arcticdb.exceptions import ArcticNativeException
-from arcticdb_ext.storage import NoDataFoundException
+from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.exceptions import InternalException, UserInputException
-from arcticdb.util.test import assert_frame_equal
+from arcticdb_ext.exceptions import InternalException,StorageException, UserInputException
+from arcticdb.util.test import assert_frame_equal, PANDAS_VERSION
 from arcticdb.util._versions import PANDAS_VERSION
 from arcticdb.util.hypothesis import (
     use_of_function_scoped_fixtures_in_hypothesis_checked,
@@ -2069,6 +2069,37 @@ def test_filter_batch_version_doesnt_exist(lmdb_version_store):
     # pandas_query = "a == 2"
     with pytest.raises(NoDataFoundException):
         batch_res = lmdb_version_store.batch_read([sym1, sym2], as_ofs=[0, 1], query_builder=q)
+
+
+def test_filter_batch_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    df3 = pd.DataFrame({"a": [5, 7, 9]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    lib.write("s3", df3)
+    lib.write("s3", df3)
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_data_key = lib_tool.find_keys_for_id(KeyType.TABLE_DATA, "s2")[0]
+    s3_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s3")
+    s3_key_to_delete = [key for key in s3_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_data_key)
+    lib_tool.remove(s3_key_to_delete)
+
+    q = QueryBuilder()
+    q = q[q["a"] == 2]
+
+    # The exception thrown is different for missing version keys to everything else, and so depends on which symbol is
+    # processed first
+    with pytest.raises((NoDataFoundException, StorageException)):
+        _ = lib.batch_read(["s1", "s2", "s3"], [None, None, 0], query_builder=q)
 
 
 def test_filter_numeric_membership_equivalence():

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -26,7 +26,7 @@ import string
 from arcticdb.exceptions import ArcticNativeException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.exceptions import InternalException,StorageException, UserInputException
+from arcticdb_ext.exceptions import InternalException, StorageException, UserInputException
 from arcticdb.util.test import assert_frame_equal, PANDAS_VERSION
 from arcticdb.util._versions import PANDAS_VERSION
 from arcticdb.util.hypothesis import (


### PR DESCRIPTION
#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

The `NativeVersionStore` API (used internally at Man Group) would previously throw an exception if there was a key missing from the storage required to complete a `batch_write_metadata` operation. This was accidentally modified in PR #476, such that `DataError` objects were returned instead. This PR restores the previous behviour, for the `NativeVersionStore` API, while maintaining the new behaviour for the `Library` API.
In addition:

- `throw_on_missing_version` was renamed everywhere to `throw_on_error`, as missing versions are not the only case in which exceptions are raised
- tests were added to cover the behaviour of `batch_read` from the `NativeVersionStore` API when there are missing keys

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
