### PR TITLE
Bugfix from 827 changes: Prevent Unnecessary Reference Decrement in PyStringWrapper Destructors

### DIFF
--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -146,7 +146,7 @@ void aggregator_set_data(
                             auto wrapper= convert::py_unicode_to_buffer(*ptr_data, scoped_gil_lock);
                             agg.set_string_at(col, s, wrapper.buffer_, wrapper.length_);
                         } else {
-                            auto wrapper = convert::pystring_to_buffer(*ptr_data);
+                            auto wrapper = convert::pystring_to_buffer(*ptr_data, false);
                             agg.set_string_at(col, s, wrapper.buffer_, wrapper.length_);
                         }
                     }

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -24,14 +24,14 @@ bool is_unicode(PyObject *obj) {
     return PyUnicode_Check(obj);
 }
 
-PyStringWrapper pystring_to_buffer(PyObject *obj) {
+PyStringWrapper pystring_to_buffer(PyObject *obj, bool is_owned) {
     char *buffer;
     ssize_t length;
     util::check(!is_unicode(obj), "Unexpected unicode object");
     if (PYBIND11_BYTES_AS_STRING_AND_SIZE(obj, &buffer, &length))
         util::raise_rte("Unable to extract string contents! (invalid type)");
 
-    return {buffer, length, obj};
+    return {buffer, length, is_owned ? obj : nullptr};
 }
 
 PyStringWrapper py_unicode_to_buffer(PyObject *obj, std::optional<ScopedGILLock>& scoped_gil_lock) {
@@ -50,7 +50,7 @@ PyStringWrapper py_unicode_to_buffer(PyObject *obj, std::optional<ScopedGILLock>
             PyObject* utf8_obj = PyUnicode_AsUTF8String(obj);
             if (!utf8_obj)
                 util::raise_rte("Unable to extract string contents! (encoding issue)");
-            return pystring_to_buffer(utf8_obj);
+            return pystring_to_buffer(utf8_obj, true);
         }
     } else {
         util::raise_rte("Expected unicode");

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -38,7 +38,7 @@ struct ARCTICDB_VISIBILITY_HIDDEN PyStringWrapper {
 };
 
 PyStringWrapper pystring_to_buffer(
-    PyObject *obj);
+    PyObject *obj, bool is_owned);
 
 PyStringWrapper py_unicode_to_buffer(
     PyObject *obj,


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

bug fix introduced in #827

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.


In the bug fix from #827, there was an issue with wrappers created in frame_util.cpp::143:

`auto wrapper = convert::pystring_to_buffer(*ptr_data);
`

Originally (before changes introduce in #827), these wrappers internally used an empty handle. Consequently, when being destructed, no references were decremented. This is evident in python_to_tensor_frame.hpp::30


```
    ~PyStringWrapper() {
         if (handle_)
             handle_.dec_ref();
```

The changes in #827 incorrectly also decremented the references of the objects contained by those wrappers. This led to a segmentation fault when the code path destructed such objects, as we were decrementing the handle of an object not owned by us.



#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
