### PR TITLE
Small LMDB Fixes: 2GiB map size for Windows, Validation before delete

### DIFF
--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -295,9 +295,10 @@ LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const C
     // Windows needs a sensible size as it allocates disk for the whole file even before any writes. Linux just gets an arbitrarily large size
     // that it probably won't ever reach.
 #ifdef _WIN32
-    constexpr uint64_t default_map_size = 1ULL << 27; /* 128 MiB */
+    // At least enough for 300 cols and 1M rows
+    constexpr uint64_t default_map_size = 2ULL * (1ULL << 30); /* 2 GiB */
 #else
-    constexpr uint64_t default_map_size = 100ULL * (4ULL << 30); /* 400 GiB */
+    constexpr uint64_t default_map_size = 400ULL * (1ULL << 30); /* 400 GiB */
 #endif
     auto mapsize = or_else(static_cast<uint64_t>(conf.map_size()), default_map_size);
     env().set_mapsize(mapsize);

--- a/cpp/arcticdb/storage/test/test_lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_lmdb_storage.cpp
@@ -32,6 +32,7 @@ TEST(TestLmdbStorage, Example) {
 
     arcticdb::proto::lmdb_storage::Config cfg;
     cfg.set_path("./");
+    cfg.set_map_size(128ULL * (1ULL << 20) );
     cfg.set_recreate_if_exists(true);
 
     asl::LmdbStorage storage({"A", "BB"}, as::OpenMode::WRITE, cfg);
@@ -123,6 +124,7 @@ TEST(TestLmdbStorage, Strings) {
 
     arcticdb::proto::lmdb_storage::Config cfg;
     cfg.set_path("./");
+    cfg.set_map_size(128ULL * (1ULL << 20) );
     cfg.set_recreate_if_exists(true);
 
     asl::LmdbStorage storage({"A", "BB"}, as::OpenMode::WRITE, cfg);

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -306,7 +306,13 @@ inline std::pair<storage::LibraryPath, arcticdb::proto::storage::LibraryConfig> 
     config.mutable_lib_desc()->set_name(unique_lib_name);
     auto temp_path = std::filesystem::temp_directory_path();
     // on windows, path is only implicitly converted to wstring, not string
-    auto lmdb_config =  arcticdb::storage::lmdb::pack_config(temp_path.string());
+    arcticdb::proto::storage::VariantStorage lmdb_config;
+    arcticdb::proto::lmdb_storage::Config cfg;
+    cfg.set_path(temp_path.string());
+    // 128 MiB - needs to be reasonably small else Windows build runs out of disk
+    cfg.set_map_size(128ULL * (1ULL << 20) );
+    util::pack_to_any(cfg, *lmdb_config.mutable_config());
+
     auto library_path = storage::LibraryPath::from_delim_path(unique_lib_name);
     auto storage_id = fmt::format("{}_store", unique_lib_name);
     config.mutable_lib_desc()->add_storage_ids(storage_id);

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -307,7 +307,7 @@ TEST_F(VersionStoreTest, StressBatchWrite) {
     std::vector<VersionId> version_ids;
     std::vector<std::shared_ptr<DeDupMap>> dedup_maps;
 
-    for(int i = 0; i < 1000; ++i) {
+    for(int i = 0; i < 100; ++i) {
         auto symbol = fmt::format("symbol_{}", i);
         symbols.emplace_back(symbol);
         version_ids.push_back(0);

--- a/docs/mkdocs/docs/index.md
+++ b/docs/mkdocs/docs/index.md
@@ -31,7 +31,7 @@ pip install arcticdb
 
 ### Setup
 
-ArcticDB is a storage engine designed for object storage, but also supports local RAM storage and local-disk storage using LMDB.
+ArcticDB is a storage engine designed for object storage, but also supports local-disk storage using LMDB.
 
 !!! Storage Compatibility
 
@@ -101,7 +101,7 @@ You may want to restrict access for the ArcticDB library to a specific path with
 >>> ac = Arctic('s3s://s3.eu-west-2.amazonaws.com:arcticdb-test-bucket?path_prefix=test&aws_auth=true')
 ```
 
-#### Azure configuration
+#### Azure
 
 ArcticDB uses the [Azure connection string](https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string) to define the connection: 
 
@@ -119,7 +119,7 @@ For example:
 
 For more information, [see the Arctic class reference](https://docs.arcticdb.io/api/arcticdb#arcticdb.Arctic.__init__).
 
-#### LMDB configuration
+#### LMDB
 
 LMDB supports configuring its map size. See its [documentation](http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5).
 
@@ -133,11 +133,12 @@ You can set a map size in the connection string:
 >>> ac = Arctic('lmdb://path/to/desired/database?map_size=2GB')
 ```
 
-The default on Windows is only 128MB. Errors with `lmdb errror code -30792` indicate that the map is getting full and that you should
-increase its size. This will happen if you are doing large writes. You should ensure that you only have one Arctic instance open over
-a given LMDB database.
+The default on Windows is 2GiB. Errors with `lmdb errror code -30792` indicate that the map is getting full and that you should
+increase its size. This will happen if you are doing large writes.
 
-For more information on the different endpoints, [see the Arctic class reference](https://docs.arcticdb.io/api/arcticdb#arcticdb.Arctic.__init__).
+In each Python process, you should ensure that you only have one Arctic instance open over a given LMDB database.
+
+LMDB does not work with remote filesystems.
 
 #### In-memory configuration
 
@@ -152,9 +153,7 @@ For example:
 >>> ac = Arctic('mem://')
 ```
 
-TODO: For concurrent access to a local backend, LMDB connected to tmpfs is recommended.
-
-### Usage
+For concurrent access to a local backend, we recommend LMDB connected to tmpfs.
 
 #### Library Setup
 

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -24,8 +24,8 @@ from arcticdb.encoding_version import EncodingVersion
 from arcticdb.exceptions import ArcticDbNotYetImplemented, LmdbOptionsError
 
 
-def _rmtree_errorhandler(func, path, exc_info):
-    log.warn("Error removing LMDB tree at path=[{}] error=[{}]", path, exc_info)
+def _rm_errorhandler(func, path, exc_info):
+    log.warn("Error removing LMDB file at path=[{}] error=[{}]", path, exc_info)
 
 
 @dataclass
@@ -162,7 +162,24 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
         return lib
 
     def cleanup_library(self, library_name: str):
-        shutil.rmtree(os.path.join(self._path, library_name), onerror=_rmtree_errorhandler)
+        lmdb_files_removed = True
+        for file in ("lock.mdb", "data.mdb"):
+            path = os.path.join(self._path, library_name, file)
+            try:
+                os.remove(path)
+            except Exception as e:
+                lmdb_files_removed = False
+                _rm_errorhandler(None, path, e)
+        dir_path = os.path.join(self._path, library_name)
+        if os.path.exists(dir_path):
+            if os.listdir(dir_path):
+                log.warn(
+                    "Skipping deletion of directory holding LMDB library during library deletion as it contains "
+                    f"files unrelated to LMDB. LMDB files {'have' if lmdb_files_removed else 'have not'} been "
+                    f"removed. directory=[{dir_path}]"
+                )
+            else:
+                shutil.rmtree(os.path.join(self._path, library_name), onerror=_rm_errorhandler)
 
     def get_storage_override(self) -> StorageOverride:
         lmdb_override = LmdbOverride()

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -131,7 +131,15 @@ class LMDBLibraryAdapter(ArcticLibraryAdapter):
     def config_library(self):
         env_cfg = EnvironmentConfigsMap()
 
-        add_lmdb_library_to_env(env_cfg, lib_name=self.CONFIG_LIBRARY_NAME, env_name=_DEFAULT_ENV, db_dir=self._path)
+        # 128 MiB - needs to be reasonably small not to waste disk on Windows
+        config_library_config = {"map_size": 128 * (1 << 20)}
+        add_lmdb_library_to_env(
+            env_cfg,
+            lib_name=self.CONFIG_LIBRARY_NAME,
+            env_name=_DEFAULT_ENV,
+            db_dir=self._path,
+            lmdb_config=config_library_config,
+        )
 
         lib = NativeVersionStore.create_store_from_config(
             env_cfg, _DEFAULT_ENV, self.CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -138,7 +138,7 @@ class Arctic:
                 |                           | The only supported units are MB / GB / TB.                                                                                                                    |
                 |                           |                                                                                                                                                               |
                 |                           | On Windows and MacOS, LMDB will materialize a file of this size, so you need to set it to a reasonable value that your system has                             |
-                |                           | room for, and it has a small default (order of 100MB). On Linux, this is an upper bound on the space used by LMDB and the default is large                    |
+                |                           | room for, and it has a small default (order of 1GB). On Linux, this is an upper bound on the space used by LMDB and the default is large                      |
                 |                           | (order of 100GB).                                                                                                                                             |
                 +---------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -235,7 +235,7 @@ def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):
     elif request.param == "Real_S3":
         ac = Arctic(request.getfixturevalue("unique_real_s3_uri"), encoding_version)
     elif request.param == "LMDB":
-        ac = Arctic(f"lmdb://{tmpdir}", encoding_version)
+        ac = Arctic(f"lmdb://{tmpdir}?map_size=16MB", encoding_version)
     elif request.param == "Mongo":
         ac = Arctic(request.getfixturevalue("mongo_test_uri"), encoding_version)
     elif request.param == "MEM":

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -398,7 +398,7 @@ def version_store_factory(lib_name, tmpdir):
     def create_version_store(
         col_per_group: Optional[int] = None,
         row_per_segment: Optional[int] = None,
-        lmdb_config: Dict[str, Any] = {},
+        lmdb_config: Dict[str, Any] = None,
         override_name: str = None,
         **kwargs,
     ) -> NativeVersionStore:
@@ -406,6 +406,9 @@ def version_store_factory(lib_name, tmpdir):
             kwargs["column_group_size"] = col_per_group
         if row_per_segment is not None and "segment_row_size" not in kwargs:
             kwargs["segment_row_size"] = row_per_segment
+        if lmdb_config is None:
+            # 128 MiB - needs to be reasonably small else Windows build runs out of disk
+            lmdb_config = {"map_size": 128 * (1 << 20)}
 
         if override_name is not None:
             library_name = override_name

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -5,9 +5,6 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-import sys
-import os
-
 import pytz
 from arcticdb_ext.exceptions import ErrorCode, ErrorCategory
 
@@ -15,7 +12,6 @@ from arcticdb.version_store import VersionedItem as PythonVersionedItem
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import VersionRequestType
 
-from arcticdb.arctic import Arctic
 from arcticdb.options import LibraryOptions
 from arcticdb import QueryBuilder, DataError
 
@@ -23,7 +19,6 @@ import pytest
 import pandas as pd
 from datetime import datetime, date, timezone, timedelta
 import numpy as np
-from numpy import datetime64
 from arcticdb.util.test import (
     assert_frame_equal,
     random_strings_of_length,
@@ -32,11 +27,6 @@ from arcticdb.util.test import (
 from arcticdb.util._versions import IS_PANDAS_TWO
 
 import random
-
-from azure.storage.blob import BlobServiceClient
-from botocore.client import BaseClient as BotoClient
-import time
-
 
 from arcticdb.version_store.library import (
     WritePayload,

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -48,6 +48,29 @@ def test_library_deletion(tmpdir):
     assert ac.list_libraries() == ["test_lib2"]
 
 
+def test_library_deletion_leave_non_lmdb_files_alone(tmpdir):
+    # See Github issue #517
+    # Given
+    ac = Arctic(f"lmdb://{tmpdir}/lmdb_instance")
+    path = os.path.join(tmpdir, "lmdb_instance", "test_lib")
+    ac.create_library("test_lib")
+    assert os.path.exists(path)
+    with open(os.path.join(path, "another"), "w") as f:
+        f.write("blah")
+    os.makedirs(os.path.join(path, "dir"))
+
+    ac.create_library("test_lib2")
+
+    # When
+    ac.delete_library("test_lib")
+
+    # Then
+    assert os.path.exists(path)
+    files = set(os.listdir(path))
+    assert files == {"dir", "another"}
+    assert ac.list_libraries() == ["test_lib2"]
+
+
 def test_lmdb(tmpdir):
     # Github Issue #520 - this used to segfault
     d = {


### PR DESCRIPTION
- Use 2GiB map size by default for LMDB on Windows (increased from 128 MiB)
- Validate the files that are deleted when an LMDB library is deleted. Only delete LMDB files, not anything unrelated. Only delete the directory that used to hold the LMDB files if it is otherwise empty.

#### Reference Issues/PRs

Fixes:

#908 
#906 