### PR TITLE
Issue #850 Ensure that LMDB libraries are readable after being moved to a different location

### DIFF
--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -120,6 +120,7 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
 
     py::class_<LmdbOverride>(storage, "LmdbOverride")
             .def(py::init<>())
+            .def_property("path", &LmdbOverride::path, &LmdbOverride::set_path)
             .def_property("map_size", &LmdbOverride::map_size, &LmdbOverride::set_map_size);
 
     py::class_<StorageOverride>(storage, "StorageOverride")

--- a/cpp/arcticdb/storage/storage_override.hpp
+++ b/cpp/arcticdb/storage/storage_override.hpp
@@ -127,11 +127,21 @@ public:
 };
 
 class LmdbOverride {
+    std::string path_;
     uint64_t map_size_;
 
 public:
+
+    [[nodiscard]] std::string path() const {
+        return path_;
+    }
+
     [[nodiscard]] uint64_t map_size() const {
         return map_size_;
+    }
+
+    void set_path(std::string path) {
+        path_ = path;
     }
 
     void set_map_size(uint64_t map_size) {
@@ -143,6 +153,7 @@ public:
             arcticdb::proto::lmdb_storage::Config lmdb_storage;
             storage.config().UnpackTo(&lmdb_storage);
 
+            lmdb_storage.set_path(path_);
             lmdb_storage.set_map_size(map_size_);
 
             util::pack_to_any(lmdb_storage, *storage.mutable_config());

--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -62,7 +62,7 @@ class ArcticLibraryAdapter(ABC):
     def create_library(self, name: str, library_options: LibraryOptions) -> NativeVersionStore:
         raise NotImplementedError
 
-    def cleanup_library(self, library_name: str, library_config: LibraryConfig):
+    def cleanup_library(self, library_name: str):
         pass
 
     def get_storage_override(self) -> StorageOverride:

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -15,7 +15,6 @@ from arcticdb.log import storage as log
 
 from arcticdb.options import LibraryOptions
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
-from arcticc.pb2.lmdb_storage_pb2 import Config as LmdbConfig
 from arcticdb.version_store.helper import add_lmdb_library_to_env
 from arcticdb.config import _DEFAULT_ENV
 from arcticdb.version_store._store import NativeVersionStore
@@ -26,7 +25,7 @@ from arcticdb.exceptions import ArcticDbNotYetImplemented, LmdbOptionsError
 
 
 def _rmtree_errorhandler(func, path, exc_info):
-    log.warn("Error removing LMDB tree at path=[{}]", path, exc_info=exc_info)
+    log.warn("Error removing LMDB tree at path=[{}] error=[{}]", path, exc_info)
 
 
 @dataclass
@@ -162,14 +161,12 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
 
         return lib
 
-    def cleanup_library(self, library_name: str, library_config: LibraryConfig):
-        for k, v in library_config.storage_by_id.items():
-            lmdb_config = LmdbConfig()
-            v.config.Unpack(lmdb_config)
-            shutil.rmtree(os.path.join(lmdb_config.path, library_name), onerror=_rmtree_errorhandler)
+    def cleanup_library(self, library_name: str):
+        shutil.rmtree(os.path.join(self._path, library_name), onerror=_rmtree_errorhandler)
 
     def get_storage_override(self) -> StorageOverride:
         lmdb_override = LmdbOverride()
+        lmdb_override.path = self._path
         if self._query_params.map_size:
             lmdb_override.map_size = self._query_params.map_size
 

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -303,11 +303,10 @@ class Arctic:
         already_open = self._open_libraries.pop(name, None)
         if not already_open and not self._library_manager.has_library(name):
             return
-        config = self._library_manager.get_library_config(name)
         (already_open or self[name])._nvs.version_store.clear()
         del already_open  # essential to free resources held by the library
         try:
-            self._library_adapter.cleanup_library(name, config)
+            self._library_adapter.cleanup_library(name)
         finally:
             self._library_manager.remove_library_config(name)
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1697,7 +1697,7 @@ class Library:
             Target for maximum no. of rows per segment, after compaction.
             If parameter is not provided, library option - "segment_row_size" will be used
             Note that no. of rows per segment, after compaction, may exceed the target.
-            It is for achieving smallest no. of segment after compaction. Please refer to below example for further explantion.
+            It is for achieving smallest no. of segment after compaction. Please refer to below example for further explanation.
 
         Returns
         -------

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import functools
 import multiprocessing
 import shutil
+import socket
 
 import boto3
 import werkzeug
@@ -30,13 +31,10 @@ import random
 from datetime import datetime, timezone, timedelta
 from typing import Optional, Any, Dict
 import subprocess
-from pathlib import Path
-import socket
 import tempfile
 import pymongo
 
 import requests
-from pytest_server_fixtures.base import get_ephemeral_port
 
 from arcticdb.arctic import Arctic
 from arcticdb.version_store.helper import (
@@ -71,13 +69,35 @@ def run_server(port):
     )
 
 
+def _get_ephemeral_port() -> int:
+    # Get a free port from the OS
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()  # possible race to bind to port now
+    return port
+
+
 @pytest.fixture(scope="session")
 def _moto_s3_uri():
-    port = get_ephemeral_port()
+    port = _get_ephemeral_port()
     p = multiprocessing.Process(target=run_server, args=(port,))
     p.start()
 
-    time.sleep(0.5)
+    attempts = 0
+    while True:
+        time.sleep(0.2)
+        try:
+            response = requests.get(f"http://localhost:{port}")
+            code = response.status_code
+            if code == 200:
+                break
+        except requests.exceptions.ConnectionError:
+            pass
+
+        attempts += 1
+        if attempts == 20:
+            pytest.fail(f"moto3 server on http://localhost:{port} failed to start up")
 
     yield f"http://localhost:{port}"
 
@@ -1039,7 +1059,7 @@ def get_wide_df():
 
 @pytest.fixture(scope="session")
 def azurite_port():
-    return get_ephemeral_port()
+    return _get_ephemeral_port()
 
 
 @pytest.fixture

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -30,7 +30,6 @@ import numpy as np
 from arcticdb.config import MACOS_CONDA_BUILD, MACOS_CONDA_BUILD_SKIP_REASON
 from arcticdb.util.test import assert_frame_equal, RUN_MONGO_TEST
 
-from azure.storage.blob import BlobServiceClient
 from botocore.client import BaseClient as BotoClient
 import time
 

--- a/python/tests/integration/arcticdb/test_arctic_move_storage.py
+++ b/python/tests/integration/arcticdb/test_arctic_move_storage.py
@@ -84,6 +84,9 @@ def test_move_lmdb_library_map_size_reduction(tmpdir_factory):
 
     assert "lmdb error code -30792" in str(exc_info.value)
 
+    # stuff should still be readable despite the error
+    assert_frame_equal(df, lib.read("sym").data)
+
 
 def test_move_lmdb_library_map_size_increase(tmpdir_factory):
     # Given - any LMDB library

--- a/python/tests/integration/arcticdb/test_arctic_move_storage.py
+++ b/python/tests/integration/arcticdb/test_arctic_move_storage.py
@@ -1,0 +1,200 @@
+import shutil
+import boto3
+import pytest
+import sys
+
+from arcticdb import Arctic
+from arcticdb.util.test import get_wide_dataframe
+from arcticdb.util.test import assert_frame_equal
+from arcticdb.exceptions import InternalException
+
+
+def test_move_lmdb_library(tmpdir_factory):
+    # Given - any LMDB library
+    original = tmpdir_factory.mktemp("original")
+    ac = Arctic(f"lmdb://{original}")
+    ac.create_library("lib")
+    lib = ac["lib"]
+
+    df = get_wide_dataframe(size=100)
+    lib.write("sym", df)
+
+    # Free resources to release the filesystem lock held by Windows
+    del lib
+    del ac
+
+    # When - we move the data
+    dest = str(tmpdir_factory.mktemp("dest"))
+    shutil.move(str(original / "_arctic_cfg"), dest)
+    shutil.move(str(original / "lib"), dest)
+
+    # Then - should be readable at new location
+    ac = Arctic(f"lmdb://{dest}")
+    assert ac.list_libraries() == ["lib"]
+    lib = ac["lib"]
+    assert lib.list_symbols() == ["sym"]
+    assert_frame_equal(df, lib.read("sym").data)
+    assert "dest" in lib.read("sym").host
+    assert "original" not in lib.read("sym").host
+
+
+def test_move_lmdb_library_map_size_reduction(tmpdir_factory):
+    # Given - any LMDB library
+    original = tmpdir_factory.mktemp("original")
+    ac = Arctic(f"lmdb://{original}?map_size=1MB")
+    ac.create_library("lib")
+    lib = ac["lib"]
+
+    df = get_wide_dataframe(size=100)
+    lib.write("sym", df)
+
+    # Free resources to release the filesystem lock held by Windows
+    del lib
+    del ac
+
+    # When - we move the data
+    dest = str(tmpdir_factory.mktemp("dest"))
+    shutil.move(str(original / "_arctic_cfg"), dest)
+    shutil.move(str(original / "lib"), dest)
+
+    # Then - should be readable at new location as long as map size still big enough
+    ac = Arctic(f"lmdb://{dest}?map_size=500KB")
+    assert ac.list_libraries() == ["lib"]
+    lib = ac["lib"]
+    assert lib.list_symbols() == ["sym"]
+    assert_frame_equal(df, lib.read("sym").data)
+    assert "dest" in lib.read("sym").host
+    assert "original" not in lib.read("sym").host
+    lib.write("another_sym", df)
+
+    del lib
+    del ac
+
+    # Then - read with new tiny map size
+    # Current data should still be readable, expect modifications to fail
+    ac = Arctic(f"lmdb://{dest}?map_size=1KB")
+    assert ac.list_libraries() == ["lib"]
+    lib = ac["lib"]
+    assert set(lib.list_symbols()) == {"sym", "another_sym"}
+    assert_frame_equal(df, lib.read("sym").data)
+
+    # TODO #866 proper exception type for this
+    with pytest.raises(InternalException) as exc_info:
+        lib.write("another_sym", df)
+
+    assert "lmdb error code -30792" in str(exc_info.value)
+
+
+def test_move_lmdb_library_map_size_increase(tmpdir_factory):
+    # Given - any LMDB library
+    original = tmpdir_factory.mktemp("original")
+    ac = Arctic(f"lmdb://{original}?map_size=500KB")
+    ac.create_library("lib")
+    lib = ac["lib"]
+
+    for i in range(10):
+        df = get_wide_dataframe(size=100)
+        lib.write(f"sym_{i}", df)
+
+    # Free resources to release the filesystem lock held by Windows
+    del lib
+    del ac
+
+    # When - we move the data
+    dest = str(tmpdir_factory.mktemp("dest"))
+    shutil.move(str(original / "_arctic_cfg"), dest)
+    shutil.move(str(original / "lib"), dest)
+
+    # Then - should be readable at new location as long as map size made big enough
+    # 20 writes of this size would fail with the old 500KB map size
+    ac = Arctic(f"lmdb://{dest}?map_size=10MB")
+    lib = ac["lib"]
+    for i in range(20):
+        df = get_wide_dataframe(size=100)
+        lib.write(f"more_sym_{i}", df)
+    assert len(lib.list_symbols()) == 30
+
+
+def test_move_s3_library(moto_s3_endpoint_and_credentials):
+    # Given - any S3 library
+    endpoint, port, bucket, aws_access_key, aws_secret_key = moto_s3_endpoint_and_credentials
+
+    original_uri = (
+        endpoint.replace("http://", "s3://").rsplit(":", 1)[0]
+        + ":"
+        + bucket
+        + "?access="
+        + aws_access_key
+        + "&secret="
+        + aws_secret_key
+        + "&port="
+        + port
+    )
+
+    ac = Arctic(original_uri)
+    ac.create_library("lib")
+    lib = ac["lib"]
+
+    df = get_wide_dataframe(size=100)
+    lib.write("sym", df)
+
+    # When - we move the data
+    client = boto3.client(
+        service_name="s3", endpoint_url=endpoint, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key
+    )
+    new_bucket = f"{bucket}-dest"
+    client.create_bucket(Bucket=new_bucket)
+
+    s3 = boto3.resource(
+        service_name="s3", endpoint_url=endpoint, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key
+    )
+    source = s3.Bucket(bucket)
+    dest = s3.Bucket(new_bucket)
+
+    for obj in source.objects.filter():
+        dest.copy({"Bucket": bucket, "Key": obj.key}, obj.key)
+
+    # Then - should be readable at new location
+    new_uri = original_uri.replace(f":{bucket}", f":{new_bucket}")
+    new_ac = Arctic(new_uri)
+    assert new_ac.list_libraries() == ["lib"]
+    lib = new_ac["lib"]
+    assert lib.list_symbols() == ["sym"]
+    assert_frame_equal(df, lib.read("sym").data)
+    assert "dest" in lib.read("sym").host
+
+
+@pytest.mark.skipif(sys.platform == "darwin", reason="Test broken on MacOS (issue #909)")
+def test_move_azure_library(azure_client_and_create_container, azurite_azure_uri, azurite_container):
+    # Given - any Azure library
+    original_uri = azurite_azure_uri
+    ac = Arctic(original_uri)
+    ac.create_library("lib")
+    lib = ac["lib"]
+
+    df = get_wide_dataframe(size=100)
+    lib.write("sym", df)
+
+    # When - we move the data
+    new_container = f"{azurite_container}-new"
+    client = azure_client_and_create_container
+    client.create_container(name=new_container)
+
+    container_client = client.get_container_client(container=azurite_container)
+    new_container_client = client.get_container_client(container=new_container)
+
+    for b in container_client.list_blobs():
+        source = container_client.get_blob_client(b.name)
+        target = new_container_client.get_blob_client(b.name)
+        target.start_copy_from_url(source.url, requires_sync=True)
+        props = target.get_blob_properties()
+        assert props.copy.status == "success"
+
+    # Then - should be readable at new location
+    new_uri = original_uri.replace(f"Container={azurite_container};", f"Container={azurite_container}-new;")
+    new_ac = Arctic(new_uri)
+    assert new_ac.list_libraries() == ["lib"]
+    lib = new_ac["lib"]
+    assert lib.list_symbols() == ["sym"]
+    assert_frame_equal(df, lib.read("sym").data)
+    assert "-new" in lib.read("sym").host


### PR DESCRIPTION
<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

See issue #850 .

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Ensure that after moving or copying an LMDB database holding arctic data, then the data is still readable when read from the _new_ location.

Previously we were persisting the LMDB path for the Arctic instance used to _create_ the library in a storage protobuf, and reading the path from that protobuf when accessing the library in a subsequent session. Instead now we just do not persist the path at all in the protobuf, and always use the path that the current Arctic instance was created with.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
