### PR TITLE
Change tmpdir to tmp_path

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -233,7 +233,7 @@ def unique_real_s3_uri():
         pytest.param("Real_S3", marks=REAL_S3_TESTS_MARK),
     ],
 )
-def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):
+def arctic_client(request, moto_s3_uri_incl_bucket, tmp_path, encoding_version):
     if request.param == "S3":
         ac = Arctic(moto_s3_uri_incl_bucket, encoding_version)
     elif request.param == "Azure":
@@ -241,7 +241,7 @@ def arctic_client(request, moto_s3_uri_incl_bucket, tmpdir, encoding_version):
     elif request.param == "Real_S3":
         ac = Arctic(request.getfixturevalue("unique_real_s3_uri"), encoding_version)
     elif request.param == "LMDB":
-        ac = Arctic(f"lmdb://{tmpdir}?map_size=16MB", encoding_version)
+        ac = Arctic(f"lmdb://{tmp_path}?map_size=16MB", encoding_version)
     elif request.param == "Mongo":
         ac = Arctic(request.getfixturevalue("mongo_test_uri"), encoding_version)
     elif request.param == "MEM":
@@ -383,7 +383,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def version_store_factory(lib_name, tmpdir):
+def version_store_factory(lib_name, tmp_path):
     """Factory to create any number of distinct LMDB libs with the given WriteOptions or VersionStoreConfig.
 
     Accepts legacy options col_per_group and row_per_segment.
@@ -412,7 +412,7 @@ def version_store_factory(lib_name, tmpdir):
         else:
             library_name = lib_name
 
-        cfg_factory = functools.partial(create_test_lmdb_cfg, db_dir=str(tmpdir), lmdb_config=lmdb_config)
+        cfg_factory = functools.partial(create_test_lmdb_cfg, db_dir=str(tmp_path), lmdb_config=lmdb_config)
         return _version_store_factory_impl(used, cfg_factory, library_name, **kwargs)
 
     try:
@@ -434,7 +434,7 @@ def version_store_factory(lib_name, tmpdir):
             result.version_store = None
             result._library = None
 
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        shutil.rmtree(tmp_path, ignore_errors=True)
 
 
 def _arctic_library_factory_impl(used, name, arctic_client, library_options) -> Library:

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -3,7 +3,11 @@ import pandas as pd
 import numpy as np
 import pytest
 from arcticdb.version_store import NativeVersionStore
-from arcticdb_ext.exceptions import InternalException, NormalizationException, SortingException
+from arcticdb_ext.exceptions import (
+    InternalException,
+    NormalizationException,
+    SortingException,
+)
 from arcticdb_ext import set_config_int
 from hypothesis import given, assume, settings, strategies as st
 from itertools import chain, product, combinations
@@ -11,7 +15,10 @@ from tests.util.mark import SLOW_TESTS_MARK
 from arcticdb.version_store._common import TimeFrame
 
 from arcticdb.util.test import assert_frame_equal, random_seed_context
-from arcticdb.util.hypothesis import InputFactories, use_of_function_scoped_fixtures_in_hypothesis_checked
+from arcticdb.util.hypothesis import (
+    InputFactories,
+    use_of_function_scoped_fixtures_in_hypothesis_checked,
+)
 
 
 def gen_params_append():
@@ -104,12 +111,22 @@ def test_incomplete_append_partial_read(version_store_factory, colnum, periods, 
         # (InputFactories.DF_RC_NON_RANGE, InputFactories.DF_DTI, "TODO(AN-722)"),
         (InputFactories.DF_RC, InputFactories.ND_ARRAY_1D, "(Pandas|ndarray)"),
         (InputFactories.DF_RC, InputFactories.DF_MULTI_RC, "index type incompatible"),
-        (InputFactories.DF_RC, InputFactories.DF_RC_NON_RANGE, "range.*index which is incompatible"),
+        (
+            InputFactories.DF_RC,
+            InputFactories.DF_RC_NON_RANGE,
+            "range.*index which is incompatible",
+        ),
         (InputFactories.DF_RC, InputFactories.DF_RC_STEP, "different.*step"),
     ],
 )
 @pytest.mark.parametrize("swap", ["swap", ""])
-def test_(initial: InputFactories, append: InputFactories, match, swap, lmdb_version_store: NativeVersionStore):
+def test_(
+    initial: InputFactories,
+    append: InputFactories,
+    match,
+    swap,
+    lmdb_version_store: NativeVersionStore,
+):
     lib = lmdb_version_store
     if swap:
         initial, append = append, initial
@@ -119,7 +136,6 @@ def test_(initial: InputFactories, append: InputFactories, match, swap, lmdb_ver
     to_append, _ = append.make(abs(next_start), 1)
     with pytest.raises(NormalizationException):
         lib.append("s", to_append, match=match)
-
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -135,7 +151,7 @@ def test_(initial: InputFactories, append: InputFactories, match, swap, lmdb_ver
     df_in_str=st.booleans(),
 )
 @SLOW_TESTS_MARK
-@pytest.mark.xfail(reason="Needs to be fixed with issue #496")
+@pytest.mark.xfail(reason="Needs to be fixed by issue #496")
 def test_append_with_defragmentation(
     sym,
     col_per_append_df,
@@ -217,7 +233,10 @@ def test_append_with_defragmentation(
             indexs = (
                 seg_details["end_index"].astype(str).str.rsplit(" ", n=2).agg(" ".join).reset_index()
             )  # start_index and end_index got merged into one column
-            assert np.array_equal(indexs.iloc[1:, 0].astype(str).values, indexs.iloc[:-1, 1].astype(str).values)
+            assert np.array_equal(
+                indexs.iloc[1:, 0].astype(str).values,
+                indexs.iloc[:-1, 1].astype(str).values,
+            )
         else:
             with pytest.raises(InternalException):
                 lib.defragment_symbol_data(sym, None)
@@ -249,4 +268,3 @@ def test_append_with_defragmentation(
             index_offset,
             num_of_rows,
         )
-

--- a/python/tests/integration/arcticdb/test_arctic_move_storage.py
+++ b/python/tests/integration/arcticdb/test_arctic_move_storage.py
@@ -8,11 +8,12 @@ from arcticdb import Arctic
 from arcticdb.util.test import get_wide_dataframe
 from arcticdb.util.test import assert_frame_equal
 from arcticdb.exceptions import LmdbMapFullError
+from tests.util.mark import AZURE_TESTS_MARK
 
 
-def test_move_lmdb_library(tmpdir_factory):
+def test_move_lmdb_library(tmp_path_factory):
     # Given - any LMDB library
-    original = tmpdir_factory.mktemp("original")
+    original = tmp_path_factory.mktemp("original")
     ac = Arctic(f"lmdb://{original}")
     ac.create_library("lib")
     lib = ac["lib"]
@@ -25,7 +26,7 @@ def test_move_lmdb_library(tmpdir_factory):
     del ac
 
     # When - we move the data
-    dest = str(tmpdir_factory.mktemp("dest"))
+    dest = str(tmp_path_factory.mktemp("dest"))
     shutil.move(str(original / "_arctic_cfg"), dest)
     shutil.move(str(original / "lib"), dest)
 
@@ -39,9 +40,9 @@ def test_move_lmdb_library(tmpdir_factory):
     assert "original" not in lib.read("sym").host
 
 
-def test_move_lmdb_library_map_size_reduction(tmpdir_factory):
+def test_move_lmdb_library_map_size_reduction(tmp_path_factory):
     # Given - any LMDB library
-    original = tmpdir_factory.mktemp("original")
+    original = tmp_path_factory.mktemp("original")
     ac = Arctic(f"lmdb://{original}?map_size=1MB")
     ac.create_library("lib")
     lib = ac["lib"]
@@ -54,7 +55,7 @@ def test_move_lmdb_library_map_size_reduction(tmpdir_factory):
     del ac
 
     # When - we move the data
-    dest = str(tmpdir_factory.mktemp("dest"))
+    dest = str(tmp_path_factory.mktemp("dest"))
     shutil.move(str(original / "_arctic_cfg"), dest)
     shutil.move(str(original / "lib"), dest)
 
@@ -90,9 +91,9 @@ def test_move_lmdb_library_map_size_reduction(tmpdir_factory):
     assert_frame_equal(df, lib.read("sym").data)
 
 
-def test_move_lmdb_library_map_size_increase(tmpdir_factory):
+def test_move_lmdb_library_map_size_increase(tmp_path_factory):
     # Given - any LMDB library
-    original = tmpdir_factory.mktemp("original")
+    original = tmp_path_factory.mktemp("original")
     ac = Arctic(f"lmdb://{original}?map_size=500KB")
     ac.create_library("lib")
     lib = ac["lib"]
@@ -106,7 +107,7 @@ def test_move_lmdb_library_map_size_increase(tmpdir_factory):
     del ac
 
     # When - we move the data
-    dest = str(tmpdir_factory.mktemp("dest"))
+    dest = str(tmp_path_factory.mktemp("dest"))
     shutil.move(str(original / "_arctic_cfg"), dest)
     shutil.move(str(original / "lib"), dest)
 
@@ -122,7 +123,13 @@ def test_move_lmdb_library_map_size_increase(tmpdir_factory):
 
 def test_move_s3_library(moto_s3_endpoint_and_credentials):
     # Given - any S3 library
-    endpoint, port, bucket, aws_access_key, aws_secret_key = moto_s3_endpoint_and_credentials
+    (
+        endpoint,
+        port,
+        bucket,
+        aws_access_key,
+        aws_secret_key,
+    ) = moto_s3_endpoint_and_credentials
 
     original_uri = (
         endpoint.replace("http://", "s3://").rsplit(":", 1)[0]
@@ -155,7 +162,10 @@ def test_move_s3_library(moto_s3_endpoint_and_credentials):
     client.create_bucket(Bucket=new_bucket)
 
     s3 = boto3.resource(
-        service_name="s3", endpoint_url=endpoint, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key
+        service_name="s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=aws_access_key,
+        aws_secret_access_key=aws_secret_key,
     )
     source = s3.Bucket(bucket)
     dest = s3.Bucket(new_bucket)
@@ -173,7 +183,7 @@ def test_move_s3_library(moto_s3_endpoint_and_credentials):
     assert "dest" in lib.read("sym").host
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="Test broken on MacOS (issue #909)")
+@AZURE_TESTS_MARK
 def test_move_azure_library(azure_client_and_create_container, azurite_azure_uri, azurite_container):
     # Given - any Azure library
     original_uri = azurite_azure_uri

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import itertools
 import time
 import sys
@@ -31,12 +32,28 @@ from arcticdb.exceptions import (
 from arcticdb import QueryBuilder
 from arcticdb.flattener import Flattener
 from arcticdb.version_store import NativeVersionStore
-from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer
-from arcticdb.version_store._store import UNSUPPORTED_S3_CHARS, MAX_SYMBOL_SIZE, VersionedItem
-from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException, StorageException
+from arcticdb.version_store._custom_normalizers import (
+    CustomNormalizer,
+    register_normalizer,
+)
+from arcticdb.version_store._store import (
+    UNSUPPORTED_S3_CHARS,
+    MAX_SYMBOL_SIZE,
+    VersionedItem,
+)
+from arcticdb_ext.exceptions import (
+    _ArcticLegacyCompatibilityException,
+    StorageException,
+)
 from arcticdb_ext.storage import KeyType, NoDataFoundException
-from arcticdb_ext.version_store import NoSuchVersionException, StreamDescriptorMismatch, ManualClockVersionStore
-from arcticc.pb2.descriptors_pb2 import NormalizationMetadata  # Importing from arcticdb dynamically loads arcticc.pb2
+from arcticdb_ext.version_store import (
+    NoSuchVersionException,
+    StreamDescriptorMismatch,
+    ManualClockVersionStore,
+)
+from arcticc.pb2.descriptors_pb2 import (
+    NormalizationMetadata,
+)  # Importing from arcticdb dynamically loads arcticc.pb2
 from arcticdb.util.test import (
     sample_dataframe,
     sample_dataframe_only_strings,
@@ -132,7 +149,8 @@ def test_unhandled_chars_default(object_version_store, unhandled_char):
 @pytest.mark.parametrize("unhandled_char", [chr(30), chr(127), chr(128)])
 def test_unhandled_chars_update_upsert(object_version_store, unhandled_char):
     df = pd.DataFrame(
-        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
+        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]},
+        index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")],
     )
     sym = f"prefix{unhandled_char}postfix"
     with pytest.raises(UserInputException):
@@ -144,7 +162,8 @@ def test_unhandled_chars_update_upsert(object_version_store, unhandled_char):
 @pytest.mark.parametrize("unhandled_char", [chr(30), chr(127), chr(128)])
 def test_unhandled_chars_append(object_version_store, unhandled_char):
     df = pd.DataFrame(
-        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
+        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]},
+        index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")],
     )
     sym = f"prefix{unhandled_char}postfix"
     with pytest.raises(UserInputException):
@@ -180,10 +199,12 @@ def test_unhandled_chars_already_present_append(object_version_store, three_col_
 @pytest.mark.parametrize("unhandled_char", [chr(127), chr(128)])
 def test_unhandled_chars_already_present_update(object_version_store, unhandled_char):
     df = pd.DataFrame(
-        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
+        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]},
+        index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")],
     )
     update_df = pd.DataFrame(
-        {"col_1": ["c", "d"], "col_2": [0.2, 0.3]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
+        {"col_1": ["c", "d"], "col_2": [0.2, 0.3]},
+        index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")],
     )
     sym = f"prefix{unhandled_char}postfix"
     with config_context("VersionStore.NoStrictSymbolCheck", 1):
@@ -299,8 +320,7 @@ def test_prune_previous_versions_multiple_times(basic_store, symbol):
 
 
 def test_prune_previous_versions_write_batch(basic_store):
-    """Verify that the batch write method correctly prunes previous versions when the corresponding option is specified.
-    """
+    """Verify that the batch write method correctly prunes previous versions when the corresponding option is specified."""
     # Given
     lib = basic_store
     lib_tool = lib.library_tool()
@@ -330,8 +350,7 @@ def test_prune_previous_versions_write_batch(basic_store):
 
 
 def test_prune_previous_versions_batch_write_metadata(basic_store):
-    """Verify that the batch write metadata method correctly prunes previous versions when the corresponding option is specified.
-    """
+    """Verify that the batch write metadata method correctly prunes previous versions when the corresponding option is specified."""
     # Given
     lib = basic_store
     lib_tool = lib.library_tool()
@@ -361,8 +380,7 @@ def test_prune_previous_versions_batch_write_metadata(basic_store):
 
 
 def test_prune_previous_versions_append_batch(basic_store):
-    """Verify that the batch append method correctly prunes previous versions when the corresponding option is specified.
-    """
+    """Verify that the batch append method correctly prunes previous versions when the corresponding option is specified."""
     # Given
     lib = basic_store
     lib_tool = lib.library_tool()
@@ -594,7 +612,10 @@ def test_date_range_row_sliced(basic_store_tiny_segment, use_date_range_clause):
         received = lib.read(sym, date_range=date_range).data
     assert_frame_equal(expected, received)
 
-    date_range = (index[0] + pd.Timedelta(12, unit="h"), index[-1] - pd.Timedelta(12, unit="h"))
+    date_range = (
+        index[0] + pd.Timedelta(12, unit="h"),
+        index[-1] - pd.Timedelta(12, unit="h"),
+    )
     if use_date_range_clause:
         received = lib.read(sym, query_builder=q).data
     else:
@@ -793,9 +814,9 @@ def test_large_symbols(basic_store_no_symbol_list):
         assert basic_store_no_symbol_list.read(valid_sized_sym).data == 1
 
         valid_punctuations = "".join(list(set(string.punctuation) - set(UNSUPPORTED_S3_CHARS)))
-        valid_char_sym = "".join(
-            [random.choice(string.ascii_letters + string.digits + valid_punctuations) for _ in range(12)]
-        )
+        valid_char_sym = "".join([
+            random.choice(string.ascii_letters + string.digits + valid_punctuations) for _ in range(12)
+        ])
 
         basic_store_no_symbol_list.write(valid_char_sym, 1)
         assert basic_store_no_symbol_list.read(valid_char_sym).data == 1
@@ -808,9 +829,9 @@ def test_unsupported_chars_in_symbols(basic_store):
 
     for _ in range(5):
         valid_punctuations = "".join(list(set(string.punctuation) - set(UNSUPPORTED_S3_CHARS)))
-        valid_char_sym = "".join(
-            [random.choice(string.ascii_letters + string.digits + valid_punctuations) for _ in range(12)]
-        )
+        valid_char_sym = "".join([
+            random.choice(string.ascii_letters + string.digits + valid_punctuations) for _ in range(12)
+        ])
 
         basic_store.write(valid_char_sym, 1)
         assert basic_store.read(valid_char_sym).data == 1
@@ -825,7 +846,10 @@ def test_partial_read_pickled_df(basic_store):
         basic_store.read("blah", columns=["does_not_matter"])
 
     with pytest.raises(InternalException):
-        basic_store.read("blah", date_range=(DateRange(pd.Timestamp("1970-01-01"), pd.Timestamp("2027-12-31"))))
+        basic_store.read(
+            "blah",
+            date_range=(DateRange(pd.Timestamp("1970-01-01"), pd.Timestamp("2027-12-31"))),
+        )
 
 
 def test_is_pickled(basic_store):
@@ -959,7 +983,10 @@ def test_list_versions_with_snapshots(basic_store):
     # v0 in a single snapshot
     assert set([v["snapshots"] for v in items_for_a if v["version"] == 0][0]) == {"snap1"}
     # v1 in a two snapshots
-    assert set([v["snapshots"] for v in items_for_a if v["version"] == 1][0]) == {"snap2", "snap3"}
+    assert set([v["snapshots"] for v in items_for_a if v["version"] == 1][0]) == {
+        "snap2",
+        "snap3",
+    }
 
 
 def test_read_ts(basic_store):
@@ -1029,22 +1056,20 @@ def test_dynamic_strings_non_contiguous(basic_store):
 
 
 def test_dynamic_strings_with_none(basic_store):
-    row = pd.Series(
-        [
-            "A",
-            "An_inordinately_long_string_for_no_sensible_purpose",
-            None,
-            "B",
-            "C",
-            None,
-            "Baca",
-            "CABA",
-            None,
-            "dog",
-            "cat",
-            None,
-        ]
-    )
+    row = pd.Series([
+        "A",
+        "An_inordinately_long_string_for_no_sensible_purpose",
+        None,
+        "B",
+        "C",
+        None,
+        "Baca",
+        "CABA",
+        None,
+        "dog",
+        "cat",
+        None,
+    ])
     df = pd.DataFrame({"x": row})
     basic_store.write("strings", df, dynamic_strings=True)
     vit = basic_store.read("strings")
@@ -1052,23 +1077,21 @@ def test_dynamic_strings_with_none(basic_store):
 
 
 def test_dynamic_strings_with_none_first_element(basic_store):
-    row = pd.Series(
-        [
-            None,
-            "A",
-            "An_inordinately_long_string_for_no_sensible_purpose",
-            None,
-            "B",
-            "C",
-            None,
-            "Baca",
-            "CABA",
-            None,
-            "dog",
-            "cat",
-            None,
-        ]
-    )
+    row = pd.Series([
+        None,
+        "A",
+        "An_inordinately_long_string_for_no_sensible_purpose",
+        None,
+        "B",
+        "C",
+        None,
+        "Baca",
+        "CABA",
+        None,
+        "dog",
+        "cat",
+        None,
+    ])
     df = pd.DataFrame({"x": row})
     basic_store.write("strings", df, dynamic_strings=True)
     vit = basic_store.read("strings")
@@ -1085,7 +1108,8 @@ def test_dynamic_strings_with_all_nones(basic_store):
 
 def test_dynamic_strings_with_all_nones_update(basic_store):
     df = pd.DataFrame(
-        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
+        {"col_1": ["a", "b"], "col_2": [0.1, 0.2]},
+        index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")],
     )
     update_df = pd.DataFrame({"col_1": [np.nan], "col_2": [0.1]}, index=[pd.Timestamp("2022-01-01")])
     basic_store.write("strings", df, dynamic_strings=True)
@@ -1101,7 +1125,12 @@ def test_dynamic_strings_with_all_nones_update(basic_store):
     assert data.data["col_1"][pd.Timestamp("2022-01-02")] == "b"
 
     basic_store.write("strings", df, dynamic_strings=True)
-    basic_store.update("strings", update_df, dynamic_strings=True, coerce_columns={"col_1": object, "col_2": "float"})
+    basic_store.update(
+        "strings",
+        update_df,
+        dynamic_strings=True,
+        coerce_columns={"col_1": object, "col_2": "float"},
+    )
 
     data = basic_store.read("strings")
     assert math.isnan(data.data["col_1"][pd.Timestamp("2022-01-01")])
@@ -1109,23 +1138,21 @@ def test_dynamic_strings_with_all_nones_update(basic_store):
 
 
 def test_dynamic_strings_with_nan(basic_store):
-    row = pd.Series(
-        [
-            np.nan,
-            "A",
-            "An_inordinately_long_string_for_no_sensible_purpose",
-            np.nan,
-            "B",
-            "C",
-            None,
-            "Baca",
-            "CABA",
-            None,
-            "dog",
-            "cat",
-            np.nan,
-        ]
-    )
+    row = pd.Series([
+        np.nan,
+        "A",
+        "An_inordinately_long_string_for_no_sensible_purpose",
+        np.nan,
+        "B",
+        "C",
+        None,
+        "Baca",
+        "CABA",
+        None,
+        "dog",
+        "cat",
+        np.nan,
+    ])
 
     df = pd.DataFrame({"x": row})
     basic_store.write("strings", df, dynamic_strings=True)
@@ -1168,7 +1195,11 @@ def test_recursively_written_data(basic_store):
     samples = [
         {"a": np.arange(5), "b": np.arange(8)},  # dict of np arrays
         (np.arange(5), np.arange(6)),  # tuple of np arrays
-        [np.arange(9), np.arange(12), (1, 2)],  # list of numpy arrays and a python tuple
+        [
+            np.arange(9),
+            np.arange(12),
+            (1, 2),
+        ],  # list of numpy arrays and a python tuple
         ({"a": np.arange(5), "b": [1, 2, 3]}),  # dict of np arrays and a python list
     ]
 
@@ -1189,7 +1220,10 @@ def test_recursively_written_data_with_metadata(basic_store):
 
     for idx, sample in enumerate(samples):
         vit = basic_store.write(
-            "sym_recursive" + str(idx), sample, metadata={"something": 1}, recursive_normalizers=True
+            "sym_recursive" + str(idx),
+            sample,
+            metadata={"something": 1},
+            recursive_normalizers=True,
         )
         recursive_data = basic_store.read("sym_recursive" + str(idx)).data
         equals(sample, recursive_data)
@@ -1320,7 +1354,9 @@ def test_batch_write(basic_store_tombstone_and_sync_passive):
         vitem = lmdb_version_store.read(sym)
         sequential_results[vitem.symbol] = vitem
     lmdb_version_store.batch_write(
-        list(multi_data.keys()), list(multi_data.values()), metadata_vector=(metadata[sym] for sym in multi_data)
+        list(multi_data.keys()),
+        list(multi_data.values()),
+        metadata_vector=(metadata[sym] for sym in multi_data),
     )
     batch_results = lmdb_version_store.batch_read(list(multi_data.keys()))
     assert len(batch_results) == len(sequential_results)
@@ -1565,7 +1601,10 @@ def test_dataframe_with_nan_and_nat_in_timestamp_column(basic_store):
 def test_dataframe_with_nan_and_nat_only(basic_store):
     df_with_nan_and_nat_only = pd.DataFrame({"col": [pd.NaT, pd.NaT, np.NaN]})  # Sample will be pd.NaT
     basic_store.write("nan_nat", df_with_nan_and_nat_only)
-    assert_frame_equal(basic_store.read("nan_nat").data, pd.DataFrame({"col": [pd.NaT, pd.NaT, pd.NaT]}))
+    assert_frame_equal(
+        basic_store.read("nan_nat").data,
+        pd.DataFrame({"col": [pd.NaT, pd.NaT, pd.NaT]}),
+    )
 
 
 def test_coercion_to_float(basic_store):
@@ -1598,7 +1637,8 @@ def test_coercion_to_str_with_dynamic_strings(basic_store):
             lib.write("sym", df)
 
     with mock.patch(
-        "arcticdb.version_store._normalization.get_sample_from_non_empty_arr", return_value="hello"
+        "arcticdb.version_store._normalization.get_sample_from_non_empty_arr",
+        return_value="hello",
     ) as sample_mock:
         # This should succeed but uses the slow path
         lib.write("sym", df, dynamic_strings=True)
@@ -1610,6 +1650,7 @@ def test_coercion_to_str_with_dynamic_strings(basic_store):
         sample_mock.assert_not_called()
 
 
+@pytest.mark.xfail(reason="Needs to be fixed by issue #496")
 def test_find_version(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_find_version"
@@ -1953,7 +1994,9 @@ def test_columns_as_nparrary(basic_store, sym):
 
 def test_simple_recursive_normalizer(object_version_store):
     object_version_store.write(
-        "rec_norm", data={"a": np.arange(5), "b": np.arange(8), "c": None}, recursive_normalizers=True
+        "rec_norm",
+        data={"a": np.arange(5), "b": np.arange(8), "c": None},
+        recursive_normalizers=True,
     )
 
 
@@ -2081,14 +2124,24 @@ def test_batch_restore_version(basic_store_tombstone):
 
 def test_batch_append(basic_store_tombstone, three_col_df):
     lmdb_version_store = basic_store_tombstone
-    multi_data = {"sym1": three_col_df(), "sym2": three_col_df(1), "sym3": three_col_df(2)}
+    multi_data = {
+        "sym1": three_col_df(),
+        "sym2": three_col_df(1),
+        "sym3": three_col_df(2),
+    }
     metadata = {"sym1": {"key1": "val1"}, "sym2": None, "sym3": None}
 
     lmdb_version_store.batch_write(
-        list(multi_data.keys()), list(multi_data.values()), metadata_vector=(metadata[sym] for sym in multi_data)
+        list(multi_data.keys()),
+        list(multi_data.values()),
+        metadata_vector=(metadata[sym] for sym in multi_data),
     )
 
-    multi_append = {"sym1": three_col_df(10), "sym2": three_col_df(11), "sym3": three_col_df(12)}
+    multi_append = {
+        "sym1": three_col_df(10),
+        "sym2": three_col_df(11),
+        "sym3": three_col_df(12),
+    }
     append_metadata = {"sym1": {"key1": "val2"}, "sym2": None, "sym3": "val3"}
     append_result = lmdb_version_store.batch_append(
         list(multi_append.keys()),
@@ -2211,7 +2264,13 @@ def test_dynamic_schema_column_hash_update(basic_store_column_buckets):
     idx = pd.date_range("2022-01-01", periods=10, freq="D")
     l = len(idx)
     df = pd.DataFrame(
-        {"a": range(l), "b": range(1, l + 1), "c": range(2, l + 2), "d": range(3, l + 3), "e": range(4, l + 4)},
+        {
+            "a": range(l),
+            "b": range(1, l + 1),
+            "c": range(2, l + 2),
+            "d": range(3, l + 3),
+            "e": range(4, l + 4),
+        },
         index=idx,
     )
 
@@ -2246,7 +2305,13 @@ def test_dynamic_schema_column_hash_append(basic_store_column_buckets):
     idx = pd.date_range("2022-01-01", periods=10, freq="D")
     l = len(idx)
     df = pd.DataFrame(
-        {"a": range(l), "b": range(1, l + 1), "c": range(2, l + 2), "d": range(3, l + 3), "e": range(4, l + 4)},
+        {
+            "a": range(l),
+            "b": range(1, l + 1),
+            "c": range(2, l + 2),
+            "d": range(3, l + 3),
+            "e": range(4, l + 4),
+        },
         index=idx,
     )
 
@@ -2277,7 +2342,13 @@ def test_dynamic_schema_column_hash(basic_store_column_buckets):
     idx = pd.date_range("2022-01-01", periods=10, freq="D")
     l = len(idx)
     df = pd.DataFrame(
-        {"a": range(l), "b": range(1, l + 1), "c": range(2, l + 2), "d": range(3, l + 3), "e": range(4, l + 4)},
+        {
+            "a": range(l),
+            "b": range(1, l + 1),
+            "c": range(2, l + 2),
+            "d": range(3, l + 3),
+            "e": range(4, l + 4),
+        },
         index=idx,
     )
 
@@ -2345,7 +2416,13 @@ def test_modification_methods_dont_return_input_data(basic_store, batch, method)
 @pytest.mark.parametrize("num", (5, 50, 1001))
 def test_diff_long_stream_descriptor_mismatch(basic_store, method, num):
     lib: NativeVersionStore = basic_store
-    lib.write("x", pd.DataFrame({f"col{i}": [i, i + 1, i + 2] for i in range(num)}, index=pd.date_range(0, periods=3)))
+    lib.write(
+        "x",
+        pd.DataFrame(
+            {f"col{i}": [i, i + 1, i + 2] for i in range(num)},
+            index=pd.date_range(0, periods=3),
+        ),
+    )
     bad_row = {f"col{i}": ["a"] if i % 20 == 4 else [i] for i in (0, *range(3, num + 1))}
     try:
         if method == "append":
@@ -2365,14 +2442,21 @@ def test_diff_long_stream_descriptor_mismatch(basic_store, method, num):
 
 def test_get_non_existing_columns_in_series(basic_store, sym):
     lib = basic_store
-    dst = pd.Series(index=pd.date_range(pd.Timestamp("2022-01-01"), pd.Timestamp("2022-02-01")), data=0.0)
+    dst = pd.Series(
+        index=pd.date_range(pd.Timestamp("2022-01-01"), pd.Timestamp("2022-02-01")),
+        data=0.0,
+    )
     lib.write(sym, dst)
     assert basic_store.read(sym, columns=["col1"]).data.empty
 
 
 def test_get_existing_columns_in_series(basic_store, sym):
     lib = basic_store
-    dst = pd.Series(index=pd.date_range(pd.Timestamp("2022-01-01"), pd.Timestamp("2022-02-01")), data=0.0, name="col1")
+    dst = pd.Series(
+        index=pd.date_range(pd.Timestamp("2022-01-01"), pd.Timestamp("2022-02-01")),
+        data=0.0,
+        name="col1",
+    )
     lib.write(sym, dst)
     assert not basic_store.read(sym, columns=["col1", "col2"]).data.empty
     if __name__ == "__main__":
@@ -2430,7 +2514,12 @@ def test_use_previous_on_failure_batch(basic_store):
         expected.append(df1)
         time.sleep(1)
         df2 = pd.DataFrame(
-            {"d": range(x + 1, l + x + 1), "e": range(x + 2, l + x + 2), "f": range(x + 3, l + x + 3)}, index=idx
+            {
+                "d": range(x + 1, l + x + 1),
+                "e": range(x + 2, l + x + 2),
+                "f": range(x + 3, l + x + 3),
+            },
+            index=idx,
         )
         lib.write(symbol, df2)
 

--- a/python/tests/integration/arcticdb/version_store/test_file_config.py
+++ b/python/tests/integration/arcticdb/version_store/test_file_config.py
@@ -10,17 +10,17 @@ from arcticdb.version_store.helper import add_lmdb_library_to_env, save_envs_con
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
 
 
-def _make_temp_lmdb_lib(tmpdir, library_name):
-    cfg_filename = "{}/{}".format(tmpdir, "test_cfg")
+def _make_temp_lmdb_lib(tmp_path, library_name):
+    cfg_filename = "{}/{}".format(tmp_path, "test_cfg")
     cfg = EnvironmentConfigsMap()
     add_lmdb_library_to_env(
-        cfg, lib_name=library_name, env_name=Defaults.ENV, description="a test library", db_dir=str(tmpdir)
+        cfg, lib_name=library_name, env_name=Defaults.ENV, description="a test library", db_dir=str(tmp_path)
     )
     save_envs_config(cfg, conf_path=cfg_filename)
     return "{}@{}".format(library_name, cfg_filename)
 
 
-def test_native_lmdb_library(tmpdir):
-    lib = get_arctic_native_lib(_make_temp_lmdb_lib(tmpdir, "test.file_config"))
+def test_native_lmdb_library(tmp_path):
+    lib = get_arctic_native_lib(_make_temp_lmdb_lib(tmp_path, "test.file_config"))
     lib.write("symbol", "thing")
     assert lib.read("symbol").data == "thing"

--- a/python/tests/unit/arcticdb/test_config.py
+++ b/python/tests/unit/arcticdb/test_config.py
@@ -22,12 +22,12 @@ def test_config_roundtrip(version_store_factory):
     assert loaded._lib_cfg == vs._lib_cfg
 
 
-def test_runtime_config_roundtrip(tmpdir):
+def test_runtime_config_roundtrip(tmp_path):
     runtime_cfg = RuntimeConfig()
     runtime_cfg.string_values["string"] = "stuff"
     runtime_cfg.double_values["double"] = 2.5
     runtime_cfg.int_values["int"] = 11
-    conf_path = "{}/{}".format(tmpdir, "test_rt_conf.yaml")
+    conf_path = "{}/{}".format(tmp_path, "test_rt_conf.yaml")
     save_runtime_config(runtime_cfg, conf_path)
     read_conf = load_runtime_config(conf_path)
     assert read_conf.string_values["string"] == "stuff"

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import pytest
 import numpy as np
 import pandas as pd
@@ -30,7 +31,10 @@ from tests.util.mark import xfail_on_linux_conda
 def test_group_on_float_column_with_nans(lmdb_version_store):
     lib = lmdb_version_store
     sym = "test_group_on_float_column_with_nans"
-    df = pd.DataFrame({"grouping_column": [1.0, 2.0, np.nan, 1.0, 2.0, 2.0], "agg_column": [1, 2, 3, 4, 5, 6]})
+    df = pd.DataFrame({
+        "grouping_column": [1.0, 2.0, np.nan, 1.0, 2.0, 2.0],
+        "agg_column": [1, 2, 3, 4, 5, 6],
+    })
     lib.write(sym, df)
     expected = df.groupby("grouping_column").agg({"agg_column": "sum"})
     q = QueryBuilder()
@@ -86,6 +90,7 @@ def test_hypothesis_mean_agg(lmdb_version_store, df):
         index=range_indexes(),
     )
 )
+@pytest.mark.xfail(reason="Needs to be fixed by issue #496")
 def test_hypothesis_sum_agg(lmdb_version_store, df):
     lib = lmdb_version_store
     assume(not df.empty)
@@ -197,7 +202,14 @@ def test_hypothesis_count_agg_strings(lmdb_version_store, df):
 def test_count_aggregation(local_object_version_store):
     df = DataFrame(
         {
-            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2", "group_3"],
+            "grouping_column": [
+                "group_1",
+                "group_1",
+                "group_1",
+                "group_2",
+                "group_2",
+                "group_3",
+            ],
             "to_count": [100, 1, 3, 2, 2, np.nan],
         },
         index=np.arange(6),
@@ -210,7 +222,11 @@ def test_count_aggregation(local_object_version_store):
     res = local_object_version_store.read(symbol, query_builder=q)
     res.data.sort_index(inplace=True)
 
-    df = pd.DataFrame({"to_count": [3, 2, 0]}, index=["group_1", "group_2", "group_3"], dtype=np.uint64)
+    df = pd.DataFrame(
+        {"to_count": [3, 2, 0]},
+        index=["group_1", "group_2", "group_3"],
+        dtype=np.uint64,
+    )
     df.index.rename("grouping_column", inplace=True)
     res.data.sort_index(inplace=True)
 
@@ -219,7 +235,10 @@ def test_count_aggregation(local_object_version_store):
 
 def test_sum_aggregation(local_object_version_store):
     df = DataFrame(
-        {"grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"], "to_sum": [1, 1, 2, 2, 2]},
+        {
+            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
+            "to_sum": [1, 1, 2, 2, 2],
+        },
         index=np.arange(5),
     )
     q = QueryBuilder()
@@ -239,7 +258,10 @@ def test_sum_aggregation(local_object_version_store):
 
 def test_mean_aggregation(local_object_version_store):
     df = DataFrame(
-        {"grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"], "to_mean": [1, 1, 2, 2, 2]},
+        {
+            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
+            "to_mean": [1, 1, 2, 2, 2],
+        },
         index=np.arange(5),
     )
     q = QueryBuilder()
@@ -356,15 +378,13 @@ def test_group_column_not_present(lmdb_version_store):
 def test_group_column_splitting(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     symbol = "test_group_column_splitting"
-    df = DataFrame(
-        {
-            "grouping_column": [1, 2, 3, 4, 1, 2, 3, 4],
-            "sum1": [1, 2, 3, 4, 1, 2, 3, 4],
-            "max1": [1, 2, 3, 4, 1, 2, 3, 4],
-            "sum2": [2, 3, 4, 5, 2, 3, 4, 5],
-            "max2": [2, 3, 4, 5, 2, 3, 4, 5],
-        }
-    )
+    df = DataFrame({
+        "grouping_column": [1, 2, 3, 4, 1, 2, 3, 4],
+        "sum1": [1, 2, 3, 4, 1, 2, 3, 4],
+        "max1": [1, 2, 3, 4, 1, 2, 3, 4],
+        "sum2": [2, 3, 4, 5, 2, 3, 4, 5],
+        "max2": [2, 3, 4, 5, 2, 3, 4, 5],
+    })
 
     lib.write(symbol, df)
     q = QueryBuilder()
@@ -379,15 +399,22 @@ def test_group_column_splitting(lmdb_version_store_tiny_segment):
 def test_group_column_splitting_strings(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     symbol = "test_group_column_splitting"
-    df = DataFrame(
-        {
-            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2", "group_1", "group_2", "group_1"],
-            "sum1": [1, 2, 3, 4, 1, 2, 3, 4],
-            "max1": [1, 2, 3, 4, 1, 2, 3, 4],
-            "sum2": [2, 3, 4, 5, 2, 3, 4, 5],
-            "max2": [2, 3, 4, 5, 2, 3, 4, 5],
-        }
-    )
+    df = DataFrame({
+        "grouping_column": [
+            "group_1",
+            "group_1",
+            "group_1",
+            "group_2",
+            "group_2",
+            "group_1",
+            "group_2",
+            "group_1",
+        ],
+        "sum1": [1, 2, 3, 4, 1, 2, 3, 4],
+        "max1": [1, 2, 3, 4, 1, 2, 3, 4],
+        "sum2": [2, 3, 4, 5, 2, 3, 4, 5],
+        "max2": [2, 3, 4, 5, 2, 3, 4, 5],
+    })
 
     lib.write(symbol, df)
     q = QueryBuilder()
@@ -463,7 +490,10 @@ def test_docstring_example_query_builder_apply(lmdb_version_store):
 
 
 def test_doctring_example_query_builder_groupby_max(lmdb_version_store):
-    df = DataFrame({"grouping_column": ["group_1", "group_1", "group_1"], "to_max": [1, 5, 4]}, index=np.arange(3))
+    df = DataFrame(
+        {"grouping_column": ["group_1", "group_1", "group_1"], "to_max": [1, 5, 4]},
+        index=np.arange(3),
+    )
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"to_max": "max"})
 
@@ -476,7 +506,11 @@ def test_doctring_example_query_builder_groupby_max(lmdb_version_store):
 
 def test_docstring_example_query_builder_groupby_max_and_mean(lmdb_version_store):
     df = DataFrame(
-        {"grouping_column": ["group_1", "group_1", "group_1"], "to_mean": [1.1, 1.4, 2.5], "to_max": [1.1, 1.4, 2.5]},
+        {
+            "grouping_column": ["group_1", "group_1", "group_1"],
+            "to_mean": [1.1, 1.4, 2.5],
+            "to_max": [1.1, 1.4, 2.5],
+        },
         index=np.arange(3),
     )
     q = QueryBuilder()

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import time
 
 from pandas import Timestamp
@@ -50,6 +51,7 @@ def test_column_names_by_snapshot(lmdb_version_store, one_col_df, two_col_df):
     assert lmdb_version_store.column_names(symbol, as_of="one_col_snap") == ["x"]
 
 
+@pytest.mark.xfail(reason="Needs to be fixed by issue #496")
 def test_column_names_by_timestamp(lmdb_version_store, one_col_df, two_col_df):
     symbol = "test_column_names_by_timestamp"
 

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -8,9 +8,14 @@ from numpy.testing import assert_array_equal
 
 from pandas import MultiIndex
 from arcticdb.version_store import NativeVersionStore
-from arcticdb_ext.exceptions import InternalException, NormalizationException, SortingException
+from arcticdb_ext.exceptions import (
+    InternalException,
+    NormalizationException,
+    SortingException,
+)
 from arcticdb_ext import set_config_int
 from arcticdb.util.test import random_integers, assert_frame_equal
+
 
 def test_append_simple(lmdb_version_store):
     symbol = "test_append_simple"
@@ -51,7 +56,10 @@ def test_append_string_of_different_sizes(lmdb_version_store):
     vit = lmdb_version_store.read(symbol)
     assert_frame_equal(vit.data, df1)
 
-    df2 = pd.DataFrame(data={"x": ["catandsomethingelse", "dogandsomethingevenlonger"]}, index=np.arange(2, 4))
+    df2 = pd.DataFrame(
+        data={"x": ["catandsomethingelse", "dogandsomethingevenlonger"]},
+        index=np.arange(2, 4),
+    )
     lmdb_version_store.append(symbol, df2)
     vit = lmdb_version_store.read(symbol)
     expected = pd.concat([df1, df2])
@@ -93,7 +101,9 @@ def _random_integers(size, dtype):
     platform_int_info = np.iinfo("int_")
     iinfo = np.iinfo(dtype)
     return np.random.randint(
-        max(iinfo.min, platform_int_info.min), min(iinfo.max, platform_int_info.max), size=size
+        max(iinfo.min, platform_int_info.min),
+        min(iinfo.max, platform_int_info.max),
+        size=size,
     ).astype(dtype)
 
 
@@ -111,7 +121,11 @@ def test_append_out_of_order_and_sort(lmdb_version_store_ignore_order):
     num_rows = 1111
     dtidx = pd.date_range("1970-01-01", periods=num_rows)
     test = pd.DataFrame(
-        {"uint8": _random_integers(num_rows, np.uint8), "uint32": _random_integers(num_rows, np.uint32)}, index=dtidx
+        {
+            "uint8": _random_integers(num_rows, np.uint8),
+            "uint32": _random_integers(num_rows, np.uint32),
+        },
+        index=dtidx,
     )
     chunk_size = 100
     list_df = [test[i : i + chunk_size] for i in range(0, test.shape[0], chunk_size)]
@@ -139,7 +153,11 @@ def test_upsert_with_delete(lmdb_version_store_big_map):
     num_rows = 1111
     dtidx = pd.date_range("1970-01-01", periods=num_rows)
     test = pd.DataFrame(
-        {"uint8": _random_integers(num_rows, np.uint8), "uint32": _random_integers(num_rows, np.uint32)}, index=dtidx
+        {
+            "uint8": _random_integers(num_rows, np.uint8),
+            "uint32": _random_integers(num_rows, np.uint32),
+        },
+        index=dtidx,
     )
     chunk_size = 100
     list_df = [test[i : i + chunk_size] for i in range(0, test.shape[0], chunk_size)]
@@ -411,7 +429,7 @@ def test_append_mix_ascending_descending(lmdb_version_store):
     assert info["sorted"] == "UNSORTED"
 
 
-@pytest.mark.xfail(reason="Needs to be fixed with issue #496")
+@pytest.mark.xfail(reason="Needs to be fixed by issue #496")
 def test_append_with_cont_mem_problem(sym, lmdb_version_store_tiny_segment_dynamic):
     set_config_int("SymbolDataCompact.SegmentCount", 1)
     df0 = pd.DataFrame({"0": ["01234567890123456"]}, index=[pd.Timestamp(0)])

--- a/python/tests/unit/arcticdb/version_store/test_engine.py
+++ b/python/tests/unit/arcticdb/version_store/test_engine.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 from itertools import product, chain, combinations
 
 import numpy as np
@@ -88,10 +89,14 @@ def test_partial_write_non_contiguous(version_store_factory, colnum, rownum, col
 
 
 @pytest.mark.parametrize("colnum,rownum,cols,tsbounds", gen_params())
+@pytest.mark.xfail(reason="Needs to be fixed by issue #316")
 def test_partial_write_hashed(version_store_factory, colnum, rownum, cols, tsbounds):
     tz = "America/New_York"
     version_store = version_store_factory(
-        col_per_group=colnum, row_per_segment=rownum, dynamic_schema=True, bucketize_dynamic=True
+        col_per_group=colnum,
+        row_per_segment=rownum,
+        dynamic_schema=True,
+        bucketize_dynamic=True,
     )
     dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
     a = np.arange(dtidx.shape[0])

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import copy
 import pickle
 import math
@@ -26,7 +27,11 @@ import string
 from arcticdb.exceptions import ArcticNativeException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.exceptions import InternalException, StorageException, UserInputException
+from arcticdb_ext.exceptions import (
+    InternalException,
+    StorageException,
+    UserInputException,
+)
 from arcticdb.util.test import assert_frame_equal, PANDAS_VERSION
 from arcticdb.util._versions import PANDAS_VERSION
 from arcticdb.util.hypothesis import (
@@ -275,7 +280,10 @@ def test_filter_clashing_values(lmdb_version_store):
 def test_filter_bool_nonbool_comparison(lmdb_version_store):
     symbol = "test_filter_bool_nonbool_comparison"
     lib = lmdb_version_store
-    df = DataFrame({"string": ["True", "False"], "numeric": [1, 0], "bool": [True, False]}, index=np.arange(2))
+    df = DataFrame(
+        {"string": ["True", "False"], "numeric": [1, 0], "bool": [True, False]},
+        index=np.arange(2),
+    )
     lib.write(symbol, df)
 
     # bool column to string column
@@ -327,11 +335,20 @@ def test_filter_bool_column_not(lmdb_version_store):
 
 
 def test_filter_bool_column_binary_boolean(lmdb_version_store):
-    df = DataFrame({"a": [True, True, False, False], "b": [True, False, True, False]}, index=np.arange(4))
+    df = DataFrame(
+        {"a": [True, True, False, False], "b": [True, False, True, False]},
+        index=np.arange(4),
+    )
     q = QueryBuilder()
     q = q[q["a"] & q["b"]]
     pandas_query = "a & b"
-    generic_filter_test(lmdb_version_store, "test_filter_bool_column_binary_boolean", df, q, pandas_query)
+    generic_filter_test(
+        lmdb_version_store,
+        "test_filter_bool_column_binary_boolean",
+        df,
+        q,
+        pandas_query,
+    )
 
 
 def test_filter_bool_column_comparison(lmdb_version_store):
@@ -353,7 +370,13 @@ def test_filter_bool_column_comparison(lmdb_version_store):
                 q = q[q["a"] > bool_value]
             elif comparator == ">=":
                 q = q[q["a"] >= bool_value]
-            generic_filter_test(lmdb_version_store, "test_filter_bool_column_comparison", df, q, pandas_query)
+            generic_filter_test(
+                lmdb_version_store,
+                "test_filter_bool_column_comparison",
+                df,
+                q,
+                pandas_query,
+            )
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -388,7 +411,10 @@ def test_filter_less_than_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -432,7 +458,10 @@ def test_filter_less_than_equals_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -476,7 +505,10 @@ def test_filter_greater_than_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -499,7 +531,13 @@ def test_filter_greater_than_equals_col_val(lmdb_version_store, df, val):
     q = QueryBuilder()
     q = q[q["a"] >= val]
     pandas_query = "a >= {}".format(val)
-    generic_filter_test(lmdb_version_store, "test_filter_greater_than_equals_col_val", df, q, pandas_query)
+    generic_filter_test(
+        lmdb_version_store,
+        "test_filter_greater_than_equals_col_val",
+        df,
+        q,
+        pandas_query,
+    )
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -513,14 +551,23 @@ def test_filter_greater_than_equals_val_col(lmdb_version_store, df, val):
     q = QueryBuilder()
     q = q[val >= q["a"]]
     pandas_query = "{} >= a".format(val)
-    generic_filter_test(lmdb_version_store, "test_filter_greater_than_equals_val_col", df, q, pandas_query)
+    generic_filter_test(
+        lmdb_version_store,
+        "test_filter_greater_than_equals_val_col",
+        df,
+        q,
+        pandas_query,
+    )
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -529,7 +576,13 @@ def test_filter_greater_than_equals_col_col(lmdb_version_store, df):
     q = QueryBuilder()
     q = q[q["a"] >= q["b"]]
     pandas_query = "a >= b"
-    generic_filter_test(lmdb_version_store, "test_filter_greater_than_equals_col_col", df, q, pandas_query)
+    generic_filter_test(
+        lmdb_version_store,
+        "test_filter_greater_than_equals_col_col",
+        df,
+        q,
+        pandas_query,
+    )
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -564,7 +617,10 @@ def test_filter_equals_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=integral_type_strategies()), column("b", elements=integral_type_strategies())],
+        [
+            column("a", elements=integral_type_strategies()),
+            column("b", elements=integral_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -608,7 +664,10 @@ def test_filter_not_equals_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=integral_type_strategies()), column("b", elements=integral_type_strategies())],
+        [
+            column("a", elements=integral_type_strategies()),
+            column("b", elements=integral_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -714,8 +773,16 @@ def test_filter_datetime_timezone_aware(lmdb_version_store):
 # Restrict datetime range to a couple of years, as this should be sufficient to catch most weird corner cases
 @settings(deadline=None)
 @given(
-    df_dt=st.datetimes(min_value=datetime(2020, 1, 1), max_value=datetime(2022, 1, 1), timezones=timezone_st()),
-    comparison_dt=st.datetimes(min_value=datetime(2020, 1, 1), max_value=datetime(2022, 1, 1), timezones=timezone_st()),
+    df_dt=st.datetimes(
+        min_value=datetime(2020, 1, 1),
+        max_value=datetime(2022, 1, 1),
+        timezones=timezone_st(),
+    ),
+    comparison_dt=st.datetimes(
+        min_value=datetime(2020, 1, 1),
+        max_value=datetime(2022, 1, 1),
+        timezones=timezone_st(),
+    ),
 )
 def test_filter_datetime_timezone_aware_hypothesis(version_store_factory, df_dt, comparison_dt):
     lmdb_version_store = version_store_factory(name="_unique_")
@@ -782,7 +849,10 @@ def test_filter_datetime_nanoseconds(lmdb_version_store):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=numeric_type_strategies())
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=numeric_type_strategies(),
+)
 def test_filter_compare_string_number_col_val(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -799,7 +869,10 @@ def test_filter_compare_string_number_col_val(lmdb_version_store, df, val):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=numeric_type_strategies())], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=numeric_type_strategies())], index=range_indexes()),
+    val=string_strategy,
+)
 def test_filter_compare_string_number_val_col(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -818,7 +891,11 @@ def test_filter_compare_string_number_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=string_strategy), column("b", elements=numeric_type_strategies())], index=range_indexes()
+        [
+            column("a", elements=string_strategy),
+            column("b", elements=numeric_type_strategies()),
+        ],
+        index=range_indexes(),
     )
 )
 def test_filter_compare_string_number_col_col(lmdb_version_store, df):
@@ -1043,7 +1120,10 @@ def test_filter_numeric_isnotin_empty_set(lmdb_version_store, df):
 def test_filter_nones_and_nans_retained_in_string_column(lmdb_version_store):
     lib = lmdb_version_store
     sym = "test_filter_nones_and_nans_retained_in_string_column"
-    df = pd.DataFrame({"filter_column": [1, 2, 1, 2, 1, 2], "string_column": ["1", "2", np.nan, "4", None, "6"]})
+    df = pd.DataFrame({
+        "filter_column": [1, 2, 1, 2, 1, 2],
+        "string_column": ["1", "2", np.nan, "4", None, "6"],
+    })
     lib.write(sym, df)
     q = QueryBuilder()
     q = q[q["filter_column"] == 1]
@@ -1078,7 +1158,12 @@ def test_filter_fixed_width_string_isin_truncation(lmdb_version_store):
     q = q[q["a"].isin(vals)]
     pandas_query = "a in {}".format(list(vals))
     generic_filter_test(
-        lmdb_version_store, "test_filter_fixed_width_string_isin_truncation", df, q, pandas_query, dynamic_strings=False
+        lmdb_version_store,
+        "test_filter_fixed_width_string_isin_truncation",
+        df,
+        q,
+        pandas_query,
+        dynamic_strings=False,
     )
 
 
@@ -1128,20 +1213,22 @@ def test_filter_stringpool_shrinking_basic(lmdb_version_store_tiny_segment):
     # - at least one segment will need all of the strings in it's pool after filtering
     # - at least one segment will need none of the strings in it's pool after filtering
     # - at least one segment will need some, but not all of the strings in it's pool after filtering
-    df = DataFrame(
-        {
-            "a": ["a1", "a2", "a3", "a4", "a5"],
-            "b": ["b11", "b22", "b3", "b4", "b5"],
-            "c": ["c1", "c2", "c3", "c4", "c5"],
-            "d": ["d11", "d2", "d3", "d4", "d5"],
-        }
-    )
+    df = DataFrame({
+        "a": ["a1", "a2", "a3", "a4", "a5"],
+        "b": ["b11", "b22", "b3", "b4", "b5"],
+        "c": ["c1", "c2", "c3", "c4", "c5"],
+        "d": ["d11", "d2", "d3", "d4", "d5"],
+    })
     q = QueryBuilder()
     q = q[q["a"] != "a1"]
     q.optimise_for_memory()
     pandas_query = "a != 'a1'"
     generic_filter_test_strings(
-        lmdb_version_store_tiny_segment, "test_filter_stringpool_shrinking_1", df, q, pandas_query
+        lmdb_version_store_tiny_segment,
+        "test_filter_stringpool_shrinking_1",
+        df,
+        q,
+        pandas_query,
     )
 
 
@@ -1156,7 +1243,11 @@ def test_filter_stringpool_shrinking_block_alignment(lmdb_version_store):
     q = q[q["a"] == string_to_find]
     pandas_query = f"a == '{string_to_find}'"
     generic_filter_test_strings(
-        lmdb_version_store, "test_filter_stringpool_shrinking_block_alignment", df, q, pandas_query
+        lmdb_version_store,
+        "test_filter_stringpool_shrinking_block_alignment",
+        df,
+        q,
+        pandas_query,
     )
 
 
@@ -1164,7 +1255,10 @@ def test_filter_stringpool_shrinking_block_alignment(lmdb_version_store):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -1180,7 +1274,10 @@ def test_filter_and(lmdb_version_store, df):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -1196,7 +1293,10 @@ def test_filter_or(lmdb_version_store, df):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -1241,7 +1341,10 @@ def test_filter_add_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -1285,7 +1388,10 @@ def test_filter_sub_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -1329,7 +1435,10 @@ def test_filter_times_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -1358,7 +1467,10 @@ def test_filter_divide_col_val(lmdb_version_store, df, val):
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
 @given(
-    df=data_frames([column("a", elements=non_zero_numeric_type_strategies())], index=range_indexes()),
+    df=data_frames(
+        [column("a", elements=non_zero_numeric_type_strategies())],
+        index=range_indexes(),
+    ),
     val=numeric_type_strategies(),
 )
 def test_filter_divide_val_col(lmdb_version_store, df, val):
@@ -1373,7 +1485,10 @@ def test_filter_divide_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=numeric_type_strategies()), column("b", elements=non_zero_numeric_type_strategies())],
+        [
+            column("a", elements=numeric_type_strategies()),
+            column("b", elements=non_zero_numeric_type_strategies()),
+        ],
         index=range_indexes(),
     )
 )
@@ -1387,7 +1502,10 @@ def test_filter_divide_col_col(lmdb_version_store, df):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=numeric_type_strategies())
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=numeric_type_strategies(),
+)
 def test_filter_arithmetic_string_number_col_val(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -1404,7 +1522,10 @@ def test_filter_arithmetic_string_number_col_val(lmdb_version_store, df, val):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=numeric_type_strategies())], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=numeric_type_strategies())], index=range_indexes()),
+    val=string_strategy,
+)
 def test_filter_arithmetic_string_number_val_col(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -1423,7 +1544,11 @@ def test_filter_arithmetic_string_number_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=string_strategy), column("b", elements=numeric_type_strategies())], index=range_indexes()
+        [
+            column("a", elements=string_strategy),
+            column("b", elements=numeric_type_strategies()),
+        ],
+        index=range_indexes(),
     )
 )
 def test_filter_arithmetic_string_number_col_col(lmdb_version_store, df):
@@ -1442,7 +1567,10 @@ def test_filter_arithmetic_string_number_col_col(lmdb_version_store, df):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 def test_filter_arithmetic_string_string_col_val(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -1459,7 +1587,10 @@ def test_filter_arithmetic_string_string_col_val(lmdb_version_store, df, val):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 def test_filter_arithmetic_string_string_val_col(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -1478,7 +1609,8 @@ def test_filter_arithmetic_string_string_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=string_strategy), column("b", elements=string_strategy)], index=range_indexes()
+        [column("a", elements=string_strategy), column("b", elements=string_strategy)],
+        index=range_indexes(),
     )
 )
 def test_filter_arithmetic_string_string_col_col(lmdb_version_store, df):
@@ -1511,7 +1643,10 @@ def test_filter_abs(lmdb_version_store, df, val):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 def test_filter_abs_string(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -1538,7 +1673,10 @@ def test_filter_neg(lmdb_version_store, df, val):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 def test_filter_neg_string(lmdb_version_store, df, val):
     assume(not df.empty)
     q = QueryBuilder()
@@ -1649,7 +1787,11 @@ def test_filter_more_columns_than_fit_in_one_segment(lmdb_version_store_tiny_seg
     q = q[(q["a"] < q["c"]) | (q["a"] < q["b"]) | (q["b"] < q["c"])]
     pandas_query = "(a < c) | (a < b) | (b < c)"
     generic_filter_test(
-        lmdb_version_store_tiny_segment, "test_filter_more_columns_than_fit_in_one_segment", df, q, pandas_query
+        lmdb_version_store_tiny_segment,
+        "test_filter_more_columns_than_fit_in_one_segment",
+        df,
+        q,
+        pandas_query,
     )
 
 
@@ -1678,7 +1820,10 @@ def test_filter_with_column_slicing(lmdb_version_store_tiny_segment, df):
 
 
 def test_filter_column_slicing_different_segments(lmdb_version_store_tiny_segment):
-    df = DataFrame({"a": np.arange(0, 10), "b": np.arange(10, 20), "c": np.arange(20, 30)}, index=np.arange(10))
+    df = DataFrame(
+        {"a": np.arange(0, 10), "b": np.arange(10, 20), "c": np.arange(20, 30)},
+        index=np.arange(10),
+    )
     symbol = "test_filter_column_slicing_different_segments"
     lmdb_version_store_tiny_segment.write(symbol, df)
     # Filter on column c (in second column slice), but only display column a (in first column slice)
@@ -1710,7 +1855,8 @@ def test_filter_with_multi_index(lmdb_version_store):
     arr1 = [dt1, dt1, dt2, dt2]
     arr2 = [0, 1, 0, 1]
     df = DataFrame(
-        data={"a": np.arange(10, 14)}, index=pd.MultiIndex.from_arrays([arr1, arr2], names=["datetime", "level"])
+        data={"a": np.arange(10, 14)},
+        index=pd.MultiIndex.from_arrays([arr1, arr2], names=["datetime", "level"]),
     )
     q = QueryBuilder()
     q = q[(q["a"] == 11) | (q["a"] == 13)]
@@ -1724,7 +1870,8 @@ def test_filter_on_multi_index(lmdb_version_store):
     arr1 = [dt1, dt1, dt2, dt2]
     arr2 = [0, 1, 0, 1]
     df = DataFrame(
-        data={"a": np.arange(10, 14)}, index=pd.MultiIndex.from_arrays([arr1, arr2], names=["datetime", "level"])
+        data={"a": np.arange(10, 14)},
+        index=pd.MultiIndex.from_arrays([arr1, arr2], names=["datetime", "level"]),
     )
     q = QueryBuilder()
     q = q[(q["level"] == 1)]
@@ -1758,7 +1905,13 @@ def test_filter_complex_expression(lmdb_version_store_tiny_segment):
     q = QueryBuilder()
     q = q[(((q["a"] * q["b"]) / 5) < (0.7 * q["c"])) & (q["b"] != 12)]
     pandas_query = "(((a * b) / 5) < (0.7 * c)) & (b != 12)"
-    generic_filter_test(lmdb_version_store_tiny_segment, "test_filter_complex_expression", df, q, pandas_query)
+    generic_filter_test(
+        lmdb_version_store_tiny_segment,
+        "test_filter_complex_expression",
+        df,
+        q,
+        pandas_query,
+    )
 
 
 def test_filter_string_backslash(lmdb_version_store):
@@ -1785,7 +1938,10 @@ def test_filter_string_single_quote(lmdb_version_store):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 @AZURE_TESTS_MARK
 def test_filter_string_equals_col_val(lmdb_version_store, df, val):
     assume(not df.empty)
@@ -1797,7 +1953,10 @@ def test_filter_string_equals_col_val(lmdb_version_store, df, val):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 @AZURE_TESTS_MARK
 def test_filter_string_equals_val_col(lmdb_version_store, df, val):
     assume(not df.empty)
@@ -1811,7 +1970,8 @@ def test_filter_string_equals_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=string_strategy), column("b", elements=string_strategy)], index=range_indexes()
+        [column("a", elements=string_strategy), column("b", elements=string_strategy)],
+        index=range_indexes(),
     )
 )
 @AZURE_TESTS_MARK
@@ -1825,7 +1985,10 @@ def test_filter_string_equals_col_col(lmdb_version_store, df):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 @AZURE_TESTS_MARK
 def test_filter_string_not_equals_col_val(lmdb_version_store, df, val):
     assume(not df.empty)
@@ -1837,7 +2000,10 @@ def test_filter_string_not_equals_col_val(lmdb_version_store, df, val):
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
-@given(df=data_frames([column("a", elements=string_strategy)], index=range_indexes()), val=string_strategy)
+@given(
+    df=data_frames([column("a", elements=string_strategy)], index=range_indexes()),
+    val=string_strategy,
+)
 @AZURE_TESTS_MARK
 def test_filter_string_not_equals_val_col(lmdb_version_store, df, val):
     assume(not df.empty)
@@ -1851,7 +2017,8 @@ def test_filter_string_not_equals_val_col(lmdb_version_store, df, val):
 @settings(deadline=None)
 @given(
     df=data_frames(
-        [column("a", elements=string_strategy), column("b", elements=string_strategy)], index=range_indexes()
+        [column("a", elements=string_strategy), column("b", elements=string_strategy)],
+        index=range_indexes(),
     )
 )
 @AZURE_TESTS_MARK
@@ -1878,7 +2045,13 @@ def test_filter_string_less_than_equal(lmdb_version_store):
     q = q[q["a"] <= "row2"]
     pandas_query = "a <= 'row2'"
     with pytest.raises(InternalException) as e_info:
-        generic_filter_test(lmdb_version_store, "test_filter_string_less_than_equal", df, q, pandas_query)
+        generic_filter_test(
+            lmdb_version_store,
+            "test_filter_string_less_than_equal",
+            df,
+            q,
+            pandas_query,
+        )
 
 
 def test_filter_string_greater_than(lmdb_version_store):
@@ -1896,7 +2069,13 @@ def test_filter_string_greater_than_equal(lmdb_version_store):
     q = q[q["a"] >= "row2"]
     pandas_query = "a >= 'row2'"
     with pytest.raises(InternalException) as e_info:
-        generic_filter_test(lmdb_version_store, "test_filter_string_greater_than_equal", df, q, pandas_query)
+        generic_filter_test(
+            lmdb_version_store,
+            "test_filter_string_greater_than_equal",
+            df,
+            q,
+            pandas_query,
+        )
 
 
 # TODO: Replace with np.array_equal with equal_nan argument (added in 1.19.0)
@@ -1958,8 +2137,30 @@ def test_filter_string_nans_col_col(lmdb_version_store):
     # Compare all combinations of string, None, np.nan, and math.nan to one another
     df = pd.DataFrame(
         {
-            "a": ["row1", "row2", "row3", "row4", None, None, None, np.nan, np.nan, math.nan],
-            "b": ["row1", None, np.nan, math.nan, None, np.nan, math.nan, np.nan, math.nan, math.nan],
+            "a": [
+                "row1",
+                "row2",
+                "row3",
+                "row4",
+                None,
+                None,
+                None,
+                np.nan,
+                np.nan,
+                math.nan,
+            ],
+            "b": [
+                "row1",
+                None,
+                np.nan,
+                math.nan,
+                None,
+                np.nan,
+                math.nan,
+                np.nan,
+                math.nan,
+                math.nan,
+            ],
         },
         index=np.arange(10),
     )


### PR DESCRIPTION
#### Reference Issues/PRs
Fix for issue #496 

#### What does this implement or fix?
Change tmpdir to tmp_path because according to the pytest docs, the tmpdir is depreciated and tmp_path is the way to create temporary paths that are safe to use in multiprocessing setups such as pytest-split and  pytest-xdist
