### PR TITLE
Cache open libraries in the LibraryManager

### DIFF
--- a/cpp/arcticdb/storage/library_manager.cpp
+++ b/cpp/arcticdb/storage/library_manager.cpp
@@ -152,6 +152,11 @@ std::shared_ptr<Library> LibraryManager::get_library(const LibraryPath& path, co
     return lib;
 }
 
+void LibraryManager::close_library_if_open(const LibraryPath &path) {
+    std::lock_guard<std::mutex> lock{open_libraries_mutex_};
+    open_libraries_.erase(path);
+}
+
 std::vector<LibraryPath> LibraryManager::get_library_paths() const {
     std::vector<LibraryPath> ids;
     store_->iterate_type(entity::KeyType::LIBRARY_CONFIG, [&ids](const VariantKey &&key) {

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -19,6 +19,10 @@ namespace arcticdb::storage {
     public:
         explicit LibraryManager(const std::shared_ptr<storage::Library>& library);
 
+        ARCTICDB_NO_MOVE_OR_COPY(LibraryManager)
+
+        ~LibraryManager();
+
         void write_library_config(const py::object& lib_cfg, const LibraryPath& path, const StorageOverride& storage_override,
                                   bool validate) const;
 
@@ -28,14 +32,19 @@ namespace arcticdb::storage {
 
         void remove_library_config(const LibraryPath& path) const;
 
-        [[nodiscard]] std::shared_ptr<Library> get_library(const LibraryPath& path, const StorageOverride& storage_override = StorageOverride{}) const;
+        [[nodiscard]] std::shared_ptr<Library> get_library(const LibraryPath& path, const StorageOverride& storage_override = StorageOverride{});
 
         [[nodiscard]] std::vector<LibraryPath> get_library_paths() const;
 
         [[nodiscard]] bool has_library(const LibraryPath& path) const;
 
     private:
+        inline static std::unordered_map<LibraryPath, std::weak_ptr<Library>> global_open_libraries_{};
+        inline static std::unordered_map<LibraryPath, uint64_t> global_open_libraries_count_{};
+        inline static std::mutex global_open_libraries_mutex_{};  // for global_* static data members above
+
         [[nodiscard]] arcticdb::proto::storage::LibraryConfig get_config_internal(const LibraryPath& path, const StorageOverride& storage_override) const;
+        std::vector<std::shared_ptr<Library>> open_libraries_;
 
         std::shared_ptr<Store> store_;
     };

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -21,8 +21,6 @@ namespace arcticdb::storage {
 
         ARCTICDB_NO_MOVE_OR_COPY(LibraryManager)
 
-        ~LibraryManager();
-
         void write_library_config(const py::object& lib_cfg, const LibraryPath& path, const StorageOverride& storage_override,
                                   bool validate) const;
 
@@ -39,13 +37,10 @@ namespace arcticdb::storage {
         [[nodiscard]] bool has_library(const LibraryPath& path) const;
 
     private:
-        inline static std::unordered_map<LibraryPath, std::weak_ptr<Library>> global_open_libraries_{};
-        inline static std::unordered_map<LibraryPath, uint64_t> global_open_libraries_count_{};
-        inline static std::mutex global_open_libraries_mutex_{};  // for global_* static data members above
-
         [[nodiscard]] arcticdb::proto::storage::LibraryConfig get_config_internal(const LibraryPath& path, const StorageOverride& storage_override) const;
-        std::vector<std::shared_ptr<Library>> open_libraries_;
 
         std::shared_ptr<Store> store_;
+        std::unordered_map<LibraryPath, std::shared_ptr<Library>> open_libraries_;
+        std::mutex open_libraries_mutex_;  // for open_libraries_
     };
 }

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -32,6 +32,8 @@ namespace arcticdb::storage {
 
         [[nodiscard]] std::shared_ptr<Library> get_library(const LibraryPath& path, const StorageOverride& storage_override = StorageOverride{});
 
+        void close_library_if_open(const LibraryPath& path);
+
         [[nodiscard]] std::vector<LibraryPath> get_library_paths() const;
 
         [[nodiscard]] bool has_library(const LibraryPath& path) const;

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -149,7 +149,7 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
         .def("remove_library_config", [](const LibraryManager& library_manager, std::string_view library_path){
             return library_manager.remove_library_config(LibraryPath{library_path, '.'});
         })
-        .def("get_library", [](const LibraryManager& library_manager, std::string_view library_path, const StorageOverride& storage_override){
+        .def("get_library", [](LibraryManager& library_manager, std::string_view library_path, const StorageOverride& storage_override){
             return library_manager.get_library(LibraryPath{library_path, '.'}, storage_override);
         }, py::arg("library_path"), py::arg("storage_override") = StorageOverride{})
         .def("has_library", [](const LibraryManager& library_manager, std::string_view library_path){

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -152,6 +152,9 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
         .def("get_library", [](LibraryManager& library_manager, std::string_view library_path, const StorageOverride& storage_override){
             return library_manager.get_library(LibraryPath{library_path, '.'}, storage_override);
         }, py::arg("library_path"), py::arg("storage_override") = StorageOverride{})
+        .def("close_library_if_open", [](LibraryManager& library_manager, std::string_view library_path) {
+            return library_manager.close_library_if_open(LibraryPath{library_path, '.'});
+        })
         .def("has_library", [](const LibraryManager& library_manager, std::string_view library_path){
             return library_manager.has_library(LibraryPath{library_path, '.'});
         })

--- a/docs/mkdocs/docs/technical/contributing.md
+++ b/docs/mkdocs/docs/technical/contributing.md
@@ -227,6 +227,14 @@ We recommend using Visual Studio 2022 (or later) to install the compiler (MSVC v
 The Python that comes with Visual Studio is sufficient for creating release builds, but for debug builds, you will have
 to separately download from [Python.org](https://www.python.org/downloads/windows/).
 
+After building `arcticdb_ext`, you need to symlink to the `.pyd` for the Python tests to run against it:
+
+```powershell
+# From the root of the ArcticDB git root checkout, in an administrator powershell session
+# Change Python version as appropriate - below is for Python 3.11.
+New-Item -Path .\python\arcticdb_ext.cp311-win_amd64.pyd -ItemType SymbolicLink -Value .\cpp\out\windows-cl-debug-build\arcticdb\arcticdb_ext.cp311-win_amd64.pyd
+```
+
 Running Python tests
 --------------------
 

--- a/python/arcticdb/adapters/in_memory_library_adapter.py
+++ b/python/arcticdb/adapters/in_memory_library_adapter.py
@@ -5,10 +5,6 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-import re
-from dataclasses import dataclass
-
-
 from arcticdb.options import LibraryOptions
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
 from arcticdb.version_store.helper import add_memory_library_to_env
@@ -32,11 +28,7 @@ class InMemoryLibraryAdapter(ArcticLibraryAdapter):
         return uri.startswith("mem://")
 
     def __init__(self, uri: str, encoding_version: EncodingVersion, *args, **kwargs):
-        match = re.match(self.REGEX, uri)
-        match_groups = match.groupdict()
-
         self._encoding_version = encoding_version
-
         super().__init__(uri, self._encoding_version)
 
     def __repr__(self):

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -304,6 +304,7 @@ class Arctic:
         if not self._library_manager.has_library(name):
             return
         self[name]._nvs.version_store.clear()
+        self._library_manager.close_library_if_open(name)
         try:
             self._library_adapter.cleanup_library(name)
         finally:

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -179,24 +179,6 @@ class Arctic:
         self._encoding_version = encoding_version
         self._library_adapter = _cls(uri, self._encoding_version)
         self._library_manager = LibraryManager(self._library_adapter.config_library)
-        # 1 - LibraryManager - keep global track of the non-config libraries
-
-        # On LibraryManager creation:
-        # instance state for what is open:
-        #  shared_ptr -> lib
-        # (thread-safely) static state for which are open:
-        #  {name: (weak_ptr->lib, count)}
-
-        # On access of library, check if it is still live in the static state first and give that
-        # back if it is.
-
-        # On LibraryManager destruction, thread-safely:
-        # Decrement count
-        # If it hits zero, remove the key in the static count
-        # (this avoids leaks of the keys)
-
-        # 2 - How to handle the config libraries? Same deal in the Python layer?
-
         self._uri = uri
 
     def __getitem__(self, name: str) -> Library:
@@ -304,7 +286,6 @@ class Arctic:
             library_options = LibraryOptions()
 
         library = self._library_adapter.create_library(name, library_options)
-        library.env = repr(self._library_adapter)
         self._library_manager.write_library_config(library._lib_cfg, name, self._library_adapter.get_masking_override())
         return self.get_library(name)
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -56,7 +56,10 @@ from arcticdb.options import LibraryOptions
 from arcticdb_ext.storage import Library
 from azure.storage.blob import BlobServiceClient, generate_account_sas, ResourceTypes, AccountSasPermissions
 
+
 PERSISTENT_STORAGE_TESTS_ENABLED = os.getenv("ARCTICDB_PERSISTENT_STORAGE_TESTS") == "1"
+FAST_TESTS_ONLY = os.getenv("ARCTICDB_FAST_TESTS_ONLY") == "1"
+
 
 configure_test_logger()
 
@@ -213,6 +216,21 @@ def unique_real_s3_uri():
         "S3",
         "LMDB",
         "MEM",
+        pytest.param(
+            "Azure",
+            marks=pytest.mark.skipif(FAST_TESTS_ONLY or MACOS_CONDA_BUILD, reason=MACOS_CONDA_BUILD_SKIP_REASON),
+        ),
+        pytest.param(
+            "Mongo",
+            marks=pytest.mark.skipif(FAST_TESTS_ONLY or not RUN_MONGO_TEST, reason="Mongo test on windows is fiddly"),
+        ),
+        pytest.param(
+            "Real_S3",
+            marks=pytest.mark.skipif(
+                FAST_TESTS_ONLY or not PERSISTENT_STORAGE_TESTS_ENABLED,
+                reason="Can be used only when persistent storage is enabled"
+            ),
+        ),
     ],
 )
 def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -11,6 +11,7 @@ import shutil
 import socket
 
 import boto3
+import moto.s3.responses
 import werkzeug
 from moto.server import DomainDispatcherApplication, create_backend_app
 
@@ -150,7 +151,8 @@ def azure_account_sas_token(azure_client_and_create_container, azurite_azure_tes
 def boto_client(_moto_s3_uri):
     endpoint = _moto_s3_uri
     client = boto3.client(
-        service_name="s3", endpoint_url=endpoint, aws_access_key_id="awd", aws_secret_access_key="awd"
+        service_name="s3", endpoint_url=endpoint, aws_access_key_id="awd", aws_secret_access_key="awd",
+        region_name=moto.s3.responses.DEFAULT_REGION_NAME
     )
 
     yield client
@@ -211,20 +213,6 @@ def unique_real_s3_uri():
         "S3",
         "LMDB",
         "MEM",
-        pytest.param(
-            "Azure",
-            marks=pytest.mark.skipif(MACOS_CONDA_BUILD, reason=MACOS_CONDA_BUILD_SKIP_REASON),
-        ),
-        pytest.param(
-            "Mongo",
-            marks=pytest.mark.skipif(not RUN_MONGO_TEST, reason="Mongo test on windows is fiddly"),
-        ),
-        pytest.param(
-            "Real_S3",
-            marks=pytest.mark.skipif(
-                not PERSISTENT_STORAGE_TESTS_ENABLED, reason="Can be used only when persistent storage is enabled"
-            ),
-        ),
     ],
 )
 def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -173,6 +173,8 @@ def test_library_options(arctic_client):
 
 
 def test_separation_between_libraries(arctic_client):
+    # This fails for mem-backed without the library caching implemented in
+    # issue #520 then re-implemented in issue #889
     """Validate that symbols in one library are not exposed in another."""
     ac = arctic_client
     assert ac.list_libraries() == []

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -17,7 +17,7 @@ from arcticdb.arctic import Arctic
 from arcticdb.exceptions import MismatchingLibraryOptions
 from arcticdb.encoding_version import EncodingVersion
 from arcticdb.options import LibraryOptions
-from arcticdb import QueryBuilder, DataError
+from arcticdb import QueryBuilder
 from arcticc.pb2.s3_storage_pb2 import Config as S3Config
 
 import math

--- a/python/tests/integration/arcticdb/test_arctic_move_storage.py
+++ b/python/tests/integration/arcticdb/test_arctic_move_storage.py
@@ -1,5 +1,6 @@
 import shutil
 import boto3
+import moto.s3.responses
 import pytest
 import sys
 
@@ -143,7 +144,8 @@ def test_move_s3_library(moto_s3_endpoint_and_credentials):
 
     # When - we move the data
     client = boto3.client(
-        service_name="s3", endpoint_url=endpoint, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key
+        service_name="s3", endpoint_url=endpoint, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key,
+        region_name=moto.s3.responses.DEFAULT_REGION_NAME
     )
     new_bucket = f"{bucket}-dest"
     client.create_bucket(Bucket=new_bucket)

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -72,7 +72,7 @@ def test_library_deletion_leave_non_lmdb_files_alone(tmpdir):
 
 
 def test_lmdb(tmpdir):
-    # Github Issue #520 - this used to segfault
+    # Github Issue #520 #889 - this used to segfault
     d = {
         "test1": pd.Timestamp("1979-01-18 00:00:00"),
         "test2": pd.Timestamp("1979-01-19 00:00:00"),

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -106,8 +106,6 @@ def test_lmdb_mapsize(tmpdir):
     # Then - even library creation fails so map size having an effect
     assert "MDB_MAP_FULL" in str(e.value)
 
-    del ac  # close LMDB env
-
     # Given - larger map size
     ac = Arctic(f"lmdb://{tmpdir}?map_size=1MB")
 

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -38,11 +38,15 @@ def get_real_s3_uri(shared_path: bool = True):
     return aws_uri
 
 
-def get_seed_libraries(ac=Arctic(get_real_s3_uri())):
+def get_seed_libraries(ac=None):
+    if ac is None:
+        ac = Arctic(get_real_s3_uri())
     return [lib for lib in ac.list_libraries() if lib.startswith("seed_")]
 
 
-def get_test_libraries(ac=Arctic(get_real_s3_uri())):
+def get_test_libraries(ac=None):
+    if ac is None:
+        ac = Arctic(get_real_s3_uri())
     return [lib for lib in ac.list_libraries() if lib.startswith("test_")]
 
 


### PR DESCRIPTION
No API changes.

#### Reference Issues/PRs

#889 #520 #981

#### What does this implement or fix?

This re-implements the library caching, which is necessary because RocksDB and LMDB databases can only be opened once from a given process. We have one such database per library.

This caches open `Library` instances in the `LibraryManager` instance, tying their lifetime to that of their owning `Arctic` object. This fixes two issues with the old Python implementation:

- Error-proneness - eg `__getitem__` on `Arctic` was not maintaining the cache correctly.
- Config library `_arctic_cfg` should also be cached.

We leave it as the user's responsibility to only open one Arctic instance over a given LMDB or RocksDB path, which we document. See alternatives section for why we do not handle this for the user.

We also make a test change to have `region_name=moto.s3.responses.DEFAULT_REGION_NAME` in the boto client. This seems to be required for some versions of moto and boto to allow bucket creation.

#### Alternatives

There are two main alternatives to this:

##### Weak Pointers

In the git history of this branch there is an alternative implementation where we store `weak_ptr`s to `Library` instances in the `LibraryManager`. This allows the `Library` instances to be cached without us extending their lifetime beyond their use, whereas the approach in this PR extends their lifetime.

In my opinion the `weak_ptr` approach is superior, but it broke memory backed libraries, since the data behind a mem-backed library is kept in the `Storage` object itself, which is collected with the `Library`. Hence data did not survive in a library after the library was collected by Python. Re-wiring the memory backed storages to handle this is quite invasive, and, since this "leak" of Library objects should be quite harmless (indeed it is the status quo), does not seem warranted.

##### Static Cache

We also considered storing open LMDB environments in a global static cache, similar to the global static AWS client, for instance. However, this leads to complexity when connection options change:

```
ac = Arctic("lmdb:///tmp/a")
lib = ac["lib"]
# lib has default map_size
ac2 = Arctic("lmdb:///tmp/a?map_size=10GB")
lib = ac2["lib"] # global cache would give us a `lib` with the default map_size, which is incorrect
```

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ x ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ x ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ x ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ x ] Are API changes highlighted in the PR description?
 - [ x ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
