### PR TITLE
Fixed aggregation on sparse grouping columns

### DIFF
--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -412,6 +412,7 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
                                                 using optional_iter_type = std::optional<decltype(input_data.bit_vector()->first())>;
                                                 optional_iter_type iter = std::nullopt;
                                                 size_t previous_value_index = 0;
+                                                constexpr size_t missing_value_group_id = 0;
 
                                                 if (is_sparse)
                                                 {
@@ -443,10 +444,10 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
                                                             val = *ptr;
                                                         }
                                                         if (is_sparse) {
-                                                            for (size_t j = previous_value_index; j != *(iter.value()); ++j) {
-                                                                row_to_group.emplace_back(size_t(0));
+                                                            for (size_t j = previous_value_index + 1; j != *(iter.value()); ++j) {
+                                                                row_to_group.emplace_back(missing_value_group_id);
                                                             }
-                                                            previous_value_index = *(iter.value()) + 1;
+                                                            previous_value_index = *(iter.value());
                                                             ++(iter.value());
                                                         }
 

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -408,7 +408,7 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
                                                 // Not worth worrying about right now
                                                 robin_hood::unordered_flat_map<RawType, size_t> offset_to_group;
 
-                                                bool is_sparse = col.column_->is_sparse();
+                                                const bool is_sparse = col.column_->is_sparse();
                                                 using optional_iter_type = std::optional<decltype(input_data.bit_vector()->first())>;
                                                 optional_iter_type iter = std::nullopt;
                                                 size_t previous_value_index = 0;
@@ -444,10 +444,10 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
                                                             val = *ptr;
                                                         }
                                                         if (is_sparse) {
-                                                            for (size_t j = previous_value_index + 1; j != *(iter.value()); ++j) {
+                                                            for (size_t j = previous_value_index; j != *(iter.value()); ++j) {
                                                                 row_to_group.emplace_back(missing_value_group_id);
                                                             }
-                                                            previous_value_index = *(iter.value());
+                                                            previous_value_index = *(iter.value()) + 1;
                                                             ++(iter.value());
                                                         }
 
@@ -461,9 +461,9 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
                                                     }
                                                 }
 
-                                                # Marking all the last non-represented values as missing.
+                                                // Marking all the last non-represented values as missing.
                                                 for (size_t i = row_to_group.size(); i <= size_t(col.column_->last_row()); ++i) {
-                                                    row_to_group.emplace_back(missing_values_group_id);
+                                                    row_to_group.emplace_back(missing_value_group_id);
                                                 }
 
                                                 num_unique = next_group_id;

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -460,8 +460,9 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
                                                     }
                                                 }
 
+                                                # Marking all the last non-represented values as missing.
                                                 for (size_t i = row_to_group.size(); i <= size_t(col.column_->last_row()); ++i) {
-                                                    row_to_group.emplace_back(0);
+                                                    row_to_group.emplace_back(missing_values_group_id);
                                                 }
 
                                                 num_unique = next_group_id;

