### PR TITLE
Integration/batch methods changes

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1610,25 +1610,52 @@ folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobu
     }
 }
 
-folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata_async(
-    folly::Future<std::optional<AtomKey>>&& version_fut){
+folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>> LocalVersionedEngine::get_metadata_async(
+    folly::Future<std::optional<AtomKey>>&& version_fut,
+    const StreamId& stream_id,
+    const VersionQuery& version_query
+    ) {
     return  std::move(version_fut)
-    .thenValue([this](std::optional<AtomKey>&& key){
+    .thenValue([this, &stream_id, &version_query](std::optional<AtomKey>&& key){
+        missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(key.has_value(),
+        "Unable to retrieve  metadata. {}@{}: version not found", stream_id, version_query);
         return get_metadata(std::move(key));
+    })
+    .thenValue([](auto&& metadata){
+        auto&& [opt_key, meta_proto] = metadata;
+        return std::make_pair(std::move(*opt_key), std::move(meta_proto));
     });
 }
-
-std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> LocalVersionedEngine::batch_read_metadata_internal(
+ 
+std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::Any>>, DataError>> LocalVersionedEngine::batch_read_metadata_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     const ReadOptions& read_options
     ) {
-    auto versions_fut = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
-    std::vector<folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>> fut_vec;
-    for (auto&& version: versions_fut){
-        fut_vec.push_back(get_metadata_async(std::move(version)));
+    auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
+    std::vector<folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>>> metadata_futures;
+    for (auto&& [idx, version]: folly::enumerate(version_futures)) {
+        metadata_futures.push_back(get_metadata_async(std::move(version), stream_ids[idx], version_queries[idx]));
     }
-    return folly::collect(fut_vec).get();
+
+    auto metadatas = folly::collectAll(metadata_futures).get();
+    std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::Any>>, DataError>> metadatas_or_errors;
+    metadatas_or_errors.reserve(metadatas.size());
+    for (auto&& [idx, metadata]: folly::enumerate(metadatas)) {
+        if (metadata.hasValue()) {
+            metadatas_or_errors.emplace_back(std::move(metadata.value()));
+        } else {
+            auto exception = metadata.exception();
+            DataError data_error(stream_ids[idx], exception.what().toStdString(), version_queries[idx].content_);
+            if (exception.is_compatible_with<NoSuchVersionException>()) {
+                data_error.set_error_code(ErrorCode::E_NO_SUCH_VERSION);
+            } else if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
+                data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+            }
+            metadatas_or_errors.emplace_back(std::move(data_error));
+        }
+    }
+    return metadatas_or_errors;
 }
 
 std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> LocalVersionedEngine::read_metadata_internal(

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -436,17 +436,43 @@ DescriptorItem LocalVersionedEngine::read_descriptor_internal(
     return get_descriptor(std::move(version->key_)).get();
 }
 
-std::vector<DescriptorItem> LocalVersionedEngine::batch_read_descriptor_internal(
+
+std::vector<std::variant<DescriptorItem, DataError>> LocalVersionedEngine::batch_read_descriptor_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     const ReadOptions& read_options) {
-    auto versions_fut = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
-    std::vector<folly::Future<DescriptorItem>> fut_vec;
-    for(const auto& stream_id : folly::enumerate(stream_ids)) {
-        fut_vec.push_back(
-            get_descriptor_async(std::move(versions_fut[stream_id.index]), *stream_id, version_queries[stream_id.index]));
+
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_missing_version_.has_value(),
+                                                    "ReadOptions::batch_throw_on_missing_version_ should always be set here");
+
+    auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
+    std::vector<folly::Future<DescriptorItem>> descriptor_futures;
+    for (auto&& [idx, version_fut]: folly::enumerate(version_futures)) {
+        descriptor_futures.push_back(
+            get_descriptor_async(std::move(version_fut), stream_ids[idx], version_queries[idx]));
     }
-    return folly::collect(fut_vec).get();
+    auto descriptors = folly::collectAll(descriptor_futures).get();
+    std::vector<std::variant<DescriptorItem, DataError>> descriptors_or_errors;
+    descriptors_or_errors.reserve(descriptors.size());
+    for (auto&& [idx, descriptor]: folly::enumerate(descriptors)) {
+        if (descriptor.hasValue()) {
+            descriptors_or_errors.emplace_back(std::move(descriptor.value()));
+        } else {
+            if (*read_options.batch_throw_on_missing_version_) {
+                descriptor.throwUnlessValue();
+            } else {
+                auto exception = descriptor.exception();
+                DataError data_error(stream_ids[idx], exception.what().toStdString(), version_queries[idx].content_);
+                if (exception.is_compatible_with<NoSuchVersionException>()) {
+                    data_error.set_error_code(ErrorCode::E_NO_SUCH_VERSION);
+                } else if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
+                    data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+                }
+                descriptors_or_errors.emplace_back(std::move(data_error));
+            }
+        }
+    }
+    return descriptors_or_errors;
 }
 
 void LocalVersionedEngine::flush_version_map() {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1330,7 +1330,7 @@ VersionIdAndDedupMapInfo LocalVersionedEngine::create_version_id_and_dedup_map(
     }
 }
 
-std::vector<VersionedItem> LocalVersionedEngine::batch_write_versioned_dataframe_internal(
+std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_write_versioned_dataframe_internal(
     const std::vector<StreamId>& stream_ids,
     std::vector<InputTensorFrame>&& frames,
     bool prune_previous_versions,
@@ -1372,7 +1372,22 @@ std::vector<VersionedItem> LocalVersionedEngine::batch_write_versioned_dataframe
             })
         );
     }
-    return folly::collect(version_futures).get();
+    auto write_versions = folly::collectAll(version_futures).get();
+    std::vector<std::variant<VersionedItem, DataError>> write_versions_or_errors;
+    write_versions_or_errors.reserve(write_versions.size());
+    for (auto&& [idx, write_version]: folly::enumerate(write_versions)) {
+        if (write_version.hasValue()) {
+            write_versions_or_errors.emplace_back(std::move(write_version.value()));
+        } else {
+            auto exception = write_version.exception();
+            DataError data_error(stream_ids[idx], exception.what().toStdString());
+            if (exception.is_compatible_with<storage::KeyNotFoundException>()) {
+                data_error.set_error_code(ErrorCode::E_KEY_NOT_FOUND);
+            }
+            write_versions_or_errors.emplace_back(std::move(data_error));
+        }
+    }
+    return write_versions_or_errors;
 }
 
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -302,7 +302,7 @@ public:
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<DescriptorItem> batch_read_descriptor_internal(
+    std::vector<std::variant<DescriptorItem, DataError>> batch_read_descriptor_internal(
             const std::vector<StreamId>& stream_ids,
             const std::vector<VersionQuery>& version_queries,
             const ReadOptions& read_options);

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -285,7 +285,7 @@ public:
         bool prune_previous_versions,
         bool validate_index,
         bool upsert,
-        bool throw_on_missing_version);
+        bool throw_on_error);
 
     std::vector<ReadVersionOutput> batch_read_keys(
         const std::vector<AtomKey> &keys,
@@ -382,7 +382,8 @@ public:
         const std::vector<StreamId>& stream_ids,
         std::vector<InputTensorFrame>&& frames,
         bool prune_previous_versions,
-        bool validate_index
+        bool validate_index,
+        bool throw_on_error
     );
 
     VersionIdAndDedupMapInfo create_version_id_and_dedup_map(

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -378,7 +378,7 @@ public:
         const std::vector<UpdateInfo>& stream_update_info_vector,
         bool prune_previous_versions);
 
