### PR TITLE
maint: Indicate the non-support of PyArrow

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -68,7 +68,9 @@ dependencies:
   # See: https://github.com/man-group/ArcticDB/pull/291
   - hypothesis < 6.73
   - pytest-sugar
-  - pymongo # for testing only
-  - azure-storage-blob # for testing only
-  - azure-identity # for testing only
+  - pymongo
+  # Python dependencies (for tests only)
+  - azure-storage-blob
+  - azure-identity
+  - pyarrow
 

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -174,7 +174,7 @@ def get_timezone_from_metadata(norm_meta):
 def _to_primitive(arr, arr_name, dynamic_strings, string_max_len=None, coerce_column_type=None, norm_meta=None):
     arr_dtype_as_str = str(arr.dtype)
     if "pyarrow" in arr_dtype_as_str:
-        raise ArcticNativeException(
+        raise ArcticDbNotYetImplemented(
             "PyArrow-backed pandas DataFrame and Series are not currently supported by ArcticDB. \n"
             "Please convert your pandas DataFrame and Series to use NumPy array before using them with ArcticDB. \n"
             "If you are interested in the support of PyArrow-backed pandas DataFrame and Series, please upvote this \n"

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -172,6 +172,15 @@ def get_timezone_from_metadata(norm_meta):
 
 
 def _to_primitive(arr, arr_name, dynamic_strings, string_max_len=None, coerce_column_type=None, norm_meta=None):
+    arr_dtype_as_str = str(arr.dtype)
+    if "pyarrow" in arr_dtype_as_str:
+        raise ArcticNativeException(
+            "PyArrow-backed pandas DataFrame and Series are not currently supported by ArcticDB. \n"
+            "Please convert your pandas DataFrame and Series to use NumPy array before using them with ArcticDB. \n"
+            "If you are interested in the support of PyArrow-backed pandas DataFrame and Series, please upvote this \n"
+            "GitHub issue and participate to its discussions: https://github.com/man-group/ArcticDB/issues/881"
+        )
+
     if isinstance(arr.dtype, pd.core.dtypes.dtypes.CategoricalDtype):
         if is_integer_dtype(arr.categories.dtype):
             norm_meta.common.int_categories[arr_name].category.extend(arr.categories)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -488,3 +488,15 @@ def test_pyarrow_error(lmdb_version_store):
     series = pd.Series(data=[1.0, 0.2], dtype="float32[pyarrow]")
     with pytest.raises(ArcticDbNotYetImplemented, match=error_msg_intro):
         lmdb_version_store.write("test_pyarrow_error_series", series)
+
+    # Mixed NumPy- and PyArrow-backed DataFrame.
+    np_ser = pd.Series([0.1], dtype="float64")
+    pa_ser = pd.Series([0.1], dtype="float64[pyarrow]")
+
+    mixed_df = pd.DataFrame({"numpy": np_ser, "pyarrow": pa_ser})
+
+    assert mixed_df["numpy"].dtype == "float64"
+    assert mixed_df["pyarrow"].dtype == "float64[pyarrow]"
+
+    with pytest.raises(ArcticDbNotYetImplemented, match=error_msg_intro):
+        lmdb_version_store.write("test_pyarrow_error_mixed_df", series)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -479,6 +479,9 @@ def test_no_inplace_index_array_modification(lmdb_version_store, sym, datetime64
     assert pandas_container.index.dtype == datetime64_dtype
 
 
+@pytest.mark.skipif(
+    not IS_PANDAS_TWO, reason="The full-support of pyarrow-backed pandas objects is pandas 2.0-specific."
+)
 def test_pyarrow_error(lmdb_version_store):
     error_msg_intro = "PyArrow-backed pandas DataFrame and Series are not currently supported by ArcticDB."
     df = pd.DataFrame(data=[[1.0, 0.2], [0.2, 0.5]], dtype="float32[pyarrow]")

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -480,8 +480,6 @@ def test_no_inplace_index_array_modification(lmdb_version_store, sym, datetime64
 
 
 def test_pyarrow_error(lmdb_version_store):
-    _ = pytest.importorskip("pyarrow")
-
     error_msg_intro = "PyArrow-backed pandas DataFrame and Series are not currently supported by ArcticDB."
     df = pd.DataFrame(data=[[1.0, 0.2], [0.2, 0.5]], dtype="float32[pyarrow]")
     with pytest.raises(ArcticDbNotYetImplemented, match=error_msg_intro):

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -484,9 +484,9 @@ def test_pyarrow_error(lmdb_version_store):
 
     error_msg_intro = "PyArrow-backed pandas DataFrame and Series are not currently supported by ArcticDB."
     df = pd.DataFrame(data=[[1.0, 0.2], [0.2, 0.5]], dtype="float32[pyarrow]")
-    with pytest.raises(ArcticNativeException, match=error_msg_intro):
+    with pytest.raises(ArcticDbNotYetImplemented, match=error_msg_intro):
         lmdb_version_store.write("test_pyarrow_error_df", df)
 
     series = pd.Series(data=[1.0, 0.2], dtype="float32[pyarrow]")
-    with pytest.raises(ArcticNativeException, match=error_msg_intro):
+    with pytest.raises(ArcticDbNotYetImplemented, match=error_msg_intro):
         lmdb_version_store.write("test_pyarrow_error_series", series)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -499,4 +499,4 @@ def test_pyarrow_error(lmdb_version_store):
     assert mixed_df["pyarrow"].dtype == "float64[pyarrow]"
 
     with pytest.raises(ArcticDbNotYetImplemented, match=error_msg_intro):
-        lmdb_version_store.write("test_pyarrow_error_mixed_df", series)
+        lmdb_version_store.write("test_pyarrow_error_mixed_df", mixed_df)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -477,3 +477,16 @@ def test_no_inplace_index_array_modification(lmdb_version_store, sym, datetime64
     lmdb_version_store.write(sym, pandas_container)
     assert pandas_container.index is original_index_array
     assert pandas_container.index.dtype == datetime64_dtype
+
+
+def test_pyarrow_error(lmdb_version_store):
+    _ = pytest.importorskip("pyarrow")
+
+    error_msg_intro = "PyArrow-backed pandas DataFrame and Series are not currently supported by ArcticDB."
+    df = pd.DataFrame(data=[[1.0, 0.2], [0.2, 0.5]], dtype="float32[pyarrow]")
+    with pytest.raises(ArcticNativeException, match=error_msg_intro):
+        lmdb_version_store.write("test_pyarrow_error_df", df)
+
+    series = pd.Series(data=[1.0, 0.2], dtype="float32[pyarrow]")
+    with pytest.raises(ArcticNativeException, match=error_msg_intro):
+        lmdb_version_store.write("test_pyarrow_error_series", series)

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,6 +114,7 @@ exclude=
 [options.extras_require]
 Testing =
     pytest
+    pyarrow
     pytest-cpp
     pytest-timeout
     packaging


### PR DESCRIPTION
#### Reference Issues/PRs

Related to https://github.com/man-group/ArcticDB/issues/881

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Providing PyArrow-backed pandas DataFrame and Series currently fails with an unclear error message.

This improves it, and make https://github.com/man-group/ArcticDB/issues/881 discoverable by users.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
