### PR TITLE
Issue #1017 Only warn if the "base" LMDB env is opened twice

### DIFF
--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -60,7 +60,7 @@ class LmdbStorage final : public Storage {
 
     std::string do_key_path(const VariantKey&) const final { return {}; };
 
-    void warn_if_lmdb_already_open(const fs::path &root_path, const std::string &lib_path_str);
+    void warn_if_lmdb_already_open();
 
     // _internal methods assume the write mutex is already held
     void do_write_internal(Composite<KeySegmentPair>&& kvs, ::lmdb::txn& txn);

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -208,3 +208,10 @@ def test_arctic_instances_across_same_lmdb_multiprocessing(tmpdir):
     ac["test"].write("a", pd.DataFrame())
     with mp.Pool(5) as p:
         p.starmap(create_arctic_instance, [(tmpdir, i) for i in range(20)])
+
+
+def test_lmdb_warnings_when_reopened(tmpdir):
+    ac = Arctic(f"lmdb://{tmpdir}")
+    lib = ac.create_library("test")
+    ac = Arctic(f"lmdb://{tmpdir}")  # expect to warn
+    lib = ac["test"]


### PR DESCRIPTION
Otherwise, if a user ignores the first error, they are then spammed with misleading errors on their subsequent interactions.

See the Github issue for a couple of examples that this change seeks to avoid.

#### Reference Issues/PRs
See #1017 and the original PR where this was introduced #1000