### PR TITLE
Parallelize aggregator_set_data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "cpp/vcpkg"]
 	path = cpp/vcpkg
 	url = https://github.com/microsoft/vcpkg.git
+[submodule "cpp/third_party/Crow"]
+	path = cpp/third_party/Crow
+	url = https://github.com/CrowCpp/Crow.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "cpp/vcpkg"]
 	path = cpp/vcpkg
 	url = https://github.com/microsoft/vcpkg.git
-[submodule "cpp/third_party/Crow"]
-	path = cpp/third_party/Crow
-	url = https://github.com/CrowCpp/Crow.git

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -866,6 +866,7 @@ if(${TEST})
     gtest_discover_tests(test_unit_arcticdb PROPERTIES DISCOVERY_TIMEOUT 60)
 
     set(benchmark_srcs
+            stream/test/stream_test_common.cpp
             column_store/test/benchmark_memory_segment.cpp
             processing/test/benchmark_clause.cpp)
 

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -16,6 +16,7 @@
 #include <arcticdb/async/tasks.hpp>
 #include <arcticdb/stream/stream_utils.hpp>
 #include <arcticdb/processing/clause.hpp>
+#include <arcticdb/storage/key_segment_pair.hpp>
 
 namespace arcticdb::async {
 
@@ -75,278 +76,266 @@ public:
             .thenValue(WriteSegmentTask{library_});
     }
 
-    folly::Future<entity::VariantKey> write(
-        stream::KeyType key_type,
-        VersionId version_id,
-        const StreamId &stream_id,
-        timestamp creation_ts,
-        IndexValue start_index,
-        IndexValue end_index,
-        SegmentInMemory &&segment) override {
+folly::Future<entity::VariantKey> write(
+    stream::KeyType key_type,
+    VersionId version_id,
+    const StreamId &stream_id,
+    timestamp creation_ts,
+    IndexValue start_index,
+    IndexValue end_index,
+    SegmentInMemory &&segment) override {
 
-        util::check(segment.descriptor().id() == stream_id,
-                    "Descriptor id mismatch in atom key {} != {}",
-                    stream_id,
-                    segment.descriptor().id());
+    util::check(segment.descriptor().id() == stream_id,
+                "Descriptor id mismatch in atom key {} != {}",
+                stream_id,
+                segment.descriptor().id());
 
-        return async::submit_cpu_task(EncodeAtomTask{
-            key_type, version_id, stream_id, start_index, end_index, creation_ts,
-            std::move(segment), codec_, encoding_version_
-        })
-            .via(&async::io_executor())
-            .thenValue(WriteSegmentTask{library_});
-    }
+    return async::submit_cpu_task(EncodeAtomTask{
+        key_type, version_id, stream_id, start_index, end_index, creation_ts,
+        std::move(segment), codec_, encoding_version_
+    })
+        .via(&async::io_executor())
+        .thenValue(WriteSegmentTask{library_});
+}
 
-    folly::Future<VariantKey> write(PartialKey pk, SegmentInMemory &&segment) override {
-        return write(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index, std::move(segment));
-    }
+folly::Future<VariantKey> write(PartialKey pk, SegmentInMemory &&segment) override {
+    return write(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index, std::move(segment));
+}
 
-    folly::Future<entity::VariantKey> write(
+folly::Future<entity::VariantKey> write(
+    KeyType key_type,
+    const StreamId &stream_id,
+    SegmentInMemory &&segment) override {
+    util::check(is_ref_key_class(key_type), "Expected ref key type got  {}", key_type);
+    return async::submit_cpu_task(EncodeRefTask{
+        key_type, stream_id, std::move(segment), codec_, encoding_version_
+    })
+        .via(&async::io_executor())
+        .thenValue(WriteSegmentTask{library_});
+}
+
+entity::VariantKey write_sync(
+    stream::KeyType key_type,
+    VersionId version_id,
+    const StreamId &stream_id,
+    IndexValue start_index,
+    IndexValue end_index,
+    SegmentInMemory &&segment) override {
+
+    util::check(segment.descriptor().id() == stream_id,
+                "Descriptor id mismatch in atom key {} != {}",
+                stream_id,
+                segment.descriptor().id());
+
+    auto encoded = EncodeAtomTask{
+        key_type, version_id, stream_id, start_index, end_index, current_timestamp(),
+        std::move(segment), codec_, encoding_version_
+    }();
+    return WriteSegmentTask{library_}(std::move(encoded));
+}
+
+entity::VariantKey write_sync(PartialKey pk, SegmentInMemory &&segment) override {
+    return write_sync(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index, std::move(segment));
+}
+
+entity::VariantKey write_sync(
+    KeyType key_type,
+    const StreamId &stream_id,
+    SegmentInMemory &&segment) override {
+    util::check(is_ref_key_class(key_type), "Expected ref key type got  {}", key_type);
+    auto encoded = EncodeRefTask{key_type, stream_id, std::move(segment), codec_, encoding_version_}();
+    return WriteSegmentTask{library_}(std::move(encoded));
+}
+
+folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair &&ks) override {
+    return async::submit_io_task(WriteCompressedTask{std::move(ks), library_});
+}
+
+folly::Future<entity::VariantKey> update(const entity::VariantKey &key,
+                                         SegmentInMemory &&segment,
+                                         storage::UpdateOpts opts) override {
+    auto stream_id = variant_key_id(key);
+    util::check(segment.descriptor().id() == stream_id,
+                "Descriptor id mismatch in variant key {} != {}",
+                stream_id,
+                segment.descriptor().id());
+
+    return async::submit_cpu_task(EncodeSegmentTask{
+        key, std::move(segment), codec_, encoding_version_
+    })
+        .via(&async::io_executor())
+        .thenValue(UpdateSegmentTask{library_, opts});
+}
+
+folly::Future<VariantKey> copy(
         KeyType key_type,
         const StreamId &stream_id,
-        SegmentInMemory &&segment) override {
-        util::check(is_ref_key_class(key_type), "Expected ref key type got  {}", key_type);
-        return async::submit_cpu_task(EncodeRefTask{
-            key_type, stream_id, std::move(segment), codec_, encoding_version_
-        })
-            .via(&async::io_executor())
-            .thenValue(WriteSegmentTask{library_});
-    }
-
-    entity::VariantKey write_sync(
-        stream::KeyType key_type,
         VersionId version_id,
-        const StreamId &stream_id,
-        IndexValue start_index,
-        IndexValue end_index,
-        SegmentInMemory &&segment) override {
+        const VariantKey &source_key) override {
+    return async::submit_io_task(CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_});
+}
 
-        util::check(segment.descriptor().id() == stream_id,
-                    "Descriptor id mismatch in atom key {} != {}",
-                    stream_id,
-                    segment.descriptor().id());
-
-        auto encoded = EncodeAtomTask{
-            key_type, version_id, stream_id, start_index, end_index, current_timestamp(),
-            std::move(segment), codec_, encoding_version_
-        }();
-        return WriteSegmentTask{library_}(std::move(encoded));
-    }
-
-    entity::VariantKey write_sync(PartialKey pk, SegmentInMemory &&segment) override {
-        return write_sync(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index, std::move(segment));
-    }
-
-    entity::VariantKey write_sync(
+VariantKey copy_sync(
         KeyType key_type,
         const StreamId &stream_id,
-        SegmentInMemory &&segment) override {
-        util::check(is_ref_key_class(key_type), "Expected ref key type got  {}", key_type);
-        auto encoded = EncodeRefTask{key_type, stream_id, std::move(segment), codec_, encoding_version_}();
-        return WriteSegmentTask{library_}(std::move(encoded));
+        VersionId version_id,
+        const VariantKey &source_key) override {
+    return CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_}();
+}
+
+timestamp current_timestamp() override {
+    return ClockType::nanos_since_epoch();
+}
+
+void iterate_type(
+        KeyType type,
+        const entity::IterateTypeVisitor& func,
+        const std::string &prefix) override {
+    library_->iterate_type(type, func, prefix);
+}
+
+folly::Future<std::pair<entity::VariantKey, SegmentInMemory>> read(
+        const entity::VariantKey &key,
+        storage::ReadKeyOpts opts) override {
+    return read_and_continue(key, library_, opts, DecodeSegmentTask{});
+}
+
+std::pair<entity::VariantKey, SegmentInMemory> read_sync(const entity::VariantKey &key,
+                                                         storage::ReadKeyOpts opts) override {
+    return DecodeSegmentTask{}(read_dispatch(key, library_, opts));
+}
+
+folly::Future<storage::KeySegmentPair> read_compressed(
+        const entity::VariantKey &key,
+        storage::ReadKeyOpts opts) override {
+    return read_and_continue(key, library_, opts, PassThroughTask{});
+}
+
+folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
+    return read_and_continue(key, library_, opts, DecodeMetadataTask{});
+}
+
+folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor>> read_metadata_and_descriptor(
+        const entity::VariantKey &key,
+        storage::ReadKeyOpts opts) override {
+    return read_and_continue(key, library_, opts, DecodeMetadataAndDescriptorTask{});
+}
+
+folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor(
+        const entity::VariantKey &key,
+        storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) override {
+    return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
+}
+
+folly::Future<bool> key_exists(const entity::VariantKey &key) override {
+    return async::submit_io_task(KeyExistsTask{&key, library_});
+}
+
+bool key_exists_sync(const entity::VariantKey &key) override {
+    return KeyExistsTask{&key, library_}();
+}
+
+bool supports_prefix_matching() const override {
+    return library_->supports_prefix_matching();
+}
+
+bool fast_delete() override {
+    return library_->fast_delete();
+}
+
+void move_storage(KeyType key_type, timestamp horizon, size_t storage_index) override {
+    library_->move_storage(key_type, horizon, storage_index);
+}
+
+folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair> kvs) override {
+    return async::submit_io_task(WriteCompressedBatchTask(std::move(kvs), library_));
+}
+
+folly::Future<RemoveKeyResultType> remove_key(const entity::VariantKey &key, storage::RemoveOpts opts) override {
+    return async::submit_io_task(RemoveTask{key, library_, opts});
+}
+
+RemoveKeyResultType remove_key_sync(const entity::VariantKey &key, storage::RemoveOpts opts) override {
+    return RemoveTask{key, library_, opts}();
+}
+
+folly::Future<std::vector<RemoveKeyResultType>> remove_keys(const std::vector<entity::VariantKey> &keys,
+                                                            storage::RemoveOpts opts) override {
+    return keys.empty() ?
+           std::vector<RemoveKeyResultType>() :
+           async::submit_io_task(RemoveBatchTask{keys, library_, opts});
+}
+
+folly::Future<std::vector<RemoveKeyResultType>> remove_keys(std::vector<entity::VariantKey> &&keys,
+                                                            storage::RemoveOpts opts) override {
+    return keys.empty() ?
+           std::vector<RemoveKeyResultType>() :
+           async::submit_io_task(RemoveBatchTask{std::move(keys), library_, opts});
+}
+
+folly::Future<std::vector<VariantKey>> batch_read_compressed(
+        std::vector<std::pair<entity::VariantKey, ReadContinuation>> &&keys_and_continuations,
+        const BatchReadArgs &args) override {
+    util::check(!keys_and_continuations.empty(), "Unexpected empty keys/continuation vector in batch_read_compressed");
+    return folly::collect(folly::window(std::move(keys_and_continuations), [this] (auto&& key_and_continuation) {
+        auto [key, continuation] = std::forward<decltype(key_and_continuation)>(key_and_continuation);
+        return read_and_continue(key, library_, storage::ReadKeyOpts{}, std::move(continuation));
+    }, args.batch_size_)).via(&async::io_executor());
+}
+
+std::vector<folly::Future<pipelines::SegmentAndSlice>> batch_read_uncompressed(
+        std::vector<pipelines::RangesAndKey>&& ranges_and_keys,
+        std::shared_ptr<std::unordered_set<std::string>> columns_to_decode) override {
+    return folly::window(
+        std::move(ranges_and_keys),
+        [this, columns_to_decode](auto&& ranges_and_key) {
+            const auto key = ranges_and_key.key_;
+            return read_and_continue(key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode});
+        }, async::TaskScheduler::instance()->io_thread_count() * 2);
+}
+
+std::vector<folly::Future<bool>> batch_key_exists(
+        const std::vector<entity::VariantKey> &keys) override {
+    std::vector<folly::Future<bool>> res;
+    res.reserve(keys.size());
+    for (auto itr = keys.cbegin(); itr < keys.cend(); ++itr) {
+        res.push_back(async::submit_io_task(KeyExistsTask(itr, library_)));
     }
+    return res;
+}
 
