### PR TITLE
Correct data pipelining in async write_batch

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -422,7 +422,7 @@ public:
         const std::shared_ptr<DeDupMap> &de_dup_map,
         const BatchWriteArgs &args) override {
         auto key_segments = std::move(key_seg_pairs);
-        std::size_t write_count = args.lib_write_count == 0 ? 16ULL : args.lib_write_count;
+        std::size_t write_count = args.lib_write_count == 0 ? 100ULL : args.lib_write_count;
 
         auto futs = folly::window(key_segments, [this, &de_dup_map](auto &&ks) {
             auto [key, seg] = std::forward<decltype(ks)>(ks);


### PR DESCRIPTION
The batch_read method creates two sets of tasks on the cpu executor, but since it does them in batches one after another they end up on the queue in that order, and the windowing around the first async operation doesn't have the desired effect of pushing the initial blocks all the way through to the end before starting other writes. This causes a memory spile as compressed blocks build up in memory without being written, and wastes potential bandwidth as chunks aren't being written to the storage as early as they could be.

We should create the whole chain in one go, without using intermediate vectors and use the window around the complete operation.