### PR TITLE
Enhancement 914: Improve error messaging when string column encoding fails due to the presence of a non-string object

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -14,7 +14,7 @@ on:
       bucket:            {default: 'arcticdb-ci-test-bucket-01', type: string, description: The name of the S3 bucket that we will test against}
       endpoint:          {default: 's3.eu-west-2.amazonaws.com', type: string, description: The address of the S3 endpoint}
       region:            {default: 'eu-west-2', type: string, description: The S3 region of the bucket}
-      clear:             {default: 1, type: number, description: Controls wheather we will clear the libraries in the versions stores that we test against}   
+      clear:             {default: 1, type: number, description: Controls wheather we will clear the libraries in the versions stores that we test against}
 jobs:
   compile:
     strategy:
@@ -115,6 +115,13 @@ jobs:
         if: inputs.job_type == 'cpp-tests'
         run: cd cpp; cmake --build --preset $ARCTIC_CMAKE_PRESET --target install
 
+      - name: Clean up build dir # To save disk space as we're close to the limit on Linux
+        if: inputs.job_type == 'cpp-tests' && matrix.os == 'linux'
+        run: |
+          cd $ARCTICDB_BUILD_DIR/*-build
+          du -m --max-depth=2 | sort -n | tail -n 50
+          nohup rm -rf * &  # Clean up while the test is running to save build time
+
       - name: C++ Rapidcheck
         if: inputs.job_type == 'cpp-tests'
         run: cpp/out/install/arcticdb_rapidcheck_tests
@@ -162,7 +169,7 @@ jobs:
       # ========================= Common =========================
       - name: Disk usage
         if: always()
-        run: du -m . "${{matrix.build_dir}}" | sort -n | tail -n 100 ; df -h
+        run: du -m . "${{matrix.build_dir}}" | sort -n | tail -n 50 ; df -h
         continue-on-error: true
 
       - name: Make build directory readable for archiving
@@ -272,7 +279,7 @@ jobs:
           aws_access_key: "${{ secrets.AWS_S3_ACCESS_KEY }}"
           aws_secret_key: "${{ secrets.AWS_S3_SECRET_KEY }}"
           strategy_branch: "${{ env.distinguishing_name }}"
-      
+
       - name: Run test
         run: |
           build_tooling/parallel_test.sh tests/${{matrix.type}}

--- a/cpp/arcticdb/version/test/test_sparse.cpp
+++ b/cpp/arcticdb/version/test/test_sparse.cpp
@@ -184,7 +184,8 @@ TEST_F(SparseTestStore, SimpleRoundtripStrings) {
     auto val1 = frame.scalar_at<PyObject*>(0, 1);
     std::optional<ScopedGILLock> scoped_gil_lock;
     auto str_wrapper = convert::py_unicode_to_buffer(val1.value(), scoped_gil_lock);
-    ASSERT_EQ(strcmp(str_wrapper.buffer_, "five"), 0);
+    ASSERT_TRUE(std::holds_alternative<convert::PyStringWrapper>(str_wrapper));
+    ASSERT_EQ(strcmp(std::get<convert::PyStringWrapper>(str_wrapper).buffer_, "five"), 0);
 
     auto val2 = frame.string_at(0, 2);
     ASSERT_EQ(val2.value()[0], char{0});
@@ -564,7 +565,8 @@ TEST_F(SparseTestStore, CompactWithStrings) {
         std::optional<ScopedGILLock> scoped_gil_lock;
         auto str_wrapper = convert::py_unicode_to_buffer(val1.value(), scoped_gil_lock);
         auto expected = fmt::format("{}", i + 1);
-        ASSERT_EQ(strcmp(str_wrapper.buffer_, expected.data()), 0);
+        ASSERT_TRUE(std::holds_alternative<convert::PyStringWrapper>(str_wrapper));
+        ASSERT_EQ(strcmp(std::get<convert::PyStringWrapper>(str_wrapper).buffer_, expected.data()), 0);
 
         auto val2 = frame.string_at(i, 2);
         ASSERT_EQ(val2.value()[0], char{0});


### PR DESCRIPTION
#### Reference Issues/PRs

#914 

#### What does this implement/fix? How does it work (high level)? Highlight notable design decisions.

Include the column name and row of the input dataframe in the error message when string encoding fails, usually due to the presence of a non-string object in the column.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings and documentation?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
