### PR TITLE
fix: Empty column handling improvements

### DIFF
--- a/cpp/arcticdb/entity/merge_descriptors.cpp
+++ b/cpp/arcticdb/entity/merge_descriptors.cpp
@@ -56,7 +56,12 @@ StreamDescriptor merge_descriptors(
                 if(auto existing = merged_fields_map.find(field.name()); existing != merged_fields_map.end()) {
                     auto existing_type_desc = existing->second;
                     if(existing_type_desc != type_desc) {
-                        log::version().info("Got incompatible types: {} {}", existing_type_desc, type_desc);
+                        log::version().info(
+                                "Merging different type descriptors for column: {}\n"
+                                "Existing type descriptor                : {}\n"
+                                "New type descriptor                     : {}",
+                                field.name(), existing_type_desc, type_desc
+                        );
                         auto new_descriptor = has_valid_common_type(existing_type_desc, type_desc);
                         if(new_descriptor) {
                             merged_fields_map[field.name()] = *new_descriptor;

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -115,7 +115,7 @@ enum class ValueType : uint8_t {
 
     UTF_DYNAMIC = 11,
     ASCII_DYNAMIC = 12,
-    // EMPTY is used by empty columns whose type has not been explicitly.
+    // EMPTY is used by empty columns whose type has not been explicitly specified.
     // EMPTY can be promoted to any type.
     // For instance, Pandas empty series whose types has not been specified is mapping to EMPTY.
     // When data is appended, the column type is inferred from the data and the column is promoted to the inferred type.

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -115,7 +115,11 @@ enum class ValueType : uint8_t {
 
     UTF_DYNAMIC = 11,
     ASCII_DYNAMIC = 12,
-    // EMPTY is used by empty columns whose type has not been explicitly specified.
+    // EMPTY is used by:
+    //  - empty columns whose type has not been explicitly specified
+    //  - columns full of placeholder values such as `None.`
+    //  (e.g. in Pandas, `pd.DataFrame({"c": [None, None, None]})`, would be mapped
+    //  within ArcticDB to a column of type `EMPTY`)
     // EMPTY can be promoted to any type.
     // For instance, Pandas empty series whose types has not been specified is mapping to EMPTY.
     // When data is appended, the column type is inferred from the data and the column is promoted to the inferred type.

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -115,7 +115,10 @@ enum class ValueType : uint8_t {
 
     UTF_DYNAMIC = 11,
     ASCII_DYNAMIC = 12,
-    /// Used to represent null types. Each type can be converted to Empty and Empty can be converted to each type.
+    // EMPTY is used by empty columns whose type has not been explicitly.
+    // EMPTY can be promoted to any type.
+    // For instance, Pandas empty series whose types has not been specified is mapping to EMPTY.
+    // When data is appended, the column type is inferred from the data and the column is promoted to the inferred type.
     EMPTY = 13,
     COUNT // Not a real value type, should not be added to proto descriptor. Used to count the number of items in the enum
 };

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -185,7 +185,7 @@ folly::Future<entity::AtomKey> append_frame(
                             auto& frame_index = frame.index_tensor.value();
                             util::check(frame_index.data_type() == DataType::NANOSECONDS_UTC64,
                                         "Expected timestamp index in append, got type {}", frame_index.data_type());
-                            if (index_segment_reader.tsd().proto().total_rows() != 0) {
+                            if (index_segment_reader.tsd().proto().total_rows() != 0 && frame_index.size() != 0) {
                                 auto first_index = NumericIndex{*frame_index.ptr_cast<timestamp>(0)};
                                 auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
                                 util::check(ignore_sort_order || prev - 1 <= first_index,

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -183,7 +183,6 @@ folly::Future<entity::AtomKey> append_frame(
                             util::check(frame.has_index(), "Cannot append timeseries without index");
                             util::check(static_cast<bool>(frame.index_tensor), "Got null index tensor in append_frame");
                             auto& frame_index = frame.index_tensor.value();
-                            util::check(frame_index.size() > 0, "Cannot append empty frame");
                             util::check(frame_index.data_type() == DataType::NANOSECONDS_UTC64,
                                         "Expected timestamp index in append, got type {}", frame_index.data_type());
                             if (index_segment_reader.tsd().proto().total_rows() != 0) {

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -73,7 +73,10 @@ NativeTensor obj_to_tensor(PyObject *ptr) {
     auto descr = pybind11::detail::array_descriptor_proxy(arr->descr);
     auto ndim = arr->nd;
     ssize_t size = ndim == 1 ? arr->dimensions[0] : arr->dimensions[0] * arr->dimensions[1];
-    auto val_type = size > 0 ? get_value_type(descr->kind) : ValueType::EMPTY;
+    // In Pandas < 2, empty series dtype is `"float"`, but as of Pandas 2.0, empty series dtype is `"object"`
+    // The Normalizer in Python cast empty `"float"` series to `"object"` so `EMPTY` is used here.
+    // See https://github.com/man-group/ArcticDB/issues/987#issue-1956701712
+    auto val_type = (size == 0 && descr->kind == 'O') ? ValueType::EMPTY : get_value_type(descr->kind);
     auto val_bytes = static_cast<uint8_t>(descr->elsize);
     auto c_style = arr->strides[0] == val_bytes;
 

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -75,7 +75,7 @@ NativeTensor obj_to_tensor(PyObject *ptr) {
     ssize_t size = ndim == 1 ? arr->dimensions[0] : arr->dimensions[0] * arr->dimensions[1];
     // In Pandas < 2, empty series dtype is `"float"`, but as of Pandas 2.0, empty series dtype is `"object"`
     // The Normalizer in Python cast empty `"float"` series to `"object"` so `EMPTY` is used here.
-    // See https://github.com/man-group/ArcticDB/issues/987#issue-1956701712
+    // See: https://github.com/man-group/ArcticDB/pull/1049
     auto val_type = (size == 0 && descr->kind == 'O') ? ValueType::EMPTY : get_value_type(descr->kind);
     auto val_bytes = static_cast<uint8_t>(descr->elsize);
     auto c_style = arr->strides[0] == val_bytes;

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -582,7 +582,7 @@ VersionedItem LocalVersionedEngine::update_internal(
             ARCTICDB_DEBUG(log::version(), "Updating existing data with an empty item has no effect. \n"
                                            "No new version is being created for symbol='{}', "
                                            "and the last version is returned", stream_id);
-            return get_version_to_read(stream_id, VersionQuery{}, ReadOptions{}).value();
+            return VersionedItem(*update_info.previous_index_key_);
         }
 
         auto versioned_item = update_impl(store(),
@@ -1427,7 +1427,7 @@ VersionedItem LocalVersionedEngine::append_internal(
             ARCTICDB_DEBUG(log::version(), "Appending an empty item to existing data has no effect. \n"
                                            "No new version has been created for symbol='{}', "
                                            "and the last version is returned", stream_id);
-            return get_version_to_read(stream_id, VersionQuery{}, ReadOptions{}).value();
+            return VersionedItem(*update_info.previous_index_key_);
         }
         auto versioned_item = append_impl(store(),
                                           update_info,

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -576,6 +576,15 @@ VersionedItem LocalVersionedEngine::update_internal(
                                                                         VersionQuery{},
                                                                         ReadOptions{});
     if (update_info.previous_index_key_.has_value()) {
+        bool frame_is_empty = frame.num_rows == 0;
+
+        if (frame_is_empty) {
+            ARCTICDB_DEBUG(log::version(), "Updating existing data with an empty item has no effect. \n"
+                                           "No new version is being created for symbol='{}', "
+                                           "and the last version is returned", stream_id);
+            return get_version_to_read(stream_id, VersionQuery{}, ReadOptions{}).value();
+        }
+
         auto versioned_item = update_impl(store(),
                                           update_info,
                                           query,
@@ -1411,6 +1420,15 @@ VersionedItem LocalVersionedEngine::append_internal(
                                                                         ReadOptions{});
 
     if(update_info.previous_index_key_.has_value()) {
+
+        bool frame_is_empty = frame.num_rows == 0;
+
+        if (frame_is_empty) {
+            ARCTICDB_DEBUG(log::version(), "Appending an empty item to existing data has no effect. \n"
+                                           "No new version has been created for symbol='{}', "
+                                           "and the last version is returned", stream_id);
+            return get_version_to_read(stream_id, VersionQuery{}, ReadOptions{}).value();
+        }
         auto versioned_item = append_impl(store(),
                                           update_info,
                                           std::move(frame),

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -344,6 +344,10 @@ VersionedItem update_impl(
                         [&](std::monostate) {
                             util::check(std::holds_alternative<TimeseriesIndex>(frame.index), "Update with row count index is not permitted");
                             orig_filter_range = frame.index_range;
+                            if (new_slice_and_keys.empty()) {
+                                // If there are no new keys, then we can't intersect with the existing data.
+                                return std::make_pair(std::vector<SliceAndKey>{}, std::vector<SliceAndKey>{});
+                            }
                             auto front_range = new_slice_and_keys.begin()->key().index_range();
                             auto back_range = new_slice_and_keys.rbegin()->key().index_range();
                             back_range.adjust_open_closed_interval();

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -202,7 +202,7 @@ def _to_primitive(arr, arr_name, dynamic_strings, string_max_len=None, coerce_co
 
     if len(arr) == 0:
         if coerce_column_type is not None:
-            # Casting using None, use float64 in any version of pandas…
+            # Casting an empty Series using None returns a Series with of "float64" dtype in any version of pandas…
             return arr.astype(coerce_column_type)
         else:
             return arr

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -688,6 +688,19 @@ class NativeVersionStore:
         write_if_missing = kwargs.get("write_if_missing", True)
 
         if isinstance(item, NPDDataFrame):
+            item_has_no_row = len(item.columns_values) == 0 or len(item.columns_values[0]) == 0
+
+            if item_has_no_row:
+                log.warn(
+                    'Appending an empty item to existing data has no effect. '
+                    f'No new version has been created for symbol="{symbol}", '
+                    f'and the last version is returned',
+                    UserWarning,
+                )
+
+                return self._find_version(symbol)
+
+
             with _diff_long_stream_descriptor_mismatch(self):
                 if incomplete:
                     self.version_store.append_incomplete(symbol, item, norm_meta, udm)
@@ -790,6 +803,17 @@ class NativeVersionStore:
         udm, item, norm_meta = self._try_normalize(symbol, data, metadata, False, dynamic_strings, coerce_columns)
 
         if isinstance(item, NPDDataFrame):
+            item_has_no_row = len(item.columns_values) == 0 or len(item.columns_values[0]) == 0
+
+            if item_has_no_row:
+                log.warn(
+                    'Updating existing data with an empty has no effect. '
+                    f'No new version has been created for symbol="{symbol}", '
+                    'and the last version is returned', UserWarning,
+                )
+
+                return self._find_version(symbol)
+
             with _diff_long_stream_descriptor_mismatch(self):
                 vit = self.version_store.update(
                     symbol, update_query, item, norm_meta, udm, upsert, dynamic_schema, prune_previous_version

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -688,19 +688,6 @@ class NativeVersionStore:
         write_if_missing = kwargs.get("write_if_missing", True)
 
         if isinstance(item, NPDDataFrame):
-            item_has_no_row = len(item.columns_values) == 0 or len(item.columns_values[0]) == 0
-
-            if item_has_no_row:
-                log.warn(
-                    'Appending an empty item to existing data has no effect. '
-                    f'No new version has been created for symbol="{symbol}", '
-                    f'and the last version is returned',
-                    UserWarning,
-                )
-
-                return self._find_version(symbol)
-
-
             with _diff_long_stream_descriptor_mismatch(self):
                 if incomplete:
                     self.version_store.append_incomplete(symbol, item, norm_meta, udm)
@@ -803,17 +790,6 @@ class NativeVersionStore:
         udm, item, norm_meta = self._try_normalize(symbol, data, metadata, False, dynamic_strings, coerce_columns)
 
         if isinstance(item, NPDDataFrame):
-            item_has_no_row = len(item.columns_values) == 0 or len(item.columns_values[0]) == 0
-
-            if item_has_no_row:
-                log.warn(
-                    'Updating existing data with an empty has no effect. '
-                    f'No new version has been created for symbol="{symbol}", '
-                    'and the last version is returned', UserWarning,
-                )
-
-                return self._find_version(symbol)
-
             with _diff_long_stream_descriptor_mismatch(self):
                 vit = self.version_store.update(
                     symbol, update_query, item, norm_meta, udm, upsert, dynamic_schema, prune_previous_version

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -740,19 +740,18 @@ def test_empty_pd_series_type_preservation(basic_store):
     basic_store.write(sym, series)
     res = basic_store.read(sym).data
     assert res.empty
-    # TODO: Fix me when the cast bug is fixed
     assert str(res.dtype) == "datetime64[ns]"
     assert basic_store.read(sym).data.empty
 
-    # basic_store.update(sym, series)
-    # res = basic_store.read(sym).data
-    # assert res.empty
-    # assert str(res.dtype) == "datetime64[ns]"
+    basic_store.update(sym, series)
+    res = basic_store.read(sym).data
+    assert res.empty
+    assert str(res.dtype) == "datetime64[ns]"
 
     basic_store.append(sym, series)
     res = basic_store.read(sym).data
     assert res.empty
-    # assert str(res.dtype) == "datetime64[ns]"
+    assert str(res.dtype) == "datetime64[ns]"
 
 
 def test_empty_df(basic_store):
@@ -761,8 +760,8 @@ def test_empty_df(basic_store):
     basic_store.write(sym, df)
     # if no index information is provided, we assume a datetimeindex
     assert basic_store.read(sym).data.empty
-    # basic_store.update(sym, df)
-    # assert basic_store.read(sym).data.empty
+    basic_store.update(sym, df)
+    assert basic_store.read(sym).data.empty
     basic_store.append(sym, df)
     assert basic_store.read(sym).data.empty
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -741,7 +741,7 @@ def test_empty_pd_series_type_preservation(basic_store):
     res = basic_store.read(sym).data
     assert res.empty
     # TODO: Fix me when the cast bug is fixed
-    # assert str(res.dtype) == "datetime64[ns]"
+    assert str(res.dtype) == "datetime64[ns]"
     assert basic_store.read(sym).data.empty
 
     # basic_store.update(sym, series)

--- a/python/tests/integration/arcticdb/version_store/test_deletion.py
+++ b/python/tests/integration/arcticdb/version_store/test_deletion.py
@@ -559,9 +559,12 @@ def test_delete_date_range_remove_everything(version_store_factory, map_timeout)
 
         range_to_delete = pd.date_range(start=start_time, end=end_time)
         lib.delete(symbol, date_range=range_to_delete)
-        df = df.drop(df.index[start : end + 1])  # Arctic is end date inclusive
 
         vit = lib.read(symbol)
+        df = df.drop(df.index[start : end + 1])  # Arctic is end date inclusive
+        assert len(df) == 0
+        # Empty DataFrames in Pandas < 2 have different default dtype.
+        df = df.astype(vit.data.dtypes)
         assert_frame_equal(vit.data, df)
 
 

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -232,29 +232,33 @@ def test_update_with_empty_dataframe_with_index(lmdb_version_store):
     lib.read(symbol, as_of=0).data
 
 
-def test_pandas_object_dtype(lmdb_version_store):
+def test_empty_column_handling(lmdb_version_store):
     # Non-regression test for https://github.com/man-group/ArcticDB/issues/987
     lib = lmdb_version_store
 
     # Columns of numeric (which includes datetimes) dtype != float64 with no values
     # must always be stored with the provided dtype (never empty-type).
 
-    symbol_info_series_index = 1 if IS_PANDAS_TWO else 0
-    def get_symbol_value_type(symbol_info):
+    symbol_type_descriptor_series_index = 1 if IS_PANDAS_TWO else 0
+    def get_symbol_type_descriptor(symbol):
         symbol_info = lib.get_info(symbol)
-        return symbol_info["dtype"][symbol_info_series_index].value_type
+        return symbol_info["dtype"][symbol_type_descriptor_series_index]
 
     symbol = "empty_as_int"
     series = pd.Series([], dtype=int)
     lib.write(symbol, series)
-    assert get_symbol_value_type(symbol) == TypeDescriptor.ValueType.INT
+    symbol_type_info = get_symbol_type_descriptor(symbol)
+    assert symbol_type_info.value_type == TypeDescriptor.ValueType.INT
+    assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
     result = lib.read(symbol).data
     assert result.dtype == int
 
     symbol = "empty_as_datetime"
     series = pd.Series([], dtype="datetime64[ns]")
     lib.write(symbol, series)
-    assert get_symbol_value_type(symbol) == TypeDescriptor.ValueType.NANOSECONDS_UTC
+    symbol_type_info = get_symbol_type_descriptor(symbol)
+    assert symbol_type_info.value_type == TypeDescriptor.ValueType.NANOSECONDS_UTC
+    assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
     result = lib.read(symbol).data
     assert result.dtype == "datetime64[ns]"
 
@@ -263,7 +267,9 @@ def test_pandas_object_dtype(lmdb_version_store):
         symbol = "empty_as_float"
         series = pd.Series([], dtype=float)
         lib.write(symbol, series)
-        assert get_symbol_value_type(symbol) == TypeDescriptor.ValueType.FLOAT
+        symbol_type_info = get_symbol_type_descriptor(symbol)
+        assert symbol_type_info.value_type == TypeDescriptor.ValueType.FLOAT
+        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
 
         result = lib.read(symbol).data
         assert result.dtype == float
@@ -272,7 +278,9 @@ def test_pandas_object_dtype(lmdb_version_store):
         symbol = "empty_as_object"
         series = pd.Series([], dtype=object)
         lib.write(symbol, series)
-        assert get_symbol_value_type(symbol) == TypeDescriptor.ValueType.EMPTY
+        symbol_type_info = get_symbol_type_descriptor(symbol)
+        assert symbol_type_info.value_type == TypeDescriptor.ValueType.EMPTY
+        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
 
         result = lib.read(symbol).data
         assert result.dtype == object
@@ -282,7 +290,9 @@ def test_pandas_object_dtype(lmdb_version_store):
         symbol = "empty_as_float"
         series = pd.Series([], dtype=float)
         lib.write(symbol, series)
-        assert get_symbol_value_type(symbol) == TypeDescriptor.ValueType.EMPTY
+        symbol_type_info = get_symbol_type_descriptor(symbol)
+        assert symbol_type_info.value_type == TypeDescriptor.ValueType.EMPTY
+        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
 
         result = lib.read(symbol).data
         assert result.dtype == float
@@ -291,7 +301,9 @@ def test_pandas_object_dtype(lmdb_version_store):
         symbol = "empty_as_object"
         series = pd.Series([], dtype=object)
         lib.write(symbol, series)
-        assert get_symbol_value_type(symbol) == TypeDescriptor.ValueType.EMPTY
+        symbol_type_info = get_symbol_type_descriptor(symbol)
+        assert symbol_type_info.value_type == TypeDescriptor.ValueType.EMPTY
+        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
 
         result = lib.read(symbol).data
         assert result.dtype == float

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -11,7 +11,7 @@ import datetime
 import pytest
 import sys
 
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, assert_series_equal
 from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 
@@ -217,6 +217,19 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
 
     # This must not fail.
     lib.update(symbol, pd.Series())
+
+
+def test_update_with_empty_dataframe_with_index(lmdb_version_store):
+    # Non-regression test for https://github.com/man-group/ArcticDB/issues/940
+    lib = lmdb_version_store
+
+    symbol = "test_update_with_empty_dataframe_with_index"
+
+    series = pd.Series(dtype="datetime64[ns]")
+    lib.write(symbol, series)
+
+    # This must not fail.
+    lib.read(symbol, as_of=0).data
 
 
 def test_pandas_object_dtype(lmdb_version_store):

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -200,6 +200,25 @@ def test_batch_write_unicode_strings(lmdb_version_store):
         lib.batch_append(syms, data)
 
 
+def test_update_with_empty_series_or_dataframe(lmdb_version_store):
+    # Non-regression test for https://github.com/man-group/ArcticDB/issues/892
+    lib = lmdb_version_store
+
+    symbol = "test_update_with_empty_dataframe"
+
+    lib.write(symbol, pd.DataFrame())
+
+    # This must not fail.
+    lib.update(symbol, pd.DataFrame())
+
+    symbol = "test_update_with_empty_series"
+
+    lib.write(symbol, pd.Series())
+
+    # This must not fail.
+    lib.update(symbol, pd.Series())
+
+
 def test_pandas_object_dtype(lmdb_version_store):
     # Non-regression test for https://github.com/man-group/ArcticDB/issues/987
     lib = lmdb_version_store

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -278,7 +278,7 @@ def test_update_with_empty_dataframe_with_index(lmdb_version_store):
     "input_empty_col_dtype, output_empty_col_dtype, value_type, size_bits",
     [
         (np.uint8, np.uint8, TypeDescriptor.ValueType.UINT, TypeDescriptor.SizeBits.S8),
-        (int, int, TypeDescriptor.ValueType.INT, TypeDescriptor.SizeBits.S64),
+        (np.int32, np.int32, TypeDescriptor.ValueType.INT, TypeDescriptor.SizeBits.S32),
         ("datetime64[ns]", "datetime64[ns]", TypeDescriptor.ValueType.NANOSECONDS_UTC, TypeDescriptor.SizeBits.S64),
 
         # For rationale see: https://github.com/man-group/ArcticDB/pull/1049

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -204,19 +204,56 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
     # Non-regression test for https://github.com/man-group/ArcticDB/issues/892
     lib = lmdb_version_store
 
-    symbol = "test_update_with_empty_dataframe"
+    empty_df = pd.DataFrame([], columns=["a", "b", "c"], dtype=float)
+    one_row_df = pd.DataFrame(
+        data=np.array([[1.0, 2.0, 3.0]]),
+        columns=["a", "b", "c"],
+        dtype=float,
+        index=pd.DatetimeIndex([
+            datetime.datetime(2019, 4, 9, 10, 5, 2, 1)
+        ]),
+    )
 
-    lib.write(symbol, pd.DataFrame())
+    symbol = "test_update_with_empty_dataframe_first"
 
-    # This must not fail.
-    lib.update(symbol, pd.DataFrame())
+    lib.write(symbol, empty_df)
+    lib.append(symbol, empty_df)
+    lib.update(symbol, one_row_df)
+    received_df = lib.read(symbol).data
 
-    symbol = "test_update_with_empty_series"
+    assert_frame_equal(one_row_df, received_df)
 
-    lib.write(symbol, pd.Series())
+    symbol = "test_update_with_empty_dataframe_second"
 
-    # This must not fail.
-    lib.update(symbol, pd.Series())
+    lib.write(symbol, one_row_df)
+    lib.append(symbol, empty_df)
+    lib.update(symbol, empty_df)
+    received_df = lib.read(symbol).data
+
+    # TODO: currently the update call with empty data does not overwrite the existing data.
+    # assert_frame_equal(empty_df, received_df)
+
+    empty_series = pd.Series([], dtype=float)
+    one_row_series = pd.Series([1.0], dtype=float, index=pd.DatetimeIndex([datetime.datetime(2019, 4, 9, 10, 5, 2, 1)]))
+
+    symbol = "test_update_with_empty_series_first"
+
+    lib.write(symbol, empty_series)
+    lib.append(symbol, empty_series)
+    lib.update(symbol, one_row_series)
+    received_series = lib.read(symbol).data
+
+    assert_series_equal(one_row_series, received_series)
+
+    symbol = "test_update_with_empty_series_second"
+
+    lib.write(symbol, one_row_series)
+    lib.append(symbol, empty_series)
+    lib.update(symbol, empty_series)
+    received_series = lib.read(symbol).data
+
+    # TODO: currently the update call with empty data does not overwrite the existing data.
+    # assert_series_equal(empty_series, received_series)
 
 
 def test_update_with_empty_dataframe_with_index(lmdb_version_store):

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -12,9 +12,8 @@ import pytest
 import sys
 
 from arcticdb.util.test import assert_frame_equal
-from arcticc.pb2.descriptors_pb2 import TypeDescriptor
-
 from arcticdb.util._versions import IS_PANDAS_TWO
+from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 
 
 def test_read_keys(object_and_mem_and_lmdb_version_store_dynamic_schema):

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -225,13 +225,18 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
     symbol = "test_update_with_empty_dataframe_second"
 
     lib.write(symbol, one_row_df)
-    # Appending and updating with an empty dataframe must not have any effect but must not fail.
-    lib.append(symbol, empty_df)
-    lib.update(symbol, empty_df)
+    if IS_PANDAS_TWO:
+        # Appending and updating with an empty dataframe must not have any effect but must not fail.
+        # TODO: Currently Padnas 1 default empty dtype series being corced to EMPTY is causing problems
+        # with changing the stored descriptors, making updating or reading symbol back impossible
+        # when empty dataframes are appended.
+        lib.append(symbol, empty_df)
+        lib.update(symbol, empty_df)
+
     received_df = lib.read(symbol).data
     assert_frame_equal(one_row_df, received_df)
 
-    empty_series = pd.Series([], dtype=float)
+    empty_series = pd.Series([], dtype=float, index=pd.DatetimeIndex([]))
     one_row_series = pd.Series([1.0], dtype=float, index=pd.DatetimeIndex([datetime.datetime(2019, 4, 9, 10, 5, 2, 1)]))
 
     symbol = "test_update_with_empty_series_first"
@@ -245,9 +250,14 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
     symbol = "test_update_with_empty_series_second"
 
     lib.write(symbol, one_row_series)
-    # Appending and updating with an empty series must not have any effect but must not fail.
-    lib.append(symbol, empty_series)
-    lib.update(symbol, empty_series)
+    if IS_PANDAS_TWO:
+        # Appending and updating with an empty series must not have any effect but must not fail.
+        # TODO: Currently Padnas 1 default empty dtype series being corced to EMPTY is causing problems
+        # with changing the stored descriptors, making updating or reading symbol back impossible
+        # when empty series are appended.
+        lib.append(symbol, empty_series)
+        lib.update(symbol, empty_series)
+
     received_series = lib.read(symbol).data
     assert_series_equal(one_row_series, received_series)
 

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -220,18 +220,16 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
     lib.append(symbol, empty_df)
     lib.update(symbol, one_row_df)
     received_df = lib.read(symbol).data
-
     assert_frame_equal(one_row_df, received_df)
 
     symbol = "test_update_with_empty_dataframe_second"
 
     lib.write(symbol, one_row_df)
+    # Appending and updating with an empty dataframe must not have any effect but must not fail.
     lib.append(symbol, empty_df)
     lib.update(symbol, empty_df)
     received_df = lib.read(symbol).data
-
-    # TODO: currently the update call with empty data does not overwrite the existing data.
-    # assert_frame_equal(empty_df, received_df)
+    assert_frame_equal(one_row_df, received_df)
 
     empty_series = pd.Series([], dtype=float)
     one_row_series = pd.Series([1.0], dtype=float, index=pd.DatetimeIndex([datetime.datetime(2019, 4, 9, 10, 5, 2, 1)]))
@@ -242,18 +240,16 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
     lib.append(symbol, empty_series)
     lib.update(symbol, one_row_series)
     received_series = lib.read(symbol).data
-
     assert_series_equal(one_row_series, received_series)
 
     symbol = "test_update_with_empty_series_second"
 
     lib.write(symbol, one_row_series)
+    # Appending and updating with an empty series must not have any effect but must not fail.
     lib.append(symbol, empty_series)
     lib.update(symbol, empty_series)
     received_series = lib.read(symbol).data
-
-    # TODO: currently the update call with empty data does not overwrite the existing data.
-    # assert_series_equal(empty_series, received_series)
+    assert_series_equal(one_row_series, received_series)
 
 
 def test_update_with_empty_dataframe_with_index(lmdb_version_store):

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -227,7 +227,7 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
     lib.write(symbol, one_row_df)
     if IS_PANDAS_TWO:
         # Appending and updating with an empty dataframe must not have any effect but must not fail.
-        # TODO: Currently Padnas 1 default empty dtype series being corced to EMPTY is causing problems
+        # TODO: Currently Pandas 1 default empty dtype series being corced to EMPTY is causing problems
         # with changing the stored descriptors, making updating or reading symbol back impossible
         # when empty dataframes are appended.
         lib.append(symbol, empty_df)
@@ -252,7 +252,7 @@ def test_update_with_empty_series_or_dataframe(lmdb_version_store):
     lib.write(symbol, one_row_series)
     if IS_PANDAS_TWO:
         # Appending and updating with an empty series must not have any effect but must not fail.
-        # TODO: Currently Padnas 1 default empty dtype series being corced to EMPTY is causing problems
+        # TODO: Currently Pandas 1 default empty dtype series being corced to EMPTY is causing problems
         # with changing the stored descriptors, making updating or reading symbol back impossible
         # when empty series are appended.
         lib.append(symbol, empty_series)
@@ -275,78 +275,31 @@ def test_update_with_empty_dataframe_with_index(lmdb_version_store):
     lib.read(symbol, as_of=0).data
 
 
-def test_empty_column_handling(lmdb_version_store):
+@pytest.mark.parametrize(
+    "input_empty_col_dtype, output_empty_col_dtype, value_type, size_bits",
+    [
+        (np.uint8, np.uint8, TypeDescriptor.ValueType.UINT, TypeDescriptor.SizeBits.S8),
+        (int, int, TypeDescriptor.ValueType.INT, TypeDescriptor.SizeBits.S64),
+        ("datetime64[ns]", "datetime64[ns]", TypeDescriptor.ValueType.NANOSECONDS_UTC, TypeDescriptor.SizeBits.S64),
+
+        # For rationale see: https://github.com/man-group/ArcticDB/pull/1049
+        (float, float, TypeDescriptor.ValueType.FLOAT if IS_PANDAS_TWO else TypeDescriptor.ValueType.EMPTY, TypeDescriptor.SizeBits.S64),  # noqa: E501
+        (object, object if IS_PANDAS_TWO else float, TypeDescriptor.ValueType.EMPTY, TypeDescriptor.SizeBits.S64),
+])
+def test_empty_column_handling(lmdb_version_store, input_empty_col_dtype, output_empty_col_dtype, value_type, size_bits):
     # Non-regression test for https://github.com/man-group/ArcticDB/issues/987
     lib = lmdb_version_store
-
-    # Columns of numeric (which includes datetimes) dtype != float64 with no values
-    # must always be stored with the provided dtype (never empty-type).
 
     symbol_type_descriptor_series_index = 1 if IS_PANDAS_TWO else 0
     def get_symbol_type_descriptor(symbol):
         symbol_info = lib.get_info(symbol)
         return symbol_info["dtype"][symbol_type_descriptor_series_index]
 
-    symbol = "empty_as_int"
-    series = pd.Series([], dtype=int)
+    symbol = "empty"
+    series = pd.Series([], dtype=input_empty_col_dtype)
     lib.write(symbol, series)
     symbol_type_info = get_symbol_type_descriptor(symbol)
-    assert symbol_type_info.value_type == TypeDescriptor.ValueType.INT
-    assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
+    assert symbol_type_info.value_type == value_type
+    assert symbol_type_info.size_bits == size_bits
     result = lib.read(symbol).data
-    assert result.dtype == int
-
-    symbol = "empty_as_datetime"
-    series = pd.Series([], dtype="datetime64[ns]")
-    lib.write(symbol, series)
-    symbol_type_info = get_symbol_type_descriptor(symbol)
-    assert symbol_type_info.value_type == TypeDescriptor.ValueType.NANOSECONDS_UTC
-    assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
-    result = lib.read(symbol).data
-    assert result.dtype == "datetime64[ns]"
-
-    if IS_PANDAS_TWO:
-        # With Pandas>=2.0, empty columns of dtype "float64" must be stored as "FLOAT" and returned as "float64".
-        symbol = "empty_as_float"
-        series = pd.Series([], dtype=float)
-        lib.write(symbol, series)
-        symbol_type_info = get_symbol_type_descriptor(symbol)
-        assert symbol_type_info.value_type == TypeDescriptor.ValueType.FLOAT
-        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
-
-        result = lib.read(symbol).data
-        assert result.dtype == float
-
-        # With Pandas>=2.0, empty columns of dtype "object" must be stored as "empty" and returned as "object".
-        symbol = "empty_as_object"
-        series = pd.Series([], dtype=object)
-        lib.write(symbol, series)
-        symbol_type_info = get_symbol_type_descriptor(symbol)
-        assert symbol_type_info.value_type == TypeDescriptor.ValueType.EMPTY
-        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
-
-        result = lib.read(symbol).data
-        assert result.dtype == object
-
-    else:
-        # With Pandas<2.0, empty columns of dtype "float64" must be stored using "EMPTY" and returned as "float64".
-        symbol = "empty_as_float"
-        series = pd.Series([], dtype=float)
-        lib.write(symbol, series)
-        symbol_type_info = get_symbol_type_descriptor(symbol)
-        assert symbol_type_info.value_type == TypeDescriptor.ValueType.EMPTY
-        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
-
-        result = lib.read(symbol).data
-        assert result.dtype == float
-
-        # With Pandas<2.0, empty columns of dtype "object" must be stored using "EMPTY" and returned as "float64".
-        symbol = "empty_as_object"
-        series = pd.Series([], dtype=object)
-        lib.write(symbol, series)
-        symbol_type_info = get_symbol_type_descriptor(symbol)
-        assert symbol_type_info.value_type == TypeDescriptor.ValueType.EMPTY
-        assert symbol_type_info.size_bits == TypeDescriptor.SizeBits.S64
-
-        result = lib.read(symbol).data
-        assert result.dtype == float
+    assert result.dtype == output_empty_col_dtype

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -94,8 +94,8 @@ def test_empty_df():
         d = pd.DataFrame(data={"C": []}, index=pd.MultiIndex(levels=[["A"], ["B"]], codes=[[], []], names=["X", "Y"]))
 
     norm = CompositeNormalizer()
-    # TODO: Remove coerce_columns (#224) and/or hard-coded index column name (#222)
-    df, norm_meta = norm.normalize(d, coerce_columns={"__idx__Y": "O", "C": "float64"})
+    # TODO: Remove coerce_columns for hard-coded index column name (#222)
+    df, norm_meta = norm.normalize(d, coerce_columns={"__idx__Y": "O"})
     fd = FrameData.from_npd_df(df)
     D = norm.denormalize(fd, norm_meta)
     if not IS_PANDAS_ZERO:

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -94,8 +94,7 @@ def test_empty_df():
         d = pd.DataFrame(data={"C": []}, index=pd.MultiIndex(levels=[["A"], ["B"]], codes=[[], []], names=["X", "Y"]))
 
     norm = CompositeNormalizer()
-    # TODO: Remove coerce_columns for hard-coded index column name (#222)
-    df, norm_meta = norm.normalize(d, coerce_columns={"__idx__Y": "O"})
+    df, norm_meta = norm.normalize(d)
     fd = FrameData.from_npd_df(df)
     D = norm.denormalize(fd, norm_meta)
     if not IS_PANDAS_ZERO:

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -70,11 +70,10 @@ def read_persistent_library(lib):
         column_names = df.columns.values.tolist()
         assert column_names == ["x", "y", "z"]
 
-    # TODO: Fix me when the cast bug is fixed #940
-    # assert "empty_s" in symbols
-    # res = lib.read("empty_s").data
-    # assert res.empty
-    # assert str(res.dtype) == "datetime64[ns]"
+    assert "empty_s" in symbols
+    res = lib.read("empty_s").data
+    assert res.empty
+    assert str(res.dtype) == "datetime64[ns]"
 
 
 def verify_library(ac):
@@ -103,10 +102,9 @@ def write_persistent_library(lib):
     three_df = test_df_3_cols(3)
     lib.append("three", three_df)
 
-    # TODO: Fix me when the cast bug is fixed #940
-    # sym = "empty_s"
-    # series = pd.Series(dtype="datetime64[ns]")
-    # lib.write(sym, series)
+    sym = "empty_s"
+    series = pd.Series(dtype="datetime64[ns]")
+    lib.write(sym, series)
 
 
 def seed_library(ac, version: str = ""):


### PR DESCRIPTION
#### Reference Issues/PRs

Fix #892.
Fix #940.
Fix #987.

#### What does this implement or fix?

This PR changes the handling of empty columns as described in https://github.com/man-group/ArcticDB/issues/987#issue-1956701712, i.e. schematically:

![Screenshot from 2023-11-13 08-52-31](https://github.com/man-group/ArcticDB/assets/13029839/0b9c51be-f919-4fb3-824f-6aeaccaf67d3)

#### Any other comments?

It also allow updating symbols with empty `DataFrame` and `Series`.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
