### PR TITLE
Bugfix: nativeversionstore read metadata batch and write batch should never return dataerror objects

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -443,8 +443,8 @@ std::vector<std::variant<DescriptorItem, DataError>> LocalVersionedEngine::batch
     const std::vector<VersionQuery>& version_queries,
     const ReadOptions& read_options) {
 
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_missing_version_.has_value(),
-                                                    "ReadOptions::batch_throw_on_missing_version_ should always be set here");
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_error_.has_value(),
+                                                    "ReadOptions::batch_throw_on_error_ should always be set here");
 
     auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
     std::vector<folly::Future<DescriptorItem>> descriptor_futures;
@@ -459,7 +459,7 @@ std::vector<std::variant<DescriptorItem, DataError>> LocalVersionedEngine::batch
         if (descriptor.hasValue()) {
             descriptors_or_errors.emplace_back(std::move(descriptor.value()));
         } else {
-            if (*read_options.batch_throw_on_missing_version_) {
+            if (*read_options.batch_throw_on_error_) {
                 descriptor.throwUnlessValue();
             } else {
                 auto exception = descriptor.exception();
@@ -1335,7 +1335,8 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     const std::vector<StreamId>& stream_ids,
     std::vector<InputTensorFrame>&& frames,
     bool prune_previous_versions,
-    bool validate_index
+    bool validate_index,
+    bool throw_on_error
 ) {
     auto write_options = get_write_options();
     auto update_info_futs = batch_get_latest_undeleted_version_and_next_version_id_async(store(),
@@ -1380,6 +1381,9 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         if (write_version.hasValue()) {
             write_versions_or_errors.emplace_back(std::move(write_version.value()));
         } else {
+            if (throw_on_error) {
+                write_version.throwUnlessValue();
+            }
             auto exception = write_version.exception();
             DataError data_error(stream_ids[idx], exception.what().toStdString());
             if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
@@ -1443,7 +1447,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     bool prune_previous_versions,
     bool validate_index,
     bool upsert,
-    bool throw_on_missing_version) {
+    bool throw_on_error) {
 
     auto stream_update_info_futures = batch_get_latest_undeleted_version_and_next_version_id_async(store(),
                                                                                                     version_map(),
@@ -1485,7 +1489,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         if (append_version.hasValue()) {
             append_versions_or_errors.emplace_back(std::move(append_version.value()));
         } else {
-            if (throw_on_missing_version) {
+            if (throw_on_error) {
                 append_version.throwUnlessValue();
             } else {
                 auto exception = append_version.exception();
@@ -1648,6 +1652,9 @@ std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::A
     const std::vector<VersionQuery>& version_queries,
     const ReadOptions& read_options
     ) {
+    // This read option should always be set when calling batch_read_metadata
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_error_.has_value(),
+                                                    "ReadOptions::batch_throw_on_error_ should always be set here");
     auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
     std::vector<folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>>> metadata_futures;
     for (auto&& [idx, version]: folly::enumerate(version_futures)) {
@@ -1662,13 +1669,18 @@ std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::A
             metadatas_or_errors.emplace_back(std::move(metadata.value()));
         } else {
             auto exception = metadata.exception();
-            DataError data_error(stream_ids[idx], exception.what().toStdString(), version_queries[idx].content_);
-            if (exception.is_compatible_with<NoSuchVersionException>()) {
-                data_error.set_error_code(ErrorCode::E_NO_SUCH_VERSION);
-            } else if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
-                data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+            // For historical reasons, batch_read_metadata does not raise if the version does not exist (unlike batch_read)
+            if (*read_options.batch_throw_on_error_ && !exception.is_compatible_with<NoSuchVersionException>()) {
+                metadata.throwUnlessValue();
+            } else {
+                DataError data_error(stream_ids[idx], exception.what().toStdString(), version_queries[idx].content_);
+                if (exception.is_compatible_with<NoSuchVersionException>()) {
+                    data_error.set_error_code(ErrorCode::E_NO_SUCH_VERSION);
+                } else if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
+                    data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+                }
+                metadatas_or_errors.emplace_back(std::move(data_error));
             }
-            metadatas_or_errors.emplace_back(std::move(data_error));
         }
     }
     return metadatas_or_errors;

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -285,7 +285,7 @@ public:
         bool prune_previous_versions,
         bool validate_index,
         bool upsert,
-        bool throw_on_missing_version);
+        bool throw_on_error);
 
     std::vector<ReadVersionOutput> batch_read_keys(
         const std::vector<AtomKey> &keys,
@@ -382,7 +382,8 @@ public:
         const std::vector<StreamId>& stream_ids,
         std::vector<InputTensorFrame>&& frames,
         bool prune_previous_versions,
-        bool validate_index
+        bool validate_index,
+        bool throw_on_error
     );
 
     VersionIdAndDedupMapInfo create_version_id_and_dedup_map(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -106,10 +106,11 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_wr
     const std::vector<py::object> &norms,
     const std::vector<py::object> &user_metas,
     bool prune_previous_versions,
-    bool validate_index) {
+    bool validate_index,
+    bool throw_on_error) {
 
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
-    return batch_write_versioned_dataframe_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index);
+    return batch_write_versioned_dataframe_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index, throw_on_error);
 }
 
 std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_append(
@@ -120,9 +121,9 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_ap
     bool prune_previous_versions,
     bool validate_index,
     bool upsert,
-    bool throw_on_missing_version) {
+    bool throw_on_error) {
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
-    return batch_append_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index, upsert, throw_on_missing_version);
+    return batch_append_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index, upsert, throw_on_error);
 }
 
 void PythonVersionStore::_clear_symbol_list_keys() {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -269,7 +269,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::vector<py::object> &norms,
         const std::vector<py::object> &user_metas,
         bool prune_previous_versions,
-        bool validate_index);
+        bool validate_index,
+        bool throw_on_error);
 
     std::vector<std::variant<VersionedItem, DataError>> batch_write_metadata(
         const std::vector<StreamId>& stream_ids,
@@ -285,7 +286,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         bool prune_previous_versions,
         bool validate_index,
         bool upsert,
-        bool throw_on_missing_version);
+        bool throw_on_error);
 
     std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> batch_restore_version(
         const std::vector<StreamId>& id,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1022,6 +1022,10 @@ class NativeVersionStore:
     def _batch_read_metadata_to_versioned_items(self, symbols, as_ofs, include_errors_and_none_meta, **kwargs):
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         read_options = self._get_read_options(**kwargs)
+        # For historical reasons, NativeVersionStore.batch_read_metadata returns None if the requested version does not
+        # exist, but should throw an exception for other errors. Library.read_metadata_batch should get DataError
+        # objects if exceptions are thrown.
+        read_options.set_batch_throw_on_error(not include_errors_and_none_meta)
         metadatas_or_errors = self.version_store.batch_read_metadata(symbols, version_queries, read_options)
         meta_items = []
         for metadata in metadatas_or_errors:
@@ -1080,6 +1084,7 @@ class NativeVersionStore:
         results_dict = {}
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         read_options = self._get_read_options(**kwargs)
+        read_options.set_batch_throw_on_error(True)
         for result in self.version_store.batch_read_metadata(symbols, version_queries, read_options):
             vitem, udm = result
             meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
@@ -1166,7 +1171,29 @@ class NativeVersionStore:
             If data is unsorted, when validate_index is set to True.
         """
         _check_batch_kwargs(NativeVersionStore.batch_write, NativeVersionStore.write, kwargs)
+        throw_on_error = True
+        return self._batch_write_internal(
+            symbols,
+            data_vector,
+            metadata_vector,
+            prune_previous_version,
+            pickle_on_failure,
+            validate_index,
+            throw_on_error,
+            **kwargs,
+        )
 
+    def _batch_write_internal(
+        self,
+        symbols: List[str],
+        data_vector: List[Any],
+        metadata_vector: Optional[List[Any]] = None,
+        prune_previous_version=None,
+        pickle_on_failure=None,
+        validate_index: bool = False,
+        throw_on_error: bool = True,
+        **kwargs,
+    ) -> List[VersionedItem]:
         for symbol in symbols:
             self.check_symbol_validity(symbol)
 
@@ -1202,7 +1229,7 @@ class NativeVersionStore:
         items = [info[1] for info in normalized_infos]
         norm_metas = [info[2] for info in normalized_infos]
         cxx_versioned_items = self.version_store.batch_write(
-            symbols, items, norm_metas, udms, prune_previous_version, validate_index
+            symbols, items, norm_metas, udms, prune_previous_version, validate_index, throw_on_error
         )
         write_results = []
         for result in cxx_versioned_items:
@@ -1313,7 +1340,7 @@ class NativeVersionStore:
         UnsortedDataException
             If data is unsorted, when validate_index is set to True.
         """
-        throw_on_missing_version = True
+        throw_on_error = True
         _check_batch_kwargs(NativeVersionStore.batch_append, NativeVersionStore.append, kwargs)
         return self._batch_append_to_versioned_items(
             symbols,
@@ -1321,7 +1348,7 @@ class NativeVersionStore:
             metadata_vector,
             prune_previous_version,
             validate_index,
-            throw_on_missing_version,
+            throw_on_error,
             **kwargs,
         )
 
@@ -1332,7 +1359,7 @@ class NativeVersionStore:
         metadata_vector,
         prune_previous_version,
         validate_index,
-        throw_on_missing_version,
+        throw_on_error,
         **kwargs,
     ):
         for symbol in symbols:
