### PR TITLE
Fix ccache's non-existence exiting the workflow

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Find and remove ccache # See PR: #945
         if: matrix.os == 'windows'
-        run: rm $(which ccache)
+        run: rm $(which ccache) || true
 
       - name: Prepare C++ compilation env
         if: inputs.job_type != 'follower'
@@ -177,7 +177,7 @@ jobs:
       # ========================= Common =========================
       - name: Disk usage
         if: always()
-        run: du -m . ${{matrix.build_dir}} ${{matrix.vcpkg_packages_dir}} | sort -n | tail -n 50; df -h
+        run: du -m . ${{matrix.build_dir}} ${{matrix.vcpkg_packages_dir}} | sort -n | tail -n 50 || true; df -h
         continue-on-error: true
 
       - name: Make build directory readable for archiving
@@ -306,7 +306,7 @@ jobs:
 
       - name: Disk usage
         if: always()
-        run: set +e ; du -m . "${PARALLEL_TEST_ROOT:-/tmp/parallel_test}" | sort -n | tail -n 100 ; df -h
+        run: set +e ; du -m . "${PARALLEL_TEST_ROOT:-/tmp/parallel_test}" | sort -n | tail -n 100 || true; df -h
         continue-on-error: true
 
       - name: Upload the logs


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

After merging the initial rocksdb work, clearly some build machines do not have the `ccache` installed, so we need a fix for this to not exit the workflow.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
