### PR TITLE
Bugfix 767: Fix segfault in batch write with string columns

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1337,6 +1337,8 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     bool validate_index,
     bool throw_on_error
 ) {
+    py::gil_scoped_release release_gil;
+
     auto write_options = get_write_options();
     auto update_info_futs = batch_get_latest_undeleted_version_and_next_version_id_async(store(),
                                                                                          version_map(),
@@ -1447,6 +1449,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     bool validate_index,
     bool upsert,
     bool throw_on_error) {
+    py::gil_scoped_release release_gil;
 
     auto stream_update_info_futures = batch_get_latest_undeleted_version_and_next_version_id_async(store(),
                                                                                                     version_map(),

--- a/cpp/arcticdb/version/test/test_sparse.cpp
+++ b/cpp/arcticdb/version/test/test_sparse.cpp
@@ -182,7 +182,8 @@ TEST_F(SparseTestStore, SimpleRoundtripStrings) {
 
     ASSERT_EQ(frame.row_count(), 2);
     auto val1 = frame.scalar_at<PyObject*>(0, 1);
-    auto str_wrapper = convert::py_unicode_to_buffer(val1.value());
+    std::optional<ScopedGILLock> scoped_gil_lock;
+    auto str_wrapper = convert::py_unicode_to_buffer(val1.value(), scoped_gil_lock);
     ASSERT_EQ(strcmp(str_wrapper.buffer_, "five"), 0);
 
     auto val2 = frame.string_at(0, 2);
@@ -560,7 +561,8 @@ TEST_F(SparseTestStore, CompactWithStrings) {
 
     for(size_t i = 0; i < num_rows; i += 2) {
         auto val1 = frame.scalar_at<PyObject*>(i, 1);
-        auto str_wrapper = convert::py_unicode_to_buffer(val1.value());
+        std::optional<ScopedGILLock> scoped_gil_lock;
+        auto str_wrapper = convert::py_unicode_to_buffer(val1.value(), scoped_gil_lock);
         auto expected = fmt::format("{}", i + 1);
         ASSERT_EQ(strcmp(str_wrapper.buffer_, expected.data()), 0);
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #767 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

The segfault was caused by the allocation of `PyObject`s in threads that were not holding the GIL. For ASCII and UTF-8 strings, we do not need to use the `PyUnicode_AsUTF8String` method performing the allocation under the hood. It is sufficient to take a view over the underlying buffer. This should speed up writes of ASCII and UTF-8 strings in general.

For other unicode strings, it was considered to re-implement the logic to produce a UTF-8 buffer, which would still involve an allocation, but without creating a `PyObject`. However, this logic is quite involved, and maintaining it would be challenging, and so this approach was not taken, although it could be in the future.

Instead, the `PyUnicode_AsUTF8String` method is still used for these strings, and so the GIL must be held while it is called. This is achieved by releasing the GIL when `batch_write` is called. If a unicode string that requires `PyUnicode_AsUTF8String` is found, the GIL is taken by that thread for the remainder of the processing of that column, under the assumption that if a column contains one such string, then it is likely to contain more. This avoids taking and releasing the GIL in quick succession for a column of unicode strings.

#### Any other comments?

Releasing the GIL on entry to batch write means that in theory the ndarrays we are writing could be modified by another thread during the writes. If this is the case, user's should be using a finer-grained lock than the GIL to control this modification. However, if necessary, we could set the ndarrays to read only on entry, and back to whatever they were before on exit using NPY_ARRAY_WRITEABLE.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
