### PR TITLE
Make azure sdk stick to winhttp if possible

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -41,10 +41,12 @@ AzureStorage::AzureStorage(const LibraryPath &library_path, OpenMode mode, const
 }
 
 Azure::Storage::Blobs::BlobClientOptions AzureStorage::get_client_options(const Config &conf) {
-    Azure::Core::Http::CurlTransportOptions curl_transport_options;
-    curl_transport_options.CAInfo = conf.ca_cert_path();
     BlobClientOptions client_options;
-    client_options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_transport_options);
+    if (!conf.ca_cert_path().empty()) {//WARNING: Setting ca_cert_path will force Azure sdk uses libcurl as backend support, instead of winhttp
+        Azure::Core::Http::CurlTransportOptions curl_transport_options;
+        curl_transport_options.CAInfo = conf.ca_cert_path();
+        client_options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_transport_options);
+    }
     return client_options;
 }
 

--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import re
 import time
 from typing import Optional
+import platform
 
 from arcticdb.options import LibraryOptions
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
@@ -54,6 +55,8 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
             ]
         )
         self._container = self._query_params.Container
+        if platform.system() == "Windows" and self._query_params.CA_cert_path:
+            raise ValueError(f"CA_cert_path cannot be set on Windows platform")
         self._ca_cert_path = self._query_params.CA_cert_path
         self._encoding_version = encoding_version
 

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -90,7 +90,7 @@ class Arctic:
                 +---------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | Path_prefix               | Path within Azure container to use for data storage                                                                                                           |
                 +---------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                | CA_cert_path              | Azure CA certificate path. If not set, default path will be used.                                                                                             |
+                | CA_cert_path              | (Non-Windows platform only) Azure CA certificate path. If not set, default path will be used.                                                                 |
                 |                           | Note: For Linux distribution, default path is set to `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`.                                                     |
                 |                           | If the certificate cannot be found in the provided path, an Azure exception with no meaningful error code will be thrown.                                     |
                 |                           | For more details, please see https://github.com/Azure/azure-sdk-for-cpp/issues/4738.                                                                          |
@@ -103,9 +103,10 @@ class Arctic:
                 |                           | "/etc/pki/tls/cacert.pem"                             OpenELEC                                                                                                |
                 |                           | "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"   CentOS/RHEL 7                                                                                           |
                 |                           | "/etc/ssl/cert.pem"                                   Alpine Linux                                                                                            |
-                |                           | WARNING for WINDOWS USER: Not leaving this empty will switch the backend support of Azure SDK from winhttp to libcurl. If ca cert path is needed to be        |
-                |                           | specified, set it in Windows setting so winhttp will be used still                                                                                            |
                 +---------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+                For Windows user, `CA_cert_path` cannot be set. Please set CA certificate related option on Windows setting.
+                For details, you may refer to https://learn.microsoft.com/en-us/skype-sdk/sdn/articles/installing-the-trusted-root-certificate
 
                 Exception: Azure exceptions message always ends with `{AZURE_SDK_HTTP_STATUS_CODE}:{AZURE_SDK_REASON_PHRASE}`.
 
@@ -127,7 +128,7 @@ class Arctic:
                 +---------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | Option                    | Description                                                                                                                                                   |
                 +===========================+===============================================================================================================================================================+
-                | map_size                  | LMDB map size (see http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5). String. Supported formats are:                               |                                                                                                              |
+                | map_size                  | LMDB map size (see http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5). String. Supported formats are:                               |
                 |                           |                                                                                                                                                               |
                 |                           | "150MB" / "20GB" / "3TB"                                                                                                                                      |
                 |                           |                                                                                                                                                               |

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -103,6 +103,8 @@ class Arctic:
                 |                           | "/etc/pki/tls/cacert.pem"                             OpenELEC                                                                                                |
                 |                           | "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"   CentOS/RHEL 7                                                                                           |
                 |                           | "/etc/ssl/cert.pem"                                   Alpine Linux                                                                                            |
+                |                           | WARNING for WINDOWS USER: Not leaving this empty will switch the backend support of Azure SDK from winhttp to libcurl. If ca cert path is needed to be        |
+                |                           | specified, set it in Windows setting so winhttp will be used still                                                                                            |
                 +---------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
                 Exception: Azure exceptions message always ends with `{AZURE_SDK_HTTP_STATUS_CODE}:{AZURE_SDK_REASON_PHRASE}`.

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -100,7 +100,7 @@ def azure_client_and_create_container(azurite_container, azurite_azure_uri):
     return client
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def azure_account_sas_token(azure_client_and_create_container, azurite_azure_test_connection_setting):
     start_time = datetime.now(timezone.utc)
     expiry_time = start_time + timedelta(days=1)
@@ -109,8 +109,12 @@ def azure_account_sas_token(azure_client_and_create_container, azurite_azure_tes
     sas_token = generate_account_sas(
         account_key=credential_key,
         account_name=credential_name,
-        resource_types=ResourceTypes.from_string("sco"),
-        permission=AccountSasPermissions.from_string("rwdlacup"),
+        resource_types=ResourceTypes.from_string(
+            "sco"
+        ),  # Each letter stands for one kind of resources; https://github.com/Azure/azure-sdk-for-python/blob/70ace4351ff78c3fe5a6f579132fc30d305fd3c9/sdk/tables/azure-data-tables/azure/data/tables/_models.py#L585
+        permission=AccountSasPermissions.from_string(
+            "rwdlacup"
+        ),  # Each letter stands for one kind of permission; https://github.com/Azure/azure-sdk-for-python/blob/70ace4351ff78c3fe5a6f579132fc30d305fd3c9/sdk/tables/azure-data-tables/azure/data/tables/_models.py#L656
         expiry=expiry_time,
         start=start_time,
     )

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1040,10 +1040,25 @@ def test_get_uri(object_storage_uri_incl_bucket):
 
 
 def test_azure_no_ca_path(azurite_azure_test_connection_setting):
-    (endpoint, container, credential_name, credential_key, ca_cert_path) = azurite_azure_test_connection_setting
-    ac = Arctic(
+    endpoint, container, credential_name, credential_key, _ = azurite_azure_test_connection_setting
+    Arctic(
         f"azure://DefaultEndpointsProtocol=http;AccountName={credential_name};AccountKey={credential_key};BlobEndpoint={endpoint}/{credential_name};Container={container}"
     )
+
+
+def test_azure_sas_token(azure_account_sas_token, azurite_azure_test_connection_setting):
+    endpoint, container, credential_name, _, _ = azurite_azure_test_connection_setting
+    ac = Arctic(
+        f"azure://DefaultEndpointsProtocol=http;SharedAccessSignature={azure_account_sas_token};BlobEndpoint={endpoint}/{credential_name};Container={container}"
+    )
+    expected = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    sym = "test"
+    lib = "lib"
+    ac.create_library(lib)
+    ac[lib].write(sym, expected)
+    assert_frame_equal(expected, ac[lib].read(sym).data)
+
+    assert ac.list_libraries() == [lib]
 
 
 def test_s3_force_uri_lib_config_handling(moto_s3_uri_incl_bucket):


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs
https://github.com/man-group/ArcticDB/issues/849
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.
Azure SDK has an undocumented feature, in the situation which if CA path is set, even it is left empty, uses libcurl instead of the default winhttp as backend support on Windows. During the test, using libcurl as backend shows buggy behaviour on ssl ca cert verification. 
This fix is to not set `CAINFO` if ca path is not specified, to give user choice to use winhttp, to avoid the buggy behaviour.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
