### PR TITLE
Enhancement 737: Support empty-type columns in QueryBuilder operations

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -712,6 +712,7 @@ if(${TEST})
             processing/test/test_clause.cpp
             processing/test/test_expression.cpp
             processing/test/test_has_valid_type_promotion.cpp
+            processing/test/test_operation_dispatch.cpp
             processing/test/test_set_membership.cpp
             processing/test/test_signed_unsigned_comparison.cpp
             processing/test/test_type_comparison.cpp

--- a/cpp/arcticdb/pipeline/value_set.cpp
+++ b/cpp/arcticdb/pipeline/value_set.cpp
@@ -64,6 +64,47 @@ namespace arcticdb {
         });
     }
 
+    ValueSet::ValueSet(NumericSetType&& value_set):
+    numeric_base_set_(std::move(value_set)) {
+        util::variant_match(
+                numeric_base_set_,
+                [this](const std::shared_ptr<std::unordered_set<uint8_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S8));
+                },
+                [this](const std::shared_ptr<std::unordered_set<uint16_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S16));
+                },
+                [this](const std::shared_ptr<std::unordered_set<uint32_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S32));
+                },
+                [this](const std::shared_ptr<std::unordered_set<uint64_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::UINT, entity::SizeBits::S64));
+                },
+                [this](const std::shared_ptr<std::unordered_set<int8_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S8));
+                },
+                [this](const std::shared_ptr<std::unordered_set<int16_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S16));
+                },
+                [this](const std::shared_ptr<std::unordered_set<int32_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S32));
+                },
+                [this](const std::shared_ptr<std::unordered_set<int64_t>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S64));
+                },
+                [this](const std::shared_ptr<std::unordered_set<float>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::FLOAT, entity::SizeBits::S32));
+                },
+                [this](const std::shared_ptr<std::unordered_set<double>>&) {
+                    base_type_ = make_scalar_type(combine_data_type(entity::ValueType::FLOAT, entity::SizeBits::S64));
+                }
+                );
+        util::variant_match(numeric_base_set_,
+                            [&](const auto& numeric_base_set) {
+                                empty_ = numeric_base_set->empty();
+                            });
+    }
+
     bool ValueSet::empty() const {
         return empty_;
     }

