### PR TITLE
Fix the dependencies for the can_merge step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,10 @@ jobs:
 
   can_merge:
     needs: [leader-cpp-test-linux, leader-cpp-test-windows, follower-linux, follower-windows, persistent_storage_verify_linux, persistent_storage_verify_windows]
+    if: |
+      always() &&
+      !failure() &&
+      !cancelled()
     runs-on: ubuntu-latest
     steps:
       - run: echo Dummy job to simplify PR merge checks configuration


### PR DESCRIPTION
#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.
It seems that when a step depends on another step and that step is skipped, the downstream one is also skipped by default. This can be fixed with a check as per this stack overflow thread: 
https://stackoverflow.com/questions/69354003/github-action-job-fire-when-previous-job-skipped
