### PR TITLE
[Aggregation tests] Replace `non_zero_numeric_type_strategies` with `numeric_type_strategies`

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -16,7 +16,6 @@ from arcticdb_ext.exceptions import InternalException, SchemaException
 from arcticdb.util.test import assert_frame_equal
 from arcticdb.util.hypothesis import (
     use_of_function_scoped_fixtures_in_hypothesis_checked,
-    non_zero_numeric_type_strategies,
     numeric_type_strategies,
     string_strategy,
 )
@@ -50,7 +49,7 @@ def test_group_on_float_column_with_nans(lmdb_version_store):
     df=data_frames(
         [
             column("grouping_column", elements=string_strategy, fill=string_strategy),
-            column("a", elements=non_zero_numeric_type_strategies()),
+            column("a", elements=numeric_type_strategies()),
         ],
         index=range_indexes(),
     )
@@ -85,7 +84,7 @@ def test_hypothesis_mean_agg(lmdb_version_store, df):
     df=data_frames(
         [
             column("grouping_column", elements=string_strategy, fill=string_strategy),
-            column("a", elements=non_zero_numeric_type_strategies()),
+            column("a", elements=numeric_type_strategies()),
         ],
         index=range_indexes(),
     )
@@ -123,8 +122,8 @@ def test_hypothesis_sum_agg(lmdb_version_store, df):
     df=data_frames(
         [
             column("grouping_column", elements=string_strategy, fill=string_strategy),
-            column("a", elements=non_zero_numeric_type_strategies()),
-            column("b", elements=non_zero_numeric_type_strategies()),
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
         ],
         index=range_indexes(),
     )

--- a/python/tests/unit/arcticdb/version_store/test_aggregation_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation_dynamic.py
@@ -23,7 +23,6 @@ from arcticdb_ext.exceptions import InternalException, SchemaException
 from arcticdb.util.test import make_dynamic, assert_frame_equal
 from arcticdb.util.hypothesis import (
     use_of_function_scoped_fixtures_in_hypothesis_checked,
-    non_zero_numeric_type_strategies,
     numeric_type_strategies,
     string_strategy,
 )
@@ -42,7 +41,7 @@ def assert_equal_value(data, expected):
     df=data_frames(
         [
             column("grouping_column", elements=string_strategy, fill=string_strategy),
-            column("a", elements=non_zero_numeric_type_strategies()),
+            column("a", elements=numeric_type_strategies()),
         ],
         index=range_indexes(),
     )
@@ -74,7 +73,7 @@ def test_hypothesis_mean_agg_dynamic(lmdb_version_store_dynamic_schema_v1, df):
     df=data_frames(
         [
             column("grouping_column", elements=string_strategy, fill=string_strategy),
-            column("a", elements=non_zero_numeric_type_strategies()),
+            column("a", elements=numeric_type_strategies()),
         ],
         index=range_indexes(),
     )
@@ -106,7 +105,7 @@ def test_hypothesis_sum_agg_dynamic(s3_version_store_dynamic_schema_v2, df):
     df=data_frames(
         [
             column("grouping_column", elements=string_strategy, fill=string_strategy),
-            column("a", elements=non_zero_numeric_type_strategies()),
+            column("a", elements=numeric_type_strategies()),
         ],
         index=range_indexes(),
     )


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
We don't need `non_zero_numeric_type_strategies` for aggregation tests.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
