### PR TITLE
Allow ampersand in symbol names

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -69,7 +69,7 @@ from arcticdb.version_store._normalization import (
 from arcticdb.util.memory import format_bytes
 
 # These chars are encoded by S3 and on doing a list_symbols they will show up as the encoded form eg. &amp
-UNSUPPORTED_S3_CHARS = {"\0", "*", "&", "<", ">"}
+UNSUPPORTED_S3_CHARS = {"\0", "*", "<", ">"}
 MAX_SYMBOL_SIZE = (2**8) - 1
 
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -86,9 +86,10 @@ def test_special_chars(object_version_store, special_char):
     assert_frame_equal(vitem.data, df)
 
 
-@pytest.mark.parametrize("breaking_char", [chr(0), "\0", "&", "*", "<", ">"])
+@pytest.mark.parametrize("breaking_char", [chr(0), "\0", "*", "<", ">"])
 def test_s3_breaking_chars(object_version_store, breaking_char):
-    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db
+    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without
+    corrupting the db.
     """
     sym = f"prefix{breaking_char}postfix"
     df = sample_dataframe()
@@ -99,7 +100,8 @@ def test_s3_breaking_chars(object_version_store, breaking_char):
 
 
 def test_s3_breaking_chars_exception_compat(object_version_store):
-    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without corrupting the db
+    """Test that chars that are not supported are raising the appropriate exception and that we fail on write without
+    corrupting the db
     """
     sym = "prefix*postfix"
     df = sample_dataframe()


### PR DESCRIPTION
Tested on:

    AWS S3
    Pure
    Vast

Our newer AWS SDK does proper URI encoding. This should be fine.

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged.

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings and documentation?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
