### PR TITLE
Minor improvemnt for calcuating the compressed size of an Empty column

### DIFF
--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -85,11 +85,11 @@ struct ColumnEncoder {
             using Encoder = BlockEncoder<TDT>;
             ARCTICDB_TRACE(log::codec(), "Column data has {} blocks", column_data.num_blocks());
 
-            while (auto block = column_data.next<TDT>()) {
-                if constexpr(!is_empty_type(TDT::DataTypeTag::data_type)) {
+            if constexpr(!is_empty_type(TDT::DataTypeTag::data_type)) {
+                while (auto block = column_data.next<TDT>()) {
                     util::check(block.value().nbytes() > 0, "Zero-sized block");
+                    Encoder::encode(codec_opts, block.value(), field, out, pos);
                 }
-                Encoder::encode(codec_opts, block.value(), field, out, pos);
             }
         });
 

--- a/cpp/arcticdb/codec/segment.cpp
+++ b/cpp/arcticdb/codec/segment.cpp
@@ -29,9 +29,9 @@ std::tuple<size_t, size_t> compressed(const arcticdb::proto::encoding::SegmentHe
             metadata_size = encoding_sizes::ndarray_field_compressed_size(seg_hdr.metadata_field().ndarray());
 
         buffer_size = encoding_sizes::segment_compressed_size(seg_hdr.fields()) + metadata_size + string_pool_size;
-    }
-    else
+    } else {
         buffer_size = seg_hdr.column_fields().offset() + sizeof(EncodedMagic) + encoding_sizes::ndarray_field_compressed_size(seg_hdr.column_fields().ndarray());
+    }
 
     return {string_pool_size, buffer_size};
 }

--- a/cpp/arcticdb/codec/segment.hpp
+++ b/cpp/arcticdb/codec/segment.hpp
@@ -155,7 +155,10 @@ class Segment {
 
     [[nodiscard]] std::size_t total_segment_size(std::size_t hdr_size) const {
         auto total = FIXED_HEADER_SIZE + hdr_size + buffer_bytes();
-        ARCTICDB_TRACE(log::storage(), "Total segment size {} + {} + {} = {}", FIXED_HEADER_SIZE, hdr_size, buffer_bytes(), total);
+        ARCTICDB_TRACE(
+                log::storage(),
+                "Total segment size (fixed header size + header size + buffer size = total) {} + {} + {} = {}",
+                FIXED_HEADER_SIZE, hdr_size, buffer_bytes(), total);
         return total;
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Improves on #646 
#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.
* We know that the max_compressed_size of a column is 0, so there is no need co iterate all blocks and call the function to compute it.
* Do not call `Encoder::encode` on an empty column as there is nothing to encode
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
