### PR TITLE
maint: Define `arcticdb::proto::logger` in `log.hpp`

### DIFF
--- a/cpp/arcticdb/entity/protobufs.hpp
+++ b/cpp/arcticdb/entity/protobufs.hpp
@@ -18,7 +18,6 @@
 #include <nfs_backed_storage.pb.h>
 #include <azure_storage.pb.h>
 #include <config.pb.h>
-#include <logger.pb.h>
 #include <utils.pb.h>
 
 namespace arcticdb::proto {
@@ -33,7 +32,6 @@ namespace arcticdb::proto {
     namespace azure_storage = arcticc::pb2::azure_storage_pb2;
     namespace config = arcticc::pb2::config_pb2;
     namespace nfs_backed_storage = arcticc::pb2::nfs_backed_storage_pb2;
-    namespace logger = arcticc::pb2::logger_pb2;
     namespace utils = arcticc::pb2::utils_pb2;
 
 } //namespace arcticdb

--- a/cpp/arcticdb/log/log.hpp
+++ b/cpp/arcticdb/log/log.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <arcticdb/entity/protobufs.hpp>
+#include <logger.pb.h>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -26,6 +26,10 @@
 #endif
 
 #define ARCTICDB_RUNTIME_DEBUG(logger, ...) logger.debug(__VA_ARGS__)
+
+namespace arcticdb::proto {
+    namespace logger = arcticc::pb2::logger_pb2;
+}
 
 namespace arcticdb::log {
 class Loggers : public std::enable_shared_from_this<Loggers> {


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

`log.hpp` is the most included file after `protobufs.hpp`. The build time analysis from @Klaim shows that:
 - `log.hpp` is included 147 times, taking 251 seconds in overall
 - `protobufs.hpp` is included 150 times, taking 200 seconds in overall

`log.hpp` is included in many files and currently includes `protobufs.hpp` which itself includes all the protobuf messages definition.

This PR moves the required definition and inclusions to only keep what is needed for `log.hpp` in this file.

#### Any other comments?


#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
