### PR TITLE
Fix run-cmake action

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -56,7 +56,8 @@ jobs:
         run: . build_tooling/prep_cpp_build.sh 
       
       - name: CMake compile
-        uses: lukka/run-cmake@v10
+        # We are pinning the version to 10.6 because >= 10.7, use node20 which is not supported in the container
+        uses: lukka/run-cmake@v10.6
         with:
           cmakeListsTxtPath: ${{github.workspace}}/cpp/CMakeLists.txt
           configurePreset: ${{env.ARCTIC_CMAKE_PRESET}}

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -114,7 +114,8 @@ jobs:
 
       - name: CMake compile
         if: inputs.job_type != 'follower'
-        uses: lukka/run-cmake@v10
+        # We are pinning the version to 10.6 because >= 10.7, use node20 which is not supported in the container
+        uses: lukka/run-cmake@v10.6
         with:
           cmakeListsTxtPath: ${{github.workspace}}/cpp/CMakeLists.txt
           configurePreset: ${{env.ARCTIC_CMAKE_PRESET}}


### PR DESCRIPTION
#### What does this implement or fix?
We are pinning the version to 10.6 because >= 10.7, use node20 which is not supported in the container