### PR TITLE
Fixes reuse_name for azure storage #1061

### DIFF
--- a/python/arcticdb/storage_fixtures/azure.py
+++ b/python/arcticdb/storage_fixtures/azure.py
@@ -94,6 +94,7 @@ class AzureContainer(StorageFixture):
             container_name=self.container,
             endpoint=self.arctic_uri,
             ca_cert_path=self.factory.ca_cert_path,
+            with_prefix=False,  # to allow azure_store_factory reuse_name to work correctly
         )
         return cfg
 

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -301,7 +301,7 @@ def get_azure_proto(
     env_name,
     container_name,
     endpoint,
-    with_prefix: Optional[bool] = True,
+    with_prefix: Optional[Union[bool, str]] = True,
     ca_cert_path: str = "",
 ):
     env = cfg.env_by_id[env_name]
@@ -331,7 +331,7 @@ def add_azure_library_to_env(
     container_name,
     endpoint,
     description: Optional[bool] = None,
-    with_prefix: Optional[bool] = True,
+    with_prefix: Optional[Union[bool, str]] = True,
     ca_cert_path: str = "",
 ):
     env = cfg.env_by_id[env_name]

--- a/python/tests/integration/arcticdb/version_store/test_symbol_list.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_list.py
@@ -201,16 +201,14 @@ def test_only_latest_compaction_key_is_used(basic_store):
 
 
 @pytest.mark.parametrize("write_another", [False, True])
-# TODO: look into why this doesn't work with azure
-# def test_turning_on_symbol_list_after_a_symbol_written(object_store_factory, write_another):
-def test_turning_on_symbol_list_after_a_symbol_written(s3_store_factory, write_another):
+def test_turning_on_symbol_list_after_a_symbol_written(object_store_factory, write_another):
     # The if(!maybe_last_compaction) case
-    lib: NativeVersionStore = s3_store_factory(symbol_list=False)
+    lib: NativeVersionStore = object_store_factory(symbol_list=False)
 
     lib.write("a", 1)
     assert not lib.library_tool().find_keys(KeyType.SYMBOL_LIST)
 
-    lib = s3_store_factory(reuse_name=True, symbol_list=True)
+    lib = object_store_factory(reuse_name=True, symbol_list=True)
     lt = lib.library_tool()
     if write_another:
         lib.write("b", 2)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1061 

#### What does this implement or fix?
- removes random part of prefix for tests using azure_storage
- modifies test_turning_on_symbol_list_after_a_symbol_is_written to use azure storage as well
- fixes some type hints

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