-    folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair &&ks) override {
-        return async::submit_io_task(WriteCompressedTask{std::move(ks), library_});
-    }
 
-    void write_compressed_sync(storage::KeySegmentPair &&ks) override {
-        library_->write(Composite<storage::KeySegmentPair>{std::move(ks)});
-    }
-
-    folly::Future<entity::VariantKey> update(const entity::VariantKey &key,
-                                             SegmentInMemory &&segment,
-                                             storage::UpdateOpts opts) override {
-        auto stream_id = variant_key_id(key);
-        util::check(segment.descriptor().id() == stream_id,
-                    "Descriptor id mismatch in variant key {} != {}",
-                    stream_id,
-                    segment.descriptor().id());
-
-        return async::submit_cpu_task(EncodeSegmentTask{
-            key, std::move(segment), codec_, encoding_version_
+    folly::Future<SliceAndKey> async_write(
+            folly::Future<std::tuple<PartialKey, SegmentInMemory, pipelines::FrameSlice>> &&input_fut,
+            const std::shared_ptr<DeDupMap> &de_dup_map) override {
+        using KeyOptSegment = std::pair<VariantKey, std::optional<Segment>>;
+        return std::move(input_fut).thenValue([this] (auto&& input) {
+            auto [key, seg, slice] = std::move(input);
+            auto key_seg = EncodeAtomTask{
+                std::move(key),
+                ClockType::nanos_since_epoch(),
+                std::move(seg),
+                codec_,
+                encoding_version_}();
+            return std::make_tuple<VariantKey, Segment, pipelines::FrameSlice>(std::move(key_seg.variant_key()), std::move(key_seg.segment()), std::move(slice));
         })
-            .via(&async::io_executor())
-            .thenValue(UpdateSegmentTask{library_, opts});
+        .thenValue([de_dup_map](auto &&ks) -> std::pair<KeyOptSegment, pipelines::FrameSlice> {
+            auto [key, seg, slice] = std::forward<decltype(ks)>(ks);
+            storage::KeySegmentPair key_seg{std::move(key), std::move(seg)};
+            return std::make_pair(lookup_match_in_dedup_map(de_dup_map, std::move(key_seg)), std::move(slice));
+        })
+        .via(&async::io_executor())
+        .thenValue([lib=library_](auto &&item) {
+            auto [key_opt_segment, slice] = std::forward<decltype(item)>(item);
+            if (key_opt_segment.second)
+                lib->write(Composite<storage::KeySegmentPair>({VariantKey{key_opt_segment.first},
+                                                               std::move(*key_opt_segment.second)}));
+
+            return SliceAndKey{slice, to_atom(key_opt_segment.first)};
+        });
     }
 
-    folly::Future<VariantKey> copy(
-            KeyType key_type,
-            const StreamId &stream_id,
-            VersionId version_id,
-            const VariantKey &source_key) override {
-        return async::submit_io_task(CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_});
-    }
-
-    VariantKey copy_sync(
-            KeyType key_type,
-            const StreamId &stream_id,
-            VersionId version_id,
-            const VariantKey &source_key) override {
-        return CopyCompressedTask<ClockType>{source_key, key_type, stream_id, version_id, library_}();
-    }
-
-    timestamp current_timestamp() override {
-        return ClockType::nanos_since_epoch();
-    }
-
-    void iterate_type(
-            KeyType type,
-            const entity::IterateTypeVisitor& func,
-            const std::string &prefix) override {
-        library_->iterate_type(type, func, prefix);
-    }
-
-    folly::Future<std::pair<entity::VariantKey, SegmentInMemory>> read(
-            const entity::VariantKey &key,
-            storage::ReadKeyOpts opts) override {
-        return read_and_continue(key, library_, opts, DecodeSegmentTask{});
-    }
-
-    std::pair<entity::VariantKey, SegmentInMemory> read_sync(const entity::VariantKey &key,
-                                                             storage::ReadKeyOpts opts) override {
-        return DecodeSegmentTask{}(read_dispatch(key, library_, opts));
-    }
-
-    folly::Future<storage::KeySegmentPair> read_compressed(
-            const entity::VariantKey &key,
-            storage::ReadKeyOpts opts) override {
-        return read_and_continue(key, library_, opts, PassThroughTask{});
-    }
-
-    folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {
-        return read_and_continue(key, library_, opts, DecodeMetadataTask{});
-    }
-
-    folly::Future<std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor>> read_metadata_and_descriptor(
-            const entity::VariantKey &key,
-            storage::ReadKeyOpts opts) override {
-        return read_and_continue(key, library_, opts, DecodeMetadataAndDescriptorTask{});
-    }
-
-    folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor(
-            const entity::VariantKey &key,
-            storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) override {
-        return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
-    }
-
-    folly::Future<bool> key_exists(const entity::VariantKey &key) override {
-        return async::submit_io_task(KeyExistsTask{&key, library_});
-    }
-
-    bool key_exists_sync(const entity::VariantKey &key) override {
-        return KeyExistsTask{&key, library_}();
-    }
-
-    bool supports_prefix_matching() const override {
-        return library_->supports_prefix_matching();
-    }
-
-    bool fast_delete() override {
-        return library_->fast_delete();
-    }
-
-    void move_storage(KeyType key_type, timestamp horizon, size_t storage_index) override {
-        library_->move_storage(key_type, horizon, storage_index);
-    }
-
-    folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair> kvs) override {
-        return async::submit_io_task(WriteCompressedBatchTask(std::move(kvs), library_));
-    }
-
-    folly::Future<RemoveKeyResultType> remove_key(const entity::VariantKey &key, storage::RemoveOpts opts) override {
-        return async::submit_io_task(RemoveTask{key, library_, opts});
-    }
-
-    RemoveKeyResultType remove_key_sync(const entity::VariantKey &key, storage::RemoveOpts opts) override {
-        return RemoveTask{key, library_, opts}();
-    }
-
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(const std::vector<entity::VariantKey> &keys,
-                                                                storage::RemoveOpts opts) override {
-        return keys.empty() ?
-               std::vector<RemoveKeyResultType>() :
-               async::submit_io_task(RemoveBatchTask{keys, library_, opts});
-    }
-
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(std::vector<entity::VariantKey> &&keys,
-                                                                storage::RemoveOpts opts) override {
-        return keys.empty() ?
-               std::vector<RemoveKeyResultType>() :
-               async::submit_io_task(RemoveBatchTask{std::move(keys), library_, opts});
-    }
-
-   folly::Future<std::vector<VariantKey>> batch_read_compressed(
-            std::vector<std::pair<entity::VariantKey, ReadContinuation>> &&keys_and_continuations,
-            const BatchReadArgs &args) override {
-        util::check(!keys_and_continuations.empty(), "Unexpected empty keys/continuation vector in batch_read_compressed");
-        return folly::collect(folly::window(std::move(keys_and_continuations), [this] (auto&& key_and_continuation) {
-            auto [key, continuation] = std::forward<decltype(key_and_continuation)>(key_and_continuation);
-            return read_and_continue(key, library_, storage::ReadKeyOpts{}, std::move(continuation));
-        }, args.batch_size_)).via(&async::io_executor());
-    }
-
-    std::vector<folly::Future<pipelines::SegmentAndSlice>> batch_read_uncompressed(
-            std::vector<pipelines::RangesAndKey>&& ranges_and_keys,
-            std::shared_ptr<std::unordered_set<std::string>> columns_to_decode) override {
-        return folly::window(
-            std::move(ranges_and_keys),
-            [this, columns_to_decode](auto&& ranges_and_key) {
-                const auto key = ranges_and_key.key_;
-                return read_and_continue(key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode});
-            }, async::TaskScheduler::instance()->io_thread_count() * 2);
-    }
-
-    std::vector<folly::Future<bool>> batch_key_exists(
-            const std::vector<entity::VariantKey> &keys) override {
-        std::vector<folly::Future<bool>> res;
-        res.reserve(keys.size());
-        for (auto itr = keys.cbegin(); itr < keys.cend(); ++itr) {
-            res.push_back(async::submit_io_task(KeyExistsTask(itr, library_)));
-        }
-        return res;
-    }
-
-    folly::Future<std::vector<VariantKey>> batch_write(
-        std::vector<std::pair<PartialKey, SegmentInMemory>> &&key_seg_pairs,
-        const std::shared_ptr<DeDupMap> &de_dup_map,
-        const BatchWriteArgs &args) override {
-        auto key_segments = std::move(key_seg_pairs);
-        std::vector<folly::Future<VariantKey>> futs;
-        futs.reserve(key_seg_pairs.size());
-        std::size_t write_count = args.lib_write_count == 0 ? 16ULL : args.lib_write_count;
-
-        auto encode_futs = folly::window(key_segments, [*this](auto &&ks) {
-            auto [key, seg] = std::forward<decltype(ks)>(ks);
-            return async::submit_cpu_task(
-                EncodeAtomTask(std::move(key),
-                               ClockType::nanos_since_epoch(),
-                               std::move(seg),
-                               codec_,
-                               encoding_version_));
-        }, write_count);
-
-        for (folly::Future<storage::KeySegmentPair>& encode_fut : encode_futs) {
-            futs.emplace_back(
-                std::move(encode_fut).thenValue([de_dup_map](auto &&ks) -> std::pair<VariantKey, std::optional<Segment>> {
-                        auto key_seg = std::forward<decltype(ks)>(ks);
-                        return lookup_match_in_dedup_map(de_dup_map, std::move(key_seg));
-                    })
-                    .via(&async::io_executor()).thenValue([lib = library_](auto &&item) {
-                        auto key_opt_segment = std::forward<decltype(item)>(item);
-                        if (key_opt_segment.second)
-                            lib->write(Composite<storage::KeySegmentPair>({VariantKey{key_opt_segment.first},
-                                                                           std::move(*key_opt_segment.second)}));
-
-                        return key_opt_segment.first;
-                    }));
-        }
-
-        return folly::collect(futs).via(&async::io_executor());
-    }
-
-    void set_failure_sim(
-        const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &cfg) override {
+    void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &cfg) override {
         library_->set_failure_sim(cfg);
     }
 

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -317,11 +317,10 @@ std::vector<folly::Future<bool>> batch_key_exists(
                 std::move(seg),
                 codec_,
                 encoding_version_}();