@@ -1377,7 +1404,7 @@ class NativeVersionStore:
             prune_previous_version,
             validate_index,
             write_if_missing,
-            throw_on_missing_version,
+            throw_on_error,
         )
         append_results = []
         for result in cxx_versioned_items:
@@ -2548,10 +2575,10 @@ class NativeVersionStore:
             - type, `str`
             - date_range, `tuple`
         """
-        throw_on_missing_version = True
-        return self._batch_read_descriptor(symbols, as_ofs, throw_on_missing_version)
+        throw_on_error = True
+        return self._batch_read_descriptor(symbols, as_ofs, throw_on_error)
 
-    def _batch_read_descriptor(self, symbols, as_ofs, throw_on_missing_version):
+    def _batch_read_descriptor(self, symbols, as_ofs, throw_on_error):
         as_ofs_lists = []
         if as_ofs == None:
             as_ofs_lists = [None] * len(symbols)
@@ -2563,7 +2590,7 @@ class NativeVersionStore:
             version_queries.append(self._get_version_query(as_of))
 
         read_options = _PythonVersionStoreReadOptions()
-        read_options.set_batch_throw_on_missing_version(throw_on_missing_version)
+        read_options.set_batch_throw_on_error(throw_on_error)
         descriptions_or_errors = self.version_store.batch_read_descriptor(symbols, version_queries, read_options)
         args_list = list(zip(descriptions_or_errors, symbols, version_queries, as_ofs_lists))
         description_results = []

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -566,13 +566,15 @@ class Library:
         self._raise_if_duplicate_symbols_in_batch(payloads)
         self._raise_if_unsupported_type_in_write_batch(payloads)
 
-        return self._nvs.batch_write(
+        throw_on_error = False
+        return self._nvs._batch_write_internal(
             [p.symbol for p in payloads],
             [p.data for p in payloads],
             [p.metadata for p in payloads],
             prune_previous_version=prune_previous_versions,
             pickle_on_failure=False,
             validate_index=validate_index,
+            throw_on_error=throw_on_error,
         )
 
     def write_pickle_batch(
@@ -739,7 +741,7 @@ class Library:
 
         self._raise_if_duplicate_symbols_in_batch(append_payloads)
         self._raise_if_unsupported_type_in_write_batch(append_payloads)
-        throw_on_missing_version = False
+        throw_on_error = False
 
         return self._nvs._batch_append_to_versioned_items(
             [p.symbol for p in append_payloads],
@@ -747,7 +749,7 @@ class Library:
             [p.metadata for p in append_payloads],
             prune_previous_version=prune_previous_versions,
             validate_index=validate_index,
-            throw_on_missing_version=throw_on_missing_version,
+            throw_on_error=throw_on_error,
         )
 
     def update(
@@ -1607,8 +1609,8 @@ class Library:
                     " [ReadInfoRequest] are supported."
                 )
 
-        throw_on_missing_version = False
-        descriptions = self._nvs._batch_read_descriptor(symbol_strings, as_ofs, throw_on_missing_version)
+        throw_on_error = False
+        descriptions = self._nvs._batch_read_descriptor(symbol_strings, as_ofs, throw_on_error)
 
         description_results = []
         for description in descriptions:

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1341,6 +1341,25 @@ def test_batch_write_then_list_symbol_without_cache(request, factory_name):
         assert set(lib.list_symbols()) == set(symbols)
 
 
+def test_batch_write_missing_keys_dedup(version_store_factory):
+    """When there is duplicate data to reuse for the current write, we need to access the index key of the previous
+    versions in order to refer to the corresponding keys for the deduplicated data."""
+    lib = version_store_factory(de_duplication=True)
+    assert lib.lib_cfg().lib_desc.version.write_options.de_duplication
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    lib_tool.remove(s1_index_key)
+
+    with pytest.raises(StorageException):
+        lib.batch_write(["s1", "s2"], [df1, df2])
+
+
 def test_batch_roundtrip_metadata(lmdb_version_store_tombstone_and_sync_passive):
     lmdb_version_store = lmdb_version_store_tombstone_and_sync_passive
     metadatas = {}
@@ -1561,7 +1580,7 @@ def test_batch_read_meta(lmdb_version_store_tombstone_and_sync_passive):
     assert results_dict["sym2"].data is None
 
 
-def test_batch_read_meta_with_missing(lmdb_version_store_tombstone_and_sync_passive):
+def test_batch_read_metadata_symbol_doesnt_exist(lmdb_version_store_tombstone_and_sync_passive):
     lmdb_version_store = lmdb_version_store_tombstone_and_sync_passive
     lib = lmdb_version_store
     for idx in range(10):
@@ -1571,6 +1590,42 @@ def test_batch_read_meta_with_missing(lmdb_version_store_tombstone_and_sync_pass
 
     assert results_dict["sym1"].metadata == {"meta": 1}
     assert "sym_doesnotexist" not in results_dict
+
+
+def test_batch_read_metadata_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    lib.write("s1", df1, metadata={"s1": "metadata"})
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    lib.write("s2", df2, metadata={"s2": "metadata"})
+    lib.write("s2", df2, metadata={"s2": "more_metadata"})
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s2")
+    s2_key_to_delete = [key for key in s2_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_key_to_delete)
+
+    with pytest.raises(StorageException):
+        _ = lib.batch_read_metadata(["s1"], [None])
+    with pytest.raises(StorageException):
+        _ = lib.batch_read_metadata(["s2"], [0])
+
+
+def test_batch_read_metadata_multi_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+    lib_tool = lib.library_tool()
+
+    lib.write("s1", 0, metadata={"s1": "metadata"})
+    key_to_delete = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    lib_tool.remove(key_to_delete)
+
+    with pytest.raises(StorageException):
+        _ = lib.batch_read_metadata_multi(["s1"], [None])
 
 
 def test_list_versions_with_deleted_symbols(lmdb_version_store_tombstone_and_pruning):
@@ -2051,6 +2106,30 @@ def test_batch_read_missing_keys(lmdb_version_store):
     # processed first
     with pytest.raises((NoDataFoundException, StorageException)):
         _ = lib.batch_read(["s1", "s2", "s3"], [None, None, 0])
+
+
+def test_batch_get_info_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [5, 7, 9]})
+    lib.write("s1", df1)
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    lib.write("s2", df2)
+    lib.write("s2", df2)
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s2")
+    s2_key_to_delete = [key for key in s2_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_key_to_delete)
+
+    with pytest.raises(StorageException):
+        _ = lib.batch_get_info(["s1"], [None])
+    with pytest.raises(StorageException):
+        _ = lib.batch_get_info(["s2"], [0])
 
 
 def test_index_keys_start_end_index(lmdb_version_store, sym):


### PR DESCRIPTION
#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

The NativeVersionStore API (used internally at Man Group) would previously throw an exception if there was a key missing from the storage required to complete a `batch_read_metadata` or `batch_write` operation. This was accidentally modified in PRs https://github.com/man-group/ArcticDB/pull/748 and https://github.com/man-group/ArcticDB/pull/757, such that DataError objects were returned instead. This was noticed prior to merging of those PRs, and so they were merged into an integration branch so that the `NativeVersionStore` API on `master` remained the same. This PR restores the previous behaviour, for the NativeVersionStore API, while maintaining the new behaviour for the Library API.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
