### PR TITLE
Fix aws auth not used, even the option is set to true

### DIFF
--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -140,10 +140,16 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
 
     def get_storage_override(self) -> StorageOverride:
         s3_override = S3Override()
-        if self._query_params.access:
-            s3_override.credential_name = self._query_params.access
-        if self._query_params.secret:
-            s3_override.credential_key = self._query_params.secret
+        # storage_override will overwrite access and key while reading config from storage
+        # access and secret whether equals to _RBAC_ are used for determining aws_auth is true on C++ layer
+        if self._query_params.aws_auth:
+            s3_override.credential_name = USE_AWS_CRED_PROVIDERS_TOKEN
+            s3_override.credential_key = USE_AWS_CRED_PROVIDERS_TOKEN
+        else:
+            if self._query_params.access:
+                s3_override.credential_name = self._query_params.access
+            if self._query_params.secret:
+                s3_override.credential_key = self._query_params.secret
         if self._query_params.region:
             s3_override.region = self._query_params.region
         if self._endpoint:

--- a/python/tests/scripts/test_update_storage.py
+++ b/python/tests/scripts/test_update_storage.py
@@ -1,6 +1,8 @@
 import sys
 
 import pytest
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
 
 from arcticdb import Arctic
 from arcticdb.scripts.update_storage import run
@@ -109,6 +111,14 @@ def test_upgrade_script_s3_rbac_ok(moto_s3_endpoint_and_credentials, monkeypatch
     assert s3_storage.bucket_name == bucket
     assert s3_storage.credential_name == USE_AWS_CRED_PROVIDERS_TOKEN
     assert s3_storage.credential_key == USE_AWS_CRED_PROVIDERS_TOKEN
+
+    expected = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    sym = "test"
+    ac = Arctic(uri)
+    ac[LIB_NAME].write(sym, expected)
+
+    ac = Arctic(uri)  # Force load lib config from storage, to check "storage-overridened" config
+    assert_frame_equal(expected, ac[LIB_NAME].read(sym).data)
 
 
 # Side effect needed from "_create_container" fixture


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

https://github.com/man-group/ArcticDB/issues/842

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

It fixes the connection failure to AWS S3 storage which requires AWS authorisation. 
The fix is primarily setting the access and key of affected libraries ' storage overrider to `_RBAC_`. These will make sure the config loaded from storage will have the access and key properly set, to trigger the special handling for AWS authorisation.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
