### PR TITLE
test: Test the absence of implace modification on datetime64 normalization for pandas 2.0

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -186,7 +186,7 @@ def _to_primitive(arr, arr_name, dynamic_strings, string_max_len=None, coerce_co
         # See: https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#construction-with-datetime64-or-timedelta64-dtype-with-unsupported-resolution  # noqa: E501
         # We want to maintain consistent behaviour, so we convert any other resolution
         # to `datetime64[ns]`.
-        arr = arr.astype(DTN64_DTYPE)
+        arr = arr.astype(DTN64_DTYPE, copy=False)
 
     if arr.dtype.hasobject is False and not (
         dynamic_strings and arr.dtype == "float" and coerce_column_type in obj_tokens

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -186,7 +186,7 @@ def _to_primitive(arr, arr_name, dynamic_strings, string_max_len=None, coerce_co
         # See: https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#construction-with-datetime64-or-timedelta64-dtype-with-unsupported-resolution  # noqa: E501
         # We want to maintain consistent behaviour, so we convert any other resolution
         # to `datetime64[ns]`.
-        arr = arr.astype(DTN64_DTYPE, copy=False)
+        arr = arr.astype(DTN64_DTYPE)
 
     if arr.dtype.hasobject is False and not (
         dynamic_strings and arr.dtype == "float" and coerce_column_type in obj_tokens


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up of https://github.com/man-group/ArcticDB/pull/540.

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

See this thread https://github.com/man-group/ArcticDB/pull/540/files#r1288498933.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