-            return std::make_tuple<VariantKey, Segment, pipelines::FrameSlice>(std::move(key_seg.variant_key()), std::move(key_seg.segment()), std::move(slice));
+            return std::pair<storage::KeySegmentPair, FrameSlice>(std::move(key_seg), std::move(slice));
         })
         .thenValue([de_dup_map](auto &&ks) -> std::pair<KeyOptSegment, pipelines::FrameSlice> {
-            auto [key, seg, slice] = std::forward<decltype(ks)>(ks);
-            storage::KeySegmentPair key_seg{std::move(key), std::move(seg)};
+            auto [key_seg, slice] = std::forward<decltype(ks)>(ks);
             return std::make_pair(lookup_match_in_dedup_map(de_dup_map, std::move(key_seg)), std::move(slice));
         })
         .via(&async::io_executor())

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -39,16 +39,30 @@ struct EncodeAtomTask : BaseTask {
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta_;
     EncodingVersion encoding_version_;
 
-    EncodeAtomTask(PartialKey &&pk,
-                   timestamp creation_ts,
-                   SegmentInMemory &&segment,
-                   std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
-                   EncodingVersion encoding_version)
-        : partial_key_(std::move(pk)),
-          creation_ts_(creation_ts),
-          segment_(std::move(segment)),
-          codec_meta_(std::move(codec_meta)),
-          encoding_version_(encoding_version){}
+    EncodeAtomTask(
+        PartialKey &&pk,
+        timestamp creation_ts,
+        SegmentInMemory &&segment,
+        std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
+        EncodingVersion encoding_version) :
+            partial_key_(std::move(pk)),
+            creation_ts_(creation_ts),
+            segment_(std::move(segment)),
+            codec_meta_(std::move(codec_meta)),
+            encoding_version_(encoding_version) {
+    }
+
+    EncodeAtomTask(
+        std::pair<PartialKey, SegmentInMemory>&& pk_seg,
+        timestamp creation_ts,
+        std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_meta,
+        EncodingVersion encoding_version) :
+            partial_key_(std::move(pk_seg.first)),
+            creation_ts_(creation_ts),
+            segment_(std::move(pk_seg.second)),
+            codec_meta_(std::move(codec_meta)),
+            encoding_version_(encoding_version) {
+    }
 
     EncodeAtomTask(
         KeyType key_type,
@@ -59,11 +73,13 @@ struct EncodeAtomTask : BaseTask {
         timestamp creation_ts,
         SegmentInMemory &&segment,
         const std::shared_ptr<arcticdb::proto::encoding::VariantCodec> &codec_meta,
-        EncodingVersion encoding_version
-    )
-        : EncodeAtomTask(PartialKey{key_type, gen_id, std::move(stream_id), std::move(start_index),
-                                    std::move(end_index)}, creation_ts,
-                         std::move(segment), codec_meta, encoding_version) {
+        EncodingVersion encoding_version) :
+            EncodeAtomTask(
+                PartialKey{key_type, gen_id, std::move(stream_id), std::move(start_index), std::move(end_index)},
+                creation_ts,
+                std::move(segment),
+                codec_meta,
+                encoding_version) {
     }
 
     ARCTICDB_MOVE_ONLY_DEFAULT(EncodeAtomTask)

--- a/cpp/arcticdb/entity/performance_tracing.hpp
+++ b/cpp/arcticdb/entity/performance_tracing.hpp
@@ -13,6 +13,8 @@
 
 #include <memory>
 
+//#define ARCTICDB_LOG_PERFORMANCE
+
 #define ARCTICDB_RUNTIME_SAMPLE(name, flags) \
 static bool _scoped_timer_active_ = ConfigsMap::instance()->get_int("Logging.timings", 0) == 1 || ConfigsMap::instance()->get_int("Logging.ALL", 0) == 1; \
 arcticdb::ScopedTimer runtime_timer = !_scoped_timer_active_ ? arcticdb::ScopedTimer() : arcticdb::ScopedTimer(#name, [](auto msg) { \

--- a/cpp/arcticdb/pipeline/frame_slice.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice.hpp
@@ -10,6 +10,7 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/util/magic_num.hpp>
 
 namespace arcticdb {
     class Store;
@@ -159,12 +160,17 @@ struct FrameSlice {
         return a.row_range == b.row_range && a.col_range == b.col_range;
     }
 
+    void check_magic() const {
+        magic_.check();
+    }
+
 private:
     // never contains index field
     std::shared_ptr<entity::StreamDescriptor> desc_;
     std::optional<uint64_t> hash_bucket_;
     std::optional<uint64_t> num_buckets_;
     std::optional<std::vector<size_t>> indices_;
+    util::MagicNum<'F', 's', 'l', 'c'> magic_;
 };
 
 // Collection of these objects is the input to batch_read_uncompressed

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -75,19 +75,19 @@ TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
 }
 
 TimeseriesDescriptor index_descriptor_from_frame(
-        pipelines::InputTensorFrame&& frame,
+        const std::shared_ptr<pipelines::InputTensorFrame>& frame,
         size_t existing_rows,
         std::optional<entity::AtomKey>&& prev_key
 ) {
     return make_timeseries_descriptor(
-        frame.num_rows + existing_rows,
-        StreamDescriptor{std::make_shared<StreamDescriptor::Proto>(std::move(frame.desc.mutable_proto())),
-           frame.desc.fields_ptr()},
-        std::move(frame.norm_meta),
-        std::move(frame.user_meta),
+        frame->num_rows + existing_rows,
+        StreamDescriptor{std::make_shared<StreamDescriptor::Proto>(std::move(frame->desc.mutable_proto())),
+           frame->desc.fields_ptr()},
+        std::move(frame->norm_meta),
+        std::move(frame->user_meta),
         std::move(prev_key),
         std::nullopt,
-        frame.bucketize_dynamic);
+        frame->bucketize_dynamic);
 }
 
 void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& pipeline_context) {

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -71,7 +71,7 @@ TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
 
 
 TimeseriesDescriptor index_descriptor_from_frame(
-    pipelines::InputTensorFrame&& frame,
+    const std::shared_ptr<pipelines::InputTensorFrame>& frame,
     size_t existing_rows,
     std::optional<entity::AtomKey>&& prev_key = {});
 

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -101,14 +101,14 @@ folly::Future<entity::AtomKey> write_index(
     const std::shared_ptr<stream::StreamSink> &sink);
 
 folly::Future<entity::AtomKey> write_index(
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     std::vector<folly::Future<SliceAndKey>> &&slice_and_keys,
     const IndexPartialKey &partial_key,
     const std::shared_ptr<stream::StreamSink> &sink
     );
 
 folly::Future<entity::AtomKey> write_index(
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     std::vector<SliceAndKey> &&slice_and_keys,
     const IndexPartialKey &partial_key,
     const std::shared_ptr<stream::StreamSink> &sink

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -59,6 +59,8 @@ struct InputTensorFrame {
 
     bool has_index() const { return desc.index().field_count() != 0ULL; }
 
+    bool empty() const { return num_rows == 0; }
+
     void set_index_range() {
         // Fill index range
         // Note RowCountIndex will normally have an index field count of 0

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -33,130 +33,183 @@ namespace arcticdb::pipelines {
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;
 
-folly::Future<std::vector<SliceAndKey>> write_slices(
-        const InputTensorFrame &frame,
-        std::vector<FrameSlice>&& slices,
-        const SlicingPolicy &slicing,
-        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
-        const std::shared_ptr<stream::StreamSink>& sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map,
-        bool sparsify_floats) {
-    ARCTICDB_SAMPLE(WriteSlices, 0)
-    std::vector<std::pair<stream::StreamSink::PartialKey, SegmentInMemory>> key_segs;
-    key_segs.reserve(slices.size());
+struct WriteToSegmentTask : public async::BaseTask {
 
-    std::vector<std::vector<folly::Future<VariantKey>>> key_groups;
+    std::shared_ptr<InputTensorFrame> frame_;
+    const FrameSlice slice_;
+    const SlicingPolicy slicing_;
+    folly::Function<stream::StreamSink::PartialKey(const FrameSlice&)> partial_key_gen_;
+    size_t slice_num_for_column_;
+    Index index_;
+    bool sparsify_floats_;
+    util::MagicNum<'W', 's', 'e', 'g'> magic_;
 
-    // construct batch
-    util::variant_match(frame.index, [&](auto &idx) {
-        using IdxType = std::decay_t<decltype(idx)>;
-        using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
+    WriteToSegmentTask(
+        std::shared_ptr<InputTensorFrame> frame,
+        FrameSlice slice,
+        const SlicingPolicy& slicing,
+        folly::Function<stream::StreamSink::PartialKey(const FrameSlice&)>&& partial_key_gen,
+        size_t slice_num_for_column,
+        Index index,
+        bool sparsify_floats
+        ) :
+        frame_(std::move(frame)),
+        slice_(std::move(slice)),
+        slicing_(slicing),
+        partial_key_gen_(std::move(partial_key_gen)),
+        slice_num_for_column_(slice_num_for_column),
+        index_(std::move(index)),
+        sparsify_floats_(sparsify_floats) {
+        slice_.check_magic();
+    }
 
-        size_t slice_num_for_column = 0;
-        std::optional<size_t> first_row;
-        for (const FrameSlice &slice : slices) {
-            // Build in mem segment
+    std::tuple<stream::StreamSink::PartialKey, SegmentInMemory, FrameSlice> operator() () {
+        slice_.check_magic();
+        magic_.check();
+        return util::variant_match(index_, [this](auto& idx) {
+            using IdxType = std::decay_t<decltype(idx)>;
+            using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
+
             ARCTICDB_SUBSAMPLE_AGG(WriteSliceCopyToSegment)
-            if(!first_row)
-                first_row = slice.row_range.first;
+            std::tuple<stream::StreamSink::PartialKey, SegmentInMemory, FrameSlice> output;
 
-            if(slice.row_range.first == *first_row)
-                slice_num_for_column = 0;
-
-            SingleSegmentAggregator agg{FixedSchema{*slice.desc(), frame.index}, [&](auto &&segment) {
-                auto key = partial_key_gen(slice);
-                key_segs.emplace_back(partial_key_gen(slice), std::forward<SegmentInMemory>(segment));
+            auto key = partial_key_gen_(slice_);
+            SingleSegmentAggregator agg{FixedSchema{*slice_.desc(), frame_->index}, [key=std::move(key), slice=slice_, &output](auto&& segment) {
+                output = std::make_tuple(key, std::forward<SegmentInMemory>(segment), slice);
             }};
 
-            auto regular_slice_size = util::variant_match(slicing,
+            auto regular_slice_size = util::variant_match(slicing_,
+                [&](const NoSlicing&) {
+                    return slice_.row_range.second - slice_.row_range.first;
+                },
+                [&](const auto& slicer) {
+                    return slicer.row_per_slice();
+                });
 
-              [&](const NoSlicing &) {
-                  return slice.row_range.second - slice.row_range.first;
-              },
-              [&](const auto &slicer) {
-                return slicer.row_per_slice();
-              });
-
-            auto offset_in_frame = slice_begin_pos(slice, frame);
             // Offset is used for index value in row-count index
+            auto offset_in_frame = slice_begin_pos(slice_, *frame_);
             agg.set_offset(offset_in_frame);
-            auto rows_to_write = slice.row_range.second - slice.row_range.first;
-            if (frame.desc.index().field_count() > 0) {
-                util::check(static_cast<bool>(frame.index_tensor), "Got null index tensor in write_slices");
+
+            auto rows_to_write = slice_.row_range.second - slice_.row_range.first;
+            if (frame_->desc.index().field_count() > 0) {
+                util::check(static_cast<bool>(frame_->index_tensor), "Got null index tensor in write_slices");
                 auto opt_error = aggregator_set_data(
-                    frame.desc.fields(0).type(),
-                    frame.index_tensor.value(),
-                    agg, 0, rows_to_write, offset_in_frame, slice_num_for_column, regular_slice_size, false);
+                    frame_->desc.fields(0).type(),
+                    frame_->index_tensor.value(),
+                    agg, 0, rows_to_write, offset_in_frame, slice_num_for_column_, regular_slice_size, false);
                 if (opt_error.has_value()) {
-                    opt_error->raise(frame.desc.fields(0).name(), offset_in_frame);
+                    opt_error->raise(frame_->desc.fields(0).name(), offset_in_frame);
                 }
             }
 
-            for (size_t col = 0, end = slice.col_range.diff(); col < end; ++col) {
-                auto abs_col = col + frame.desc.index().field_count();
-                auto &fd = slice.non_index_field(col);
-                auto &tensor = frame.field_tensors[slice.absolute_field_col(col)];
+            for (size_t col = 0, end = slice_.col_range.diff(); col < end; ++col) {
+                auto abs_col = col + frame_->desc.index().field_count();
+                auto& fd = slice_.non_index_field(col);
+                auto& tensor = frame_->field_tensors[slice_.absolute_field_col(col)];
                 auto opt_error = aggregator_set_data(
                     fd.type(),
-                    tensor, agg, abs_col, rows_to_write, offset_in_frame, slice_num_for_column,
-                    regular_slice_size, sparsify_floats);
+                    tensor, agg, abs_col, rows_to_write, offset_in_frame, slice_num_for_column_,
+                    regular_slice_size, sparsify_floats_);
                 if (opt_error.has_value()) {
                     opt_error->raise(fd.name(), offset_in_frame);
                 }
             }
 
-            ++slice_num_for_column;
             agg.end_block_write(rows_to_write);
             agg.commit();
-        }
-    });
+            return output;
+        });
+    }
+};
 
-    auto fut_writes = sink->batch_write(std::move(key_segs), de_dup_map);
+folly::Future<std::vector<SliceAndKey>> write_slices(
+        const std::shared_ptr<InputTensorFrame> &frame,
+        std::vector<FrameSlice>&& slices,
+        const SlicingPolicy &slicing,
+        IndexPartialKey&& key,
+        const std::shared_ptr<stream::StreamSink>& sink,
+        const std::shared_ptr<DeDupMap>& de_dup_map,
+        bool sparsify_floats) {
+    ARCTICDB_SAMPLE(WriteSlices, 0)
 
-    ARCTICDB_SUBSAMPLE_DEFAULT(WriteSlicesWait)
-    return std::move(fut_writes).thenValue([slices = std::move(slices)](auto &&keys) mutable {
-        std::vector<SliceAndKey> res;
-        res.reserve(keys.size());
-        for (std::size_t i = 0; i < res.capacity(); ++i) {
-            res.emplace_back(SliceAndKey{slices[i], std::move(to_atom(keys[i]))});
-        }
-        return res;
-    });
+    std::vector<std::pair<FrameSlice, size_t>> slice_and_rowcount;
+    slice_and_rowcount.reserve(slices.size());
+    size_t slice_num_for_column = 0;
+    std::optional<size_t> first_row;
+    for(const auto& slice : slices) {
+        if (!first_row)
+            first_row = slice.row_range.first;
+
+        if (slice.row_range.first == first_row.value())
+            slice_num_for_column = 0;
+
+        slice_and_rowcount.emplace_back(slice, slice_num_for_column);
+        ++slice_num_for_column;
+    }
+
+    const auto write_window = ConfigsMap::instance()->get_int("VersionStore.BatchWriteWindow", 50);
+    return folly::collect(folly::window(std::move(slice_and_rowcount), [de_dup_map, frame, slicing, key=std::move(key), sink, sparsify_floats](auto&& slice) {
+            return async::submit_cpu_task(WriteToSegmentTask(
+                frame,
+                slice.first,
+                slicing,
+                get_partial_key_gen(frame, key),
+                slice.second,
+                frame->index,
+                sparsify_floats))
+            .then([sink, de_dup_map] (auto&& ks) {
+                return sink->async_write(ks, de_dup_map);
+            });
+    }, write_window)).via(&async::io_executor());
+}
+
+folly::Future<entity::VariantKey> write_multi_index(
+        const std::shared_ptr<InputTensorFrame>& frame,
+        std::vector<SliceAndKey>&& slice_and_keys,
+        const IndexPartialKey& partial_key,
+        const std::shared_ptr<stream::StreamSink>& sink
+) {
+    auto timeseries_desc = index_descriptor_from_frame(frame, frame->offset);
+    index::IndexWriter<stream::RowCountIndex> writer(sink, partial_key, std::move(timeseries_desc));
+    for (auto &slice_and_key : slice_and_keys) {
+        writer.add(slice_and_key.key(), slice_and_key.slice_);
+    }
+    return writer.commit();
 }
 
 folly::Future<std::vector<SliceAndKey>> slice_and_write(
-        InputTensorFrame &frame,
+        const std::shared_ptr<InputTensorFrame> &frame,
         const SlicingPolicy &slicing,
-        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
+        IndexPartialKey&& key,
         const std::shared_ptr<stream::StreamSink>& sink,
         const std::shared_ptr<DeDupMap>& de_dup_map,
         bool sparsify_floats) {
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceFrame)
-    auto slices = slice(frame, slicing);
+    auto slices = slice(*frame, slicing);
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
-    return write_slices(frame, std::move(slices), slicing, std::move(partial_key_gen), sink, de_dup_map, sparsify_floats);
+    return write_slices(frame, std::move(slices), slicing, std::move(key), sink, de_dup_map, sparsify_floats);
 }
 
 folly::Future<entity::AtomKey>
 write_frame(
         IndexPartialKey&& key,
-        InputTensorFrame&& frame,
+        const std::shared_ptr<InputTensorFrame>& frame,
         const SlicingPolicy &slicing,
         const std::shared_ptr<Store>& store,
         const std::shared_ptr<DeDupMap>& de_dup_map,
         bool sparsify_floats) {
     ARCTICDB_SAMPLE_DEFAULT(WriteFrame)
-    auto fut_slice_keys = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store, de_dup_map, sparsify_floats);
+    auto fut_slice_keys = slice_and_write(frame, slicing, IndexPartialKey{key}, store, de_dup_map, sparsify_floats);
     // Write the keys of the slices into an index segment
     ARCTICDB_SUBSAMPLE_DEFAULT(WriteIndex)
-    return std::move(fut_slice_keys).thenValue([frame = std::move(frame), key = std::move(key), &store](auto&& slice_keys) mutable {
-        return index::write_index(std::move(frame), std::forward<decltype(slice_keys)>(slice_keys), key, store);
+    return std::move(fut_slice_keys).thenValue([frame=frame, key = std::move(key), &store](auto&& slice_keys) mutable {
+        return index::write_index(frame, std::forward<decltype(slice_keys)>(slice_keys), key, store);
     });
 }
 
 folly::Future<entity::AtomKey> append_frame(
-        const IndexPartialKey& key,
-        InputTensorFrame&& frame,
+        IndexPartialKey&& key,
+        const std::shared_ptr<InputTensorFrame>& frame,
         const SlicingPolicy& slicing,
         index::IndexSegmentReader& index_segment_reader,
         const std::shared_ptr<Store>& store,
@@ -164,11 +217,11 @@ folly::Future<entity::AtomKey> append_frame(
         bool ignore_sort_order)
 {
     ARCTICDB_SAMPLE_DEFAULT(AppendFrame)
-    util::variant_match(frame.index,
+    util::variant_match(frame->index,
                         [&index_segment_reader, &frame, ignore_sort_order](const TimeseriesIndex &) {
-                            util::check(frame.has_index(), "Cannot append timeseries without index");
-                            util::check(static_cast<bool>(frame.index_tensor), "Got null index tensor in append_frame");
-                            auto& frame_index = frame.index_tensor.value();
+                            util::check(frame->has_index(), "Cannot append timeseries without index");
+                            util::check(static_cast<bool>(frame->index_tensor), "Got null index tensor in append_frame");
+                            auto& frame_index = frame->index_tensor.value();
                             util::check(frame_index.data_type() == DataType::NANOSECONDS_UTC64,
                                         "Expected timestamp index in append, got type {}", frame_index.data_type());
                             if (index_segment_reader.tsd().proto().total_rows() != 0 && frame_index.size() != 0) {
@@ -185,21 +238,21 @@ folly::Future<entity::AtomKey> append_frame(
     );
 
     auto existing_slices = unfiltered_index(index_segment_reader);
-    auto keys_fut = slice_and_write(frame, slicing, get_partial_key_gen(frame, key), store);
+    auto keys_fut = slice_and_write(frame, slicing, IndexPartialKey{key}, store);
     return std::move(keys_fut)
-    .thenValue([dynamic_schema, slices_to_write = std::move(existing_slices), frame = std::move(frame), index_segment_reader = std::move(index_segment_reader), key = key, &store](auto&& slice_and_keys_to_append) mutable {
+    .thenValue([dynamic_schema, slices_to_write=std::move(existing_slices), frame=frame, index_segment_reader=std::move(index_segment_reader), key=std::move(key), store](auto&& slice_and_keys_to_append) mutable {
         slices_to_write.insert(std::end(slices_to_write), std::make_move_iterator(std::begin(slice_and_keys_to_append)), std::make_move_iterator(std::end(slice_and_keys_to_append)));
         std::sort(std::begin(slices_to_write), std::end(slices_to_write));
         if(dynamic_schema) {
             auto merged_descriptor =
-                merge_descriptors(frame.desc, std::vector< std::shared_ptr<FieldCollection>>{ index_segment_reader.tsd().fields_ptr()}, {});
-            merged_descriptor.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame.desc.get_sorted()));
+                merge_descriptors(frame->desc, std::vector< std::shared_ptr<FieldCollection>>{ index_segment_reader.tsd().fields_ptr()}, {});
+            merged_descriptor.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame->desc.get_sorted()));
             auto tsd =
-                make_timeseries_descriptor(frame.num_rows + frame.offset, std::move(merged_descriptor), std::move(frame.norm_meta), std::move(frame.user_meta), std::nullopt, std::nullopt, frame.bucketize_dynamic);
-            return index::write_index(stream::index_type_from_descriptor(frame.desc), std::move(tsd), std::move(slices_to_write), key, store);
+                make_timeseries_descriptor(frame->num_rows + frame->offset, std::move(merged_descriptor), std::move(frame->norm_meta), std::move(frame->user_meta), std::nullopt, std::nullopt, frame->bucketize_dynamic);
+            return index::write_index(stream::index_type_from_descriptor(frame->desc), std::move(tsd), std::move(slices_to_write), key, store);
         } else {
-            frame.desc.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame.desc.get_sorted()));
-            return index::write_index(std::move(frame), std::move(slices_to_write), key, store);
+            frame->desc.set_sorted(deduce_sorted(index_segment_reader.get_sorted(), frame->desc.get_sorted()));
+            return index::write_index(frame, std::move(slices_to_write), key, store);
         }
     });
 }

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -147,7 +147,7 @@ folly::Future<std::vector<SliceAndKey>> write_slices(
         ++slice_num_for_column;
     }
 
-    const auto write_window = ConfigsMap::instance()->get_int("VersionStore.BatchWriteWindow", 50);
+    const auto write_window = ConfigsMap::instance()->get_int("VersionStore.BatchWriteWindow", 2 * async::TaskScheduler::instance()->io_thread_count());
     return folly::collect(folly::window(std::move(slice_and_rowcount), [de_dup_map, frame, slicing, key=std::move(key), sink, sparsify_floats](auto&& slice) {
             return async::submit_cpu_task(WriteToSegmentTask(
                 frame,

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -27,26 +27,26 @@ namespace arcticdb::pipelines {
 using namespace arcticdb::stream;
 
 folly::Future<std::vector<SliceAndKey>> slice_and_write(
-        InputTensorFrame &frame,
+        const std::shared_ptr<InputTensorFrame> &frame,
         const SlicingPolicy &slicing,
-        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)> &&partial_key_gen,
+        IndexPartialKey&& partial_key,
         const std::shared_ptr<stream::StreamSink> &sink,
         const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
         bool allow_sparse = false
 );
 
 folly::Future<std::vector<SliceAndKey>> write_slices(
-        const InputTensorFrame &frame,
+        const std::shared_ptr<InputTensorFrame> &frame,
         std::vector<FrameSlice>&& slices,
         const SlicingPolicy &slicing,
-        folly::Function<stream::StreamSink::PartialKey(const FrameSlice &)>&& partial_key_gen,
+        IndexPartialKey&& partial_key,
         const std::shared_ptr<stream::StreamSink>& sink,
         const std::shared_ptr<DeDupMap>& de_dup_map,
         bool sparsify_floats);
 
 folly::Future<entity::AtomKey> write_frame(
     IndexPartialKey &&key,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const SlicingPolicy &slicing,
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
@@ -54,8 +54,8 @@ folly::Future<entity::AtomKey> write_frame(
 );
 
 folly::Future<entity::AtomKey> append_frame(
-        const IndexPartialKey& key,
-        InputTensorFrame&& frame,
+        IndexPartialKey&& key,
+        const std::shared_ptr<InputTensorFrame>& frame,
         const SlicingPolicy& slicing,
         index::IndexSegmentReader &index_segment_reader,
         const std::shared_ptr<Store>& store,

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -153,7 +153,6 @@ NativeTensor obj_to_tensor(PyObject *ptr) {
                 empty = true;
                 all_nans = true;
                 util::check(c_style, "Non contiguous columns with first element as None not supported yet.");
-                PyObject** current_object = obj;
                 const auto* end = obj + size;
                 while(current_object < end) {
 
@@ -196,18 +195,18 @@ NativeTensor obj_to_tensor(PyObject *ptr) {
     return {nbytes, arr->nd, strides.data(), shapes.data(), dt, descr->elsize, data, ndim};
 }
 
-InputTensorFrame py_ndf_to_frame(
+std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
     const StreamId& stream_name,
     const py::tuple &item,
     const py::object &norm_meta,
     const py::object &user_meta) {
     ARCTICDB_SUBSAMPLE_DEFAULT(NormalizeFrame)
-    InputTensorFrame res;
-    res.desc.set_id(stream_name);
-    res.num_rows = 0u;
-    python_util::pb_from_python(norm_meta, res.norm_meta);
+    auto res = std::make_shared<InputTensorFrame>();
+    res->desc.set_id(stream_name);
+    res->num_rows = 0u;
+    python_util::pb_from_python(norm_meta, res->norm_meta);
     if (!user_meta.is_none())
-        python_util::pb_from_python(user_meta, res.user_meta);
+        python_util::pb_from_python(user_meta, res->user_meta);
 
     // Fill index
     auto idx_names = item[0].cast<std::vector<std::string>>();
@@ -217,30 +216,29 @@ InputTensorFrame py_ndf_to_frame(
                 idx_names.size(), idx_vals.size());
 
     if (idx_names.empty()) {
-        res.index = stream::RowCountIndex();
-        res.desc.set_index_type(IndexDescriptor::ROWCOUNT);
+        res->index = stream::RowCountIndex();
+        res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
     } else {
         util::check(idx_names.size() == 1, "Multi-indexed dataframes not handled");
         auto index_tensor = obj_to_tensor(idx_vals[0].ptr());
         util::check(index_tensor.ndim() == 1, "Multi-dimensional indexes not handled");
         util::check(index_tensor.shape() != nullptr, "Index tensor expected to contain shapes");
         std::string index_column_name = !idx_names.empty() ? idx_names[0] : "index";
-        res.num_rows = index_tensor.shape(0);
+        res->num_rows = index_tensor.shape(0);
         //TODO handle string indexes
         if (index_tensor.data_type() == DataType::NANOSECONDS_UTC64) {
 
-            res.desc.set_index_field_count(1);
-            res.desc.set_index_type(IndexDescriptor::TIMESTAMP);
+            res->desc.set_index_field_count(1);
+            res->desc.set_index_type(IndexDescriptor::TIMESTAMP);
 
-            res.desc.add_scalar_field(index_tensor.dt_, index_column_name);
-            res.index = stream::TimeseriesIndex(index_column_name);
-            res.index_tensor = std::move(index_tensor);
+            res->desc.add_scalar_field(index_tensor.dt_, index_column_name);
+            res->index = stream::TimeseriesIndex(index_column_name);
+            res->index_tensor = std::move(index_tensor);
         } else {
-            // Just treat this field as a simple field, since we can't really handle it
-            res.index = stream::RowCountIndex();
-            res.desc.set_index_type(IndexDescriptor::ROWCOUNT);
-            res.desc.add_scalar_field(index_tensor.dt_, index_column_name);
-            res.field_tensors.push_back(std::move(index_tensor));
+            res->index = stream::RowCountIndex();
+            res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
+            res->desc.add_scalar_field(index_tensor.dt_, index_column_name);
+            res->field_tensors.push_back(std::move(index_tensor));
         }
     }
 
@@ -249,54 +247,54 @@ InputTensorFrame py_ndf_to_frame(
     auto col_vals = item[3].cast<std::vector<py::object>>();
     auto sorted = item[4].cast<SortedValue>();
 
-    res.set_sorted(sorted);
+    res->set_sorted(sorted);
 
     for (auto i = 0u; i < col_vals.size(); ++i) {
         auto tensor = obj_to_tensor(col_vals[i].ptr());
-        res.num_rows = std::max(res.num_rows, static_cast<ssize_t>(tensor.shape(0)));
+        res->num_rows = std::max(res->num_rows, static_cast<ssize_t>(tensor.shape(0)));
         if(tensor.expanded_dim() == 1) {
-            res.desc.add_field(scalar_field(tensor.data_type(), col_names[i]));
+            res->desc.add_field(scalar_field(tensor.data_type(), col_names[i]));
         } else if(tensor.expanded_dim() == 2) {
-            res.desc.add_field(FieldRef{TypeDescriptor{tensor.data_type(), Dimension::Dim1}, col_names[i]});
+            res->desc.add_field(FieldRef{TypeDescriptor{tensor.data_type(), Dimension::Dim1}, col_names[i]});
         }
-        res.field_tensors.push_back(std::move(tensor));
+        res->field_tensors.push_back(std::move(tensor));
     }
 
-    ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res.desc);
-    res.set_index_range();
+    ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res->desc);
+    res->set_index_range();
     return res;
 }
 
-InputTensorFrame py_none_to_frame() {
+std::shared_ptr<InputTensorFrame> py_none_to_frame() {
     ARCTICDB_SUBSAMPLE_DEFAULT(NormalizeNoneFrame)
-    InputTensorFrame res;
-    res.num_rows = 0u;
+    auto res = std::make_shared<InputTensorFrame>();
+    res->num_rows = 0u;
 
     arcticdb::proto::descriptors::NormalizationMetadata::MsgPackFrame msg;
     msg.set_size_bytes(1);
     msg.set_version(1);
-    res.norm_meta.mutable_msg_pack_frame()->CopyFrom(msg);
+    res->norm_meta.mutable_msg_pack_frame()->CopyFrom(msg);
 
     // Fill index
-    res.index = stream::RowCountIndex();
-    res.desc.set_index_type(IndexDescriptor::ROWCOUNT);
+    res->index = stream::RowCountIndex();
+    res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
 
     // Fill tensors
     auto col_name = "bytes";
     auto sorted = SortedValue::UNKNOWN;
 
-    res.set_sorted(sorted);
+    res->set_sorted(sorted);
 
     const stride_t strides = 8;
     const shape_t shapes = 1;
     constexpr int ndim = 1;
     auto tensor = NativeTensor{8, ndim, &strides, &shapes, DataType::UINT64, 8, none_char, ndim};
-    res.num_rows = std::max(res.num_rows, static_cast<ssize_t>(tensor.shape(0)));
-    res.desc.add_field(scalar_field(tensor.data_type(), col_name));
-    res.field_tensors.push_back(std::move(tensor));
+    res->num_rows = std::max(res->num_rows, static_cast<ssize_t>(tensor.shape(0)));
+    res->desc.add_field(scalar_field(tensor.data_type(), col_name));
+    res->field_tensors.push_back(std::move(tensor));
 
-    ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res.desc);
-    res.set_index_range();
+    ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res->desc);
+    res->set_index_range();
     return res;
 }
 

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -82,12 +82,12 @@ std::variant<StringEncodingError, PyStringWrapper> py_unicode_to_buffer(
 
 NativeTensor obj_to_tensor(PyObject *ptr);
 
-pipelines::InputTensorFrame py_ndf_to_frame(
+std::shared_ptr<pipelines::InputTensorFrame> py_ndf_to_frame(
     const StreamId& stream_name,
     const py::tuple &item,
     const py::object &norm_meta,
     const py::object &user_meta);
 
-pipelines::InputTensorFrame py_none_to_frame();
+std::shared_ptr<pipelines::InputTensorFrame> py_none_to_frame();
 
 } // namespace arcticdb::convert

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -55,6 +55,19 @@ namespace arcticdb {
             throw std::runtime_error("Not implemented for tests");
         }
 
+
+        AtomKey get_key(
+            stream::KeyType key_type,
+            VersionId gen_id,
+            const StreamId& stream_id,
+            IndexValue start_index,
+            IndexValue end_index,
+            std::optional<timestamp> creation_ts = std::nullopt
+        ) {
+            return atom_key_builder().gen_id(gen_id).content_hash(content_hash_).creation_ts(creation_ts.value_or(PilotedClock::nanos_since_epoch()))
+                .start_index(start_index).end_index(end_index).build(stream_id, key_type);
+        }
+
         folly::Future<VariantKey> write(
                 KeyType key_type,
                 VersionId gen_id,
@@ -63,8 +76,7 @@ namespace arcticdb {
                 IndexValue end_index,
                 SegmentInMemory &&segment
         ) override {
-            auto key = atom_key_builder().gen_id(gen_id).content_hash(content_hash_).creation_ts(PilotedClock::nanos_since_epoch())
-                    .start_index(start_index).end_index(end_index).build(stream_id, key_type);
+            auto key = get_key(key_type, gen_id, stream_id, start_index, end_index);
             add_segment(key, std::move(segment));
             ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
             return folly::makeFuture(key);
@@ -79,8 +91,7 @@ namespace arcticdb {
                 IndexValue end_index,
                 SegmentInMemory &&segment
         ) override {
-            auto key = atom_key_builder().gen_id(gen_id).content_hash(content_hash_).creation_ts(creation_ts)
-                    .start_index(start_index).end_index(end_index).build(stream_id, key_type);
+            auto key = get_key(key_type, gen_id, stream_id, start_index, end_index, creation_ts);
             add_segment(key, std::move(segment));
             ARCTICDB_DEBUG(log::storage(), "Mock store adding atom key {}", key);
             return folly::makeFuture(key);
@@ -204,10 +215,6 @@ namespace arcticdb {
             util::raise_rte("Not implemented");
         }
 
-        void write_compressed_sync(storage::KeySegmentPair&&) override {
-            util::raise_rte("Not implemented");
-        }
-
         RemoveKeyResultType remove_key_sync(const entity::VariantKey &key, storage::RemoveOpts opts) override {
             StorageFailureSimulator::instance()->go(FailureType::DELETE);
             std::lock_guard lock{mutex_};
@@ -255,16 +262,15 @@ namespace arcticdb {
             }
         }
 
-        folly::Future<std::vector<VariantKey>> batch_write(
-                std::vector<std::pair<PartialKey, SegmentInMemory>> &&key_segments,
-                const std::shared_ptr<DeDupMap> &,
-                const BatchWriteArgs &
-        ) override {
-            std::vector<VariantKey> output;
-            for (auto &pair : key_segments) {
-                output.emplace_back(std::get<AtomKey>(write(pair.first, std::move(pair.second)).value()));
-            }
-            return folly::makeFuture(std::move(output));
+        folly::Future<pipelines::SliceAndKey> async_write(
+            folly::Future<std::tuple<PartialKey, SegmentInMemory, pipelines::FrameSlice>> &&input_fut,
+            const std::shared_ptr<DeDupMap> &) override {
+            return std::move(input_fut).thenValue([this] (auto&& input) {
+                auto [pk, seg, slice] = std::move(input);
+                auto key = get_key(pk.key_type, 0, pk.stream_id, pk.start_index, pk.end_index);
+                add_segment(key, std::move(seg));
+                return SliceAndKey{std::move(slice), std::move(key)};
+            });
         }
 
         std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey> &keys) override {

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -151,7 +151,7 @@ TimeseriesDescriptor pack_timeseries_descriptor(
 }
 
 SegmentInMemory incomplete_segment_from_frame(
-    pipelines::InputTensorFrame&& frame,
+    const std::shared_ptr<pipelines::InputTensorFrame>& frame,
     size_t existing_rows,
     std::optional<entity::AtomKey>&& prev_key,
     bool allow_sparse
@@ -160,18 +160,18 @@ SegmentInMemory incomplete_segment_from_frame(
 
     auto offset_in_frame = 0;
     auto slice_num_for_column = 0;
-    const auto num_rows = frame.num_rows;
-    auto index_tensor = std::move(frame.index_tensor);
-    const bool has_index = frame.has_index();
-    const auto index = std::move(frame.index);
+    const auto num_rows = frame->num_rows;
+    auto index_tensor = std::move(frame->index_tensor);
+    const bool has_index = frame->has_index();
+    const auto index = std::move(frame->index);
     SegmentInMemory output;
-    auto field_tensors = std::move(frame.field_tensors);
+    auto field_tensors = std::move(frame->field_tensors);
 
     std::visit([&](const auto& idx) {
         using IdxType = std::decay_t<decltype(idx)>;
         using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
 
-        auto timeseries_desc = index_descriptor_from_frame(pipelines::InputTensorFrame{frame}, existing_rows, std::move(prev_key));
+        auto timeseries_desc = index_descriptor_from_frame(frame, existing_rows, std::move(prev_key));
         util::check(!timeseries_desc.fields().empty(), "Expected fields not to be empty in incomplete segment");
         auto norm_meta = timeseries_desc.proto().normalization();
         StreamDescriptor descriptor(std::make_shared<StreamDescriptor::Proto>(std::move(*timeseries_desc.mutable_proto().mutable_stream_descriptor())), timeseries_desc.fields_ptr());
@@ -211,12 +211,12 @@ SegmentInMemory incomplete_segment_from_frame(
 folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     std::optional<AtomKey>&& next_key)  {
     using namespace arcticdb::pipelines;
 
-    auto index_range = frame.index_range;
-    auto segment = incomplete_segment_from_frame(std::move(frame), 0, std::move(next_key), false);
+    auto index_range = frame->index_range;
+    auto segment = incomplete_segment_from_frame(frame, 0, std::move(next_key), false);
     return store->write(
         KeyType::APPEND_DATA,
         VersionId(0),
@@ -229,9 +229,9 @@ folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(
 void write_parallel(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    InputTensorFrame&& frame) {
+    const std::shared_ptr<InputTensorFrame>& frame) {
     // TODO: dynamic bucketize doesn't work with incompletes
-    (void)write_incomplete_frame(store, stream_id, std::move(frame), std::nullopt).get();
+    (void)write_incomplete_frame(store, stream_id, frame, std::nullopt).get();
 }
 
 std::vector<SliceAndKey> get_incomplete(
@@ -372,17 +372,17 @@ AppendMapEntry entry_from_key(const std::shared_ptr<StreamSource>& store, const 
 void append_incomplete(
         const std::shared_ptr<Store>& store,
         const StreamId& stream_id,
-        InputTensorFrame&& frame) {
+        const std::shared_ptr<InputTensorFrame>& frame) {
     using namespace arcticdb::proto::descriptors;
     using namespace arcticdb::stream;
     ARCTICDB_SAMPLE_DEFAULT(AppendIncomplete)
     ARCTICDB_DEBUG(log::version(), "Writing incomplete frame for stream {}", stream_id);
 
     auto [next_key, total_rows] = read_head(store, stream_id);
-    const auto num_rows = frame.num_rows;
+    const auto num_rows = frame->num_rows;
     total_rows += num_rows;
-    auto desc = frame.desc.clone();
-    auto new_key = write_incomplete_frame(store, stream_id, std::move(frame), std::move(next_key)).get();
+    auto desc = frame->desc.clone();
+    auto new_key = write_incomplete_frame(store, stream_id, frame, std::move(next_key)).get();
 
 
     ARCTICDB_DEBUG(log::version(), "Wrote incomplete frame for stream {}, {} rows, total rows {}", stream_id, num_rows, total_rows);

--- a/cpp/arcticdb/stream/append_map.hpp
+++ b/cpp/arcticdb/stream/append_map.hpp
@@ -47,13 +47,13 @@ void remove_incomplete_segments(
 /*folly::Future<entity::VariantKey> write_incomplete_frame(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    pipelines::InputTensorFrame&& frame,
+    pipelines::std::shared_ptr<InputTensorFrame>& frame,
     std::optional<AtomKey>&& next_key);
 */
 void write_parallel(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    pipelines::InputTensorFrame&& frame);
+    const std::shared_ptr<pipelines::InputTensorFrame>& frame);
 
 void write_head(
     const std::shared_ptr<Store>& store,
@@ -68,7 +68,7 @@ void append_incomplete_segment(
 void append_incomplete(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    pipelines::InputTensorFrame&& frame);
+    const std::shared_ptr<pipelines::InputTensorFrame>& frame);
 
 std::optional<int64_t> latest_incomplete_timestamp(
     const std::shared_ptr<Store>& store,

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -13,6 +13,7 @@
 #include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/version/de_dup_map.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
 
 #include <folly/futures/Future.h>
 // FIXME: winnt.h is included by folly/futures/Future.h at some point and adds unwanted macros
@@ -105,13 +106,9 @@ struct StreamSink {
 
     [[nodiscard]] virtual folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&& ks) = 0;
 
-    virtual void write_compressed_sync(
-        storage::KeySegmentPair &&ks) = 0;
-
-    [[nodiscard]] virtual folly::Future<std::vector<entity::VariantKey>> batch_write(
-        std::vector<std::pair<PartialKey, SegmentInMemory>> &&key_segments,
-        const std::shared_ptr<DeDupMap> &de_dup_map,
-        const BatchWriteArgs &args = BatchWriteArgs()) = 0;
+    [[nodiscard]] virtual folly::Future<pipelines::SliceAndKey> async_write(
+        folly::Future<std::tuple<PartialKey, SegmentInMemory, pipelines::FrameSlice>> &&input_fut,
+        const std::shared_ptr<DeDupMap> &de_dup_map) = 0;
 
     [[nodiscard]] virtual folly::Future<folly::Unit> batch_write_compressed(
         std::vector<storage::KeySegmentPair> kvs) = 0;

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -206,7 +206,7 @@ struct TestTensorFrame {
         segment_(std::move(desc), num_rows) {}
 
     SegmentInMemory segment_;
-    arcticdb::pipelines::InputTensorFrame frame_;
+    std::shared_ptr<arcticdb::pipelines::InputTensorFrame> frame_ = std::make_shared<arcticdb::pipelines::InputTensorFrame>();
 };
 
 template<class ContainerType, typename DTT>
@@ -275,14 +275,14 @@ TestTensorFrame get_test_frame(const StreamId &id,
     using namespace arcticdb::pipelines;
     TestTensorFrame output(get_test_descriptor<IndexType>(id, fields), num_rows);
 
-    output.frame_.desc = get_test_descriptor<IndexType>(id, fields);
-    output.frame_.index = index_type_from_descriptor(output.frame_.desc);
-    output.frame_.num_rows = num_rows;
-    output.frame_.desc.set_sorted(SortedValue::ASCENDING);
+    output.frame_->desc = get_test_descriptor<IndexType>(id, fields);
+    output.frame_->index = index_type_from_descriptor(output.frame_->desc);
+    output.frame_->num_rows = num_rows;
+    output.frame_->desc.set_sorted(SortedValue::ASCENDING);
 
-    fill_test_frame(output.segment_, output.frame_, num_rows, start_val, opt_row_offset);
+    fill_test_frame(output.segment_, *output.frame_, num_rows, start_val, opt_row_offset);
 
-    output.frame_.set_index_range();
+    output.frame_->set_index_range();
 
     return output;
 }

--- a/cpp/arcticdb/stream/test/test_append_map.cpp
+++ b/cpp/arcticdb/stream/test/test_append_map.cpp
@@ -22,8 +22,8 @@ TEST(Append, Simple) {
     StreamId stream_id{"test_append"};
     auto wrapper = get_test_simple_frame(stream_id, 10, 0);
     auto& frame = wrapper.frame_;
-    auto desc = frame.desc.clone();
-    append_incomplete(store, stream_id, std::move(frame));
+    auto desc = frame->desc.clone();
+    append_incomplete(store, stream_id, frame);
     pipelines::FilterRange range;
     auto pipeline_context = std::make_shared<PipelineContext>(desc);
     pipeline_context->selected_columns_ = util::BitSet(2);
@@ -36,7 +36,7 @@ TEST(Append, Simple) {
     generate_filtered_field_descriptors(pipeline_context, {});
 
     SegmentInMemory allocated_frame = allocate_frame(pipeline_context);
-    ASSERT_EQ(allocated_frame.row_count(), size_t(frame.num_rows));
+    ASSERT_EQ(allocated_frame.row_count(), size_t(frame->num_rows));
 }
 
 TEST(Append, MergeDescriptorsPromote) {

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -340,32 +340,32 @@ inline NativeTensor tensor_from_column(const Column &column) {
 
 struct SegmentToInputFrameAdapter {
     SegmentInMemory segment_;
-    pipelines::InputTensorFrame input_frame_;
+    std::shared_ptr<pipelines::InputTensorFrame> input_frame_ = std::make_shared<pipelines::InputTensorFrame>();
 
     explicit SegmentToInputFrameAdapter(SegmentInMemory &&segment) :
         segment_(std::move(segment)) {
-        input_frame_.desc = segment_.descriptor();
-        input_frame_.num_rows = segment_.row_count();
+        input_frame_->desc = segment_.descriptor();
+        input_frame_->num_rows = segment_.row_count();
         size_t col{0};
         if (segment_.descriptor().index().type() != IndexDescriptor::ROWCOUNT) {
             for (size_t i = 0; i < segment_.descriptor().index().field_count(); ++i) {
-                input_frame_.index_tensor = tensor_from_column(segment_.column(col));
+                input_frame_->index_tensor = tensor_from_column(segment_.column(col));
                 ++col;
             }
         }
 
         while (col < segment_.num_columns())
-            input_frame_.field_tensors.emplace_back(tensor_from_column(segment_.column(col++)));
+            input_frame_->field_tensors.emplace_back(tensor_from_column(segment_.column(col++)));
 
-        input_frame_.set_index_range();
+        input_frame_->set_index_range();
     }
 
     void synthesize_norm_meta() {
         if (segment_.metadata()) {
             auto segment_tsd = segment_.index_descriptor();
-            input_frame_.norm_meta.CopyFrom(segment_tsd.proto().normalization());
+            input_frame_->norm_meta.CopyFrom(segment_tsd.proto().normalization());
         }
-        ensure_timeseries_norm_meta(input_frame_.norm_meta, input_frame_.desc.id(), false);
+        ensure_timeseries_norm_meta(input_frame_->norm_meta, input_frame_->desc.id(), false);
     }
 
 };
@@ -375,10 +375,11 @@ struct SegmentSinkWrapperImpl {
     using SchemaPolicy = typename AggregatorType::SchemaPolicy;
     using IndexType =  typename AggregatorType::IndexType;
 
-        SegmentSinkWrapperImpl(StreamId stream_id, const IndexType& index, FieldCollection&& fields) :
-        sink_(std::make_shared<SegmentsSink>()),
+    SegmentSinkWrapperImpl(StreamId stream_id, const IndexType& index, const FieldCollection& fields) :
         aggregator_(
-            [](pipelines::FrameSlice&&) {},
+            [](pipelines::FrameSlice&&) {
+                // Do nothing
+                },
             SchemaPolicy{
                 index.create_stream_descriptor(std::move(stream_id), fields_from_range(fields)), index
             },
@@ -393,7 +394,7 @@ struct SegmentSinkWrapperImpl {
         return sink_->segments_[0];
     }
 
-    std::shared_ptr<SegmentsSink> sink_;
+    std::shared_ptr<SegmentsSink> sink_ = std::make_shared<SegmentsSink>();
     AggregatorType aggregator_;
 };
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -56,14 +56,14 @@ public:
     VersionedItem update_internal(
         const StreamId& stream_id,
         const UpdateQuery & query,
-        InputTensorFrame&& frame,
+        const std::shared_ptr<InputTensorFrame>& frame,
         bool upsert,
         bool dynamic_schema,
         bool prune_previous_versions) override;
 
     VersionedItem append_internal(
         const StreamId& stream_id,
-        InputTensorFrame&& frame,
+        const std::shared_ptr<InputTensorFrame>& frame,
         bool upsert,
         bool prune_previous_versions,
         bool validate_index) override;
@@ -84,7 +84,7 @@ public:
 
     void append_incomplete_frame(
         const StreamId& stream_id,
-        InputTensorFrame&& frame) const override;
+        const std::shared_ptr<InputTensorFrame>& frame) const override;
 
     void remove_incomplete(
         const StreamId& stream_id
@@ -140,7 +140,7 @@ public:
 
     void write_parallel_frame(
         const StreamId& stream_id,
-        InputTensorFrame&& frame) const override;
+        const std::shared_ptr<InputTensorFrame>& frame) const override;
 
     bool has_stream(
         const StreamId & stream_id
@@ -180,7 +180,7 @@ public:
 
     VersionedItem  write_versioned_dataframe_internal(
         const StreamId& stream_id,
-        InputTensorFrame&& frame,
+        const std::shared_ptr<InputTensorFrame>& frame,
         bool prune_previous_versions,
         bool allow_sparse,
         bool validate_index
@@ -266,7 +266,7 @@ public:
     std::vector<folly::Future<AtomKey>> batch_write_internal(
         const std::vector<VersionId>& version_ids,
         const std::vector<StreamId>& stream_ids,
-        std::vector<InputTensorFrame>&& frames,
+        std::vector<std::shared_ptr<pipelines::InputTensorFrame>>&& frames,
         std::vector<std::shared_ptr<DeDupMap>> de_dup_maps,
         bool validate_index
     );
@@ -279,7 +279,7 @@ public:
 
     std::vector<std::variant<VersionedItem, DataError>> batch_append_internal(
         const std::vector<StreamId>& stream_ids,
-        std::vector<InputTensorFrame>&& frames,
+        std::vector<std::shared_ptr<pipelines::InputTensorFrame>>&& frames,
         bool prune_previous_versions,
         bool validate_index,
         bool upsert,
@@ -366,7 +366,7 @@ public:
         bool prune_previous_versions,
         bool add_new_symbol);
 
-    void write_version_and_prune_previous_if_needed(
+    void write_version_and_prune_previous(
         bool prune_previous_versions,
         const AtomKey& new_version,
         const std::optional<IndexTypeKey>& previous_key);
@@ -378,7 +378,7 @@ public:
 
     std::vector<std::variant<VersionedItem, DataError>> batch_write_versioned_dataframe_internal(
         const std::vector<StreamId>& stream_ids,
-        std::vector<InputTensorFrame>&& frames,
+        std::vector<std::shared_ptr<pipelines::InputTensorFrame>>&& frames,
         bool prune_previous_versions,
         bool validate_index,
         bool throw_on_error

--- a/cpp/arcticdb/version/test/test_snapshot.cpp
+++ b/cpp/arcticdb/version/test/test_snapshot.cpp
@@ -81,7 +81,7 @@ TEST(SnapshotCreate, Basic) {
     frame.index_range = IndexRange{0, num_rows};
     frame.num_rows = num_rows;
 
-    auto fut = write::write_frame(std::move(pk), std::move(frame), slicing, store);
+    auto fut = write::write_frame(std::move(pk), frame, slicing, store);
 
 
     auto version_key = std::move(fut.wait().value());

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -47,7 +47,7 @@ auto write_version_frame(
     auto wrapper = get_test_simple_frame(stream_id, rows, start_val);
     auto& frame = wrapper.frame_;
     auto store = pvs._test_get_store();
-    auto var_key = write_frame(std::move(pk), std::move(frame), slicing, store, de_dup_map).get();
+    auto var_key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
     auto key = to_atom(var_key); // Moves
     if (update_version_map) {
         pvs._test_get_version_map()->write_version(store, key);
@@ -303,7 +303,7 @@ TEST_F(VersionStoreTest, StressBatchWrite) {
 
     std::vector<StreamId> symbols;
     std::vector<TestTensorFrame> wrappers;
-    std::vector<InputTensorFrame> frames;
+    std::vector<std::shared_ptr<pipelines::InputTensorFrame>> frames;
     std::vector<VersionId> version_ids;
     std::vector<std::shared_ptr<DeDupMap>> dedup_maps;
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -73,22 +73,22 @@ void modify_descriptor(const std::shared_ptr<pipelines::PipelineContext>& pipeli
 VersionedItem write_dataframe_impl(
     const std::shared_ptr<Store>& store,
     VersionId version_id,
-    pipelines::InputTensorFrame&& frame,
+    const std::shared_ptr<pipelines::InputTensorFrame>& frame,
     const WriteOptions& options,
     const std::shared_ptr<DeDupMap>& de_dup_map,
     bool sparsify_floats,
     bool validate_index
     ) {
     ARCTICDB_SUBSAMPLE_DEFAULT(WaitForWriteCompletion)
-    ARCTICDB_DEBUG(log::version(), "write_dataframe_impl stream_id: {} , version_id: {}, {} rows", frame.desc.id(), version_id, frame.num_rows);
-    auto atom_key_fut = async_write_dataframe_impl(store, version_id, std::move(frame), options, de_dup_map, sparsify_floats, validate_index);
+    ARCTICDB_DEBUG(log::version(), "write_dataframe_impl stream_id: {} , version_id: {}, {} rows", frame->desc.id(), version_id, frame->num_rows);
+    auto atom_key_fut = async_write_dataframe_impl(store, version_id, frame, options, de_dup_map, sparsify_floats, validate_index);
     return VersionedItem(std::move(atom_key_fut).get());
 }
 
 folly::Future<entity::AtomKey> async_write_dataframe_impl(
     const std::shared_ptr<Store>& store,
     VersionId version_id,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
     const std::shared_ptr<DeDupMap> &de_dup_map,
     bool sparsify_floats,
@@ -96,14 +96,14 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
     ) {
     ARCTICDB_SAMPLE(DoWrite, 0)
     if (0 == version_id)
-        verify_stream_id(frame.desc.id());
+        verify_stream_id(frame->desc.id());
     // Slice the frame according to the write options
-    frame.set_bucketize_dynamic(options.bucketize_dynamic);
-    auto slicing_arg = get_slicing_policy(options, frame);
-    auto partial_key = IndexPartialKey{frame.desc.id(), version_id};
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(!validate_index || frame.desc.get_sorted() == SortedValue::ASCENDING || !std::holds_alternative<stream::TimeseriesIndex>(frame.index),
+    frame->set_bucketize_dynamic(options.bucketize_dynamic);
+    auto slicing_arg = get_slicing_policy(options, *frame);
+    auto partial_key = IndexPartialKey{frame->desc.id(), version_id};
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(!validate_index || frame->desc.get_sorted() == SortedValue::ASCENDING || !std::holds_alternative<stream::TimeseriesIndex>(frame->index),
                 "When calling write with validate_index enabled, input data must be sorted.");
-    return write_frame(std::move(partial_key), std::move(frame), slicing_arg, store, de_dup_map, sparsify_floats);
+    return write_frame(std::move(partial_key), frame, slicing_arg, store, de_dup_map, sparsify_floats);
 }
 
 namespace {
@@ -135,37 +135,37 @@ void sorted_data_check_append(InputTensorFrame& frame, index::IndexSegmentReader
 folly::Future<AtomKey> async_append_impl(
     const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
     bool validate_index) {
 
     util::check(update_info.previous_index_key_.has_value(), "Cannot append as there is no previous index key to append to");
-    const StreamId stream_id = frame.desc.id();
+    const StreamId stream_id = frame->desc.id();
     ARCTICDB_DEBUG(log::version(), "append stream_id: {} , version_id: {}", stream_id, update_info.next_version_id_);
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     auto row_offset = index_segment_reader.tsd().proto().total_rows();
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
-    sorted_data_check_append(frame, index_segment_reader, validate_index);
-    frame.set_offset(static_cast<ssize_t>(row_offset));
-    fix_descriptor_mismatch_or_throw(APPEND, options.dynamic_schema, index_segment_reader, frame);
+    sorted_data_check_append(*frame, index_segment_reader, validate_index);
+    frame->set_offset(static_cast<ssize_t>(row_offset));
+    fix_descriptor_mismatch_or_throw(APPEND, options.dynamic_schema, index_segment_reader, *frame);
 
-    frame.set_bucketize_dynamic(bucketize_dynamic);
-    auto slicing_arg = get_slicing_policy(options, frame);
-    return append_frame(IndexPartialKey{stream_id, update_info.next_version_id_}, std::move(frame), slicing_arg, index_segment_reader, store, options.dynamic_schema, options.ignore_sort_order);
+    frame->set_bucketize_dynamic(bucketize_dynamic);
+    auto slicing_arg = get_slicing_policy(options, *frame);
+    return append_frame(IndexPartialKey{stream_id, update_info.next_version_id_}, frame, slicing_arg, index_segment_reader, store, options.dynamic_schema, options.ignore_sort_order);
 }
 
 VersionedItem append_impl(
     const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
     bool validate_index) {
 
     ARCTICDB_SUBSAMPLE_DEFAULT(WaitForWriteCompletion)
     auto version_key_fut = async_append_impl(store,
                                              update_info,
-                                             std::move(frame),
+                                             frame,
                                              options,
                                              validate_index);
     auto version_key = std::move(version_key_fut).get();
@@ -306,24 +306,24 @@ VersionedItem update_impl(
     const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     const UpdateQuery& query,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions&& options,
     bool dynamic_schema) {
     util::check(update_info.previous_index_key_.has_value(), "Cannot update as there is no previous index key to update into");
-    const StreamId stream_id = frame.desc.id();
+    const StreamId stream_id = frame->desc.id();
     ARCTICDB_DEBUG(log::version(), "Update versioned dataframe for stream_id: {} , version_id = {}", stream_id, update_info.previous_index_key_->version_id());
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot update pickled data");
-    auto index_desc = check_index_match(frame.index, index_segment_reader.tsd().proto().stream_descriptor().index());
+    auto index_desc = check_index_match(frame->index, index_segment_reader.tsd().proto().stream_descriptor().index());
     util::check(index_desc.kind() == IndexDescriptor::TIMESTAMP, "Update not supported for non-timeseries indexes");
-    sorted_data_check_update(frame, index_segment_reader);
+    sorted_data_check_update(*frame, index_segment_reader);
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     (void)check_and_mark_slices(index_segment_reader, dynamic_schema, false, std::nullopt, bucketize_dynamic);
-    auto combined_sorting_info = deduce_sorted(frame.desc.get_sorted(), index_segment_reader.get_sorted());
-    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, frame);
+    auto combined_sorting_info = deduce_sorted(frame->desc.get_sorted(), index_segment_reader.get_sorted());
+    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, *frame);
 
     std::vector<FilterQuery<index::IndexSegmentReader>> queries =
-        build_update_query_filters<index::IndexSegmentReader>(query.row_filter, frame.index, frame.index_range, dynamic_schema, index_segment_reader.bucketize_dynamic());
+        build_update_query_filters<index::IndexSegmentReader>(query.row_filter, frame->index, frame->index_range, dynamic_schema, index_segment_reader.bucketize_dynamic());
     auto combined = combine_filter_functions(queries);
     auto affected_keys = filter_index(index_segment_reader, std::move(combined));
     std::vector<SliceAndKey> unaffected_keys;
@@ -336,17 +336,17 @@ VersionedItem update_impl(
     util::check(affected_keys.size() + unaffected_keys.size() == index_segment_reader.size(), "Unaffected vs affected keys split was inconsistent {} + {} != {}",
                 affected_keys.size(), unaffected_keys.size(), index_segment_reader.size());
 
-    frame.set_bucketize_dynamic(bucketize_dynamic);
-    auto slicing_arg = get_slicing_policy(options, frame);
+    frame->set_bucketize_dynamic(bucketize_dynamic);
+    auto slicing_arg = get_slicing_policy(options, *frame);
 
-    auto new_slice_and_keys = slice_and_write(frame, slicing_arg, get_partial_key_gen(frame, IndexPartialKey{stream_id, update_info.next_version_id_}), store).wait().value();
+    auto new_slice_and_keys = slice_and_write(frame, slicing_arg, IndexPartialKey{stream_id, update_info.next_version_id_}, store).wait().value();
     std::sort(std::begin(new_slice_and_keys), std::end(new_slice_and_keys));
 
     IndexRange orig_filter_range;
     auto[intersect_before, intersect_after] = util::variant_match(query.row_filter,
                         [&](std::monostate) {
-                            util::check(std::holds_alternative<TimeseriesIndex>(frame.index), "Update with row count index is not permitted");
-                            orig_filter_range = frame.index_range;
+                            util::check(std::holds_alternative<TimeseriesIndex>(frame->index), "Update with row count index is not permitted");
+                            orig_filter_range = frame->index_range;
                             if (new_slice_and_keys.empty()) {
                                 // If there are no new keys, then we can't intersect with the existing data.
                                 return std::make_pair(std::vector<SliceAndKey>{}, std::vector<SliceAndKey>{});
@@ -382,9 +382,9 @@ VersionedItem update_impl(
 
     std::sort(std::begin(flattened_slice_and_keys), std::end(flattened_slice_and_keys));
     auto existing_desc = index_segment_reader.tsd().as_stream_descriptor();
-    auto desc = merge_descriptors(existing_desc, std::vector<std::shared_ptr<FieldCollection>>{ frame.desc.fields_ptr() }, {});
+    auto desc = merge_descriptors(existing_desc, std::vector<std::shared_ptr<FieldCollection>>{ frame->desc.fields_ptr() }, {});
     desc.set_sorted(combined_sorting_info);
-    auto time_series = make_timeseries_descriptor(row_count, std::move(desc), std::move(frame.norm_meta), std::move(frame.user_meta), std::nullopt, std::nullopt, bucketize_dynamic);
+    auto time_series = make_timeseries_descriptor(row_count, std::move(desc), std::move(frame->norm_meta), std::move(frame->user_meta), std::nullopt, std::nullopt, bucketize_dynamic);
     auto index = index_type_from_descriptor(time_series.as_stream_descriptor());
 
     auto version_key_fut = util::variant_match(index, [&time_series, &flattened_slice_and_keys, &stream_id, &update_info, &store] (auto idx) {
@@ -1339,10 +1339,10 @@ PredefragmentationInfo get_pre_defragmentation_info(
         }
         ++segment_idx;
         if (compaction_start_info && slice.row_range.start() < compaction_start_info->first){
-            auto col_it = std::lower_bound(first_col_segment_idx.begin(), first_col_segment_idx.end(), slice.row_range.start(), [](auto lhs, auto rhs){return lhs.first < rhs;});
-            if (col_it != first_col_segment_idx.end())
-                compaction_start_info = *col_it;
-            else{
+            auto start_point = std::lower_bound(first_col_segment_idx.begin(), first_col_segment_idx.end(), slice.row_range.start(), [](auto lhs, auto rhs){return lhs.first < rhs;});
+            if (start_point != first_col_segment_idx.end())
+                compaction_start_info = *start_point;
+            else {
                 log::version().warn("Missing segment containing column 0 for row {}; Resetting compaction starting point to 0", slice.row_range.start());
                 compaction_start_info = {0u, 0u};
             }

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -32,7 +32,7 @@ using namespace arcticdb::pipelines;
 VersionedItem write_dataframe_impl(
     const std::shared_ptr<Store>& store,
     VersionId version_id,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
     const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
     bool allow_sparse = false,
@@ -42,7 +42,7 @@ VersionedItem write_dataframe_impl(
 folly::Future<entity::AtomKey> async_write_dataframe_impl(
     const std::shared_ptr<Store>& store,
     VersionId version_id,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
     const std::shared_ptr<DeDupMap>& de_dup_map,
     bool allow_sparse,
@@ -52,14 +52,14 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
 folly::Future<AtomKey> async_append_impl(
     const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
     bool validate_index);
 
 VersionedItem append_impl(
     const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
     bool validate_index);
 
@@ -67,7 +67,7 @@ VersionedItem update_impl(
     const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     const UpdateQuery & query,
-    InputTensorFrame&& frame,
+    const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions&& options,
     bool dynamic_schema);
 

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -48,14 +48,14 @@ public:
     virtual VersionedItem update_internal(
         const StreamId& stream_id,
         const UpdateQuery & query,
-        InputTensorFrame&& frame,
+        const std::shared_ptr<InputTensorFrame>& frame,
         bool upsert,
         bool dynamic_schema,
         bool prune_previous_versions) = 0;
 
     virtual VersionedItem append_internal(
         const StreamId& stream_id,
-        InputTensorFrame&& frame,
+        const std::shared_ptr<InputTensorFrame>& frame,
         bool upsert,
         bool prune_previous_versions,
         bool validate_index) = 0;
@@ -70,7 +70,7 @@ public:
 
     virtual void append_incomplete_frame(
         const StreamId& stream_id,
-        InputTensorFrame&& frame) const = 0;
+        const std::shared_ptr<InputTensorFrame>& frame) const = 0;
 
     virtual void append_incomplete_segment(
         const StreamId& stream_id,
@@ -82,7 +82,7 @@ public:
 
     virtual void write_parallel_frame(
         const StreamId& stream_id,
-        InputTensorFrame&& frame) const = 0;
+        const std::shared_ptr<InputTensorFrame>& frame) const = 0;
 
     virtual bool has_stream(
         const StreamId & stream_id
@@ -116,7 +116,7 @@ public:
 
     virtual VersionedItem write_versioned_dataframe_internal(
         const StreamId& stream_id,
-        InputTensorFrame&& frame,
+        const std::shared_ptr<InputTensorFrame>& frame,
         bool prune_previous_versions,
         bool allow_sparse,
         bool validate_index


### PR DESCRIPTION
It was originally envisaged that aggregator_set_data would be almost weightless, however we now do quite a bit of string processing in this function, which can potentially be quite slow. We should parallelize earlier in the write pipeline, releasing the GIL and only retaking it if we know that we need to do allocations in Python (because there are strings that are not currently in compact utf8 format)