### PR TITLE
fix: Change comparison in `test_hypothesis_{sum,mean}_agg`

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -63,7 +63,7 @@ def test_hypothesis_mean_agg(lmdb_version_store, df):
     # Older versions of Pandas treat values which exceeds limits as `np.inf` or `-np.inf`.
     # ArcticDB adopted this behaviour.
     #
-    # Yet, wew version of Pandas treats values which exceeds limits as `np.nan` instead.
+    # Yet, new version of Pandas treats values which exceeds limits as `np.nan` instead.
     # To be able to compare the results, we need to replace `np.inf` and `-np.inf` with `np.nan`.
     received_df.replace(-np.inf, np.nan, inplace=True)
     received_df.replace(np.inf, np.nan, inplace=True)

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -53,16 +53,22 @@ def test_hypothesis_mean_agg(lmdb_version_store, df):
 
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"a": "mean"})
-    expected = df.groupby("grouping_column").agg({"a": "mean"})
-    expected.replace(
-        np.nan, np.inf, inplace=True
-    )  # New version of pandas treats values which exceeds limits as np.nan rather than np.inf, as in old version and arcticdb
+    expected_df = df.groupby("grouping_column").agg({"a": "mean"})
 
     symbol = "mean_agg"
     lib.write(symbol, df)
-    vit = lib.read(symbol, query_builder=q)
-    vit.data.sort_index(inplace=True)
-    assert_frame_equal(expected, vit.data)
+    received_df = lib.read(symbol, query_builder=q).data
+    received_df.sort_index(inplace=True)
+
+    # Older versions of Pandas treat values which exceeds limits as `np.inf` or `-np.inf`.
+    # ArcticDB adopted this behaviour.
+    #
+    # Yet, wew version of Pandas treats values which exceeds limits as `np.nan` instead.
+    # To be able to compare the results, we need to replace `np.inf` and `-np.inf` with `np.nan`.
+    received_df.replace(-np.inf, np.nan, inplace=True)
+    received_df.replace(np.inf, np.nan, inplace=True)
+
+    assert_frame_equal(expected_df, received_df)
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -82,16 +88,22 @@ def test_hypothesis_sum_agg(lmdb_version_store, df):
 
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"a": "sum"})
-    expected = df.groupby("grouping_column").agg({"a": "sum"})
-    expected.replace(
-        np.nan, np.inf, inplace=True
-    )  # New version of pandas treats values which exceeds limits as np.nan rather than np.inf, as in old version and arcticdb
+    expected_df = df.groupby("grouping_column").agg({"a": "sum"})
 
     symbol = "sum_agg"
     lib.write(symbol, df)
-    vit = lib.read(symbol, query_builder=q)
-    vit.data.sort_index(inplace=True)
-    assert_frame_equal(expected, vit.data)
+    received_df = lib.read(symbol, query_builder=q).data
+    received_df.sort_index(inplace=True)
+
+    # Older versions of Pandas treat values which exceeds limits as `np.inf` or `-np.inf`.
+    # ArcticDB adopted this behaviour.
+    #
+    # Yet, wew version of Pandas treats values which exceeds limits as `np.nan` instead.
+    # To be able to compare the results, we need to replace `np.inf` and `-np.inf` with `np.nan`.
+    received_df.replace(-np.inf, np.nan, inplace=True)
+    received_df.replace(np.inf, np.nan, inplace=True)
+
+    assert_frame_equal(expected_df, received_df)
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -98,7 +98,7 @@ def test_hypothesis_sum_agg(lmdb_version_store, df):
     # Older versions of Pandas treat values which exceeds limits as `np.inf` or `-np.inf`.
     # ArcticDB adopted this behaviour.
     #
-    # Yet, wew version of Pandas treats values which exceeds limits as `np.nan` instead.
+    # Yet, new version of Pandas treats values which exceeds limits as `np.nan` instead.
     # To be able to compare the results, we need to replace `np.inf` and `-np.inf` with `np.nan`.
     received_df.replace(-np.inf, np.nan, inplace=True)
     received_df.replace(np.inf, np.nan, inplace=True)


### PR DESCRIPTION
#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Fix #911.

Simply applies @joe-iddon's suggestion proposed in https://github.com/man-group/ArcticDB/issues/911#issue-1917550888.

#### Any other comments?

Trying to find which version of pandas introduced this change.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
