### PR TITLE
Docs versioning

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -50,10 +50,10 @@ flowchart LR
     leader --> follower
     leader --> cpp_tests
     leader --> persistent_storage{Should test against real storages?} --> persistent_storage_tests --> can_merge
-    follower --> docs
-    docs --> can_merge
     cpp_tests --> can_merge
     can_merge --> pub_check{publish_env} --> publish
+    A((manual)) --> docs_build
+    A((manual)) --> docs_publish
 ```
 
 This diagram shows the structure of the CI system.
@@ -87,12 +87,12 @@ They are designed to run concurrently with the Follower jobs, which test against
 
 After the leader jobs have passed successfully, we run Follower jobs that compile and test against the all of the supported Python versions.
 
-## Docs job
+## Docs jobs
 
-The Docs job compiles and publishes the latest docs.
-It needs a valid ArcticDB wheel to run, so it depends on the Linux jobs.
-Also currently, the automatic builds trigger only from changes in the code.
-**So if you make changes that are only in the docs, you will need to start a manual build and supply a valid ArcticDB wheel.**
+The docs_build job compiles and deploys versions of the docs into the `docs-pages` branch.
+The docs_publish job upload the complete `docs-pages` branch to Cloudflare Pages.
+See [Docs README](https://github.com/man-group/ArcticDB/blob/master/docs/README.md) for more info.
+Currently this is manual.  Automatic build (on push) and publish (for releases) is TODO.
 
 ## can_merge check
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,8 +52,8 @@ flowchart LR
     leader --> persistent_storage{Should test against real storages?} --> persistent_storage_tests --> can_merge
     cpp_tests --> can_merge
     can_merge --> pub_check{publish_env} --> publish
-    A((manual)) --> docs_build
-    A((manual)) --> docs_publish
+    B((manual)) --> docs_build
+    B((manual)) --> docs_publish
 ```
 
 This diagram shows the structure of the CI system.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -90,7 +90,7 @@ After the leader jobs have passed successfully, we run Follower jobs that compil
 ## Docs jobs
 
 The docs_build job compiles and deploys versions of the docs into the `docs-pages` branch.
