### PR TITLE
Make dependency of pymongo optional in running

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -70,9 +70,9 @@ dependencies:
   - hypothesis < 6.73
   - pytest-sugar
   - pytest-xdist
-  - pymongo
   # Python dependencies (for tests only)
   - azure-storage-blob
   - azure-identity
   - pyarrow
   - asv
+  - pymongo

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     msgpack
     pyyaml
     packaging
-    pymongo
 
 [flake8]
 # max line length for black
@@ -127,6 +126,7 @@ Testing =
     coverage
     asv
     virtualenv
+    pymongo
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://github.com/man-group/ArcticDB/issues/910

#### What does this implement or fix?
Make dependency of pymongo optional in running. 
pymongo offers uri_parser which offers fantastic error message for incorrect uri syntax. However it is not necessary. So this PR makes the dependency optional. If user's environment does not come with pymongo, a simple regex will be used for extracting the endpoint. And mongo C++ driver will detect any incorrect syntax still, but with relatively simple error message.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
