### PR TITLE
maint: Remove unneeded includes

### DIFF
--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -30,6 +30,8 @@
 
 
 #ifdef _WIN32
+// `ssize_t` is defined in `sys/types.h` but it is not ISO C (it simply is POSIX), hence its is not defined natively by MSVC.
+// See: https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types
 #include <BaseTsd.h>
 using ssize_t = SSIZE_T;
 #endif

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -28,6 +28,12 @@
 #include <optional>
 #include <variant>
 
+
+#ifdef _WIN32
+#include <BaseTsd.h>
+using ssize_t = SSIZE_T;
+#endif
+
 namespace arcticdb::entity {
 
  enum class SortedValue : uint8_t {

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -14,9 +14,7 @@
 #include <arcticdb/entity/protobufs.hpp>
 #include <google/protobuf/util/message_differencer.h>
 
-#include <folly/Range.h>
 #include <fmt/format.h>
-#include <folly/Likely.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -14,14 +14,12 @@
 #include <arcticdb/util/composite.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <boost/callable_traits.hpp>
-#include <folly/Range.h>
 #include <type_traits>
 #include <iterator>
 #include <array>
 #include <string_view>
 #include <storage/key_segment_pair.hpp>
 #include <util/composite.hpp>
-#include <folly/futures/Future.h>
 
 namespace arcticdb::storage {
 

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -12,7 +12,6 @@
 #include <arcticdb/util/memory_tracing.hpp>
 #include <arcticdb/util/clock.hpp>
 #include <folly/concurrency/ConcurrentHashMap.h>
-#include <arcticdb/util/slab_allocator.hpp>
 #include <arcticdb/util/configs_map.hpp>
 #include <folly/ThreadCachedInt.h>
 #include <arcticdb/util/timer.hpp>
@@ -26,6 +25,10 @@
 // for malloc_trim on linux
 #if defined(__linux__) && defined(__GLIBC__) 
     #include <malloc.h>
+#endif
+
+#if USE_SLAB_ALLOCATOR
+    #include <arcticdb/util/slab_allocator.hpp>
 #endif
 
 //#define ARCTICDB_TRACK_ALLOCS


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?

`allocator.hpp` and `types.hpp` are first and third of the most fundamental headers (the second is (`column.hpp`). The build time analysis from @Klaim shows that:
 - `allocator.hpp` is included 124 times, taking 325 seconds in overall
 - `types.hpp` is included 135 times, taking 300 seconds in overall

Currently:
 - the SLAB allocator only is used if the `USE_SLAB_ALLOCATOR` macro is defined ; yet `allocator.hpp` include `slab_allocator.hpp` unconditionally
 - `types.hpp` includes unneeded headers

#### Any other comments?

While `allocator.cpp` is quite shallow, `allocator.hpp` defines non-template functions and methods and includes a lot of other headers:

https://github.com/man-group/ArcticDB/blob/8be0c62391dc29e57305297d9627577f350038bf/cpp/arcticdb/util/allocator.hpp#L10-L24

It also defines tracing utilities.

Similar observations apply to `types.hpp`.

Those can be split into several smaller pairs of header and translation units, to have a finer granularity and implementations can be defined in translation units when possible.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
