### PR TITLE
DRAFT: Fix QB floats issue by updating the hash

### DIFF
--- a/cpp/arcticdb/processing/test/test_clause.cpp
+++ b/cpp/arcticdb/processing/test/test_clause.cpp
@@ -58,10 +58,33 @@ TEST(Clause, Partition) {
     auto entity_ids = Composite<EntityIds>(push_entities(component_manager, std::move(proc_unit)));
     auto partitioned = gather_entities(component_manager, partition.process(std::move(entity_ids)));
 
-    std::vector<std::unordered_set<int8_t>> tags = {{1, 3}, {2}};
-    std::array<size_t, 2> sizes = {180, 90};
+    std::vector<std::unordered_set<int8_t>> tags = {{1}, {3}, {2}};
+    std::array<size_t, 3> sizes = {90, 90, 90};
+    ASSERT_EQ(tags.size(), partitioned.size());
     for (auto inner_seg : folly::enumerate(partitioned.as_range())){
         segment_scalar_assert_all_values_equal<int8_t>(*inner_seg, ColumnName("int8"), tags[inner_seg.index], sizes[inner_seg.index]);
+    }
+}
+
+TEST(Clause, PartitionFloats) {
+    // This test is fragile as it depends on both the hash function used for grouping and the partitioning strategy
+    // Remove if either of these change and the test starts failing
+    using namespace arcticdb;
+    ScopedConfig num_buckets("Partition.NumBuckets", 16);
+    auto component_manager = std::make_shared<ComponentManager>();
+
+    PartitionClause<arcticdb::grouping::HashingGroupers, arcticdb::grouping::ModuloBucketizer> partition{"double"};
+    partition.set_component_manager(component_manager);
+
+    auto proc_unit = ProcessingUnit{get_groupable_timeseries_segment_floats("groupable", 30, {1.0,2.0,3.0,1.0,2.0,3.0,1.0,2.0,3.0})};
+    auto entity_ids = Composite<EntityIds>(push_entities(component_manager, std::move(proc_unit)));
+    auto partitioned = gather_entities(component_manager, partition.process(std::move(entity_ids)));
+
+    std::vector<std::unordered_set<double>> tags = {{2.0}, {1.0}, {3.0}};
+    std::array<size_t, 3> sizes = {90, 90, 90};
+    ASSERT_EQ(tags.size(), partitioned.size());
+    for (auto inner_seg : folly::enumerate(partitioned.as_range())){
+        segment_scalar_assert_all_values_equal<double>(*inner_seg, ColumnName("double"), tags[inner_seg.index], sizes[inner_seg.index]);
     }
 }
 

--- a/cpp/arcticdb/util/hash.hpp
+++ b/cpp/arcticdb/util/hash.hpp
@@ -32,7 +32,7 @@ constexpr std::size_t DEFAULT_SEED = 0x42;
 
 template<class T, std::size_t seed = DEFAULT_SEED>
 HashedValue hash(T *d, std::size_t count = 1) {
-    return XXH64(reinterpret_cast<const void *>(d), count * sizeof(T), seed);
+    return XXH3_64bits_withSeed(reinterpret_cast<const void *>(d), count * sizeof(T), seed);
 }
 
 inline HashedValue hash(std::string_view sv) {
@@ -46,19 +46,19 @@ class HashAccum {
     }
 
     void reset(HashedValue seed = DEFAULT_SEED) {
-        XXH64_reset(&state_, seed);
+        XXH3_64bits_reset_withSeed(&state_, seed);
     }
 
     template<typename T>
     void operator()(T *d, std::size_t count = 1) {
-        XXH64_update(&state_, d, sizeof(T) * count);
+        XXH3_64bits_update(&state_, d, sizeof(T) * count);
     }
 
     [[nodiscard]] HashedValue digest() const {
-        return XXH64_digest(&state_);
+        return XXH3_64bits_digest(&state_);
     }
   private:
-    XXH64_state_t state_ = XXH64_state_t{};
+    XXH3_state_t state_ = XXH3_state_t{};
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/util/hash.hpp
+++ b/cpp/arcticdb/util/hash.hpp
@@ -27,12 +27,12 @@
 
 namespace arcticdb {
 
-using HashedValue = XXH64_hash_t;
+using HashedValue = XXH32_hash_t;
 constexpr std::size_t DEFAULT_SEED = 0x42;
 
 template<class T, std::size_t seed = DEFAULT_SEED>
 HashedValue hash(T *d, std::size_t count = 1) {
-    return XXH3_64bits_withSeed(reinterpret_cast<const void *>(d), count * sizeof(T), seed);
+    return XXH32(reinterpret_cast<const void *>(d), count * sizeof(T), seed);
 }
 
 inline HashedValue hash(std::string_view sv) {
@@ -46,19 +46,19 @@ class HashAccum {
     }
 
     void reset(HashedValue seed = DEFAULT_SEED) {
-        XXH3_64bits_reset_withSeed(&state_, seed);
+        XXH32_reset(&state_, seed);
     }
 
     template<typename T>
     void operator()(T *d, std::size_t count = 1) {
-        XXH3_64bits_update(&state_, d, sizeof(T) * count);
+        XXH32_update(&state_, d, sizeof(T) * count);
     }
 
     [[nodiscard]] HashedValue digest() const {
-        return XXH3_64bits_digest(&state_);
+        return XXH32_digest(&state_);
     }
   private:
-    XXH3_state_t state_ = XXH3_state_t{};
+    XXH32_state_t state_ = XXH32_state_t{};
 };
 
 } // namespace arcticdb

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -24,10 +24,7 @@ from arcticdb.util.hypothesis import (
 from hypothesis import assume, given, settings
 from hypothesis.extra.pandas import column, data_frames, range_indexes
 
-from tests.util.mark import xfail_on_linux_conda
 
-
-@xfail_on_linux_conda(reason="Test fails on linux conda, should be fixed by issue #1035")
 def test_group_on_float_column_with_nans(lmdb_version_store):
     lib = lmdb_version_store
     sym = "test_group_on_float_column_with_nans"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1035 

#### What does this implement or fix?
The problem in #1035 seems to be caused only on some GCC compilers when we use the maximum optimizations (O3).
In that case, the hashing functions doesn't work correctly and is producing bogus hashes.

This PR updates the hashing function to use the [XXH3 family of xxhash functions](https://github.com/Cyan4973/xxHash).
This should make the hashing both faster and more consistent. 

#### Other comments
**This might be a breaking change, so should be evaluated carefully.**