### PR TITLE
Fix list versions latest only

### DIFF
--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -212,14 +212,16 @@ VersionResultVector get_latest_versions_for_symbols(
     VersionResultVector res;
     std::unordered_set<std::pair<StreamId, VersionId>> unpruned_versions;
     for (auto &s_id: stream_ids) {
-            auto version_key = get_latest_undeleted_version(store, version_map, s_id, version_query, ReadOptions{}).value();
-            res.emplace_back(
-                s_id,
-                version_key.version_id(),
-                version_key.creation_ts(),
-                snapshots_for_symbol[{s_id, version_key.version_id()}],
-                false);
-
+            auto opt_version_key = get_latest_undeleted_version(store, version_map, s_id, version_query, ReadOptions{});
+            if (opt_version_key) {
+                auto version_key = opt_version_key.value();
+                res.emplace_back(
+                    s_id,
+                    version_key.version_id(),
+                    version_key.creation_ts(),
+                    snapshots_for_symbol[{s_id, version_key.version_id()}],
+                    false);
+            }
     }
     std::sort(res.begin(), res.end(), VersionComp());
     return res;

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -212,14 +212,13 @@ VersionResultVector get_latest_versions_for_symbols(
     VersionResultVector res;
     std::unordered_set<std::pair<StreamId, VersionId>> unpruned_versions;
     for (auto &s_id: stream_ids) {
-            auto opt_version_key = get_latest_undeleted_version(store, version_map, s_id, version_query, ReadOptions{});
+            const auto& opt_version_key = get_latest_undeleted_version(store, version_map, s_id, version_query, ReadOptions{});
             if (opt_version_key) {
-                auto version_key = opt_version_key.value();
                 res.emplace_back(
                     s_id,
-                    version_key.version_id(),
-                    version_key.creation_ts(),
-                    snapshots_for_symbol[{s_id, version_key.version_id()}],
+                    opt_version_key->version_id(),
+                    opt_version_key->creation_ts(),
+                    snapshots_for_symbol[{s_id, opt_version_key->version_id()}],
                     false);
             }
     }

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -454,8 +454,11 @@ def test_delete_version(arctic_library):
 
 def test_non_existent_list_versions_latest_only(arctic_library):
     lib = arctic_library
-    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
     assert len(lib.list_versions("symbol", latest_only=True)) == 0
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    lib.write("symbol2", df)
+    lib.delete("symbol2")
+    assert len(lib.list_versions("symbol2", latest_only=True)) == 0
 
 
 def test_delete_version_with_snapshot(arctic_library):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -454,7 +454,7 @@ def test_delete_version(arctic_library):
 def test_non_existent_list_versions_latest_only(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
-    assert len(lib.list_versions('symbol', latest_only=True)) == 0
+    assert len(lib.list_versions("symbol", latest_only=True)) == 0
 
 def test_delete_version_with_snapshot(arctic_library):
     lib = arctic_library

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -451,6 +451,10 @@ def test_delete_version(arctic_library):
     assert lib["symbol"].version == 0
     assert lib["symbol"].metadata == {"very": "interesting"}
 
+def test_non_existent_list_versions_latest_only(arctic_library):
+    lib = arctic_library
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    assert len(lib.list_versions('symbol', latest_only=True)) == 0
 
 def test_delete_version_with_snapshot(arctic_library):
     lib = arctic_library

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -474,7 +474,7 @@ def test_list_versions_latest_only(arctic_library):
     lib.write("symbol", df)
     lib.write("symbol", df)
     lib.write("symbol", df)
-    assert len(lib.list_versions("symbol", latest_only=True)) == 3
+    assert len(lib.list_versions("symbol", latest_only=True)) == 1
 
 
 def test_non_existent_list_versions_latest_only(arctic_library):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -451,10 +451,12 @@ def test_delete_version(arctic_library):
     assert lib["symbol"].version == 0
     assert lib["symbol"].metadata == {"very": "interesting"}
 
+
 def test_non_existent_list_versions_latest_only(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
     assert len(lib.list_versions("symbol", latest_only=True)) == 0
+
 
 def test_delete_version_with_snapshot(arctic_library):
     lib = arctic_library


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fixes #831.

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Bug whereby `lib.list_versions("symbol", latest_only=True)` would return an `InternalException` if the symbol name did not exist (e.g. it had been deleted, or was never there in first place).

Solution was to check `std::optional<AtomKey>` returned from `get_latest_undeleted_version` contains a value before calling `.value()`. Was throwing `std::bad_optional_access` error before.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