-The docs_publish job upload the complete `docs-pages` branch to Cloudflare Pages.
+The docs_publish job uploads the complete `docs-pages` branch to Cloudflare Pages.
 See [Docs README](https://github.com/man-group/ArcticDB/blob/master/docs/README.md) for more info.
 Currently this is manual.  Automatic build (on push) and publish (for releases) is TODO.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,11 +321,3 @@ jobs:
     permissions: {contents: write}
     with:
       environment: ${{needs.common_config.outputs.publish_env}}
-
-  docs:
-    if: ${{ false }}
-    needs: [common_config, follower-linux] # Needs a Linux wheel to build the API docs
-    uses: ./.github/workflows/docs.yml
-    secrets: inherit
-    with:
-      environment: ${{needs.common_config.outputs.publish_env}}

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,22 +1,21 @@
-name: Docs
+name: Docs Build
 on:
-  workflow_call:
-    inputs:
-      environment: { type: string, required: false }
   workflow_dispatch:
     inputs:
-      environment: { type: environment, required: false }
-      api_wheel: { type: string, description: Override the wheel to generate API docs from }
+      version: { type: string, required: false, description: The version to build docs for, used as git tag and pypi version.  If not specified then use master and wheel from the last successful build.}
+      latest: { type: boolean, required: false, description: Alias this version as the 'latest' stable docs.}
+      deploy: { type: boolean, required: false, description: Push the built docs to the docs-pages branch on github.}
+      
 jobs:
-  can_merge:
+  build_docs:
     runs-on: ubuntu-latest
-    environment: ${{inputs.environment}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        ref: ${{inputs.version || 'master'}}
 
       - name: Detect runner Python implementation
-        if: ${{!inputs.api_wheel}}
+        if: ${{!inputs.version}}
         run: |
           python3 -c 'import platform
           prefix = {"CPython": "cp", "PyPy": "pp"}[platform.python_implementation()]
@@ -25,7 +24,7 @@ jobs:
   
       - id: download-wheel-artifact
         name: Download wheel artifact from last successful build
-        if: ${{!inputs.api_wheel}}
+        if: ${{!inputs.version}}
         uses: dawidd6/action-download-artifact@v2
         with:
           name: wheel-${{env.PY_IMPL}}-manylinux_x86_64
@@ -35,7 +34,7 @@ jobs:
 
       - name: Install documenation dependencies (including ArcticDB)
         run: |
-          pip3 install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-stubgen ${{inputs.api_wheel || '*.whl'}}
+          pip3 install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-stubgen ${{inputs.version && join('arcticdb==',inputs.version) || 'arcticdb-*.whl'}}
 
       - name: Stubfile generation for arcticdb_ext
         # stubfiles will be generated into docs/mkdocs/arcticdb_ext and so imported as arcticdb_ext by mkdocs when it builds
@@ -44,18 +43,13 @@ jobs:
           cd docs/mkdocs
           pybind11-stubgen arcticdb_ext.version_store --ignore-all-errors -o .
 
-      - name: MkDocs build
-        # FIXME mkdocs build --strict should be enabled when we are compliant
+      - name: List docs versions deployed to docs-pages branch
         run: |
-          cd docs/mkdocs  
-          mkdocs build -d /tmp/docs_build
+          cd docs/mkdocs
+          mike list
 
-      - name: Publish to Cloudflare Pages
-        if: inputs.environment && vars.CLOUDFLARE_PAGE_BRANCH
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{secrets.CLOUDFLARE_API_TOKEN}}
-          accountId: ${{vars.CLOUDFLARE_ACCOUNT_ID}}
-          projectName: ${{vars.CLOUDFLARE_PAGES_PROJECT}}
-          branch: ${{vars.CLOUDFLARE_PAGE_BRANCH}}
-          directory: /tmp/docs_build
+      - name: Versioned mkDocs build 
+        run: |
+          cd docs/mkdocs
+          mike set-default latest
+          mike deploy ${{inputs.deploy && '--push'}} ${{inputs.version || 'dev'}} ${{inputs.latest && 'latest'}} --message "Deploying docs for ${{inputs.version || 'dev'}} ${{inputs.latest && 'latest'}}"

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -2,23 +2,18 @@ name: Docs Build
 on:
   workflow_dispatch:
     inputs:
-      version: { type: string, required: false, description: The version to build docs for, used as git tag and pypi version.  If not specified then use master and wheel from the last successful build.}
-      latest: { type: boolean, required: false, description: Alias this version as the 'latest' stable docs.}
+      version: { type: string, required: false, description: The version to build docs for used as git tag and pypi version.  If not specified then use master and wheel from the last successful build.}
+      latest: { type: boolean, required: false, description: Alias this version as the 'latest' stable docs.  This should be set for the latest stable release.}
       deploy: { type: boolean, required: false, description: Push the built docs to the docs-pages branch on github.}
       
 jobs:
   docs_build:
     runs-on: ubuntu-latest
     steps:
-      - name: Display inputs
-        run: |
-          echo version=${{inputs.version}}
-          echo latest=${{inputs.latest}}
-          echo deploy=${{inputs.deploy}}
-
       - name: Checkout
         uses: actions/checkout@v3
-        ref: ${{inputs.version || 'master'}}
+        with:
+          ref: ${{inputs.version || 'master'}}
 
       - name: Detect runner Python implementation
         if: ${{!inputs.version}}

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -7,9 +7,15 @@ on:
       deploy: { type: boolean, required: false, description: Push the built docs to the docs-pages branch on github.}
       
 jobs:
-  build_docs:
+  docs_build:
     runs-on: ubuntu-latest
     steps:
+      - name: Display inputs
+        run: |
+          echo version=${{inputs.version}}
+          echo latest=${{inputs.latest}}
+          echo deploy=${{inputs.deploy}}
+
       - name: Checkout
         uses: actions/checkout@v3
         ref: ${{inputs.version || 'master'}}
@@ -32,24 +38,38 @@ jobs:
           workflow_conclusion: success
           branch: master
 
-      - name: Install documenation dependencies (including ArcticDB)
+      - name: Install documentation dependencies (including ArcticDB)
         run: |
-          pip3 install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-stubgen ${{inputs.version && join('arcticdb==',inputs.version) || 'arcticdb-*.whl'}}
+          set -x
+          pip3 install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-stubgen mike ${{inputs.version && format('arcticdb=={0}',inputs.version) || 'arcticdb-*.whl'}}
 
       - name: Stubfile generation for arcticdb_ext
-        # stubfiles will be generated into docs/mkdocs/arcticdb_ext and so imported as arcticdb_ext by mkdocs when it builds
-        # FIXME --ignore-all-errors may mask new errors and should be removed when we are compliant
-        run: |  
+        run: |
+          set -x
           cd docs/mkdocs
+          # stubfiles will be generated into docs/mkdocs/arcticdb_ext and so imported as arcticdb_ext by mkdocs when it builds
+          # FIXME --ignore-all-errors may mask new errors and should be removed when we are compliant
           pybind11-stubgen arcticdb_ext.version_store --ignore-all-errors -o .
 
-      - name: List docs versions deployed to docs-pages branch
+      - name: List docs versions before deploy
         run: |
+          set -x
           cd docs/mkdocs
           mike list
 
       - name: Versioned mkDocs build 
         run: |
+          set -x
           cd docs/mkdocs
+          # mike needs a git user to be set
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           mike set-default latest
-          mike deploy ${{inputs.deploy && '--push'}} ${{inputs.version || 'dev'}} ${{inputs.latest && 'latest'}} --message "Deploying docs for ${{inputs.version || 'dev'}} ${{inputs.latest && 'latest'}}"
+          git_hash=$(git rev-parse --short HEAD)
+          mike deploy ${{inputs.version || 'dev'}} ${{inputs.latest && 'latest' || ''}} --update-aliases ${{inputs.deploy && '--push' || ''}} --message "Deploying docs: ${{inputs.version || 'dev'}} $git_hash ${{inputs.latest && '[latest]' || ''}}"
+
+      - name: List docs versions after deploy
+        run: |
+          set -x
+          cd docs/mkdocs
+          mike list

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -10,7 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        ref: docs-pages
+        with:
+          ref: docs-pages
 
       - name: Publish docs-pages branch to Cloudflare Pages
         if: inputs.environment && vars.CLOUDFLARE_PAGE_BRANCH

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -1,0 +1,22 @@
+name: Docs Publish
+on:
+  workflow_dispatch:
+    inputs:
+      environment: { type: environment, required: false }
+jobs:
+  publish_docs:
+    runs-on: ubuntu-latest
+    environment: ${{inputs.environment}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        ref: docs-pages
+
+      - name: Publish docs-pages branch to Cloudflare Pages
+        if: inputs.environment && vars.CLOUDFLARE_PAGE_BRANCH
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{secrets.CLOUDFLARE_API_TOKEN}}
+          accountId: ${{vars.CLOUDFLARE_ACCOUNT_ID}}
+          projectName: ${{vars.CLOUDFLARE_PAGES_PROJECT}}
+          branch: ${{vars.CLOUDFLARE_PAGE_BRANCH}}

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       environment: { type: environment, required: false }
 jobs:
-  publish_docs:
+  docs_publish:
     runs-on: ubuntu-latest
     environment: ${{inputs.environment}}
     steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ pip install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-s
 - mkdocstrings[python]: python docstring support, like sphinx docs
 - black: for signature formatting
 - pybind11-stubgen: for generating stubs for pybind11 extensions, so that mkdocstrings can parse them
-- mke: for deploying versioned docs
+- mike: for deploying versioned docs
 
 You need to have ArcticDB installed to generate the API docs, so install it from source:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,17 +17,16 @@ and diagrams are generated, even undocumented classes / functions. This gives ab
 
 ### mkdocs
 
-
 Install
 ```
-pip install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-stubgen
+pip install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-stubgen mike
 ```
 - mkdocs-material: theme
 - mkdocs-jupyter: jupyter notebook support
 - mkdocstrings[python]: python docstring support, like sphinx docs
 - black: for signature formatting
 - pybind11-stubgen: for generating stubs for pybind11 extensions, so that mkdocstrings can parse them
-
+- mke: for deploying versioned docs
 
 You need to have ArcticDB installed to generate the API docs, so install it from source:
 
@@ -49,7 +48,7 @@ cd python
 pybind11-stubgen arcticdb_ext.version_store --ignore-all-errors -o .
 ```
 
-To build mkdocs to docs/mkdocs/site:
+To build the latest mkdocs to docs/mkdocs/site:
 ```
 cd docs/mkdocs
 mkdocs build -s
@@ -67,11 +66,12 @@ ERROR   -  mkdocstrings: Template 'alias.html' not found for 'python' handler an
 ERROR   -  Error reading page 'api/library.md': alias.html
 ```
 
+We use `mike` to version the docs.  The docs are first built into the `docs-pages` branch and then deployed to `docs.arcticdb.io` from there.
 
-## Deploying to `docs.arcticdb.io`
+To serve the versioned docs locally, run `mike serve` from the `docs/mkdocs` directory.
 
-Run the `Docs` github action.
-- Branch: Master
-- Environment: ProdPypi
-- Override: arcticdb
+## Publishing `docs.arcticdb.io`
 
+Run the `Docs Publish` github action.
+- Environment: ProdPypi, to push to docs.arcticdb.io
+- Environment: TestPypi, to push to a preview site

--- a/docs/mkdocs/docs/technical/releasing.md
+++ b/docs/mkdocs/docs/technical/releasing.md
@@ -121,8 +121,12 @@ schedule table [in the readme](https://github.com/man-group/ArcticDB/blob/master
 The conversion date will be two years from when the release is [published on GitHub](https://github.com/man-group/ArcticDB/releases/). This is not required if you are releasing a patch release.
 
 ## 6. Docs
-The release worflow will also trigger the workflow releasing the documentation to the ArcticDB site. The documentation which will be uploaded is based of the branch from which the release will happen.
-In case a release candidate is promoted to a release the workflow will upload outdated docs to the site. In this case the documentation must be deployed again by running the [docs workflow](https://github.com/man-group/ArcticDB/tree/master/.github/workflows#docsyml).
+To release do docs,
+- Run the [Docs Build action](https://github.com/man-group/ArcticDB/actions/workflows/docs_build.yml) for your new tag with `deploy` selected.  If this is the latest stable release of ArcticDB (i.e. not a backport) then also select `latest`.
+- Run the [Docs Publish action](https://github.com/man-group/ArcticDB/actions/workflows/docs_publish.yml) with the Prod environment.  The Publish action needs approval and will upload to https://docs.arcticdb.io (hosted by Cloudflare Pages).
+
+See ths [Docs README](https://github.com/man-group/ArcticDB/blob/master/docs/README.md) for more information.
+
 
 # Removing a release
 

--- a/docs/mkdocs/docs/technical/releasing.md
+++ b/docs/mkdocs/docs/technical/releasing.md
@@ -121,7 +121,7 @@ schedule table [in the readme](https://github.com/man-group/ArcticDB/blob/master
 The conversion date will be two years from when the release is [published on GitHub](https://github.com/man-group/ArcticDB/releases/). This is not required if you are releasing a patch release.
 
 ## 6. Docs
-To release do docs,
+To release the docs,
 - Run the [Docs Build action](https://github.com/man-group/ArcticDB/actions/workflows/docs_build.yml) for your new tag with `deploy` selected.  If this is the latest stable release of ArcticDB (i.e. not a backport) then also select `latest`.
 - Run the [Docs Publish action](https://github.com/man-group/ArcticDB/actions/workflows/docs_publish.yml) with the Prod environment.  The Publish action needs approval and will upload to https://docs.arcticdb.io (hosted by Cloudflare Pages).
 

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -1,6 +1,8 @@
 site_name: ArcticDB
+site_url: https://docs.arcticdb.io/
 repo_url: https://github.com/man-group/ArcticDB
 repo_name: man-group/ArcticDB
+remote_branch: docs-pages
 
 markdown_extensions:
   - admonition
@@ -25,6 +27,11 @@ theme:
   features:
     - navigation.tabs
     - navigation.sections
+
+extra:
+  version:
+    provider: mike
+    default: latest
 
 extra_css:
   - stylesheets/extra.css

--- a/docs/mkdocs/overrides/main.html
+++ b/docs/mkdocs/overrides/main.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %}
+
 {% block content %}
 {% if page.nb_url %}
 <p>


### PR DESCRIPTION
Add `mike` to version the documentation.

`mike` docs are deployed to `docs-pages` branch from where they are published to cloudflare.
Normally you would use `gh-pages` branch, but we are already using that for `asv`.

The workflows are still manual at the moment.  Will automate next.

![image](https://github.com/man-group/ArcticDB/assets/283605/15db9db5-11c3-475a-9ea1-8e234bc417fb)
