### PR TITLE
Improve handling on obsolete S3 option "force_uri_lib_config"

### DIFF
--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -38,6 +38,9 @@ class ParsedQuery:
 
     path_prefix: Optional[str] = None
 
+    # DEPRECATED - see https://github.com/man-group/ArcticDB/pull/833
+    force_uri_lib_config: Optional[bool] = True
+
 
 class S3LibraryAdapter(ArcticLibraryAdapter):
     REGEX = r"s3(s)?://(?P<endpoint>.*):(?P<bucket>[-_a-zA-Z0-9.]+)(?P<query>\?.*)?"
@@ -54,6 +57,12 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         self._bucket = match_groups["bucket"]
 
         self._query_params: ParsedQuery = self._parse_query(match["query"])
+
+        if self._query_params.force_uri_lib_config is False:
+            raise ValueError(
+                "The support of 'force_uri_lib_config=false' has been dropped due to security concerns. Please refer to"
+                " https://github.com/man-group/ArcticDB/pull/803 for more information."
+            )
 
         if self._query_params.port:
             self._endpoint += f":{self._query_params.port}"

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1054,3 +1054,12 @@ def test_azure_no_ca_path(azurite_azure_test_connection_setting):
     ac = Arctic(
         f"azure://DefaultEndpointsProtocol=http;AccountName={credential_name};AccountKey={credential_key};BlobEndpoint={endpoint}/{credential_name};Container={container}"
     )
+
+
+def test_s3_force_uri_lib_config_handling(moto_s3_uri_incl_bucket):
+    # force_uri_lib_config is a obsolete configuration. However, user still include this option in their setup. For backward compatitbility, we need to make sure such setup will still work
+    # Why it becomes obsolete: https://github.com/man-group/ArcticDB/pull/803
+    Arctic(f"{moto_s3_uri_incl_bucket}&force_uri_lib_config=true)")
+
+    with pytest.raises(ValueError):
+        Arctic(f"{moto_s3_uri_incl_bucket}&force_uri_lib_config=false)")


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs
https://github.com/man-group/ArcticDB/issues/832
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.
Add `force_uri_lib_config=True` support for backward compatibility

Before https://github.com/man-group/ArcticDB/issues/802:
- No `force_uri_lib_config`: accept
- `force_uri_lib_config=true`: accept
- `force_uri_lib_config=false`: accept

After https://github.com/man-group/ArcticDB/issues/802:
- No `force_uri_lib_config`: accept
- `force_uri_lib_config=true`: raise exception
- `force_uri_lib_config=false`: raise exception

With this PR:
- No `force_uri_lib_config`: accept
- `force_uri_lib_config=true`: accept
- `force_uri_lib_config=false`: raise exception

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
