### PR TITLE
perf(VectorDB): parallelise top-k queries.

### DIFF
--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -553,8 +553,8 @@ Composite<ProcessingUnit> MergeClause::process(std::shared_ptr<Store> store,
 }
 
 std::optional<std::vector<Composite<ProcessingUnit>>> MergeClause::repartition(
-        std::vector<Composite<ProcessingUnit>> &&comps,
-        ARCTICDB_UNUSED const std::shared_ptr<Store>& store) const {
+        ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+        std::vector<Composite<ProcessingUnit>> &&comps) const {
     std::vector<Composite<ProcessingUnit>> v;
     v.push_back(merge_composites_shallow(std::move(comps)));
     return v;

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -553,7 +553,8 @@ Composite<ProcessingUnit> MergeClause::process(std::shared_ptr<Store> store,
 }
 
 std::optional<std::vector<Composite<ProcessingUnit>>> MergeClause::repartition(
-        std::vector<Composite<ProcessingUnit>> &&comps) const {
+        std::vector<Composite<ProcessingUnit>> &&comps,
+        ARCTICDB_UNUSED const std::shared_ptr<Store>& store) const {
     std::vector<Composite<ProcessingUnit>> v;
     v.push_back(merge_composites_shallow(std::move(comps)));
     return v;

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -79,8 +79,9 @@ struct IClause {
         }
 
         [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-                [[maybe_unused]] std::vector<Composite<ProcessingUnit>> &&comps) const {
-            return folly::poly_call<2>(*this, std::move(comps));
+                [[maybe_unused]] std::vector<Composite<ProcessingUnit>> &&comps,
+                [[maybe_unused]] const std::shared_ptr<Store>& store) const {
+            return folly::poly_call<2>(*this, std::move(comps), store);
         }
 
         [[nodiscard]] const ClauseInfo& clause_info() const { return folly::poly_call<3>(*this); };
@@ -120,7 +121,8 @@ struct PassthroughClause {
             ) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&comps) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&comps,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -159,7 +161,8 @@ struct FilterClause {
             ) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -205,7 +208,8 @@ struct ProjectClause {
     process(std::shared_ptr<Store> store, Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&comps) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -255,7 +259,8 @@ struct PartitionClause {
     }
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&c) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&c,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         auto comps = std::move(c);
         std::unordered_map<size_t, Composite<ProcessingUnit>> partition_map;
         schema::check<ErrorCode::E_COLUMN_DOESNT_EXIST>(
@@ -330,8 +335,8 @@ struct AggregationClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&comps
-            ) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -364,7 +369,8 @@ struct RemoveColumnPartitioningClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -393,7 +399,8 @@ struct SplitClause {
                                                     Composite<ProcessingUnit> &&procs) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&comps) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -421,7 +428,8 @@ struct SortClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&comps) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -462,7 +470,8 @@ struct MergeClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            std::vector<Composite<ProcessingUnit>> &&comps) const;
+            std::vector<Composite<ProcessingUnit>> &&comps,
+            const std::shared_ptr<Store>& store) const;
 
     [[nodiscard]] const ClauseInfo& clause_info() const {
         return clause_info_;
@@ -496,7 +505,8 @@ struct ColumnStatsGenerationClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -542,7 +552,8 @@ struct RowRangeClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 
@@ -578,7 +589,8 @@ struct DateRangeClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
         return std::nullopt;
     }
 

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -79,9 +79,9 @@ struct IClause {
         }
 
         [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-                [[maybe_unused]] std::vector<Composite<ProcessingUnit>> &&comps,
-                [[maybe_unused]] const std::shared_ptr<Store>& store) const {
-            return folly::poly_call<2>(*this, std::move(comps), store);
+                [[maybe_unused]] const std::shared_ptr<Store>& store,
+                [[maybe_unused]] std::vector<Composite<ProcessingUnit>> &&comps) const {
+            return folly::poly_call<2>(*this, store, std::move(comps));
         }
 
         [[nodiscard]] const ClauseInfo& clause_info() const { return folly::poly_call<3>(*this); };
