### PR TITLE
Fix emptyval

### DIFF
--- a/cpp/arcticdb/codec/codec-inl.hpp
+++ b/cpp/arcticdb/codec/codec-inl.hpp
@@ -61,11 +61,11 @@ struct TypedBlockEncoderImpl {
      */
     template <typename EncodedFieldType>
     static void encode(
-        const arcticdb::proto::encoding::VariantCodec &codec_opts,
-       TypedBlock<TD> &typed_block,
-       EncodedFieldType &field,
-       Buffer &out,
-       std::ptrdiff_t &pos) {
+            const arcticdb::proto::encoding::VariantCodec &codec_opts,
+            TypedBlock<TD> &typed_block,
+            EncodedFieldType &field,
+            Buffer &out,
+            std::ptrdiff_t &pos) {
         switch (codec_opts.codec_case()) {
             case arcticdb::proto::encoding::VariantCodec::kZstd:
                 encode_zstd(codec_opts.zstd(), typed_block, field, out, pos);
@@ -179,15 +179,12 @@ std::size_t decode_ndarray(
         }
 
         auto data_size = encoding_sizes::data_uncompressed_size(field);
-        if(data_size == 0)
-            return;
-
-        // Note that when DS == StringPool (and probably other cases), this will result in a ChunkedBuffer with one massive chunk
         auto data_begin = static_cast<uint8_t *>(data_sink.allocate_data(data_size));
         util::check(data_begin != nullptr, "Failed to allocate data of size {}", data_size);
         auto data_out = data_begin;
         auto data_in = input;
         auto num_blocks = field.values_size();
+
         ARCTICDB_TRACE(log::codec(), "Decoding ndarray with type {}, uncompressing {} ({}) bytes in {} blocks",
             td, data_size, encoding_sizes::ndarray_field_compressed_size(field), num_blocks);
 

--- a/cpp/arcticdb/codec/encoded_field.hpp
+++ b/cpp/arcticdb/codec/encoded_field.hpp
@@ -351,7 +351,7 @@ struct EncodedField {
     }
 
     const EncodedBlock &values(size_t n) const {
-        util::check(n < items_count(), "Cannot return block {} from {} blocks", n, items_count());
+        util::check(n < values_count_ + shapes_count_, "Cannot return block {} from {} blocks ({} shapes)", n, values_count_, shapes_count_);
         return blocks()[shapes_count_ + n];
     }
 

--- a/cpp/arcticdb/python/python_handlers.cpp
+++ b/cpp/arcticdb/python/python_handlers.cpp
@@ -6,43 +6,46 @@
  */
 #include <python/python_handlers.hpp>
 #include <python/gil_lock.hpp>
+#include <arcticdb/codec/codec.hpp>
 
 namespace arcticdb {
-    void EmptyHandler::handle_type(
-        const uint8_t*& input,
-        uint8_t* dest,
-        const VariantField& variant_field,
-        const entity::TypeDescriptor&,
-        size_t dest_bytes,
-        std::shared_ptr<BufferHolder>
-    ) {
-        ARCTICDB_SAMPLE(HandleEmpty, 0);
-        util::check(dest != nullptr, "Got null destination pointer");
-        const size_t num_rows = dest_bytes / get_type_size(DataType::EMPTYVAL);
-        static_assert(get_type_size(DataType::EMPTYVAL) == sizeof(PyObject*));
-        const PyObject** ptr_dest = reinterpret_cast<const PyObject**>(dest);
-        py::none none = {};
-        for(auto row = 0u; row < num_rows; ++row) {
-            none.inc_ref();
-            *ptr_dest++ = none.ptr();
-        }
 
-        util::variant_match(variant_field, [&input] (const auto& field) {
-            using EncodedFieldType = std::decay_t<decltype(*field)>;
-                switch (field->encoding_case()) {
-                    case EncodedFieldType::kNdarray: {
-                        const auto& ndarray_field = field->ndarray();
-                        const auto num_blocks = ndarray_field.values_size();
-                        util::check(num_blocks <= 1, "Unexpected number of empty type blocks: {}", num_blocks);
-                        for (auto block_num = 0; block_num < num_blocks; ++block_num) {
-                            const auto &block_info = ndarray_field.values(block_num);
-                            input += block_info.out_bytes();
-                        }
-                        break;
-                    }
-                    default:
-                        util::raise_error_msg("Unsupported encoding {}", *field);
-                    }
-                });
+void EmptyHandler::handle_type(
+    const uint8_t *&input,
+    uint8_t *dest,
+    const VariantField &variant_field,
+    const entity::TypeDescriptor &,
+    size_t dest_bytes,
+    std::shared_ptr<BufferHolder>
+) {
+    ARCTICDB_SAMPLE(HandleEmpty, 0)
+    util::check(dest != nullptr, "Got null destination pointer");
+    const size_t num_rows = dest_bytes / get_type_size(DataType::EMPTYVAL);
+    static_assert(get_type_size(DataType::EMPTYVAL) == sizeof(PyObject *));
+    auto ptr_dest = reinterpret_cast<const PyObject **>(dest);
+    py::none none = {};
+    for (auto row = 0u; row < num_rows; ++row) {
+        none.inc_ref();
+        *ptr_dest++ = none.ptr();
     }
+
+    util::variant_match(variant_field, [&input](const auto &field) {
+        using EncodedFieldType = std::decay_t<decltype(*field)>;
+        if constexpr (std::is_same_v<EncodedFieldType, arcticdb::EncodedField>)
+            check_magic<ColumnMagic>(input);
+
+        if (field->encoding_case() == EncodedFieldType::kNdarray) {
+            const auto &ndarray_field = field->ndarray();
+            const auto num_blocks = ndarray_field.values_size();
+            util::check(num_blocks <= 1, "Unexpected number of empty type blocks: {}", num_blocks);
+            for (auto block_num = 0; block_num < num_blocks; ++block_num) {
+                const auto &block_info = ndarray_field.values(block_num);
+                input += block_info.out_bytes();
+            }
+        } else {
+            util::raise_error_msg("Unsupported encoding {}", *field);
+        }
+    });
 }
+
+} //namespace arcticdb

--- a/python/tests/unit/arcticdb/version_store/test_empty_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_writes.py
@@ -159,3 +159,13 @@ def test_append_empty_series(lmdb_version_store_dynamic_schema, sym, dtype):
     new_ser = pd.Series([1, 2, 3], dtype=dtype)
     lmdb_version_store_dynamic_schema.append(sym, new_ser)
     assert_series_equal(lmdb_version_store_dynamic_schema.read(sym).data, new_ser)
+
+
+def test_entirely_empty_column(lmdb_version_store):
+    data = {"Bat": ["String1"], "Cow": [None], "Pig": [1.23]}
+
+    columns = ["Bat", "Cow", "Pig"]
+    df = pd.DataFrame(data, columns=columns)
+    lib = lmdb_version_store
+    lib.write("test_entirely_empty_column", df)
+    assert_frame_equal(df, lib.read("test_entirely_empty_column").data)


### PR DESCRIPTION
We are writing a single byte of compressed data when there is a column of the type EMPTYVAL, but we aren't adviancing the read pointer in the python handler. This causes an LZ4 decode error when reading the subsequent column.