### PR TITLE
Symbol list refactor

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -274,6 +274,7 @@ set(arcticdb_srcs
         stream/aggregator.hpp
         stream/aggregator-inl.hpp
         stream/append_map.hpp
+        stream/merge_utils.hpp
         stream/index_aggregator.hpp
         stream/index.hpp
         stream/merge.hpp

--- a/cpp/arcticdb/async/async_store.cpp
+++ b/cpp/arcticdb/async/async_store.cpp
@@ -25,8 +25,8 @@ std::pair<entity::VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
     } else {
         ARCTICDB_DEBUG(log::version(),
                        "Found existing key with same contents: using existing object {}",
-                       de_dup_key.value());
-        return std::make_pair(de_dup_key.value(), std::nullopt);
+                       *de_dup_key);
+        return std::make_pair(*de_dup_key, std::nullopt);
     }
 }
 }

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -152,8 +152,8 @@ class TaskScheduler {
     using IOSchedulerType = folly::FutureExecutor<folly::IOThreadPoolExecutor>;
 
      explicit TaskScheduler(const std::optional<size_t>& cpu_thread_count = std::nullopt, const std::optional<size_t>& io_thread_count = std::nullopt) :
-     cpu_thread_count_(cpu_thread_count ? cpu_thread_count.value() : ConfigsMap::instance()->get_int("VersionStore.NumCPUThreads", get_default_num_cpus())),
-        io_thread_count_(io_thread_count ? io_thread_count.value() : ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", std::min(100, (int) (cpu_thread_count_ * 1.5)))),
+        cpu_thread_count_(cpu_thread_count ? *cpu_thread_count : ConfigsMap::instance()->get_int("VersionStore.NumCPUThreads", get_default_num_cpus())),
+        io_thread_count_(io_thread_count ? *io_thread_count : ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", std::min(100, (int) (cpu_thread_count_ * 1.5)))),
         cpu_exec_(cpu_thread_count_, std::make_shared<InstrumentedNamedFactory>("CPUPool")) ,
         io_exec_(io_thread_count_,  std::make_shared<InstrumentedNamedFactory>("IOPool")){
         ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Task scheduler created with {:d} {:d}", cpu_thread_count_, io_thread_count_);

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -173,7 +173,6 @@ folly::Future<std::string> do_read(folly::Future<IndexSegmentReader>&& fut) {
 TEST(Async, SemiFuturePassing) {
     using namespace folly;
     using namespace arcticdb;
-    StreamId id{"thing"};
     Promise<StreamId> p;
     Future<StreamId> f = p.getFuture();
     auto f2 = get_index_segment_reader(std::move(f));
@@ -215,12 +214,10 @@ auto multiplex(folly::Future<int> &&n) {
 TEST(Async, DynamicSizing) {
     using namespace folly;
     using namespace arcticdb;
-    StreamId id{"thing"};
     Promise<int> p;
     Future<int> f = p.getFuture();
     auto f1 = num_slices(std::move(f));
     auto f2 = multiplex(std::move(f1));
     p.setValue(5);
     auto v = std::move(f2).get();
-    std::cout << "thing" << std::endl;
 }

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -87,9 +87,9 @@ struct ColumnEncoder {
 
             while (auto block = column_data.next<TDT>()) {
                 if constexpr(!is_empty_type(TDT::DataTypeTag::data_type)) {
-                    util::check(block.value().nbytes() > 0, "Zero-sized block");
+                    util::check(block->nbytes() > 0, "Zero-sized block");
                 }
-                Encoder::encode(codec_opts, block.value(), field, out, pos);
+                Encoder::encode(codec_opts, *block, field, out, pos);
             }
         });
 

--- a/cpp/arcticdb/codec/encoded_field.hpp
+++ b/cpp/arcticdb/codec/encoded_field.hpp
@@ -79,11 +79,11 @@ static_assert(sizeof(TurboPforCodec) == encoding_size);
 struct Lz4Codec {
     static constexpr Codec type_ = Codec::Lz4;
 
-    void MergeFrom(arcticdb::proto::encoding::VariantCodec::Lz4 lz4) {
+    void MergeFrom(const arcticdb::proto::encoding::VariantCodec::Lz4& lz4) {
         acceleration_ = lz4.acceleration();
     }
 
-    int32_t acceleration_;
+    int32_t acceleration_ = 1;
     int16_t padding_ = 0;
 };
 
@@ -205,10 +205,6 @@ struct EncodedBlock {
 
     uint32_t in_bytes() const {
         return in_bytes_;
-    }
-
-    void set_version(uint16_t version) {
-        encoder_version_ = version;
     }
 
     BlockCodec *mutable_codec() {

--- a/cpp/arcticdb/codec/lz4.hpp
+++ b/cpp/arcticdb/codec/lz4.hpp
@@ -34,14 +34,14 @@ struct Lz4BlockEncoder {
 
     template<class T, class CodecType>
     static std::size_t encode_block(
-            const Opts &opts,
+            const Opts& opts,
             const T *in,
             BlockProtobufHelper &block_utils,
             HashAccum &hasher,
             T *out,
             std::size_t out_capacity,
             std::ptrdiff_t &pos,
-            CodecType &out_codec) {
+            CodecType& out_codec) {
         int compressed_bytes = LZ4_compress_default(
             reinterpret_cast<const char *>(in),
             reinterpret_cast<char *>(out),
@@ -77,8 +77,8 @@ struct Lz4Decoder {
             int(in_bytes),
             int(out_bytes)
         );
-        util::check_arg(real_decomp > 0, "Error while decoding with lz4 at address {:x} with size {}. Code {}", uintptr_t(in), in_bytes, real_decomp);
-        util::check_arg(std::size_t(real_decomp) == out_bytes,
+        codec::check<ErrorCode::E_DECODE_ERROR>(real_decomp > 0, "Error while decoding with lz4 at address {:x} with size {}. Code {}", uintptr_t(in), in_bytes, real_decomp);
+        codec::check<ErrorCode::E_DECODE_ERROR>(std::size_t(real_decomp) == out_bytes,
                         "expected out_bytes == lz4 decompressed bytes, actual {} != {}",
                         out_bytes,
                         real_decomp);

--- a/cpp/arcticdb/codec/passthrough.hpp
+++ b/cpp/arcticdb/codec/passthrough.hpp
@@ -93,8 +93,6 @@ struct PassthroughDecoder {
         arcticdb::util::check_arg(in_bytes == out_bytes, "expected  in_bytes==out_bytes, actual {} != {}", in_bytes,
                                  out_bytes);
         memcpy(t_out, in, in_bytes);
-        in += in_bytes;
-        t_out += in_bytes / sizeof(T);
     }
 };
 

--- a/cpp/arcticdb/codec/segment.hpp
+++ b/cpp/arcticdb/codec/segment.hpp
@@ -32,7 +32,7 @@ enum class EncodingVersion : uint16_t {
 
 static constexpr uint16_t HEADER_VERSION_V1 = 1;
 
-inline EncodingVersion encoding_version(const storage::LibraryDescriptor::VariantStoreConfig cfg) {
+inline EncodingVersion encoding_version(const storage::LibraryDescriptor::VariantStoreConfig& cfg) {
     return util::variant_match(cfg,
                                [](const arcticdb::proto::storage::VersionStoreConfig &version_config) {
                                    return EncodingVersion(version_config.encoding_version());
@@ -112,7 +112,7 @@ class Segment {
                             [&b](const std::shared_ptr<Buffer>& buf) { buf->copy_to(*b); }
                             );
         buffer_ = std::move(b);
-        fields_ = std::move(that.fields_);
+        fields_ = that.fields_;
         return *this;
     }
 

--- a/cpp/arcticdb/codec/zstd.hpp
+++ b/cpp/arcticdb/codec/zstd.hpp
@@ -69,10 +69,10 @@ struct ZstdDecoder {
         std::size_t out_bytes) {
 
         const std::size_t decomp_size = ZSTD_getFrameContentSize(in, in_bytes);
-        util::check_arg(decomp_size == out_bytes, "expected out_bytes == zstd deduced bytes, actual {} != {}",
+        codec::check<ErrorCode::E_DECODE_ERROR>(decomp_size == out_bytes, "expected out_bytes == zstd deduced bytes, actual {} != {}",
                         out_bytes, decomp_size);
         std::size_t real_decomp = ZSTD_decompress(t_out, out_bytes, in, in_bytes);
-        util::check_arg(real_decomp == out_bytes, "expected out_bytes == zstd decompressed bytes, actual {} != {}",
+        codec::check<ErrorCode::E_DECODE_ERROR>(real_decomp == out_bytes, "expected out_bytes == zstd decompressed bytes, actual {} != {}",
                         out_bytes, real_decomp);
     }
 #pragma GCC diagnostic pop

--- a/cpp/arcticdb/column_store/block.hpp
+++ b/cpp/arcticdb/column_store/block.hpp
@@ -114,7 +114,7 @@ struct MemBlock {
 
     size_t bytes_;
     size_t capacity_;
-    const uint8_t *external_data_;
+    const uint8_t *external_data_ = nullptr;
     size_t offset_;
     entity::timestamp ts_;
 

--- a/cpp/arcticdb/column_store/chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.cpp
@@ -56,7 +56,7 @@ std::vector<ChunkedBufferImpl<BlockSize>> split(const ChunkedBufferImpl<BlockSiz
 
             if(remaining_current_bytes == 0) {
                 ARCTICDB_DEBUG(log::version(), "Pushing buffer");
-                output.push_back(std::move(current_buf.value()));
+                output.push_back(std::move(*current_buf));
                 current_buf.reset();
             }
         }

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -345,6 +345,7 @@ class ChunkedBufferImpl {
     friend struct BufferView;
 
     BlockType &last_block() {
+        util::check(!blocks_.empty(), "There should never be no blocks");
         return **blocks_.rbegin();
     }
 

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -95,14 +95,14 @@ public:
 
         void set_block_range() {
             if(block_) {
-                block_pos_ = std::begin(block_.value());
-                block_end_ = std::end(block_.value());
+                block_pos_ = std::begin(*block_);
+                block_end_ = std::end(*block_);
             }
         }
 
         void set_next_block() {
             if(auto block  = parent_.next<TDT>(); block)
-                block_.emplace(std::move(block.value()));
+                block_.emplace(std::move(*block));
             else
                 block_ = std::nullopt;
 
@@ -131,7 +131,7 @@ public:
                 if(!other.block_)
                     return false;
 
-                return block_.value() == other.block_.value() && block_pos_ == other.block_pos_;
+                return *block_ == *other.block_ && block_pos_ == other.block_pos_;
             }
             return !other.block_;
         }
@@ -155,8 +155,8 @@ public:
                 }
             } else {
                 --block_pos_;
-                if (block_pos_ < block_.value().begin()) {
-                    auto offset = block_.value().offset() - type_size;
+                if (block_pos_ < block_->begin()) {
+                    auto offset = block_->offset() - type_size;
                     set_offset(offset);
                 }
             }
@@ -166,8 +166,8 @@ public:
             if(!block_)
                 return parent_.buffer().bytes() / type_size;
 
-            const auto off = block_.value().offset();
-            const auto dist = std::distance(std::begin(block_.value()), block_pos_);
+            const auto off = block_->offset();
+            const auto dist = std::distance(std::begin(*block_), block_pos_);
             return off + dist;
         }
 
@@ -175,7 +175,7 @@ public:
             const auto bytes = offset * type_size;
             auto block_and_offset = parent_.buffer().block_and_offset(bytes);
             block_ = ColumnData::make_typed_block<TDT>(block_and_offset.block_);
-            block_pos_ = std::begin(block_.value());
+            block_pos_ = std::begin(*block_);
             std::advance(block_pos_, block_and_offset.offset_ / type_size);
             block_end_ = std::end(block_.value());
         }
@@ -528,7 +528,7 @@ public:
                 if (last_physical_row_ != -1)
                     backfill_sparse_map(last_physical_row_);
                 else
-                    sparse_map();
+                    (void)sparse_map();
             }
             last_logical_row_ += static_cast<ssize_t>(num_rows);
         } else {
@@ -561,7 +561,7 @@ public:
         last_logical_row_ = row_id;
         const auto last_stored_row = row_count() - 1;
         if(sparse_map_) {
-            last_physical_row_ = sparse_map_.value().count() - 1;
+            last_physical_row_ = sparse_map_->count() - 1;
         }
         else if (last_logical_row_ != last_stored_row) {
             last_physical_row_ = last_stored_row;
@@ -580,7 +580,7 @@ public:
             return 0u;
 
         // TODO: cache index
-        std::unique_ptr<bm::bvector<>::rs_index_type> rs(new bm::bvector<>::rs_index_type());
+        auto rs = std::make_unique<bm::bvector<>::rs_index_type>();
         sparse_map().build_rs_index(rs.get());
         return sparse_map().count_to(bv_size(row - 1), *rs);
     }
@@ -610,7 +610,7 @@ public:
         if(!physical_row)
             return std::nullopt;
 
-        return *data_.buffer().ptr_cast<T>(bytes_offset(physical_row.value()), sizeof(T));
+        return *data_.buffer().ptr_cast<T>(bytes_offset(*physical_row), sizeof(T));
     }
 
     bool has_value_at(position_t row) const {
@@ -801,7 +801,7 @@ public:
     }
 
     ColumnData data() const {
-        return ColumnData(&data_.buffer(), &shapes_.buffer(), type_, sparse_map_ ? &sparse_map_.value() : nullptr);
+        return ColumnData(&data_.buffer(), &shapes_.buffer(), type_, sparse_map_ ? &*sparse_map_ : nullptr);
     }
 
     const uint8_t* ptr() const {
@@ -979,7 +979,7 @@ private:
         sparse_map()[bv_size(sparse_location)] = true;
     }
 
-    util::BitMagic& sparse_map() {
+    [[nodiscard]] util::BitMagic& sparse_map() {
         if(!sparse_map_)
             sparse_map_ = std::make_optional<util::BitMagic>(0);
 

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -479,7 +479,7 @@ public:
         std::vector<SegmentInMemory> output;
         auto new_impls = impl_->split(rows);
         for(const auto& impl : new_impls)
-            output.push_back(SegmentInMemory{impl});
+            output.emplace_back(SegmentInMemory{impl});
 
         return output;
     }

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -552,7 +552,7 @@ public:
     void set_array(position_t pos, py::array_t<T>& val) {
         magic_.check();
         ARCTICDB_SAMPLE(MemorySegmentSetArray, 0)
-            column_unchecked(pos).set_array(row_id_ + 1, val);
+        column_unchecked(pos).set_array(row_id_ + 1, val);
     }
 
     void set_string(position_t pos, std::string_view str) {
@@ -842,7 +842,9 @@ public:
             return false;
 
         for(auto col = 0u; col < left.columns_.size(); ++col) {
-            if (is_sequence_type(left.column(col).type().data_type())) {
+            const auto left_data_type = left.column(col).type().data_type();
+            if (is_sequence_type(left_data_type)) {
+
                 const auto& left_col = left.column(col);
                 const auto& right_col = right.column(col);
                 if(left_col.type() != right_col.type())
@@ -854,10 +856,10 @@ public:
                 for(auto row = 0u; row < left_col.row_count(); ++row)
                     if(left.string_at(row, col) != right.string_at(row, col))
                         return false;
-            } else if (is_numeric_type(left.column(col).type().data_type()) || is_bool_type(left.column(col).type().data_type())) {
+            } else if (is_numeric_type(left_data_type) || is_bool_type(left_data_type)) {
                 if (left.column(col) != right.column(col))
                     return false;
-            } else if (is_empty_type(left.column(col).type().data_type())) {
+            } else if (is_empty_type(left_data_type)) {
                 if (!is_empty_type(right.column(col).type().data_type()))
                     return false;
             } else {
@@ -1043,9 +1045,9 @@ public:
                             } else {
                                 internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unexpected column type in SegmentInMemoryImpl::filter");
                             }
-                            output_ptr++;
+                            ++output_ptr;
                             output_col.opt_sparse_map().value()[pos_output++] = true;
-                            bitset_iter++;
+                            ++bitset_iter;
                         }
                     } else {
                         const auto row_count = block.value().row_count();

--- a/cpp/arcticdb/column_store/segment_utils.hpp
+++ b/cpp/arcticdb/column_store/segment_utils.hpp
@@ -30,7 +30,7 @@ robin_hood::unordered_set<StringPool::offset_t> unique_values_for_string_column(
             output.reserve(column.row_count() / map_reserve_ratio);
 
             while (auto block = column_data.next<TDT>()) {
-                auto ptr = reinterpret_cast<const RawType *>(block.value().data());
+                auto ptr = reinterpret_cast<const RawType *>(block->data());
                 const auto row_count = block->row_count();
                 for (auto i = 0u; i < row_count; ++i) {
                     output.insert(*ptr++);

--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -24,11 +24,7 @@ py::buffer_info StringPool::as_buffer_info() const {
     };
 }
 
-bool StringPool::string_exists(const std::string_view& str) {
-    return map_.find(str)  != map_.end();
-}
-
-OffsetString StringPool::get(const std::string_view &s, bool deduplicate) {
+OffsetString StringPool::get(std::string_view s, bool deduplicate) {
     if(deduplicate) {
         if (auto it = map_.find(s); it != map_.end())
             return OffsetString(it->second, this);
@@ -56,11 +52,11 @@ OffsetString StringPool::get(const char *data, size_t size, bool deduplicate) {
     return str;
 }
 
-std::string_view StringPool::get_view(const offset_t &o) {
+std::string_view StringPool::get_view(offset_t o) {
     return block_.at(o);
 }
 
-std::string_view StringPool::get_const_view(const offset_t &o) const {
+std::string_view StringPool::get_const_view(offset_t o) const {
     return block_.const_at(o);
 }
 

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -215,17 +215,15 @@ class StringPool {
         // Not used
     }
 
-    OffsetString get(const std::string_view &s, bool deduplicate = true);
+    OffsetString get(std::string_view s, bool deduplicate = true);
 
     const ChunkedBuffer &data() const {
         return block_.buffer();
     }
 
-    std::string_view get_view(const offset_t &o);
+    std::string_view get_view(offset_t o);
 
-    std::string_view get_const_view(const offset_t &o) const;
-
-    bool string_exists(const std::string_view& str);
+    std::string_view get_const_view(offset_t o) const;
 
     void clear() {
         map_.clear();

--- a/cpp/arcticdb/column_store/test/rapidcheck_column.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column.cpp
@@ -147,7 +147,7 @@ RC_GTEST_PROP(Column, TruncateSparse, (const std::vector<int64_t> &input)) {
     }
 }
 
-RC_GTEST_PROP(Column, SearchSorted, (const std::vector<int64_t>& input, const int64_t& value_to_find)) {
+RC_GTEST_PROP(Column, SearchSorted, (const std::vector<int64_t>& input, int64_t value_to_find)) {
     using namespace arcticdb;
     RC_PRE(input.size() > 0u);
     auto sorted_input = input;
@@ -162,9 +162,7 @@ RC_GTEST_PROP(Column, SearchSorted, (const std::vector<int64_t>& input, const in
     }
     auto left_idx = column.search_sorted<int64_t>(value_to_find, false);
     auto right_idx = column.search_sorted<int64_t>(value_to_find, true);
-    RC_ASSERT(left_idx >= 0);
     RC_ASSERT(left_idx <= n);
-    RC_ASSERT(right_idx >= 0);
     RC_ASSERT(right_idx <= n);
     if (left_idx == 0) {
         RC_ASSERT(value_to_find <= smallest_value);

--- a/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
@@ -30,9 +30,9 @@ TEST(ChunkedBuffer, Iterator) {
 }
 TEST(ChunkedBuffer, Split) {
     using namespace arcticdb;
-    std::vector<uint8_t> input{1, 0, 0};
-    auto chunk_size = 1;
-    auto split_size = 2;
+    std::array<uint8_t, 17> input{1, 0, 0, 2, 3, 4, 5, 1, 2, 6, 4, 5, 6, 2, 3, 4, 4};
+    auto chunk_size = 5;
+    auto split_size = 7;
     CursoredBuffer<ChunkedBufferImpl<64>> cb;
     auto n = input.size();
     auto top = n - (n % chunk_size);
@@ -44,7 +44,7 @@ TEST(ChunkedBuffer, Split) {
 
     auto buffers = ::arcticdb::split(cb.buffer(), split_size);
     auto buf = buffers.begin();
-    for (size_t i = 0; i < top; i += chunk_size) {
+    for (size_t i = 0; i < top; ++i) {
         const auto where = i % split_size;
         ASSERT_NE(buf, buffers.end());
         ASSERT_EQ(buf->cast<uint8_t>(where), input[i]);

--- a/cpp/arcticdb/column_store/test/test_column.cpp
+++ b/cpp/arcticdb/column_store/test/test_column.cpp
@@ -119,8 +119,8 @@ TEST(Column, IterateData) {
 
     auto column_data = column.data();
     while (auto block = column_data.next<TDT>()) {
-        for (const auto& item : block.value())
-            output.push_back(item);
+        for (const auto& item : *block)
+            output.emplace_back(item);
     }
 
     ASSERT_EQ(output.size(), 10u);

--- a/cpp/arcticdb/column_store/test/test_index_filtering.cpp
+++ b/cpp/arcticdb/column_store/test/test_index_filtering.cpp
@@ -42,7 +42,7 @@ std::pair<TimeseriesDescriptor , std::vector<SliceAndKey>> get_sample_slice_and_
         auto start_val = 0;
         auto end_val = start_val + step;
         for (auto i = 0u; i < row_slices; ++i) {
-            slice_and_keys.push_back(
+            slice_and_keys.emplace_back(
                 SliceAndKey{
                     FrameSlice{
                         ColRange{start_col, end_col},

--- a/cpp/arcticdb/column_store/test/test_memory_segment.cpp
+++ b/cpp/arcticdb/column_store/test/test_memory_segment.cpp
@@ -40,7 +40,7 @@ void test_segment_type(size_t num_values = 20, size_t num_tests = 50, size_t num
     const Dimension dimensions = TDT::DimensionTag::value;
 
     TypeDescriptorTag typeDescriptorTag;
-    const auto tsd = create_tsd<DTT, Dimension::Dim0>();
+    auto tsd = create_tsd<DTT, Dimension::Dim0>();
     SegmentInMemory s(StreamDescriptor{std::move(tsd)});
     for (size_t i = 0; i < num_tests; ++i) {
         auto ts = timestamp(i);
@@ -71,7 +71,7 @@ void test_segment_type(size_t num_values = 20, size_t num_tests = 50, size_t num
                 ASSERT_EQ(v.value(), test_row[j - 1].get_scalar());
             } else {
                 auto t = s.tensor_at<raw_type>(i, j);
-                ASSERT_FALSE(t = std::nullopt);
+                ASSERT_FALSE(t == std::nullopt);
                 ASSERT_TRUE(test_row.check(j - 1, t.value()));
             }
         }
@@ -469,7 +469,7 @@ TEST(MemSegment, Filter) {
     seg.set_row_id(num_rows - 1);
 
     util::BitSet filter_bitset(num_rows);
-    std::vector<size_t> retained_rows{0, 4, num_rows - 1};
+    std::array<size_t, 3> retained_rows{0, 4, num_rows - 1};
     for (auto retained_row: retained_rows) {
         filter_bitset.set_bit(retained_row);
     }

--- a/cpp/arcticdb/entity/atom_key.hpp
+++ b/cpp/arcticdb/entity/atom_key.hpp
@@ -26,8 +26,8 @@ class AtomKeyImpl {
         VersionId version_id,
         timestamp creation_ts,
         ContentHash content_hash,
-        const IndexValueType start_index,
-        const IndexValueType end_index,
+        IndexValueType start_index,
+        IndexValueType end_index,
         KeyType key_type)
         :
         id_(std::move(id)),
@@ -107,7 +107,7 @@ class AtomKeyImpl {
             hash_ = folly::hash::hash_combine(id_, version_id_, creation_ts_, content_hash_, key_type_, index_start_,
                     index_end_);
         }
-        return hash_.value();
+        return *hash_;
     }
 
     void set_string() const {

--- a/cpp/arcticdb/entity/data_error.hpp
+++ b/cpp/arcticdb/entity/data_error.hpp
@@ -107,11 +107,13 @@ public:
                             static_cast<uint32_t>(*version_request_type_));
             }
         }
+        auto category = error_category();
+        auto category_name = category ? get_error_category_names().at(*category) : "UNKNOWN";
         return fmt::format(
                 "Version {} of symbol '{}' unable to be retrieved: Error Category: '{}' Exception String: '{}'",
                 version_request_explanation,
                 symbol_,
-                error_category().has_value() ? get_error_category_names().at(*error_category()) : "UNKNOWN",
+                category_name,
                 exception_string_);
     }
 private:

--- a/cpp/arcticdb/entity/merge_descriptors.cpp
+++ b/cpp/arcticdb/entity/merge_descriptors.cpp
@@ -65,7 +65,7 @@ StreamDescriptor merge_descriptors(
                         }
                     }
                 } else {
-                    merged_fields.push_back(field.name());
+                    merged_fields.emplace_back(field.name());
                     merged_fields_map.try_emplace(field.name(), type_desc);
                 }
             }

--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -46,8 +46,8 @@ namespace arcticdb {
             // IMP: This is the GROUPING_KEY - every push overwrites the previous grouping key
             auto labels = prometheus::Gateway::GetInstanceLabel(getHostName());
             mongo_instance_ = cfg.instance();
-            labels.insert(std::pair<std::string, std::string>(MONGO_INSTANCE_LABEL, mongo_instance_));
-            labels.insert(std::pair<std::string, std::string>(PROMETHEUS_ENV_LABEL, cfg.prometheus_env()));
+            labels.try_emplace(MONGO_INSTANCE_LABEL, mongo_instance_);
+            labels.try_emplace(PROMETHEUS_ENV_LABEL, cfg.prometheus_env());
             gateway_= std::make_shared<prometheus::Gateway>(cfg.host(), cfg.port(), cfg.job_name(), labels);
             registry_ = std::make_shared<prometheus::Registry>();
             gateway_->RegisterCollectable(registry_);

--- a/cpp/arcticdb/entity/read_result.hpp
+++ b/cpp/arcticdb/entity/read_result.hpp
@@ -51,7 +51,8 @@ inline ReadResult create_python_read_result(
     auto python_frame = pipelines::PythonOutputFrame{result.frame_, result.buffers_};
     util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
 
-    return {version, std::move(python_frame), result.desc_.proto().normalization(),
-            result.desc_.proto().user_meta(), result.desc_.proto().multi_key_meta(), std::move(result.keys_)};
+    const auto& desc_proto = result.desc_.proto();
+    return {version, std::move(python_frame), desc_proto.normalization(),
+            desc_proto.user_meta(), desc_proto.multi_key_meta(), std::move(result.keys_)};
 }
 } //namespace arcticdb

--- a/cpp/arcticdb/entity/serialized_key.hpp
+++ b/cpp/arcticdb/entity/serialized_key.hpp
@@ -37,7 +37,7 @@ constexpr size_t NumOldKeyFields = size_t(OldKeyField::num_key_fields);
 constexpr size_t NumNewKeyFields = size_t(NewKeyField::num_key_fields);
 
 
-inline VariantId variant_id_from_token(const std::string_view &strv, VariantType variant_type) {
+inline VariantId variant_id_from_token(std::string_view strv, VariantType variant_type) {
     switch (variant_type) {
         case VariantType::STRING_TYPE:
             return VariantId(std::string(strv));
@@ -157,7 +157,7 @@ struct KeyDescriptor {
             format_type(format_type) {
     }
 
-    KeyDescriptor(const StringId id, IndexDescriptor::Type index_type, FormatType format_type) :
+    KeyDescriptor(const StringId& id, IndexDescriptor::Type index_type, FormatType format_type) :
             identifier(SerializedKeyIdentifier),
             id_type(variant_type_from_id(id)),
             index_type(to_type_char(index_type)),

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -17,6 +17,7 @@ struct StreamDescriptor {
 
     std::shared_ptr<Proto> data_ = std::make_shared<Proto>();
     std::shared_ptr<FieldCollection> fields_ = std::make_shared<FieldCollection>();
+    ;
 
     StreamDescriptor() = default;
     ~StreamDescriptor() = default;
@@ -32,16 +33,6 @@ struct StreamDescriptor {
             set_data_type(field.type().data_type(), *new_field->mutable_type_desc());
         }
         return proto;
-    }
-
-    void copy_to_self_proto() {
-        data_->mutable_fields()->Clear();
-        for(const auto& field : *fields_) {
-            auto new_field = data_->mutable_fields()->Add();
-            new_field->set_name(std::string(field.name()));
-            new_field->mutable_type_desc()->set_dimension(static_cast<uint32_t>(field.type().dimension()));
-            set_data_type(field.type().data_type(), *new_field->mutable_type_desc());
-        }
     }
 
     void set_id(const StreamId& id) {
@@ -118,6 +109,7 @@ struct StreamDescriptor {
     }
 
     StreamDescriptor(const StreamDescriptor& other) = default;
+    StreamDescriptor& operator=(const StreamDescriptor& other) = default;
 
     friend void swap(StreamDescriptor& left, StreamDescriptor& right) noexcept {
         using std::swap;
@@ -129,7 +121,7 @@ struct StreamDescriptor {
         swap(left.fields_, right.fields_);
     }
 
-    StreamDescriptor& operator=(StreamDescriptor other) {
+    StreamDescriptor& operator=(StreamDescriptor&& other) {
         swap(*this, other);
         return *this;
     }

--- a/cpp/arcticdb/entity/test/test_tensor.cpp
+++ b/cpp/arcticdb/entity/test/test_tensor.cpp
@@ -13,8 +13,8 @@ auto get_f_tensor(size_t num_rows) {
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows);
-    const std::vector<stride_t>  strides = {4u, 40u};
-    const std::vector<shape_t> shapes = {10u, 10u};
+    const std::array<stride_t, 2>  strides = {4u, 40u};
+    const std::array<shape_t, 2> shapes = {10u, 10u};
     size_t count = 0;
     for(auto i = 0u; i < shapes[0]; ++i) {
         auto row = i * (strides[0] / sizeof(data_t));
@@ -36,8 +36,8 @@ auto get_c_tensor(size_t num_rows) {
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows);
-    const std::vector<stride_t>  strides = {40u, 4u};
-    const std::vector<shape_t> shapes = {10u, 10u};
+    const std::array<stride_t, 2>  strides = {40u, 4u};
+    const std::array<shape_t, 2>shapes = {10u, 10u};
     for(auto i = 0u; i < num_rows; ++i) {
             (*data)[i] = i;
     }
@@ -148,8 +148,8 @@ auto get_sparse_array(size_t num_rows) {
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows * 2);
-    const std::vector<stride_t>  strides = {8u, 0u};
-    const std::vector<shape_t> shapes = {100u, 0u};
+    const std::array<stride_t, 2>  strides = {8u, 0u};
+    const std::array<shape_t, 2>shapes = {100u, 0u};
 
     for(auto i = 0u; i < num_rows; ++i) {
         (*data)[i * 2] = i;
@@ -214,8 +214,8 @@ auto get_sparse_array_funky_strides() {
     const auto num_rows = 100u;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<uint8_t>>(num_rows * 19 * sizeof(data_t));
-    const std::vector<stride_t>  strides = {19u, 0u};
-    const std::vector<shape_t> shapes = {100u, 0u};
+    const std::array<stride_t, 2>  strides = {19u, 0u};
+    const std::array<shape_t, 2>shapes = {100u, 0u};
 
     for(auto i = 0u; i < num_rows; ++i) {
         *reinterpret_cast<data_t*>(&(*data)[i * 19] )= i;
@@ -279,14 +279,14 @@ auto get_sparse_array_uneven(size_t num_rows) {
     using namespace arcticdb::entity;
     using data_t = uint32_t;
     auto data = std::make_shared<std::vector<data_t>>(num_rows * 2);
-    const std::vector<stride_t>  strides = {8u, 0u};
-    const std::vector<shape_t> shapes = {109u, 0u};
+    const std::array<stride_t, 2>  strides = {8u, 0u};
+    const std::array<shape_t, 2>shapes = {109u, 0u};
 
     for(auto i = 0u; i < num_rows; ++i) {
         (*data)[i * 2] = i;
     }
 
-    const ssize_t nbytes = num_rows * sizeof(data_t);
+    const auto nbytes = static_cast<ssize_t>(num_rows * sizeof(data_t));
     const auto ndim = 1;
     const DataType dt = DataType::UINT32;
 

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -52,7 +52,7 @@ inline arcticc::pb2::descriptors_pb2::SortedValue sorted_value_to_proto(SortedVa
     }
 }
 
-inline SortedValue sorted_value_from_proto(const arcticc::pb2::descriptors_pb2::SortedValue &sorted_proto) {
+inline SortedValue sorted_value_from_proto(arcticc::pb2::descriptors_pb2::SortedValue sorted_proto) {
     switch (sorted_proto) {
     case arcticc::pb2::descriptors_pb2::SortedValue::UNSORTED:
         return SortedValue::UNSORTED;
@@ -79,9 +79,8 @@ using stride_t = ssize_t;
 using position_t = ssize_t;
 
 /** The VariantId holds int64 (NumericId) but is also used to store sizes up to uint64, so needs safe conversion */
-inline NumericId safe_convert_to_numeric_id(uint64_t input, const char* input_name) {
-    util::check(input <= static_cast<uint64_t>(std::numeric_limits<NumericId>::max()),
-        "{} greater than 2^63 is not supported.", input_name);
+inline NumericId safe_convert_to_numeric_id(uint64_t input) {
+    util::check(input <= static_cast<uint64_t>(std::numeric_limits<NumericId>::max()), "Numeric symbol greater than 2^63 is not supported.");
     return static_cast<NumericId>(input);
 }
 
@@ -507,7 +506,7 @@ inline TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::T
     };
 }
 
-inline DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor type_desc) {
+inline DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
     return type_desc_from_proto((type_desc)).data_type();
 }
 
@@ -519,11 +518,12 @@ inline arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor field_prot
     if(!name.empty())
         output.set_name(name.data(), name.size());
 
-    output.mutable_type_desc()->set_dimension(static_cast<uint32_t>(dim));
-    output.mutable_type_desc()->set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
+    auto output_desc = output.mutable_type_desc();
+    output_desc->set_dimension(static_cast<uint32_t>(dim));
+    output_desc->set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
                                                   static_cast<std::uint8_t>(slice_bit_size(dt))));
 
-    output.mutable_type_desc()->set_value_type(
+    output_desc->set_value_type(
         static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
             static_cast<std::uint8_t>(slice_value_type(dt))));
 
@@ -792,7 +792,7 @@ struct formatter<FieldRef> {
     constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    auto format(const FieldRef f, FormatContext &ctx) const {
+    auto format(const FieldRef& f, FormatContext &ctx) const {
         auto out = ctx.out();
         return format_to(ctx.out(), "{}: {}", f.type_, f.name_);
         return out;

--- a/cpp/arcticdb/pipeline/column_mapping.hpp
+++ b/cpp/arcticdb/pipeline/column_mapping.hpp
@@ -58,8 +58,8 @@ struct StaticColumnMappingIterator {
         bit_set_(context.get_selected_columns()) {
             prev_col_offset_ = first_slice_col_offset_ - 1;
             if(bit_set_) {
-                source_col_ = bit_set_.value()[bv_size(first_slice_col_offset_)] ? first_slice_col_offset_ : bit_set_->get_next(bv_size(first_slice_col_offset_));
-                if (bit_set_.value()[bv_size(first_slice_col_offset_)]) {
+                source_col_ = (*bit_set_)[bv_size(first_slice_col_offset_)] ? first_slice_col_offset_ : bit_set_->get_next(bv_size(first_slice_col_offset_));
+                if ((*bit_set_)[bv_size(first_slice_col_offset_)]) {
                     source_col_ = first_slice_col_offset_;
                 } else {
                     auto next_pos = bit_set_->get_next(bv_size(first_slice_col_offset_));
@@ -97,7 +97,7 @@ struct StaticColumnMappingIterator {
         prev_col_offset_ = source_col_;
         auto new_source_col = get_next_source_col();
         if(new_source_col) {
-            source_col_ = new_source_col.value();
+            source_col_ = *new_source_col;
             source_field_pos_ = (source_col_ - first_slice_col_offset_) + index_fieldcount_;
         } else {
             source_field_pos_ = field_count_;

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -186,7 +186,7 @@ void ColumnStats::drop(const ColumnStats& to_drop, bool warn_if_missing) {
         if (it->second.empty()) {
             it = column_stats_.erase(it);
         } else {
-            it++;
+            ++it;
         }
     }
 }

--- a/cpp/arcticdb/pipeline/frame_slice.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice.hpp
@@ -227,7 +227,7 @@ struct SliceAndKey {
     }
 
     bool invalid() const {
-        return (!segment_ && !key_) || segment_->is_null();
+        return (!segment_ && !key_) || (segment_ && segment_->is_null());
     }
 
     const AtomKey& key() const {

--- a/cpp/arcticdb/pipeline/frame_slice_map.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice_map.hpp
@@ -22,7 +22,7 @@ struct FrameSliceMap {
     robin_hood::unordered_flat_map<std::string_view, std::map<RowRange, ContextData>> columns_;
     std::shared_ptr<PipelineContext> context_;
 
-    FrameSliceMap(const std::shared_ptr<PipelineContext>& context, bool dynamic_schema) :
+    FrameSliceMap(std::shared_ptr<PipelineContext> context, bool dynamic_schema) :
         context_(std::move(context)) {
 
         for (const auto &context_row: *context_) {

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -211,7 +211,7 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     }
 
     bool is_in_filter_columns_set(std::string_view name) {
-        return !filter_columns_set_ || filter_columns_set_.value().find(name) != filter_columns_set_.value().end();
+        return !filter_columns_set_ || filter_columns_set_->find(name) != filter_columns_set_->end();
     }
 
     void clear_vectors() {

--- a/cpp/arcticdb/pipeline/python_output_frame.cpp
+++ b/cpp/arcticdb/pipeline/python_output_frame.cpp
@@ -41,7 +41,7 @@ PythonOutputFrame::~PythonOutputFrame() {
                 using TDT = decltype(type_desc_tag);
                 if constexpr (is_dynamic_string_type(TDT::DataTypeTag::data_type)) {
                     while (auto block = column_data.next<TDT>()) {
-                        for (auto item : block.value()) {
+                        for (auto item : *block) {
                           util::check(reinterpret_cast<PyObject *>(item) != nullptr, "Can't delete null item");
                           Py_DECREF(reinterpret_cast<PyObject *>(item));
                         }

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -40,12 +40,15 @@ std::optional<util::BitSet> check_and_mark_slices(
     std::set<RowRange> row_ranges;
     for (auto[opt_seg, slice, key] : slice_and_keys) {
         is_first = row_ranges.insert(slice.row_range).second;
-        if(return_bitset)
-            output.value()[output.value().size()] = (dynamic_schema && !has_column_groups) || is_first || (incompletes_after && count >= incompletes_after.value());
+        if(return_bitset) {
+            util::check(static_cast<bool>(output), "Expected output bitset to be none-null");
+            output.value()[output->size()] = (dynamic_schema && !has_column_groups) || is_first
+                || (incompletes_after && count >= *incompletes_after);
+        }
 
         ++count;
     }
-    util::check(!return_bitset || slice_and_keys.size() == output.value().size(),
+    util::check(!return_bitset || (output && slice_and_keys.size() == output->size()),
                 "Index fetch vector size should match slice and key size");
 
     if(!row_ranges.empty()) {

--- a/cpp/arcticdb/pipeline/slicing.cpp
+++ b/cpp/arcticdb/pipeline/slicing.cpp
@@ -140,7 +140,7 @@ std::vector<FrameSlice> HashedSlicer::operator()(const arcticdb::pipelines::Inpu
         
         for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
             auto rdist = std::min(last_row-r, row_per_slice_);
-            slices.push_back(FrameSlice(desc,
+            slices.emplace_back(FrameSlice(desc,
                                         ColRange{col, col + distance},
                                         RowRange{r, r+rdist},
                                         current_bucket,

--- a/cpp/arcticdb/pipeline/test/test_pipeline.cpp
+++ b/cpp/arcticdb/pipeline/test/test_pipeline.cpp
@@ -118,10 +118,11 @@ struct TestAggregation {
         aggregation_func_(std::move(func)) {}
 
     SegmentInMemory operator()(SegmentInMemory input) {
-        auto index_field_count = input.descriptor().index().field_count();
-        StreamDescriptor desc{input.descriptor().id(), input.descriptor().index()};
+        const auto& input_desc = input.descriptor();
+        auto index_field_count = input_desc.index().field_count();
+        StreamDescriptor desc{input_desc.id(), input_desc.index()};
         for(auto i = 0u; i < index_field_count; ++i) {
-            const auto& field = input.descriptor().fields(i);
+            const auto& field = input_desc.fields(i);
             desc.add_field(FieldRef{field.type(), field.name()});
         }
 

--- a/cpp/arcticdb/pipeline/test/test_query.cpp
+++ b/cpp/arcticdb/pipeline/test/test_query.cpp
@@ -18,8 +18,7 @@ TEST(BitsetForIndex, DynamicSchemaStrictlyBefore) {
     container.seg().set_range(3, 4);
     container.seg().set_range(5, 7);
     IndexRange rg(0, 2);
-    std::unique_ptr<util::BitSet> input;
-    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::move(input));
+    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ(bitset->count(), 0);
 }
 
@@ -30,8 +29,7 @@ TEST(BitsetForIndex, DynamicSchemaStrictlyAfter) {
     container.seg().set_range(0, 2);
     container.seg().set_range(3, 4);
     IndexRange rg(5, 7);
-    std::unique_ptr<util::BitSet> input;
-    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::move(input));
+    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ(bitset->count(), 0);
 }
 
@@ -42,8 +40,7 @@ TEST(BitsetForIndex, DynamicSchemaMiddle) {
    container.seg().set_range(0, 2);
    container.seg().set_range(5, 7);
    IndexRange rg(3, 4);
-   std::unique_ptr<util::BitSet> input;
-   auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::move(input));
+   auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
    ASSERT_EQ(bitset->count(), 0);
 }
 
@@ -54,8 +51,7 @@ TEST(BitsetForIndex, DynamicSchemaOverlapBegin) {
     container.seg().set_range(2, 4);
     container.seg().set_range(5, 7);
     IndexRange rg(1, 3);
-    std::unique_ptr<util::BitSet> input;
-    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::move(input));
+    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ((*bitset)[0], true);
     ASSERT_EQ(bitset->count(), 1);
 }
@@ -67,8 +63,7 @@ TEST(BitsetForIndex, DynamicSchemaOverlapEnd) {
     container.seg().set_range(2, 4);
     container.seg().set_range(5, 7);
     IndexRange rg(6, 8);
-    std::unique_ptr<util::BitSet> input;
-    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::move(input));
+    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ((*bitset)[1], true);
     ASSERT_EQ(bitset->count(), 1);
 }

--- a/cpp/arcticdb/pipeline/value.hpp
+++ b/cpp/arcticdb/pipeline/value.hpp
@@ -34,7 +34,7 @@ struct ValueIterator {
 struct Value {
     Value() = default;
     DataType data_type_;
-    char data_[8];
+    char data_[8] = {};
     size_t len_ = 0;
 
     template <typename T>
@@ -43,12 +43,22 @@ struct Value {
         *reinterpret_cast<T*>(&data_) = t;
     }
 
-    Value(const Value& other) :
-        data_type_(other.data_type_){
+    void assign(const Value& other) {
         if(is_sequence_type(other.data_type_))
             assign_string(*other.str_data(), other.len_);
         else
             memcpy(data_, other.data_, 8);
+    }
+
+    Value(const Value& other) :
+        data_type_(other.data_type_) {
+        assign(other);
+    }
+
+    Value& operator==(const Value& other) {
+        data_type_ = other.data_type_;
+        assign(other);
+        return *this;
     }
 
     ValueIterator get_iterator() {

--- a/cpp/arcticdb/pipeline/value_set.hpp
+++ b/cpp/arcticdb/pipeline/value_set.hpp
@@ -55,7 +55,7 @@ public:
     std::shared_ptr<std::unordered_set<std::string>> get_fixed_width_string_set(size_t width);
 
 private:
-    bool empty_;
+    bool empty_ = false;
     entity::TypeDescriptor base_type_;
     NumericSetType numeric_base_set_;
 

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -60,7 +60,7 @@ folly::Future<std::vector<SliceAndKey>> write_slices(
             if(!first_row)
                 first_row = slice.row_range.first;
 
-            if(slice.row_range.first == first_row.value())
+            if(slice.row_range.first == *first_row)
                 slice_num_for_column = 0;
 
             SingleSegmentAggregator agg{FixedSchema{*slice.desc(), frame.index}, [&](auto &&segment) {
@@ -202,7 +202,7 @@ folly::Future<entity::AtomKey> append_frame(
     auto existing_slices = unfiltered_index(index_segment_reader);
     auto keys_fut = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store);
     return std::move(keys_fut)
-    .thenValue([dynamic_schema, slices_to_write = std::move(existing_slices), frame = std::move(frame), index_segment_reader = std::move(index_segment_reader), key = std::move(key), &store](auto&& slice_and_keys_to_append) mutable {
+    .thenValue([dynamic_schema, slices_to_write = std::move(existing_slices), frame = std::move(frame), index_segment_reader = std::move(index_segment_reader), key = key, &store](auto&& slice_and_keys_to_append) mutable {
         slices_to_write.insert(std::end(slices_to_write), std::make_move_iterator(std::begin(slice_and_keys_to_append)), std::make_move_iterator(std::end(slice_and_keys_to_append)));
         std::sort(std::begin(slices_to_write), std::end(slices_to_write));
         if(dynamic_schema) {

--- a/cpp/arcticdb/pipeline/write_options.hpp
+++ b/cpp/arcticdb/pipeline/write_options.hpp
@@ -30,13 +30,13 @@ struct WriteOptions {
 
     size_t column_group_size = 127;
     size_t segment_row_size = 100'000;
-    bool prune_previous_version;
-    bool de_duplication;
-    bool snapshot_dedup;
-    bool dynamic_schema;
-    bool ignore_sort_order;
-    bool bucketize_dynamic;
+    bool prune_previous_version = false;
+    bool de_duplication = false;
+    bool snapshot_dedup = false;
+    bool dynamic_schema = false;
+    bool ignore_sort_order = false;
+    bool bucketize_dynamic = false;
     size_t max_num_buckets = 150;
-    bool compact_incomplete_dedup_rows;
+    bool compact_incomplete_dedup_rows = false;
 };
 } //namespace arcticdb

--- a/cpp/arcticdb/processing/aggregation.cpp
+++ b/cpp/arcticdb/processing/aggregation.cpp
@@ -20,8 +20,8 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
             using RawType = typename DescriptorType::raw_type;
             auto col_data = input_column.column_->data();
             while (auto block = col_data.next<ScalarTagType<DescriptorType>>()) {
-                auto ptr = reinterpret_cast<const RawType *>(block.value().data());
-                for (auto i = 0u; i < block.value().row_count(); ++i, ++ptr) {
+                auto ptr = reinterpret_cast<const RawType *>(block->data());
+                for (auto i = 0u; i < block->row_count(); ++i, ++ptr) {
                     const auto& curr = RawType(*ptr);
                     if (UNLIKELY(!that->min_.has_value())) {
                         that->min_ = std::make_optional<Value>(curr, DescriptorType::DataTypeTag::data_type);

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -84,7 +84,7 @@ struct ColumnWithStrings {
         for(position_t i = 0; i < column_->row_count(); ++i) {
             auto offset = column_->scalar_at<StringPool::offset_t>(i);
             if (offset != std::nullopt) {
-                std::string_view raw = string_pool_->get_view(offset.value());
+                std::string_view raw = string_pool_->get_view(*offset);
                 return raw.size();
             }
         }

--- a/cpp/arcticdb/processing/operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch.cpp
@@ -56,8 +56,8 @@ VariantData transform_to_bitset(const VariantData& data) {
                         util::BitSet::bulk_insert_iterator inserter(*output);
                         auto pos = 0u;
                         while (auto block = column_data.next<ColumnDescriptorType>()) {
-                            auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
-                            const auto row_count = block.value().row_count();
+                            auto ptr = reinterpret_cast<const ColumnType*>(block->data());
+                            const auto row_count = block->row_count();
                             for (auto i = 0u; i < row_count; ++i, ++pos) {
                                 if(*ptr++)
                                     inserter = pos;

--- a/cpp/arcticdb/processing/operation_dispatch_binary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.cpp
@@ -91,31 +91,31 @@ VariantData visit_binary_boolean(const VariantData& left, const VariantData& rig
     auto left_transformed = transform_to_bitset(left);
     auto right_transformed = transform_to_bitset(right);
     return std::visit(util::overload {
-            [&operation] (const std::shared_ptr<util::BitSet>& l, const std::shared_ptr<util::BitSet>& r) {
+            [operation] (const std::shared_ptr<util::BitSet>& l, const std::shared_ptr<util::BitSet>& r) {
                 return transform_to_placeholder(binary_boolean(l, r, operation));
             },
-            [&operation] (const std::shared_ptr<util::BitSet>& l, EmptyResult r) {
+            [operation] (const std::shared_ptr<util::BitSet>& l, EmptyResult r) {
                 return transform_to_placeholder(binary_boolean(l, r, operation));
             },
-            [&operation] (const std::shared_ptr<util::BitSet>& l, FullResult r) {
+            [operation] (const std::shared_ptr<util::BitSet>& l, FullResult r) {
                 return transform_to_placeholder(binary_boolean(l, r, operation));
             },
-            [&operation] (EmptyResult l, const std::shared_ptr<util::BitSet>& r) {
+            [operation] (EmptyResult l, const std::shared_ptr<util::BitSet>& r) {
                 return binary_boolean(r, l, operation);
             },
-            [&operation] (FullResult l, const std::shared_ptr<util::BitSet>& r) {
+            [operation] (FullResult l, const std::shared_ptr<util::BitSet>& r) {
                 return transform_to_placeholder(binary_boolean(r, l, operation));
             },
-            [&operation] (FullResult l, EmptyResult r) {
+            [operation] (FullResult l, EmptyResult r) {
                 return binary_boolean(r, l, operation);
             },
-            [&operation] (EmptyResult l, FullResult r) {
+            [operation] (EmptyResult l, FullResult r) {
                 return binary_boolean(l, r, operation);
             },
-            [&operation] (FullResult l, FullResult r) {
+            [operation] (FullResult l, FullResult r) {
                 return binary_boolean(l, r, operation);
             },
-            [&operation] (EmptyResult l, EmptyResult r) {
+            [operation] (EmptyResult l, EmptyResult r) {
                 return binary_boolean(r, l, operation);
             },
             [](const auto &, const auto&) -> VariantData {

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -85,8 +85,8 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                     util::BitSet::bulk_insert_iterator inserter(*output);
                     auto pos = 0u;
                     while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
-                        auto ptr = reinterpret_cast<const StringPool::offset_t*>(block.value().data());
-                        const auto row_count = block.value().row_count();
+                        auto ptr = reinterpret_cast<const StringPool::offset_t*>(block->data());
+                        const auto row_count = block->row_count();
                         for (auto i = 0u; i < row_count; ++i, ++pos) {
                             auto offset = *ptr++;
                             if(func(offset, offset_set))
@@ -106,8 +106,8 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                     util::BitSet::bulk_insert_iterator inserter(*output);
                     auto pos = 0u;
                     while (auto block = column_data.next<ScalarTagType<ColumnTagType>>()) {
-                        auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
-                        const auto row_count = block.value().row_count();
+                        auto ptr = reinterpret_cast<const ColumnType*>(block->data());
+                        const auto row_count = block->row_count();
                         for (auto i = 0u; i < row_count; ++i, ++pos) {
                             if constexpr (MembershipOperator::needs_uint64_special_handling<ColumnType, ValueSetBaseType>) {
                                 // Avoid narrowing conversion on *ptr:
@@ -196,8 +196,8 @@ VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
                 while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
-                    auto ptr = reinterpret_cast<const StringPool::offset_t*>(block.value().data());
-                    const auto row_count = block.value().row_count();
+                    auto ptr = reinterpret_cast<const StringPool::offset_t*>(block->data());
+                    const auto row_count = block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         auto offset = *ptr++;
                         if(func(offset, value_offset))
@@ -215,8 +215,8 @@ VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
                 while (auto block = column_data.next<ColumnDescriptorType>()) {
-                    auto ptr = reinterpret_cast<const ColumnType*>(block.value().data());
-                    const auto row_count = block.value().row_count();
+                    auto ptr = reinterpret_cast<const ColumnType*>(block->data());
+                    const auto row_count = block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         if(func(value, static_cast<typename comp::right_type>(*ptr++)))
                             inserter = pos;
@@ -262,9 +262,9 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
                 auto pos = 0u;
                 while (auto left_block = left_column_data.next<LeftDescriptorType>()) {
                     auto right_block = right_column_data.next<RightDescriptorType>();
-                    auto left_ptr = reinterpret_cast<const LeftType*>(left_block.value().data());
-                    auto right_ptr = reinterpret_cast<const RightType*>(right_block.value().data());
-                    const auto row_count = left_block.value().row_count();
+                    auto left_ptr = reinterpret_cast<const LeftType*>(left_block->data());
+                    auto right_ptr = reinterpret_cast<const RightType*>(right_block->data());
+                    const auto row_count = left_block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         if(func(left.string_at_offset(*left_ptr++, strip_fixed_width_trailing_nulls), right.string_at_offset(*right_ptr++, strip_fixed_width_trailing_nulls)))
                             inserter = pos;
@@ -282,9 +282,9 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
                 auto pos = 0u;
                 while (auto left_block = left_column_data.next<LeftDescriptorType>()) {
                     auto right_block = right_column_data.next<RightDescriptorType>();
-                    auto left_ptr = reinterpret_cast<const LeftType*>(left_block.value().data());
-                    auto right_ptr = reinterpret_cast<const RightType*>(right_block.value().data());
-                    const auto row_count = left_block.value().row_count();
+                    auto left_ptr = reinterpret_cast<const LeftType*>(left_block->data());
+                    auto right_ptr = reinterpret_cast<const RightType*>(right_block->data());
+                    const auto row_count = left_block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         if(func(static_cast<typename comp::left_type>(*left_ptr++), static_cast<typename comp::right_type>(*right_ptr++)))
                             inserter = pos;
@@ -335,8 +335,8 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
                 while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
-                    auto ptr = reinterpret_cast<const StringPool::offset_t*>(block.value().data());
-                    const auto row_count = block.value().row_count();
+                    auto ptr = reinterpret_cast<const StringPool::offset_t*>(block->data());
+                    const auto row_count = block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         auto offset = *ptr++;
                         if(func(value_offset, offset))
@@ -354,8 +354,8 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
                 while (auto block = column_data.next<ColumnDescriptorType>()) {
-                    auto ptr = reinterpret_cast<const ColumnType *>(block.value().data());
-                    const auto row_count = block.value().row_count();
+                    auto ptr = reinterpret_cast<const ColumnType *>(block->data());
+                    const auto row_count = block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         if (func(static_cast<typename comp::right_type>(*ptr++), value))
                             inserter = pos;
@@ -454,7 +454,7 @@ VariantData binary_operator(const Value& val, const Column& col, Func&& func) {
             output = std::make_unique<Column>(make_scalar_type(output_data_type), col.is_sparse());
 
             while(auto opt_right_block = right_data.next<RTDT>()) {
-                auto right_block = opt_right_block.value();
+                auto right_block = *opt_right_block;
                 const auto nbytes = sizeof(TargetType) * right_block.row_count();
                 auto ptr = reinterpret_cast<TargetType*>(output->allocate_data(nbytes));
 
@@ -500,8 +500,8 @@ VariantData binary_operator(const Column& left, const Column& right, Func&& func
             auto right_data = right.data();
             auto opt_right_block = right_data.next<RTDT>();
             while (opt_left_block && opt_right_block) {
-                auto& left_block = opt_left_block.value();
-                auto& right_block = opt_right_block.value();
+                auto& left_block = *opt_left_block;
+                auto& right_block = *opt_right_block;
                 util::check(left_block.row_count() == right_block.row_count(), "Non-matching row counts in dense blocks: {} != {}", left_block.row_count(), right_block.row_count());
                 const auto nbytes = sizeof(TargetType) * right_block.row_count();
                 auto ptr = reinterpret_cast<TargetType*>(output->allocate_data(nbytes));
@@ -547,7 +547,7 @@ VariantData binary_operator(const Column& col, const Value& val, Func&& func) {
             output = std::make_unique<Column>(make_scalar_type(output_data_type), col.is_sparse());
 
             while(auto opt_left_block = left_data.next<LTDT>()) {
-                auto left_block = opt_left_block.value();
+                const auto& left_block = *opt_left_block;
                 const auto nbytes = sizeof(TargetType) * left_block.row_count();
                 auto ptr = reinterpret_cast<TargetType*>(output->allocate_data(nbytes));
 

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -76,7 +76,7 @@ VariantData unary_operator(const Column& col, Func&& func) {
         output = std::make_unique<Column>(make_scalar_type(output_data_type), col.is_sparse());
         auto data = col.data();
         while(auto opt_block = data.next<DT>()) {
-            auto block = opt_block.value();
+            const auto& block = *opt_block;
             const auto nbytes = sizeof(TargetType) * block.row_count();
             auto ptr = reinterpret_cast<TargetType*>(output->allocate_data(nbytes));
             for(auto idx = 0u; idx < block.row_count(); ++idx)

--- a/cpp/arcticdb/processing/processing_unit.cpp
+++ b/cpp/arcticdb/processing/processing_unit.cpp
@@ -48,12 +48,12 @@ VariantData ProcessingUnit::get(const VariantNode &name, const std::shared_ptr<S
     return util::variant_match(name,
         [&](const ColumnName &column_name) {
         for (auto &slice_and_key: data_) {
-            slice_and_key.segment(store).init_column_map();
-            if (auto opt_idx = slice_and_key.segment(store).column_index(column_name.value)) {
+            auto segment = slice_and_key.segment(store);
+            segment.init_column_map();
+            if (auto opt_idx = segment.column_index(column_name.value)) {
                 return VariantData(ColumnWithStrings(
-                        slice_and_key.segment(store).column_ptr(
-                        position_t(position_t(opt_idx.value()))),
-                        slice_and_key.segment(store).string_pool_ptr()));
+                    segment.column_ptr(position_t(*opt_idx)),
+                    segment.string_pool_ptr()));
             }
         }
         // Try multi-index column names
@@ -63,7 +63,7 @@ VariantData ProcessingUnit::get(const VariantNode &name, const std::shared_ptr<S
             if (auto opt_idx = slice_and_key.segment(store).column_index(multi_index_column_name)) {
                 return VariantData(ColumnWithStrings(
                         slice_and_key.segment(store).column_ptr(
-                        position_t(opt_idx.value())),
+                        position_t(*opt_idx)),
                         slice_and_key.segment(store).string_pool_ptr()));
             }
         }

--- a/cpp/arcticdb/processing/test/test_expression.cpp
+++ b/cpp/arcticdb/processing/test/test_expression.cpp
@@ -34,14 +34,13 @@ TEST(ExpressionNode, AddBasic) {
     expression_context->root_node_name_ = ExpressionName("new_thing");
     expression_context->add_expression_node("new_thing", node);
     proc.set_expression_context(expression_context);
-    std::shared_ptr<Store> empty;
-    auto ret = proc.get(ExpressionName("new_thing"), empty);
+    auto ret = proc.get(ExpressionName("new_thing"), std::shared_ptr<Store>{});
     const auto& col = std::get<ColumnWithStrings>(ret).column_;
 
     for(auto j = 0; j < 20; ++j ) {
-        auto v1 =proc.data_[0].segment(empty).scalar_at<uint64_t>(j, 1) ;
+        auto v1 =proc.data_[0].segment(std::shared_ptr<Store>{}).scalar_at<uint64_t>(j, 1) ;
         ASSERT_EQ(v1.value(), j);
-        auto v2 = proc.data_[0].segment(empty).scalar_at<uint64_t>(j, 2);
+        auto v2 = proc.data_[0].segment(std::shared_ptr<Store>{}).scalar_at<uint64_t>(j, 2);
         ASSERT_EQ(v2.value(), j + 1);
         ASSERT_EQ(col->scalar_at<uint64_t>(j), v1.value() + v2.value());
     }

--- a/cpp/arcticdb/python/gil_lock.hpp
+++ b/cpp/arcticdb/python/gil_lock.hpp
@@ -36,7 +36,7 @@ public:
 
 private:
     bool acquired_gil_;
-    PyGILState_STATE state_;
+    PyGILState_STATE state_ = PyGILState_UNLOCKED;
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -78,6 +78,7 @@ void register_log(py::module && log) {
              .value("TIMINGS", LoggerId::TIMINGS)
              .value("LOCK", LoggerId::LOCK)
              .value("SCHEDULE", LoggerId::SCHEDULE)
+             .value("SYMBOL", LoggerId::SCHEDULE)
              .export_values()
     ;
     auto choose_logger = [&](LoggerId log_id) -> decltype(arcticdb::log::storage()) /* logger ref */{
@@ -236,10 +237,12 @@ void register_error_code_ecosystem(py::module& m, py::exception<arcticdb::Arctic
     py::register_exception<SchemaException>(m, "SchemaException", compat_exception.ptr());
     py::register_exception<NormalizationException>(m, "NormalizationException", compat_exception.ptr());
     py::register_exception<MissingDataException>(m, "MissingDataException", compat_exception.ptr());
-    auto sorting_exception =
-            py::register_exception<SortingException>(m, "SortingException", compat_exception.ptr());
+
+    auto sorting_exception = py::register_exception<SortingException>(m, "SortingException", compat_exception.ptr());
     py::register_exception<UnsortedDataException>(m, "UnsortedDataException", sorting_exception.ptr());
+    py::register_exception<UserInputException>(m, "UserInputException", compat_exception.ptr());
     py::register_exception<CompatibilityException>(m, "CompatibilityException", compat_exception.ptr());
+    py::register_exception<CodecException>(m, "CodecException", compat_exception.ptr());
 }
 
 void reinit_scheduler() {

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -240,7 +240,6 @@ void register_error_code_ecosystem(py::module& m, py::exception<arcticdb::Arctic
 
     auto sorting_exception = py::register_exception<SortingException>(m, "SortingException", compat_exception.ptr());
     py::register_exception<UnsortedDataException>(m, "UnsortedDataException", sorting_exception.ptr());
-    py::register_exception<UserInputException>(m, "UserInputException", compat_exception.ptr());
     py::register_exception<CompatibilityException>(m, "CompatibilityException", compat_exception.ptr());
     py::register_exception<CodecException>(m, "CodecException", compat_exception.ptr());
 }

--- a/cpp/arcticdb/python/reader.hpp
+++ b/cpp/arcticdb/python/reader.hpp
@@ -78,7 +78,7 @@ public:
                         auto string_refs = segment_.tensor_at<OffsetString::offset_t>(row, col).value();
                         std::vector<std::string_view > output;
                         for(ssize_t i = 0; i < string_refs.size(); ++i )
-                            output.push_back(view_at(string_refs.at(i)));
+                            output.emplace_back(view_at(string_refs.at(i)));
 
                         res.append(output);
                     }

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -315,7 +315,7 @@ void AzureStorage::do_iterate_type(KeyType key_type, const IterateTypeVisitor& v
         return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
     };
 
-    detail::do_iterate_type_impl(key_type, std::move(visitor), root_folder_, container_client_, FlatBucketizer{}, std::move(prefix_handler), prefix);
+    detail::do_iterate_type_impl(key_type, visitor, root_folder_, container_client_, FlatBucketizer{}, std::move(prefix_handler), prefix);
 }
 
 bool AzureStorage::do_key_exists(const VariantKey& key) {

--- a/cpp/arcticdb/storage/config_resolvers.cpp
+++ b/cpp/arcticdb/storage/config_resolvers.cpp
@@ -30,7 +30,7 @@ std::optional<InMemoryConfigResolver::MemoryConfig> InMemoryConfigResolver::get_
 InMemoryConfigResolver::MemoryConfig& InMemoryConfigResolver::get_or_add_environment(const EnvironmentName& environment_name) {
     auto env = environments_.find(environment_name);
     if(env == environments_.end()) {
-        env = environments_.insert(std::make_pair(environment_name, MemoryConfig())).first;
+        env = environments_.try_emplace(environment_name, MemoryConfig()).first;
     }
 
     return env->second;
@@ -42,7 +42,7 @@ std::vector<std::pair<LibraryPath, arcticdb::proto::storage::LibraryDescriptor>>
     if(!config.has_value())
         return output;
 
-    for(auto& pair : config.value().libraries_)
+    for(auto& pair : config->libraries_)
         output.emplace_back(pair);
 
     return output;
@@ -54,7 +54,7 @@ std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> In
     if(!config.has_value())
         return output;
 
-    for(auto& pair : config.value().storages_)
+    for(auto& pair : config->storages_)
         output.emplace_back(pair);
 
     return output;
@@ -62,12 +62,12 @@ std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> In
 
 void InMemoryConfigResolver::add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) {
     auto& config = get_or_add_environment(environment_name);
-    config.libraries_.insert(std::make_pair(LibraryPath::from_delim_path(library_descriptor.name()), library_descriptor));
+    config.libraries_.try_emplace(LibraryPath::from_delim_path(library_descriptor.name()), library_descriptor);
 }
 
 void InMemoryConfigResolver::add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) {
     auto& config = get_or_add_environment(environment_name);
-    config.storages_.insert(std::make_pair(StorageName(storage_name), storage));
+    config.storages_.try_emplace(StorageName(storage_name), storage);
 }
 
 }

--- a/cpp/arcticdb/storage/config_resolvers.hpp
+++ b/cpp/arcticdb/storage/config_resolvers.hpp
@@ -53,7 +53,7 @@ class InMemoryConfigResolver final : public ConfigResolver {
     explicit InMemoryConfigResolver(const T &environments) :
         environments_() {
         for (auto &&[environment_name, env_storages] : environments) {
-            environments_.emplace(environment_name, env_storages);
+            environments_.insert(std::make_pair(environment_name, env_storages));
         }
     }
 

--- a/cpp/arcticdb/storage/library_index.hpp
+++ b/cpp/arcticdb/storage/library_index.hpp
@@ -23,7 +23,7 @@ class LibraryIndex {
         ARCTICDB_DEBUG(log::storage(), "Creating library index with resolver type {}", resolver->resolver_type());
     }
 
-    std::vector<LibraryPath> list_libraries(const std::string_view &prefix) {
+    std::vector<LibraryPath> list_libraries(std::string_view prefix) {
         std::lock_guard<std::mutex> lock{mutex_};
         return config_cache_.list_libraries(prefix);
     }
@@ -62,7 +62,7 @@ class LibraryIndex {
             cfg = desc->config_;
         }
         auto lib = std::make_shared<Library>(path, config_cache_.create_storages(path, mode), cfg);
-        if (auto &&[it, inserted] = library_cache_.insert(std::make_pair(path, lib)); !inserted) {
+        if (auto &&[it, inserted] = library_cache_.try_emplace(path, lib); !inserted) {
             lib = it->second;
         }
         return lib;

--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -44,6 +44,8 @@ class DefaultStringViewable : public std::shared_ptr<std::string> {
         return hash_;
     }
 
+    DefaultStringViewable operator=(const DefaultStringViewable&) = delete;
+
   private:
     HashedValue hash_;
 };
@@ -73,7 +75,7 @@ class LibraryPathImpl {
             return parts_.empty();
         }
 
-    LibraryPathImpl(const std::string_view &delim_path, char delim) :
+    LibraryPathImpl(std::string_view delim_path, char delim) :
         parts_(),
         hash_() {
         folly::StringPiece p{delim_path};
@@ -85,7 +87,7 @@ class LibraryPathImpl {
         hash_ = compute_hash();
     }
 
-    static LibraryPathImpl<StringViewable> from_delim_path(const std::string_view &delim_path, char delim = '.') {
+    static LibraryPathImpl<StringViewable> from_delim_path(std::string_view delim_path, char delim = '.') {
         return LibraryPathImpl<StringViewable>{delim_path, delim};
     }
 

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -318,7 +318,7 @@ LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const C
     arcticdb::entity::foreach_key_type([&txn, this](KeyType&& key_type) {
         std::string db_name = fmt::format("{}", key_type);
         ::lmdb::dbi dbi = ::lmdb::dbi::open(txn, db_name.data(), MDB_CREATE);
-        dbi_by_key_type_.insert({std::move(db_name), std::move(dbi)});
+        dbi_by_key_type_.insert(std::make_pair(std::move(db_name), std::move(dbi)));
     });
 
     txn.commit();

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -411,9 +411,9 @@ void MongoClientImpl::iterate_type(const std::string &database_name,
     ARCTICDB_SUBSAMPLE(MongoStorageItTypeGetCol, 0)
     auto collection = client->database(database_name)[collection_name];
     ARCTICDB_SUBSAMPLE(MongoStorageItTypeFindAll, 0)
-    bool has_prefix = prefix.has_value() && (!prefix.value().empty());
+    bool has_prefix = prefix.has_value() && (!prefix->empty());
     auto cursor =  has_prefix ?
-            collection.find(document{} << "stream_id" << prefix.value() << finalize):
+            collection.find(document{} << "stream_id" << *prefix << finalize):
             collection.find({});
 
     for (auto &doc : cursor) {

--- a/cpp/arcticdb/storage/protobuf_mappings.hpp
+++ b/cpp/arcticdb/storage/protobuf_mappings.hpp
@@ -54,7 +54,7 @@ inline storage::LibraryDescriptor decode_library_descriptor(const arcticdb::prot
     output.name_ = protobuf_descriptor.name();
     output.description_ = protobuf_descriptor.description();
     for(int i = 0; i < protobuf_descriptor.storage_ids_size(); ++i)
-        output.storage_ids_.push_back(StorageName(protobuf_descriptor.storage_ids(i)));
+        output.storage_ids_.emplace_back(StorageName(protobuf_descriptor.storage_ids(i)));
 
     switch (protobuf_descriptor.store_type_case()){
         case arcticdb::proto::storage::LibraryDescriptor::StoreTypeCase::kVersion:
@@ -76,12 +76,12 @@ inline std::vector<std::pair<std::string, MemConfig>> convert_environment_config
     for (auto&[env_key, env_config] : envs.env_by_id()) {
         MemConfig current;
         for (auto &[storage_key, storage_value] : env_config.storage_by_id())
-            current.storages_.insert(std::make_pair(storage::StorageName(storage_key), storage_value));
+            current.storages_.try_emplace(storage::StorageName(storage_key), storage_value);
 
         for (auto &[library_key, library_value] : env_config.lib_by_path())
-            current.libraries_.insert(std::make_pair(LibraryPath::from_delim_path(library_key), library_value));
+            current.libraries_.try_emplace(LibraryPath::from_delim_path(library_key), library_value);
 
-        env_by_id.push_back(std::make_pair(env_key, current));
+        env_by_id.emplace_back(env_key, current);
     }
     return env_by_id;
 }

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -165,7 +165,7 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
         .def("list_libraries", [](const LibraryManager& library_manager){
             std::vector<std::string> res;
             for(auto & lp:library_manager.get_library_paths()){
-                res.push_back(lp.to_delim_path());
+                res.emplace_back(lp.to_delim_path());
             }
             return res;
         });
@@ -182,7 +182,7 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
         .def("list_libraries", [](LibraryIndex &library_index, std::string_view prefix = ""){
             std::vector<std::string> res;
             for(const auto& lp:library_index.list_libraries(prefix)){
-                res.push_back(lp.to_delim_path());
+                res.emplace_back(lp.to_delim_path());
             }
             return res;
         } )

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -150,7 +150,7 @@ void NfsBackedStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
 }
 
 void NfsBackedStorage::do_iterate_type(KeyType key_type, const IterateTypeVisitor& visitor, const std::string& prefix) {
-    auto func = [v = std::move(visitor), prefix=prefix] (VariantKey&& k) mutable {
+    auto func = [&v = visitor, prefix=prefix] (VariantKey&& k) mutable {
         auto key = unencode_object_id(k);
         if(prefix.empty() || variant_key_id(key) == StreamId{prefix})
             v(std::move(key));

--- a/cpp/arcticdb/storage/s3/s3_client_accessor.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_accessor.hpp
@@ -49,7 +49,7 @@ public:
     }
 
     void do_iterate_type(KeyType key_type, const IterateTypeVisitor& visitor, const std::string &prefix) {
-        storage_.do_iterate_type(key_type, std::move(visitor), prefix);
+        storage_.do_iterate_type(key_type, visitor, prefix);
     }
 
     bool do_key_exists(const VariantKey& key) {

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -78,11 +78,11 @@ void S3Storage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
 }
 
 void S3Storage::do_iterate_type(KeyType key_type, const IterateTypeVisitor& visitor, const std::string& prefix) {
-    auto prefix_handler = [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor key_descriptor, KeyType) {
+    auto prefix_handler = [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
         return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
     };
 
-    detail::do_iterate_type_impl(key_type, std::move(visitor), root_folder_, bucket_name_, s3_client_, FlatBucketizer{}, std::move(prefix_handler), prefix);
+    detail::do_iterate_type_impl(key_type, visitor, root_folder_, bucket_name_, s3_client_, FlatBucketizer{}, std::move(prefix_handler), prefix);
 }
 
 bool S3Storage::do_key_exists(const VariantKey& key) {
@@ -98,17 +98,17 @@ namespace arcticdb::storage::s3 {
 
 namespace detail {
 std::streamsize S3StreamBuffer::xsputn(const char_type* s, std::streamsize n) {
-    ARCTICDB_DEBUG(log::version(), "xsputn {} pos at {}, {} bytes", uintptr_t(buffer_.get()), pos_, n);
+    ARCTICDB_TRACE(log::version(), "xsputn {} pos at {}, {} bytes", uintptr_t(buffer_.get()), pos_, n);
     if(buffer_->bytes() < pos_ + n) {
-        ARCTICDB_DEBUG(log::version(), "{} Calling ensure for {}", uintptr_t(buffer_.get()), (pos_ + n) * 2);
+        ARCTICDB_TRACE(log::version(), "{} Calling ensure for {}", uintptr_t(buffer_.get()), (pos_ + n) * 2);
         buffer_->ensure((pos_ + n) * 2);
     }
 
     auto target = buffer_->ptr_cast<char_type>(pos_, n);
-    ARCTICDB_DEBUG(log::version(), "Putting {} bytes at {}", n, uintptr_t(target));
+    ARCTICDB_TRACE(log::version(), "Putting {} bytes at {}", n, uintptr_t(target));
     memcpy(target, s, n);
     pos_ += n;
-    ARCTICDB_DEBUG(log::version(), "{} pos is now {}, returning {}", uintptr_t(buffer_.get()), pos_, n);
+    ARCTICDB_TRACE(log::version(), "{} pos is now {}, returning {}", uintptr_t(buffer_.get()), pos_, n);
     return n;
 }
 }

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -197,13 +197,13 @@ inline Aws::Client::ClientConfiguration get_proxy_config(Aws::Http::Scheme endpo
         for (const auto& env_var_name: {"no_proxy", "NO_PROXY"}) {
             char* opt_env_var = std::getenv(env_var_name);
             auto non_proxy_hosts = parse_no_proxy_env_var(opt_env_var);
-            if (non_proxy_hosts.has_value()) {
-                client_configuration->nonProxyHosts = non_proxy_hosts.value();
+            if (non_proxy_hosts) {
+                client_configuration->nonProxyHosts = *non_proxy_hosts;
                 log::storage().info("S3 proxy exclusion list set from env var '{}'", opt_env_var);
                 break;
             }
         }
-        return client_configuration.value();
+        return *client_configuration;
     } else {
         return Aws::Client::ClientConfiguration();
     }

--- a/cpp/arcticdb/storage/storage_override.hpp
+++ b/cpp/arcticdb/storage/storage_override.hpp
@@ -141,7 +141,7 @@ public:
     }
 
     void set_path(std::string path) {
-        path_ = path;
+        path_ = std::move(path);
     }
 
     void set_map_size(uint64_t map_size) {

--- a/cpp/arcticdb/storage/storage_utils.hpp
+++ b/cpp/arcticdb/storage/storage_utils.hpp
@@ -46,7 +46,7 @@ inline void filter_keys_on_existence(std::vector<AtomKey>& keys, const std::shar
         bool resolved = key_existence[i].wait().value();
         if (resolved == pred) {
             *keys_itr = std::move(std::get<AtomKey>(var_vector[i]));
-            keys_itr++;
+            ++keys_itr;
         }
     }
     keys.erase(keys_itr, keys.end());

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -273,10 +273,10 @@ namespace arcticdb {
             for(const auto& key : keys) {
                 util::variant_match(key,
                                     [&output, &refs=seg_by_ref_key_] (const RefKey& ref) {
-                    output.push_back(folly::makeFuture<bool>(refs.find(ref) != refs.end()));
+                    output.emplace_back(folly::makeFuture<bool>(refs.find(ref) != refs.end()));
                 },
                 [&output, &atoms=seg_by_atom_key_] (const AtomKey& atom) {
-                    output.push_back(folly::makeFuture<bool>(atoms.find(atom) != atoms.end()));
+                    output.emplace_back(folly::makeFuture<bool>(atoms.find(atom) != atoms.end()));
                 });
             }
             return output;
@@ -318,10 +318,6 @@ namespace arcticdb {
             }
 
             return output;
-        }
-
-        void insert_atom_key(const AtomKey &key) {
-            seg_by_atom_key_.insert(std::make_pair(key, std::make_unique<SegmentInMemory>()));
         }
 
         size_t num_atom_keys() const { return seg_by_atom_key_.size(); }

--- a/cpp/arcticdb/storage/test/test_embedded.cpp
+++ b/cpp/arcticdb/storage/test/test_embedded.cpp
@@ -149,11 +149,7 @@ TEST_P(SimpleTestSuite, Example) {
     ASSERT_TRUE(executed);
 }
 
-<<<<<<< HEAD:cpp/arcticdb/storage/test/test_embedded.cpp
 TEST_P(SimpleTestSuite, Strings) {
-=======
-TEST(TestLmdbStorage, Strings) {
->>>>>>> 6ea4115 (Refactor symbol list to used observed version ids):cpp/arcticdb/storage/test/test_lmdb_storage.cpp
     auto tsd = create_tsd<DataTypeTag<DataType::ASCII_DYNAMIC64>, Dimension::Dim0>();
     SegmentInMemory s{StreamDescriptor{std::move(tsd)}};
     s.set_scalar(0, timestamp(123));
@@ -186,11 +182,6 @@ TEST(TestLmdbStorage, Strings) {
 
     std::unique_ptr<as::Storage> storage = GetParam().new_backend();
 
-<<<<<<< HEAD:cpp/arcticdb/storage/test/test_embedded.cpp
-=======
-    asl::LmdbStorage storage({"A", "BB"}, as::OpenMode::WRITE, cfg);
-    std::array<std::string, 2> lib_parts{"A", "BB"};
->>>>>>> 6ea4115 (Refactor symbol list to used observed version ids):cpp/arcticdb/storage/test/test_lmdb_storage.cpp
     ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(999);
     auto save_k = k;
     as::KeySegmentPair kv(std::move(k), std::move(seg));

--- a/cpp/arcticdb/storage/test/test_embedded.cpp
+++ b/cpp/arcticdb/storage/test/test_embedded.cpp
@@ -94,7 +94,6 @@ TEST_P(SimpleTestSuite, ConstructDestruct) {
 
 TEST_P(SimpleTestSuite, Example) {
     std::unique_ptr<as::Storage> storage = GetParam().new_backend();
-
     ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(999);
 
     as::KeySegmentPair kv(k);
@@ -150,7 +149,11 @@ TEST_P(SimpleTestSuite, Example) {
     ASSERT_TRUE(executed);
 }
 
+<<<<<<< HEAD:cpp/arcticdb/storage/test/test_embedded.cpp
 TEST_P(SimpleTestSuite, Strings) {
+=======
+TEST(TestLmdbStorage, Strings) {
+>>>>>>> 6ea4115 (Refactor symbol list to used observed version ids):cpp/arcticdb/storage/test/test_lmdb_storage.cpp
     auto tsd = create_tsd<DataTypeTag<DataType::ASCII_DYNAMIC64>, Dimension::Dim0>();
     SegmentInMemory s{StreamDescriptor{std::move(tsd)}};
     s.set_scalar(0, timestamp(123));
@@ -183,6 +186,11 @@ TEST_P(SimpleTestSuite, Strings) {
 
     std::unique_ptr<as::Storage> storage = GetParam().new_backend();
 
+<<<<<<< HEAD:cpp/arcticdb/storage/test/test_embedded.cpp
+=======
+    asl::LmdbStorage storage({"A", "BB"}, as::OpenMode::WRITE, cfg);
+    std::array<std::string, 2> lib_parts{"A", "BB"};
+>>>>>>> 6ea4115 (Refactor symbol list to used observed version ids):cpp/arcticdb/storage/test/test_lmdb_storage.cpp
     ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(999);
     auto save_k = k;
     as::KeySegmentPair kv(std::move(k), std::move(seg));

--- a/cpp/arcticdb/storage/test/test_mongo_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_mongo_storage.cpp
@@ -32,7 +32,7 @@ TEST(MongoStorage, ClientSession) {
 
     asmongo::MongoStorage storage({"testdb", "stuff"}, as::OpenMode::WRITE, cfg);
 
-    std::vector<std::string> lib_parts{"testdb", "stuff"};
+    std::array<std::string, 2> lib_parts{"testdb", "stuff"};
     ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>("999");
 
     as::KeySegmentPair kv(k);

--- a/cpp/arcticdb/stream/aggregator.hpp
+++ b/cpp/arcticdb/stream/aggregator.hpp
@@ -161,7 +161,7 @@ class Aggregator {
         C &&c,
         SegmentingPolicy &&segmenting_policy = SegmentingPolicyType(),
         const std::optional<StreamDescriptor>& desc = std::nullopt,
-        const std::optional<size_t> row_count = std::nullopt) :
+        const std::optional<size_t>& row_count = std::nullopt) :
         schema_policy_(std::move(schema)),
         row_builder_(schema_policy_, self()),
         callback_(std::forward<Callback>(c)),

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -122,7 +122,7 @@ std::set<StreamId> get_active_incomplete_refs(const std::shared_ptr<Store>& stor
         ref_keys.insert(vk);
     });
     for (const auto& vk: ref_keys) {
-        auto stream_id = variant_key_id(vk);
+        const auto& stream_id = variant_key_id(vk);
         auto [next_key, _] = read_head(store, stream_id);
         if (next_key && store->key_exists(next_key.value()).get()) {
             output.insert(stream_id);

--- a/cpp/arcticdb/stream/index.hpp
+++ b/cpp/arcticdb/stream/index.hpp
@@ -60,7 +60,7 @@ class TimeseriesIndex : public BaseIndex<TimeseriesIndex> {
 public:
     static constexpr const char* DefaultName = "time" ;
 
-    explicit TimeseriesIndex(const std::string name) :
+    explicit TimeseriesIndex(const std::string& name) :
         name_(name) {
     }
 
@@ -324,7 +324,7 @@ inline Index default_index_type_from_descriptor(const IndexDescriptor::Proto &de
 }
 
 // Only to be used for visitation to get field count etc as the name is not set
-inline Index variant_index_from_type(const IndexDescriptor::Type &type) {
+inline Index variant_index_from_type(IndexDescriptor::Type type) {
     switch (type) {
     case IndexDescriptor::TIMESTAMP:
         return TimeseriesIndex{TimeseriesIndex::DefaultName};

--- a/cpp/arcticdb/stream/merge_utils.hpp
+++ b/cpp/arcticdb/stream/merge_utils.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <arcticdb/column_store/chunked_buffer.hpp>
+#include <arcticdb/column_store/string_pool.hpp>
+#include <arcticdb/column_store/memory_segment.hpp>
+
+namespace arcticdb {
+inline void merge_string_column(
+    ChunkedBuffer& src_buffer,
+    const std::shared_ptr<StringPool>& src_pool,
+    const std::shared_ptr<StringPool>& merged_pool,
+    CursoredBuffer<ChunkedBuffer>& output,
+    bool verify
+) {
+    using OffsetType = StringPool::offset_t;
+    constexpr auto offset_size =  sizeof(OffsetType);
+    auto num_strings = src_buffer.bytes() / offset_size;
+    for(auto row = 0ULL; row < num_strings; ++row) {
+        auto offset = get_offset_string_at(row, src_buffer);
+        StringPool::offset_t new_value;
+        if (offset != not_a_string() && offset != nan_placeholder()) {
+            auto sv = get_string_from_pool(offset, *src_pool);
+            new_value = merged_pool->get(sv).offset();
+        } else {
+            new_value = offset;
+        }
+        output.ensure<OffsetType>(1);
+        util::check(new_value >= 0, "Unexpected negative number {} in merge string column", new_value);
+        output.typed_cursor<OffsetType>() = new_value;
+        output.commit();
+    }
+    if (verify) {
+        const auto& out_buffer = output.buffer();
+        auto num_out = out_buffer.bytes() /offset_size;
+        util::check(num_strings == num_out, "Mismatch in input/output size {} != {}", num_strings, num_out);
+        for(auto row = size_t(0); row < num_out; ++row) {
+            auto offset = get_offset_string_at(row, out_buffer);
+            if (offset != not_a_string() && offset != nan_placeholder()) {
+                auto sv ARCTICDB_UNUSED = get_string_from_pool(offset, *merged_pool);
+                ARCTICDB_DEBUG(log::version(), "Accessed {} from string pool", sv);
+            }
+        }
+    }
+}
+
+inline void merge_string_columns(const SegmentInMemory& segment, const std::shared_ptr<StringPool>& merged_pool, bool verify) {
+    for (size_t c = 0; c < segment.descriptor().field_count(); ++c) {
+        auto &frame_field = segment.field(c);
+        const auto& field_type = frame_field.type();
+
+        if (!is_sequence_type(field_type.data_type_))
+            continue;
+
+        auto &src = segment.column(static_cast<position_t>(c)).data().buffer();
+        CursoredBuffer<ChunkedBuffer> cursor{src.bytes(), false};
+        merge_string_column(src, segment.string_pool_ptr(), merged_pool, cursor, verify);
+        std::swap(src, cursor.buffer());
+    }
+}
+
+inline void merge_segments(
+    std::vector<SegmentInMemory>& segments,
+    SegmentInMemory& merged,
+    bool is_sparse) {
+    ARCTICDB_DEBUG(log::version(), "Appending {} segments", segments.size());
+    timestamp min_idx = std::numeric_limits<timestamp>::max();
+    timestamp max_idx = std::numeric_limits<timestamp>::min();
+    for (auto &segment : segments) {
+        std::vector<SegmentInMemory> history{{segment}};
+        const auto& latest = *history.rbegin();
+        ARCTICDB_DEBUG(log::version(), "Appending segment with {} rows", latest.row_count());
+        for(const auto& field : latest.descriptor().fields()) {
+            if(!merged.column_index(field.name())){//TODO: Bottleneck for wide segments
+                auto pos = merged.add_column(field, 0, false);
+                if (!is_sparse){
+                    merged.column(pos).mark_absent_rows(merged.row_count());
+                }
+            }
+        }
+        if (latest.row_count() && latest.descriptor().index().type() == IndexDescriptor::TIMESTAMP) {
+            min_idx = std::min(min_idx, latest.begin()->begin()->value<timestamp>());
+            max_idx = std::max(max_idx, (latest.end() - 1)->begin()->value<timestamp>());
+        }
+        merge_string_columns(latest, merged.string_pool_ptr(), false);
+        merged.append(*history.rbegin());
+        merged.set_compacted(true);
+        util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
+    }
+}
+
+inline pipelines::FrameSlice merge_slices(
+    std::vector<pipelines::FrameSlice>& slices,
+    const StreamDescriptor& desc) {
+    util::check(!slices.empty(), "Expected to merge non-empty slices_vector");
+
+    pipelines::FrameSlice output{slices[0]};
+    for(const auto& slice : slices) {
+        output.row_range.first = std::min(output.row_range.first, slice.row_range.first);
+        output.row_range.second = std::max(output.row_range.second, slice.row_range.second);
+    }
+
+    output.col_range.first = desc.index().field_count();
+    output.col_range.second = desc.field_count();
+    return output;
+}
+}

--- a/cpp/arcticdb/stream/protobuf_mappings.hpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.hpp
@@ -29,16 +29,35 @@ inline arcticdb::proto::descriptors::NormalizationMetadata make_timeseries_norm_
     return norm_meta;
 }
 
+inline arcticdb::proto::descriptors::NormalizationMetadata make_rowcount_norm_meta(const entity::StreamId& stream_id) {
+    using namespace arcticdb::proto::descriptors;
+    NormalizationMetadata norm_meta;
+    NormalizationMetadata_PandasDataFrame pandas;
+    auto id = std::get<entity::StringId>(stream_id);
+    pandas.mutable_common()->set_name(std::move(id));
+    NormalizationMetadata_PandasIndex pandas_index;
+    pandas_index.set_is_not_range_index(true);
+    pandas.mutable_common()->mutable_index()->CopyFrom(pandas_index);
+    norm_meta.mutable_df()->CopyFrom(pandas);
+    return norm_meta;
+}
+
 /**
  * Set the minimum defaults into norm_meta. Originally created to synthesize norm_meta for incomplete compaction.
  */
-inline void ensure_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_meta, const entity::StreamId& stream_id, bool set_tz) {
+inline void ensure_timeseries_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_meta, const entity::StreamId& stream_id, bool set_tz) {
     if(norm_meta.input_type_case() == arcticdb::proto::descriptors::NormalizationMetadata::INPUT_TYPE_NOT_SET) {
         norm_meta.CopyFrom(make_timeseries_norm_meta(stream_id));
     }
 
     if(set_tz && norm_meta.df().common().index().tz().empty())
         norm_meta.mutable_df()->mutable_common()->mutable_index()->set_tz("UTC");
+}
+
+inline void ensure_rowcount_norm_meta(arcticdb::proto::descriptors::NormalizationMetadata& norm_meta, const entity::StreamId& stream_id) {
+    if(norm_meta.input_type_case() == arcticdb::proto::descriptors::NormalizationMetadata::INPUT_TYPE_NOT_SET) {
+        norm_meta.CopyFrom(make_rowcount_norm_meta(stream_id));
+    }
 }
 
 } //namespace arcticdb

--- a/cpp/arcticdb/stream/python_bindings.cpp
+++ b/cpp/arcticdb/stream/python_bindings.cpp
@@ -80,7 +80,7 @@ void register_types(py::module &m) {
     //TODO re-add at the end
    python_util::add_repr(py::class_<StreamDescriptor>(m, "StreamDescriptor")
     .def(py::init([](StreamId stream_id, IndexDescriptor idx_desc, const std::vector<FieldRef>& fields) {
-                                  auto index = default_index_type_from_descriptor(idx_desc.proto());
+                                  auto index = stream::default_index_type_from_descriptor(idx_desc.proto());
                                   return util::variant_match(index, [&stream_id, &fields] (auto idx_type){
                                       return StreamDescriptor{index_descriptor(stream_id, idx_type, fields_from_range(fields))};
                                   });

--- a/cpp/arcticdb/stream/row_builder.hpp
+++ b/cpp/arcticdb/stream/row_builder.hpp
@@ -214,7 +214,7 @@ class RowBuilder {
     }
     
     const IndexType& index() const {
-        return schema_->index();
+        return index_;
     }
 
     IndexType& index() {

--- a/cpp/arcticdb/stream/schema.hpp
+++ b/cpp/arcticdb/stream/schema.hpp
@@ -108,7 +108,7 @@ public:
             ARCTICDB_TRACE(log::version(), "Added column {} to position: {}", col_name, pos);
             return pos;
         } else {
-            return static_cast<position_t>(opt_col.value());
+            return static_cast<position_t>(*opt_col);
         }
     }
 

--- a/cpp/arcticdb/stream/segment_aggregator.hpp
+++ b/cpp/arcticdb/stream/segment_aggregator.hpp
@@ -11,109 +11,9 @@
 #include <arcticdb/pipeline/frame_utils.hpp>
 #include <arcticdb/util/format_date.hpp>
 #include <arcticdb/pipeline/filter_segment.hpp>
+#include <arcticdb/stream/merge_utils.hpp>
 
 namespace arcticdb::stream {
-
-inline void merge_string_column(
-    ChunkedBuffer& src_buffer,
-    const std::shared_ptr<StringPool>& src_pool,
-    const std::shared_ptr<StringPool>& merged_pool,
-    CursoredBuffer<ChunkedBuffer>& output,
-    bool verify
-    ) {
-    using OffsetType = StringPool::offset_t;
-    constexpr auto offset_size =  sizeof(OffsetType);
-    auto num_strings = src_buffer.bytes() / offset_size;
-    for(auto row = size_t(0); row < num_strings; ++row) {
-        auto offset = get_offset_string_at(row, src_buffer);
-        StringPool::offset_t new_value;
-        if (offset != not_a_string() && offset != nan_placeholder()) {
-            auto sv = get_string_from_pool(offset, *src_pool);
-            new_value = merged_pool->get(sv).offset();
-        } else {
-            new_value = offset;
-        }
-        output.ensure<OffsetType>(1);
-        util::check(new_value >= 0, "Unexpected negative number {} in merge string column", new_value);
-        output.typed_cursor<OffsetType>() = new_value;
-        output.commit();
-    }
-    if (verify) {
-        const auto& out_buffer = output.buffer();
-        auto num_out = out_buffer.bytes() /offset_size;
-        util::check(num_strings == num_out, "Mismatch in input/output size {} != {}", num_strings, num_out);
-        for(auto row = size_t(0); row < num_out; ++row) {
-            auto offset = get_offset_string_at(row, out_buffer);
-            if (offset != not_a_string() && offset != nan_placeholder()) {
-                auto sv = get_string_from_pool(offset, *merged_pool);
-                // Checking every position is accessible or not
-                auto str = std::string(sv);
-                log::version().debug("Accessed {} from string pool");
-            }
-        }
-    }
-}
-
-inline void merge_string_columns(const SegmentInMemory& segment, const std::shared_ptr<StringPool>& merged_pool, bool verify) {
-    for (size_t c = 0; c < segment.descriptor().field_count(); ++c) {
-        auto &frame_field = segment.field(c);
-        const auto& field_type = frame_field.type();
-
-        if (!is_sequence_type(field_type.data_type_))
-            continue;
-
-        auto &src = segment.column(static_cast<position_t>(c)).data().buffer();
-        CursoredBuffer<ChunkedBuffer> cursor{src.bytes(), false};
-        merge_string_column(src, segment.string_pool_ptr(), merged_pool, cursor, verify);
-        std::swap(src, cursor.buffer());
-    }
-}
-
-inline void merge_segments(
-    std::vector<SegmentInMemory>& segments,
-    SegmentInMemory& merged,
-    bool is_sparse) {
-    ARCTICDB_DEBUG(log::version(), "Appending {} segments", segments.size());
-    timestamp min_idx = std::numeric_limits<timestamp>::max();
-    timestamp max_idx = std::numeric_limits<timestamp>::min();
-    for (auto &segment : segments) {
-        std::vector<SegmentInMemory> history{{segment}};
-        const auto& latest = *history.rbegin();
-        ARCTICDB_DEBUG(log::version(), "Appending segment with {} rows", latest.row_count());
-        for(const auto& field : latest.descriptor().fields()) {
-            if(!merged.column_index(field.name())){//TODO: Bottleneck for wide segments
-                auto pos = merged.add_column(field, 0, false);
-                if (!is_sparse){
-                    merged.column(pos).mark_absent_rows(merged.row_count());
-                }
-            }
-        }
-        if (latest.row_count() && latest.descriptor().index().type() == IndexDescriptor::TIMESTAMP) {
-            min_idx = std::min(min_idx, latest.begin()->begin()->value<timestamp>());
-            max_idx = std::max(max_idx, (latest.end() - 1)->begin()->value<timestamp>());
-        }
-        merge_string_columns(latest, merged.string_pool_ptr(), false);
-        merged.append(*history.rbegin());
-        merged.set_compacted(true);
-        util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
-    }
-}
-
-inline pipelines::FrameSlice merge_slices(
-    std::vector<pipelines::FrameSlice>& slices,
-    const StreamDescriptor& desc) {
-    util::check(!slices.empty(), "Expected to merge non-empty slices_vector");
-
-    pipelines::FrameSlice output{slices[0]};
-    for(const auto& slice : slices) {
-        output.row_range.first = std::min(output.row_range.first, slice.row_range.first);
-        output.row_range.second = std::max(output.row_range.second, slice.row_range.second);
-    }
-
-    output.col_range.first = desc.index().field_count();
-    output.col_range.second = desc.field_count();
-    return output;
-}
 
 inline void convert_descriptor_types(StreamDescriptor & descriptor) {
     for(size_t i = 0; i < descriptor.field_count(); ++i) {
@@ -185,8 +85,9 @@ public:
             AggregatorType::segment().init_column_map();
             merge_segments(segments_, AggregatorType::segment(), DensityPolicy::allow_sparse);
         }
-        auto slice = merge_slices(slices_, AggregatorType::segment().descriptor());
+
         if (AggregatorType::segment().row_count() > 0) {
+            auto slice = merge_slices(slices_, AggregatorType::segment().descriptor());
             AggregatorType::commit_impl();
             slice_callback_(std::move(slice));
         }

--- a/cpp/arcticdb/stream/stream_reader.hpp
+++ b/cpp/arcticdb/stream/stream_reader.hpp
@@ -51,7 +51,7 @@ class RowsFromSegIterator : public IndexRangeFilter {
             }
 
             auto index_type = seg_->descriptor().index().type();
-            auto res = std::make_optional<RowType>(seg_.value().template make_row_ref<RowType>(row_id));
+            auto res = std::make_optional<RowType>(seg_->template make_row_ref<RowType>(row_id));
 
             // Not filtering rows where we have a rowcount index - the assumption is that it's essentially an un-indexed blob
             // that we need to segment somehow.
@@ -85,7 +85,7 @@ class StreamReader {
     using DataSegmentIteratorType = SegmentIterator<KeysFromSegIteratorType, DATA_PREFETCH_WINDOW>;
     using RowsIteratorType = RowsFromSegIterator<DataSegmentIteratorType, RowType>;
 
-    StreamReader(KeySupplierType &&gen, std::shared_ptr<StreamSource> store, const storage::ReadKeyOpts opts = storage::ReadKeyOpts{},  const IndexRange &index_range = unspecified_range()) :
+    StreamReader(KeySupplierType &&gen, std::shared_ptr<StreamSource> store, const storage::ReadKeyOpts& opts = storage::ReadKeyOpts{},  const IndexRange &index_range = unspecified_range()) :
         key_gen_(std::move(gen)),
         index_range_(index_range),
         store_(store),

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -21,17 +21,15 @@
 
 namespace arcticdb::stream {
 
-using ReadKeyOutput = std::pair<entity::VariantKey, SegmentInMemory>;
-
 struct StreamSource {
 
     virtual ~StreamSource() = default;
 
-    virtual folly::Future<ReadKeyOutput> read(
+    virtual folly::Future<std::pair<entity::VariantKey, SegmentInMemory>> read(
         const entity::VariantKey &key,
         storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
-    virtual ReadKeyOutput read_sync(
+    virtual std::pair<entity::VariantKey, SegmentInMemory> read_sync(
         const entity::VariantKey &key,
         storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 

--- a/cpp/arcticdb/stream/stream_writer.hpp
+++ b/cpp/arcticdb/stream/stream_writer.hpp
@@ -47,8 +47,8 @@ folly::Future<VariantKey> collect_and_commit(
     IndexValue end_index;
 
     if(specified_range) {
-        start_index = specified_range.value().start_;
-        end_index = specified_range.value().end_;
+        start_index = specified_range->start_;
+        end_index = specified_range->end_;
     }
     else if (!keys.empty()){
         start_index = to_atom(*keys.begin()).start_index();
@@ -152,7 +152,7 @@ class StreamWriter : boost::noncopyable {
         auto seg_start = segment_start(segment);
         auto seg_end = segment_end(segment);
 
-        written_data_keys_.push_back(store_->write(
+        written_data_keys_.emplace_back(store_->write(
             get_key_type_for_data_stream(stream_id()),
             version_id_,
             stream_id(),

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -138,7 +138,7 @@ struct DefaultStringGenerator {
         vec.resize(num_rows * strides_);
         const char *strings[] = {"dog", "cat", "horse"};
         for (size_t i = 0; i < num_rows; ++i) {
-            memcpy(&vec[i * strides_], &strings[i % 3], sizeof(strings[i % 3]));
+            memcpy(&vec[i * strides_], &strings[i % 3], strlen(strings[i % 3]));
         }
     }
 };
@@ -219,9 +219,9 @@ void fill_test_column(arcticdb::pipelines::InputTensorFrame &frame,
     using RawType = typename decltype(data_type_tag)::raw_type;
     if (!is_index) {
         if constexpr (std::is_integral_v<RawType> || std::is_floating_point_v<RawType>)
-            frame.field_tensors.push_back(test_column(container, data_type_tag, num_rows, start_val, is_index));
+            frame.field_tensors.emplace_back(test_column(container, data_type_tag, num_rows, start_val, is_index));
         else
-            frame.field_tensors.push_back(test_string_column(container, data_type_tag, num_rows, start_val, is_index));
+            frame.field_tensors.emplace_back(test_string_column(container, data_type_tag, num_rows, start_val, is_index));
     } else {
         if constexpr (std::is_integral_v<RawType>)
             frame.index_tensor =

--- a/cpp/arcticdb/stream/test/test_append_map.cpp
+++ b/cpp/arcticdb/stream/test/test_append_map.cpp
@@ -71,9 +71,10 @@ TEST(Append, MergeDescriptorsPromote) {
     std::vector<std::shared_ptr<FieldCollection>> new_desc_fields;
     new_desc_fields.emplace_back(std::make_shared<FieldCollection>(fields_from_range(get_new_fields()[0])));
     auto new_desc = merge_descriptors(original, std::move(new_desc_fields), std::vector<std::string>{});
-    new_desc_fields.emplace_back(std::make_shared<FieldCollection>(fields_from_range(get_new_fields()[0])));
+    std::vector<std::shared_ptr<FieldCollection>> expected_desc_fields;
+    expected_desc_fields.emplace_back(std::make_shared<FieldCollection>(fields_from_range(get_new_fields()[0])));
 
-    auto result = std::equal(std::begin(new_desc.fields()), std::end(new_desc.fields()), std::begin(*new_desc_fields[0]), std::end(*new_desc_fields[0]), []
+    auto result = std::equal(std::begin(new_desc.fields()), std::end(new_desc.fields()), std::begin(*expected_desc_fields[0]), std::end(*expected_desc_fields[0]), []
         (const auto& left, const auto& right) {
         return left == right;
     });

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -12,14 +12,23 @@
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/types.hpp>
+#include <arcticdb/pipeline/pipeline_utils.hpp>
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/util/clock.hpp>
 #include <arcticdb/util/key_utils.hpp>
 #include <arcticdb/util/variant.hpp>
+#include <arcticdb/version/version_utils.hpp>
 
 namespace arcticdb::toolbox::apy {
 
 using namespace arcticdb::entity;
+
+ReadResult LibraryTool::read(const VariantKey& key) {
+    auto segment = read_to_segment(key);
+    auto segment_in_memory = decode_segment(std::move(segment));
+    auto frame_and_descriptor = frame_and_descriptor_from_segment(std::move(segment_in_memory));
+    return pipelines::make_read_result_from_frame(frame_and_descriptor, to_atom(key));
+}
 
 Segment LibraryTool::read_to_segment(const VariantKey& key) {
     auto kv = std::visit([lib=lib_](const auto &k) { return lib->read(k); }, key);

--- a/cpp/arcticdb/toolbox/library_tool.hpp
+++ b/cpp/arcticdb/toolbox/library_tool.hpp
@@ -13,6 +13,7 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/storage.hpp>
+#include <arcticdb/entity/read_result.hpp>
 
 #include <memory>
 
@@ -30,6 +31,8 @@ class LibraryTool {
 
 public:
     explicit LibraryTool(std::shared_ptr<storage::Library> lib) : lib_(std::move(lib)) {}
+
+    ReadResult read(const VariantKey& key);
 
     Segment read_to_segment(const VariantKey& key);
 

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -7,12 +7,14 @@
 
 #include <pybind11/functional.h>
 
+#include <arcticdb/python/adapt_read_dataframe.hpp>
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/s3/s3_storage_tool.hpp>
 #include <arcticdb/toolbox/library_tool.hpp>
 #include <arcticdb/util/memory_tracing.hpp>
 #include <arcticdb/version/symbol_list.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
+#include <arcticdb/util/storage_lock.hpp>
 
 namespace arcticdb::toolbox::apy {
 
@@ -35,7 +37,12 @@ void register_bindings(py::module &m) {
             .def("get_key_path", &LibraryTool::get_key_path)
             .def("find_keys_for_id", &LibraryTool::find_keys_for_id)
             .def("clear_ref_keys", &LibraryTool::clear_ref_keys)
-            .def("batch_key_exists", &LibraryTool::batch_key_exists, py::call_guard<SingleThreadMutexHolder>());
+            .def("batch_key_exists", &LibraryTool::batch_key_exists, py::call_guard<SingleThreadMutexHolder>())
+            .def("read_to_read_result",
+             [&](LibraryTool& lt, const VariantKey& key){
+                 return adapt_read_df(lt.read(key));
+             },
+             "Read the most recent dataframe from the store");
 
     // S3 Storage tool
     using namespace arcticdb::storage::s3;

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -99,7 +99,7 @@ struct SharedMemoryAllocator {
         if (!ptr)
             return nullptr;
 
-        allocations_.insert(std::make_pair(ptr, size));
+        allocations_.try_emplace(ptr, size);
         return ptr;
     }
 

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -55,7 +55,7 @@ struct BufferView : public BaseBuffer<BufferView, false> {
 };
 
 struct Buffer : public BaseBuffer<Buffer, true> {
-    void init(size_t size, std::optional<size_t> preamble = std::nullopt) {
+    void init(size_t size, const std::optional<size_t>& preamble = std::nullopt) {
         preamble_bytes_ = preamble.value_or(0);
         ensure(size);
         check_invariants();

--- a/cpp/arcticdb/util/configs_map.hpp
+++ b/cpp/arcticdb/util/configs_map.hpp
@@ -66,13 +66,13 @@ public:
 
     void read_proto(const RuntimeConfig& config) {
         for(auto& val : config.int_values())
-            map_of_int.insert(std::make_pair(boost::to_upper_copy<std::string>(val.first), val.second));
+            map_of_int.try_emplace(boost::to_upper_copy<std::string>(val.first), val.second);
 
         for(auto& val : config.string_values())
-            map_of_string.insert(std::make_pair(boost::to_upper_copy<std::string>(val.first), val.second));
+            map_of_string.try_emplace(boost::to_upper_copy<std::string>(val.first), val.second);
 
         for(auto& val : config.double_values())
-            map_of_double.insert(std::make_pair(boost::to_upper_copy<std::string>(val.first), val.second));
+            map_of_double.try_emplace(boost::to_upper_copy<std::string>(val.first), val.second);
     }
 
      static ConfigsMap from_proto(const RuntimeConfig& config) {

--- a/cpp/arcticdb/util/encoding_conversion.hpp
+++ b/cpp/arcticdb/util/encoding_conversion.hpp
@@ -36,7 +36,7 @@ class PortableEncodingConversion {
     public:
     PortableEncodingConversion(const char*, const char*) { }
 
-        static bool convert(const char* input, size_t input_size, uint8_t* output, size_t& output_size) {
+        static bool convert(const char* input, size_t input_size, uint8_t* output, const size_t& output_size) {
             memset(output, 0, output_size);
             auto pos = output;
             for (auto c = 0u; c < input_size; ++c) {

--- a/cpp/arcticdb/util/hash.hpp
+++ b/cpp/arcticdb/util/hash.hpp
@@ -28,10 +28,7 @@
 namespace arcticdb {
 
 using HashedValue = XXH64_hash_t;
-
-namespace {
 constexpr std::size_t DEFAULT_SEED = 0x42;
-}
 
 template<class T, std::size_t seed = DEFAULT_SEED>
 HashedValue hash(T *d, std::size_t count = 1) {

--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -123,7 +123,7 @@ std::unordered_set<AtomKey> recurse_segment(const std::shared_ptr<stream::Stream
  * If the version_id argument is provided, the returned set will only contain keys matching that version_id. */
 inline std::unordered_set<AtomKey> recurse_index_key(const std::shared_ptr<stream::StreamSource>& store,
                                                      const IndexTypeKey& index_key,
-                                                     std::optional<VersionId> version_id=std::nullopt) {
+                                                     const std::optional<VersionId>& version_id=std::nullopt) {
     auto segment = store->read_sync(index_key).second;
     auto res = recurse_segment(store, segment, version_id);
     res.emplace(index_key);
@@ -132,7 +132,7 @@ inline std::unordered_set<AtomKey> recurse_index_key(const std::shared_ptr<strea
 
 inline std::unordered_set<AtomKey> recurse_segment(const std::shared_ptr<stream::StreamSource>& store,
                                                    SegmentInMemory segment,
-                                                   std::optional<VersionId> version_id) {
+                                                   const std::optional<VersionId>& version_id) {
     std::unordered_set<AtomKey> res;
     for (size_t idx = 0; idx < segment.row_count(); idx++) {
         auto key = stream::read_key_row(segment, idx);
@@ -158,10 +158,10 @@ inline VersionId get_next_version_from_key(const AtomKey& prev) {
     return ++version;
 }
 
-inline VersionId get_next_version_from_key(std::optional<AtomKey> maybe_prev) {
+inline VersionId get_next_version_from_key(const std::optional<AtomKey>& maybe_prev) {
     VersionId version = 0;
     if (maybe_prev) {
-       version = get_next_version_from_key(maybe_prev.value());
+       version = get_next_version_from_key(*maybe_prev);
     }
 
     return version;

--- a/cpp/arcticdb/util/magic_num.hpp
+++ b/cpp/arcticdb/util/magic_num.hpp
@@ -16,10 +16,10 @@ namespace arcticdb::util {
 template<char a, char b, char c, char d>
 struct MagicNum {
     static constexpr uint64_t Magic =
-        a << CHAR_BIT * 0 |
-            b << CHAR_BIT * 1 |
-            c << CHAR_BIT * 2 |
-            d << CHAR_BIT * 3;
+        a << (CHAR_BIT * 0) |
+        b << (CHAR_BIT * 1) |
+        c << (CHAR_BIT * 2) |
+        d << (CHAR_BIT * 3);
 
     ~MagicNum() {
         magic_ = ~magic_;

--- a/cpp/arcticdb/util/optional_defaults.hpp
+++ b/cpp/arcticdb/util/optional_defaults.hpp
@@ -11,11 +11,8 @@
 
 namespace arcticdb {
 
-inline bool opt_true(const std::optional<bool> &opt) {
-    return !opt || opt.value();
-}
-
+//TODO remove
 inline bool opt_false(const std::optional<bool> &opt) {
-    return opt && opt.value();
+    return opt && *opt;
 }
 } //namespace

--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -126,7 +126,13 @@ namespace compatibility {
     constexpr auto raise = check<code>.raise;
 }
 
+namespace codec {
+template<ErrorCode code>
+constexpr auto check = util::detail::Check<code, ErrorCategory::CODEC>{};
 
+template<ErrorCode code>
+constexpr auto raise = check<code>.raise;
+}
 
 // TODO Change legacy codes to internal::
 namespace util {

--- a/cpp/arcticdb/util/simple_string_hash.hpp
+++ b/cpp/arcticdb/util/simple_string_hash.hpp
@@ -49,11 +49,11 @@ inline uint32_t murmur3_32(std::string_view str) {
 }
 
 
-inline size_t bucketize(std::string_view name, std::optional<size_t> num_buckets) {
+inline size_t bucketize(std::string_view name, const std::optional<size_t>& num_buckets) {
     auto hash = murmur3_32(name);
-    if (!num_buckets.has_value())
+    if (!num_buckets)
         return hash;
-    return hash % num_buckets.value();
+    return hash % *num_buckets;
 }
 
 }

--- a/cpp/arcticdb/util/string_utils.cpp
+++ b/cpp/arcticdb/util/string_utils.cpp
@@ -50,12 +50,10 @@ std::string safe_decode(const std::string& value) {
         auto curr = value.find(escape_char, pos)  ;
         if(curr == std::string::npos) {
             unescaped << strv_from_pos(value, pos, len - pos);
-            auto test = unescaped.str();
             break;
         }
 
         unescaped << strv_from_pos(value, pos, curr - pos);
-        auto test = unescaped.str();
 
         auto is_escaped = len - curr > 2 && std::isxdigit(value[curr + 1]) != 0 && std::isxdigit(value[curr + 2]) != 0;
         if(is_escaped) {
@@ -63,7 +61,6 @@ std::string safe_decode(const std::string& value) {
             pos = curr + 3;
         }  else {
             unescaped << escape_char;
-            test = unescaped.str();
             pos = curr + 1;
         }
 

--- a/cpp/arcticdb/util/string_utils.hpp
+++ b/cpp/arcticdb/util/string_utils.hpp
@@ -60,7 +60,7 @@ inline std::vector<std::string_view> split_to_vector(std::string_view strv, char
     while (first != strv.end()) {
         const auto second = std::find(first, last, delim);
         if (first != second)
-            output.push_back(strv.substr(std::distance(strv.begin(), first), std::distance(first, second)));
+            output.emplace_back(strv.substr(std::distance(strv.begin(), first), std::distance(first, second)));
 
         if (second == strv.end())
             break;

--- a/cpp/arcticdb/util/test/config_common.hpp
+++ b/cpp/arcticdb/util/test/config_common.hpp
@@ -28,11 +28,11 @@ inline auto get_test_environment_config(
     cfg.set_path("./"); //TODO local path is a bit annoying. TMPDIR?
     cfg.set_recreate_if_exists(true);
     util::pack_to_any(cfg, *storage_conf.mutable_config());
-    mem_config.storages_.insert(std::make_pair(storage_name, storage_conf));
+    mem_config.storages_.try_emplace(storage_name, storage_conf);
 
     arcticdb::proto::storage::LibraryDescriptor library_descriptor;
     library_descriptor.add_storage_ids(storage_name.value);
-    mem_config.libraries_.insert(std::make_pair(path, library_descriptor));
+    mem_config.libraries_.try_emplace(path, library_descriptor);
 
     std::vector <std::pair<std::string, MemoryConfig>> output;
     output.emplace_back(environment_name.value, mem_config);

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -325,9 +325,8 @@ struct SegmentToInputFrameAdapter {
             }
         }
 
-        while (col < segment_.num_columns()) {
-            input_frame_.field_tensors.push_back(tensor_from_column(segment_.column(col++)));
-        }
+        while (col < segment_.num_columns())
+            input_frame_.field_tensors.emplace_back(tensor_from_column(segment_.column(col++)));
 
         input_frame_.set_index_range();
     }
@@ -337,7 +336,7 @@ struct SegmentToInputFrameAdapter {
             auto segment_tsd = segment_.index_descriptor();
             input_frame_.norm_meta.CopyFrom(segment_tsd.proto().normalization());
         }
-        ensure_norm_meta(input_frame_.norm_meta, input_frame_.desc.id(), false);
+        ensure_timeseries_norm_meta(input_frame_.norm_meta, input_frame_.desc.id(), false);
     }
 
 };

--- a/cpp/arcticdb/util/test/rapidcheck_generators.hpp
+++ b/cpp/arcticdb/util/test/rapidcheck_generators.hpp
@@ -150,7 +150,7 @@ folly::Future<arcticdb::entity::VariantKey> write_frame_data(const TestDataFrame
     return writer.commit();
 }
 
-inline folly::Future<arcticdb::entity::VariantKey> write_test_frame(StreamId stream_id,
+inline folly::Future<arcticdb::entity::VariantKey> write_test_frame(const StreamId& stream_id,
                                                                 const TestDataFrame &data_frame,
                                                                 std::shared_ptr<StreamSink> store) {
     auto schema = schema_from_test_frame(data_frame, stream_id);
@@ -182,13 +182,13 @@ bool check_read_frame(const TestDataFrame &data_frame, ReaderType &reader, std::
                 arcticdb::entity::DataType
                     stored_dt = row_ref.segment().column_descriptor(col + 1).type().data_type();
                 if (dt != stored_dt) {
-                    errors.push_back(fmt::format("Type mismatch {} != {} at pos {}:{}", dt, stored_dt, col, row));
+                    errors.emplace_back(fmt::format("Type mismatch {} != {} at pos {}:{}", dt, stored_dt, col, row));
                     success = false;
                 }
                 auto dimension = static_cast<uint64_t>(TypeDescriptor(type_desc_tag).dimension());
                 auto stored_dimension = row_ref.segment().column_descriptor(col + 1).type().dimension();
                 if (dimension != static_cast<uint64_t>(stored_dimension)) {
-                    errors.push_back(fmt::format("Dimension mismatch {} != {} at pos {}:{}",
+                    errors.emplace_back(fmt::format("Dimension mismatch {} != {} at pos {}:{}",
                                                  dimension,
                                                  stored_dimension,
                                                  col,

--- a/cpp/arcticdb/util/test/rapidcheck_string_pool.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_string_pool.cpp
@@ -18,7 +18,7 @@ RC_GTEST_PROP(StringPool, WriteAndRead, (const std::map<size_t, std::string> &in
     StringPool pool;
     std::unordered_map<size_t, OffsetString> strings;
     for (auto &item : input) {
-        strings.insert(std::make_pair(item.first, pool.get(item.second)));
+        strings.try_emplace(item.first, pool.get(item.second));
     }
 
     for (auto &stored : strings) {

--- a/cpp/arcticdb/util/test/test_hash.cpp
+++ b/cpp/arcticdb/util/test/test_hash.cpp
@@ -34,7 +34,6 @@ TEST(HashComm, Commutative) {
     using namespace arcticdb;
     using namespace folly::hash;
 
-    std::vector<int> v = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     auto h = commutative_hash_combine(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
     EXPECT_EQ(h, commutative_hash_combine(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));

--- a/cpp/arcticdb/util/test/test_slab_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_slab_allocator.cpp
@@ -198,7 +198,7 @@ TEST(SlabAlloc, MultipleThreads) {
         ASSERT_EQ(mc.get_approx_free_blocks(), cap);
         std::vector<std::future<std::vector<SlabAllocType::pointer>>> res;
         for (size_t i = 0; i < num_thds; i++) {
-            res.push_back(std::async(std::launch::async, perform_allocations, std::ref(mc), cap / num_thds));
+            res.emplace_back(std::async(std::launch::async, perform_allocations, std::ref(mc), cap / num_thds));
         }
 
         for (size_t i = 0; i < num_thds; i++) {
@@ -218,11 +218,11 @@ TEST(SlabAlloc, Callbacks) {
     mc.add_cb_when_full([&cb_called](){cb_called.fetch_add(1);});
     std::vector<std::future<std::vector<SlabAllocType::pointer>>> res;
     for (size_t i = 0; i < num_thds; i++) {
-        res.push_back(std::async(std::launch::async, perform_allocations, std::ref(mc), cap / num_thds));
+        res.emplace_back(std::async(std::launch::async, perform_allocations, std::ref(mc), cap / num_thds));
     }
     std::vector<std::vector<SlabAllocType::pointer>> res2;
     for (size_t i = 0; i < num_thds; i++) {
-        res2.push_back(res[i].get());
+        res2.emplace_back(res[i].get());
     }
     ASSERT_EQ(mc.get_approx_free_blocks(), 0);
     for (size_t i = 0; i < num_thds; i++) {

--- a/cpp/arcticdb/util/test/test_storage_lock.cpp
+++ b/cpp/arcticdb/util/test/test_storage_lock.cpp
@@ -131,7 +131,7 @@ struct PessimisticLockTask {
         for (auto i = size_t(0); i < data_->num_tests_; ++i) {
             try {
                 if(timeout_ms_)
-                    lock.lock_timeout(data_->store_, timeout_ms_.value());
+                    lock.lock_timeout(data_->store_, *timeout_ms_);
                 else
                     lock.lock(data_->store_);
 
@@ -202,7 +202,6 @@ TEST(StorageLock, Wait) {
 TEST(StorageLock, Timeouts) {
     SKIP_MAC("StorageLock is not supported");
     using namespace arcticdb;
-    std::unordered_map<std::string, spdlog::level::level_enum> log_levels{ {"lock", spdlog::level::debug}};
 
     auto lock_data = std::make_shared<LockData>(4);
     folly::FutureExecutor<folly::CPUThreadPoolExecutor> exec{4};
@@ -218,7 +217,6 @@ TEST(StorageLock, Timeouts) {
 TEST(StorageLock, ForceReleaseLock) {
     SKIP_MAC("StorageLock is not supported");
     using namespace arcticdb;
-    std::unordered_map<std::string, spdlog::level::level_enum> log_levels{ {"lock", spdlog::level::debug}};
 
     auto lock_data = std::make_shared<LockData>(4);
     folly::FutureExecutor<folly::CPUThreadPoolExecutor> exec{4};

--- a/cpp/arcticdb/util/test/test_string_pool.cpp
+++ b/cpp/arcticdb/util/test/test_string_pool.cpp
@@ -32,7 +32,7 @@ TEST(StringPool, MultipleReadWrite) {
         if ((it = positions.find(s)) != positions.end())
             ASSERT_EQ(str.offset(), it->second);
         else
-            positions.insert(std::make_pair(s, str.offset()));
+            positions.try_emplace(s, str.offset());
     }
 
     const size_t NumTests = 100;

--- a/cpp/arcticdb/util/test/test_tracing_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_tracing_allocator.cpp
@@ -15,9 +15,9 @@ TEST(Allocator, Tracing) {
     std::vector<std::pair<uint8_t*, arcticdb::entity::timestamp>> blocks;
 
     ASSERT_EQ(AllocType::allocated_bytes(), 0);
-    blocks.push_back(AllocType::alloc(10));
+    blocks.emplace_back(AllocType::alloc(10));
     ASSERT_EQ(AllocType::allocated_bytes(), 10);
-    blocks.push_back(AllocType::alloc(10));
+    blocks.emplace_back(AllocType::alloc(10));
     ASSERT_EQ(AllocType::allocated_bytes(), 20);
 
     auto last = *blocks.rbegin();
@@ -25,7 +25,7 @@ TEST(Allocator, Tracing) {
     ASSERT_EQ(AllocType::allocated_bytes(), 10);
     blocks.pop_back();
 
-    blocks.push_back(AllocType::alloc(30));
+    blocks.emplace_back(AllocType::alloc(30));
     ASSERT_EQ(AllocType::allocated_bytes(), 40);
 
     auto new_ptr = AllocType::realloc(blocks[0], 100);

--- a/cpp/arcticdb/util/test/test_utils.hpp
+++ b/cpp/arcticdb/util/test/test_utils.hpp
@@ -143,7 +143,7 @@ struct TestRow {
         values_() {
         std::iota(std::begin(starts_), std::end(starts_), start_val);
         for (auto &s : starts_)
-            values_.push_back(TestValue<TDT>{s, num_vals});
+            values_.emplace_back(TestValue<TDT>{s, num_vals});
         auto prev_size = bitset_.size();
         bitset_.resize(num_columns + 1);
         bitset_.set_range(prev_size, bitset_.size() - 1, true);

--- a/cpp/arcticdb/util/timer.hpp
+++ b/cpp/arcticdb/util/timer.hpp
@@ -119,7 +119,7 @@ public:
 
     ~interval_timer() {
         for (const auto &current : intervals_) {
-            if (current.second != NULL)
+            if (current.second != nullptr)
                 delete (current.second);
         }
     }
@@ -128,7 +128,7 @@ public:
         auto it = intervals_.find(name);
         if (it == intervals_.end()) {
             auto created = new interval();
-            intervals_.insert(interval_type(name, created));
+            intervals_.try_emplace(name, created);
             created->start();
         } else
             (*it).second->start();

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -175,26 +175,25 @@ std::set<StreamId> LocalVersionedEngine::list_streams_internal(
     std::optional<SnapshotId> snap_name,
     const std::optional<std::string>& regex,
     const std::optional<std::string>& prefix,
-    const std::optional<bool>& opt_use_symbol_list,
-    const std::optional<bool>& opt_all_symbols
+    const std::optional<bool>& use_symbol_list,
+    const std::optional<bool>& all_symbols
     ) {
     ARCTICDB_SAMPLE(ListStreamsInternal, 0)
     auto res = std::set<StreamId>();
-    bool use_symbol_list = opt_use_symbol_list.value_or(cfg().symbol_list());
 
     if (snap_name) {
-        res = list_streams_in_snapshot(store(), snap_name.value());
+        res = list_streams_in_snapshot(store(), *snap_name);
     } else {
-        if(use_symbol_list)
+        if(use_symbol_list.value_or(cfg().symbol_list()))
             res = symbol_list().get_symbol_set(store());
         else
-            res = list_streams(store(), version_map(), prefix, opt_false(opt_all_symbols));
+            res = list_streams(store(), version_map(), prefix, all_symbols.value_or(false));
     }
 
     if (regex) {
         return filter_by_regex(res, regex);
     } else if (prefix) {
-        return filter_by_regex(res, std::optional("^" + prefix.value()));
+        return filter_by_regex(res, std::optional("^" + *prefix));
     }
     return res;
 }
@@ -212,7 +211,7 @@ std::optional<VersionedItem> LocalVersionedEngine::get_latest_version(
         ARCTICDB_DEBUG(log::version(), "get_latest_version didn't find version for stream_id: {}", stream_id);
         return std::nullopt;
     }
-    return VersionedItem{std::move(key.value())};
+    return VersionedItem{std::move(*key)};
 }
 
 std::optional<VersionedItem> LocalVersionedEngine::get_specific_version(
@@ -278,7 +277,7 @@ std::optional<VersionedItem> LocalVersionedEngine::get_version_at_time(
         return std::nullopt;
     }
 
-    return VersionedItem(std::move(index_key.value()));
+    return VersionedItem(std::move(*index_key));
 }
 
 std::optional<VersionedItem> LocalVersionedEngine::get_version_from_snapshot(
@@ -291,7 +290,7 @@ std::optional<VersionedItem> LocalVersionedEngine::get_version_from_snapshot(
     }
     // A snapshot will normally be in a ref key, but for old libraries it still needs to fall back to iteration of
     // atom keys.
-    auto segment = opt_snapshot.value().second;
+    auto segment = opt_snapshot->second;
     for (size_t idx = 0; idx < segment.row_count(); idx++) {
         auto stream_index = read_key_row(segment, static_cast<ssize_t>(idx));
         if (stream_index.id() == stream_id) {
@@ -331,7 +330,7 @@ IndexRange LocalVersionedEngine::get_index_range(
     if(!version)
         return unspecified_range();
 
-    return index::get_index_segment_range(version.value().key_, store());
+    return index::get_index_segment_range(version->key_, store());
 }
 
 ReadVersionOutput LocalVersionedEngine::read_dataframe_version_internal(
@@ -351,7 +350,7 @@ ReadVersionOutput LocalVersionedEngine::read_dataframe_version_internal(
         }
     }
     else  {
-        identifier = version.value();
+        identifier = *version;
     }
 
     auto frame_and_descriptor = read_dataframe_internal(identifier, read_query, read_options);
@@ -359,7 +358,8 @@ ReadVersionOutput LocalVersionedEngine::read_dataframe_version_internal(
 }
 
 folly::Future<DescriptorItem> LocalVersionedEngine::get_descriptor(
-    AtomKey&& key){
+    AtomKey&& k){
+    const auto key = std::move(k);
     return store()->read(key)
     .thenValue([](auto&& key_seg_pair) -> DescriptorItem {
         auto key_seg = std::move(std::get<0>(key_seg_pair));
@@ -378,7 +378,7 @@ folly::Future<DescriptorItem> LocalVersionedEngine::get_descriptor(
                     const auto row_count = block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i) {
                         auto value = *ptr++;
-                        start_index = start_index.has_value() ? std::min(start_index.value(), value) : value; 
+                        start_index = start_index.has_value() ? std::min(*start_index, value) : value;
                     }
                 }
                 return start_index;
@@ -400,7 +400,7 @@ folly::Future<DescriptorItem> LocalVersionedEngine::get_descriptor(
                     const auto row_count = block.value().row_count();
                     for (auto i = 0u; i < row_count; ++i) {
                         auto value = *ptr++;
-                        end_index = end_index.has_value() ? std::max(end_index.value(), value) : value; 
+                        end_index = end_index.has_value() ? std::max(*end_index, value) : value;
                     }
                 }
                 return end_index;
@@ -448,7 +448,7 @@ std::vector<std::variant<DescriptorItem, DataError>> LocalVersionedEngine::batch
     auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
     std::vector<folly::Future<DescriptorItem>> descriptor_futures;
     for (auto&& [idx, version_fut]: folly::enumerate(version_futures)) {
-        descriptor_futures.push_back(
+        descriptor_futures.emplace_back(
             get_descriptor_async(std::move(version_fut), stream_ids[idx], version_queries[idx]));
     }
     auto descriptors = folly::collectAll(descriptor_futures).get();
@@ -513,8 +513,8 @@ std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
 VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool dynamic_schema) {
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
-    auto version_id = get_next_version_from_key(maybe_prev.value());
-    auto [index_segment_reader, slice_and_keys] = index::read_index_to_vector(store(), maybe_prev.value());
+    auto version_id = get_next_version_from_key(*maybe_prev);
+    auto [index_segment_reader, slice_and_keys] = index::read_index_to_vector(store(), *maybe_prev);
     if(dynamic_schema) {
         std::sort(std::begin(slice_and_keys), std::end(slice_and_keys), [](const auto &left, const auto &right) {
             return left.key().start_index() < right.key().start_index();
@@ -531,11 +531,12 @@ VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool d
 
     auto index = index_type_from_descriptor(index_segment_reader.tsd().as_stream_descriptor());
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
+    auto& tsd = index_segment_reader.mutable_tsd();
     auto time_series = make_timeseries_descriptor(
         total_rows,
-        StreamDescriptor{index_segment_reader.mutable_tsd().as_stream_descriptor()},
-        std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_normalization()),
-        std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_user_meta()),
+        StreamDescriptor{tsd.as_stream_descriptor()},
+        std::move(*tsd.mutable_proto().mutable_normalization()),
+        std::move(*tsd.mutable_proto().mutable_user_meta()),
         std::nullopt,
         std::nullopt,
         bucketize_dynamic);
@@ -553,7 +554,7 @@ VersionedItem LocalVersionedEngine::delete_range_internal(
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto versioned_item = delete_range_impl(store(),
-                                            maybe_prev.value(),
+                                            *maybe_prev,
                                             query,
                                             get_write_options(),
                                             dynamic_schema);
@@ -598,7 +599,7 @@ VersionedItem LocalVersionedEngine::update_internal(
                                                         true);
 
             if(cfg_.symbol_list())
-                symbol_list().add_symbol(store_, stream_id);
+                symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
 
             version_map()->write_version(store(), versioned_item.key_);
             return versioned_item;
@@ -632,7 +633,7 @@ VersionedItem LocalVersionedEngine::write_versioned_metadata_internal(
         frame.user_meta = std::move(user_meta);
         auto versioned_item = write_versioned_dataframe_internal(stream_id, std::move(frame), prune_previous_versions, false, false);
         if(cfg_.symbol_list())
-            symbol_list().add_symbol(store_, stream_id);
+            symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
         return versioned_item;
     }
 }
@@ -650,7 +651,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     for (const auto&& [idx, stream_update_info_fut] : folly::enumerate(stream_update_info_futures)) {
         write_metadata_versions_futs.push_back(
             std::move(stream_update_info_fut)
-            .thenValue([this, prune_previous_versions, user_meta_proto = std::move(user_meta_protos[idx]), &stream_id = stream_ids[idx]](auto&& update_info) mutable -> folly::Future<IndexKeyAndUpdateInfo> {
+            .thenValue([this, user_meta_proto = std::move(user_meta_protos[idx]), &stream_id = stream_ids[idx]](auto&& update_info) mutable -> folly::Future<IndexKeyAndUpdateInfo> {
                 auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                 if (update_info.previous_index_key_.has_value()) {
                     index_key_fut = async::submit_io_task(UpdateMetadataTask{store(), update_info, std::move(user_meta_proto)});
@@ -720,6 +721,9 @@ VersionedItem LocalVersionedEngine::write_versioned_dataframe_internal(
         de_dup_map,
         allow_sparse,
         validate_index);
+
+    if(cfg().symbol_list())
+        symbol_list().add_symbol(store(), stream_id, versioned_item.key_.version_id());
 
     write_version_and_prune_previous_if_needed(prune_previous_versions, versioned_item.key_, maybe_prev);
     return versioned_item;
@@ -843,7 +847,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
                     // Check 1)
                     const auto& snaps = snaps_itr->second;
                     auto count_for_snapshot_being_deleted = snapshot_being_deleted ?
-                                                            snaps.count(snapshot_being_deleted.value()) : 0;
+                                                            snaps.count(*snapshot_being_deleted) : 0;
                     if (snaps.size() > count_for_snapshot_being_deleted) {
                         log::version().debug(
                                 "Skipping the deletion of index {}:{} because it exists in another snapshot",
@@ -868,7 +872,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
                         ? LoadParameter{load_type, static_cast<SignedVersionId>(min.second)}
                         : LoadParameter{load_type};
                 const auto entry = version_map()->check_reload(store(), min.first, load_param, __FUNCTION__);
-                entry_map.emplace(std::move(min.first), entry);
+                entry_map.try_emplace(std::move(min.first), entry);
             }
         }
 
@@ -972,14 +976,6 @@ std::set<StreamId> LocalVersionedEngine::get_active_incomplete_refs() {
     return ::arcticdb::get_active_incomplete_refs(store_);
 }
 
-void LocalVersionedEngine::push_incompletes_to_symbol_list(const std::set<StreamId>& incompletes) {
-    auto existing = list_streams_internal(std::nullopt, std::nullopt, std::nullopt, cfg().symbol_list(), false);
-    for(const auto& incomplete : incompletes) {
-        if(existing.find(incomplete) == existing.end())
-            symbol_list().add_symbol(store_, incomplete);
-    }
-}
-
 void LocalVersionedEngine::append_incomplete_frame(
     const StreamId& stream_id,
     InputTensorFrame&& frame) const {
@@ -1017,7 +1013,7 @@ VersionedItem LocalVersionedEngine::compact_incomplete_dynamic(
         prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
 
     if(cfg_.symbol_list())
-        symbol_list().add_symbol(store_, stream_id);
+        symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
 
     return versioned_item;
 }
@@ -1039,12 +1035,12 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& strea
 
     auto versioned_item = defragment_symbol_data_impl(
             store(), stream_id, update_info, get_write_options(),
-            segment_size.has_value() ? segment_size.value() : cfg_.write_options().segment_row_size());
+            segment_size.has_value() ? *segment_size : cfg_.write_options().segment_row_size());
 
     version_map_->write_version(store_, versioned_item.key_);
 
     if(cfg_.symbol_list())
-        symbol_list().add_symbol(store_, stream_id);
+        symbol_list().add_symbol(store_, stream_id, versioned_item.key_.version_id());
     
     return versioned_item;
 }
@@ -1096,7 +1092,7 @@ std::vector<ReadVersionOutput> LocalVersionedEngine::batch_read_keys(
     py::gil_scoped_release release_gil;
     std::vector<folly::Future<std::pair<entity::VariantKey, SegmentInMemory>>> index_futures;
     for (auto &index_key: keys) {
-        index_futures.push_back(store()->read(index_key));
+        index_futures.emplace_back(store()->read(index_key));
     }
     auto indexes = folly::collect(index_futures).get();
 
@@ -1104,7 +1100,7 @@ std::vector<ReadVersionOutput> LocalVersionedEngine::batch_read_keys(
     auto i = 0u;
     util::check(read_queries.empty() || read_queries.size() == keys.size(), "Expected read queries to either be empty or equal to size of keys");
     for (auto&& [index_key, index_segment] : indexes) {
-        results_fut.push_back(async_read_direct(store(), keys[i], std::move(index_segment), read_queries.empty() ? ReadQuery{} : read_queries[i], std::make_shared<BufferHolder>(), read_options));
+        results_fut.emplace_back(async_read_direct(store(), keys[i], std::move(index_segment), read_queries.empty() ? ReadQuery{} : read_queries[i], std::make_shared<BufferHolder>(), read_options));
         ++i;
     }
     Allocator::instance()->trim();
@@ -1132,7 +1128,7 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::te
             .thenValue([store = store(), read_query, read_options](auto&& key_segment_pair) {
                 auto [index_key, index_segment] = std::move(key_segment_pair);
                 return async_read_direct(store,
-                                         std::move(index_key),
+                                         index_key,
                                          std::move(index_segment),
                                          read_query,
                                          std::make_shared<BufferHolder>(),
@@ -1285,8 +1281,8 @@ folly::Future<VersionedItem> LocalVersionedEngine::write_index_key_to_version_ma
 
     if(add_new_symbol){
         write_version_fut = std::move(write_version_fut)
-        .then([this, index_key_id = index_key.id()](auto &&) {
-            return async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), index_key_id));
+        .then([this, index_key_id = index_key.id(), reference_id = index_key.version_id()](auto &&) {
+            return async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), index_key_id, reference_id));
         });
     }
     return std::move(write_version_fut)
@@ -1296,7 +1292,7 @@ folly::Future<VersionedItem> LocalVersionedEngine::write_index_key_to_version_ma
 }
 
 std::vector<folly::Future<AtomKey>> LocalVersionedEngine::batch_write_internal(
-    std::vector<VersionId> version_ids,
+    const std::vector<VersionId>& version_ids,
     const std::vector<StreamId>& stream_ids,
     std::vector<InputTensorFrame>&& frames,
     std::vector<std::shared_ptr<DeDupMap>> de_dup_maps,
@@ -1306,7 +1302,7 @@ std::vector<folly::Future<AtomKey>> LocalVersionedEngine::batch_write_internal(
     ARCTICDB_DEBUG(log::version(), "Batch writing {} dataframes", stream_ids.size());
     std::vector<folly::Future<entity::AtomKey>> results_fut;
     for (size_t idx = 0; idx < stream_ids.size(); idx++) {
-        results_fut.push_back(async_write_dataframe_impl(
+        results_fut.emplace_back(async_write_dataframe_impl(
             store(),
             version_ids[idx],
             std::move(frames[idx]),
@@ -1432,7 +1428,7 @@ VersionedItem LocalVersionedEngine::append_internal(
                                                         );
 
             if(cfg_.symbol_list())
-                symbol_list().add_symbol(store_, stream_id);
+                symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
 
             version_map()->write_version(store(), versioned_item.key_);
             return versioned_item;
@@ -1573,7 +1569,7 @@ std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> LocalVersionedEngine
 
     std::vector<folly::Future<folly::Unit>> symbol_write_futs;
     for(const auto& item : output) {
-        symbol_write_futs.emplace_back(async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.first.key_.id())));
+        symbol_write_futs.emplace_back(async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.first.key_.id(), item.first.key_.version_id())));
     }
     folly::collect(symbol_write_futs).wait();
     return output;
@@ -1660,7 +1656,7 @@ std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::A
     auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
     std::vector<folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>>> metadata_futures;
     for (auto&& [idx, version]: folly::enumerate(version_futures)) {
-        metadata_futures.push_back(get_metadata_async(std::move(version), stream_ids[idx], version_queries[idx]));
+        metadata_futures.emplace_back(get_metadata_async(std::move(version), stream_ids[idx], version_queries[idx]));
     }
 
     auto metadatas = folly::collectAll(metadata_futures).get();
@@ -1752,10 +1748,10 @@ void LocalVersionedEngine::configure(const storage::LibraryDescriptor::VariantSt
 
 timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
     if(auto latest_incomplete = latest_incomplete_timestamp(store(), symbol); latest_incomplete)
-        return latest_incomplete.value();
+        return *latest_incomplete;
 
     if(auto latest_key = get_latest_version(symbol, VersionQuery{}, ReadOptions{}); latest_key)
-        return latest_key.value().key_.end_time();
+        return latest_key->key_.end_time();
 
     return -1;
 }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -252,8 +252,6 @@ public:
     std::set<StreamId> get_incomplete_refs() override;
     std::set<StreamId> get_active_incomplete_refs() override;
 
-    void push_incompletes_to_symbol_list(const std::set<StreamId>& incompletes) override;
-
     void flush_version_map() override;
 
     VersionedItem sort_merge_internal(
@@ -266,7 +264,7 @@ public:
         );
 
     std::vector<folly::Future<AtomKey>> batch_write_internal(
-        std::vector<VersionId> version_ids,
+        const std::vector<VersionId>& version_ids,
         const std::vector<StreamId>& stream_ids,
         std::vector<InputTensorFrame>&& frames,
         std::vector<std::shared_ptr<DeDupMap>> de_dup_maps,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -580,14 +580,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::call_guard<SingleThreadMutexHolder>(), "Restore a previous version of a symbol.")
         .def("check_ref_key",
              &PythonVersionStore::check_ref_key,
-<<<<<<< HEAD
              py::call_guard<SingleThreadMutexHolder>(), "Fix reference keys.")
-=======
-             "Fix reference keys.")
-        .def("indexes_sorted",
-             &PythonVersionStore::indexes_sorted,
-             "Assert indexes are sorted.")
->>>>>>> 6ea4115 (Refactor symbol list to used observed version ids)
         .def("dump_versions",
              &PythonVersionStore::dump_versions,
              py::call_guard<SingleThreadMutexHolder>(), "Dump version data.")

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -69,7 +69,7 @@ void iterate_snapshots(std::shared_ptr <Store> store, folly::Function<void(entit
 std::optional<size_t> row_id_for_stream_in_snapshot_segment(
     SegmentInMemory &seg,
     bool using_ref_key,
-    StreamId stream_id);
+    const StreamId& stream_id);
 
 // Get a set of the index keys of a particular symbol that exist in any snapshot
 std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(
@@ -97,7 +97,7 @@ std::optional<std::pair<VariantKey, SegmentInMemory>> get_snapshot(
 
 std::set<StreamId> list_streams_in_snapshot(
     const std::shared_ptr<Store>& store,
-    SnapshotId snap_name);
+    const SnapshotId& snap_name);
 
 using SnapshotMap = std::unordered_map<SnapshotId, std::vector<AtomKey>>;
 

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -6,292 +6,745 @@
  */
 
 #include <arcticdb/version/symbol_list.hpp>
+#include <arcticdb/version/version_map_batch_methods.hpp>
+#include <arcticdb/entity/atom_key.hpp>
+#include <arcticdb/entity/ref_key.hpp>
+#include <arcticdb/util/variant.hpp>
+#include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/storage_lock.hpp>
+#include <arcticdb/util/key_utils.hpp>
+#include <arcticdb/storage/storage_exceptions.hpp>
+#include <arcticdb/version/version_map.hpp>
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/storage/store.hpp>
+#include <arcticdb/stream/merge_utils.hpp>
 
 namespace arcticdb {
 
 using namespace arcticdb::stream;
 
-static const StreamId compaction_id {CompactionId};
+static const StreamId compaction_id{StringId{CompactionId}};
 
-struct SymbolList::LoadResult {
-    mutable KeyVector symbol_list_keys;
-    /** The last CompactionId key in symbol_list_keys, if any. */
-    std::optional<KeyVectorItr> maybe_last_compaction;
-    mutable CollectionType symbols;
-    arcticdb::timestamp timestamp;
+using MapType =  std::unordered_map<StreamId, std::vector<SymbolEntryData>>;
+using Compaction = std::vector<AtomKey>::const_iterator;
+using MaybeCompaction = std::optional<Compaction>;
+using CollectionType = std::vector<SymbolListEntry>;
 
-    KeyVector&& detach_symbol_list_keys() const { return std::move(symbol_list_keys); }
-    CollectionType&& detach_symbols() const { return std::move(symbols); }
+constexpr std::string_view version_string = "_v2_";
+constexpr NumericIndex version_identifier = std::numeric_limits<NumericIndex>::max();
+
+SymbolListData::SymbolListData(std::shared_ptr<VersionMap> version_map, entity::StreamId type_indicator) :
+    type_holder_(std::move(type_indicator)),
+    max_delta_(ConfigsMap::instance()->get_int("SymbolList.MaxDelta", 500)),
+    version_map_(std::move(version_map)){
+}
+
+struct LoadResult {
+    std::vector<AtomKey> symbol_list_keys_;
+    MaybeCompaction maybe_previous_compaction;
+    CollectionType symbols_;
+    timestamp timestamp_ = 0L;
+
+    std::vector<AtomKey>&& detach_symbol_list_keys() { return std::move(symbol_list_keys_); }
 };
 
-SymbolList::LoadResult SymbolList::attempt_load(const std::shared_ptr<Store>& store) {
-    SYMBOL_LIST_RUNTIME_LOG("Symbol list load attempt");
-    LoadResult load_result;
-    load_result.symbol_list_keys = get_all_symbol_list_keys(store);
-    load_result.maybe_last_compaction = last_compaction(load_result.symbol_list_keys);
+std::vector<SymbolListEntry> load_previous_from_version_keys(
+        const std::shared_ptr<Store>& store,
+        SymbolListData& data) {
+    std::vector<StreamId> stream_ids;
+    store->iterate_type(KeyType::VERSION_REF, [&data, &stream_ids] (const auto& key) {
+        auto id = variant_key_id(key);
+        stream_ids.push_back(id);
 
-    if (load_result.maybe_last_compaction) {
-        load_result.timestamp = load_result.symbol_list_keys.rbegin()->creation_ts();
-        load_result.symbols = load_from_symbol_list_keys(store,
-                {*load_result.maybe_last_compaction, load_result.symbol_list_keys.cend()});
-    } else {
-        load_result.timestamp = store->current_timestamp();
-        load_result.symbols = load_from_version_keys(store);
+        if (stream_ids.size() == data.max_delta_ * 2 && !data.warned_expected_slowdown_) {
+            log::symbol().warn(
+                "No compacted symbol list cache found. "
+                "`list_symbols` may take longer than expected. \n\n"
+                "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
+                "To resolve, run `list_symbols` through to completion to compact the symbol list cache.\n"
+                "Note: This warning will only appear once.\n");
+
+            data.warned_expected_slowdown_ = true;
+        }
+    });
+    auto res = folly::collect(batch_get_latest_undeleted_and_latest_versions_async(store, data.version_map_, stream_ids)).get();
+
+    std::vector<SymbolListEntry> symbols;
+    for(auto&& [idx, opt_key_pair]: folly::enumerate(res)) {
+        const auto& [maybe_undeleted, _]  = opt_key_pair;
+        if(maybe_undeleted) {
+            const auto version_id = maybe_undeleted->version_id();
+            const auto timestamp = maybe_undeleted->creation_ts();
+            symbols.emplace_back(stream_ids[idx], version_id, timestamp, ActionType::ADD);
+        }
     }
+
+    data.version_map_->flush();
+    return symbols;
+}
+
+std::vector<AtomKey> get_all_symbol_list_keys(
+        const std::shared_ptr<StreamSource>& store,
+        SymbolListData& data) {
+    std::vector<AtomKey> output;
+    uint64_t uncompacted_keys_found = 0;
+    store->iterate_type(KeyType::SYMBOL_LIST, [&data, &output, &uncompacted_keys_found] (auto&& key) {
+        auto atom_key = to_atom(std::forward<decltype(key)>(key));
+        if(atom_key.id() != compaction_id) {
+            uncompacted_keys_found++;
+        }
+        if (uncompacted_keys_found == data.max_delta_ * 2 && !data.warned_expected_slowdown_) {
+            log::symbol().warn(
+                "`list_symbols` may take longer than expected as there have been many modifications since `list_symbols` was last called. \n\n"
+                "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
+                "To resolve, run `list_symbols` through to completion frequently.\n"
+                "Note: This warning will only appear once.\n");
+
+            data.warned_expected_slowdown_ = true;
+        }
+
+        output.push_back(atom_key);
+    });
+
+    std::sort(output.begin(), output.end(), [] (const AtomKey& left, const AtomKey& right) {
+        return std::tie(left.start_index(), left.version_id(), left.creation_ts()) < std::tie(right.start_index(), right.version_id(), right.creation_ts());
+    });
+    return output;
+}
+
+MaybeCompaction last_compaction(const std::vector<AtomKey>& keys) {
+    auto pos = std::find_if(keys.rbegin(), keys.rend(), [] (const auto& key) {
+        return key.id() == compaction_id;
+    }) ;
+
+    if (pos == keys.rend()) {
+        return std::nullopt;
+    } else {
+        return { (pos + 1).base() }; // reverse_iterator -> forward itr has an offset of 1 per docs
+    }
+}
+
+StreamId stream_id_from_segment(
+        DataType data_type,
+        const SegmentInMemory& seg,
+        position_t row_id,
+        position_t column) {
+    if (data_type == DataType::UINT64) {
+            auto num_id = seg.scalar_at<uint64_t>(row_id, column).value();
+            ARCTICDB_DEBUG(log::symbol(), "Reading numeric symbol {}", num_id);
+            return safe_convert_to_numeric_id(num_id);
+    } else {
+        auto sym = std::string(seg.string_at(row_id, column).value());
+        ARCTICDB_DEBUG(log::symbol(), "Reading string symbol '{}'", sym);
+        return {std::move(sym)};
+    }
+}
+
+DataType get_symbol_data_type(const SegmentInMemory& seg) {
+    const auto& field_desc = seg.descriptor().field(0);
+    auto data_type =  field_desc.type().data_type();
+
+    missing_data::check<ErrorCode::E_UNREADABLE_SYMBOL_LIST>(data_type== DataType::UINT64 || data_type == DataType::ASCII_DYNAMIC64,
+        "The symbol list contains unsupported symbol type: {}", data_type);
+
+    return data_type;
+}
+
+std::vector<SymbolListEntry> read_old_style_list_from_storage(const SegmentInMemory& seg) {
+    std::vector<SymbolListEntry> output;
+    if(seg.empty())
+        return output;
+
+    const auto data_type = get_symbol_data_type(seg);
+
+    for(auto row : seg)
+        output.emplace_back(stream_id_from_segment(data_type, seg, row.row_id_, 0), 0, 0, ActionType::ADD);
+
+    return output;
+}
+
+std::vector<SymbolListEntry> read_new_style_list_from_storage(const SegmentInMemory& seg) {
+    std::vector<SymbolListEntry> output;
+    if(seg.row_count() == 0)
+        return output;
+
+    const auto data_type = get_symbol_data_type(seg);
+
+    // Because we need to be backwards compatible with the old style symbol list, the additions and deletions are
+    // in separate columns. The first three columns are the symbol, version and timestamp for the additions, and the
+    // next three are the same for the deletions. Old-style symbol lists will ignore everything but the first column
+    // which will mean that they can't do any conflict resolution but will get the correct data.
+    util::check(seg.column(0).row_count() == seg.column(1).row_count() && seg.column(0).row_count() == seg.column(2).row_count(),
+                "Column mismatch in symbol segment additions: {} {} {}", seg.column(0).row_count(), seg.column(1).row_count(), seg.column(2).row_count());
+
+    for(auto i = 0L; i < seg.column(0).row_count(); ++i) {
+        auto stream_id = stream_id_from_segment(data_type, seg, i, 0);
+        auto reference_id = VersionId{seg.scalar_at<uint64_t>(i, 1).value()};
+        auto reference_time = timestamp{seg.scalar_at<int64_t>(i, 2).value()};
+        ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Reading added symbol {}: {}@{}", stream_id, reference_id, reference_time);
+        output.emplace_back(stream_id, reference_id, reference_time, ActionType::ADD);
+    }
+
+    if(seg.descriptor().field_count() == 6) {
+        util::check(seg.column(3).row_count() == seg.column(4).row_count() && seg.column(3).row_count() == seg.column(5).row_count(),
+                    "Column mismatch in symbol segment deletions: {} {} {}", seg.column(3).row_count(), seg.column(4).row_count(), seg.column(5).row_count());
+
+        for (auto i = 0L; i < seg.column(3).row_count(); ++i) {
+            auto stream_id = stream_id_from_segment(data_type, seg, i, 3);
+            auto reference_id = VersionId{seg.scalar_at<uint64_t>(i, 4).value()};
+            auto reference_time = timestamp{seg.scalar_at<int64_t>(i, 5).value()};
+            ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Reading deleted symbol {}: {}@{}", stream_id, reference_id, reference_time);
+            output.emplace_back(stream_id, reference_id, reference_time, ActionType::DELETE);
+        }
+    }
+
+    return output;
+}
+
+std::vector<SymbolListEntry> read_from_storage(
+        const std::shared_ptr<StreamSource>& store,
+        const AtomKey& key) {
+    ARCTICDB_DEBUG(log::symbol(), "Reading list from storage with key {}", key);
+    auto [_, seg] = store->read_sync(key);
+    if(seg.row_count() == 0)
+        return {};
+
+    missing_data::check<ErrorCode::E_UNREADABLE_SYMBOL_LIST>( seg.descriptor().field_count() > 0,
+                                                              "Expected at least one column in symbol list with key {}", key);
+
+    if(seg.descriptor().field_count() == 1)
+        return read_old_style_list_from_storage(seg);
+    else
+        return read_new_style_list_from_storage(seg);
+}
+
+bool is_new_style_key(const AtomKey& key) {
+    return util::variant_match(key.end_index(),
+    [] (std::string_view str) {
+        return str == version_string;
+    },
+    [] (NumericIndex n) {
+        return n == version_identifier;
+    });
+}
+
+MapType load_journal_keys(const std::vector<AtomKey>& keys) {
+    MapType map;
+    for(const auto& key : keys) {
+        const auto& action_id = key.id();
+        if(action_id == compaction_id)
+            continue;
+
+        const auto& symbol = key.start_index();
+        const auto version_id = is_new_style_key(key) ? key.version_id() : unknown_version_id;
+        const auto timestamp = key.creation_ts();
+        ActionType action = std::get<StringId>(action_id) == DeleteSymbol ? ActionType::DELETE : ActionType::ADD;
+        map[symbol].emplace_back(version_id, timestamp, action);
+    }
+    return map;
+}
+
+auto tail_range(const std::vector<SymbolEntryData>& updated) {
+    auto it = std::crbegin(updated);
+    const auto reference_id = it->reference_id_;
+    auto action = it->action_;
+    bool all_same_action = true;
+    ++it;
+
+    while(it != std::crend(updated) && it->reference_id_ == reference_id) {
+        if(it->action_ != action)
+            all_same_action = false;
+
+        ++it;
+    }
+
+    return std::make_pair(it, all_same_action);
+}
+
+std::optional<SymbolEntryData> timestamps_too_close(
+        const std::vector<SymbolEntryData>::const_reverse_iterator& first,
+        const std::vector<SymbolEntryData>& updated,
+        timestamp min_allowed_interval,
+        bool all_same_action) {
+    if(first == std::crend(updated))
+        return std::nullopt;
+
+    const auto& latest = *updated.rbegin();
+    const bool same_as_updates = all_same_action && latest.action_ == first->action_;
+    const auto diff = latest.timestamp_ - first->timestamp_;
+
+    if(same_as_updates || diff >= min_allowed_interval)
+        return std::nullopt;
+
+    return latest;
+}
+
+bool has_unknown_reference_id(const SymbolEntryData& data) {
+    return data.reference_id_ == unknown_version_id;
+}
+
+bool contains_unknown_reference_ids(const std::vector<SymbolEntryData>& updated) {
+    return std::any_of(std::begin(updated), std::end(updated), [] (const auto& data) {
+        return has_unknown_reference_id(data);
+    });
+}
+
+
+SymbolVectorResult cannot_validate_symbol_vector() {
+    return {ProblematicResult{true}};
+}
+
+SymbolVectorResult vector_has_problem(const SymbolEntryData& data) {
+    return {ProblematicResult{data}};
+}
+
+SymbolVectorResult vector_okay(bool all_same_version, bool all_same_action, size_t latest_id_count) {
+    return {ProblematicResult{false}, all_same_version, all_same_action, latest_id_count};
+}
+
+SymbolVectorResult is_problematic_vector(
+        const std::vector<SymbolEntryData>& updated,
+        timestamp min_allowed_interval) {
+    if(contains_unknown_reference_ids(updated))
+        return cannot_validate_symbol_vector();
+
+    const auto [start, all_same_action] = tail_range(updated);
+    const auto latest_id_count = std::distance(std::crbegin(updated), start);
+    const auto all_same_version = start == std::crend(updated);
+
+    if(auto timestamp_problem = timestamps_too_close(start, updated, min_allowed_interval, all_same_action); timestamp_problem)
+        return vector_has_problem(*timestamp_problem);
+
+    if(latest_id_count <= 2 || all_same_action)
+        return vector_okay(all_same_version, all_same_action, latest_id_count);
+
+    return vector_has_problem(*std::crbegin(updated));
+}
+
+ProblematicResult is_problematic(
+    const std::vector<SymbolEntryData>& updated,
+    timestamp min_allowed_interval) {
+    return is_problematic_vector(updated, min_allowed_interval).problematic_result_;
+}
+
+ProblematicResult is_problematic(
+        const SymbolListEntry& existing,
+        const std::vector<SymbolEntryData>& updated,
+        timestamp min_allowed_interval) {
+    ARCTICDB_DEBUG(log::symbol(), "{} {} {}", existing.stream_id_, static_cast<const SymbolEntryData&>(existing), updated);
+
+    const auto& latest = *std::crbegin(updated);
+    if(existing.reference_id_ > latest.reference_id_)
+        return ProblematicResult{existing};
+
+    auto [problematic_result, vector_all_same_version, vector_all_same_action, last_id_count] = is_problematic_vector(updated, min_allowed_interval);
+    if(problematic_result)
+        return problematic_result;
+
+    if(problematic_result.contains_unknown_reference_ids_ || has_unknown_reference_id(existing))
+        return cannot_determine_validity();
+
+    const bool all_same_action = vector_all_same_action && existing.action_ == latest.action_;
+
+    if(latest.timestamp_ - existing.timestamp_ < min_allowed_interval && !all_same_action)
+        return ProblematicResult{latest.reference_id_ > existing.reference_id_ ? latest : existing};
+
+    if(existing.reference_id_ < latest.reference_id_)
+        return not_a_problem();
+
+
+
+    if(all_same_action)
+        return not_a_problem();
+
+    if(last_id_count == 1)
+        return not_a_problem();
+
+    return ProblematicResult{latest};
+}
+
+CollectionType merge_existing_with_journal_keys(
+        const std::shared_ptr<VersionMap>& version_map,
+        const std::shared_ptr<Store>& store,
+        const std::vector<AtomKey>& keys,
+        std::vector<SymbolListEntry>&& existing) {
+    auto existing_keys = std::move(existing);
+    auto update_map = load_journal_keys(keys);
+
+    CollectionType symbols;
+    std::map<StreamId, std::pair<VersionId, timestamp>> problematic_symbols;
+    const auto min_allowed_interval = ConfigsMap::instance()->get_int("SymbolList.MinIntervalNs", 100'000'000LL);
+
+    for(auto& previous_entry : existing_keys) {
+        const auto& stream_id = previous_entry.stream_id_;
+        auto updated = update_map.find(stream_id);
+        if(updated == std::end(update_map)) {
+            if(previous_entry.action_ == ActionType::ADD)
+                symbols.emplace_back(std::move(previous_entry));
+            else
+                util::check(previous_entry.action_ == ActionType::DELETE, "Unknown action type {} in symbol list", static_cast<uint8_t>(previous_entry.action_));
+        } else {
+            util::check(!updated->second.empty(), "Unexpected empty entry for symbol {}", updated->first);
+            if(auto problematic_entry = is_problematic(previous_entry, updated->second, min_allowed_interval); problematic_entry) {
+                problematic_symbols.try_emplace(stream_id, std::make_pair(problematic_entry.reference_id(), problematic_entry.time()));
+            } else {
+                const auto& last_entry = updated->second.rbegin();
+                symbols.emplace_back(updated->first, last_entry->reference_id_, last_entry->timestamp_, last_entry->action_);
+            }
+            update_map.erase(updated);
+        }
+    }
+
+    for(const auto& [symbol, entries] : update_map) {
+        ARCTICDB_DEBUG(log::symbol(), "{} {}", symbol, entries);
+        if(auto problematic_entry = is_problematic(entries, min_allowed_interval); problematic_entry) {
+            problematic_symbols.try_emplace(symbol, problematic_entry.reference_id(), problematic_entry.time());
+        } else {
+            const auto& last_entry = entries.rbegin();
+            symbols.emplace_back(symbol, last_entry->reference_id_, last_entry->timestamp_, last_entry->action_);
+        }
+    }
+
+    if(!problematic_symbols.empty()) {
+        auto symbol_versions = std::make_shared<std::vector<StreamId>>();
+        for(const auto& [symbol, reference_pair] : problematic_symbols)
+            symbol_versions->emplace_back(symbol);
+
+        auto versions = batch_check_latest_id_and_status(store, version_map, symbol_versions);
+
+        for (const auto& [symbol, reference_pair] : problematic_symbols) {
+            auto reference_id = reference_pair.first;
+
+            if (auto version = versions->find(symbol); version != versions->end()) {
+                const auto& symbol_state = version->second;
+                if(symbol_state.exists_) {
+                    ARCTICDB_DEBUG(log::symbol(), "Problematic symbol/version pair: {}@{}: exists at id {}", symbol, reference_id, symbol_state.version_id_);
+                    symbols.emplace_back(symbol, symbol_state.version_id_, symbol_state.timestamp_, ActionType::ADD);
+                } else {
+                    symbols.emplace_back(symbol, symbol_state.version_id_, symbol_state.timestamp_, ActionType::DELETE);
+                    ARCTICDB_DEBUG(log::symbol(), "Problematic symbol/version pair: {}@{}: deleted at id {}",
+                                   symbol, reference_id, symbol_state.version_id_);
+                }
+            }
+            else {
+                ARCTICDB_DEBUG(log::symbol(), "Problematic symbol/version pair: {}@{}: cannot be found", symbol, reference_id);
+                symbols.emplace_back(symbol, reference_id, reference_pair.second, ActionType::DELETE);
+            }
+        }
+        std::sort(std::begin(symbols), std::end(symbols), [] (const auto& l, const auto& r) {
+            return l.stream_id_ < r.stream_id_;
+        });
+    }
+
+    return symbols;
+}
+
+CollectionType load_from_symbol_list_keys(
+        const std::shared_ptr<VersionMap>& version_map,
+        const std::shared_ptr<Store>& store,
+        const std::vector<AtomKey>& keys,
+        const Compaction& compaction) {
+    ARCTICDB_RUNTIME_DEBUG(log::symbol(),"Loading symbols from symbol list keys");
+
+    auto previous_compaction = read_from_storage(store, *compaction);
+    return merge_existing_with_journal_keys(version_map, store, keys, std::move(previous_compaction));
+}
+
+CollectionType load_from_version_keys(
+        const std::shared_ptr<VersionMap>& version_map,
+        const std::shared_ptr<Store>& store,
+        const std::vector<AtomKey>& keys,
+        SymbolListData& data) {
+    ARCTICDB_RUNTIME_DEBUG(log::symbol(),"Loading symbols from version keys");
+    auto previous_entries = load_previous_from_version_keys(store, data);
+    return merge_existing_with_journal_keys(version_map, store, keys, std::move(previous_entries));
+}
+
+LoadResult attempt_load(
+        const std::shared_ptr<VersionMap>& version_map,
+        const std::shared_ptr<Store>& store,
+        SymbolListData& data) {
+    ARCTICDB_RUNTIME_DEBUG(log::symbol(),"Symbol list load attempt");
+    LoadResult load_result;
+    load_result.symbol_list_keys_ = get_all_symbol_list_keys(store, data);
+    load_result.maybe_previous_compaction = last_compaction(load_result.symbol_list_keys_);
+
+    if (load_result.maybe_previous_compaction)
+        load_result.symbols_ = load_from_symbol_list_keys(version_map, store, load_result.symbol_list_keys_, *load_result.maybe_previous_compaction);
+    else {
+        load_result.symbols_ = load_from_version_keys(version_map, store, load_result.symbol_list_keys_, data);
+        std::unordered_set<StreamId> keys_in_versions;
+        for (const auto &entry : load_result.symbols_)
+            keys_in_versions.emplace(entry.stream_id_);
+
+        for (const auto &key : load_result.symbol_list_keys_)
+            util::check(keys_in_versions.find(StreamId{std::get<StringIndex>(key.start_index())}) != keys_in_versions.end(), "Would delete unseen key {}", key);
+    }
+
+    load_result.timestamp_ = store->current_timestamp();
     return load_result;
 }
 
-SymbolList::CollectionType SymbolList::load(const std::shared_ptr<Store>& store, bool no_compaction) {
-    // TODO: tighten the exception that triggers retry. https://github.com/man-group/ArcticDB/issues/447
-    const LoadResult load_result = ExponentialBackoff<std::runtime_error>(100, 2000)
-            .go([this, &store]() { return attempt_load(store); });
-
-    if (!no_compaction && (load_result.symbol_list_keys.size() > max_delta_ || !load_result.maybe_last_compaction)) {
-        SYMBOL_LIST_RUNTIME_LOG("Compaction necessary. Obtaining lock...");
-        try {
-            if (StorageLock lock{CompactionLockName}; lock.try_lock(store)) {
-                OnExit x([&lock, &store] { lock.unlock(store); });
-
-                SYMBOL_LIST_RUNTIME_LOG("Checking whether we still need to compact under lock");
-                if (can_update_symbol_list(store, load_result.maybe_last_compaction)) {
-                    auto written = write_symbols(store, load_result.symbols, compaction_id, load_result.timestamp).get();
-                    delete_keys(store, load_result.detach_symbol_list_keys(), std::get<AtomKey>(written)).get();
-                }
-            } else {
-                SYMBOL_LIST_RUNTIME_LOG("Not compacting the symbol list due to lock contention");
-            }
-        } catch (const storage::PermissionException& ex) {
-            // Note: this only reflects AN's permission check and is not thrown by the Storage
-            SYMBOL_LIST_RUNTIME_LOG("Not compacting the symbol list due to lack of permission");
-        } catch (const std::exception& ex) {
-            log::version().warn("Ignoring the error while trying to compact the symbol list: {}", ex.what());
-        }
-    }
-
-    return load_result.detach_symbols();
+inline StreamDescriptor journal_stream_descriptor(ActionType action, const StreamId& id) {
+    return util::variant_match(id,
+       [action] (const NumericId&) {
+           return StreamDescriptor{stream_descriptor(action_id(action), RowCountIndex(), { scalar_field(DataType::UINT64, "symbol") })};
+       },
+       [action] (const StringId&) {
+           return StreamDescriptor{stream_descriptor(action_id(action), RowCountIndex(), { scalar_field(DataType::UTF_DYNAMIC64, "symbol") })};
+       });
 }
 
-bool SymbolList::can_update_symbol_list(const std::shared_ptr<Store>& store,
-        const std::optional<KeyVectorItr>& maybe_last_compaction) {
-    bool found_last = false;
-    bool has_newer = false;
+void write_journal(
+        const std::shared_ptr<Store>& store,
+        const StreamId& symbol,
+        ActionType action,
+        VersionId reference_id) {
+    SegmentInMemory seg{journal_stream_descriptor(action, symbol)};
 
-    if (maybe_last_compaction.has_value()) {
-        // Symbol list keys source
-        store->iterate_type(KeyType::SYMBOL_LIST,
-                [&found_last, &has_newer, &last_compaction_key = *maybe_last_compaction.value()](auto&& key) {
-                    auto atom = to_atom(key);
-                    if (atom == last_compaction_key) found_last = true;
-                    if (atom.creation_ts() > last_compaction_key.creation_ts()) has_newer = true;
-            }, std::get<std::string>(compaction_id));
-    } else {
-        // Version keys source
-        store->iterate_type(KeyType::SYMBOL_LIST, [&has_newer](auto&&) {
-                has_newer = true;
-            }, std::get<std::string>(compaction_id));
-    }
+    IndexValue version_indicator;
+    util::variant_match(symbol,
+                        [&seg, &version_indicator] (const StringId& id) {
+                            seg.set_string(0, id);
+                            version_indicator = StringIndex{version_string};
+                        },
+                        [&seg, &version_indicator] (const NumericId& id) {
+                            seg.set_scalar<uint64_t>(0, id);
+                            version_indicator = version_identifier;
+                        });
 
-    SYMBOL_LIST_RUNTIME_LOG_VAL("found_last={}", found_last);
-    SYMBOL_LIST_RUNTIME_LOG_VAL("has_newer={}", has_newer);
-    return (!maybe_last_compaction || found_last) && !has_newer;
+    seg.end_row();
+    store->write_sync(KeyType::SYMBOL_LIST, reference_id, action_id(action), IndexValue{ symbol }, version_indicator,
+                      std::move(seg));
 }
 
-    void SymbolList::write_journal(const std::shared_ptr<Store>& store, const StreamId& symbol, std::string action) {
-        SegmentInMemory seg{journal_stream_descriptor(action, symbol)};
-        util::variant_match(symbol,
-            [&seg] (const StringId& id) {
-                seg.set_string(0, id);
-            },
-            [&seg] (const NumericId& id) {
-                seg.set_scalar<uint64_t>(0, id);
-            });
+void write_symbol(const std::shared_ptr<Store>& store, const StreamId& symbol, VersionId reference_id) {
+    write_journal(store, symbol, ActionType::ADD, reference_id);
+}
 
-        seg.end_row();
-        try {
-            store->write_sync(KeyType::SYMBOL_LIST, 0, StreamId{ action }, IndexValue{ symbol }, IndexValue{ symbol },
-                std::move(seg));
-        } catch ([[maybe_unused]] const arcticdb::storage::DuplicateKeyException& e)  {
-            // Both version and content hash are fixed, so collision is possible
-            ARCTICDB_DEBUG(log::storage(), "Symbol list DuplicateKeyException: {}", e.what());
+void delete_symbol(const std::shared_ptr<Store>& store, const StreamId& symbol, VersionId reference_id) {
+    write_journal(store, symbol, ActionType::DELETE, reference_id);
+}
+
+void SymbolList::add_symbol(const std::shared_ptr<Store>& store, const StreamId& symbol, VersionId reference_id) {
+    write_symbol(store, symbol, reference_id);
+}
+
+void SymbolList::remove_symbol(const std::shared_ptr<Store>& store, const StreamId& symbol, VersionId reference_id) {
+    delete_symbol(store, symbol, reference_id);
+}
+
+void SymbolList::clear(const std::shared_ptr<Store>& store) {
+    delete_all_keys_of_type(KeyType::SYMBOL_LIST, store, true);
+}
+
+StreamDescriptor add_symbol_stream_descriptor(const StreamId& stream_id, const StreamId& type_holder) {
+    auto data_type = std::holds_alternative<StringId>(type_holder) ? DataType::ASCII_DYNAMIC64 : DataType::UINT64;
+    return stream_descriptor(stream_id, RowCountIndex(), {
+        scalar_field(data_type, "added_symbol"),
+        scalar_field(DataType::UINT64, "added_reference_id"),
+        scalar_field(DataType::NANOSECONDS_UTC64, "added_timestamp")
+    });
+}
+
+StreamDescriptor delete_symbol_stream_descriptor(const StreamId& stream_id, const StreamId& type_holder) {
+    auto data_type = std::holds_alternative<StringId>(type_holder) ? DataType::ASCII_DYNAMIC64 : DataType::UINT64;
+    return stream_descriptor(stream_id, RowCountIndex(), {
+        scalar_field(data_type, "deleted_symbol"),
+        scalar_field(DataType::UINT64, "deleted_reference_id"),
+        scalar_field(DataType::NANOSECONDS_UTC64, "deleted_timestamp")
+    });
+}
+
+bool SymbolList::needs_compaction(const LoadResult& load_result) const {
+    return load_result.symbol_list_keys_.size() > data_.max_delta_ || !load_result.maybe_previous_compaction;
+}
+
+void write_symbol_at(
+        const StreamId& type_holder,
+        SegmentInMemory& list_segment,
+        const SymbolListEntry& entry,
+        position_t column) {
+    util::variant_match(type_holder,
+        [&entry, &list_segment, column](const StringId&) {
+            util::check(std::holds_alternative<StringId>(entry.stream_id_), "Cannot write string symbol name, existing symbols are numeric");
+            list_segment.set_string(column, std::get<StringId>(entry.stream_id_));
+        },
+        [&entry, &list_segment, column](const NumericId&) {
+            util::check(std::holds_alternative<NumericId>(entry.stream_id_), "Cannot write numeric symbol name, existing symbols are strings");
+            list_segment.set_scalar(column, std::get<NumericId>(entry.stream_id_));
         }
+    );
+}
+
+void write_entry(
+    const StreamId& type_holder,
+    SegmentInMemory& segment,
+    const SymbolListEntry& entry) {
+    write_symbol_at(type_holder, segment, entry, 0);
+    segment.set_scalar(1, entry.reference_id_);
+    segment.set_scalar(2, entry.timestamp_);
+    segment.end_row();
+}
+
+SegmentInMemory write_entries_to_symbol_segment(
+    const StreamId& stream_id,
+    const StreamId& type_holder,
+    const CollectionType& symbols
+    ) {
+    SegmentInMemory added_segment{add_symbol_stream_descriptor(stream_id, type_holder)};
+    SegmentInMemory deleted_segment{delete_symbol_stream_descriptor(stream_id, type_holder)};
+
+    for(const auto& entry : symbols) {
+        if (entry.action_ == ActionType::ADD)
+            write_entry(type_holder, added_segment, entry);
+        else
+            write_entry(type_holder, deleted_segment, entry);
     }
 
-    SymbolList::CollectionType SymbolList::load_from_version_keys(const std::shared_ptr<Store>& store) {
-        SYMBOL_LIST_RUNTIME_LOG("Loading symbols from version keys");
-        std::vector<StreamId> stream_ids;
-        store->iterate_type(KeyType::VERSION_REF, [&] (const auto& key) {
-            auto id = variant_key_id(key);
-            stream_ids.push_back(id);
-
-            if (stream_ids.size() == this->max_delta_ * 2 && !warned_expected_slowdown_) {
-                log::version().warn(
-                        "No compacted symbol list cache found. "
-                        "`list_symbols` may take longer than expected. \n\n"
-                        "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
-                        "To resolve, run `list_symbols` through to completion to compact the symbol list cache.\n"
-                        "Note: This warning will only appear once.\n");
-
-                warned_expected_slowdown_ = true;
-            }
-        });
-        auto res = batch_get_latest_version(store, version_map_, stream_ids, false);
-
-        CollectionType symbols{};
-        for(const auto& map_pair: *res) {
-            symbols.insert(map_pair.first);
+    if(!deleted_segment.empty()) {
+        for (auto col = 0UL; col < deleted_segment.descriptor().fields().size(); ++col) {
+            const auto &field = deleted_segment.descriptor().fields(col);
+            added_segment.add_column(FieldRef{field.type(), field.name()},
+                                     deleted_segment.column_ptr(static_cast<position_t>(col)));
         }
+        util::check(added_segment.descriptor().field_count() == 6, "Unexpected number of compacted symbol fields: {}",
+                    added_segment.descriptor().field_count());
 
-        version_map_->flush();
-        return symbols;
+        auto &src = added_segment.column(static_cast<position_t>(3)).data().buffer();
+        CursoredBuffer<ChunkedBuffer> cursor{src.bytes(), false};
+        merge_string_column(src, deleted_segment.string_pool_ptr(), added_segment.string_pool_ptr(), cursor, false);
+        std::swap(src, cursor.buffer());
     }
 
-    folly::Future<VariantKey> SymbolList::write_symbols(
+    util::check(added_segment.row_count() == static_cast<size_t>(added_segment.column(0).row_count()), "Segment row_count should match initial column row_count {} != {}",
+                added_segment.row_count(), added_segment.column(0).row_count());
+
+    return added_segment;
+}
+
+SegmentInMemory create_empty_segment(const StreamId& stream_id) {
+    SegmentInMemory output{StreamDescriptor{stream_id}};
+    google::protobuf::Any any = {};
+    arcticdb::proto::descriptors::SymbolListDescriptor metadata;
+    metadata.set_enabled(true);
+    any.PackFrom(metadata);
+    output.set_metadata(std::move(any));
+    return output;
+}
+
+folly::Future<VariantKey> write_symbols(
         const std::shared_ptr<Store>& store,
         const CollectionType& symbols,
         const StreamId& stream_id,
-        timestamp creation_ts)  {
+        timestamp creation_ts,
+        const StreamId& type_holder)  {
+    ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Writing {} symbols to symbol list cache", symbols.size());
 
-        SYMBOL_LIST_RUNTIME_LOG_VAL("Writing following number of symbols to symbol list cache: {}", symbols.size());
-        SegmentInMemory list_segment{symbol_stream_descriptor(stream_id)};
-
-        for(const auto& symbol : symbols) {
-            ARCTICDB_DEBUG(log::version(), "Writing symbol '{}' to list", symbol);
-            util::variant_match(type_holder_,
-                [&](const StringId&) {
-                    util::check(std::holds_alternative<StringId>(symbol), "Cannot write string symbol name, existing symbols are numeric");
-                    list_segment.set_string(0, std::get<StringId>(symbol));
-                },
-                [&](const NumericId&) {
-                    util::check(std::holds_alternative<NumericId>(symbol), "Cannot write numeric symbol name, existing symbols are strings");
-                    list_segment.set_scalar(0, std::get<NumericId>(symbol));
-                }
-            );
-            list_segment.end_row();
-        }
-        if(symbols.empty()) {
-            google::protobuf::Any any = {};
-            arcticdb::proto::descriptors::SymbolListDescriptor metadata;
-            metadata.set_enabled(true);
-            any.PackFrom(metadata);
-            list_segment.set_metadata(std::move(any));
-        }
-        return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, 0, 0, std::move(list_segment));
+    SegmentInMemory segment;
+    if(std::none_of(std::begin(symbols), std::end(symbols), [] (const auto& entry) {
+        return entry.action_ == ActionType::ADD;
+    })) {
+        segment = create_empty_segment(stream_id);
+    } else {
+        segment = write_entries_to_symbol_segment(stream_id, type_holder, symbols);
     }
 
-    SymbolList::CollectionType SymbolList::load_from_symbol_list_keys(
-            const std::shared_ptr<StreamSource>& store,
-            const folly::Range<KeyVectorItr>& keys) {
-        SYMBOL_LIST_RUNTIME_LOG("Loading symbols from symbol list keys");
-        bool read_compaction = false;
-        CollectionType symbols{};
-        for(const auto& key : keys) {
-            if(key.id() == compaction_id) {
-                read_list_from_storage(store, key, symbols);
-                read_compaction = true;
-            }
-            else {
-                const auto& action = key.id();
-                const auto& symbol = key.start_index();
-                if(action == StreamId{DeleteSymbol}) {
-                    ARCTICDB_DEBUG(log::version(), "Got delete action for symbol '{}'", symbol);
-                    symbols.erase(symbol);
-                }
-                else {
-                    ARCTICDB_DEBUG(log::version(), "Got insert action for symbol '{}'", symbol);
-                    symbols.insert(symbol);
-                }
-            }
-        }
-        SYMBOL_LIST_RUNTIME_LOG_VAL("Post load, got following number of symbols: {}", symbols.size());
-        if(!read_compaction) {
-            SYMBOL_LIST_RUNTIME_LOG_VAL("Read no compacted segment from symbol list of size: {}", keys.size());
-        }
-        return symbols;
+    return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, 0, 0, std::move(segment));
+}
+
+folly::Future<std::vector<Store::RemoveKeyResultType>> delete_keys(
+        const std::shared_ptr<Store>& store,
+        std::vector<AtomKey>&& remove,
+        const AtomKey& exclude) {
+    auto to_remove = std::move(remove);
+    std::vector<VariantKey> variant_keys;
+    variant_keys.reserve(to_remove.size());
+    for(auto& atom_key: to_remove) {
+        // Corner case: if the newly written Compaction key (exclude) has the same timestamp as an existing one
+        // (e.g. when a previous compaction round failed in the deletion step), we don't want to delete the former
+        if (atom_key != exclude) 
+            variant_keys.emplace_back(atom_key);
     }
 
-    void SymbolList::read_list_from_storage(
-        const std::shared_ptr<StreamSource>& store,
-        const AtomKey& key,
-        CollectionType& symbols) {
-        ARCTICDB_DEBUG(log::version(), "Reading list from storage with key {}", key);
-        auto key_seg = store->read(key).get().second;
-        missing_data::check<ErrorCode::E_UNREADABLE_SYMBOL_LIST>( key_seg.descriptor().field_count() > 0,
-            "Expected at least one column in symbol list with key {}", key);
+    return store->remove_keys(variant_keys);
+}
 
-        const auto& field_desc = key_seg.descriptor().field(0);
-        if (key_seg.row_count() > 0) {
-            auto data_type =  field_desc.type().data_type();
-            if (data_type == DataType::UINT64) {
-                for (auto row : key_seg) {
-                    auto num_id = key_seg.scalar_at<uint64_t>(row.row_id_, 0).value();
-                    ARCTICDB_DEBUG(log::version(), "Reading numeric symbol {}", num_id);
-                    symbols.emplace(safe_convert_to_numeric_id(num_id, "Numeric symbol"));
-                }
-            } else if (data_type == DataType::ASCII_DYNAMIC64) {
-                for (auto row : key_seg) {
-                    auto sym = key_seg.string_at(row.row_id_, 0).value();
-                    ARCTICDB_DEBUG(log::version(), "Reading string symbol '{}'", sym);
-                    symbols.emplace(std::string{sym});
+bool has_recent_compaction(
+        const std::shared_ptr<Store>& store,
+        const std::optional<std::vector<AtomKey>::const_iterator>& maybe_previous_compaction) {
+    bool found_last = false;
+    bool has_newer = false;
+
+    if (maybe_previous_compaction.has_value()) {
+        // Symbol list keys source
+        store->iterate_type(KeyType::SYMBOL_LIST,
+                            [&found_last, &has_newer, &last_compaction_key = *maybe_previous_compaction.value()](const VariantKey& key) {
+                                const auto& atom = to_atom(key);
+                                if (atom == last_compaction_key)
+                                    found_last = true;
+                                if (atom.creation_ts() > last_compaction_key.creation_ts())
+                                    has_newer = true;
+                            }, std::get<std::string>(compaction_id));
+    } else {
+        // Version keys source
+        store->iterate_type(KeyType::SYMBOL_LIST, [&has_newer](const VariantKey&) {
+            has_newer = true;
+        }, std::get<std::string>(compaction_id));
+    }
+
+    return (maybe_previous_compaction && !found_last) || has_newer;
+}
+
+std::set<StreamId> SymbolList::load(
+        const std::shared_ptr<VersionMap>& version_map,
+        const std::shared_ptr<Store>& store,
+        bool no_compaction) {
+    LoadResult load_result = ExponentialBackoff<StorageException>(100, 2000)
+            .go([this, &version_map, &store]() { return attempt_load(version_map, store, data_); });
+
+    if (!no_compaction && needs_compaction(load_result)) {
+        ARCTICDB_RUNTIME_DEBUG(log::symbol(),"Compaction necessary. Obtaining lock...");
+        try {
+            if (StorageLock lock{StringId{CompactionLockName}}; lock.try_lock(store)) {
+                OnExit x([&lock, &store] { lock.unlock(store); });
+
+                ARCTICDB_RUNTIME_DEBUG(log::symbol(),"Checking whether we still need to compact under lock");
+                if(!has_recent_compaction(store, load_result.maybe_previous_compaction)) {
+                    auto written = write_symbols(store,
+                                                 load_result.symbols_,
+                                                 compaction_id,
+                                                 load_result.timestamp_,
+                                                 data_.type_holder_).get();
+                    delete_keys(store, load_result.detach_symbol_list_keys(), std::get<AtomKey>(written)).get();
                 }
             } else {
-                missing_data::raise<ErrorCode::E_UNREADABLE_SYMBOL_LIST>(
-                        "The symbol list contains unsupported symbol type: {}", data_type);
+                ARCTICDB_RUNTIME_DEBUG(log::symbol(),"Not compacting the symbol list due to lock contention");
             }
+        } catch (const storage::PermissionException& ex) {
+            // Note: this only reflects AN's permission check and is not thrown by the Storage
+            ARCTICDB_RUNTIME_DEBUG(log::symbol(),"Not compacting the symbol list due to lack of permission", ex.what());
+        } catch (const std::exception& ex) {
+            log::symbol().warn("Ignoring error while trying to compact the symbol list: {}", ex.what());
         }
     }
 
-    SymbolList::KeyVector SymbolList::get_all_symbol_list_keys(const std::shared_ptr<StreamSource>& store) {
-        std::vector<AtomKey> output;
-        uint64_t uncompacted_keys_found = 0;
-        store->iterate_type(KeyType::SYMBOL_LIST, [&] (auto&& key) -> void {
-            auto atom_key = to_atom(key);
-            if(atom_key.id() != compaction_id) {
-                uncompacted_keys_found++;
-            }
-            if (uncompacted_keys_found == this->max_delta_ * 2 && !warned_expected_slowdown_) {
-                log::version().warn(
-                        "`list_symbols` may take longer than expected as there have been many modifications since `list_symbols` was last called. \n\n"
-                        "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
-                        "To resolve, run `list_symbols` through to completion frequently.\n"
-                        "Note: This warning will only appear once.\n");
-
-                warned_expected_slowdown_ = true;
-            }
-
-            output.push_back(atom_key);
-        });
-
-        std::sort(output.begin(), output.end(), [] (const AtomKey& left, const AtomKey& right) {
-            return left.creation_ts() < right.creation_ts();
-        });
-        return output;
+    std::set<StreamId> output;
+    for(const auto& entry : load_result.symbols_) {
+        if(entry.action_ == ActionType::ADD)
+            output.insert(entry.stream_id_);
     }
 
-    folly::Future<std::vector<Store::RemoveKeyResultType>>
-    SymbolList::delete_keys(const std::shared_ptr<Store>& store, KeyVector&& to_remove, const AtomKey& exclude) {
-        std::vector<VariantKey> variant_keys;
-        variant_keys.reserve(to_remove.size());
-        for(auto& atom_key: to_remove) {
-            // Corner case: if the newly written Compaction key (exclude) has the same timestamp as an existing one
-            // (e.g. when a previous compaction round failed in the deletion step), we don't want to delete the former
-            if (atom_key != exclude) {
-                variant_keys.emplace_back(std::move(atom_key));
-            }
-        }
-
-        return store->remove_keys(variant_keys);
-    }
-
-std::optional<SymbolList::KeyVectorItr> SymbolList::last_compaction(const KeyVector& keys) {
-        auto pos = std::find_if(keys.rbegin(), keys.rend(), [] (const auto& key) {
-            return key.id() == compaction_id;
-        }) ;
-
-        if (pos == keys.rend()) {
-            return std::nullopt;
-        } else {
-            return { (pos + 1).base() }; // reverse_iterator -> forward itr has an offset of 1 per docs
-        }
-    }
+    return output;
+}
 
 } //namespace arcticdb
+
+namespace std {
+template <> struct hash<arcticdb::ActionType>
+{
+    size_t operator()(arcticdb::ActionType at) const {
+        return std::hash<int>{}(static_cast<int>(at));
+    }
+};
+}

--- a/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
+++ b/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
@@ -24,7 +24,7 @@ template <typename Model>
 void check_latest_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
     using namespace arcticdb;
     auto prev = get_latest_version(sut.store_,sut.map_, symbol, pipelines::VersionQuery{}, ReadOptions{});
-    auto sut_version_id = prev ? prev.value().version_id() : 0;
+    auto sut_version_id = prev ? prev->version_id() : 0;
     auto model_prev = s0.get_latest_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
     RC_ASSERT(sut_version_id == model_version_id);
@@ -37,7 +37,7 @@ void check_latest_undeleted_versions(const Model&  s0, MapStorePair &sut, std::s
     version_query.set_skip_compat(true),
     version_query.set_iterate_on_failure(true);
     auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, version_query, ReadOptions{});
-    auto sut_version_id = prev ? prev.value().version_id() : 0;
+    auto sut_version_id = prev ? prev->version_id() : 0;
     auto model_prev = s0.get_latest_undeleted_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
     RC_ASSERT(sut_version_id == model_version_id);

--- a/cpp/arcticdb/version/test/symbol_list_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/symbol_list_backwards_compat.hpp
@@ -1,0 +1,166 @@
+#include <arcticdb/entity/types.hpp>
+#include <arcticdb/version/symbol_list.hpp>
+
+/*
+ * This file represents the way that the symbol list used to work, so that we can test that new- and old-style symbol
+ * list functionalirt can co-exist
+ */
+
+namespace arcticdb {
+
+using BackwardsCompatCollectionType = std::set<StreamId>;
+
+void backwards_compat_read_list_from_storage(
+    const std::shared_ptr<StreamSource>& store,
+    const AtomKey& key,
+    BackwardsCompatCollectionType& symbols) {
+    ARCTICDB_DEBUG(log::version(), "Reading list from storage with key {}", key);
+    auto key_seg = store->read(key).get().second;
+    missing_data::check<ErrorCode::E_UNREADABLE_SYMBOL_LIST>( key_seg.descriptor().field_count() > 0,
+                                                              "Expected at least one column in symbol list with key {}", key);
+
+    const auto& field_desc = key_seg.descriptor().field(0);
+    if (key_seg.row_count() > 0) {
+        auto data_type =  field_desc.type().data_type();
+        if (data_type == DataType::UINT64) {
+            for (auto row : key_seg) {
+                auto num_id = key_seg.scalar_at<uint64_t>(row.row_id_, 0).value();
+                ARCTICDB_DEBUG(log::version(), "Reading numeric symbol {}", num_id);
+                symbols.emplace(safe_convert_to_numeric_id(num_id));
+            }
+        } else if (data_type == DataType::ASCII_DYNAMIC64) {
+            for (auto row : key_seg) {
+                auto sym = key_seg.string_at(row.row_id_, 0).value();
+                ARCTICDB_DEBUG(log::version(), "Reading string symbol '{}'", sym);
+                symbols.emplace(std::string{sym});
+            }
+        } else {
+            missing_data::raise<ErrorCode::E_UNREADABLE_SYMBOL_LIST>(
+                "The symbol list contains unsupported symbol type: {}", data_type);
+        }
+    }
+}
+
+std::vector<AtomKey> backwards_compat_get_all_symbol_list_keys(const std::shared_ptr<StreamSource>& store) {
+    std::vector<AtomKey> output;
+    uint64_t uncompacted_keys_found = 0;
+    store->iterate_type(KeyType::SYMBOL_LIST, [&] (auto&& key) -> void {
+        auto atom_key = to_atom(key);
+        if(atom_key.id() != StreamId{std::string{CompactionId}}) {
+            uncompacted_keys_found++;
+        }
+
+        output.push_back(atom_key);
+    });
+
+    std::sort(output.begin(), output.end(), [] (const AtomKey& left, const AtomKey& right) {
+        return left.creation_ts() < right.creation_ts();
+    });
+    return output;
+}
+
+BackwardsCompatCollectionType backwards_compat_load(
+    const std::shared_ptr<StreamSource> &store,
+    const std::vector<AtomKey>& keys) {
+    BackwardsCompatCollectionType symbols{};
+    for (const auto &key : keys) {
+        if (key.id() == StreamId{std::string{CompactionId}}) {
+            backwards_compat_read_list_from_storage(store, key, symbols);
+        } else {
+            const auto &action = key.id();
+            const auto &symbol = key.start_index();
+            if (action == StreamId{std::string{DeleteSymbol}}) {
+                ARCTICDB_DEBUG(log::version(), "Got delete action for symbol '{}'", symbol);
+                symbols.erase(symbol);
+            } else {
+                ARCTICDB_DEBUG(log::version(), "Got insert action for symbol '{}'", symbol);
+                symbols.insert(symbol);
+            }
+        }
+    }
+    return symbols;
+}
+
+BackwardsCompatCollectionType backwards_compat_get_symbols(const std::shared_ptr<Store>& store) {
+    auto keys = backwards_compat_get_all_symbol_list_keys(store);
+    return backwards_compat_load(store, keys);
+}
+
+inline StreamDescriptor backwards_compat_symbol_stream_descriptor(const StreamId& stream_id, const StreamId& type_holder) {
+    auto data_type = std::holds_alternative<StringId>(type_holder) ? DataType::ASCII_DYNAMIC64 : DataType::UINT64;
+    return StreamDescriptor{stream_descriptor(stream_id, RowCountIndex(), {
+        scalar_field(data_type, "symbol")}
+    )};
+}
+
+inline StreamDescriptor baackward_compat_journal_stream_descriptor(const StreamId& action, const StreamId& id) {
+    return util::variant_match(id,
+                               [&action] (const NumericId&) {
+                                   return StreamDescriptor{stream_descriptor(action, RowCountIndex(), { scalar_field(DataType::UINT64, "symbol") })};
+                               },
+                               [&action] (const StringId&) {
+                                   return StreamDescriptor{stream_descriptor(action, RowCountIndex(), { scalar_field(DataType::UTF_DYNAMIC64, "symbol") })};
+                               });
+}
+
+folly::Future<VariantKey> backwards_compat_write(
+    const std::shared_ptr<Store> &store,
+    const BackwardsCompatCollectionType &symbols,
+    const StreamId &stream_id,
+    timestamp creation_ts,
+    const StreamId& type_holder) {
+
+    SegmentInMemory list_segment{backwards_compat_symbol_stream_descriptor(stream_id, type_holder)};
+
+    for (const auto &symbol : symbols) {
+        ARCTICDB_DEBUG(log::version(), "Writing symbol '{}' to list", symbol);
+        util::variant_match(type_holder,
+                            [&](const StringId &) {
+                                util::check(std::holds_alternative<StringId>(symbol),
+                                            "Cannot write string symbol name, existing symbols are numeric");
+                                list_segment.set_string(0, std::get<StringId>(symbol));
+                            },
+                            [&](const NumericId &) {
+                                util::check(std::holds_alternative<NumericId>(symbol),
+                                            "Cannot write numeric symbol name, existing symbols are strings");
+                                list_segment.set_scalar(0, std::get<NumericId>(symbol));
+                            }
+        );
+        list_segment.end_row();
+    }
+    if (symbols.empty()) {
+        google::protobuf::Any any = {};
+        arcticdb::proto::descriptors::SymbolListDescriptor metadata;
+        metadata.set_enabled(true);
+        any.PackFrom(metadata);
+        list_segment.set_metadata(std::move(any));
+    }
+    return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, 0, 0, std::move(list_segment));
+}
+
+void backwards_compat_write_journal(const std::shared_ptr<Store>& store, const StreamId& symbol, std::string action) {
+    SegmentInMemory seg{baackward_compat_journal_stream_descriptor(action, symbol)};
+    util::variant_match(symbol,
+                        [&seg] (const StringId& id) {
+                            seg.set_string(0, id);
+                        },
+                        [&seg] (const NumericId& id) {
+                            seg.set_scalar<uint64_t>(0, id);
+                        });
+
+    seg.end_row();
+    try {
+        store->write_sync(KeyType::SYMBOL_LIST, 0, StreamId{ action }, IndexValue{ symbol }, IndexValue{ symbol },
+                          std::move(seg));
+    } catch ([[maybe_unused]] const arcticdb::storage::DuplicateKeyException& e)  {
+        // Both version and content hash are fixed, so collision is possible
+        ARCTICDB_DEBUG(log::storage(), "Symbol list DuplicateKeyException: {}", e.what());
+    }
+}
+
+void backwards_compat_compact(const std::shared_ptr<Store>& store, std::vector<AtomKey>&& old_keys, const BackwardsCompatCollectionType& symbols) {
+    auto compacted_key = backwards_compat_write(store, symbols, StreamId{std::string{CompactionId}}, timestamp(12), StringId{}).get();
+    delete_keys(store, std::move(old_keys), to_atom(compacted_key)).get();
+}
+
+} //namespace arcticdb

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -53,8 +53,8 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
     for(uint64_t i = 0; i < num_streams; i++){
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
-            stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            stream_ids.emplace_back(stream);
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
         }
     }
 
@@ -95,8 +95,8 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     for(uint64_t i = 0; i < num_streams; i++){
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
-            stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            stream_ids.emplace_back(stream);
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
         }
     }
 
@@ -108,7 +108,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     for(uint64_t i = 0; i < num_streams; i++){
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
-            version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false, false});
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false, false});
         }
     }
 
@@ -145,8 +145,8 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
 
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
-        stream_ids.push_back(StreamId{"stream_0"});
-        version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
+        stream_ids.emplace_back(StreamId{"stream_0"});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
     }
 
     // Do query
@@ -178,8 +178,8 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
 
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
-        stream_ids.push_back(StreamId{"stream_0"});
-        version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
+        stream_ids.emplace_back(StreamId{"stream_0"});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
     }
 
     // Do query
@@ -188,7 +188,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
     for(uint64_t i = 0; i < num_versions; i++){
-        version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts())}, false, false});
+        version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts())}, false, false});
     }
 
     // Now we can perform the actual batch query per timestamps
@@ -225,8 +225,8 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
     for(uint64_t i = 0; i < num_streams; i++){
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
-            stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            stream_ids.emplace_back(stream);
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
         }
     }
 
@@ -240,12 +240,12 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
-            stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
-            stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false, false});
-            stream_ids.push_back(StreamId{stream});
-            version_queries.push_back(VersionQuery{std::monostate{}, false, false});
+            stream_ids.emplace_back(stream);
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            stream_ids.emplace_back(stream);
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false, false});
+            stream_ids.emplace_back(stream);
+            version_queries.emplace_back(VersionQuery{std::monostate{}, false, false});
         }
     }
 

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -15,6 +15,7 @@
 #include <arcticdb/util/test/generators.hpp>
 #include <arcticdb/util/allocator.hpp>
 #include <arcticdb/codec/default_codecs.hpp>
+#include <arcticdb/version/version_functions.hpp>
 
 #include <filesystem>
 #include <chrono>
@@ -226,7 +227,7 @@ TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
         }
 
         wrapper.aggregator_.commit();
-        wrapper.segment().drop_column(fmt::format("thing{}", (i % 3) + 1));
+        wrapper.segment().drop_column(fmt::format("thing{}", (i % 4) + 1));
         data.emplace_back( SegmentToInputFrameAdapter{std::move(wrapper.segment())});
     }
     std::mt19937 mt{42};
@@ -248,7 +249,7 @@ TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
     auto col4_pos = seg.column_index( "thing4").value();
 
     for (size_t i = 0; i < 10; ++i) {
-        auto dropped_column = (i % 3) + 1;
+        auto dropped_column = (i % 4) + 1;
         for(size_t j = 0; j < 20; ++j ) {
             auto idx = seg.scalar_at<uint64_t>(count, 0);
             ASSERT_EQ(idx.value(), count);
@@ -423,7 +424,6 @@ TEST(VersionStore, UpdateWithin) {
     ScopedConfig reload_interval("VersionMap.ReloadInterval", 0);
 
     PilotedClock::reset();
-    std::string lib_name("test.update_schema_change");
     StreamId symbol("update_schema");
     auto version_store = get_test_engine();
     size_t num_rows{100};
@@ -465,7 +465,6 @@ TEST(VersionStore, UpdateBefore) {
     using namespace arcticdb::pipelines;
 
     PilotedClock::reset();
-    std::string lib_name("test.update_schema_change");
     StreamId symbol("update_schema");
     auto version_store = get_test_engine();
     size_t num_rows{100};
@@ -507,7 +506,6 @@ TEST(VersionStore, UpdateAfter) {
     using namespace arcticdb::pipelines;
 
     PilotedClock::reset();
-    std::string lib_name("test.update_schema_change");
     StreamId symbol("update_schema");
     auto version_store = get_test_engine();
     size_t num_rows{100};
@@ -549,7 +547,6 @@ TEST(VersionStore, UpdateIntersectBefore) {
     using namespace arcticdb::pipelines;
 
     PilotedClock::reset();
-    std::string lib_name("test.update_schema_change");
     StreamId symbol("update_schema");
     auto version_store = get_test_engine();
     size_t num_rows{100};
@@ -592,7 +589,6 @@ TEST(VersionStore, UpdateIntersectAfter) {
     using namespace arcticdb::pipelines;
 
     PilotedClock::reset();
-    std::string lib_name("test.update_schema_change");
     StreamId symbol("update_schema");
     auto version_store = get_test_engine();
     size_t num_rows{100};
@@ -635,7 +631,6 @@ TEST(VersionStore, UpdateWithinSchemaChange) {
     using namespace arcticdb::pipelines;
 
     PilotedClock::reset();
-    std::string lib_name("test.update_schema_change");
     StreamId symbol("update_schema");
     auto version_store = get_test_engine();
     size_t num_rows{100};
@@ -758,7 +753,6 @@ TEST(VersionStore, TestWriteAppendMapHead) {
     using namespace arcticdb::pipelines;
 
     PilotedClock::reset();
-    std::string lib_name("test.write_append_map_head");
     StreamId symbol("append");
     auto version_store = get_test_engine();
     size_t num_rows{100};

--- a/cpp/arcticdb/version/version_core-inl.hpp
+++ b/cpp/arcticdb/version/version_core-inl.hpp
@@ -122,7 +122,7 @@ void do_compact(
                 pk{KeyType::TABLE_DATA, pipeline_context->version_id_, pipeline_context->stream_id_, local_index_start, local_index_end};
                 fut_vec.emplace_back(store->write(pk, std::move(segment)));
             },
-            segment_size.has_value() ? SegmentationPolicy{segment_size.value()} : SegmentationPolicy{}
+            segment_size.has_value() ? SegmentationPolicy{*segment_size} : SegmentationPolicy{}
         };
 
         for(auto it = target_start; it != target_end; ++it) {

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -110,6 +110,10 @@ FrameAndDescriptor read_dataframe_impl(
     const ReadOptions& read_options
     );
 
+FrameAndDescriptor read_segment_impl(
+    const std::shared_ptr<Store>& store,
+    const VariantKey& key);
+
 FrameAndDescriptor read_index_impl(
     const std::shared_ptr<Store>& store,
     const VersionedItem& version);

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -102,7 +102,6 @@ class VersionMapImpl {
      *
      * Methods already declared with const& were not touched during this change.
      */
-    using StreamIdArg = const StreamId&;
     using MapType =  std::map<StreamId, std::shared_ptr<VersionMapEntry>>;
 
     static constexpr uint64_t DEFAULT_CLOCK_UNSYNC_TOLERANCE = ONE_SECOND * 2;
@@ -154,6 +153,7 @@ public:
             entry->keys_.push_back(ref_entry.keys_[0]);
         } else {
             do {
+                ARCTICDB_DEBUG(log::version(), "Loading version key {}", next_key.value());
                 auto [key, seg] = store->read_sync(next_key.value());
                 next_key = read_segment_with_keys(seg, entry, load_progress);
                 set_latest_version(entry, latest_version);
@@ -207,7 +207,7 @@ public:
 
     void load_via_iteration(
         std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
+        const StreamId& stream_id,
         std::shared_ptr<VersionMapEntry>& entry,
         bool use_index_keys_for_iteration=false) const {
         ARCTICDB_DEBUG(log::version(), "Attempting to iterate version keys");
@@ -248,7 +248,7 @@ public:
      * @param first_key_to_tombstone The first key in the version chain that should be tombstoned. When empty
      * then the first index key onwards is tombstoned, so the whole chain is tombstoned.
      */
-    std::vector<AtomKey> tombstone_from_key_or_all(
+    std::pair<VersionId, std::vector<AtomKey>> tombstone_from_key_or_all(
             std::shared_ptr<Store> store,
             const StreamId& stream_id,
             std::optional<AtomKey> first_key_to_tombstone = std::nullopt
@@ -256,7 +256,7 @@ public:
         return tombstone_from_key_or_all_internal(store, stream_id, first_key_to_tombstone);
     }
 
-    std::string dump_entry(const std::shared_ptr<Store> store, const StreamId& stream_id) {
+    std::string dump_entry(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
         const auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
         return entry->dump();
     }
@@ -271,7 +271,7 @@ public:
                 key.id(),
                 LoadParameter{LoadType::LOAD_UNDELETED},
                 __FUNCTION__);
-        auto result = tombstone_from_key_or_all_internal(store, key.id(), previous_key, entry);
+        auto [_, result] = tombstone_from_key_or_all_internal(store, key.id(), previous_key, entry);
 
         do_write(store, key, entry);
 
@@ -281,12 +281,12 @@ public:
         return result;
     }
 
-    std::deque<AtomKey> delete_all_versions(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    std::pair<VersionId, std::deque<AtomKey>> delete_all_versions(std::shared_ptr<Store> store, const StreamId& stream_id) {
         ARCTICDB_DEBUG(log::version(), "Version map deleting all versions for stream {}", stream_id);
         std::deque<AtomKey> output;
-        auto index_keys = tombstone_from_key_or_all(store, stream_id);
+        auto [version_id, index_keys] = tombstone_from_key_or_all(store, stream_id);
         output.assign(std::begin(index_keys), std::end(index_keys));
-        return output;
+        return {version_id, std::move(output)};
     }
 
     bool requires_compaction(const std::shared_ptr<VersionMapEntry>& entry) const {
@@ -303,7 +303,7 @@ public:
         }
     }
 
-    void compact_and_remove_deleted_indexes(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void compact_and_remove_deleted_indexes(std::shared_ptr<Store> store, const StreamId& stream_id) {
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
         auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
         if (!requires_compaction(entry))
@@ -348,11 +348,38 @@ public:
         std::swap(entry, new_entry);
     }
 
+    VariantKey journal_single_key(
+            std::shared_ptr<StreamSink> store,
+            const AtomKey &key,
+            std::optional<AtomKey> prev_journal_key) {
+        ARCTICDB_SAMPLE(WriteJournalEntry, 0)
+        ARCTICDB_DEBUG(log::version(), "Version map writing version for key {}", key);
+
+        VariantKey journal_key;
+        IndexAggregator<RowCountIndex> journal_agg(key.id(), [&store, &journal_key, &key](auto &&segment) {
+            stream::StreamSink::PartialKey pk{
+                    KeyType::VERSION,
+                    key.version_id(),
+                    key.id(),
+                    IndexValue(0),
+                    IndexValue(0)
+            };
+
+            journal_key = store->write_sync(pk, std::forward<decltype(segment)>(segment));
+        });
+        journal_agg.add_key(key);
+        if (prev_journal_key)
+            journal_agg.add_key(*prev_journal_key);
+
+        journal_agg.commit();
+        return journal_key;
+    }
+
     AtomKey update_version_key(
         std::shared_ptr<Store> store,
         const VariantKey& version_key,
         const std::vector<AtomKey>& index_keys,
-        StreamIdArg stream_id) const {
+        const StreamId& stream_id) const {
         folly::Future<VariantKey> journal_key_fut = folly::Future<VariantKey>::makeEmpty();
 
         IndexAggregator<RowCountIndex> version_agg(stream_id, [&journal_key_fut, &store, &version_key](auto &&segment) {
@@ -369,7 +396,7 @@ public:
 
     std::shared_ptr<VersionMapEntry> compact_entry(
         std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
+        const StreamId& stream_id,
         const std::shared_ptr<VersionMapEntry>& entry) {
         // For compacting an entry, we compact from the second version key in the chain
         // This makes it concurrent safe (when use_tombstones is enabled)
@@ -427,7 +454,7 @@ public:
         log::version().info("Compacted {} out of {} total symbols", num_sym_compacted, total_symbols);
     }
 
-    void compact(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void compact(std::shared_ptr<Store> store, const StreamId& stream_id) {
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
         auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
         if (entry->empty()) {
@@ -450,7 +477,7 @@ public:
     }
 
     void overwrite_symbol_tree(
-            std::shared_ptr<Store> store, StreamIdArg stream_id, const std::vector<AtomKey>& index_keys) {
+            std::shared_ptr<Store> store, const StreamId& stream_id, const std::vector<AtomKey>& index_keys) {
         auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
         auto old_entry = *entry;
         if (!index_keys.empty()) {
@@ -469,10 +496,10 @@ public:
      */
     std::shared_ptr<VersionMapEntry> check_reload(
         std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
+        const StreamId& stream_id,
         const LoadParameter& load_param,
         const char* function ARCTICDB_UNUSED) {
-        ARCTICDB_DEBUG(log::version(), "Check reload in function {}", function);
+        ARCTICDB_DEBUG(log::version(), "Check reload in function {} for id {}", function, stream_id);
 
         if (has_cached_entry(stream_id, load_param))
             return get_entry(stream_id);
@@ -498,7 +525,7 @@ public:
     AtomKey write_tombstone(
         std::shared_ptr<Store> store,
         const std::variant<AtomKey, VersionId>& key,
-        StreamIdArg stream_id,
+        const StreamId& stream_id,
         const std::shared_ptr<VersionMapEntry>& entry,
         const std::optional<timestamp>& creation_ts=std::nullopt) {
         if (validate_)
@@ -526,9 +553,9 @@ public:
         const VersionMapEntry& entry,
         const StreamId &stream_id) const {
         if (entry.head_) {
-            util::check(entry.head_.value().id() == stream_id, "Id mismatch for entry {} vs symbol {}",
-                        entry.head_.value().id(), stream_id);
-            store->remove_key_sync(entry.head_.value());
+            util::check(entry.head_->id() == stream_id, "Id mismatch for entry {} vs symbol {}",
+                        entry.head_->id(), stream_id);
+            store->remove_key_sync(*entry.head_);
         }
         std::vector<folly::Future<Store::RemoveKeyResultType>> key_futs;
         for (const auto &key : entry.keys_) {
@@ -566,44 +593,46 @@ private:
 
     bool has_cached_entry(const StreamId &stream_id, const LoadParameter& load_param) const {
         load_param.validate();
-        MapType::const_iterator entry;
-        if(!find_entry(entry, stream_id))
+        MapType::const_iterator entry_it;
+        if(!find_entry(entry_it, stream_id))
             return false;
 
         const timestamp reload_interval = reload_interval_.value_or(ConfigsMap::instance()->get_int("VersionMap.ReloadInterval", DEFAULT_RELOAD_INTERVAL));
 
-        if (const timestamp cache_timing = now() - entry->second->last_reload_time_; cache_timing > reload_interval) {
+        const auto& entry = entry_it->second;
+        if (const timestamp cache_timing = now() - entry->last_reload_time_; cache_timing > reload_interval) {
             ARCTICDB_DEBUG(log::version(),
-                    "Latest read time {} too long ago for last acceptable cached timing {} (cache period {})",
-                    entry->second->last_reload_time_, cache_timing, reload_interval);
+                    "Latest read time {} too long ago for last acceptable cached timing {} (cache period {}) for symbol {}",
+                    entry->last_reload_time_, cache_timing, reload_interval, stream_id);
 
             return false;
         }
 
         // TODO: Fix #587
-        if (entry->second->load_type_ < load_param.load_type_) {
-            ARCTICDB_DEBUG(log::version(), "Required load type {} exceeds existing load type {}, will reload", load_param.load_type_, entry->second->load_type_);
+        if (entry->load_type_ < load_param.load_type_) {
+            ARCTICDB_DEBUG(log::version(), "Required load type {} exceeds existing load type {}, will reload {}",
+                           load_param.load_type_, entry->load_type_, stream_id);
             return false;
         }
 
-        if(entry->second->load_type_ == LoadType::LOAD_DOWNTO) {
+        if(entry->load_type_ == LoadType::LOAD_DOWNTO) {
             if (load_param.load_type_ == LoadType::LOAD_UNDELETED) {
                 return false;
             }
             if (load_param.load_type_ == LoadType::LOAD_DOWNTO ) {
                 if (is_positive_version_query(load_param)) {
-                    if (entry->second->loaded_until_ > static_cast<VersionId>(load_param.load_until_.value())) {
+                    if (entry->loaded_until_ > static_cast<VersionId>(load_param.load_until_.value())) {
                         ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {}",
-                                       load_param.load_until_.value(), entry->second->loaded_until_);
+                                       load_param.load_until_.value(), entry->loaded_until_);
                         return false;
                     }
                 } else {
-                    auto opt_latest = entry->second->get_first_index(true);
+                    auto opt_latest = entry->get_first_index(true);
                     if (opt_latest.has_value()) {
                         auto opt_version_id = get_version_id_negative_index(opt_latest->version_id(), *load_param.load_until_);
-                        if (opt_version_id.has_value() && entry->second->loaded_until_ > *opt_version_id) {
+                        if (opt_version_id.has_value() && entry->loaded_until_ > *opt_version_id) {
                             ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {} and there are {} total versions",
-                                           load_param.load_until_.value(), entry->second->loaded_until_, opt_latest->version_id());
+                                           load_param.load_until_.value(), entry->loaded_until_, opt_latest->version_id());
                             return false;
                         }
                     }
@@ -612,8 +641,8 @@ private:
             }
         }
 
-        if(load_param.load_type_ == LoadType::LOAD_UNDELETED && !entry->second->tombstone_all_ &&
-           entry->second->load_type_ != LoadType::LOAD_UNDELETED)
+        if(load_param.load_type_ == LoadType::LOAD_UNDELETED && !entry->tombstone_all_ &&
+           entry->load_type_ != LoadType::LOAD_UNDELETED)
             return false;
 
         ARCTICDB_DEBUG(log::version(), "{} Using cached entry for symbol {}", uintptr_t(this), stream_id);
@@ -656,13 +685,13 @@ private:
         return journal_key;
     }
 
-    bool has_stored_entry(std::shared_ptr<StreamSource> store, const StreamId &stream_id) const {
+    bool has_stored_entry(const std::shared_ptr<StreamSource>& store, const StreamId &stream_id) const {
         return static_cast<bool>(get_symbol_ref_key(store, stream_id));
     }
 
     std::shared_ptr<VersionMapEntry> storage_reload(
         std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
+        const StreamId& stream_id,
         const LoadParameter& load_param,
         bool iterate_on_failure) {
         /*
@@ -705,47 +734,22 @@ private:
         return entry;
     }
 
-    VariantKey journal_single_key(
-        std::shared_ptr<StreamSink> store,
-        const AtomKey &key,
-        std::optional<AtomKey> prev_journal_key) {
-        ARCTICDB_SAMPLE(WriteJournalEntry, 0)
-        ARCTICDB_DEBUG(log::version(), "Version map writing version for key {}", key);
-
-        VariantKey journal_key;
-        IndexAggregator<RowCountIndex> journal_agg(key.id(), [&store, &journal_key, &key](auto &&segment) {
-            stream::StreamSink::PartialKey pk{
-                KeyType::VERSION,
-                key.version_id(),
-                key.id(),
-                IndexValue(0),
-                IndexValue(0)
-            };
-
-            journal_key = store->write_sync(pk, std::forward<decltype(segment)>(segment));
-        });
-        journal_agg.add_key(key);
-        if (prev_journal_key)
-            journal_agg.add_key(prev_journal_key.value());
-
-        journal_agg.commit();
-        return journal_key;
-    }
-
     timestamp now() const {
         return Clock::nanos_since_epoch();
     }
 
     std::shared_ptr<VersionMapEntry> rewrite_entry(
         std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
+        const StreamId& stream_id,
         const std::shared_ptr<VersionMapEntry>& entry) {
         auto new_entry = std::make_shared<VersionMapEntry>();
         std::copy_if(std::begin(entry->keys_), std::end(entry->keys_), std::back_inserter(new_entry->keys_),
                      [](const auto &key) {
                          return is_index_or_tombstone(key);
                      });
-        auto version_id = new_entry->get_first_index(true).value().version_id();
+        const auto first_index = new_entry->get_first_index(true);
+        util::check(static_cast<bool>(first_index), "No index exists in rewrite entry");
+        auto version_id = first_index->version_id();
         new_entry->head_ = write_entry_to_storage(store, stream_id, version_id, new_entry);
         remove_entry_version_keys(store, entry, stream_id);
 
@@ -756,7 +760,7 @@ private:
     }
 
 public:
-    bool check_ref_key(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    bool check_ref_key(std::shared_ptr<Store> store, const StreamId& stream_id) {
         auto entry_iteration = std::make_shared<VersionMapEntry>();
         load_via_iteration(store, stream_id, entry_iteration);
         auto maybe_latest_pair = get_latest_key_pair(entry_iteration);
@@ -774,12 +778,12 @@ public:
         }
 
         util::check(static_cast<bool>(ref_entry.head_), "Expected head to be set");
-        if(maybe_latest_pair.value().first != ref_entry.keys_[0] || maybe_latest_pair.value().second != ref_entry.head_.value()) {
+        if(maybe_latest_pair->first != ref_entry.keys_[0] || maybe_latest_pair->second != *ref_entry.head_) {
             log::version().warn("Ref entry is incorrect for stream {}, either {} != {} or {} != {}",
                     stream_id,
-                    maybe_latest_pair.value().first,
+                    maybe_latest_pair->first,
                     ref_entry.head_.value(),
-                    maybe_latest_pair.value().second,
+                    maybe_latest_pair->second,
                     ref_entry.keys_[0]);
             return false;
         }
@@ -797,7 +801,16 @@ public:
         return true;
     }
 
-    void scan_and_rewrite(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    bool indexes_sorted(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
+        auto entry_ref = std::make_shared<VersionMapEntry>();
+        load_via_ref_key(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, entry_ref);
+        auto indexes = entry_ref->get_indexes(true);
+        return std::is_sorted(std::cbegin(indexes), std::cend(indexes), [] (const auto& l, const auto& r) {
+            return l > r;
+        });
+    }
+
+    void scan_and_rewrite(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
         log::version().warn("Version map scanning and rewriting  versions for stream {}", stream_id);
         auto entry = get_entry(stream_id);
         entry->clear();
@@ -807,7 +820,7 @@ public:
         (void)rewrite_entry(store, stream_id, entry);
     }
 
-    void remove_and_rewrite_version_keys(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void remove_and_rewrite_version_keys(std::shared_ptr<Store> store, const StreamId& stream_id) {
         log::version().warn("Rewriting all index keys for {}", stream_id);
         auto entry = get_entry(stream_id);
         auto old_entry = entry;
@@ -819,7 +832,7 @@ public:
         remove_entry_version_keys(store, old_entry, stream_id);
     }
 
-    void fix_ref_key(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void fix_ref_key(std::shared_ptr<Store> store, const StreamId& stream_id) {
         if(check_ref_key(store, stream_id)) {
             log::version().warn("Key {} is fine, not fixing", stream_id);
             return;
@@ -831,7 +844,7 @@ public:
 
     std::vector<AtomKey> find_deleted_version_keys_for_entry(
         std::shared_ptr<Store> store,
-        StreamIdArg stream_id,
+        const StreamId& stream_id,
         const std::shared_ptr<VersionMapEntry>& entry) {
         std::vector<AtomKey> missing_versions;
 
@@ -850,13 +863,13 @@ public:
         return missing_versions;
     }
 
-    std::vector<AtomKey> find_deleted_version_keys(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    std::vector<AtomKey> find_deleted_version_keys(std::shared_ptr<Store> store, const StreamId& stream_id) {
         auto entry = std::make_shared<VersionMapEntry>();
         load_via_iteration(store, stream_id, entry);
         return find_deleted_version_keys_for_entry(store, stream_id, entry);
     }
 
-    void recover_deleted(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    void recover_deleted(std::shared_ptr<Store> store, const StreamId& stream_id) {
         auto &entry = get_entry(stream_id);
         entry->clear();
         load_via_iteration(store, stream_id, entry);
@@ -893,7 +906,7 @@ private:
         return entry;
     }
 
-    std::shared_ptr<VersionMapEntry> do_backwards_compat_check(std::shared_ptr<Store> store, StreamIdArg stream_id) {
+    std::shared_ptr<VersionMapEntry> do_backwards_compat_check(std::shared_ptr<Store> store, const StreamId& stream_id) {
         ARCTICDB_TRACE(log::version(), "Didn't find a ref entry, scanning for old-style journal keys");
         auto entry = get_entry(stream_id);
         if (auto old_entry = load_from_old_journal_keys(store, stream_id); !old_entry->keys_.empty()) {
@@ -904,7 +917,8 @@ private:
         return entry;
     }
 
-    std::vector<AtomKey> tombstone_from_key_or_all_internal(std::shared_ptr<Store> store, const StreamId& stream_id,
+    std::pair<VersionId, std::vector<AtomKey>> tombstone_from_key_or_all_internal(std::shared_ptr<Store> store,
+                                                            const StreamId& stream_id,
                                                             std::optional<AtomKey> first_key_to_tombstone = std::nullopt,
                                                             std::shared_ptr<VersionMapEntry> entry = nullptr) {
         if (!entry) {
@@ -914,6 +928,7 @@ private:
                     LoadParameter{LoadType::LOAD_UNDELETED},
                     __FUNCTION__);
         }
+
         if (!first_key_to_tombstone)
             first_key_to_tombstone = entry->get_first_index(false);
 
@@ -925,13 +940,17 @@ private:
             }
         }
 
+        const auto& latest_version = entry->get_first_index(true);
+        const VersionId version_id = latest_version ? latest_version->version_id() : 0;
+
         if (!output.empty()) {
             auto tombstone_key = write_tombstone_all_key(store, first_key_to_tombstone.value(), entry);
             if(log_changes_) {
                 log_tombstone_all(store, stream_id, tombstone_key.version_id());
             }
         }
-        return output;
+
+        return {version_id, std::move(output)};
     }
 };
 

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -93,7 +93,7 @@ inline void check_is_index_or_tombstone(const AtomKey &key) {
     util::check(is_index_or_tombstone(key), "Expected index or tombstone key type but got {}", key);
 }
 
-inline AtomKey index_to_tombstone(const AtomKey &index_key, StreamId stream_id, timestamp creation_ts) {
+inline AtomKey index_to_tombstone(const AtomKey &index_key, const StreamId& stream_id, timestamp creation_ts) {
     return atom_key_builder()
         .version_id(index_key.version_id())
         .creation_ts(creation_ts)
@@ -103,7 +103,7 @@ inline AtomKey index_to_tombstone(const AtomKey &index_key, StreamId stream_id, 
         .build(stream_id, KeyType::TOMBSTONE);
 }
 
-inline AtomKey index_to_tombstone(VersionId version_id, StreamId stream_id, timestamp creation_ts) {
+inline AtomKey index_to_tombstone(VersionId version_id, const StreamId& stream_id, timestamp creation_ts) {
     return atom_key_builder()
         .version_id(version_id)
         .creation_ts(creation_ts)
@@ -184,7 +184,7 @@ struct VersionMapEntry {
     }
 
     bool is_tombstoned_via_tombstone_all(VersionId version_id) const {
-        return tombstone_all_ && tombstone_all_.value().version_id() >= version_id;
+        return tombstone_all_ && tombstone_all_->version_id() >= version_id;
     }
 
     bool is_tombstoned(const AtomKey &key) const {
@@ -196,7 +196,7 @@ struct VersionMapEntry {
     }
 
     std::optional<AtomKey> get_tombstone_if_any(VersionId version_id) {
-        if (tombstone_all_ && tombstone_all_.value().version_id() >= version_id) {
+        if (tombstone_all_ && tombstone_all_->version_id() >= version_id) {
             return tombstone_all_;
         }
         auto it = tombstones_.find(version_id);
@@ -208,10 +208,10 @@ struct VersionMapEntry {
         strm << std::endl << "Last reload time: " << last_reload_time_ << std::endl;
 
         if(head_)
-            strm << "Head: " << fmt::format("{}", head_.value()) << std::endl;
+            strm << "Head: " << fmt::format("{}", *head_) << std::endl;
 
         if(tombstone_all_)
-            strm << "Tombstone all: " << fmt::format("{}", tombstone_all_.value()) << std::endl;
+            strm << "Tombstone all: " << fmt::format("{}", *tombstone_all_) << std::endl;
 
         strm << "Keys: " << std::endl << std::endl;
         for(const auto& key: keys_)
@@ -273,7 +273,7 @@ struct VersionMapEntry {
                 if(!version_timestamp)
                     version_timestamp = key.creation_ts();
                 else {
-                    util::check(key.creation_ts() <= version_timestamp.value(), "out of order timestamp: {} > {}", key.creation_ts(), version_timestamp.value());
+                    util::check(key.creation_ts() <= *version_timestamp, "out of order timestamp: {} > {}", key.creation_ts(), version_timestamp.value());
                 }
             }
             if (is_index_key_type(key.type())) {
@@ -300,7 +300,7 @@ struct VersionMapEntry {
 
         std::unordered_map<StreamId, std::vector<VersionId>> id_to_version_id;
         if (head_)
-            id_to_version_id[head_.value().id()].push_back(head_.value().version_id());
+            id_to_version_id[head_->id()].push_back(head_->version_id());
         for (const auto& k: keys_)
             id_to_version_id[k.id()].push_back(k.version_id());
         util::check_rte(id_to_version_id.size() == 1, "Multiple symbols in keys: {}", fmt::format("{}", id_to_version_id));
@@ -308,7 +308,7 @@ struct VersionMapEntry {
 
     void try_set_tombstone_all(const AtomKey& key) {
         util::check(key.type() == KeyType::TOMBSTONE_ALL, "Can't set tombstone all key with key {}", key);
-        if(!tombstone_all_ || tombstone_all_.value().version_id() < key.version_id())
+        if(!tombstone_all_ || tombstone_all_->version_id() < key.version_id())
             tombstone_all_ = key;
     }
 
@@ -377,7 +377,7 @@ inline std::optional<VersionId> get_next_version_in_entry(const std::shared_ptr<
 inline std::optional<AtomKey> find_index_key_for_version_id(
     VersionId version_id,
     const std::shared_ptr<VersionMapEntry>& entry,
-    bool included_deleted=true) {
+    bool included_deleted = true) {
     auto key = std::find_if(std::begin(entry->keys_), std::end(entry->keys_), [version_id] (const auto& key) {
         return is_index_key_type(key.type()) && key.version_id() == version_id;
     });
@@ -392,13 +392,14 @@ inline std::optional<std::pair<AtomKey, AtomKey>> get_latest_key_pair(const std:
         auto journal_key = entry->head_.value();
         auto index_key = entry->get_first_index(false);
         util::check(static_cast<bool>(index_key), "Did not find undeleted version");
-        return std::make_pair(std::move(index_key.value()), std::move(journal_key));
+        return std::make_pair(std::move(*index_key), std::move(journal_key));
     }
     return std::nullopt;
 }
 
 inline void remove_duplicate_index_keys(const std::shared_ptr<VersionMapEntry>& entry) {
-    entry->keys_.erase(std::unique(entry->keys_.begin(), entry->keys_.end()), entry->keys_.end());
+    auto& keys = entry->keys_;
+    keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
 }
 }
 
@@ -409,7 +410,7 @@ namespace fmt {
         constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    auto format(const arcticdb::LoadType &l, FormatContext &ctx) const {
+    auto format(arcticdb::LoadType l, FormatContext &ctx) const {
         switch(l) {
         case arcticdb::LoadType::NOT_LOADED:
             return format_to(ctx.out(), "NOT_LOADED");

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -52,7 +52,7 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
     ARCTICDB_DEBUG(log::version(), "write_dataframe_specific_version stream_id: {} , version_id: {}", stream_id, version_id);
     if (auto version_key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id, VersionQuery{}, ReadOptions{}); version_key) {
         log::version().warn("Symbol stream_id: {} already exists with version_id: {}", stream_id, version_id);
-        return {std::move(version_key.value())};
+        return {std::move(*version_key)};
     }
 
     auto versioned_item = write_dataframe_impl(
@@ -63,7 +63,7 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
 
     version_map()->write_version(store(), versioned_item.key_);
     if(cfg().symbol_list())
-        symbol_list().add_symbol(store(), stream_id);
+        symbol_list().add_symbol(store(), stream_id, version_id);
 
     return versioned_item;
 }
@@ -76,7 +76,7 @@ std::vector<InputTensorFrame> create_input_tensor_frames(
     std::vector<InputTensorFrame> output;
     output.reserve(stream_ids.size());
     for (size_t idx = 0; idx < stream_ids.size(); idx++) {
-        output.push_back(convert::py_ndf_to_frame(stream_ids[idx], items[idx], norms[idx], user_metas[idx]));
+        output.emplace_back(convert::py_ndf_to_frame(stream_ids[idx], items[idx], norms[idx], user_metas[idx]));
     }
     return output;
 }
@@ -93,7 +93,7 @@ std::vector<VersionedItem> PythonVersionStore::batch_write_index_keys_to_version
 
     std::vector<folly::Future<folly::Unit>> symbol_write_futs;
     for(const auto& item : output) {
-        symbol_write_futs.emplace_back(async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.key_.id())));
+        symbol_write_futs.emplace_back(async::submit_io_task(WriteSymbolTask(store(), symbol_list_ptr(), item.key_.id(), item.key_.version_id())));
     }
     folly::collect(symbol_write_futs).wait();
 
@@ -132,7 +132,7 @@ void PythonVersionStore::_clear_symbol_list_keys() {
 
 void PythonVersionStore::reload_symbol_list() {
     symbol_list().clear(store());
-    symbol_list().load(store(), false);
+    symbol_list().load(version_map(), store(), false);
 }
 
 // To be sorted on timestamp
@@ -210,7 +210,6 @@ VersionResultVector get_latest_versions_for_symbols(
     const VersionQuery& version_query
 ) {
     VersionResultVector res;
-    std::unordered_set<std::pair<StreamId, VersionId>> unpruned_versions;
     for (auto &s_id: stream_ids) {
             const auto& opt_version_key = get_latest_undeleted_version(store, version_map, s_id, version_query, ReadOptions{});
             if (opt_version_key) {
@@ -273,11 +272,10 @@ VersionResultVector PythonVersionStore::list_versions(
     const std::optional<bool>& skip_snapshots) {
     ARCTICDB_SAMPLE(ListVersions, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: list_versions");
-    VersionResultVector res;
     auto stream_ids = std::set<StreamId>();
 
     if (stream_id) {
-        stream_ids.insert(stream_id.value());
+        stream_ids.insert(*stream_id);
     } else {
         stream_ids = list_streams(snap_name);
     }
@@ -303,7 +301,7 @@ VersionResultVector PythonVersionStore::list_versions(
        return get_all_versions_for_symbols(store(), version_map(), stream_ids, snapshots_for_symbol, creation_ts_for_version_symbol);
 }
 
-std::vector<std::pair<SnapshotId, py::object>> PythonVersionStore::list_snapshots(const std::optional<bool> load_metadata) {
+std::vector<std::pair<SnapshotId, py::object>> PythonVersionStore::list_snapshots(std::optional<bool> load_metadata) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: list_snapshots");
     auto snap_ids = std::vector<std::pair<SnapshotId, py::object>>();
     auto fetch_metadata = opt_false(load_metadata);
@@ -326,7 +324,7 @@ void PythonVersionStore::add_to_snapshot(
     if (!opt_snapshot) {
         throw NoDataFoundException(snap_name);
     }
-    auto [snap_key, snap_segment] = opt_snapshot.value();
+    auto [snap_key, snap_segment] = std::move(*opt_snapshot);
     auto [snapshot_contents, user_meta] = get_versions_and_metadata_from_snapshot(store(), snap_key);
     auto [specific_versions_index_map, latest_versions_index_map] = get_stream_index_map(stream_ids, version_queries);
     for(const auto& latest_version : *latest_versions_index_map) {
@@ -380,7 +378,7 @@ void PythonVersionStore::remove_from_snapshot(
     if (!opt_snapshot) {
         throw NoDataFoundException(snap_name);
     }
-    auto [snap_key, snap_segment] = opt_snapshot.value();
+    auto [snap_key, snap_segment] = std::move(*opt_snapshot);
     auto [snapshot_contents, user_meta] = get_versions_and_metadata_from_snapshot(store(), snap_key);
 
     using SymbolVersion = std::pair<StreamId, VersionId>;
@@ -481,8 +479,7 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     auto version_id = get_next_version_from_key(maybe_prev);
 
     //    TODO: We are not actually partitioning stuff atm, just assuming a single partition is passed for now.
-    std::vector<py::object> partitioned_dfs;
-    partitioned_dfs.push_back(item);
+    std::array<py::object, 1> partitioned_dfs{item};
 
     auto write_options = get_write_options();
     auto de_dup_map = std::make_shared<DeDupMap>();
@@ -554,7 +551,7 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     write_version_and_prune_previous_if_needed(prune_previous_versions, versioned_item.key_, maybe_prev);
 
     if(cfg().symbol_list())
-        symbol_list().add_symbol(store(), stream_id);
+        symbol_list().add_symbol(store(), stream_id, version_id);
 
     return versioned_item;
 }
@@ -570,9 +567,6 @@ VersionedItem PythonVersionStore::write_versioned_dataframe(
     ARCTICDB_SAMPLE(WriteVersionedDataframe, 0)
     auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta);
     auto versioned_item = write_versioned_dataframe_internal(stream_id, std::move(frame), prune_previous_versions, sparsify_floats, validate_index);
-
-    if(cfg().symbol_list())
-        symbol_list().add_symbol(store(), stream_id);
 
     return versioned_item;
 }
@@ -802,7 +796,7 @@ void PythonVersionStore::delete_snapshot(const SnapshotId& snap_name) {
     if (!opt_snapshot) {
         throw NoDataFoundException(snap_name);
     }
-    auto [snap_key, snap_segment] = opt_snapshot.value();
+    auto [snap_key, snap_segment] = std::move(*opt_snapshot);
 
     if (variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
         ARCTICDB_DEBUG(log::version(), "Delaying deletion of Snapshot {}", snap_name);
@@ -876,10 +870,8 @@ std::vector<SnapshotVariantKey> ARCTICDB_UNUSED iterate_snapshot_tombstones (
 } // namespace
 
 void PythonVersionStore::delete_version(
-    const StreamId& stream_id,
-    const VersionId& version_id
-    ) {
-
+        const StreamId& stream_id,
+        VersionId version_id) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_version");
     auto result = ::arcticdb::tombstone_version(store(), version_map(), stream_id, version_id, VersionQuery{}, ReadOptions{});
 
@@ -888,7 +880,7 @@ void PythonVersionStore::delete_version(
     }
 
     if(result.no_undeleted_left && cfg().symbol_list()) {
-        symbol_list().remove_symbol(store(), stream_id);
+        symbol_list().remove_symbol(store(), stream_id, result.latest_version_);
     }
 }
 
@@ -917,16 +909,16 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
             __FUNCTION__);
     storage::check<ErrorCode::E_SYMBOL_NOT_FOUND>(!entry->empty(), "Symbol {} is not found", stream_id);
     auto latest = entry->get_first_index(false);
-
+    util::check(static_cast<bool>(latest), "Failed to find latest index");
     auto prev_id = get_prev_version_in_entry(entry, latest->version_id());
     if (!prev_id) {
         ARCTICDB_DEBUG(log::version(), "No previous versions to prune for stream_id={}", stream_id);
         return;
     }
 
-    auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, prev_id.value(), VersionQuery{}, ReadOptions{});
-    auto pruned_indexes = version_map()->tombstone_from_key_or_all(store(), stream_id, previous);
-    delete_unreferenced_pruned_indexes(pruned_indexes, latest.value()).get();
+    auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, *prev_id, VersionQuery{}, ReadOptions{});
+    auto [_, pruned_indexes] = version_map()->tombstone_from_key_or_all(store(), stream_id, previous);
+    delete_unreferenced_pruned_indexes(pruned_indexes, *latest).get();
 }
 
 void PythonVersionStore::delete_all_versions(const StreamId& stream_id) {
@@ -937,17 +929,28 @@ void PythonVersionStore::delete_all_versions(const StreamId& stream_id) {
         log::version().warn("Symbol: {} does not exist.", stream_id);
         return;
     }
-    auto all_index_keys = version_map()->delete_all_versions(store(), stream_id);
-    ARCTICDB_DEBUG(log::version(), "Version heads deleted for symbol {}. Proceeding with index keys total of {}", stream_id, all_index_keys.size());
-    if (!cfg().write_options().delayed_deletes()) {
-        delete_tree({all_index_keys.begin(), all_index_keys.end()});
-    } else {
-        ARCTICDB_DEBUG(log::version(), "Not deleting data for {}", stream_id);
-    }
 
-    if(cfg().symbol_list())
-        symbol_list().remove_symbol(store(), stream_id);
-    ARCTICDB_DEBUG(log::version(), "Delete of Symbol {} successful", stream_id);
+    try {
+        auto [version_id, all_index_keys] = version_map()->delete_all_versions(store(), stream_id);
+        if (cfg().symbol_list())
+            symbol_list().remove_symbol(store(), stream_id, version_id);
+
+        ARCTICDB_DEBUG(log::version(),
+                       "Version heads deleted for symbol {}. Proceeding with index keys total of {}",
+                       stream_id,
+                       all_index_keys.size());
+        if (!cfg().write_options().delayed_deletes()) {
+            delete_tree({all_index_keys.begin(), all_index_keys.end()});
+        } else {
+            ARCTICDB_DEBUG(log::version(), "Not deleting data for {}", stream_id);
+        }
+
+        ARCTICDB_DEBUG(log::version(), "Delete of Symbol {} successful", stream_id);
+    } catch(const StorageException& ex) {
+        log::version().error("Got storage exception in delete - possible parallel deletion?: {}", ex.what());
+    } catch(const CodecException& ex) {
+        log::version().error("Got codec exception in delete - possible parallel deletion?: {}", ex.what());
+    }
 }
 
 std::vector<timestamp> PythonVersionStore::get_update_times(
@@ -963,12 +966,11 @@ timestamp PythonVersionStore::get_update_time(
 }
 
 namespace {
-py::object metadata_protobuf_to_pyobject(std::optional<google::protobuf::Any> metadata_proto) {
+py::object metadata_protobuf_to_pyobject(const std::optional<google::protobuf::Any>& metadata_proto) {
     py::object pyobj;
-
     if (metadata_proto) {
         arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
-        metadata_proto.value().UnpackTo(&tsd);
+        metadata_proto->UnpackTo(&tsd);
         pyobj = python_util::pb_to_python(tsd.user_meta());
     }
     else {
@@ -1027,7 +1029,7 @@ std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> Pytho
     std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> results;
     for (auto&& metadata_or_error: metadatas_or_errors) {
         if (std::holds_alternative<std::pair<VariantKey, std::optional<google::protobuf::Any>>>(metadata_or_error)) {
-            auto&& [key, meta_proto] = std::get<std::pair<VariantKey, std::optional<google::protobuf::Any>>>(metadata_or_error);
+            auto& [key, meta_proto] = std::get<std::pair<VariantKey, std::optional<google::protobuf::Any>>>(metadata_or_error);
             VersionedItem version{std::move(to_atom(key))};
             if(meta_proto.has_value()) {
                 auto res = std::make_pair(std::move(version), metadata_protobuf_to_pyobject(std::move(meta_proto)));
@@ -1063,14 +1065,13 @@ ReadResult PythonVersionStore::read_index(
     const StreamId& stream_id,
     const VersionQuery& version_query
     ) {
-    ARCTICDB_SAMPLE(ReadDescriptor, 0)
+    ARCTICDB_SAMPLE(ReadIndex, 0)
 
-    py::object pyobj;
     auto version = get_version_to_read(stream_id, version_query, ReadOptions{});
     if(!version)
         throw NoDataFoundException(fmt::format("read_index: version not found for symbol '{}'", stream_id));
 
-    auto res = read_index_impl(store(), version.value());
+    auto res = read_index_impl(store(), *version);
     return make_read_result_from_frame(res, version->key_);
 }
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -207,7 +207,7 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     void delete_version(
         const StreamId& stream_id,
-        const VersionId& version_id);
+        VersionId version_id);
 
     void prune_previous_versions(
         const StreamId& stream_id);
@@ -233,6 +233,10 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     inline bool check_ref_key(StreamId stream_id) {
         return version_map()->check_ref_key(store(), std::move(stream_id));
+    }
+
+    inline bool indexes_sorted(StreamId stream_id) {
+        return version_map()->indexes_sorted(store(), stream_id);
     }
 
     void snapshot(
@@ -355,12 +359,13 @@ inline std::vector<std::variant<ReadResult, DataError>> frame_to_read_result(std
     std::vector<std::variant<ReadResult, DataError>> read_results;
     read_results.reserve(keys_frame_and_descriptors.size());
     for (auto& read_version_output : keys_frame_and_descriptors) {
+        const auto& desc_proto = read_version_output.frame_and_descriptor_.desc_.proto();
         read_results.emplace_back(ReadResult(
             read_version_output.versioned_item_,
             PythonOutputFrame{read_version_output.frame_and_descriptor_.frame_, read_version_output.frame_and_descriptor_.buffers_},
-            read_version_output.frame_and_descriptor_.desc_.proto().normalization(),
-            read_version_output.frame_and_descriptor_.desc_.proto().user_meta(),
-            read_version_output.frame_and_descriptor_.desc_.proto().multi_key_meta(),
+            desc_proto.normalization(),
+            desc_proto.user_meta(),
+            desc_proto.multi_key_meta(),
             std::vector<AtomKey>{}));
     }
     return read_results;

--- a/cpp/arcticdb/version/version_store_objects.hpp
+++ b/cpp/arcticdb/version/version_store_objects.hpp
@@ -65,7 +65,11 @@ struct TombstoneVersionResult : PreDeleteChecks {
     /**
      * If the tombstoning of this version caused the entire symbol to disappear.
      */
-    bool no_undeleted_left;
+    bool no_undeleted_left = false;
+    /**
+     * The most recent version written to the version list
+     */
+     VersionId latest_version_ = 0;
 };
 
 /**

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -19,7 +19,7 @@ struct UpdateMetadataTask : async::BaseTask {
     const version_store::UpdateInfo update_info_;
     const AtomKey index_key_;
     arcticdb::proto::descriptors::UserDefinedMetadata user_meta_;
-    VersionId version_id_;
+    VersionId version_id_ = 0;
 
     UpdateMetadataTask(
         std::shared_ptr<Store> store,

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -14,6 +14,7 @@
 #include <arcticdb/stream/index_aggregator.hpp>
 #include <arcticdb/version/version_map_entry.hpp>
 #include <arcticdb/python/python_utils.hpp>
+#include <arcticdb/entity/frame_and_descriptor.hpp>
 
 #include <utility>
 #include <memory>
@@ -82,7 +83,7 @@ inline std::optional<AtomKey> read_segment_with_keys(
 
     for (; row < ssize_t(seg.row_count()); ++row) {
         auto key = read_key_row(seg, row);
-        ARCTICDB_TRACE(log::version(), "Reading key {}", key);
+        ARCTICDB_DEBUG(log::version(), "Reading key {}", key);
 
         if (is_index_key_type(key.type())) {
             entry.keys_.push_back(key);
@@ -226,7 +227,7 @@ inline void read_symbol_ref(const std::shared_ptr<StreamSource>& store, const St
     if (!maybe_ref_key)
         return;
 
-    auto [key, seg] = store->read_sync(maybe_ref_key.value());
+    auto [key, seg] = store->read_sync(*maybe_ref_key);
 
     LoadProgress load_progress;
     entry.head_ = read_segment_with_keys(seg, entry, load_progress);
@@ -272,12 +273,12 @@ inline bool loaded_until_version_id(const LoadParameter &load_params, const Load
         return false;
 
     if (is_positive_version_query(load_params)) {
-        if (load_progress.loaded_until_ > static_cast<VersionId>(load_params.load_until_.value())) {
+        if (load_progress.loaded_until_ > static_cast<VersionId>(*load_params.load_until_)) {
             return false;
         }
     } else {
         if (latest_version.has_value()) {
-            if (auto opt_version_id = get_version_id_negative_index(latest_version.value(), *load_params.load_until_);
+            if (auto opt_version_id = get_version_id_negative_index(*latest_version, *load_params.load_until_);
                 opt_version_id && load_progress.loaded_until_ > *opt_version_id) {
                     return false;
             }
@@ -288,7 +289,7 @@ inline bool loaded_until_version_id(const LoadParameter &load_params, const Load
     ARCTICDB_DEBUG(log::version(),
                    "Exiting load downto because loaded to version {} for request {} with {} total versions",
                    load_progress.loaded_until_,
-                   load_params.load_until_.value(),
+                   *load_params.load_until_,
                    latest_version.value()
                   );
     return true;
@@ -307,12 +308,12 @@ static constexpr timestamp nanos_to_seconds(timestamp nanos) {
 }
 
 inline bool loaded_until_timestamp(const LoadParameter &load_params, const LoadProgress& load_progress) {
-    if (!load_params.load_from_time_ || load_progress.earliest_loaded_timestamp_ > load_params.load_from_time_.value())
+    if (!load_params.load_from_time_ || load_progress.earliest_loaded_timestamp_ > *load_params.load_from_time_)
         return false;
 
     ARCTICDB_DEBUG(log::version(),
                    "Exiting load from timestamp because request {} <= {}",
-                   load_params.load_from_time_.value(),
+                   *load_params.load_from_time_,
                    load_progress.earliest_loaded_timestamp_);
     return true;
 }
@@ -349,8 +350,10 @@ inline bool looking_for_undeleted(const LoadParameter& load_params, const std::s
 }
 
 inline bool key_exists_in_ref_entry(const LoadParameter& load_params, const VersionMapEntry& ref_entry, const std::optional<AtomKey>&, LoadProgress&) {
-    if (is_latest_load_type(load_params.load_type_) && is_index_key_type(ref_entry.keys_[0].type()))
+    if (is_latest_load_type(load_params.load_type_) && is_index_key_type(ref_entry.keys_[0].type())) {
+        ARCTICDB_DEBUG(log::version(), "Not following version chain as key for {} exists in ref entry", ref_entry.head_->id());
         return true;
+    }
 
     return false;
 }
@@ -403,6 +406,19 @@ inline SortedValue deduce_sorted(SortedValue existing_frame, SortedValue input_f
         break;
     }
     return final_state;
+}
+
+inline FrameAndDescriptor frame_and_descriptor_from_segment(SegmentInMemory&& seg) {
+    TimeseriesDescriptor tsd;
+    auto& tsd_proto = tsd.mutable_proto();
+    tsd_proto.set_total_rows(seg.row_count());
+    const auto& seg_descriptor = seg.descriptor();
+    tsd_proto.mutable_stream_descriptor()->CopyFrom(seg_descriptor.proto());
+    if(seg.descriptor().index().type() == IndexDescriptor::ROWCOUNT)
+        ensure_rowcount_norm_meta(*tsd_proto.mutable_normalization(), seg_descriptor.id());
+    else
+        ensure_timeseries_norm_meta(*tsd.mutable_proto().mutable_normalization(), seg_descriptor.id(), false);
+    return {SegmentInMemory(std::move(seg)), tsd, {}, {}};
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -14,6 +14,7 @@
 #include <arcticdb/pipeline/write_options.hpp>
 #include <arcticdb/entity/versioned_item.hpp>
 #include <arcticdb/pipeline/query.hpp>
+#include <arcticdb/util/storage_lock.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
@@ -94,7 +95,7 @@ public:
      */
     virtual void delete_tree(
         const std::vector<IndexTypeKey>& idx_to_be_deleted,
-        const PreDeleteChecks& checks = default_pre_delete_checks
+        const PreDeleteChecks& checks
     ) = 0;
 
     virtual std::pair<VersionedItem,   TimeseriesDescriptor> restore_version(
@@ -146,8 +147,6 @@ public:
 
     virtual std::set<StreamId> get_active_incomplete_refs() = 0;
 
-    virtual void push_incompletes_to_symbol_list(const std::set<StreamId>& incompletes) = 0;
-
     virtual bool is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) = 0;
 
     virtual VersionedItem defragment_symbol_data(const StreamId& stream_id, std::optional<size_t> segment_size) = 0;
@@ -165,10 +164,10 @@ public:
     virtual void configure(
         const storage::LibraryDescriptor::VariantStoreConfig & cfg) = 0;
 
-    virtual WriteOptions get_write_options() const = 0;
+    [[nodiscard]] virtual WriteOptions get_write_options() const = 0;
 
     virtual std::shared_ptr<Store>& store() = 0;
-    virtual const arcticdb::proto::storage::VersionStoreConfig& cfg() const  = 0;
+    [[nodiscard]] virtual const arcticdb::proto::storage::VersionStoreConfig& cfg() const  = 0;
     virtual std::shared_ptr<VersionMap>& version_map() = 0;
     virtual SymbolList& symbol_list() = 0;
     virtual void set_store(std::shared_ptr<Store> store)= 0;

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -3,6 +3,7 @@ Copyright 2023 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+import pandas as pd
 import numpy as np
 import pytest
 
@@ -40,7 +41,7 @@ def test_get_types(object_and_mem_and_lmdb_version_store):
     index_keys = lib_tool.read_to_keys(key)
     assert len(index_keys) == 1
     index_df = lib_tool.read_to_dataframe(index_keys[0])
-    assert index_df.at[0, "version_id"] == 0
+    assert index_df.at[pd.Timestamp(0), "version_id"] == 0
 
 
 def test_read_keys(object_and_mem_and_lmdb_version_store):

--- a/python/tests/unit/arcticdb/test_column_stats.py
+++ b/python/tests/unit/arcticdb/test_column_stats.py
@@ -86,7 +86,6 @@ def test_column_stats_infinity(lmdb_version_store_tiny_segment):
     expected_column_stats = expected_column_stats.iloc[[0, 1, 2]]
     expected_column_stats["v1.0_MIN(col_1)"] = [df0["col_1"].min(), df1["col_1"].min(), df2["col_1"].min()]
     expected_column_stats["v1.0_MAX(col_1)"] = [df0["col_1"].max(), df1["col_1"].max(), df2["col_1"].max()]
-
     column_stats_dict = {"col_1": {"MINMAX"}}
 
     lib.create_column_stats(sym, column_stats_dict)
@@ -105,7 +104,6 @@ def test_column_stats_as_of(lmdb_version_store_tiny_segment):
         axis=1,
         inplace=True,
     )
-
     column_stats_dict = {"col_1": {"MINMAX"}}
     lib.create_column_stats(sym, column_stats_dict, as_of=0)
     assert lib.get_column_stats_info(sym, as_of=0) == column_stats_dict
@@ -370,7 +368,6 @@ def test_column_stats_dynamic_schema_missing_data(lmdb_version_store_tiny_segmen
         np.nan,
         df4["col_2"].max(),
     ]
-
     column_stats_dict = {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
     lib.create_column_stats(sym, column_stats_dict)
     assert lib.get_column_stats_info(sym) == column_stats_dict
@@ -446,7 +443,6 @@ def test_column_stats_dynamic_schema_types_changing(lmdb_version_store_tiny_segm
 
     expected_column_stats["v1.0_MIN(float_to_int)"] = [df0["float_to_int"].min(), df1["float_to_int"].min()]
     expected_column_stats["v1.0_MAX(float_to_int)"] = [df0["float_to_int"].max(), df1["float_to_int"].max()]
-
     column_stats_dict = {
         "int_widening": {"MINMAX"},
         "int_narrowing": {"MINMAX"},


### PR DESCRIPTION
Fixes issue #773

Design doc: https://github.com/man-group/arcticdb-bloomberg/blob/main/RFCs/00005-symbol-list-refactor.md

Depending on timestamps being accurate in the symbol list has proved to be troublesome. Instead, we should use the most recent version id known to a client as an indication of the client's view of the world at the time as symbol list entry is written. That way, we can identify and correct symbol list entries that refer to conflicting writes. 

The timestamp is still stored, but is now only used as a coarse heuristic to determine whether writes to the same symbol occurred close enough together to constitute a possible overlapping write. 

When a problematic symbol list entry is encountered, it is added to a list, and at the end of the scan a batch operation is performed to determine whether the problematic symbol/version pairs exist or not. 

Regarding backwards compatibility, older clients will be able to read the new symbol keys, both journalled and compacted, however they will not make any use of the information in compaction. If a newer client detects that there are keys produced by an older client for a particular symbol, that entry will not be flagged as problematic on this run, since the information to determine whether or not it is genuinely problematic is not present.