### PR TITLE
maint: Replace deprecated `ZSTD_getDecompressedSize`

### DIFF
--- a/cpp/arcticdb/codec/zstd.hpp
+++ b/cpp/arcticdb/codec/zstd.hpp
@@ -68,7 +68,7 @@ struct ZstdDecoder {
         T *t_out,
         std::size_t out_bytes) {
 
-        const std::size_t decomp_size = ZSTD_getDecompressedSize(in, in_bytes);
+        const std::size_t decomp_size = ZSTD_getFrameContentSize(in, in_bytes);
         util::check_arg(decomp_size == out_bytes, "expected out_bytes == zstd deduced bytes, actual {} != {}",
                         out_bytes, decomp_size);
         std::size_t real_decomp = ZSTD_decompress(t_out, out_bytes, in, in_bytes);


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

This replaces it with `ZSTD_getFrameContentSize` to avoid this kind of warning:

```
In file included from /home/jjerphan/dev/ArcticDB/cpp/arcticdb/codec/codec-inl.hpp:15,
                 from /home/jjerphan/dev/ArcticDB/cpp/arcticdb/codec/codec.hpp:185,
                 from /home/jjerphan/dev/ArcticDB/cpp/arcticdb/storage/storage.hpp:2,
                 from /home/jjerphan/dev/ArcticDB/cpp/arcticdb/storage/memory/memory_storage.hpp:10,
                 from /home/jjerphan/dev/ArcticDB/cpp/arcticdb/storage/memory/memory_storage-inl.hpp:15,
                 from /home/jjerphan/dev/ArcticDB/cpp/arcticdb/storage/memory/memory_storage.cpp:8:
/home/jjerphan/dev/ArcticDB/cpp/arcticdb/codec/zstd.hpp: In static member function 'static void arcticdb::detail::ZstdDecoder::decode_block(uint32_t, const uint8_t*, std::size_t, T*, std::size_t)':
/home/jjerphan/dev/ArcticDB/cpp/arcticdb/codec/zstd.hpp:71:65: warning: 'long long unsigned int ZSTD_getDecompressedSize(const void*, size_t)' is deprecated: Replaced by ZSTD_getFrameContentSize [-Wdeprecated-declarations]
   71 |         const std::size_t decomp_size = ZSTD_getDecompressedSize(in, in_bytes);
      |
~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
