### PR TITLE
Pin all our Github actions deps

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -35,12 +35,12 @@ jobs:
       VCPKG_MAN_NUGET_TOKEN: ${{secrets.VCPKG_MAN_NUGET_TOKEN}}
       ARCTIC_CMAKE_PRESET: linux-debug
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           submodules: recursive
 
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v1
+        uses: SimenB/github-actions-cpu-cores@v1.1.0
         id: cpu-cores
 
       - name: Extra envs
@@ -117,20 +117,20 @@ jobs:
           echo "CPP_COV_PERCENT=$(cat output.txt | grep 'TOTAL' | awk '{print $NF}' | tr -d '%')" >> $GITHUB_ENV
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: cpp-coverage-artifact
           path: cpp/out/linux-debug-build/coverage.zip
 
       - name: Upload Python Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: python-coverage-artifact
           path: python/python_cov.zip
 
       - name: Restore cached CPP Coverage Percentage from the previous run
         id: cache-cov-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v3.3.2
         with:
           path: prev_coverage.txt
           key: coverage
@@ -159,7 +159,7 @@ jobs:
 
       - name: Save the current CPP Coverage Percentage to the cache
         id: cache-cov-save
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v3.3.2
         with:
           path: current_coverage.txt
           key: coverage
@@ -203,7 +203,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           submodules: recursive
           fetch-depth: 0
@@ -320,14 +320,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           submodules: recursive
           fetch-depth: 0
           token: ${{ secrets.ARCTICDB_TEST_PAT }}
 
       - name: Install Conda environment from environment_unix.yml
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v1.6.0
         with:
           environment-file: environment_unix.yml
           init-shell: >-

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -134,7 +134,7 @@ jobs:
           buildPreset: ${{env.ARCTIC_CMAKE_PRESET}}
 
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v1
+        uses: SimenB/github-actions-cpu-cores@v1.1.0
         id: cpu-cores
 
       - name: Compile C++ tests
@@ -174,7 +174,7 @@ jobs:
 
       - name: Store wheel artifact
         if: inputs.job_type == 'build-python-wheels'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: wheel-${{env.CIBW_BUILD}}
           path: wheelhouse/*.whl
@@ -196,7 +196,7 @@ jobs:
         run: sudo chown -R $UID ${{matrix.build_dir}}
 
       - name: Archive build metadata
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         if: always()
         env:
           _exclusion: "\n!${{matrix.build_dir}}/**/"
@@ -255,7 +255,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Get wheel artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           name: wheel-${{needs.compile.outputs.cibw_build}}
           path: ${{runner.temp}}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Select Python (Windows)
         if: matrix.os == 'windows'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: "3.${{inputs.python3}}"
 
@@ -330,7 +330,7 @@ jobs:
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: crashdump-${{env.distinguishing_name}}
           path: ${{env.LOCALAPPDATA}}/CrashDumps/
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload the logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: pytest-${{env.distinguishing_name}}
           path: |

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -28,16 +28,16 @@ jobs:
       mongodb:
         image: mongo:4.4
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           submodules: recursive
 
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v1
+        uses: SimenB/github-actions-cpu-cores@v1.1.0
         id: cpu-cores
 
       - name: Install Conda environment from environment_unix.yml
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v1.6.0
         with:
           environment-file: environment_unix.yml
           init-shell: >-
@@ -103,16 +103,16 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           submodules: recursive
 
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v1
+        uses: SimenB/github-actions-cpu-cores@v1.1.0
         id: cpu-cores
 
       - name: Install Conda environment from environment_unix.yml
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v1.6.0
         with:
           environment-file: environment_unix.yml
           environment-name: arcticdb

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
         with:
           ref: ${{inputs.version && format('v{0}-docs', inputs.version) || 'master'}}
 
@@ -32,7 +32,7 @@ jobs:
       - id: download-wheel-artifact
         name: Download wheel artifact from last successful build
         if: ${{!inputs.version}}
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2.28.0
         with:
           name: wheel-${{env.PY_IMPL}}-manylinux_x86_64
           workflow: build.yml

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -9,13 +9,13 @@ jobs:
     environment: ${{inputs.environment}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
         with:
           ref: docs-pages
 
       - name: Publish docs-pages branch to Cloudflare Pages
         if: inputs.environment && vars.CLOUDFLARE_PAGE_BRANCH
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/pages-action@v1.5.0
         with:
           apiToken: ${{secrets.CLOUDFLARE_API_TOKEN}}
           accountId: ${{vars.CLOUDFLARE_ACCOUNT_ID}}

--- a/.github/workflows/ec2_runner_jobs.yml
+++ b/.github/workflows/ec2_runner_jobs.yml
@@ -25,7 +25,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY }}
@@ -33,7 +33,7 @@ jobs:
           aws-default-region: "eu-west-1"
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@v2.3.3
         with:
           mode: start
           github-token: ${{ secrets.ARCTICDB_TEST_PAT }}
@@ -49,14 +49,14 @@ jobs:
     continue-on-error: true
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY }}
           aws-region: "eu-west-1"
           aws-default-region: "eu-west-1"
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@v2.3.3
         with:
           mode: stop
           github-token: ${{ secrets.ARCTICDB_TEST_PAT }}

--- a/.github/workflows/persistent_storage.yml
+++ b/.github/workflows/persistent_storage.yml
@@ -38,7 +38,7 @@ jobs:
       run: {shell: bash}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Select Python (Linux)
         if: matrix.os == 'linux'
@@ -46,7 +46,7 @@ jobs:
 
       - name: Select Python (Windows)
         if: matrix.os == 'windows'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: "3.${{inputs.python3}}"
 
@@ -89,7 +89,7 @@ jobs:
       run: {shell: bash}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Select Python (Linux)
         run: echo /opt/python/${{env.python_impl_name}}*/bin >> $GITHUB_PATH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       SYMBOLS_ARTIFACT: /tmp/symbols.tar.zst # Use absolute path to workaround a bug in action-gh-release
     steps:
       # Copy and pasted from the pypi job below, until GitHub adds selective artifact download
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.8.2
         if: inputs.run_id <= 0
         with:
           node-version: 16
@@ -26,7 +26,7 @@ jobs:
       - id: download
         name: Fetch wheel artifacts
         if: inputs.run_id <= 0
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const dhc = require("./node_modules/@actions/artifact/lib/internal/download-http-client.js");
@@ -66,11 +66,11 @@ jobs:
         continue-on-error: true
 
       - name: Checkout # Needed by the release action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - id: changelog
         name: Release Changelog Builder
-        uses: mikepenz/release-changelog-builder-action@v3
+        uses: mikepenz/release-changelog-builder-action@v3.7.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -104,7 +104,7 @@ jobs:
           GH_REPO: ${{github.repository}}
 
       # Above `gh` command don't work on the current run, so will have to hack:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.8.2
         if: inputs.run_id <= 0
         with:
           node-version: 16
@@ -112,7 +112,7 @@ jobs:
         if: inputs.run_id <= 0
       - name: Fetch wheel artifacts
         if: inputs.run_id <= 0
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const dhc = require("./node_modules/@actions/artifact/lib/internal/download-http-client.js");


### PR DESCRIPTION
This is because floating deps can break our build without code changes in ArcticDB.

None left after this except softprops/, which only has a v1 tag.

```
➜  .github git:(pin-actions) ✗ rg -i "uses: " . | grep "@" | grep -v "@v[0-9\.]{3}"
./workflows/publish.yml:        uses: softprops/action-gh-release@v1
➜  .github git:(pin-actions) ✗ pwd
/home/alex/source/ArcticDB/.github
```