### PR TITLE
Add a mechanism to extend storage transaction lifetime to lifetime of…

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -23,6 +23,17 @@ std::pair<VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
     const std::shared_ptr<DeDupMap> &de_dup_map,
     storage::KeySegmentPair&& key_seg);
 
+template <typename Callable>
+auto read_and_continue(const VariantKey& key, std::shared_ptr<storage::Library> library, const storage::ReadKeyOpts& opts, Callable&& c) {
+    return async::submit_io_task(ReadCompressedTask{key, library, opts, std::forward<decltype(c)>(c)})
+        .via(&async::cpu_executor())
+        .thenValue([](auto &&result) mutable {
+            auto&& [key_seg, continuation] = std::forward<decltype(result)>(result);
+            return continuation(std::move(key_seg));
+        }
+    );
+}
+
 /*
  * AsyncStore is a wrapper around a Store that provides async methods for writing and reading data.
  * It is used by the VersionStore to write data to the Store asynchronously.
@@ -159,18 +170,19 @@ public:
             .thenValue(UpdateSegmentTask{library_, opts});
     }
 
-    folly::Future<VariantKey> copy(KeyType key_type,
-                                   const StreamId &stream_id,
-                                   VersionId version_id,
-                                   const VariantKey &source_key) override {
-        return async::submit_io_task(CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id,
-                                                                   library_});
+    folly::Future<VariantKey> copy(
+            KeyType key_type,
+            const StreamId &stream_id,
+            VersionId version_id,
+            const VariantKey &source_key) override {
+        return async::submit_io_task(CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_});
     }
 
-    VariantKey copy_sync(KeyType key_type,
-                         const StreamId &stream_id,
-                         VersionId version_id,
-                         const VariantKey &source_key) override {
+    VariantKey copy_sync(
+            KeyType key_type,
+            const StreamId &stream_id,
+            VersionId version_id,
+            const VariantKey &source_key) override {
         return CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_}();
     }
 
@@ -178,51 +190,43 @@ public:
         return ClockType::nanos_since_epoch();
     }
 
-    void iterate_type(KeyType type, entity::IterateTypeVisitor func,
-                      const std::string &prefix) override {
+    void iterate_type(
+            KeyType type,
+            const entity::IterateTypeVisitor& func,
+            const std::string &prefix) override {
         library_->iterate_type(type, func, prefix);
     }
 
-    folly::Future<std::pair<entity::VariantKey, SegmentInMemory>> read(const entity::VariantKey &key,
-                                                                       storage::ReadKeyOpts opts) override {
-        return async::submit_io_task(ReadCompressedTask{key, library_, opts})
-            .via(&async::cpu_executor())
-            .thenValue(DecodeSegmentTask{});
+    folly::Future<std::pair<entity::VariantKey, SegmentInMemory>> read(
+            const entity::VariantKey &key,
+            storage::ReadKeyOpts opts) override {
+        return read_and_continue(key, library_, opts, DecodeSegmentTask{});
     }
 
     std::pair<entity::VariantKey, SegmentInMemory> read_sync(const entity::VariantKey &key,
                                                              storage::ReadKeyOpts opts) override {
-        auto read_task = ReadCompressedTask{key, library_, opts};
-        return DecodeSegmentTask{}(read_task());
+        return DecodeSegmentTask{}(read_dispatch(key, library_, opts));
     }
 
-    folly::Future<storage::KeySegmentPair> read_compressed(const entity::VariantKey &key,
-                                                           storage::ReadKeyOpts opts) override {
-        return async::submit_io_task(ReadCompressedTask{key, library_, opts});
+    folly::Future<storage::KeySegmentPair> read_compressed(
+            const entity::VariantKey &key,
+            storage::ReadKeyOpts opts) override {
+        return read_and_continue(key, library_, opts, PassThroughTask{});
     }
 
-    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>>
-    read_metadata(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
-        return async::submit_io_task(ReadCompressedTask{key, library_, opts})
-            .via(&async::cpu_executor())
-            .thenValue(DecodeMetadataTask{});
+    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
+        return read_and_continue(key, library_, opts, DecodeMetadataTask{});
     }
 
-    folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor>>
-    read_metadata_and_descriptor(
-        const entity::VariantKey &key,
-        storage::ReadKeyOpts opts) override {
-        return async::submit_io_task(ReadCompressedTask{key, library_, opts})
-            .via(&async::cpu_executor())
-            .thenValue(DecodeMetadataAndDescriptorTask{});
+    folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor>> read_metadata_and_descriptor(
+            const entity::VariantKey &key,
+            storage::ReadKeyOpts opts) override {
+        return read_and_continue(key, library_, opts, DecodeMetadataAndDescriptorTask{});
     }
 
-    folly::Future<std::pair<VariantKey, TimeseriesDescriptor>>
-    read_timeseries_descriptor(
-        const entity::VariantKey &key) override {
-        return async::submit_io_task(ReadCompressedTask{key, library_, storage::ReadKeyOpts{}})
-            .via(&async::cpu_executor())
-            .thenValue(DecodeTimeseriesDescriptorTask{});
+    folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor(
+            const entity::VariantKey &key) override {
+        return read_and_continue(key, library_, storage::ReadKeyOpts{}, DecodeTimeseriesDescriptorTask{});
     }
 
     folly::Future<bool> key_exists(const entity::VariantKey &key) override {
@@ -271,85 +275,14 @@ public:
                async::submit_io_task(RemoveBatchTask{std::move(keys), library_, opts});
     }
 
-    void copy_to_results(
-        std::vector<folly::Future<storage::KeySegmentPair>> &batch,
-        std::vector<storage::KeySegmentPair> &res
-    ) const {
-        auto vec = folly::collect(batch).get();
-        res.insert(end(res), std::make_move_iterator(std::begin(vec)), std::make_move_iterator(std::end(vec)));
-    }
-
-    void copy_to_results_with_failure(
-        std::vector<folly::Future<storage::KeySegmentPair>> &batch,
-        std::vector<storage::KeySegmentPair> &res,
-        const std::vector<VariantKey> &keys) const {
-        auto collected_kvs = folly::collectAll(batch).get();
-        for (size_t idx = 0; idx != batch.size(); idx++) {
-            if (collected_kvs[idx].hasValue()) {
-                res.emplace_back(std::move(collected_kvs[idx].value()));
-            } else {
-                log::storage().warn("Found an unreadable key {}", keys[idx]);
-            }
-        }
-    }
-
-    std::vector<storage::KeySegmentPair> batch_read_compressed(
-        std::vector<entity::VariantKey> &&ks,
-        const BatchReadArgs &args,
-        bool may_fail) override {
-        auto keys = std::move(ks);
-        std::vector<folly::Future<storage::KeySegmentPair>> batch{};
-        batch.reserve(args.batch_size_);
-        std::vector<storage::KeySegmentPair> res;
-        res.reserve(keys.size());
-        for (auto key : keys) {
-            batch.push_back(async::submit_io_task(ReadCompressedTask(std::move(key),
-                                                                     library_,
-                                                                     storage::ReadKeyOpts{})));
-            if (batch.size() == args.batch_size_) {
-                if (may_fail)
-                    copy_to_results_with_failure(batch, res, keys);
-                else
-                    copy_to_results(batch, res);
-
-                batch.clear();
-            }
-        }
-        if (!batch.empty()) {
-            if (may_fail)
-                copy_to_results_with_failure(batch, res, keys);
-            else
-                copy_to_results(batch, res);
-        }
-
-        return res;
-    }
-
-    folly::Future<std::vector<VariantKey>> batch_read_compressed(
-        std::vector<entity::VariantKey> &&ks,
-        std::vector<ReadContinuation> &&continuations,
-        const BatchReadArgs &args) override {
-        auto keys = std::move(ks);
-        util::check(!keys.empty(), "Unexpected empty keys in batch_read_compressed");
-
-        auto key_seg_futs = folly::window(keys, [*this](auto &&key) {
-            return async::submit_io_task(ReadCompressedTask(std::forward<decltype(key)>(key), library_, storage::ReadKeyOpts{}));
-        }, args.batch_size_);
-
-        util::check(key_seg_futs.size() == keys.size(),
-                    "Size mismatch in batch_read_compressed: {} != {}",
-                    key_seg_futs.size(),
-                    keys.size());
-        std::vector<folly::Future<VariantKey>> result;
-        result.reserve(key_seg_futs.size());
-        for (auto &&key_seg_fut : folly::enumerate(key_seg_futs)) {
-            result.emplace_back(std::move(*key_seg_fut).thenValue([continuation =
-            std::move(continuations[key_seg_fut.index])](auto &&key_seg) mutable {
-                return continuation(std::forward<decltype(key_seg)>(key_seg));
-            }));
-        }
-
-        return folly::collect(result).via(&async::io_executor());
+   folly::Future<std::vector<VariantKey>> batch_read_compressed(
+            std::vector<std::pair<entity::VariantKey, ReadContinuation>> &&keys_and_continuations,
+            const BatchReadArgs &args) override {
+        util::check(!keys_and_continuations.empty(), "Unexpected empty keys/continuation vector in batch_read_compressed");
+        return folly::collect(folly::window(std::move(keys_and_continuations), [this] (auto&& key_and_continuation) {
+            auto [key, continuation] = std::forward<decltype(key_and_continuation)>(key_and_continuation);
+            return read_and_continue(key, library_, storage::ReadKeyOpts{}, std::move(continuation));
+        }, args.batch_size_)).via(&async::io_executor());
     }
 
     std::vector<folly::Future<pipelines::SegmentAndSlice>> batch_read_uncompressed(
@@ -364,21 +297,14 @@ public:
             }, async::TaskScheduler::instance()->io_thread_count() * 2);
     }
 
-    std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey> &keys)
-    override {
+    std::vector<folly::Future<bool>> batch_key_exists(
+            const std::vector<entity::VariantKey> &keys) override {
         std::vector<folly::Future<bool>> res;
         res.reserve(keys.size());
         for (auto itr = keys.cbegin(); itr < keys.cend(); ++itr) {
             res.push_back(async::submit_io_task(KeyExistsTask(itr, library_)));
         }
         return res;
-    }
-
-    bool batch_all_keys_exist_sync(const std::unordered_set<entity::VariantKey> &keys)
-    override {
-        return std::all_of(keys.begin(), keys.end(), [that = this](const entity::VariantKey &key) {
-            return that->key_exists_sync(key);
-        });
     }
 
     folly::Future<std::vector<VariantKey>> batch_write(
@@ -402,8 +328,7 @@ public:
 
         for (folly::Future<storage::KeySegmentPair>& encode_fut : encode_futs) {
             futs.emplace_back(
-                std::move(encode_fut).thenValue([de_dup_map](auto &&ks) -> std::pair<VariantKey,
-                                                                                     std::optional<Segment>> {
+                std::move(encode_fut).thenValue([de_dup_map](auto &&ks) -> std::pair<VariantKey, std::optional<Segment>> {
                         auto key_seg = std::forward<decltype(ks)>(ks);
                         return lookup_match_in_dedup_map(de_dup_map, std::move(key_seg));
                     })
@@ -420,8 +345,8 @@ public:
         return folly::collect(futs).via(&async::io_executor());
     }
 
-    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &cfg)
-    override {
+    void set_failure_sim(
+        const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &cfg) override {
         library_->set_failure_sim(cfg);
     }
 

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -291,9 +291,8 @@ public:
         return folly::window(
             std::move(ranges_and_keys),
             [this, columns_to_decode](auto&& ranges_and_key) {
-                return async::submit_io_task(ReadCompressedTask(ranges_and_key.key_, library_, storage::ReadKeyOpts{}))
-                .via(&async::cpu_executor())
-                .thenValue(DecodeSliceTask(std::move(ranges_and_key), columns_to_decode));
+                const auto key = ranges_and_key.key_;
+                return read_and_continue(key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode});
             }, async::TaskScheduler::instance()->io_thread_count() * 2);
     }
 

--- a/cpp/arcticdb/codec/segment.cpp
+++ b/cpp/arcticdb/codec/segment.cpp
@@ -11,7 +11,6 @@
 
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/util/dump_bytes.hpp>
-#include <arcticdb/codec/encoded_field_collection.hpp>
 #include <arcticdb/codec/codec.hpp>
 
 namespace arcticdb {
@@ -91,7 +90,7 @@ Segment Segment::from_bytes(const std::uint8_t* src, std::size_t readable_size, 
                        arcticdb::Segment::FIXED_HEADER_SIZE,
                        fixed_hdr->header_bytes,
                        header_bytes);
-    google::protobuf::io::ArrayInputStream ais(src + arcticdb::Segment::FIXED_HEADER_SIZE, fixed_hdr->header_bytes);
+    google::protobuf::io::ArrayInputStream ais(src + arcticdb::Segment::FIXED_HEADER_SIZE, static_cast<int>(fixed_hdr->header_bytes));
     auto arena = std::make_unique<google::protobuf::Arena>();
     auto seg_hdr = google::protobuf::Arena::CreateMessage<arcticdb::proto::encoding::SegmentHeader>(arena.get());
     seg_hdr->ParseFromZeroCopyStream(&ais);
@@ -197,8 +196,6 @@ Segment Segment::from_buffer(std::shared_ptr<Buffer>&& buffer) {
         check_magic<DescriptorMagic>(fields_ptr);
         if(seg_hdr->has_descriptor_field() && seg_hdr->descriptor_field().has_ndarray())
             fields = decode_fields(*seg_hdr, fields_ptr);
-
-        preamble_size = fields_ptr - buffer->data();
     }
 
     buffer->set_preamble(arcticdb::Segment::FIXED_HEADER_SIZE + fixed_hdr->header_bytes);
@@ -207,7 +204,7 @@ Segment Segment::from_buffer(std::shared_ptr<Buffer>&& buffer) {
 
 }
 
-void Segment::write_header(uint8_t* dst, size_t hdr_size) {
+void Segment::write_header(uint8_t* dst, size_t hdr_size) const {
     FixedHeader hdr = {MAGIC_NUMBER, HEADER_VERSION_V1, std::uint32_t(hdr_size)};
     hdr.write(dst);
     if(!header_->has_metadata_field())

--- a/cpp/arcticdb/codec/segment.hpp
+++ b/cpp/arcticdb/codec/segment.hpp
@@ -17,7 +17,7 @@
 
 #include <iostream>
 #include <variant>
-
+#include <any>
 
 namespace arcticdb {
 
@@ -54,7 +54,6 @@ class Segment {
     constexpr static uint16_t MAGIC_NUMBER = 0xFA57;
 
     struct FixedHeader {
-        //TODO we have two magic number classes now
         std::uint16_t magic_number;
         std::uint16_t encoding_version;
         std::uint32_t header_bytes;
@@ -76,7 +75,7 @@ class Segment {
         header_(google::protobuf::Arena::CreateMessage<arcticdb::proto::encoding::SegmentHeader>(arena_.get())) {
     }
 
-    Segment(std::unique_ptr<google::protobuf::Arena>&& arena, arcticdb::proto::encoding::SegmentHeader* header, std::shared_ptr<Buffer> &&buffer, std::shared_ptr<FieldCollection> fields) :
+    Segment(std::unique_ptr<google::protobuf::Arena>&& arena, arcticdb::proto::encoding::SegmentHeader* header, std::shared_ptr<Buffer> buffer, std::shared_ptr<FieldCollection> fields) :
         arena_(std::move(arena)),
         header_(header),
         buffer_(std::move(buffer)),
@@ -86,12 +85,13 @@ class Segment {
     Segment(std::unique_ptr<google::protobuf::Arena>&& arena, arcticdb::proto::encoding::SegmentHeader* header, BufferView &&buffer, std::shared_ptr<FieldCollection> fields) :
         arena_(std::move(arena)),
         header_(header),
-        buffer_(std::move(buffer)),
+        buffer_(buffer),
         fields_(std::move(fields)){}
 
     // for rvo only, go to solution should be to move
     Segment(const Segment &that) :
-            header_(google::protobuf::Arena::CreateMessage<arcticdb::proto::encoding::SegmentHeader>(arena_.get())) {
+            header_(google::protobuf::Arena::CreateMessage<arcticdb::proto::encoding::SegmentHeader>(arena_.get())),
+            keepalive_(that.keepalive_) {
         header_->CopyFrom(*that.header_);
         auto b = std::make_shared<Buffer>();
         util::variant_match(that.buffer_,
@@ -100,10 +100,14 @@ class Segment {
             [&b](const std::shared_ptr<Buffer>& buf) { buf->copy_to(*b); }
             );
         buffer_ = std::move(b);
-        fields_ = that.fields_ ? std::make_shared<FieldCollection>(that.fields_->clone()) : nullptr;
+        if(that.fields_)
+            fields_ = std::make_shared<FieldCollection>(that.fields_->clone());
     }
 
     Segment &operator=(const Segment &that) {
+        if(this == &that)
+            return *this;
+
         header_->CopyFrom(*that.header_);
         auto b = std::make_shared<Buffer>();
         util::variant_match(that.buffer_,
@@ -113,6 +117,7 @@ class Segment {
                             );
         buffer_ = std::move(b);
         fields_ = that.fields_;
+        keepalive_ = that.keepalive_;
         return *this;
     }
 
@@ -121,6 +126,7 @@ class Segment {
         swap(header_, that.header_);
         swap(arena_, that.arena_);
         swap(fields_, that.fields_);
+        swap(keepalive_, that.keepalive_);
         move_buffer(std::move(that));
     }
 
@@ -129,6 +135,7 @@ class Segment {
         swap(header_, that.header_);
         swap(arena_, that.arena_);
         swap(fields_, that.fields_);
+        swap(keepalive_, that.keepalive_);
         move_buffer(std::move(that));
         return *this;
     }
@@ -147,7 +154,7 @@ class Segment {
 
     std::pair<uint8_t*, size_t> try_internal_write(std::shared_ptr<Buffer>& tmp, size_t hdr_size);
 
-    void write_header(uint8_t* dst, size_t hdr_size);
+    void write_header(uint8_t* dst, size_t hdr_size) const;
 
     [[nodiscard]] std::size_t total_segment_size() const {
         return total_segment_size(segment_header_bytes_size());
@@ -226,6 +233,14 @@ class Segment {
         }
     }
 
+    void set_keepalive(std::any&& keepalive) {
+        keepalive_ = std::move(keepalive);
+    }
+
+    const std::any& keepalive() const  {
+        return keepalive_;
+    }
+
   private:
     void move_buffer(Segment &&that) {
         if(is_uninitialized() || that.is_uninitialized()) {
@@ -249,6 +264,7 @@ class Segment {
     arcticdb::proto::encoding::SegmentHeader* header_ = nullptr;
     VariantBuffer buffer_;
     std::shared_ptr<FieldCollection> fields_;
+    std::any keepalive_;
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/codec/test/test_codec.cpp
+++ b/cpp/arcticdb/codec/test/test_codec.cpp
@@ -218,3 +218,28 @@ TEST(SegmentEncoderTest, StressTestString) {
         });
     }
 }
+
+struct TransactionalThing {
+    arcticdb::util::MagicNum<'K', 'e', 'e', 'p'> magic_;
+    static bool destroyed;
+    ~TransactionalThing() {
+        TransactionalThing::destroyed = true;
+    }
+};
+
+bool TransactionalThing::destroyed = false;
+
+TEST(Segment, KeepAlive) {
+    {
+        Segment segment;
+        segment.set_keepalive(std::any(TransactionalThing{}));
+
+        auto seg1 = std::move(segment);
+        Segment seg2{std::move(seg1)};
+        auto seg3 = seg2;
+        Segment seg4{seg3};
+
+        std::any_cast<TransactionalThing>(seg4.keepalive()).magic_.check();
+    }
+    ASSERT_EQ(TransactionalThing::destroyed, true);
+}

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -195,12 +195,12 @@ void decode_index_field_impl(
 
 void decode_index_field(
         SegmentInMemory &frame,
-        VariantField field,
+        VariantField variant_field,
         const uint8_t*& data,
         const uint8_t *begin ARCTICDB_UNUSED,
         const uint8_t* end ARCTICDB_UNUSED,
         PipelineContextRow &context) {
-    util::variant_match(field, [&] (auto field) {
+    util::variant_match(variant_field, [&] (auto field) {
         decode_index_field_impl(frame, *field, data, begin, end, context);
     });
 }
@@ -262,11 +262,11 @@ size_t get_field_range_compressed_size(size_t start_idx, size_t num_fields,
 void decode_or_expand(
     const uint8_t*& data,
     uint8_t* dest,
-    const VariantField& field,
+    const VariantField& variant_field,
     const TypeDescriptor& type_descriptor,
     size_t dest_bytes,
     std::shared_ptr<BufferHolder> buffers) {
-    util::variant_match(field, [&] (auto field) {
+    util::variant_match(variant_field, [&data, dest, &type_descriptor, dest_bytes, buffers] (auto field) {
         decode_or_expand_impl(data, dest, *field, type_descriptor, dest_bytes, buffers);
     });
 }
@@ -1120,31 +1120,25 @@ folly::Future<std::vector<VariantKey>> fetch_data(
     if (frame.empty())
         return folly::Future<std::vector<VariantKey>>(std::vector<VariantKey>{});
 
-    std::vector<VariantKey> keys;
-    keys.reserve(context->slice_and_keys_.size());
-    std::vector<stream::StreamSource::ReadContinuation> continuations;
-    continuations.reserve(keys.capacity());
+    std::vector<std::pair<VariantKey, stream::StreamSource::ReadContinuation>> keys_and_continuations;
+    keys_and_continuations.reserve(context->slice_and_keys_.size());
     context->ensure_vectors();
     {
         ARCTICDB_SUBSAMPLE_DEFAULT(QueueReadContinuations)
         for ( auto& row : *context) {
-            keys.push_back(row.slice_and_key().key());
-            continuations.emplace_back([
-                row = row,
-                frame = frame,
-                dynamic_schema=dynamic_schema,
-                buffers](auto &&ks) mutable {
+            keys_and_continuations.emplace_back(row.slice_and_key().key(),
+            [row=row, frame=frame, dynamic_schema=dynamic_schema, buffers](auto &&ks) mutable {
                 auto key_seg = std::forward<storage::KeySegmentPair>(ks);
                 if(dynamic_schema)
                     decode_into_frame_dynamic(frame, row, std::move(key_seg.segment()), buffers);
                 else
                     decode_into_frame_static(frame, row, std::move(key_seg.segment()), buffers);
-                return std::get<AtomKey>(key_seg.variant_key());
+                return key_seg.variant_key();
             });
         }
     }
     ARCTICDB_SUBSAMPLE_DEFAULT(DoBatchReadCompressed)
-    return ssource->batch_read_compressed(std::move(keys), std::move(continuations), BatchReadArgs{});
+    return ssource->batch_read_compressed(std::move(keys_and_continuations), BatchReadArgs{});
 }
 
 } // namespace read

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -124,20 +124,6 @@ folly::Future<std::vector<SliceAndKey>> write_slices(
     });
 }
 
-folly::Future<entity::VariantKey> write_multi_index(
-        InputTensorFrame&& frame,
-        std::vector<SliceAndKey>&& slice_and_keys,
-        const IndexPartialKey& partial_key,
-        const std::shared_ptr<stream::StreamSink>& sink
-) {
-    auto timeseries_desc = index_descriptor_from_frame(std::move(frame), frame.offset);
-    index::IndexWriter<stream::RowCountIndex> writer(sink, partial_key, std::move(timeseries_desc));
-    for (auto &slice_and_key : slice_and_keys) {
-        writer.add(slice_and_key.key(), slice_and_key.slice_);
-    }
-    return writer.commit();
-}
-
 folly::Future<std::vector<SliceAndKey>> slice_and_write(
         InputTensorFrame &frame,
         const SlicingPolicy &slicing,

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -35,10 +35,6 @@ namespace arcticdb {
             util::raise_rte("Not implemented");
         }
 
-        bool batch_all_keys_exist_sync(const std::unordered_set<entity::VariantKey>&) override {
-            util::raise_rte("Not implemented");
-        }
-
         bool supports_prefix_matching() const override {
             return false;
         }
@@ -228,8 +224,7 @@ namespace arcticdb {
         }
 
 
-        void iterate_type(KeyType kt, entity::IterateTypeVisitor func, const std::string& prefix = "")
-        override {
+        void iterate_type(KeyType kt, const entity::IterateTypeVisitor& func, const std::string& prefix = "") override {
             auto prefix_matcher = stream_id_prefix_matcher(prefix);
             auto failure_sim = StorageFailureSimulator::instance();
 
@@ -277,24 +272,6 @@ namespace arcticdb {
                     output.emplace_back(folly::makeFuture<bool>(atoms.find(atom) != atoms.end()));
                 });
             }
-            return output;
-        }
-
-        std::vector<storage::KeySegmentPair>
-        batch_read_compressed(std::vector<entity::VariantKey> &&, const BatchReadArgs &, bool) override {
-            throw std::runtime_error("Not implemented");
-        }
-
-        folly::Future<std::vector<VariantKey>> batch_read_compressed(
-                std::vector<entity::VariantKey>&& keys,
-                std::vector<ReadContinuation>&&,
-                const BatchReadArgs &
-        ) override {
-            std::lock_guard lock{mutex_};
-            std::vector<VariantKey> output;
-            for (auto &key : keys)
-                output.push_back(key);
-
             return output;
         }
 

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -49,6 +49,12 @@ namespace arcticdb {
             throw std::runtime_error("Not implemented for tests");
         }
 
+        folly::Future<std::vector<VariantKey>> batch_read_compressed(
+            std::vector<std::pair<entity::VariantKey, ReadContinuation>>&&,
+            const BatchReadArgs&) override {
+            throw std::runtime_error("Not implemented for tests");
+        }
+
         folly::Future<VariantKey> write(
                 KeyType key_type,
                 VersionId gen_id,

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -39,7 +39,7 @@ struct StreamSource {
 
     virtual void iterate_type(
         KeyType type,
-        entity::IterateTypeVisitor func,
+        const entity::IterateTypeVisitor& func,
         const std::string &prefix = std::string{}) = 0;
 
     [[nodiscard]] virtual folly::Future<bool> key_exists(const entity::VariantKey &key) = 0;
@@ -47,24 +47,14 @@ struct StreamSource {
     virtual bool supports_prefix_matching() const = 0;
     virtual bool fast_delete() = 0;
 
-    virtual std::vector<storage::KeySegmentPair> batch_read_compressed(
-        std::vector<entity::VariantKey> &&keys, const BatchReadArgs &args, bool may_fail) = 0;
-
     using ReadContinuation = folly::Function<entity::VariantKey(storage::KeySegmentPair &&)>;
 
-    virtual folly::Future<std::vector<entity::VariantKey>> batch_read_compressed(
-        std::vector<entity::VariantKey>&& keys,
-        std::vector<ReadContinuation>&& continuations,
+    virtual folly::Future<std::vector<VariantKey>> batch_read_compressed(
+        std::vector<std::pair<entity::VariantKey, ReadContinuation>> &&ks,
         const BatchReadArgs &args) = 0;
 
-    /**
-     * See storage_utils for the wrapper filter_keys_on_existence(vector).
-     */
     [[nodiscard]] virtual std::vector<folly::Future<bool>> batch_key_exists(
             const std::vector<entity::VariantKey> &keys) = 0;