-    std::vector<VersionedItem> batch_write_versioned_dataframe_internal(
+    std::vector<std::variant<VersionedItem, DataError>> batch_write_versioned_dataframe_internal(
         const std::vector<StreamId>& stream_ids,
         std::vector<InputTensorFrame>&& frames,
         bool prune_previous_versions,

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -195,8 +195,10 @@ public:
     folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata(
         std::optional<AtomKey>&& key);
 
-    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> get_metadata_async(
-        folly::Future<std::optional<AtomKey>>&& version_fut);
+    folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>> get_metadata_async(
+        folly::Future<std::optional<AtomKey>>&& version_fut,
+        const StreamId& stream_id,
+        const VersionQuery& version_query);
 
     folly::Future<DescriptorItem> get_descriptor(
         AtomKey&& key);
@@ -317,7 +319,7 @@ public:
             const std::vector<StreamId>& stream_ids,
             const std::vector<VersionQuery>& version_queries);
 
-    std::vector<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> batch_read_metadata_internal(
+    std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::Any>>, DataError>> batch_read_metadata_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -100,7 +100,7 @@ std::vector<VersionedItem> PythonVersionStore::batch_write_index_keys_to_version
     return output;
 }
 
-std::vector<VersionedItem> PythonVersionStore::batch_write(
+std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_write(
     const std::vector<StreamId>& stream_ids,
     const std::vector<py::tuple> &items,
     const std::vector<py::object> &norms,

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -106,10 +106,11 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_wr
     const std::vector<py::object> &norms,
     const std::vector<py::object> &user_metas,
     bool prune_previous_versions,
-    bool validate_index) {
+    bool validate_index,
+    bool throw_on_error) {
 
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
-    return batch_write_versioned_dataframe_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index);
+    return batch_write_versioned_dataframe_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index, throw_on_error);
 }
 
 std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_append(
@@ -120,9 +121,9 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_ap
     bool prune_previous_versions,
     bool validate_index,
     bool upsert,
-    bool throw_on_missing_version) {
+    bool throw_on_error) {
     auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas);
