### PR TITLE
Convert semimap to switch

### DIFF
--- a/cpp/arcticdb/entity/key.cpp
+++ b/cpp/arcticdb/entity/key.cpp
@@ -38,32 +38,35 @@ KeyData get_key_data(KeyType key_type) {
 #define STRING_REF(kt, name, c)  case kt: return KeyData{ #name, c, VariantType::STRING_TYPE, KeyClass::REF_KEY,  #kt };
 
     switch (key_type) {
-    NUMERIC_KEY(KeyType::STREAM_GROUP, sg, 'g')
-    NUMERIC_KEY(KeyType::GENERATION, gen, 'G')
+    // Important ones
+    STRING_REF(KeyType::VERSION_REF, vref, 'r')
     STRING_KEY(KeyType::TABLE_DATA, tdata, 'd')
     STRING_KEY(KeyType::TABLE_INDEX, tindex, 'i')
     STRING_KEY(KeyType::VERSION, ver, 'V')
     STRING_KEY(KeyType::VERSION_JOURNAL, vj, 'v')
-    STRING_KEY(KeyType::METRICS, met, 'M')
     STRING_KEY(KeyType::SNAPSHOT, snap, 's')
     STRING_KEY(KeyType::SYMBOL_LIST, sl, 'l')
-    STRING_REF(KeyType::VERSION_REF, vref, 'r')
-    STRING_REF(KeyType::STORAGE_INFO, sref, 'h')
-    STRING_REF(KeyType::APPEND_REF, aref, 'a')
-    STRING_KEY(KeyType::MULTI_KEY, mref, 'm')
-    STRING_REF(KeyType::LOCK, lref, 'x')
-    STRING_REF(KeyType::SNAPSHOT_REF, tref, 't')
-    STRING_REF(KeyType::SNAPSHOT_TOMBSTONE, ttomb, 'X')
-    STRING_KEY(KeyType::PARTITION, pref, 'p')
+    STRING_KEY(KeyType::TOMBSTONE_ALL, tall, 'q')
     STRING_KEY(KeyType::TOMBSTONE, tomb, 'x')
-    STRING_KEY(KeyType::APPEND_DATA, app, 'b')
+    STRING_REF(KeyType::LIBRARY_CONFIG, cref, 'C')
+    STRING_KEY(KeyType::COLUMN_STATS, cstats, 'S')
+    STRING_REF(KeyType::SNAPSHOT_REF, tref, 't')
+    // Less important
     STRING_KEY(KeyType::LOG, log, 'o')
     STRING_KEY(KeyType::LOG_COMPACTED, logc, 'O')
     STRING_REF(KeyType::OFFSET, off, 'f')
     STRING_REF(KeyType::BACKUP_SNAPSHOT_REF, bref, 'B')
-    STRING_KEY(KeyType::TOMBSTONE_ALL, tall, 'q')
-    STRING_REF(KeyType::LIBRARY_CONFIG, cref, 'C')
-    STRING_KEY(KeyType::COLUMN_STATS, cstats, 'S')
+    STRING_KEY(KeyType::METRICS, met, 'M')
+    STRING_REF(KeyType::APPEND_REF, aref, 'a')
+    STRING_KEY(KeyType::MULTI_KEY, mref, 'm')
+    STRING_REF(KeyType::LOCK, lref, 'x')
+    STRING_REF(KeyType::SNAPSHOT_TOMBSTONE, ttomb, 'X')
+    STRING_KEY(KeyType::APPEND_DATA, app, 'b')
+    // Unused
+    STRING_KEY(KeyType::PARTITION, pref, 'p')
+    STRING_REF(KeyType::STORAGE_INFO, sref, 'h')
+    NUMERIC_KEY(KeyType::STREAM_GROUP, sg, 'g')
+    NUMERIC_KEY(KeyType::GENERATION, gen, 'G')
     default:util::raise_rte("Could not get data for key_type {}", static_cast<int>(key_type));
     };
 }


### PR DESCRIPTION
The mixed compile-time/run-time behaviour of this map is not really what we want, as if the map is modified at runtime it can lead to incorrect behaviour and segfaults. Convert it to a switch statement.