### PR TITLE
941 self hosted runners for ci

### DIFF
--- a/.github/actions/run_local_pytest/action.yml
+++ b/.github/actions/run_local_pytest/action.yml
@@ -1,0 +1,27 @@
+name: 'Run Local Pytest'
+description: 'Installs Python dependencies and runs Pytest against locally built ArcticDB binaries'
+inputs:
+  build_type:        {default: 'release', type: string, description: Specifies whether the build that we are testing is release or debug}
+  threads:           {default: '1', type: string, description: Specifies the number of threads that will be used for tests }
+  fast_tests_only:   {default: '0', type: string, description: Specifies whether we want to run only the fast tests or not }
+  other_params:      {default: '', type: string, description: Other params that should be passed to the python command }
+runs:
+  using: "composite"
+  steps:
+    - name: Run local pytests
+      shell: bash
+      run: |
+        yum install nodejs npm -y
+        npm config set strict-ssl false
+        npm install -g azurite
+        
+        cd python
+        ln -s ../cpp/out/linux-${{ inputs.build_type }}-build/arcticdb/arcticdb_ext.cpython-36m-x86_64-linux-gnu.so
+        export ARCTICDB_RAND_SEED=$RANDOM
+        python ${{inputs.other_params}} -m pytest -n ${{ inputs.threads }} tests
+      env:
+        TEST_OUTPUT_DIR: ${{ runner.temp }}
+        ARCTICDB_FAST_TESTS_ONLY: ${{ inputs.fast_tests_only }}
+        # Use the Mongo created in the service container above to test against
+        CI_MONGO_HOST: mongodb
+        CI_MONGO_HOST_2: mongodb_2

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -7,6 +7,9 @@ on:
 
   schedule: # Schdeule the job to run at 12 a.m. daily
     - cron: '0 0 * * *'
+
+  pull_request:
+
 jobs:
   cibw_docker_image:
     uses: ./.github/workflows/cibw_docker_image.yml
@@ -26,13 +29,10 @@ jobs:
         ports:
           - 27017:27017
     env:
-      SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
       VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
       VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
       VCPKG_MAN_NUGET_USER: ${{secrets.VCPKG_MAN_NUGET_USER}} # For forks to download pre-compiled dependencies from the Man repo
       VCPKG_MAN_NUGET_TOKEN: ${{secrets.VCPKG_MAN_NUGET_TOKEN}}
-      CMAKE_C_COMPILER_LAUNCHER: sccache
-      CMAKE_CXX_COMPILER_LAUNCHER: sccache
       ARCTIC_CMAKE_PRESET: linux-debug
     steps:
       - uses: actions/checkout@v3
@@ -49,6 +49,7 @@ jobs:
           echo -e "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES
           VCPKG_ROOT=$PLATFORM_VCPKG_ROOT" | tee -a $GITHUB_ENV
           cmake -P cpp/CMake/CpuCount.cmake | sed 's/^-- //' | tee -a $GITHUB_ENV
+          echo "ARCTICDB_CODE_COVERAGE_BUILD=1" | tee -a $GITHUB_ENV
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{vars.CMAKE_BUILD_PARALLEL_LEVEL}}
 
@@ -63,7 +64,6 @@ jobs:
           configurePreset: ${{env.ARCTIC_CMAKE_PRESET}}
           buildPreset: ${{env.ARCTIC_CMAKE_PRESET}}
         env:
-          ARCTICDB_CODE_COVERAGE_BUILD: 1
           ARCTICDB_DEBUG_FIND_PYTHON: ${{vars.ARCTICDB_DEBUG_FIND_PYTHON}}
           python_impl_name: 'cp311'
         
@@ -80,36 +80,20 @@ jobs:
       # and this python for the rest of the testing
       - name: Select Python (Linux)
         run: echo /opt/python/cp36-cp36m/bin >> $GITHUB_PATH
-      
-      - name: Test with pytest
-        shell: bash -l {0}
+
+      - name: Install local dependencies with pip
+        shell: bash
         run: |
-          yum install nodejs npm -y
-          npm config set strict-ssl false
-          npm install -g azurite
           python -m pip install --upgrade pip
+          ARCTIC_CMAKE_PRESET=skip pip install -ve .[Testing]
 