-    return batch_append_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index, upsert, throw_on_missing_version);
+    return batch_append_internal(stream_ids, std::move(frames), prune_previous_versions, validate_index, upsert, throw_on_error);
 }
 
 void PythonVersionStore::_clear_symbol_list_keys() {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1043,7 +1043,7 @@ DescriptorItem PythonVersionStore::read_descriptor(
     return read_descriptor_internal(stream_id, version_query, read_options);
 }
 
-std::vector<DescriptorItem> PythonVersionStore::batch_read_descriptor(
+std::vector<std::variant<DescriptorItem, DataError>> PythonVersionStore::batch_read_descriptor(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options){

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1014,23 +1014,28 @@ std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> PythonVersionStore::
     return batch_restore_version_internal(stream_ids, version_queries);
 }
 
-std::vector<std::pair<VersionedItem, py::object>> PythonVersionStore::batch_read_metadata(
+std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> PythonVersionStore::batch_read_metadata(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     const ReadOptions& read_options) {
     ARCTICDB_SAMPLE(BatchReadMetadata, 0)
-    auto metadata = batch_read_metadata_internal(stream_ids, version_queries, read_options);
+    auto metadatas_or_errors = batch_read_metadata_internal(stream_ids, version_queries, read_options);
 
-    std::vector<std::pair<VersionedItem, py::object>> results;
-    for (auto [key, meta_proto]: metadata) {
+    std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> results;
+    for (auto&& metadata_or_error: metadatas_or_errors) {
+        if (std::holds_alternative<std::pair<VariantKey, std::optional<google::protobuf::Any>>>(metadata_or_error)) {
+            auto&& [key, meta_proto] = std::get<std::pair<VariantKey, std::optional<google::protobuf::Any>>>(metadata_or_error);
+            VersionedItem version{std::move(to_atom(key))};
             if(meta_proto.has_value()) {
-                VersionedItem version{std::move(to_atom(*key))};
-                auto res = std::make_pair(version, metadata_protobuf_to_pyobject(meta_proto));
-                results.push_back(res);
+                auto res = std::make_pair(std::move(version), metadata_protobuf_to_pyobject(std::move(meta_proto)));
+                results.push_back(std::move(res));
             }else{
-                auto res = std::make_pair(VersionedItem(), py::none());
-                results.push_back(res);   
+                auto res = std::make_pair(std::move(version), py::none());
+                results.push_back(std::move(res));   
             }
+        } else {
+            results.push_back(std::get<DataError>(std::move(metadata_or_error)));   
+        }
     }
     return results;
 }

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -297,7 +297,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         std::vector<ReadQuery>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::pair<VersionedItem, py::object>> batch_read_metadata(
+    std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> batch_read_metadata(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -188,7 +188,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const ReadOptions& read_options
     );
 
-    std::vector<DescriptorItem> batch_read_descriptor(
+    std::vector<std::variant<DescriptorItem, DataError>> batch_read_descriptor(
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options);

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -269,7 +269,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::vector<py::object> &norms,
         const std::vector<py::object> &user_metas,
         bool prune_previous_versions,
-        bool validate_index);
+        bool validate_index,
+        bool throw_on_error);
 
     std::vector<std::variant<VersionedItem, DataError>> batch_write_metadata(
         const std::vector<StreamId>& stream_ids,
@@ -285,7 +286,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         bool prune_previous_versions,
         bool validate_index,
         bool upsert,
-        bool throw_on_missing_version);
+        bool throw_on_error);
 
     std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> batch_restore_version(
         const std::vector<StreamId>& id,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -263,7 +263,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::optional<bool>& skip_snapshots);
 
     // Batch methods
-    std::vector<VersionedItem> batch_write(
+    std::vector<std::variant<VersionedItem, DataError>> batch_write(
         const std::vector<StreamId> &stream_ids,
         const std::vector<py::tuple> &items,
         const std::vector<py::object> &norms,

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -5,7 +5,9 @@ dependencies:
   # Build tools
   - cxx-compiler
   - c-compiler
-  - cmake
+  # See: https://github.com/man-group/ArcticDB/actions/runs/6035269959/job/16375303050
+  # See: https://github.com/conda-forge/cmake-feedstock/issues/192
+  - cmake < 3.27.4
   - gtest
   - gflags
   - doxygen

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2542,6 +2542,10 @@ class NativeVersionStore:
             - type, `str`
             - date_range, `tuple`
         """
+        throw_on_missing_version = True
+        return self._batch_read_descriptor(symbols, as_ofs, throw_on_missing_version)
+
+    def _batch_read_descriptor(self, symbols, as_ofs, throw_on_missing_version):
         as_ofs_lists = []
         if as_ofs == None:
             as_ofs_lists = [None] * len(symbols)
@@ -2553,12 +2557,16 @@ class NativeVersionStore:
             version_queries.append(self._get_version_query(as_of))
 
         read_options = _PythonVersionStoreReadOptions()
-        list_descriptors = self.version_store.batch_read_descriptor(symbols, version_queries, read_options)
-        args_list = list(zip(list_descriptors, symbols, version_queries, as_ofs_lists))
-        list_infos = []
+        read_options.set_batch_throw_on_missing_version(throw_on_missing_version)
+        descriptions_or_errors = self.version_store.batch_read_descriptor(symbols, version_queries, read_options)
+        args_list = list(zip(descriptions_or_errors, symbols, version_queries, as_ofs_lists))
+        description_results = []
         for dit, symbol, version_query, as_of in args_list:
-            list_infos.append(self._process_info(symbol, dit, as_of))
-        return list_infos
+            if isinstance(dit, DataError):
+                description_results.append(dit)
+            else:
+                description_results.append(self._process_info(symbol, dit, as_of))
+        return description_results
 
     def write_metadata(
         self, symbol: str, metadata: Any, prune_previous_version: Optional[bool] = None

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1013,34 +1013,35 @@ class NativeVersionStore:
             Dictionary of symbol mapping with the versioned items. The data attribute will be None.
         """
         _check_batch_kwargs(NativeVersionStore.batch_read_metadata, NativeVersionStore.read_metadata, kwargs)
-        meta_items = self._batch_read_meta_to_versioned_items(symbols, as_ofs, kwargs)
-        return {v.symbol: v for v in meta_items if v is not None}
+        include_errors_and_none_meta = False
+        meta_items = self._batch_read_metadata_to_versioned_items(
+            symbols, as_ofs, include_errors_and_none_meta, **kwargs
+        )
+        return {v.symbol: v for v in meta_items}
 
-    def _batch_read_meta_to_versioned_items(self, symbols, as_ofs, kwargs=None):
-        if kwargs is None:
-            kwargs = dict()
-        meta_data_list = []
+    def _batch_read_metadata_to_versioned_items(self, symbols, as_ofs, include_errors_and_none_meta, **kwargs):
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         read_options = self._get_read_options(**kwargs)
-        result = self.version_store.batch_read_metadata(symbols, version_queries, read_options)
-        result_list = list(zip(symbols, result))
-        for original_symbol, result in result_list:
-            vitem, udm = result
-            if original_symbol != vitem.symbol:
-                meta_data_list.append(None)
-            else:
-                meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
-                meta_data_list.append(
-                    VersionedItem(
-                        symbol=vitem.symbol,
-                        library=self._library.library_path,
-                        data=None,
-                        version=vitem.version,
-                        metadata=meta,
-                        host=self.env,
+        metadatas_or_errors = self.version_store.batch_read_metadata(symbols, version_queries, read_options)
+        meta_items = []
+        for metadata in metadatas_or_errors:
+            if isinstance(metadata, DataError) and include_errors_and_none_meta:
+                meta_items.append(metadata)
+            if not isinstance(metadata, DataError):
+                vitem, udm = metadata
+                if udm is not None or include_errors_and_none_meta:
+                    meta = denormalize_user_metadata(udm, self._normalizer) if udm is not None else None
+                    meta_items.append(
+                        VersionedItem(
+                            symbol=vitem.symbol,
+                            library=self._library.library_path,
+                            data=None,
+                            version=vitem.version,
+                            metadata=meta,
+                            host=self.env,
+                        )
                     )
-                )
-        return meta_data_list
+        return meta_items
 
     def batch_read_metadata_multi(
         self, symbols: List[str], as_ofs: Optional[List[VersionQueryInput]] = None, **kwargs

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1204,7 +1204,13 @@ class NativeVersionStore:
         cxx_versioned_items = self.version_store.batch_write(
             symbols, items, norm_metas, udms, prune_previous_version, validate_index
         )
-        return [self._convert_thin_cxx_item_to_python(v) for v in cxx_versioned_items]
+        write_results = []
+        for result in cxx_versioned_items:
+            if isinstance(result, DataError):
+                write_results.append(result)
+            else:
+                write_results.append(self._convert_thin_cxx_item_to_python(result))
+        return write_results
 
     def _batch_write_metadata_to_versioned_items(
         self, symbols: List[str], metadata_vector: List[Any], prune_previous_version, throw_on_error

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -566,13 +566,15 @@ class Library:
         self._raise_if_duplicate_symbols_in_batch(payloads)
         self._raise_if_unsupported_type_in_write_batch(payloads)
 
-        return self._nvs.batch_write(
+        throw_on_error = False
+        return self._nvs._batch_write_internal(
             [p.symbol for p in payloads],
             [p.data for p in payloads],
             [p.metadata for p in payloads],
             prune_previous_version=prune_previous_versions,
             pickle_on_failure=False,
             validate_index=validate_index,
+            throw_on_error=throw_on_error,
         )
 
     def write_pickle_batch(
@@ -739,7 +741,7 @@ class Library:
 
         self._raise_if_duplicate_symbols_in_batch(append_payloads)
         self._raise_if_unsupported_type_in_write_batch(append_payloads)
-        throw_on_missing_version = False
+        throw_on_error = False
 
         return self._nvs._batch_append_to_versioned_items(
             [p.symbol for p in append_payloads],
@@ -747,7 +749,7 @@ class Library:
             [p.metadata for p in append_payloads],
             prune_previous_version=prune_previous_versions,
             validate_index=validate_index,
-            throw_on_missing_version=throw_on_missing_version,
+            throw_on_error=throw_on_error,
         )
 
     def update(
@@ -1607,8 +1609,8 @@ class Library:
                     " [ReadInfoRequest] are supported."
                 )
 
-        throw_on_missing_version = False
-        descriptions = self._nvs._batch_read_descriptor(symbol_strings, as_ofs, throw_on_missing_version)
+        throw_on_error = False
+        descriptions = self._nvs._batch_read_descriptor(symbol_strings, as_ofs, throw_on_error)
 
         description_results = []
         for description in descriptions:

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -504,7 +504,7 @@ class Library:
 
     def write_batch(
         self, payloads: List[WritePayload], prune_previous_versions: bool = False, validate_index=True
-    ) -> List[VersionedItem]:
+    ) -> List[Union[VersionedItem, DataError]]:
         """
         Write a batch of multiple symbols.
 
@@ -521,9 +521,13 @@ class Library:
 
         Returns
         -------
-        List[VersionedItem]
-            Structure containing metadata and version number of the written symbols in the store, in the
+        List[Union[VersionedItem, DataError]]
+            List of versioned items. The data attribute will be None for each versioned item.
+            i-th entry corresponds to i-th element of `payloads`. Each result correspond to
+            a structure containing metadata and version number of the written symbols in the store, in the
             same order as `payload`.
+            If a key error or any other internal exception is raised, a DataError object is returned, with symbol,
+            error_code, error_category, and exception_string properties.
 
         Raises
         ------
@@ -531,8 +535,6 @@ class Library:
             When duplicate symbols appear in payload.
         ArcticUnsupportedDataTypeException
             If data that is not of NormalizableType appears in any of the payloads.
-        UnsortedDataException
-            If data is unsorted, when validate_index is set to True.
 
         See Also
         --------
@@ -724,7 +726,7 @@ class Library:
         List[Union[VersionedItem, DataError]]
             List of versioned items. i-th entry corresponds to i-th element of `append_payloads`.
             Each result correspond to a structure containing metadata and version number of the affected
-            symbol in the store. If any internal exception is raised, a DataError object is returned, with symbol,
+            symbol in the store. If a key error or any other internal exception is raised, a DataError object is returned, with symbol,
             error_code, error_category, and exception_string properties.
 
         Raises

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1001,7 +1001,8 @@ class Library:
         List[Union[VersionedItem, DataError]]
             A list of the read results, whose i-th element corresponds to the i-th element of the ``symbols`` parameter.
             If the specified version does not exist, a DataError object is returned, with symbol, version_request_type,
-            version_request_data properties, error_code, error_category, and exception_string properties.
+            version_request_data properties, error_code, error_category, and exception_string properties. If a key error or
+            any other internal exception occurs, the same DataError object is also returned.
 
         Raises
         ------
@@ -1553,7 +1554,9 @@ class Library:
             date_range=date_range,
         )
 
-    def get_description_batch(self, symbols: List[Union[str, ReadInfoRequest]]) -> List[SymbolDescription]:
+    def get_description_batch(
+        self, symbols: List[Union[str, ReadInfoRequest]]
+    ) -> List[Union[SymbolDescription, DataError]]:
         """
         Returns descriptive data for a list of ``symbols``.
 
@@ -1561,12 +1564,14 @@ class Library:
         ----------
         symbols : List[Union[str, ReadInfoRequest]]
             List of symbols to read.
-            Params columns, date_range and query_builder from ReadInfoRequest are not used
 
         Returns
         -------
-        List[SymbolDescription]
+        List[Union[SymbolDescription, DataError]]
             A list of the descriptive data, whose i-th element corresponds to the i-th element of the ``symbols`` parameter.
+            If the specified version does not exist, a DataError object is returned, with symbol, version_request_type,
+            version_request_data properties, error_code, error_category, and exception_string properties. If a key error or
+            any other internal exception occurs, the same DataError object is also returned.
 
         See Also
         --------
@@ -1595,29 +1600,36 @@ class Library:
                     " [ReadInfoRequest] are supported."
                 )
 
-        infos = self._nvs.batch_get_info(symbol_strings, as_ofs)
-        list_descriptions = []
-        for info in infos:
-            last_update_time = pd.to_datetime(info["last_update"], utc=True)
-            columns = tuple(NameWithDType(n, t) for n, t in zip(info["col_names"]["columns"], info["dtype"]))
-            index = NameWithDType(info["col_names"]["index"], info["col_names"]["index_dtype"])
-            date_range = tuple(
-                map(
-                    lambda x: x.replace(tzinfo=datetime.timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-                    info["date_range"],
+        throw_on_missing_version = False
+        descriptions = self._nvs._batch_read_descriptor(symbol_strings, as_ofs, throw_on_missing_version)
+
+        description_results = []
+        for description in descriptions:
+            if isinstance(description, DataError):
+                description_results.append(description)
+            else:
+                last_update_time = pd.to_datetime(description["last_update"], utc=True)
+                columns = tuple(
+                    NameWithDType(n, t) for n, t in zip(description["col_names"]["columns"], description["dtype"])
                 )
-            )
-            list_descriptions.append(
-                SymbolDescription(
-                    columns=columns,
-                    index=index,
-                    row_count=info["rows"],
-                    last_update_time=last_update_time,
-                    index_type=info["index_type"],
-                    date_range=date_range,
+                index = NameWithDType(description["col_names"]["index"], description["col_names"]["index_dtype"])
+                date_range = tuple(
+                    map(
+                        lambda x: x.replace(tzinfo=datetime.timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+                        description["date_range"],
+                    )
                 )
-            )
-        return list_descriptions
+                description_results.append(
+                    SymbolDescription(
+                        columns=columns,
+                        index=index,
+                        row_count=description["rows"],
+                        last_update_time=last_update_time,
+                        index_type=description["index_type"],
+                        date_range=date_range,
+                    )
+                )
+        return description_results
 
     def reload_symbol_list(self):
         """

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -62,131 +62,6 @@ def generate_dataframe(columns, dt, num_days, num_rows_per_day):
     return pd.concat(dataframes)
 
 
-def test_read_meta_batch_with_tombstones(arctic_library):
-    lib = arctic_library
-    lib.write_pickle("sym1", 1, {"meta1": 1}, prune_previous_versions=False)
-    lib.write_pickle("sym2", 2, {"meta2": 2}, prune_previous_versions=False)
-    lib.write_pickle("sym3", 3, {"meta3": 3}, prune_previous_versions=False)
-    lib.write_pickle("sym_no_meta", 4, prune_previous_versions=False)
-
-    lib.write_pickle("sym1", 1, {"meta1": 4}, prune_previous_versions=False)
-    lib.write_pickle("sym2", 2, {"meta2": 5}, prune_previous_versions=False)
-    lib.write_pickle("sym3", 3, {"meta3": 6}, prune_previous_versions=False)
-    lib.write_pickle("sym_no_meta", 4, prune_previous_versions=False)
-
-    lib.write_pickle("sym1", 1, {"meta1": 6}, prune_previous_versions=False)
-    lib.write_pickle("sym2", 2, {"meta2": 7}, prune_previous_versions=False)
-    lib.write_pickle("sym3", 3, {"meta3": 8}, prune_previous_versions=False)
-    lib.write_pickle("sym_no_meta", 4, prune_previous_versions=False)
-
-    results_list = lib.read_metadata_batch(["sym1", "sym2", "sym_no_exist", "sym3", "sym_no_meta"])
-
-    assert results_list[0].metadata == {"meta1": 6}
-    assert results_list[1].metadata == {"meta2": 7}
-    assert results_list[2] is None
-    assert results_list[3].metadata == {"meta3": 8}
-    assert results_list[4].metadata is None
-
-    lib.delete("sym1", versions=2)
-    lib.delete("sym2", versions=2)
-    lib.delete("sym3", versions=2)
-    lib.delete("sym_no_meta", versions=2)
-
-    results_list = lib.read_metadata_batch(["sym1", "sym2", "sym_no_exist", "sym3", "sym_no_meta"])
-    assert results_list[0].metadata == {"meta1": 4}
-    assert results_list[1].metadata == {"meta2": 5}
-    assert results_list[2] is None
-    assert results_list[3].metadata == {"meta3": 6}
-    assert results_list[4].metadata is None
-
-    assert lib.read_metadata("sym1").metadata == results_list[0].metadata
-    assert lib.read_metadata("sym2").metadata == results_list[1].metadata
-    assert lib.read_metadata("sym3").metadata == results_list[3].metadata
-    assert lib.read_metadata("sym_no_meta").metadata == results_list[4].metadata
-
-
-def test_read_meta_batch_with_as_ofs_and_non_existent_version(arctic_library):
-    lib = arctic_library
-    lib.write_pickle("sym1", 1, {"meta1": 1}, prune_previous_versions=False)
-    lib.write_pickle("sym2", 2, {"meta2": 2}, prune_previous_versions=False)
-    lib.write_pickle("sym3", 3, {"meta3": 3}, prune_previous_versions=False)
-
-    lib.write_pickle("sym1", 1, {"meta1": 4}, prune_previous_versions=False)
-    lib.write_pickle("sym2", 2, {"meta2": 5}, prune_previous_versions=False)
-    lib.write_pickle("sym3", 3, {"meta3": 6}, prune_previous_versions=False)
-
-    lib.write_pickle("sym1", 1, {"meta1": 7}, prune_previous_versions=False)
-    lib.write_pickle("sym2", 2, {"meta2": 8}, prune_previous_versions=False)
-    lib.write_pickle("sym3", 3, {"meta3": 9}, prune_previous_versions=False)
-
-    results_list = lib.read_metadata_batch(
-        [
-            ReadInfoRequest("sym1", as_of=0),
-            ReadInfoRequest("sym2", as_of=0),
-            ReadInfoRequest("sym2", as_of=5),
-            "sym_no_exist",
-            ReadInfoRequest("sym3", as_of=0),
-        ]
-    )
-    assert results_list[0].metadata == {"meta1": 1}
-    assert results_list[1].metadata == {"meta2": 2}
-    assert results_list[2] is None
-    assert results_list[3] is None
-    assert results_list[4].metadata == {"meta3": 3}
-
-    results_list = lib.read_metadata_batch(
-        [
-            ReadInfoRequest("sym1", as_of=1),
-            ReadInfoRequest("sym2", as_of=1),
-            ReadInfoRequest("sym2", as_of=5),
-            "sym_no_exist",
-            ReadInfoRequest("sym3", as_of=1),
-        ]
-    )
-    assert results_list[0].metadata == {"meta1": 4}
-    assert results_list[1].metadata == {"meta2": 5}
-    assert results_list[2] is None
-    assert results_list[3] is None
-    assert results_list[4].metadata == {"meta3": 6}
-
-    results_list = lib.read_metadata_batch(
-        [
-            ReadInfoRequest("sym2", as_of=0),
-            ReadInfoRequest("sym2", as_of=1),
-            ReadInfoRequest("sym3", as_of=1),
-            "sym1",
-            ReadInfoRequest("sym2", as_of=2),
-        ]
-    )
-    assert results_list[0].metadata == {"meta2": 2}
-    assert results_list[1].metadata == {"meta2": 5}
-    assert results_list[2].metadata == {"meta3": 6}
-    assert results_list[3].metadata == {"meta1": 7}
-    assert results_list[4].metadata == {"meta2": 8}
-
-
-def test_read_meta_batch_with_as_ofs(arctic_library):
-    lib = arctic_library
-    num_symbols = 10
-    num_versions = 4
-
-    for version in range(num_versions):
-        write_requests = []
-        for sym in range(num_symbols):
-            write_requests.append(WritePayload("sym_" + str(sym), version, metadata={"meta_" + str(sym): version}))
-        lib.write_pickle_batch(write_requests, prune_previous_versions=False)
-    requests = [
-        ReadInfoRequest("sym_" + str(sym), as_of=version)
-        for sym in range(num_symbols)
-        for version in range(num_versions)
-    ]
-    results_list = lib.read_metadata_batch(requests)
-    for sym in range(num_symbols):
-        for version in range(num_versions):
-            idx = sym * num_versions + version
-            assert results_list[idx].metadata == {"meta_" + str(sym): version}
-
-
 def test_write_meta_batch_with_as_ofs(arctic_library):
     lib = arctic_library
     num_symbols = 2
@@ -240,6 +115,142 @@ def test_write_metadata_batch_with_none(arctic_library):
         assert results_read[sym].data is None
         assert results_read[sym].metadata == {"meta_" + str(sym): sym}
         assert results_read[sym].version == 0
+
+
+def test_read_meta_batch_with_as_ofs(arctic_library):
+    lib = arctic_library
+
+    # Given
+    lib.write_pickle("sym1", 1, {"meta1": 0})
+    lib.write_pickle("sym1", 1, {"meta1": 1})
+    lib.write_pickle("sym2", 2, {"meta2": 0})
+    lib.write_pickle("sym2", 2, {"meta2": 1})
+
+    # When
+    batch = lib.read_metadata_batch(
+        [
+            ReadInfoRequest("sym1", as_of=0),
+            "sym1",
+            ReadInfoRequest("sym2", as_of=0),
+            "sym2",
+        ]
+    )
+
+    # Then
+    assert batch[0].metadata == {"meta1": 0}
+    assert batch[1].metadata == {"meta1": 1}
+    assert batch[2].metadata == {"meta2": 0}
+    assert batch[3].metadata == {"meta2": 1}
+
+
+def test_read_metadata_batch_with_none(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df1 = pd.DataFrame({"a": [5, 7, 9]})
+    df2 = pd.DataFrame({"a": [7, 9, 11]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+
+    # When
+    batch = lib.read_metadata_batch(["s1", "s2"])
+
+    # Then
+    assert batch[0].data is None
+    assert batch[0].metadata is None
+    assert batch[0].version == 0
+
+    assert batch[1].data is None
+    assert batch[1].metadata is None
+    assert batch[1].version == 0
+
+
+def test_read_metadata_batch_missing_keys(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    lib.write("s1", df1, metadata={"meta1": 0})
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    df2 = pd.DataFrame({"a": [5, 7, 9]})
+    lib.write("s2", df2, metadata={"meta2": 0})
+    lib.write("s2", df2, metadata={"meta2": 1})
+    df3 = pd.DataFrame({"a": [7, 9, 11]})
+    lib.write("s3", df3, metadata={"meta3": 0})
+
+    lib_tool = lib._nvs.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s2")
+    s2_key_to_delete = [key for key in s2_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_key_to_delete)
+
+    # When
+    batch = lib.read_metadata_batch(["s1", ReadInfoRequest("s2", as_of=0), "s3"])
+
+    # Then
+    assert isinstance(batch[0], DataError)
+    assert batch[0].symbol == "s1"
+    assert batch[0].version_request_type == VersionRequestType.LATEST
+    assert batch[0].version_request_data is None
+    assert batch[0].error_code == ErrorCode.E_KEY_NOT_FOUND
+    assert batch[0].error_category == ErrorCategory.STORAGE
+
+    assert isinstance(batch[1], DataError)
+    assert batch[1].symbol == "s2"
+    assert batch[1].version_request_type == VersionRequestType.SPECIFIC
+    assert batch[1].version_request_data == 0
+    assert batch[1].error_code == ErrorCode.E_KEY_NOT_FOUND
+    assert batch[1].error_category == ErrorCategory.STORAGE
+
+    assert not isinstance(batch[2], DataError)
+    assert batch[2].metadata == {"meta3": 0}
+
+
+def test_read_metadata_batch_symbol_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df = pd.DataFrame({"a": [3, 5, 7]})
+    lib.write("s1", df, {"meta1": 0})
+
+    # When
+    batch = lib.read_metadata_batch(["s1", "s2"])
+
+    # Then
+    assert not isinstance(batch[0], DataError)
+    assert batch[0].metadata == {"meta1": 0}
+
+    assert isinstance(batch[1], DataError)
+    assert batch[1].symbol == "s2"
+    assert batch[1].version_request_type == VersionRequestType.LATEST
+    assert batch[1].version_request_data == None
+    assert batch[1].error_code == ErrorCode.E_NO_SUCH_VERSION
+    assert batch[1].error_category == ErrorCategory.MISSING_DATA
+
+
+def test_read_metadata_batch_version_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df = pd.DataFrame({"a": [3, 5, 7]})
+    lib.write("s1", df, {"meta1": 0})
+
+    # When
+    batch = lib.read_metadata_batch([ReadInfoRequest("s1", as_of=0), ReadInfoRequest("s1", as_of=1)])
+
+    # Then
+    assert not isinstance(batch[0], DataError)
+    assert batch[0].metadata == {"meta1": 0}
+
+    assert isinstance(batch[1], DataError)
+    assert batch[1].symbol == "s1"
+    assert batch[1].version_request_type == VersionRequestType.SPECIFIC
+    assert batch[1].version_request_data == 1
+    assert batch[1].error_code == ErrorCode.E_NO_SUCH_VERSION
+    assert batch[1].error_category == ErrorCategory.MISSING_DATA
 
 
 class A:

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -846,6 +846,135 @@ def test_read_batch_query_builder_missing_keys(arctic_library):
     assert batch[2].error_category == ErrorCategory.STORAGE
 
 
+def test_get_description_batch_missing_keys(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df1 = pd.DataFrame({"a": [3, 5, 7]}, index=pd.date_range(start="1/1/2018", end="1/3/2018"))
+    df2 = pd.DataFrame({"a": [5, 7, 9]}, index=pd.date_range(start="1/1/2018", end="1/3/2018"))
+    df3 = pd.DataFrame({"a": [7, 9, 11]}, index=pd.date_range(start="1/1/2018", end="1/3/2018"))
+    df3.index.rename("named_index", inplace=True)
+
+    lib.write("s1", df1)
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    lib.write("s2", df2)
+    lib.write("s2", df2)
+    lib.write("s3", df3)
+    lib_tool = lib._nvs.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s2")
+    s2_key_to_delete = [key for key in s2_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_key_to_delete)
+
+    # When
+    batch = lib.get_description_batch(["s1", ReadInfoRequest("s2", as_of=0), "s3"])
+
+    # Then
+    assert isinstance(batch[0], DataError)
+    assert batch[0].symbol == "s1"
+    assert batch[0].version_request_type == VersionRequestType.LATEST
+    assert batch[0].version_request_data is None
+    assert batch[0].error_code == ErrorCode.E_KEY_NOT_FOUND
+    assert batch[0].error_category == ErrorCategory.STORAGE
+
+    assert isinstance(batch[1], DataError)
+    assert batch[1].symbol == "s2"
+    assert batch[1].version_request_type == VersionRequestType.SPECIFIC
+    assert batch[1].version_request_data == 0
+    assert batch[1].error_code == ErrorCode.E_KEY_NOT_FOUND
+    assert batch[1].error_category == ErrorCategory.STORAGE
+
+    assert not isinstance(batch[2], DataError)
+    assert batch[2].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2018, 1, 1), datetime(2018, 1, 3)),
+        )
+    )
+    assert [c[0] for c in batch[2].columns] == ["a"]
+    assert batch[2].index[0] == ["named_index"]
+    assert batch[2].index_type == "index"
+    assert batch[2].row_count == 3
+
+
+def test_get_description_batch_symbol_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df = pd.DataFrame({"a": [3, 5, 7, 9]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
+    df.index.rename("named_index", inplace=True)
+    lib.write("s1", df)
+
+    # When
+    batch = lib.get_description_batch(["s1", "s2"])
+
+    # Then
+    assert not isinstance(batch[0], DataError)
+    assert batch[0].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
+        )
+    )
+    assert [c[0] for c in batch[0].columns] == ["a"]
+    assert batch[0].index[0] == ["named_index"]
+    assert batch[0].index_type == "index"
+    assert batch[0].row_count == 4
+
+    assert isinstance(batch[1], DataError)
+    assert batch[1].symbol == "s2"
+    assert batch[1].version_request_type == VersionRequestType.LATEST
+    assert batch[1].version_request_data == None
+    assert batch[1].error_code == ErrorCode.E_NO_SUCH_VERSION
+    assert batch[1].error_category == ErrorCategory.MISSING_DATA
+
+
+def test_get_description_batch_version_doesnt_exist(arctic_library):
+    lib = arctic_library
+
+    # Given
+    df1 = pd.DataFrame({"a": [3, 5, 7, 9]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
+    df1.index.rename("named_index", inplace=True)
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+
+    # When
+    batch = lib.get_description_batch(
+        [ReadInfoRequest("s1", as_of=0), ReadInfoRequest("s1", as_of=1), ReadInfoRequest("s2", as_of=1)]
+    )
+
+    # Then
+    assert not isinstance(batch[0], DataError)
+    assert batch[0].date_range == tuple(
+        map(
+            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
+            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
+        )
+    )
+    assert [c[0] for c in batch[0].columns] == ["a"]
+    assert batch[0].index[0] == ["named_index"]
+    assert batch[0].index_type == "index"
+    assert batch[0].row_count == 4
+
+    assert isinstance(batch[1], DataError)
+    assert batch[1].symbol == "s1"
+    assert batch[1].version_request_type == VersionRequestType.SPECIFIC
+    assert batch[1].version_request_data == 1
+    assert batch[1].error_code == ErrorCode.E_NO_SUCH_VERSION
+    assert batch[1].error_category == ErrorCategory.MISSING_DATA
+
+    assert isinstance(batch[2], DataError)
+    assert batch[2].symbol == "s2"
+    assert batch[2].version_request_type == VersionRequestType.SPECIFIC
+    assert batch[2].version_request_data == 1
+    assert batch[2].error_code == ErrorCode.E_NO_SUCH_VERSION
+    assert batch[2].error_category == ErrorCategory.MISSING_DATA
+
+
 def test_read_batch_query_builder_symbol_doesnt_exist(arctic_library):
     lib = arctic_library
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1341,6 +1341,25 @@ def test_batch_write_then_list_symbol_without_cache(request, factory_name):
         assert set(lib.list_symbols()) == set(symbols)
 
 
+def test_batch_write_missing_keys_dedup(version_store_factory):
+    """When there is duplicate data to reuse for the current write, we need to access the index key of the previous
+    versions in order to refer to the corresponding keys for the deduplicated data."""
+    lib = version_store_factory(de_duplication=True)
+    assert lib.lib_cfg().lib_desc.version.write_options.de_duplication
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    lib.write("s1", df1)
+    lib.write("s2", df2)
+
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    lib_tool.remove(s1_index_key)
+
+    with pytest.raises(StorageException):
+        lib.batch_write(["s1", "s2"], [df1, df2])
+
+
 def test_batch_roundtrip_metadata(lmdb_version_store_tombstone_and_sync_passive):
     lmdb_version_store = lmdb_version_store_tombstone_and_sync_passive
     metadatas = {}
@@ -1561,7 +1580,7 @@ def test_batch_read_meta(lmdb_version_store_tombstone_and_sync_passive):
     assert results_dict["sym2"].data is None
 
 
-def test_batch_read_meta_with_missing(lmdb_version_store_tombstone_and_sync_passive):
+def test_batch_read_metadata_symbol_doesnt_exist(lmdb_version_store_tombstone_and_sync_passive):
     lmdb_version_store = lmdb_version_store_tombstone_and_sync_passive
     lib = lmdb_version_store
     for idx in range(10):
@@ -1571,6 +1590,42 @@ def test_batch_read_meta_with_missing(lmdb_version_store_tombstone_and_sync_pass
 
     assert results_dict["sym1"].metadata == {"meta": 1}
     assert "sym_doesnotexist" not in results_dict
+
+
+def test_batch_read_metadata_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [4, 6, 8]})
+    lib.write("s1", df1, metadata={"s1": "metadata"})
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    lib.write("s2", df2, metadata={"s2": "metadata"})
+    lib.write("s2", df2, metadata={"s2": "more_metadata"})
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s2")
+    s2_key_to_delete = [key for key in s2_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_key_to_delete)
+
+    with pytest.raises(StorageException):
+        _ = lib.batch_read_metadata(["s1"], [None])
+    with pytest.raises(StorageException):
+        _ = lib.batch_read_metadata(["s2"], [0])
+
+
+def test_batch_read_metadata_multi_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+    lib_tool = lib.library_tool()
+
+    lib.write("s1", 0, metadata={"s1": "metadata"})
+    key_to_delete = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    lib_tool.remove(key_to_delete)
+
+    with pytest.raises(StorageException):
+        _ = lib.batch_read_metadata_multi(["s1"], [None])
 
 
 def test_list_versions_with_deleted_symbols(lmdb_version_store_tombstone_and_pruning):
@@ -2051,6 +2106,30 @@ def test_batch_read_missing_keys(lmdb_version_store):
     # processed first
     with pytest.raises((NoDataFoundException, StorageException)):
         _ = lib.batch_read(["s1", "s2", "s3"], [None, None, 0])
+
+
+def test_batch_get_info_missing_keys(lmdb_version_store):
+    lib = lmdb_version_store
+
+    df1 = pd.DataFrame({"a": [3, 5, 7]})
+    df2 = pd.DataFrame({"a": [5, 7, 9]})
+    lib.write("s1", df1)
+    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
+    # latest index key in the version ref key means it will still work if we just write one version key and then delete
+    # it
+    lib.write("s2", df2)
+    lib.write("s2", df2)
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    s2_version_keys = lib_tool.find_keys_for_id(KeyType.VERSION, "s2")
+    s2_key_to_delete = [key for key in s2_version_keys if key.version_id == 0][0]
+    lib_tool.remove(s1_index_key)
+    lib_tool.remove(s2_key_to_delete)
+
+    with pytest.raises(StorageException):
+        _ = lib.batch_get_info(["s1"], [None])
+    with pytest.raises(StorageException):
+        _ = lib.batch_get_info(["s2"], [0])
 
 
 def test_index_keys_start_end_index(lmdb_version_store, sym):


### PR DESCRIPTION
#### API CHANGE

`get_description_batch`, `read_metadata_batch`, and `write_batch` now return `DataError` objects if there are any issues with individual elements of the batch requests.

Previous behaviour was to raise an exception. This behaviour has been maintained on the `NativeVersionStore` API.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