--- a/cpp/arcticdb/pipeline/value_set.hpp
+++ b/cpp/arcticdb/pipeline/value_set.hpp
@@ -25,10 +25,23 @@ namespace arcticdb {
 
 namespace py = pybind11;
 
+using NumericSetType = std::variant<
+        std::shared_ptr<std::unordered_set<uint8_t>>,
+        std::shared_ptr<std::unordered_set<uint16_t>>,
+        std::shared_ptr<std::unordered_set<uint32_t>>,
+        std::shared_ptr<std::unordered_set<uint64_t>>,
+        std::shared_ptr<std::unordered_set<int8_t>>,
+        std::shared_ptr<std::unordered_set<int16_t>>,
+        std::shared_ptr<std::unordered_set<int32_t>>,
+        std::shared_ptr<std::unordered_set<int64_t>>,
+        std::shared_ptr<std::unordered_set<float>>,
+        std::shared_ptr<std::unordered_set<double>>>;
+
 class ValueSet {
 public:
     explicit ValueSet(std::vector<std::string>&& value_list);
     explicit ValueSet(py::array value_list);
+    explicit ValueSet(NumericSetType&& value_set);
 
     bool empty() const;
 
@@ -42,18 +55,6 @@ public:
     std::shared_ptr<std::unordered_set<std::string>> get_fixed_width_string_set(size_t width);
 
 private:
-    using NumericSetType = std::variant<
-            std::shared_ptr<std::unordered_set<uint8_t>>,
-            std::shared_ptr<std::unordered_set<uint16_t>>,
-            std::shared_ptr<std::unordered_set<uint32_t>>,
-            std::shared_ptr<std::unordered_set<uint64_t>>,
-            std::shared_ptr<std::unordered_set<int8_t>>,
-            std::shared_ptr<std::unordered_set<int16_t>>,
-            std::shared_ptr<std::unordered_set<int32_t>>,
-            std::shared_ptr<std::unordered_set<int64_t>>,
-            std::shared_ptr<std::unordered_set<float>>,
-            std::shared_ptr<std::unordered_set<double>>>;
-
     bool empty_;
     entity::TypeDescriptor base_type_;
     NumericSetType numeric_base_set_;

--- a/cpp/arcticdb/processing/aggregation.cpp
+++ b/cpp/arcticdb/processing/aggregation.cpp
@@ -77,7 +77,9 @@ SegmentInMemory MinMaxAggregatorData::finalize(const std::vector<ColumnName>& ou
 void SumAggregatorData::aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values) {
     // If data_type_ has no value, it means there is no data for this aggregation
     // For sums, we want this to display as zero rather than NaN
-    data_type_ = data_type_.value_or(DataType::FLOAT64);
+    if (!data_type_.has_value() || *data_type_ == DataType::EMPTYVAL) {
+        data_type_ = DataType::FLOAT64;
+    }
     entity::details::visit_type(*data_type_, [&input_column, unique_values, &groups, that=this] (auto global_type_desc_tag) {
         using GlobalInputType = decltype(global_type_desc_tag);
         if constexpr(!is_sequence_type(GlobalInputType::DataTypeTag::data_type)) {

--- a/cpp/arcticdb/processing/aggregation.hpp
+++ b/cpp/arcticdb/processing/aggregation.hpp
@@ -159,7 +159,7 @@ struct MaxOrMinAggregatorData {
         add_data_type_impl(data_type, data_type_);
     }
     void aggregate(const std::optional<ColumnWithStrings>& input_column, const std::vector<size_t>& groups, size_t unique_values) {
-        if(data_type_.has_value() && input_column.has_value()) {
+        if(data_type_.has_value() && *data_type_ != DataType::EMPTYVAL && input_column.has_value()) {
             entity::details::visit_type(*data_type_, [&input_column, unique_values, &groups, that=this] (auto global_type_desc_tag) {
                 using GlobalInputType = decltype(global_type_desc_tag);
                 if constexpr(!is_sequence_type(GlobalInputType::DataTypeTag::data_type)) {

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -339,7 +339,11 @@ Composite<ProcessingUnit> AggregationClause::process(std::shared_ptr<Store> stor
                                                     auto input_column = proc_.get(input_column_name, store);
                                                     std::optional<ColumnWithStrings> opt_input_column;
                                                     if (std::holds_alternative<ColumnWithStrings>(input_column)) {
-                                                        opt_input_column.emplace(std::get<ColumnWithStrings>(input_column));
+                                                        auto column_with_strings = std::get<ColumnWithStrings>(input_column);
+                                                        // Empty columns don't contribute to aggregations
+                                                        if (!is_empty_type(column_with_strings.column_->type().data_type())) {
+                                                            opt_input_column.emplace(std::move(column_with_strings));
+                                                        }
                                                     }
                                                     agg_data->aggregate(opt_input_column, row_to_group, num_unique);
                                                 }

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -59,6 +59,9 @@ VariantData unary_operator(const Value& val, Func&& func) {
 
 template <typename Func>
 VariantData unary_operator(const Column& col, Func&& func) {
+    schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
+            !is_empty_type(col.type().data_type()),
+            "Empty column provided to unary operator");
     std::unique_ptr<Column> output;
 
     details::visit_type(col.type().data_type(), [&](auto col_desc_tag) {

--- a/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
@@ -1,0 +1,139 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/processing/expression_node.hpp>
+#include <arcticdb/processing/operation_dispatch_binary.hpp>
+#include <arcticdb/processing/operation_dispatch_unary.hpp>
+#include <arcticdb/pipeline/value.hpp>
+#include <arcticdb/pipeline/value_set.hpp>
+#include <arcticdb/util/test/generators.hpp>
+
+TEST(OperationDispatch, unary_operator) {
+    using namespace arcticdb;
+    size_t num_rows = 100;
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+
+    // int col
+    auto variant_data = visit_unary_operator(int_column, NegOperator{});
+    ASSERT_TRUE(std::holds_alternative<ColumnWithStrings>(variant_data));
+    auto results_column = std::get<ColumnWithStrings>(variant_data).column_;
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(-idx, results_column->scalar_at<int64_t>(idx));
+    }
+    // empty col
+    EXPECT_THROW(visit_unary_operator(empty_column, NegOperator{}), SchemaException);
+}
+
+TEST(OperationDispatch, binary_operator) {
+    using namespace arcticdb;
+    size_t num_rows = 100;
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+    auto value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
+
+    // int col + int col
+    auto variant_data_0 = visit_binary_operator(int_column, int_column, PlusOperator{});
+    ASSERT_TRUE(std::holds_alternative<ColumnWithStrings>(variant_data_0));
+    auto results_column_0 = std::get<ColumnWithStrings>(variant_data_0).column_;
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(idx + idx, results_column_0->scalar_at<int64_t>(idx));
+    }
+    // int col + val
+    auto variant_data_1 = visit_binary_operator(int_column, value, PlusOperator{});
+    ASSERT_TRUE(std::holds_alternative<ColumnWithStrings>(variant_data_1));
+    auto results_column_1 = std::get<ColumnWithStrings>(variant_data_1).column_;
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(idx + 50, results_column_1->scalar_at<int64_t>(idx));
+    }
+    // val + int col
+    auto variant_data_2 = visit_binary_operator(value, int_column, PlusOperator{});
+    ASSERT_TRUE(std::holds_alternative<ColumnWithStrings>(variant_data_2));
+    auto results_column_2 = std::get<ColumnWithStrings>(variant_data_2).column_;
+    ASSERT_TRUE(*results_column_1 == *results_column_2);
+    // val + val
+    auto variant_data_3 = visit_binary_operator(value, value, PlusOperator{});
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<Value>>(variant_data_3));
+    auto results_value = std::get<std::shared_ptr<Value>>(variant_data_3)->get<int64_t>();
+    ASSERT_EQ(results_value, 100);
+    // int col + empty col
+    EXPECT_THROW(visit_binary_operator(int_column, empty_column, PlusOperator{}), SchemaException);
+    // empty col + int col
+    EXPECT_THROW(visit_binary_operator(empty_column, int_column, PlusOperator{}), SchemaException);
+    // empty col + empty col
+    EXPECT_THROW(visit_binary_operator(empty_column, empty_column, PlusOperator{}), SchemaException);
+    // empty col + val
+    EXPECT_THROW(visit_binary_operator(empty_column, value, PlusOperator{}), SchemaException);
+    // val + empty col
+    EXPECT_THROW(visit_binary_operator(value, empty_column, PlusOperator{}), SchemaException);
+}
+
+TEST(OperationDispatch, binary_comparator) {
+    using namespace arcticdb;
+    size_t num_rows = 100;
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+    auto value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
+
+    // int col < int col
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(visit_binary_comparator(int_column, int_column, LessThanOperator{})));
+    // int col < val
+    auto variant_data_0 = visit_binary_comparator(int_column, value, LessThanOperator{});
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<util::BitSet>>(variant_data_0));
+    auto results_bitset_0 = std::get<std::shared_ptr<util::BitSet>>(variant_data_0);
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(idx < 50, results_bitset_0->get_bit(idx));
+    }
+    // val < int col
+    auto variant_data_1 = visit_binary_comparator(value, int_column, LessThanOperator{});
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<util::BitSet>>(variant_data_1));
+    auto results_bitset_1 = std::get<std::shared_ptr<util::BitSet>>(variant_data_1);
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(50 < idx, results_bitset_1->get_bit(idx));
+    }
+    // val < val not supported, should be handled at expression evaluation time
+    // int col < empty col
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(visit_binary_comparator(int_column, empty_column, LessThanOperator{})));
+    // empty col < int col
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(visit_binary_comparator(empty_column, int_column, LessThanOperator{})));
+    // empty col < empty col
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(visit_binary_comparator(empty_column, empty_column, LessThanOperator{})));
+    // empty col < val
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(visit_binary_comparator(empty_column, value, LessThanOperator{})));
+    // val < empty col
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(visit_binary_comparator(value, empty_column, LessThanOperator{})));
+}
+
+TEST(OperationDispatch, binary_membership) {
+    using namespace arcticdb;
+    size_t num_rows = 100;
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+    std::unordered_set<int64_t> raw_set{0, 23, 82, static_cast<int64_t>(num_rows) - 1, 1000000};
+    auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<int64_t>>(raw_set));
+
+    // int col isin set
+    auto variant_data_0 = visit_binary_membership(int_column, value_set, IsInOperator{});
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<util::BitSet>>(variant_data_0));
+    auto results_bitset_0 = std::get<std::shared_ptr<util::BitSet>>(variant_data_0);
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(raw_set.count(static_cast<int64_t>(idx)) > 0, results_bitset_0->get_bit(idx));
+    }
+    // int col isnotin set
+    auto variant_data_1 = visit_binary_membership(int_column, value_set, IsNotInOperator{});
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<util::BitSet>>(variant_data_0));
+    auto results_bitset_1 = std::get<std::shared_ptr<util::BitSet>>(variant_data_1);
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(raw_set.count(static_cast<int64_t>(idx)) == 0, results_bitset_1->get_bit(idx));
+    }
+    // empty col isin set
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(visit_binary_membership(empty_column, value_set, IsInOperator{})));
+    // empty col isnotin set
+    ASSERT_TRUE(std::holds_alternative<FullResult>(visit_binary_membership(empty_column, value_set, IsNotInOperator{})));
+}

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -79,6 +79,48 @@ using SinkWrapper = SinkWrapperImpl<TestAggregator>;
 using TestSparseAggregator = Aggregator<TimeseriesIndex, FixedSchema, stream::NeverSegmentPolicy, SparseColumnPolicy>;
 using SparseSinkWrapper = SinkWrapperImpl<TestSparseAggregator>;
 
