### PR TITLE
maint: Add a minimal Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+| ArcticDB Version |       Supported      |
+| ---------------- | -------------------- |
+| 1.0              |          :x:         |
+| 1.2              |          :x:         |
+| 1.3              |          :x:         |
+| 1.4              |          :x:         |
+| 1.5              |          :x:         |
+| 1.6              |          :x:         |
+| 2.0              |          :x:         |
+| 3.0              |  :white_check_mark:  |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report security vulnerabilities by email to [`arcticdb@man.com`](mailto:arcticdb@man.com).
+
+### Email content
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. unsafe code, known vulnerabilities in dependencies, arbitrary code execution)
+  * Full paths of the (source) file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * The commit which introduced the vulnerability, if applicable
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+Reporters will receive a response within 48 hours. If the vulnerability is confirmed, we will release a patch as soon as possible.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

This adds a minimal Security Policy. This is highly inspired from other projects', such as [scikit-learn's](https://github.com/ory/examples/blob/master/SECURITY.md), [ory's](https://github.com/ory/examples/blob/master/SECURITY.md), and [Microsoft's](https://github.com/microsoft/.github/blob/main/SECURITY.md).

#### Any other comments?

For now, only the last version is supported, with version being explicitly enumerated in the table. We could also just mentioned that the latest minor version is the only one supported (with its patched versions).

Moreover, we could have another security policy based on [the Common Vulnerability Scoring Systems](https://www.first.org/cvss/) such as [ory's](https://github.com/ory/examples/blob/master/SECURITY.md).

If we want to have a complete Security Policy, then it might be worth adopting one which is similar to [CSAN's](https://gitlab.in2p3.fr/csan/csan/-/blob/master/SECURITY.md).

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
