### PR TITLE
fix/774 Rename ArcticNativeNotYetImplemented in backwards compatible way

### DIFF
--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -22,7 +22,7 @@ from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter, set_library_options
 from arcticdb_ext.storage import StorageOverride, LmdbOverride
 from arcticdb.encoding_version import EncodingVersion
-from arcticdb.exceptions import ArcticNativeNotYetImplemented, LmdbOptionsError
+from arcticdb.exceptions import ArcticDbNotYetImplemented, LmdbOptionsError
 
 
 def _rmtree_errorhandler(func, path, exc_info):
@@ -91,7 +91,7 @@ def parse_query(query: str) -> ParsedQuery:
             map_size_bytes = convert_size_str_to_bytes(value)
             result["map_size"] = map_size_bytes
         else:
-            raise ArcticNativeNotYetImplemented(
+            raise ArcticDbNotYetImplemented(
                 "Support for option {key} not implemented correctly. This is a bug in "
                 "ArcticDB. Please report on ArcticDB Github."
             )

--- a/python/arcticdb/exceptions.py
+++ b/python/arcticdb/exceptions.py
@@ -11,8 +11,12 @@ from arcticdb_ext.storage import DuplicateKeyException, NoDataFoundException, Pe
 from arcticdb_ext.version_store import NoSuchVersionException, StreamDescriptorMismatch
 
 
-class ArcticNativeNotYetImplemented(ArcticException):
+class ArcticDbNotYetImplemented(ArcticException):
     pass
+
+
+# Backwards compat - this is the old name of ArcticDbNotYetImplemented
+ArcticNativeNotYetImplemented = ArcticDbNotYetImplemented
 
 
 class LibraryNotFound(ArcticException):

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -48,7 +48,7 @@ from arcticdb_ext.version_store import ColumnStats as _ColumnStats
 from arcticdb_ext.version_store import StreamDescriptorMismatch
 from arcticdb_ext.version_store import DataError
 from arcticdb.authorization.permissions import OpenMode
-from arcticdb.exceptions import ArcticNativeNotYetImplemented, ArcticNativeException
+from arcticdb.exceptions import ArcticDbNotYetImplemented, ArcticNativeException
 from arcticdb.flattener import Flattener
 from arcticdb.log import version as log
 from arcticdb.version_store._custom_normalizers import get_custom_normalizer, CompositeCustomNormalizer
@@ -150,7 +150,7 @@ def _handle_categorical_columns(symbol, data, throw=True):
                 " columns: {}".format(symbol, categorical_columns)
             )
             if throw:
-                raise ArcticNativeNotYetImplemented(message)
+                raise ArcticDbNotYetImplemented(message)
             else:
                 log.warn(message)
 
@@ -233,7 +233,7 @@ class NativeVersionStore:
                 MsgPackNormalizer(nfh), use_norm_failure_handler_known_types=use_norm_failure_handler_known_types
             )
         else:
-            raise ArcticNativeNotYetImplemented("No other normalization failure handler")
+            raise ArcticDbNotYetImplemented("No other normalization failure handler")
 
     def _initialize(self, library, env, lib_cfg, custom_normalizer, open_mode):
         self._library = library
@@ -336,7 +336,7 @@ class NativeVersionStore:
                     dynamic_schema=dynamic_schema,
                     **kwargs,
                 )
-        except ArcticNativeNotYetImplemented as ex:
+        except ArcticDbNotYetImplemented as ex:
             log.error("Not supported: normalizing symbol={}, data={}, metadata={}, {}", symbol, dataframe, metadata, ex)
             raise
         except Exception as ex:
@@ -351,12 +351,12 @@ class NativeVersionStore:
     @staticmethod
     def check_symbol_validity(symbol):
         if not len(symbol) < MAX_SYMBOL_SIZE:
-            raise ArcticNativeNotYetImplemented(
+            raise ArcticDbNotYetImplemented(
                 f"Symbol length {len(symbol)} chars exceeds the max supported length of {MAX_SYMBOL_SIZE} chars."
             )
 
         if len(set(symbol).intersection(UNSUPPORTED_S3_CHARS)):
-            raise ArcticNativeNotYetImplemented(
+            raise ArcticDbNotYetImplemented(
                 f"The symbol '{symbol}' has one or more unsupported characters({','.join(UNSUPPORTED_S3_CHARS)})."
             )
 
@@ -2691,9 +2691,7 @@ class NativeVersionStore:
         """
 
         if self._lib_cfg.lib_desc.version.write_options.bucketize_dynamic:
-            raise ArcticNativeNotYetImplemented(
-                f"Support for library with 'bucketize_dynamic' ON is not implemented yet"
-            )
+            raise ArcticDbNotYetImplemented(f"Support for library with 'bucketize_dynamic' ON is not implemented yet")
 
         result = self.version_store.defragment_symbol_data(symbol, segment_size)
         return VersionedItem(

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -9,7 +9,7 @@ import sys
 
 import pytz
 from arcticdb_ext.exceptions import InternalException
-from arcticdb.exceptions import ArcticNativeNotYetImplemented, LibraryNotFound
+from arcticdb.exceptions import ArcticDbNotYetImplemented, LibraryNotFound
 
 from arcticdb_ext.storage import NoDataFoundException
 
@@ -875,7 +875,7 @@ def test_numpy_string(arctic_library):
 
 @pytest.mark.skipif(sys.platform != "win32", reason="SKIP_WIN Numpy strings not supported yet")
 def test_numpy_string_fails_on_windows(arctic_library):
-    with pytest.raises(ArcticNativeNotYetImplemented):
+    with pytest.raises(ArcticDbNotYetImplemented):
         arctic_library.write("symbol", np.array(["ab", "cd", "efg"]))
 
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -23,10 +23,9 @@ from numpy.testing import assert_array_equal
 from pytz import timezone
 
 from arcticdb.exceptions import (
+    ArcticDbNotYetImplemented,
     ArcticNativeNotYetImplemented,
     InternalException,
-    NoSuchVersionException,
-    StreamDescriptorMismatch,
     UserInputException,
 )
 from arcticdb import QueryBuilder
@@ -114,15 +113,28 @@ def test_special_chars(s3_version_store, special_char):
 
 
 @pytest.mark.parametrize("breaking_char", [chr(0), "\0", "&", "*", "<", ">"])
-def test_s3_breaking_chars(s3_version_store, breaking_char):
+def test_s3_breaking_chars(s3_version_store_v2, breaking_char):
     """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db
     """
     sym = f"prefix{breaking_char}postfix"
     df = sample_dataframe()
-    with pytest.raises(ArcticNativeNotYetImplemented):
-        s3_version_store.write(sym, df)
+    with pytest.raises(ArcticDbNotYetImplemented):
+        s3_version_store_v2.write(sym, df)
 
-    assert sym not in s3_version_store.list_symbols()
+    assert sym not in s3_version_store_v2.list_symbols()
+
+
+def test_s3_breaking_chars_exception_compat(s3_version_store_v2):
+    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db
+    """
+    sym = "prefix*postfix"
+    df = sample_dataframe()
+    # Check that ArcticNativeNotYetImplemented is aliased correctly as ArcticDbNotYetImplemented for backwards compat
+    with pytest.raises(ArcticNativeNotYetImplemented) as e_info:
+        s3_version_store_v2.write(sym, df)
+
+    assert isinstance(e_info.value, ArcticNativeNotYetImplemented)
+    assert sym not in s3_version_store_v2.list_symbols()
 
 
 @pytest.mark.parametrize("unhandled_char", [chr(30), chr(127), chr(128)])
@@ -765,7 +777,7 @@ def test_empty_ndarr(lmdb_version_store):
 
 # See AN-765 for why we need no_symbol_list fixture
 def test_large_symbols(lmdb_version_store_no_symbol_list):
-    with pytest.raises(ArcticNativeNotYetImplemented):
+    with pytest.raises(ArcticDbNotYetImplemented):
         lmdb_version_store_no_symbol_list.write("a" * (MAX_SYMBOL_SIZE + 1), 1)
 
     for _ in range(5):
@@ -784,7 +796,7 @@ def test_large_symbols(lmdb_version_store_no_symbol_list):
 
 def test_unsupported_chars_in_symbols(lmdb_version_store):
     for ch in UNSUPPORTED_S3_CHARS:
-        with pytest.raises(ArcticNativeNotYetImplemented):
+        with pytest.raises(ArcticDbNotYetImplemented):
             lmdb_version_store.write(ch, 1)
 
     for _ in range(5):
@@ -1436,7 +1448,7 @@ def test_coercion_to_float(lmdb_version_store_string_coercion):
     assert df["col"].dtype == np.object_
 
     if sys.platform != "win32":  # SKIP_WIN Windows always uses dynamic strings
-        with pytest.raises(ArcticNativeNotYetImplemented):
+        with pytest.raises(ArcticDbNotYetImplemented):
             # Needs pickling due to the obj column
             lib.write("test", df)
 
@@ -1453,7 +1465,7 @@ def test_coercion_to_str_with_dynamic_strings(lmdb_version_store_string_coercion
     assert df["col"].dtype == np.object_
 
     if sys.platform != "win32":  # SKIP_WIN Windows always uses dynamic strings
-        with pytest.raises(ArcticNativeNotYetImplemented):
+        with pytest.raises(ArcticDbNotYetImplemented):
             lib.write("sym", df)
 
     with mock.patch(

--- a/python/tests/integration/arcticdb/version_store/test_categorical.py
+++ b/python/tests/integration/arcticdb/version_store/test_categorical.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from arcticdb.exceptions import ArcticNativeNotYetImplemented
+from arcticdb.exceptions import ArcticDbNotYetImplemented
 from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticdb.util.test import assert_frame_equal
 
@@ -168,7 +168,7 @@ def test_categorical_append(lmdb_version_store):
     original_df = pd.DataFrame({"a": ["hello", "hi", "hello"]}, dtype="category")
     lib.write(symbol, original_df)
     append_df = pd.DataFrame({"a": ["hi", "hi", "hello"]}, dtype="category")
-    with pytest.raises(ArcticNativeNotYetImplemented) as e_info:
+    with pytest.raises(ArcticDbNotYetImplemented):
         lib.append(symbol, append_df)
 
 
@@ -178,7 +178,7 @@ def test_categorical_update(lmdb_version_store):
     original_df = pd.DataFrame({"a": ["hello", "hi", "hello"]}, dtype="category")
     lib.write(symbol, original_df)
     append_df = pd.DataFrame({"a": ["hi", "hi", "hello"]}, dtype="category")
-    with pytest.raises(ArcticNativeNotYetImplemented) as e_info:
+    with pytest.raises(ArcticDbNotYetImplemented):
         lib.update(symbol, append_df)
 
 
@@ -188,7 +188,7 @@ def test_categorical_series(lmdb_version_store):
     original_series = pd.Series(["hello", "hi", "hello"], dtype="category")
     lib.write(symbol, original_series)
     append_series = pd.Series(["hi", "hi", "hello"], dtype="category")
-    with pytest.raises(ArcticNativeNotYetImplemented) as e_info:
+    with pytest.raises(ArcticDbNotYetImplemented):
         lib.append(symbol, append_series)
 
 
@@ -213,5 +213,5 @@ def test_categorical_multi_index(lmdb_version_store):
         dtype="category",
         index=pd.MultiIndex.from_arrays([arr1, arr2], names=["datetime", "level"]),
     )
-    with pytest.raises(ArcticNativeNotYetImplemented) as e_info:
+    with pytest.raises(ArcticDbNotYetImplemented):
         lib.append(symbol, append_df)

--- a/python/tests/integration/arcticdb/version_store/test_metadata_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_metadata_support.py
@@ -10,7 +10,7 @@ from pandas import DataFrame, Timestamp
 import pytest
 
 from arcticdb.version_store import NativeVersionStore, VersionedItem
-from arcticdb.exceptions import ArcticNativeNotYetImplemented
+from arcticdb.exceptions import ArcticDbNotYetImplemented
 from arcticdb_ext.storage import NoDataFoundException
 from arcticdb.util.test import assert_frame_equal, distinct_timestamps
 
@@ -31,7 +31,7 @@ def test_rt_df_with_small_meta(object_and_lmdb_version_store):
 
 
 def test_rt_df_with_humonguous_meta(object_and_lmdb_version_store):
-    with pytest.raises(ArcticNativeNotYetImplemented):
+    with pytest.raises(ArcticDbNotYetImplemented):
         from arcticdb.version_store._normalization import _MAX_USER_DEFINED_META as MAX
 
         df = DataFrame(data=["A", "B", "C"])

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -16,7 +16,7 @@ import pytz
 from numpy.testing import assert_equal, assert_array_equal
 from arcticdb_ext.version_store import SortedValue as _SortedValue
 
-from arcticdb.exceptions import ArcticNativeNotYetImplemented
+from arcticdb.exceptions import ArcticDbNotYetImplemented
 from arcticdb.version_store._custom_normalizers import (
     register_normalizer,
     get_custom_normalizer,
@@ -73,7 +73,7 @@ def test_user_meta_and_msg_pack(d):
 
 
 def test_fails_humongous_meta():
-    with pytest.raises(ArcticNativeNotYetImplemented):
+    with pytest.raises(ArcticDbNotYetImplemented):
         from arcticdb.version_store._normalization import _MAX_USER_DEFINED_META as MAX
 
         meta = {"a": "x" * (MAX)}
@@ -82,7 +82,7 @@ def test_fails_humongous_meta():
 
 def test_fails_humongous_data():
     norm = test_msgpack_normalizer
-    with pytest.raises(ArcticNativeNotYetImplemented):
+    with pytest.raises(ArcticDbNotYetImplemented):
         big = [1] * (norm.MMAP_DEFAULT_SIZE + 1)
         norm.normalize(big)
 
@@ -198,7 +198,7 @@ def test_timestamp_without_tz():
 
 def test_column_with_mixed_types():
     df = pd.DataFrame({"col": [1, "a"]})
-    with pytest.raises(ArcticNativeNotYetImplemented):
+    with pytest.raises(ArcticDbNotYetImplemented):
         DataFrameNormalizer().normalize(df)
 
 
@@ -305,7 +305,7 @@ def test_force_pickle_on_norm_failure():
     _d, _meta = norm.normalize(normal_df)
 
     # This should fail as the df has mixed type
-    with pytest.raises(ArcticNativeNotYetImplemented):
+    with pytest.raises(ArcticDbNotYetImplemented):
         norm.normalize(mixed_type_df)
 
     # Explicitly passing in pickle settings without global pickle flag being set should work


### PR DESCRIPTION
Issue #774 

Simple rename of exception, with compatibility:

```
class ArcticDbNotYetImplemented(ArcticException):
    pass


# Backwards compat - this is the old name of ArcticDbNotYetImplemented
ArcticNativeNotYetImplemented = ArcticDbNotYetImplemented
```

Implemented by find and replace.

Added test for the compat.