-
-    [[nodiscard]] virtual bool batch_all_keys_exist_sync(
-            const std::unordered_set<entity::VariantKey> &keys) = 0;
 
     using DecodeContinuation = folly::Function<folly::Unit(SegmentInMemory &&)>;
 

--- a/cpp/arcticdb/stream/test/mock_stores.hpp
+++ b/cpp/arcticdb/stream/test/mock_stores.hpp
@@ -124,21 +124,13 @@ class NullStore :
         throw std::runtime_error("Not implemented for tests");
     }
 
-    std::vector<folly::Future<storage::KeySegmentPair>>
-    batch_read_compressed(std::vector<entity::VariantKey> &&, const BatchReadArgs &) override {
+    std::vector<folly::Future<bool>> batch_key_exists(std::vector<entity::VariantKey> &) override {
         throw std::runtime_error("Not implemented for tests");
     }
 
-    virtual std::vector<folly::Future<bool>> batch_key_exists(std::vector<entity::VariantKey> &) {
-        throw std::runtime_error("Not implemented for tests");
-    }
-
-    folly::Future<std::vector<VariantKey>>
-    batch_read_compressed(
-        std::vector<entity::VariantKey>&&,
-        std::vector<ReadContinuation>&&,
-        const BatchReadArgs &
-    ) override {
+    folly::Future<std::vector<VariantKey>> batch_read_compressed(
+            std::vector<std::pair<entity::VariantKey, ReadContinuation>> &&ks,
+            const BatchReadArgs&) override {
         throw std::runtime_error("Not implemented for tests");
     }
 

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -815,7 +815,6 @@ public:
         auto entry = get_entry(stream_id);
         entry->clear();
         load_via_iteration(store, stream_id, entry, false);
-        fix_stream_ids_of_index_keys(store, stream_id, entry);
         remove_duplicate_index_keys(entry);
         (void)rewrite_entry(store, stream_id, entry);
     }
@@ -826,7 +825,6 @@ public:
         auto old_entry = entry;
         entry->clear();
         load_via_iteration(store, stream_id, entry, true);
-        fix_stream_ids_of_index_keys(store, stream_id, entry);
         remove_duplicate_index_keys(entry);
         (void)rewrite_entry(store, stream_id, entry);
         remove_entry_version_keys(store, old_entry, stream_id);

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -362,12 +362,6 @@ inline void set_loaded_until(const LoadProgress& load_progress, const std::share
     entry->loaded_until_ = load_progress.loaded_until_;
 }
 
-
-void fix_stream_ids_of_index_keys(
-    const std::shared_ptr<Store> &store,
-    const StreamId &stream_id,
-    const std::shared_ptr<VersionMapEntry> &entry);
-
 inline SortedValue deduce_sorted(SortedValue existing_frame, SortedValue input_frame) {
     using namespace arcticdb;
     constexpr auto UNKNOWN = SortedValue::UNKNOWN;


### PR DESCRIPTION
We discovered that in some cases a zero-copy reference to an LMDB read transaction is maintained longer than the transaction itself. This change add a type-erased mechanism for RAII extension of transaction lifetime for storages where this is necessary