### PR TITLE
Issue #992 Throw the LMDB map full exception on put

### DIFF
--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -56,6 +56,8 @@ void LmdbStorage::do_write_internal(Composite<KeySegmentPair>&& kvs, ::lmdb::txn
             int res = ::mdb_put(txn.handle(), dbi.handle(), &mdb_key, &mdb_val, MDB_RESERVE | overwrite_flag);
             if (res == MDB_KEYEXIST) {
                 throw DuplicateKeyException(kv.variant_key());
+            } else if (res == MDB_MAP_FULL) {
+                throw ::lmdb::map_full_error("mdb_put", res);
             } else if (res != 0) {
                 throw std::runtime_error(fmt::format("Invalid lmdb error code {} while putting key {}",
                                                      res, kv.key_view()));

--- a/python/tests/integration/arcticdb/test_arctic_move_storage.py
+++ b/python/tests/integration/arcticdb/test_arctic_move_storage.py
@@ -7,7 +7,7 @@ import sys
 from arcticdb import Arctic
 from arcticdb.util.test import get_wide_dataframe
 from arcticdb.util.test import assert_frame_equal
-from arcticdb.exceptions import InternalException
+from arcticdb.exceptions import LmdbMapFullError
 
 
 def test_move_lmdb_library(tmpdir_factory):
@@ -79,11 +79,12 @@ def test_move_lmdb_library_map_size_reduction(tmpdir_factory):
     assert set(lib.list_symbols()) == {"sym", "another_sym"}
     assert_frame_equal(df, lib.read("sym").data)
 
-    # TODO #866 proper exception type for this
-    with pytest.raises(InternalException) as exc_info:
+    with pytest.raises(LmdbMapFullError) as e:
         lib.write("another_sym", df)
 
-    assert "lmdb error code -30792" in str(exc_info.value)
+    assert "MDB_MAP_FULL" in str(e.value)
+    assert "E5003" in str(e.value)
+    assert "-30792" in str(e.value)
 
     # stuff should still be readable despite the error
     assert_frame_equal(df, lib.read("sym").data)


### PR DESCRIPTION
Previously, writing data to LMDB and exceeding its map size (as opposed to creating a library) did not throw the map_full_error and hence was not translated to Python properly.

See PR #1006 for the Python exception translator for this LMDB exception.