@@ -121,8 +121,8 @@ struct PassthroughClause {
             ) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&comps,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -161,8 +161,8 @@ struct FilterClause {
             ) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -208,8 +208,8 @@ struct ProjectClause {
     process(std::shared_ptr<Store> store, Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -259,8 +259,8 @@ struct PartitionClause {
     }
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&c,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&c) const {
         auto comps = std::move(c);
         std::unordered_map<size_t, Composite<ProcessingUnit>> partition_map;
         schema::check<ErrorCode::E_COLUMN_DOESNT_EXIST>(
@@ -335,8 +335,8 @@ struct AggregationClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -369,8 +369,8 @@ struct RemoveColumnPartitioningClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -399,8 +399,8 @@ struct SplitClause {
                                                     Composite<ProcessingUnit> &&procs) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -428,8 +428,8 @@ struct SortClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -470,8 +470,8 @@ struct MergeClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            std::vector<Composite<ProcessingUnit>> &&comps,
-            const std::shared_ptr<Store>& store) const;
+            const std::shared_ptr<Store>& store,
+            std::vector<Composite<ProcessingUnit>> &&comps) const;
 
     [[nodiscard]] const ClauseInfo& clause_info() const {
         return clause_info_;
@@ -505,8 +505,8 @@ struct ColumnStatsGenerationClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -552,8 +552,8 @@ struct RowRangeClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 
@@ -589,8 +589,8 @@ struct DateRangeClause {
                                                     Composite<ProcessingUnit> &&p) const;
 
     [[nodiscard]] std::optional<std::vector<Composite<ProcessingUnit>>> repartition(
-            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&,
-            ARCTICDB_UNUSED const std::shared_ptr<Store>&) const {
+            ARCTICDB_UNUSED const std::shared_ptr<Store>&,
+            ARCTICDB_UNUSED std::vector<Composite<ProcessingUnit>> &&) const {
         return std::nullopt;
     }
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -409,7 +409,7 @@ Composite<ProcessingUnit> process_remaining_clauses(
         std::vector<std::shared_ptr<Clause>> clauses ) { // pass by copy deliberately as we don't want to modify read_query
     while (!clauses.empty()) {
         if (clauses[0]->clause_info().requires_repartition_) {
-            std::vector<Composite<ProcessingUnit>> repartitioned_procs = clauses[0]->repartition(std::move(procs)).value();
+            std::vector<Composite<ProcessingUnit>> repartitioned_procs = clauses[0]->repartition(std::move(procs), store).value();
             // Erasing from front of vector not ideal, but they're just shared_ptr and there shouldn't be loads of clauses
             clauses.erase(clauses.begin());
             std::vector<folly::Future<Composite<ProcessingUnit>>> fut_procs;

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -409,7 +409,7 @@ Composite<ProcessingUnit> process_remaining_clauses(
         std::vector<std::shared_ptr<Clause>> clauses ) { // pass by copy deliberately as we don't want to modify read_query
     while (!clauses.empty()) {
         if (clauses[0]->clause_info().requires_repartition_) {
-            std::vector<Composite<ProcessingUnit>> repartitioned_procs = clauses[0]->repartition(std::move(procs), store).value();
+            std::vector<Composite<ProcessingUnit>> repartitioned_procs = clauses[0]->repartition(store, std::move(procs)).value();
             // Erasing from front of vector not ideal, but they're just shared_ptr and there shouldn't be loads of clauses
             clauses.erase(clauses.begin());
             std::vector<folly::Future<Composite<ProcessingUnit>>> fut_procs;

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -55,6 +55,7 @@ def test_remove_incomplete(lmdb_version_store):
     lib.write(sym3, df1)
     lib.remove_incomplete(sym3)
 
+
 from arcticdb.util._versions import IS_PANDAS_TWO
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ ARCTICDB_BUILD_CPP_TESTS = os.environ.get("ARCTICDB_BUILD_CPP_TESTS", "0")
 ARCTICDB_BUILD_CPP_TESTS = ARCTICDB_BUILD_CPP_TESTS != "0"
 print(f"ARCTICDB_BUILD_CPP_TESTS={ARCTICDB_BUILD_CPP_TESTS}")
 
+
 def _log_and_run(*cmd, **kwargs):
     print("Running " + " ".join(cmd))
     subprocess.check_call(cmd, **kwargs)


### PR DESCRIPTION
#### Reference Issues/PRs

Partially closes #714 pending investigation of relative performance.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Following Alex (Owens') changes, some mechanical changes are needed to make `TopKClause` conform to the new specification of `IClause`: we need a `structure_for_processing`, which naturally is by column slice, and then we need to repartition since we want the top-k, not the top-k-per-segment=top-|segments|k. 

#### Any other comments?

I unfortunately rebased the integration branch so it's presently broken; these changes are hopefully mechanical.

Does anybody have a better way to get `store` into my `repartition` function other than changing the signature everywhere?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
