### PR TITLE
Clauses are now processed in order matching intent, tail/head/row_range are processed last (fixes #245)

### DIFF
--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -39,6 +39,12 @@ using SliceAndKey = pipelines::SliceAndKey;
 
 using NormMetaDescriptor = std::shared_ptr<arcticdb::proto::descriptors::NormalizationMetadata>;
 
+enum class ClauseOrder  // Specifies ordered groups in which clauses will be processed, first group, then the followings
+{
+    first,  // The clause must be processed in the first group of clauses
+    last,   // The clause must be processed in the last group of clauses
+};
+
 // Contains constant data about the clause identifiable at construction time
 struct ClauseInfo {
     // Whether processing segments need to be split into new processing segments after this clause's process method has finished
@@ -52,6 +58,9 @@ struct ClauseInfo {
     std::optional<std::string> new_index_{std::nullopt};
     // Whether this clause modifies the output descriptor
     bool modifies_output_descriptor_{false};
+
+    // Specify in which group of clauses (first, last, etc.) this clause will be processed
+    ClauseOrder processing_order_{ ClauseOrder::first };
 };
 
 // Changes how the clause behaves based on information only available after it is constructed
@@ -527,6 +536,7 @@ struct RowRangeClause {
     explicit RowRangeClause(RowRangeType row_range_type, int64_t n):
             row_range_type_(row_range_type),
             n_(n) {
+        clause_info_.processing_order_ = ClauseOrder::last; // Always process head/tail/row_range clauses last.
     }
 
     RowRangeClause() = delete;


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #245 

#### What does this implement or fix?

Clauses now have a property (in `ClauseInfo`) specifying in which ordered group of clauses they should be processed, which allows to specify that `tail`, `head` and `row_range` clauses will be processed last.

#### Any other comments?

I believe this fixes the issue but feel free to point me if my understanding is incorrect as I'm learning how users use this kind of tool and might have misunderstood some things.
Thanks @Hind-M for helping me with that.


#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