--- a/cpp/arcticdb/processing/test/test_clause.cpp
+++ b/cpp/arcticdb/processing/test/test_clause.cpp
@@ -259,6 +259,8 @@ TEST(Clause, AggregationSparseGroupby) {
     std::shared_ptr<Store> empty_store;
     size_t num_rows{100};
     size_t unique_grouping_values{10};
+    // 1 more group because of missing values
+    size_t unique_groups{unique_grouping_values + 1};
     auto seg = generate_sparse_groupby_testing_segment(num_rows, unique_grouping_values);
 
     ProcessingUnit processing_unit(std::move(seg), pipelines::FrameSlice{});
@@ -272,21 +274,21 @@ TEST(Clause, AggregationSparseGroupby) {
     ASSERT_EQ(1, slice_and_keys.size());
 
     using aggregation_test::check_column;
-    check_column<int64_t>(slice_and_keys[0], "sum_int", unique_grouping_values + 1, [&](size_t idx) -> int64_t {
+    check_column<int64_t>(slice_and_keys[0], "sum_int", unique_groups, [unique_groups](size_t idx) -> int64_t {
         if (idx == 0) {
             return 495;
         } else {
             return 450 - static_cast<int64_t>(idx % unique_grouping_values);
         }
     });
-    check_column<int64_t>(slice_and_keys[0], "min_int", unique_grouping_values + 1, [](size_t idx) -> int64_t {
+    check_column<int64_t>(slice_and_keys[0], "min_int", unique_groups, [](size_t idx) -> int64_t {
         if (idx == 0) {
             return 0;
         } else {
             return idx;
         }
     });
-    check_column<int64_t>(slice_and_keys[0], "max_int", unique_grouping_values + 1, [&](size_t idx) -> int64_t {
+    check_column<int64_t>(slice_and_keys[0], "max_int", unique_groups, [unique_groups](size_t idx) -> int64_t {
         if (idx == 0) {
             return 99;
         }
@@ -296,14 +298,14 @@ TEST(Clause, AggregationSparseGroupby) {
             return 90 + idx % unique_grouping_values;
         }
     });
-    check_column<double>(slice_and_keys[0], "mean_int", unique_grouping_values + 1, [&](size_t idx) -> double {
+    check_column<double>(slice_and_keys[0], "mean_int", unique_groups, [unique_grouping_values](size_t idx) -> double {
         if (idx == 0) {
             return 49.5;
         } else {
             return (450 - static_cast<int64_t>(idx % unique_grouping_values)) / 9.;
         }
     });
-    check_column<uint64_t>(slice_and_keys[0], "count_int", unique_grouping_values + 1, [](size_t idx) -> uint64_t {
+    check_column<uint64_t>(slice_and_keys[0], "count_int", unique_groups, [](size_t idx) -> uint64_t {
         if (idx == 0) {
             return 10;
         } else {

--- a/cpp/arcticdb/processing/test/test_clause.cpp
+++ b/cpp/arcticdb/processing/test/test_clause.cpp
@@ -253,6 +253,65 @@ TEST(Clause, AggregationSparseColumn)
     });
 }
 
+TEST(Clause, AggregationSparseGroupby) {
+    using namespace arcticdb;
+
+    std::shared_ptr<Store> empty_store;
+    size_t num_rows{100};
+    size_t unique_grouping_values{10};
+    auto seg = generate_sparse_groupby_testing_segment(num_rows, unique_grouping_values);
+
+    ProcessingUnit processing_unit(std::move(seg), pipelines::FrameSlice{});
+    Composite<ProcessingUnit> comp;
+    comp.push_back(std::move(processing_unit));
+    AggregationClause aggregation("int_sparse_repeated_values", {{"sum_int", "sum"}, {"min_int", "min"}, {"max_int", "max"}, {"mean_int", "mean"}, {"count_int", "count"}});
+
+    auto aggregated = aggregation.process(std::shared_ptr<Store>(), std::move(comp)).as_range();
+    ASSERT_EQ(1, aggregated.size());
+    auto slice_and_keys = aggregated[0].data();
+    ASSERT_EQ(1, slice_and_keys.size());
+
+    using aggregation_test::check_column;
+    check_column<int64_t>(slice_and_keys[0], "sum_int", unique_grouping_values + 1, [&](size_t idx) -> int64_t {
+        if (idx == 0) {
+            return 495;
+        } else {
+            return 450 - static_cast<int64_t>(idx % unique_grouping_values);
+        }
+    });
+    check_column<int64_t>(slice_and_keys[0], "min_int", unique_grouping_values + 1, [](size_t idx) -> int64_t {
+        if (idx == 0) {
+            return 0;
+        } else {
+            return idx;
+        }
+    });
+    check_column<int64_t>(slice_and_keys[0], "max_int", unique_grouping_values + 1, [&](size_t idx) -> int64_t {
+        if (idx == 0) {
+            return 99;
+        }
+        else if (idx == 9) {
+            return 89;
+        } else {
+            return 90 + idx % unique_grouping_values;
+        }
+    });
+    check_column<double>(slice_and_keys[0], "mean_int", unique_grouping_values + 1, [&](size_t idx) -> double {
+        if (idx == 0) {
+            return 49.5;
+        } else {
+            return (450 - static_cast<int64_t>(idx % unique_grouping_values)) / 9.;
+        }
+    });
+    check_column<uint64_t>(slice_and_keys[0], "count_int", unique_grouping_values + 1, [](size_t idx) -> uint64_t {
+        if (idx == 0) {
+            return 10;
+        } else {
+            return 9;
+        }
+    });
+}
+
 TEST(Clause, Passthrough) {
     using namespace arcticdb;
     auto component_manager = std::make_shared<ComponentManager>();

--- a/cpp/arcticdb/processing/test/test_clause.cpp
+++ b/cpp/arcticdb/processing/test/test_clause.cpp
@@ -274,7 +274,7 @@ TEST(Clause, AggregationSparseGroupby) {
     ASSERT_EQ(1, slice_and_keys.size());
 
     using aggregation_test::check_column;
-    check_column<int64_t>(slice_and_keys[0], "sum_int", unique_groups, [unique_groups](size_t idx) -> int64_t {
+    check_column<int64_t>(slice_and_keys[0], "sum_int", unique_groups, [unique_grouping_values](size_t idx) -> int64_t {
         if (idx == 0) {
             return 495;
         } else {
@@ -288,7 +288,7 @@ TEST(Clause, AggregationSparseGroupby) {
             return idx;
         }
     });
-    check_column<int64_t>(slice_and_keys[0], "max_int", unique_groups, [unique_groups](size_t idx) -> int64_t {
+    check_column<int64_t>(slice_and_keys[0], "max_int", unique_groups, [unique_grouping_values](size_t idx) -> int64_t {
         if (idx == 0) {
             return 99;
         }


### PR DESCRIPTION
#### Reference Issues/PRs

Second part of #1007
Fixes #528 

#### What does this implement or fix?

- Fixes aggregations when grouping on a sparse column
- Adds C++ tests for this use case

#### Any other comments?

- Limitation: this requires to call `mark_absent_rows` on the grouping column, which is fragile. More generally, Column constructors should force the user to pass the size of the column for sparse columns.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
