### PR TITLE
Fix storage lock implementation for Windows debug builds

### DIFF
--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -8,10 +8,8 @@
 #include <gtest/gtest.h>
 
 #include <arcticdb/version/version_store_api.hpp>
-#include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/open_mode.hpp>
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/storage/lmdb/lmdb_storage.hpp>
 #include <arcticdb/storage/memory/memory_storage.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
 #include <arcticdb/util/test/generators.hpp>


### PR DESCRIPTION
This avoids error messages complaining that mutexes are destroyed while still active.

This has also makes `lock` consistent with `lock_timeout`. `lock_timeout` _always_ used to release the mutex on-exit, whereas to be consistent with `lock`, it should only release when there actually is a timeout.