### PR TITLE
conda-build: Explicitly depend on `azure-core-cpp`

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -32,6 +32,7 @@ dependencies:
   - libprotobuf < 4
   - bitmagic
   - spdlog
+  - azure-core-cpp
   - azure-identity-cpp
   - azure-storage-blobs-cpp
   # Incompatibility with fmt last version


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #840. 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

For context, see: https://github.com/conda-forge/arcticdb-feedstock/pull/53/files#r1324602175

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
