### PR TITLE
Refactor get_descriptions lib methods to be more consistent

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1130,26 +1130,7 @@ class Library:
         --------
         read_metadata
         """
-        symbol_strings = []
-        as_ofs = []
-
-        def handle_read_request(s_):
-            symbol_strings.append(s_.symbol)
-            as_ofs.append(s_.as_of)
-
-        def handle_symbol(s_):
-            symbol_strings.append(s_)
-            as_ofs.append(None)
-
-        for s in symbols:
-            if isinstance(s, str):
-                handle_symbol(s)
-            elif isinstance(s, ReadInfoRequest):
-                handle_read_request(s)
-            else:
-                raise ArcticInvalidApiUsageException(
-                    f"Invalid symbol type s=[{s}] type(s)=[{type(s)}]. Only [str] and [ReadInfoRequest] are supported."
-                )
+        symbol_strings, as_ofs = self.parse_list_of_symbols(symbols)
 
         include_errors_and_none_meta = True
         return self._nvs._batch_read_metadata_to_versioned_items(symbol_strings, as_ofs, include_errors_and_none_meta)
@@ -1520,28 +1501,8 @@ class Library:
         """
         return self._nvs.tail(symbol=symbol, n=n, as_of=as_of, columns=columns)
 
-    def get_description(self, symbol: str, as_of: Optional[AsOf] = None) -> SymbolDescription:
-        """
-        Returns descriptive data for ``symbol``.
-
-        Parameters
-        ----------
-        symbol
-            Symbol name.
-        as_of : AsOf, default=None
-            See documentation on `read`.
-
-        Returns
-        -------
-        SymbolDescription
-            Named tuple containing the descriptive data.
-
-        See Also
-        --------
-        SymbolDescription
-            For documentation on each field.
-        """
-        info = self._nvs.get_info(symbol, as_of)
+    @staticmethod
+    def _info_to_desc(info: Dict[str, Any]) -> SymbolDescription:
         last_update_time = pd.to_datetime(info["last_update"], utc=True)
         if IS_PANDAS_TWO:
             # Pandas 2.0.0 now uses `datetime.timezone.utc` instead of `pytz.UTC`.
@@ -1564,6 +1525,56 @@ class Library:
             index_type=info["index_type"],
             date_range=date_range,
         )
+
+    def get_description(self, symbol: str, as_of: Optional[AsOf] = None) -> SymbolDescription:
+        """
+        Returns descriptive data for ``symbol``.
+
+        Parameters
+        ----------
+        symbol
+            Symbol name.
+        as_of : AsOf, default=None
+            See documentation on `read`.
+
+        Returns
+        -------
+        SymbolDescription
+            Named tuple containing the descriptive data.
+
+        See Also
+        --------
+        SymbolDescription
+            For documentation on each field.
+        """
+        info = self._nvs.get_info(symbol, as_of)
+        return self._info_to_desc(info)
+
+    @staticmethod
+    def parse_list_of_symbols(symbols: List[Union[str, ReadInfoRequest]]) -> (List, List):
+        symbol_strings = []
+        as_ofs = []
+
+        def handle_read_request(s: ReadInfoRequest):
+            symbol_strings.append(s.symbol)
+            as_ofs.append(s.as_of)
+
+        def handle_symbol(s: str):
+            symbol_strings.append(s)
+            as_ofs.append(None)
+
+        for s in symbols:
+            if isinstance(s, str):
+                handle_symbol(s)
+            elif isinstance(s, ReadInfoRequest):
+                handle_read_request(s)
+            else:
+                raise ArcticInvalidApiUsageException(
+                    f"Unsupported item in the symbols argument s=[{s}] type(s)=[{type(s)}]. Only [str] and"
+                    " [ReadInfoRequest] are supported."
+                )
+
+        return (symbol_strings, as_ofs)
 
     def get_description_batch(
         self, symbols: List[Union[str, ReadInfoRequest]]
@@ -1589,57 +1600,16 @@ class Library:
         SymbolDescription
             For documentation on each field.
         """
-        symbol_strings = []
-        as_ofs = []
-
-        def handle_read_request(s):
-            symbol_strings.append(s.symbol)
-            as_ofs.append(s.as_of)
-
-        def handle_symbol(s):
-            symbol_strings.append(s)
-            as_ofs.append(None)
-
-        for s in symbols:
-            if isinstance(s, str):
-                handle_symbol(s)
-            elif isinstance(s, ReadInfoRequest):
-                handle_read_request(s)
-            else:
-                raise ArcticInvalidApiUsageException(
-                    f"Unsupported item in the symbols argument s=[{s}] type(s)=[{type(s)}]. Only [str] and"
-                    " [ReadInfoRequest] are supported."
-                )
+        symbol_strings, as_ofs = self.parse_list_of_symbols(symbols)
 
         throw_on_error = False
         descriptions = self._nvs._batch_read_descriptor(symbol_strings, as_ofs, throw_on_error)
 
-        description_results = []
-        for description in descriptions:
-            if isinstance(description, DataError):
-                description_results.append(description)
-            else:
-                last_update_time = pd.to_datetime(description["last_update"], utc=True)
-                columns = tuple(
-                    NameWithDType(n, t) for n, t in zip(description["col_names"]["columns"], description["dtype"])
-                )
-                index = NameWithDType(description["col_names"]["index"], description["col_names"]["index_dtype"])
-                date_range = tuple(
-                    map(
-                        lambda x: x.replace(tzinfo=datetime.timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-                        description["date_range"],
-                    )
-                )
-                description_results.append(
-                    SymbolDescription(
-                        columns=columns,
-                        index=index,
-                        row_count=description["rows"],
-                        last_update_time=last_update_time,
-                        index_type=description["index_type"],
-                        date_range=date_range,
-                    )
-                )
+        description_results = [
+            description if isinstance(description, DataError) else self._info_to_desc(description)
+            for description in descriptions
+        ]
+
         return description_results
 
     def reload_symbol_list(self):

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -1269,14 +1269,8 @@ def test_read_description_batch_high_amount(arctic_library):
                 result_last_update_time = results_list[idx].last_update_time
                 tz = result_last_update_time.tz
 
-                if IS_PANDAS_TWO:
-                    # Pandas 2.0.0 now uses `datetime.timezone.utc` instead of `pytz.UTC`.
-                    # See: https://github.com/pandas-dev/pandas/issues/34916
-                    # TODO: is there a better way to handle this edge case?
-                    assert tz == timezone.utc
-                else:
-                    assert isinstance(tz, pytz.BaseTzInfo)
-                    assert tz == pytz.UTC
+                assert isinstance(tz, pytz.BaseTzInfo)
+                assert tz == pytz.UTC
 
 
 def test_read_description_batch_empty_nat(arctic_library):


### PR DESCRIPTION
Refactor get_descriptions lib methods to be more consistent

#### What does this implement or fix?
Some of the common logic for get_description and get_description_batch is extracted to make the behavior of the 2 functions more consistent.
For example, there was some custom logic for pandas 2 that was appliad only to get_descrription, but not to get_description_batch.

The logic of get_description_batch has been refactored to make it more readable.

#### Any other comments?
This does **not** change the APIs for get_description and get_description_batch.