+// Generates an int64_t Column where the value in each row is equal to the row index
+inline Column generate_int_column(size_t num_rows) {
+    using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
+    Column column(static_cast<TypeDescriptor>(TDT{}), 0, false, false);
+    for(size_t idx = 0; idx < num_rows; ++idx) {
+        column.set_scalar<int64_t>(static_cast<ssize_t>(idx), static_cast<int64_t>(idx));
+    }
+    return column;
+}
+
+// Generates an int64_t Column where the value in each row is equal to the row index modulo the number of unique values
+inline Column generate_int_column_repeated_values(size_t num_rows, size_t unique_values) {
+    using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
+    Column column(static_cast<TypeDescriptor>(TDT{}), 0, false, false);
+    for(size_t idx = 0; idx < num_rows; ++idx) {
+        column.set_scalar<int64_t>(static_cast<ssize_t>(idx), static_cast<int64_t>(idx % unique_values));
+    }
+    return column;
+}
+
+// Generates a Column of empty type
+inline Column generate_empty_column() {
+    using TDT = TypeDescriptorTag<DataTypeTag<DataType::EMPTYVAL>, DimensionTag<Dimension ::Dim0>>;
+    Column column(static_cast<TypeDescriptor>(TDT{}), 0, false, false);
+    return column;
+}
+
+// Generate a segment in memory suitable for testing groupby's empty type column behaviour with 5 columns:
+// * int_repeating_values - an int64_t column with unique_values repeating values
+// * empty_<agg> - an empty column for each supported aggregation
+inline SegmentInMemory generate_groupby_testing_segment(size_t num_rows, size_t unique_values) {
+    SegmentInMemory seg;
+    auto int_repeated_values_col = std::make_shared<Column>(generate_int_column_repeated_values(num_rows, unique_values));
+    seg.add_column(scalar_field(int_repeated_values_col->type().data_type(), "int_repeated_values"), int_repeated_values_col);
+    seg.add_column(scalar_field(DataType::EMPTYVAL, "empty_sum"), std::make_shared<Column>(generate_empty_column()));
+    seg.add_column(scalar_field(DataType::EMPTYVAL, "empty_min"), std::make_shared<Column>(generate_empty_column()));
+    seg.add_column(scalar_field(DataType::EMPTYVAL, "empty_max"), std::make_shared<Column>(generate_empty_column()));
+    seg.add_column(scalar_field(DataType::EMPTYVAL, "empty_mean"), std::make_shared<Column>(generate_empty_column()));
+    seg.set_row_id(num_rows - 1);
+    return seg;
+}
+
 inline SegmentInMemory get_standard_timeseries_segment(const std::string& name, size_t num_rows = 10) {
     auto wrapper = SinkWrapper(name, {
         scalar_field(DataType::INT8, "int8"),

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -15,7 +15,6 @@
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/storage_lock.hpp>
-#include <arcticdb/util/test/generators.hpp>
 #include <arcticdb/entity/metrics.hpp>
 #include <arcticdb/version/version_tasks.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #737
Closes #738 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Support empty-type columns in all places that used `if_numeric_type/is_sequence_type/is_bool_type` with an `else` statement that made assumptions that all types fell into one of those 3 categories.

This mostly involved fixing `QueryBuilder` operations, and adding tests for them in the C++ layer as there is currently no way to create a column of empty-type from the Python layer.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