-          python >build_tooling/requirements-analysis-workflow.txt <<END
-          from configparser import ConfigParser
-          cf = ConfigParser()
-          cf.read("setup.cfg");
-
-          # setup_requires is not needed
-          print(cf['options']['setup_requires'])
-          print(cf['options']['install_requires'])
-          print(cf['options.extras_require']['Testing'])
-          END
-
-          python -m pip install -r build_tooling/requirements-analysis-workflow.txt
-          python -m grpc_tools.protoc -Icpp/proto --python_out=./python cpp/proto/arcticc/pb2/*.proto
-          cd python
-          ln -s ../cpp/out/linux-debug-build/arcticdb/arcticdb_ext.cpython-36m-x86_64-linux-gnu.so
-          python -m coverage run -m pytest tests
-        env:
-          TEST_OUTPUT_DIR: ${{runner.temp}}
-          ARCTICDB_CODE_COVERAGE_BUILD: 1
-          # Use the Mongo created in the service container above to test against
-          CI_MONGO_HOST: mongodb
+      - name: Test with pytest
+        uses: ./.github/actions/run_local_pytest
+        with:
+          build_type: debug
+          threads: 1
+          fast_tests_only: 0
+          other_params: '-m coverage run '
 
       - name: Get python Coverage report
         shell: bash -l {0}
@@ -201,6 +185,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ARCTICDB_DEV_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
   start_ec2_runner:
     uses: ./.github/workflows/ec2_runner_jobs.yml
     secrets: inherit
@@ -242,35 +227,20 @@ jobs:
           ls /opt/python  
           echo /opt/python/cp36-cp36m/bin >> $GITHUB_PATH
 
-      - name: Install dependencies
-        shell: bash -el {0}
+      - name: Install local dependencies with pip
+        shell: bash
         run: |
           python -m pip install --upgrade pip
-
-          python >build_tooling/requirements-analysis-workflow.txt <<END
-          from configparser import ConfigParser
-          cf = ConfigParser()
-          cf.read("setup.cfg");
-
-          # setup_requires is not needed
-          print(cf['options']['setup_requires'])
-          print(cf['options']['install_requires'])
-          print(cf['options.extras_require']['Testing'])
-          END
-
-          python -m pip install -r build_tooling/requirements-analysis-workflow.txt
-          python -m grpc_tools.protoc -Icpp/proto --python_out=./python cpp/proto/arcticc/pb2/*.proto
-          
-          git config --global --add safe.directory .
+          ARCTIC_CMAKE_PRESET=skip pip install -ve .[Testing]
 
       - name: Benchmark all commits
         if: inputs.run_all_benchmarks == true
         shell: bash -el {0}
         run: |
+          git config --global --add safe.directory .
           python -m asv machine -v --yes --machine ArcticDB-Runner-Medium
           python -m asv run -v --show-stderr HASHFILE:python/hashes_to_benchmark.txt
         env:
-          CMAKE_BUILD_PARALLEL_LEVEL: 8
           SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
           VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
           VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
@@ -280,14 +250,30 @@ jobs:
           CMAKE_CXX_COMPILER_LAUNCHER: sccache
 
       - name: Benchmark only latest commit
-        if: inputs.run_all_benchmarks == false
+        if: github.event_name != 'pull_request' && inputs.run_all_benchmarks == false
         shell: bash -el {0}
         run: |
+          git config --global --add safe.directory .  
           python -m asv machine -v --yes --machine ArcticDB-Runner-Medium
           python -m asv run -v --show-stderr HEAD^!
           git log HEAD^..HEAD --oneline -n1 --decorate=no | awk '{print $1;}' >> python/hashes_to_benchmark.txt
         env:
-          CMAKE_BUILD_PARALLEL_LEVEL: 8
+          SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
+          VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
+          VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
+          VCPKG_MAN_NUGET_USER: ${{secrets.VCPKG_MAN_NUGET_USER}} # For forks to download pre-compiled dependencies from the Man repo
+          VCPKG_MAN_NUGET_TOKEN: ${{secrets.VCPKG_MAN_NUGET_TOKEN}}
+          CMAKE_C_COMPILER_LAUNCHER: sccache
+          CMAKE_CXX_COMPILER_LAUNCHER: sccache
+
+      - name: Benchmark against master
+        if: github.event_name == 'pull_request' && inputs.run_all_benchmarks == false
+        shell: bash -el {0}
+        run: |
+          git config --global --add safe.directory .
+          python -m asv machine -v --yes --machine ArcticDB-Runner-Medium
+          python -m asv continuous -v --show-stderr origin/master HEAD -f 1.15
+        env:
           SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
           VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
           VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
@@ -297,6 +283,7 @@ jobs:
           CMAKE_CXX_COMPILER_LAUNCHER: sccache
 
       - name: Publish results
+        if: github.event_name != 'pull_request' 
         shell: bash -el {0}
         run: |
           git config --global user.email "arcticdb@man.com"

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -241,6 +241,7 @@ jobs:
           python -m asv machine -v --yes --machine ArcticDB-Runner-Medium
           python -m asv run -v --show-stderr HASHFILE:python/hashes_to_benchmark.txt
         env:
+          # this is potentially overflowing the cache, so should be looked into after we address issue #1057
           SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
           VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
           VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
@@ -258,6 +259,7 @@ jobs:
           python -m asv run -v --show-stderr HEAD^!
           git log HEAD^..HEAD --oneline -n1 --decorate=no | awk '{print $1;}' >> python/hashes_to_benchmark.txt
         env:
+          # this is potentially overflowing the cache, so should be looked into after we address issue #1057
           SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
           VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
           VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
@@ -274,6 +276,7 @@ jobs:
           python -m asv machine -v --yes --machine ArcticDB-Runner-Medium
           python -m asv continuous -v --show-stderr origin/master HEAD -f 1.15
         env:
+          # this is potentially overflowing the cache, so should be looked into after we address issue #1057
           SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
           VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
           VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
           # Please declare any key you added below in build_steps.yaml's dummy matrix as well to aid the linting tools
           - linux_matrix:
               - os: linux
-                distro: ubuntu-latest
                 cmake_preset_prefix: linux
                 cibw_build_suffix: manylinux_x86_64
                 build_dir: /tmp/cpp_build
@@ -64,7 +63,6 @@ jobs:
                     - /:/mnt
             windows_matrix:
               - os: windows
-                distro: windows-latest
                 cmake_preset_prefix: windows-cl
                 cibw_build_suffix: win_amd64
                 build_dir: C:/cpp_build
@@ -145,22 +143,8 @@ jobs:
       matrix: ${{toJson(matrix.matrix_override)}}
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
 
-  leader-compile-linux:
-    # First do the C++ core compilation using one Python version to seed the compilation caches (and fail quicker)
+  cpp-test-linux:
     needs: [cibw_docker_image, common_config]
-    name: Linux Compile
-    uses: ./.github/workflows/build_steps.yml
-    secrets: inherit
-    permissions: {packages: write}
-    with:
-      job_type: leader-compile
-      cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
-      cibw_image_tag: ${{needs.cibw_docker_image.outputs.tag}}
-      matrix: ${{needs.common_config.outputs.linux_matrix}}
-
-  leader-cpp-test-linux:
-    # Compile and run the C++ tests separately concurrently with the following job
-    needs: [leader-compile-linux, cibw_docker_image, common_config]
     name: Linux C++ Tests
     uses: ./.github/workflows/build_steps.yml
     secrets: inherit
@@ -169,10 +153,11 @@ jobs:
       cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
       cibw_image_tag: ${{needs.cibw_docker_image.outputs.tag}}
       matrix: ${{needs.common_config.outputs.linux_matrix}}
+      distro: compile-on-ec2
 
-  follower-linux:
+  build-python-wheels-linux:
     # Then use the cached compilation artifacts to build other python versions concurrently in cibuildwheels
-    needs: [leader-compile-linux, cibw_docker_image, common_config]
+    needs: [cibw_docker_image, common_config]
     strategy:
       fail-fast: false
       matrix:
@@ -197,7 +182,7 @@ jobs:
     secrets: inherit
     permissions: {packages: write}
     with:
-      job_type: follower
+      job_type: build-python-wheels
       python3: ${{matrix.python3}}
       cibw_image_tag: ${{needs.cibw_docker_image.outputs.tag}}
       cibw_version: ${{needs.common_config.outputs.cibuildwheel_ver}}
@@ -205,20 +190,10 @@ jobs:
       matrix: ${{toJson(matrix.matrix_override)}}
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
       persistent_storage: ${{inputs.persistent_storage}}
-  
-  leader-compile-windows:
-    needs: [common_config]
-    name: Windows Compile
-    uses: ./.github/workflows/build_steps.yml
-    secrets: inherit
-    permissions: {packages: write}
-    with:
-      job_type: leader-compile
-      cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
-      matrix: ${{needs.common_config.outputs.windows_matrix}}
+      distro: compile-on-ec2
 
-  leader-cpp-test-windows:
-    needs: [leader-compile-windows, common_config]
+  cpp-test-windows:
+    needs: [common_config]
     name: Windows C++ Tests
     uses: ./.github/workflows/build_steps.yml
     secrets: inherit
@@ -226,9 +201,10 @@ jobs:
       job_type: cpp-tests
       cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
       matrix: ${{needs.common_config.outputs.windows_matrix}}
+      distro: windows-latest
 
-  follower-windows:
-    needs: [leader-compile-windows, common_config]
+  build-python-wheels-windows:
+    needs: [common_config]
     strategy:
       fail-fast: false
       matrix:
@@ -238,15 +214,16 @@ jobs:
     secrets: inherit
     permissions: {packages: write}
     with:
-      job_type: follower
+      job_type: build-python-wheels
       python3: ${{matrix.python3}}
       cibw_version: ${{needs.common_config.outputs.cibuildwheel_ver}}
       cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
       matrix: ${{needs.common_config.outputs.windows_matrix}}
       persistent_storage: ${{ inputs.persistent_storage }}
+      distro: windows-latest
 
   persistent_storage_verify_linux:
-    needs: [common_config, follower-linux, follower-windows]
+    needs: [common_config, build-python-wheels-linux, build-python-wheels-windows]
     if: inputs.persistent_storage == true
     strategy:
       fail-fast: false
@@ -268,7 +245,7 @@ jobs:
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
 
   persistent_storage_verify_windows:
-    needs: [common_config, follower-windows, follower-linux]
+    needs: [common_config, build-python-wheels-windows, build-python-wheels-linux]
     if: inputs.persistent_storage == true
     strategy:
       fail-fast: false
@@ -299,7 +276,7 @@ jobs:
       job_type: cleanup
 
   can_merge:
-    needs: [leader-cpp-test-linux, leader-cpp-test-windows, follower-linux, follower-windows, persistent_storage_verify_linux, persistent_storage_verify_windows]
+    needs: [cpp-test-linux, cpp-test-windows, build-python-wheels-linux, build-python-wheels-windows, persistent_storage_verify_linux, persistent_storage_verify_windows]
     if: |
       always() &&
       !failure() &&

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -5,9 +5,10 @@ on:
       job_type:          {required: true, type: string, description: Selects the steps to enable}
       cmake_preset_type: {required: true, type: string, description: release/debug}
       matrix:            {required: true, type: string, description: JSON string to feed into the matrix}
+      distro:            {required: true, type: string, description: Label of the runner that will be used for running the workflow}
       cibw_image_tag:    {required: false, type: string, description: Linux only. As built by cibw_docker_image.yml workflow}
-      cibw_version:      {required: false, type: string, description: Follower only. Must match the cibw_image_tag}
-      python_deps_ids:   {default: '[""]', type: string, description: Follower test matrix parameter. JSON string.}
+      cibw_version:      {required: false, type: string, description: build-python-wheels only. Must match the cibw_image_tag}
+      python_deps_ids:   {default: '[""]', type: string, description: build-python-wheels test matrix parameter. JSON string.}
       python3:           {default: -1, type: number, description: Python 3 minor version}
       persistent_storage:      {default: "false", type: string, description: Specifies whether the python tests should tests against real storages e.g. AWS S3  }
       # TODO: Maybe we should add these as GitHub variables
@@ -16,19 +17,30 @@ on:
       region:            {default: 'eu-west-2', type: string, description: The S3 region of the bucket}
       clear:             {default: 1, type: number, description: Controls wheather we will clear the libraries in the versions stores that we test against}
 jobs:
+  start_ec2_runner:
+    if: inputs.distro == 'compile-on-ec2'
+    uses: ./.github/workflows/ec2_runner_jobs.yml
+    secrets: inherit
+    with:
+      job_type: start
+
   compile:
+    needs: [start_ec2_runner]
+    if: |
+      always() &&
+      !failure() &&
+      !cancelled()
     strategy:
       matrix:
         # Declaring the dummy fields here to aid the Github Actions linting in VSCode and to provide documentation
         os: [0] # Decouples the steps from any distro version changes
-        distro: [0]
         cmake_preset_prefix: [0]
         cibw_build_suffix: [0]
         envs: [0]
         build_dir: [0] # Must be an absolute path
         vcpkg_installed_dir: [0]
         vcpkg_packages_dir: [0]
-        symbols: [0] # Glob for symbol symbol files. Used for including in follower builds and exclusion on others.
+        symbols: [0] # Glob for symbol symbol files. Used for including in build-python-wheels builds and exclusion on others.
         do_not_archive: [0]
         test_services: [0] # Github service containers to spin up for the pytest run
         container: [0]
@@ -37,8 +49,8 @@ jobs:
         include:
             - ${{fromJSON(inputs.matrix)[0]}} # The items after 0 are for tests only
 
-    runs-on: ${{matrix.distro}}
-    container: ${{ (matrix.os == 'linux' && inputs.job_type != 'follower') && matrix.container || null}}
+    runs-on: ${{ needs.start_ec2_runner.outputs.label || inputs.distro}}
+    container: ${{ (matrix.os == 'linux' && inputs.job_type != 'build-python-wheels') && matrix.container || null}}
     env:
       SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
       VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
@@ -89,7 +101,7 @@ jobs:
       - name: Extra envs
         # This has to come after msvc-dev-cmd to overwrite the bad VCPKG_ROOT it sets
         run: |
-          . build_tooling/vcpkg_caching.sh # Linux follower needs another call in CIBW
+          HOME=~ . build_tooling/vcpkg_caching.sh # Linux build-python-wheels needs another call in CIBW
           echo -e "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES
           VCPKG_ROOT=$PLATFORM_VCPKG_ROOT
           ${{matrix.envs || ''}}" | tee -a $GITHUB_ENV
@@ -109,11 +121,11 @@ jobs:
         run: rm $(which ccache) || true
 
       - name: Prepare C++ compilation env
-        if: inputs.job_type != 'follower'
+        if: inputs.job_type != 'build-python-wheels'
         run: . build_tooling/prep_cpp_build.sh # Also applies to Windows
 
       - name: CMake compile
-        if: inputs.job_type != 'follower'
+        if: inputs.job_type != 'build-python-wheels'
         # We are pinning the version to 10.6 because >= 10.7, use node20 which is not supported in the container
         uses: lukka/run-cmake@v10.6
         with:
@@ -122,16 +134,13 @@ jobs:
           configurePresetAdditionalArgs: "['-DVCPKG_INSTALL_OPTIONS=--clean-after-build']"
           buildPreset: ${{env.ARCTIC_CMAKE_PRESET}}
 
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v1
+        id: cpu-cores
+
       - name: Compile C++ tests
         if: inputs.job_type == 'cpp-tests'
         run: cd cpp; cmake --build --preset $ARCTIC_CMAKE_PRESET --target install
-
-      - name: Clean up build dir # To save disk space as we're close to the limit on Linux
-        if: inputs.job_type == 'cpp-tests' && matrix.os == 'linux'
-        run: |
-          cd $ARCTICDB_BUILD_DIR/*-build
-          du -m --max-depth=2 | sort -n | tail -n 50
-          nohup rm -rf * &  # Clean up while the test is running to save build time
 
       - name: C++ Rapidcheck
         if: inputs.job_type == 'cpp-tests'
@@ -149,9 +158,9 @@ jobs:
         env:
           ARCTICDB_memory_loglevel: INFO
 
-      # ========================= Follower (CIBW) steps =========================
+      # ========================= build-python-wheels (CIBW) steps =========================
       - name: Get CIBuildWheel image & metadata
-        if: inputs.job_type == 'follower' && matrix.os == 'linux'
+        if: inputs.job_type == 'build-python-wheels' && matrix.os == 'linux'
         run: |
             docker login ghcr.io -u token -p "${{secrets.GITHUB_TOKEN}}"
             docker pull "${{inputs.cibw_image_tag}}"
@@ -159,23 +168,23 @@ jobs:
               --format='manylinux_image={{index .Config.Labels "io.arcticdb.base"}}' | tee -a $GITHUB_ENV
 
       - name: Build wheel
-        if: inputs.job_type == 'follower'
+        if: inputs.job_type == 'build-python-wheels'
         run: pipx run cibuildwheel==${{inputs.cibw_version}}
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: ${{inputs.cibw_image_tag}}
 
       - name: Store wheel artifact
-        if: inputs.job_type == 'follower'
+        if: inputs.job_type == 'build-python-wheels'
         uses: actions/upload-artifact@v3
         with:
           name: wheel-${{env.CIBW_BUILD}}
           path: wheelhouse/*.whl
 
       - name: Discover test directory names
-        if: inputs.job_type == 'follower'
+        if: inputs.job_type == 'build-python-wheels'
         # There are so few nonreg tests, run them in the hypothesis runner
-        run: find python/tests/* -maxdepth 0 -type d ! -regex '.*\(__pycache__\|util\|nonreg\)' -printf '"%f",' |
-              sed 's/^/test_dirs=[/ ; s/"hypothesis"/"{hypothesis,nonreg}"/ ; s/,$/]/' | tee -a $GITHUB_ENV
+        run: find python/tests/* -maxdepth 0 -type d ! -regex '.*\(__pycache__\|util\|nonreg\|scripts\)' -printf '"%f",' |
+              sed 's/^/test_dirs=[/ ; s/"hypothesis"/"{hypothesis,nonreg,scripts}"/ ; s/,$/]/' | tee -a $GITHUB_ENV
 
       # ========================= Common =========================
       - name: Disk usage
@@ -184,7 +193,7 @@ jobs:
         continue-on-error: true
 
       - name: Make build directory readable for archiving
-        if: inputs.job_type == 'follower' && matrix.os == 'linux' && always()
+        if: inputs.job_type == 'build-python-wheels' && matrix.os == 'linux' && always()
         run: sudo chown -R $UID ${{matrix.build_dir}}
 
       - name: Archive build metadata
@@ -198,7 +207,7 @@ jobs:
           # On Windows, exclusions like "!**/*.ext" are prefixed with a drive letter (D:\) of the current working dir
           # before matching. This breaks since we moved the build_dir to C:. Work around by templating exclusions:
           path: ${{matrix.build_dir}}/*-build
-            ${{env._exclusion}}${{inputs.job_type == 'follower' && 'nofile' || matrix.symbols}}
+            ${{env._exclusion}}${{inputs.job_type == 'build-python-wheels' && 'nofile' || matrix.symbols}}
             ${{env._exclusion}}${{join(matrix.do_not_archive, env._exclusion)}}
 
     outputs:
@@ -207,8 +216,24 @@ jobs:
       test_dirs: ${{env.test_dirs}}
       cibw_build: ${{env.CIBW_BUILD}}
 
+  stop-ec2-runner:
+    needs: [start_ec2_runner, compile]
+    if: |
+      always() &&
+      inputs.distro == 'compile-on-ec2'
+    uses: ./.github/workflows/ec2_runner_jobs.yml
+    secrets: inherit
+    with:
+      job_type: stop
+      label: ${{ needs.start_ec2_runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start_ec2_runner.outputs.ec2-instance-id }}
+
   python_tests:
-    if: inputs.job_type == 'follower'
+    if: |
+      always() &&
+      !failure() &&
+      !cancelled() &&
+      inputs.job_type == 'build-python-wheels'
     needs: [compile]
     strategy:
       fail-fast: false
@@ -218,7 +243,7 @@ jobs:
         include:
           ${{fromJSON(inputs.matrix)}}
     name: ${{matrix.type}}${{matrix.python_deps_id}}
-    runs-on: ${{matrix.distro}}
+    runs-on: ${{inputs.distro != 'compile-on-ec2' && inputs.distro || 'ubuntu-latest'}}
     container: ${{matrix.os == 'linux' && needs.compile.outputs.manylinux_image || null}}
     defaults:
       run: {shell: bash}
@@ -299,6 +324,10 @@ jobs:
           # Use the Mongo created in the service container above to test against
           CI_MONGO_HOST: mongodb
           CI_MONGO_HOST_2: mongodb_2
+          # On windows, we can allocate more threads for running the tests
+          # because we are not testing against mongo
+          PYTEST_THREADS: ${{ (matrix.os == 'windows' && matrix.type != 'stress') && 4 || 0}}
+          HYPOTHESIS_PROFILE: ci_${{matrix.os}}
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -11,28 +11,19 @@ on:
   pull_request:
 
 jobs:
+  start_ec2_runner:
+    uses: ./.github/workflows/ec2_runner_jobs.yml
+    secrets: inherit
+    permissions: write-all
+    with:
+      job_type: start
+
   linux:
-    strategy:
-      matrix:
-        # we use two jobs for python and cpp tests st. they can run in parallel
-        include:
-          - os: ubuntu-latest
-            cpp_tests: "1"
-            python_tests: "0"
-
-          - os: ubuntu-latest
-            cpp_tests: "0"
-            python_tests: "1"
-
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-
+    needs: [start_ec2_runner]
+    runs-on: ${{ needs.start_ec2_runner.outputs.label }}
     services:
       mongodb:
         image: mongo:4.4
-        ports:
-          - 27017:27017
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -58,12 +49,9 @@ jobs:
           python -m pip install --no-build-isolation --no-deps -v -e .
         env:
           ARCTICDB_USING_CONDA: 1
-          # Using one thread to avoid swapping which might freeze CI machines.
-          CMAKE_BUILD_PARALLEL_LEVEL: 1
-          ARCTICDB_BUILD_CPP_TESTS: ${{ matrix.cpp_tests }}
+          ARCTICDB_BUILD_CPP_TESTS: 1
 
       - name: Build C++ Tests
-        if: matrix.cpp_tests == '1'
         shell: bash -l {0}
         run: |
           cd cpp/out/linux-conda-release-build/
@@ -71,33 +59,42 @@ jobs:
           make -j ${{ steps.cpu-cores.outputs.count }} test_unit_arcticdb
 
       - name: Run C++ Tests
-        if: matrix.cpp_tests == '1'
         shell: bash -l {0}
         run: |
           cd cpp/out/linux-conda-release-build/
           make test
 
       - name: Install npm # Linux github runner image does not come with npm
-        if: matrix.os == 'linux'
         uses: actions/setup-node@v3.3.0
         with:
           node-version: '16'
 
       - name: Test with pytest
         shell: bash -l {0}
-        if: matrix.python_tests == '1'
         run: |
           npm install -g azurite
           cd python
+          export ARCTICDB_RAND_SEED=$RANDOM
           python -m pytest tests
         env:
           ARCTICDB_USING_CONDA: 1
+
+  stop-ec2-runner:
+    needs: [start_ec2_runner, linux]
+    if: ${{ always() }}
+    uses: ./.github/workflows/ec2_runner_jobs.yml
+    secrets: inherit
+    permissions: write-all
+    with:
+      job_type: stop
+      label: ${{ needs.start_ec2_runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start_ec2_runner.outputs.ec2-instance-id }}
 
   macos:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-13
 
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -128,8 +125,6 @@ jobs:
           python -m pip install --no-build-isolation --no-deps -v -e .
         env:
           ARCTICDB_USING_CONDA: 1
-          # Using one thread to avoid swapping which might freeze the CI machine.
-          CMAKE_BUILD_PARALLEL_LEVEL: 1
           ARCTICDB_BUILD_CPP_TESTS: 1
 
       - name: Build C++ Tests
@@ -155,7 +150,8 @@ jobs:
         run: |
           npm install -g azurite
           cd python
-          python -m pytest tests
+          export ARCTICDB_RAND_SEED=$RANDOM
+          python -m pytest -n ${{ steps.cpu-cores.outputs.count }} tests
         env:
           ARCTICDB_USING_CONDA: 1
 

--- a/.github/workflows/ec2_runner_jobs.yml
+++ b/.github/workflows/ec2_runner_jobs.yml
@@ -2,9 +2,13 @@ name: __ec2_runner
 on:
   workflow_call:
     inputs:
-      job_type:          {required: true, type: string, description: Selects the steps to enable}
-      label:             {type: string, description: the label of the machine that was create by the start-runner job needed by the stop-runner job}
-      ec2-instance-id:   {type: string, description: the ec2-instance-id of the machine that was create by the start-runner job needed by the stop-runner job}
+      job_type:           {required: true, type: string, description: Selects the steps to enable}
+      label:              {type: string, description: the label of the machine that was create by the start-runner job needed by the stop-runner job}
+      ec2-instance-id:    {type: string, description: the ec2-instance-id of the machine that was create by the start-runner job needed by the stop-runner job}
+      image-id:           {default: ami-0936679d3002e5be3, type: string, description: ID of the Amazon Image that should be used as a base for the runner}
+      instance-type:      {default: m6i.4xlarge, type: string, description: Instace type that will be used to create the runner VM}
+      subnet-id:          {default: subnet-04ee7771eea5d61d9, type: string, description: VPC Subnet to be used when creating the runner}
+      security-group-id:  {default: sg-08bd5ce9b15ba4f4b, type: string, description: Security Group to be used when creating the runner}
     outputs:
       label:             
         value: ${{ jobs.start-runner.outputs.label }}
@@ -15,7 +19,6 @@ jobs:
     if: inputs.job_type == 'start'
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
-    permissions: write-all
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -33,16 +36,15 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.ARCTICDB_TEST_PAT }}
-          ec2-image-id: ami-07ee6ba755b7f58f6
-          ec2-instance-type: c6i.4xlarge
-          subnet-id: subnet-04ee7771eea5d61d9
-          security-group-id: sg-08bd5ce9b15ba4f4b
+          ec2-image-id: ${{ inputs.image-id }}
+          ec2-instance-type: ${{ inputs.instance-type }}
+          subnet-id: ${{ inputs.subnet-id }}
+          security-group-id: ${{ inputs.security-group-id }}
 
   stop-runner:
     name: Stop self-hosted EC2 runner
     if: inputs.job_type == 'stop'
     runs-on: ubuntu-latest
-    permissions: write-all
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -33,7 +33,8 @@ function worker() {
     MSYS=winsymlinks:nativestrict ln -s "$(realpath "$tooling_dir/../python/tests")" $new_root/
     cd $new_root
 
-    $catch python -m pytest -v --show-capture=no --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
+    export ARCTICDB_RAND_SEED=$RANDOM
+    $catch python -m pytest -v -n $PYTEST_THREADS --show-capture=no --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --splits $splits --group $group --durations-path="$duration_file" --store-durations \
         --basetemp="$new_root/temp-pytest-output" \

--- a/build_tooling/vcpkg_caching.sh
+++ b/build_tooling/vcpkg_caching.sh
@@ -6,7 +6,7 @@ pushd $VCPKG_ROOT
 PLATFORM_VCPKG_ROOT=`cygpath -wa . 2>/dev/null || pwd`
 
 [[ -x vcpkg ]] || ./bootstrap-vcpkg.sh -disableMetrics
-nuget="`which mono 2>/dev/null` `./vcpkg fetch nuget | tail -n 1`"  # which mono will return empty on windows
+nuget="`which mono 2>/dev/null` `./vcpkg fetch nuget | tail -n 1`" # which mono will return empty on windows
 echo "Using nuget=$nuget"
 
 VCPKG_BINARY_SOURCES="clear;nuget,github,readwrite"

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -69,6 +69,7 @@ dependencies:
   # See: https://github.com/man-group/ArcticDB/pull/291
   - hypothesis < 6.73
   - pytest-sugar
+  - pytest-xdist
   - pymongo
   # Python dependencies (for tests only)
   - azure-storage-blob

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -502,3 +502,14 @@ def distinct_timestamps(lib: NativeVersionStore):
         while get_ts() == right_after:
             time.sleep(0.000001)
         out.after = pd.Timestamp(get_ts(), unit="ns")
+
+
+@contextmanager
+def random_seed_context():
+    seed = os.getenv("ARCTICDB_RAND_SEED")
+    state = random.getstate()
+    random.seed(int(seed) if seed is not None else state)
+    try:
+        yield
+    finally:
+        random.setstate(state)

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -249,10 +249,9 @@ class NativeVersionStore:
         return cls(library=lib, lib_cfg=lib_cfg, env=env, open_mode=open_mode)
 
     @staticmethod
-    def create_library_config(
-            cfg, env, lib_name, encoding_version=EncodingVersion.V1
-    ):
+    def create_library_config(cfg, env, lib_name, encoding_version=EncodingVersion.V1):
         from arcticdb.version_store.helper import extract_lib_config
+
         lib_cfg = extract_lib_config(cfg.env_by_id[env], lib_name)
         lib_cfg.lib_desc.version.encoding_version = encoding_version
         return lib_cfg
@@ -261,9 +260,7 @@ class NativeVersionStore:
     def create_store_from_config(
         cls, cfg, env, lib_name, open_mode=OpenMode.DELETE, encoding_version=EncodingVersion.V1
     ):
-        lib_cfg = NativeVersionStore.create_library_config(
-            cfg, env, lib_name, encoding_version=encoding_version
-        )
+        lib_cfg = NativeVersionStore.create_library_config(cfg, env, lib_name, encoding_version=encoding_version)
         lib = cls.create_lib_from_lib_config(lib_cfg, env, open_mode)
         return cls(library=lib, lib_cfg=lib_cfg, env=env, open_mode=open_mode)
 

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -2,7 +2,9 @@ import random
 import pandas as pd
 import numpy as np
 import pytest
-
+from arcticdb.version_store import NativeVersionStore
+from arcticdb_ext.exceptions import InternalException, NormalizationException, SortingException
+from arcticdb_ext import set_config_int
 from hypothesis import given, assume, settings, strategies as st
 from itertools import chain, product, combinations
 from tests.util.mark import SLOW_TESTS_MARK

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -1,0 +1,249 @@
+import random
+import pandas as pd
+import numpy as np
+import pytest
+
+from hypothesis import given, assume, settings, strategies as st
+from itertools import chain, product, combinations
+from tests.util.mark import SLOW_TESTS_MARK
+from arcticdb.version_store._common import TimeFrame
+
+from arcticdb.util.test import assert_frame_equal, random_seed_context
+from arcticdb.util.hypothesis import InputFactories, use_of_function_scoped_fixtures_in_hypothesis_checked
+
+
+def gen_params_append():
+    with random_seed_context():
+        # colnums
+        p = [list(range(2, 5))]
+        # periods
+        periods = 6
+        p.append([periods])
+        # rownums
+        p.append([1, 4, periods + 2])
+        # cols
+        p.append(list(chain(*[list(combinations(["a", "b", "c"], c)) for c in range(1, 4, 2)])))
+        # tsbounds
+        p.append([(j, i) for i in [1, periods - 1] for j in range(i)])
+        # append_point
+        p.append([k for k in range(1, periods - 1)])
+        result = sorted(random.sample(list(product(*p)), 10))
+    return result
+
+
+def gen_params_append_single():
+    # colnums
+    p = [[2]]
+    # periods
+    periods = 6
+    p.append([periods])
+    # rownums
+    p.append([1])
+    # cols
+    p.append([["a"]])
+    # tsbounds
+    p.append([[0, 5]])
+    # append_point
+    p.append([1])
+    return list(product(*p))
+
+
+@pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
+def test_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
+    tz = "America/New_York"
+    version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
+    dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
+    a = np.arange(dtidx.shape[0])
+    tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
+    c1 = dtidx[append_point]
+    c2 = dtidx[append_point + 1]
+    tf1 = tf.tsloc[:c1]
+    sid = "XXX"
+    version_store.write(sid, tf1)
+    tf2 = tf.tsloc[c2:]
+    version_store.append(sid, tf2)
+
+    dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
+    vit = version_store.read(sid, date_range=dtr, columns=list(cols))
+    rtf = tf.tsloc[dtr[0] : dtr[1]]
+    col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
+    rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
+    assert rtf == vit.data
+
+
+@pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
+def test_incomplete_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
+    tz = "America/New_York"
+    version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
+    dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
+    a = np.arange(dtidx.shape[0])
+    tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
+    c1 = dtidx[append_point]
+    c2 = dtidx[append_point + 1]
+    tf1 = tf.tsloc[:c1]
+    sid = "XXX"
+    version_store.write(sid, tf1)
+    tf2 = tf.tsloc[c2:]
+    version_store.append(sid, tf2, incomplete=True)
+
+    dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
+    vit = version_store.read(sid, date_range=dtr, columns=list(cols), incomplete=True)
+    rtf = tf.tsloc[dtr[0] : dtr[1]]
+    col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
+    rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
+    assert rtf == vit.data
+
+
+# test_hypothesis_version_store.py covers the appends that are allowed.
+# Only need to check the forbidden ones have useful error messages:
+@pytest.mark.parametrize(
+    "initial, append, match",
+    [
+        # (InputFactories.DF_RC_NON_RANGE, InputFactories.DF_DTI, "TODO(AN-722)"),
+        (InputFactories.DF_RC, InputFactories.ND_ARRAY_1D, "(Pandas|ndarray)"),
+        (InputFactories.DF_RC, InputFactories.DF_MULTI_RC, "index type incompatible"),
+        (InputFactories.DF_RC, InputFactories.DF_RC_NON_RANGE, "range.*index which is incompatible"),
+        (InputFactories.DF_RC, InputFactories.DF_RC_STEP, "different.*step"),
+    ],
+)
+@pytest.mark.parametrize("swap", ["swap", ""])
+def test_(initial: InputFactories, append: InputFactories, match, swap, lmdb_version_store: NativeVersionStore):
+    lib = lmdb_version_store
+    if swap:
+        initial, append = append, initial
+    init_data, next_start = initial.make(1, 3)
+    lib.write("s", init_data)
+
+    to_append, _ = append.make(abs(next_start), 1)
+    with pytest.raises(NormalizationException):
+        lib.append("s", to_append, match=match)
+
+
+
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(deadline=None)
+@given(
+    col_per_append_df=st.integers(2, 100),
+    col_name_set=st.integers(1, 10000),
+    num_rows_per_test_cycle=st.lists(st.lists(st.integers(1, 20), min_size=1, max_size=10), max_size=2),
+    column_group_size=st.integers(2, 100),
+    segment_row_size=st.integers(2, 100),
+    dynamic_schema=st.booleans(),
+    dynamic_strings=st.booleans(),
+    df_in_str=st.booleans(),
+)
+@SLOW_TESTS_MARK
+def test_append_with_defragmentation(
+    sym,
+    col_per_append_df,
+    col_name_set,
+    num_rows_per_test_cycle,
+    get_wide_df,
+    column_group_size,
+    segment_row_size,
+    dynamic_schema,
+    dynamic_strings,
+    df_in_str,
+    basic_store_factory,
+):
+    def get_wide_and_long_df(start_idx, end_idx, col_per_append_df, col_name_set, df_in_str):
+        df = pd.DataFrame()
+        for idx in range(start_idx, end_idx):
+            df = pd.concat([df, get_wide_df(idx, col_per_append_df, col_name_set)])
+        if col_per_append_df == col_name_set:  # manually sort them for static schema, for newer version of panda
+            df = df.reindex(sorted(list(df.columns)), axis=1)
+        df = df.astype(str if df_in_str else np.float64)
+        return df
+
+    def get_no_of_segments_after_defragmentation(df, merged_segment_row_size):
+        new_segment_row_size = no_of_segments = 0
+        for start_row, end_row in pd.Series(df.end_row.values, index=df.start_row).to_dict().items():
+            no_of_segments = no_of_segments + 1 if new_segment_row_size == 0 else no_of_segments
+            new_segment_row_size += end_row - start_row
+            if new_segment_row_size >= merged_segment_row_size:
+                new_segment_row_size = 0
+        return no_of_segments
+
+    def get_no_of_column_merged_segments(df):
+        return len(pd.Series(df.end_row.values, index=df.start_row).to_dict().items())
+
+    def run_test(
+        lib,
+        col_per_append_df,
+        col_name_set,
+        merged_segment_row_size,
+        df_in_str,
+        before_compact,
+        index_offset,
+        num_of_rows,
+    ):
+        for num_of_row in num_of_rows:
+            start_index = index_offset
+            index_offset += num_of_row
+            end_index = index_offset
+            df = get_wide_and_long_df(start_index, end_index, col_per_append_df, col_name_set, df_in_str)
+            before_compact = pd.concat([before_compact, df])
+            if start_index == 0:
+                lib.write(sym, df)
+            else:
+                lib.append(sym, df)
+            segment_details = lib.read_index(sym)
+            assert lib.is_symbol_fragmented(sym, None) is (
+                get_no_of_segments_after_defragmentation(segment_details, merged_segment_row_size)
+                != get_no_of_column_merged_segments(segment_details)
+            )
+        if get_no_of_segments_after_defragmentation(
+            segment_details, merged_segment_row_size
+        ) != get_no_of_column_merged_segments(segment_details):
+            seg_details_before_compaction = lib.read_index(sym)
+            lib.defragment_symbol_data(sym, None)
+            res = lib.read(sym).data
+            res = res.reindex(sorted(list(res.columns)), axis=1)
+            res = res.replace("", 0.0)
+            res = res.fillna(0.0)
+            before_compact = before_compact.reindex(sorted(list(before_compact.columns)), axis=1)
+            before_compact = before_compact.fillna(0.0)
+
+            seg_details = lib.read_index(sym)
+
+            assert_frame_equal(before_compact, res)
+
+            assert len(seg_details) == get_no_of_segments_after_defragmentation(
+                seg_details_before_compaction, merged_segment_row_size
+            )
+            indexs = (
+                seg_details["end_index"].astype(str).str.rsplit(" ", n=2).agg(" ".join).reset_index()
+            )  # start_index and end_index got merged into one column
+            assert np.array_equal(indexs.iloc[1:, 0].astype(str).values, indexs.iloc[:-1, 1].astype(str).values)
+        else:
+            with pytest.raises(InternalException):
+                lib.defragment_symbol_data(sym, None)
+        return before_compact, index_offset
+
+    assume(col_per_append_df <= col_name_set)
+    assume(
+        num_of_row % 2 != 0 for num_of_rows in num_rows_per_test_cycle for num_of_row in num_of_rows
+    )  # Make sure at least one successful compaction run per cycle
+
+    set_config_int("SymbolDataCompact.SegmentCount", 1)
+    before_compact = pd.DataFrame()
+    index_offset = 0
+    lib = basic_store_factory(
+        column_group_size=column_group_size,
+        segment_row_size=segment_row_size,
+        dynamic_schema=dynamic_schema,
+        dynamic_strings=dynamic_strings,
+        reuse_name=True,
+    )
+    for num_of_rows in num_rows_per_test_cycle:
+        before_compact, index_offset = run_test(
+            lib,
+            col_per_append_df,
+            col_name_set if dynamic_schema else col_per_append_df,
+            segment_row_size,
+            df_in_str,
+            before_compact,
+            index_offset,
+            num_of_rows,
+        )
+

--- a/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
+++ b/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
@@ -322,7 +322,7 @@ def test_stateful(lib_type, request):
         settings=settings(  # Note: timeout is a legacy parameter
             max_examples=int(os.getenv("HYPOTHESIS_EXAMPLES", 100)),
             deadline=None,
-            stateful_step_count=10,
+            stateful_step_count=100,
             suppress_health_check=[HealthCheck.filter_too_much],
         ),
     )

--- a/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
+++ b/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
@@ -20,6 +20,7 @@ from hypothesis.stateful import RuleBasedStateMachine, Bundle, rule, invariant, 
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.util.test import assert_frame_equal
 
+from tests.util.mark import SLOW_TESTS_MARK
 
 # Patches future hypothesis features
 consumes = getattr(stateful, "consumes", lambda x: x)  # consumes() first introduced in hypothesis 3.85
@@ -313,6 +314,7 @@ class VersionStoreComparison(RuleBasedStateMachine):
 
 
 @pytest.mark.parametrize("lib_type", ["lmdb_version_store_delayed_deletes_v1", "lmdb_version_store_delayed_deletes_v2"])
+@SLOW_TESTS_MARK
 def test_stateful(lib_type, request):
     VersionStoreComparison._lib = request.getfixturevalue(lib_type)
     run_state_machine_as_test(
@@ -320,7 +322,7 @@ def test_stateful(lib_type, request):
         settings=settings(  # Note: timeout is a legacy parameter
             max_examples=int(os.getenv("HYPOTHESIS_EXAMPLES", 100)),
             deadline=None,
-            stateful_step_count=100,
+            stateful_step_count=10,
             suppress_health_check=[HealthCheck.filter_too_much],
         ),
     )

--- a/python/tests/integration/arcticdb/test_arctic_move_storage.py
+++ b/python/tests/integration/arcticdb/test_arctic_move_storage.py
@@ -145,8 +145,11 @@ def test_move_s3_library(moto_s3_endpoint_and_credentials):
 
     # When - we move the data
     client = boto3.client(
-        service_name="s3", endpoint_url=endpoint, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key,
-        region_name=moto.s3.responses.DEFAULT_REGION_NAME
+        service_name="s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=aws_access_key,
+        aws_secret_access_key=aws_secret_key,
+        region_name=moto.s3.responses.DEFAULT_REGION_NAME,
     )
     new_bucket = f"{bucket}-dest"
     client.create_bucket(Bucket=new_bucket)

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -128,7 +128,7 @@ def test_lmdb_mapsize(tmpdir):
 
 def test_lmdb_mapsize_write(tmpdir):
     ac = Arctic(f"lmdb://{tmpdir}?map_size=1MB")
-    df = pd.DataFrame(np.random.randint(0, 100, size=(int(1e6), 4)), columns=list('ABCD'))
+    df = pd.DataFrame(np.random.randint(0, 100, size=(int(1e6), 4)), columns=list("ABCD"))
     lib = ac.create_library("test")
 
     with pytest.raises(LmdbMapFullError) as e:

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -75,14 +75,20 @@ def test_simple_flow(basic_store_no_symbol_list, symbol):
     assert basic_store_no_symbol_list.list_symbols() == basic_store_no_symbol_list.list_versions() == []
 
 
-@pytest.mark.parametrize("special_char", list("$@=;/:+ ,?\\{^}%`[]\"'~#|!-_.()"))
-def test_special_chars(object_version_store, special_char):
+def test_special_chars(object_version_store):
     """Test chars with special URI encoding under RFC 3986"""
-    sym = f"prefix{special_char}postfix"
-    df = sample_dataframe()
-    object_version_store.write(sym, df)
-    vitem = object_version_store.read(sym)
-    assert_frame_equal(vitem.data, df)
+    errors = []
+    # we are doing manual iteration due to a limitation that should be fixed by issue #1053
+    for special_char in list("$@=;/:+ ,?\\{^}%`[]\"'~#|!-_.()"):
+        try:
+            sym = f"prefix{special_char}postfix"
+            df = sample_dataframe()
+            object_version_store.write(sym, df)
+            vitem = object_version_store.read(sym)
+            assert_frame_equal(vitem.data, df)
+        except AssertionError as e:
+            errors.append(f"Failed for character {special_char}: {str(e)}")
+    assert not errors, "errors occurred:\n" + "\n".join(errors)
 
 
 @pytest.mark.parametrize("breaking_char", [chr(0), "\0", "*", "<", ">"])
@@ -293,7 +299,8 @@ def test_prune_previous_versions_multiple_times(basic_store, symbol):
 
 
 def test_prune_previous_versions_write_batch(basic_store):
-    """Verify that the batch write method correctly prunes previous versions when the corresponding option is specified."""
+    """Verify that the batch write method correctly prunes previous versions when the corresponding option is specified.
+    """
     # Given
     lib = basic_store
     lib_tool = lib.library_tool()
@@ -323,7 +330,8 @@ def test_prune_previous_versions_write_batch(basic_store):
 
 
 def test_prune_previous_versions_batch_write_metadata(basic_store):
-    """Verify that the batch write metadata method correctly prunes previous versions when the corresponding option is specified."""
+    """Verify that the batch write metadata method correctly prunes previous versions when the corresponding option is specified.
+    """
     # Given
     lib = basic_store
     lib_tool = lib.library_tool()
@@ -353,7 +361,8 @@ def test_prune_previous_versions_batch_write_metadata(basic_store):
 
 
 def test_prune_previous_versions_append_batch(basic_store):
-    """Verify that the batch append method correctly prunes previous versions when the corresponding option is specified."""
+    """Verify that the batch append method correctly prunes previous versions when the corresponding option is specified.
+    """
     # Given
     lib = basic_store
     lib_tool = lib.library_tool()

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -23,7 +23,10 @@ from arcticdb.util.hypothesis import (
 from hypothesis import assume, given, settings
 from hypothesis.extra.pandas import column, data_frames, range_indexes
 
+from tests.util.mark import xfail_on_linux_conda
 
+
+@xfail_on_linux_conda(reason="Test fails on linux conda, should be fixed by issue #1035")
 def test_group_on_float_column_with_nans(lmdb_version_store):
     lib = lmdb_version_store
     sym = "test_group_on_float_column_with_nans"

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -2,23 +2,15 @@ import random
 import pandas as pd
 import numpy as np
 from datetime import datetime
-from itertools import chain, product, combinations
 import pytest
 import sys
-import os
 from numpy.testing import assert_array_equal
-from hypothesis import given, assume, settings, strategies as st
 
 from pandas import MultiIndex
-from arcticdb.version_store._common import TimeFrame
 from arcticdb.version_store import NativeVersionStore
-from arcticdb.util.test import random_integers, assert_frame_equal, random_seed_context
-from arcticdb.util.hypothesis import InputFactories, use_of_function_scoped_fixtures_in_hypothesis_checked
 from arcticdb_ext.exceptions import InternalException, NormalizationException, SortingException
 from arcticdb_ext import set_config_int
-
-from tests.util.mark import SLOW_TESTS_MARK
-
+from arcticdb.util.test import random_integers, assert_frame_equal
 
 def test_append_simple(lmdb_version_store):
     symbol = "test_append_simple"
@@ -64,88 +56,6 @@ def test_append_string_of_different_sizes(lmdb_version_store):
     vit = lmdb_version_store.read(symbol)
     expected = pd.concat([df1, df2])
     assert_frame_equal(vit.data, expected)
-
-
-def gen_params_append():
-    with random_seed_context():
-        # colnums
-        p = [list(range(2, 5))]
-        # periods
-        periods = 6
-        p.append([periods])
-        # rownums
-        p.append([1, 4, periods + 2])
-        # cols
-        p.append(list(chain(*[list(combinations(["a", "b", "c"], c)) for c in range(1, 4, 2)])))
-        # tsbounds
-        p.append([(j, i) for i in [1, periods - 1] for j in range(i)])
-        # append_point
-        p.append([k for k in range(1, periods - 1)])
-        result = sorted(random.sample(list(product(*p)), 10))
-    return result
-
-
-def gen_params_append_single():
-    # colnums
-    p = [[2]]
-    # periods
-    periods = 6
-    p.append([periods])
-    # rownums
-    p.append([1])
-    # cols
-    p.append([["a"]])
-    # tsbounds
-    p.append([[0, 5]])
-    # append_point
-    p.append([1])
-    return list(product(*p))
-
-
-@pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
-def test_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
-    tz = "America/New_York"
-    version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
-    dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
-    a = np.arange(dtidx.shape[0])
-    tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
-    c1 = dtidx[append_point]
-    c2 = dtidx[append_point + 1]
-    tf1 = tf.tsloc[:c1]
-    sid = "XXX"
-    version_store.write(sid, tf1)
-    tf2 = tf.tsloc[c2:]
-    version_store.append(sid, tf2)
-
-    dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
-    vit = version_store.read(sid, date_range=dtr, columns=list(cols))
-    rtf = tf.tsloc[dtr[0] : dtr[1]]
-    col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
-    rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
-    assert rtf == vit.data
-
-
-@pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
-def test_incomplete_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
-    tz = "America/New_York"
-    version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
-    dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
-    a = np.arange(dtidx.shape[0])
-    tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
-    c1 = dtidx[append_point]
-    c2 = dtidx[append_point + 1]
-    tf1 = tf.tsloc[:c1]
-    sid = "XXX"
-    version_store.write(sid, tf1)
-    tf2 = tf.tsloc[c2:]
-    version_store.append(sid, tf2, incomplete=True)
-
-    dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
-    vit = version_store.read(sid, date_range=dtr, columns=list(cols), incomplete=True)
-    rtf = tf.tsloc[dtr[0] : dtr[1]]
-    col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
-    rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
-    assert rtf == vit.data
 
 
 def test_append_snapshot_delete(lmdb_version_store):
@@ -265,31 +175,6 @@ def test_append_pickled_symbol(lmdb_version_store):
     assert lmdb_version_store.is_symbol_pickled(symbol)
     with pytest.raises(InternalException):
         _ = lmdb_version_store.append(symbol, np.arange(100).tolist())
-
-
-# test_hypothesis_version_store.py covers the appends that are allowed.
-# Only need to check the forbidden ones have useful error messages:
-@pytest.mark.parametrize(
-    "initial, append, match",
-    [
-        # (InputFactories.DF_RC_NON_RANGE, InputFactories.DF_DTI, "TODO(AN-722)"),
-        (InputFactories.DF_RC, InputFactories.ND_ARRAY_1D, "(Pandas|ndarray)"),
-        (InputFactories.DF_RC, InputFactories.DF_MULTI_RC, "index type incompatible"),
-        (InputFactories.DF_RC, InputFactories.DF_RC_NON_RANGE, "range.*index which is incompatible"),
-        (InputFactories.DF_RC, InputFactories.DF_RC_STEP, "different.*step"),
-    ],
-)
-@pytest.mark.parametrize("swap", ["swap", ""])
-def test_(initial: InputFactories, append: InputFactories, match, swap, lmdb_version_store: NativeVersionStore):
-    lib = lmdb_version_store
-    if swap:
-        initial, append = append, initial
-    init_data, next_start = initial.make(1, 3)
-    lib.write("s", init_data)
-
-    to_append, _ = append.make(abs(next_start), 1)
-    with pytest.raises(NormalizationException):
-        lib.append("s", to_append, match=match)
 
 
 def test_append_not_sorted_exception(lmdb_version_store):
@@ -524,134 +409,6 @@ def test_append_mix_ascending_descending(lmdb_version_store):
     lmdb_version_store.append(symbol, df2)
     info = lmdb_version_store.get_info(symbol)
     assert info["sorted"] == "UNSORTED"
-
-
-@use_of_function_scoped_fixtures_in_hypothesis_checked
-@settings(deadline=None)
-@given(
-    col_per_append_df=st.integers(2, 100),
-    col_name_set=st.integers(1, 10000),
-    num_rows_per_test_cycle=st.lists(st.lists(st.integers(1, 20), min_size=1, max_size=10), max_size=2),
-    column_group_size=st.integers(2, 100),
-    segment_row_size=st.integers(2, 100),
-    dynamic_schema=st.booleans(),
-    dynamic_strings=st.booleans(),
-    df_in_str=st.booleans(),
-)
-@SLOW_TESTS_MARK
-def test_append_with_defragmentation(
-    sym,
-    col_per_append_df,
-    col_name_set,
-    num_rows_per_test_cycle,
-    get_wide_df,
-    column_group_size,
-    segment_row_size,
-    dynamic_schema,
-    dynamic_strings,
-    df_in_str,
-    basic_store_factory,
-):
-    def get_wide_and_long_df(start_idx, end_idx, col_per_append_df, col_name_set, df_in_str):
-        df = pd.DataFrame()
-        for idx in range(start_idx, end_idx):
-            df = pd.concat([df, get_wide_df(idx, col_per_append_df, col_name_set)])
-        if col_per_append_df == col_name_set:  # manually sort them for static schema, for newer version of panda
-            df = df.reindex(sorted(list(df.columns)), axis=1)
-        df = df.astype(str if df_in_str else np.float64)
-        return df
-
-    def get_no_of_segments_after_defragmentation(df, merged_segment_row_size):
-        new_segment_row_size = no_of_segments = 0
-        for start_row, end_row in pd.Series(df.end_row.values, index=df.start_row).to_dict().items():
-            no_of_segments = no_of_segments + 1 if new_segment_row_size == 0 else no_of_segments
-            new_segment_row_size += end_row - start_row
-            if new_segment_row_size >= merged_segment_row_size:
-                new_segment_row_size = 0
-        return no_of_segments
-
-    def get_no_of_column_merged_segments(df):
-        return len(pd.Series(df.end_row.values, index=df.start_row).to_dict().items())
-
-    def run_test(
-        lib,
-        col_per_append_df,
-        col_name_set,
-        merged_segment_row_size,
-        df_in_str,
-        before_compact,
-        index_offset,
-        num_of_rows,
-    ):
-        for num_of_row in num_of_rows:
-            start_index = index_offset
-            index_offset += num_of_row
-            end_index = index_offset
-            df = get_wide_and_long_df(start_index, end_index, col_per_append_df, col_name_set, df_in_str)
-            before_compact = pd.concat([before_compact, df])
-            if start_index == 0:
-                lib.write(sym, df)
-            else:
-                lib.append(sym, df)
-            segment_details = lib.read_index(sym)
-            assert lib.is_symbol_fragmented(sym, None) is (
-                get_no_of_segments_after_defragmentation(segment_details, merged_segment_row_size)
-                != get_no_of_column_merged_segments(segment_details)
-            )
-        if get_no_of_segments_after_defragmentation(
-            segment_details, merged_segment_row_size
-        ) != get_no_of_column_merged_segments(segment_details):
-            seg_details_before_compaction = lib.read_index(sym)
-            lib.defragment_symbol_data(sym, None)
-            res = lib.read(sym).data
-            res = res.reindex(sorted(list(res.columns)), axis=1)
-            res = res.replace("", 0.0)
-            res = res.fillna(0.0)
-            before_compact = before_compact.reindex(sorted(list(before_compact.columns)), axis=1)
-            before_compact = before_compact.fillna(0.0)
-
-            seg_details = lib.read_index(sym)
-
-            assert_frame_equal(before_compact, res)
-
-            assert len(seg_details) == get_no_of_segments_after_defragmentation(
-                seg_details_before_compaction, merged_segment_row_size
-            )
-            indexs = (
-                seg_details["end_index"].astype(str).str.rsplit(" ", n=2).agg(" ".join).reset_index()
-            )  # start_index and end_index got merged into one column
-            assert np.array_equal(indexs.iloc[1:, 0].astype(str).values, indexs.iloc[:-1, 1].astype(str).values)
-        else:
-            with pytest.raises(InternalException):
-                lib.defragment_symbol_data(sym, None)
-        return before_compact, index_offset
-
-    assume(col_per_append_df <= col_name_set)
-    assume(
-        num_of_row % 2 != 0 for num_of_rows in num_rows_per_test_cycle for num_of_row in num_of_rows
-    )  # Make sure at least one successful compaction run per cycle
-
-    set_config_int("SymbolDataCompact.SegmentCount", 1)
-    before_compact = pd.DataFrame()
-    index_offset = 0
-    lib = basic_store_factory(
-        column_group_size=column_group_size,
-        segment_row_size=segment_row_size,
-        dynamic_schema=dynamic_schema,
-        dynamic_strings=dynamic_strings,
-        reuse_name=True,
-    )
-    for num_of_rows in num_rows_per_test_cycle:
-        before_compact, index_offset = run_test(
-            lib,
-            col_per_append_df,
-            col_name_set if dynamic_schema else col_per_append_df,
-            segment_row_size,
-            df_in_str,
-            before_compact,
-            index_offset,
-            num_of_rows,
-        )
 
 
 def test_append_with_cont_mem_problem(sym, lmdb_version_store_tiny_segment_dynamic):

--- a/python/tests/unit/arcticdb/version_store/test_engine.py
+++ b/python/tests/unit/arcticdb/version_store/test_engine.py
@@ -14,32 +14,37 @@ import pytest
 import random
 import sys
 from arcticdb.version_store import TimeFrame
+from arcticdb.util.test import random_seed_context
 
 
 def gen_params():
-    # colnums
-    p = [list(range(2, 5))]
-    # rownums
-    periods = 6
-    p.append(list(range(1, periods + 2)))
-    # cols
-    p.append(list(chain(*[list(combinations(["a", "b", "c"], c)) for c in range(1, 4)])))
-    # tsbounds
-    p.append([(j, i) for i in range(periods) for j in range(i)])
-    return random.sample(list(product(*p)), 1000)
+    with random_seed_context():
+        # colnums
+        p = [list(range(2, 5))]
+        # rownums
+        periods = 6
+        p.append(list(range(1, periods + 2)))
+        # cols
+        p.append(list(chain(*[list(combinations(["a", "b", "c"], c)) for c in range(1, 4)])))
+        # tsbounds
+        p.append([(j, i) for i in range(periods) for j in range(i)])
+        result = sorted(random.sample(list(product(*p)), 10))
+    return result
 
 
 def gen_params_non_contiguous():
-    # colnums
-    p = [list(range(2, 5))]
-    # rownums
-    periods = 10
-    p.append(list(range(1, periods + 2)))
-    # cols
-    p.append(list(chain(*[list(combinations([2, 5, 7], c)) for c in range(1, 4)])))
-    # bounds
-    p.append([(j, i) for i in range(20, 29) for j in range(i)])
-    return random.sample(list(product(*p)), 1000)
+    with random_seed_context():
+        # colnums
+        p = [list(range(2, 5))]
+        # rownums
+        periods = 10
+        p.append(list(range(1, periods + 2)))
+        # cols
+        p.append(list(chain(*[list(combinations([2, 5, 7], c)) for c in range(1, 4)])))
+        # bounds
+        p.append([(j, i) for i in range(20, 29) for j in range(i)])
+        result = random.sample(list(product(*p)), 10)
+    return result
 
 
 @pytest.mark.parametrize("colnum,rownum,cols,tsbounds", gen_params())

--- a/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
@@ -249,12 +249,12 @@ def test_filter_numeric_isnotin_unsigned(lmdb_version_store_dynamic_schema, df, 
     ),
     vals=st.frozensets(string_strategy, min_size=1),
 )
-def test_filter_string_isin(lmdb_version_store_dynamic_schema, df, vals):
+def test_filter_string_isin(in_memory_version_store_dynamic_schema, df, vals):
     assume(not df.empty)
     q = QueryBuilder()
     q = q[q["a"].isin(vals)]
     pandas_query = "a in {}".format(list(vals))
-    generic_dynamic_filter_test(lmdb_version_store_dynamic_schema, "test_filter_string_isin", df, q, pandas_query)
+    generic_dynamic_filter_test(in_memory_version_store_dynamic_schema, "test_filter_string_isin", df, q, pandas_query)
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -264,14 +264,14 @@ def test_filter_string_isin(lmdb_version_store_dynamic_schema, df, vals):
         [column("a", elements=string_strategy), column("b", elements=string_strategy)], index=range_indexes()
     )
 )
-def test_filter_string_isin_empty_set(lmdb_version_store_dynamic_schema, df):
+def test_filter_string_isin_empty_set(in_memory_version_store_dynamic_schema, df):
     assume(not df.empty)
     vals = []
     q = QueryBuilder()
     q = q[q["a"].isin(vals)]
     pandas_query = "a in {}".format(list(vals))
     generic_dynamic_filter_test(
-        lmdb_version_store_dynamic_schema, "test_filter_string_isin_empty_set", df, q, pandas_query
+        in_memory_version_store_dynamic_schema, "test_filter_string_isin_empty_set", df, q, pandas_query
     )
 
 
@@ -283,12 +283,12 @@ def test_filter_string_isin_empty_set(lmdb_version_store_dynamic_schema, df):
     ),
     vals=st.frozensets(string_strategy, min_size=1),
 )
-def test_filter_string_isnotin(lmdb_version_store_dynamic_schema, df, vals):
+def test_filter_string_isnotin(in_memory_version_store_dynamic_schema, df, vals):
     assume(not df.empty)
     q = QueryBuilder()
     q = q[q["a"].isnotin(vals)]
     pandas_query = "a not in {}".format(list(vals))
-    generic_dynamic_filter_test(lmdb_version_store_dynamic_schema, "test_filter_string_isnotin", df, q, pandas_query)
+    generic_dynamic_filter_test(in_memory_version_store_dynamic_schema, "test_filter_string_isnotin", df, q, pandas_query)
 
 
 def test_numeric_filter_dynamic_schema(lmdb_version_store_tiny_segment_dynamic):

--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -14,7 +14,8 @@ from numpy import datetime64
 
 # TODO: Some tests are either segfaulting or failing on MacOS with conda builds.
 # This is meant to be used as a temporary flag to skip/xfail those tests.
-MACOS_CONDA_BUILD = sys.platform == "darwin" and os.getenv("ARCTICDB_USING_CONDA", "0") == "1"
+ARCTICDB_USING_CONDA = os.getenv("ARCTICDB_USING_CONDA", "0") == "1"
+MACOS_CONDA_BUILD = sys.platform == "darwin" and ARCTICDB_USING_CONDA
 _MACOS_CONDA_BUILD_SKIP_REASON = (
     "Tests fail for macOS conda builds, either because Azurite is improperly configured"
     "on the CI or because there's problem with Azure SDK for C++ in this configuration."
@@ -27,6 +28,7 @@ FAST_TESTS_ONLY = os.getenv("ARCTICDB_FAST_TESTS_ONLY") == "1"
 
 # !!!!!!!!!!!!!!!!!!!!!! Below mark (variable) names should reflect where they will be used, not what they do.
 # This is to avoid the risk of the name becoming out of sync with the actual condition.
+SLOW_TESTS_MARK = pytest.mark.skipif(FAST_TESTS_ONLY, reason="Skipping test as it takes a long time to run")
 
 AZURE_TESTS_MARK = pytest.mark.skipif(FAST_TESTS_ONLY or MACOS_CONDA_BUILD, reason=_MACOS_CONDA_BUILD_SKIP_REASON)
 """Mark to skip all Azure tests when MACOS_CONDA_BUILD or ARCTICDB_FAST_TESTS_ONLY is set."""
@@ -43,6 +45,13 @@ REAL_S3_TESTS_MARK = pytest.mark.skipif(
 )
 """Mark on tests using the real (i.e. hosted by AWS as opposed to moto) S3.
 Currently controlled by the ARCTICDB_PERSISTENT_STORAGE_TESTS and ARCTICDB_FAST_TESTS_ONLY env vars."""
+
+
+def xfail_on_linux_conda(reason=""):
+    def decorator(func):
+        return pytest.mark.xfail(ARCTICDB_USING_CONDA and sys.platform == "linux", reason=reason)(func)
+
+    return decorator
 
 
 def _no_op_decorator(fun):

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -50,17 +50,6 @@ def get_test_libraries(ac=None):
     return [lib for lib in ac.list_libraries() if lib.startswith("test_")]
 
 
-def test_df_3_cols(start=0):
-    return pd.DataFrame(
-        {
-            "x": np.arange(start, start + 10, dtype=np.int64),
-            "y": np.arange(start + 10, start + 20, dtype=np.int64),
-            "z": np.arange(start + 20, start + 30, dtype=np.int64),
-        },
-        index=np.arange(start, start + 10, dtype=np.int64),
-    )
-
-
 def read_persistent_library(lib):
     symbols = lib.list_symbols()
 
@@ -91,16 +80,16 @@ def is_strategy_branch_valid_format(input_string):
 
 
 def write_persistent_library(lib):
-    one_df = test_df_3_cols()
+    one_df = three_col_df()
     lib.write("one", one_df)
 
-    two_df = test_df_3_cols(1)
+    two_df = three_col_df(1)
     lib.write("two", two_df)
 
-    two_df = test_df_3_cols(2)
+    two_df = three_col_df(2)
     lib.append("two", two_df)
 
-    three_df = test_df_3_cols(3)
+    three_df = three_col_df(3)
     lib.append("three", three_df)
 
     # TODO: Fix me when the cast bug is fixed #940

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,6 +112,7 @@ Testing =
     pyarrow
     pytest-cpp
     pytest-timeout
+    pytest-xdist
     packaging
     future
     pytest-server-fixtures


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #941

#### What does this implement or fix?
Adds self-hosted Linux runners for the Leader job in build.yml and build_with_conda.yml.
Before this changes, just the compilation of a Linux leader takes more than 20 min.
With these changes the Linux leader build takes less than 20 min to compile and test against all cpp and almost all pytests.

This way, developers can get pretty good feedback on their changes, faster than before.

#### Other comments
Some of the pytests have been changed to make them more consistent so we can paralelize them with [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/known-limitations.html).
Some have been disabled to make the runs faster.
 