### PR TITLE
hot-fix: Use previous build of libmongocxx to avoid missing symbols

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -18,7 +18,8 @@ dependencies:
   - lz4-c
   - double-conversion
   - libevent
-  - libmongocxx
+  # TODO: Fix builds for missing symbols.
+  - libmongocxx < 3.9
   - zstd
   # TODO: pybind 2.11.X became stricter regarding the handling of reference counts
   # See: https://github.com/pybind/pybind11/issues/4748#issuecomment-1639445403


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Hot-fix missing symbols in `libbsoncxx`.

`libmongocxx` 3.9.0 has been released two day ago with https://github.com/conda-forge/libmongocxx-feedstock/pull/14 and it seems it builds come with missing symbol for `libbsoncxx`. As reported in https://github.com/man-group/ArcticDB/actions/runs/6822131813/job/18553650903?pr=1049#step:10:25 :
```
 arcticdb/__init__.py:1: in <module>
    import arcticdb_ext as _ext
E   ImportError: /home/runner/micromamba/envs/arcticdb/lib/libbsoncxx.so._noabi: undefined symbol: bson_array_as_relaxed_extended_json
```

`libbsoncxx` has not released new builds since the previous version of `libmongocxx` it seems.

Hence there are problems with the new builds of `libmongocxx`; let's use the previous ones for now.


#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
