### PR TITLE
maint: Remove headers in `types.hpp`

### DIFF
--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -14,6 +14,8 @@
     #include <arcticdb/util/third_party/robin_hood.hpp>
 #endif
 
+#include <pybind11/pybind11.h>
+
 namespace arcticdb {
 py::buffer_info StringPool::as_buffer_info() const {
     return py::buffer_info{

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -20,6 +20,10 @@
 #include <cstdint>
 #include <mutex>
 
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
 #ifdef ARCTICDB_USING_CONDA
     #include <robin_hood.h>
 #else

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -21,7 +21,7 @@
 #include <mutex>
 
 namespace pybind11 {
-    class buffer_info;
+    struct buffer_info;
 }
 
 namespace py = pybind11;

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -20,7 +20,9 @@
 #include <cstdint>
 #include <mutex>
 
-#include <pybind11/pybind11.h>
+namespace pybind11 {
+    class buffer_info;
+}
 
 namespace py = pybind11;
 

--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -11,6 +11,13 @@
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/magic_num.hpp>
 
+// for std::accumulate
+#include <numeric>
+
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
 namespace arcticdb::entity {
 
 inline ssize_t calc_elements(const shape_t* shape, ssize_t ndim) {

--- a/cpp/arcticdb/entity/protobufs.hpp
+++ b/cpp/arcticdb/entity/protobufs.hpp
@@ -9,7 +9,6 @@
 
 #include <storage.pb.h>
 #include <encoding.pb.h>
-#include <descriptors.pb.h>
 #include <s3_storage.pb.h>
 #include <lmdb_storage.pb.h>
 #include <mongo_storage.pb.h>
@@ -23,7 +22,6 @@
 namespace arcticdb::proto {
     namespace encoding = arcticc::pb2::encoding_pb2;
     namespace storage = arcticc::pb2::storage_pb2;
-    namespace descriptors = arcticc::pb2::descriptors_pb2;
     namespace s3_storage = arcticc::pb2::s3_storage_pb2;
     namespace lmdb_storage = arcticc::pb2::lmdb_storage_pb2;
     namespace mongo_storage = arcticc::pb2::mongo_storage_pb2;

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -11,12 +11,9 @@
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/log/log.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <google/protobuf/util/message_differencer.h>
 
 #include <fmt/format.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -38,33 +35,33 @@ using ssize_t = SSIZE_T;
 
 namespace arcticdb::entity {
 
- enum class SortedValue : uint8_t {
+enum class SortedValue : uint8_t {
     UNKNOWN = 0,
     UNSORTED = 1,
     ASCENDING = 2,
     DESCENDING = 3,
 };
 
-inline arcticc::pb2::descriptors_pb2::SortedValue sorted_value_to_proto(SortedValue sorted) {
+inline arcticdb::proto::descriptors::SortedValue sorted_value_to_proto(SortedValue sorted) {
     switch (sorted) {
     case SortedValue::UNSORTED:
-        return arcticc::pb2::descriptors_pb2::SortedValue::UNSORTED;
+        return arcticdb::proto::descriptors::SortedValue::UNSORTED;
     case SortedValue::DESCENDING:
-        return arcticc::pb2::descriptors_pb2::SortedValue::DESCENDING;
+        return arcticdb::proto::descriptors::SortedValue::DESCENDING;
     case SortedValue::ASCENDING:
-        return arcticc::pb2::descriptors_pb2::SortedValue::ASCENDING;
+        return arcticdb::proto::descriptors::SortedValue::ASCENDING;
     default:
-        return arcticc::pb2::descriptors_pb2::SortedValue::UNKNOWN;
+        return arcticdb::proto::descriptors::SortedValue::UNKNOWN;
     }
 }
 
-inline SortedValue sorted_value_from_proto(arcticc::pb2::descriptors_pb2::SortedValue sorted_proto) {
+inline SortedValue sorted_value_from_proto(arcticdb::proto::descriptors::SortedValue sorted_proto) {
     switch (sorted_proto) {
-    case arcticc::pb2::descriptors_pb2::SortedValue::UNSORTED:
+    case arcticdb::proto::descriptors::SortedValue::UNSORTED:
         return SortedValue::UNSORTED;
-    case arcticc::pb2::descriptors_pb2::SortedValue::DESCENDING:
+    case arcticdb::proto::descriptors::SortedValue::DESCENDING:
         return SortedValue::DESCENDING;
-    case arcticc::pb2::descriptors_pb2::SortedValue::ASCENDING:
+    case arcticdb::proto::descriptors::SortedValue::ASCENDING:
         return SortedValue::ASCENDING;
     default:
         return SortedValue::UNKNOWN;
@@ -90,11 +87,11 @@ inline NumericId safe_convert_to_numeric_id(uint64_t input) {
     return static_cast<NumericId>(input);
 }
 
-namespace py = pybind11;
 
-
-// See https://sourceforge.net/p/numpy/mailman/numpy-discussion/thread/1139250278.7538.52.camel%40localhost.localdomain/#msg11998404
-constexpr size_t UNICODE_WIDTH = sizeof(Py_UNICODE);
+// See: https://github.com/python/cpython/issues/105156
+// See: https://peps.python.org/pep-0393/
+using UnicodeType = wchar_t;
+constexpr size_t UNICODE_WIDTH = sizeof(UnicodeType);
 constexpr size_t ASCII_WIDTH = 1;
 //TODO: Fix unicode width for windows
 #ifndef _WIN32
@@ -542,31 +539,7 @@ inline arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor field_prot
 
     return output;
 }
-/*
-inline auto scalar_field (DataType dt, std::string_view name) {
-    return field_proto<Dimension::Dim0>(dt, name);
-}
 
-inline auto scalar_field(TypeDescriptor::Proto&& proto, std::string_view name = std::string_view()) {
-    using namespace pb2::descriptors_pb2;
-    StreamDescriptor_FieldDescriptor output;
-    if(!name.empty())
-        output.set_name(name.data(), name.size());
-
-    *output.mutable_type_desc() = std::move(proto);
-    return output;
-}
-
-inline auto scalar_field_proto(const TypeDescriptor::Proto& proto, std::string_view name = std::string_view()) {
-    using namespace pb2::descriptors_pb2;
-    StreamDescriptor_FieldDescriptor output;
-    if(!name.empty())
-        output.set_name(name.data(), name.size());
-
-    output.mutable_type_desc()->CopyFrom(proto);
-    return output;
-}
-*/
 struct IndexDescriptor {
         using Proto = arcticdb::proto::descriptors::IndexDescriptor;
 
@@ -766,9 +739,7 @@ inline bool operator!=(const Field& l, const Field& r) {
     return !(l == r);
 }
 
-using UnicodeType = Py_UNICODE;
-
-} // namespace arcticdb
+} // namespace arcticdb::entity
 
 // StreamId ordering - numbers before strings
 namespace std {

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -33,6 +33,13 @@
 using ssize_t = SSIZE_T;
 #endif
 
+// TODO: Forward declare further and move the inclusion of `descriptors.pb.h` in `types.cpp`.
+#include <descriptors.pb.h>
+
+namespace arcticdb::proto {
+    namespace descriptors = arcticc::pb2::descriptors_pb2;
+}
+
 namespace arcticdb::entity {
 
 enum class SortedValue : uint8_t {

--- a/cpp/arcticdb/util/flatten_utils.hpp
+++ b/cpp/arcticdb/util/flatten_utils.hpp
@@ -10,6 +10,10 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/preconditions.hpp>
 
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
 namespace arcticdb::util {
 
 using namespace arcticdb::entity;

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -8,6 +8,9 @@
 #pragma once
 
 #include <limits>
+
+// For `PyObject` and `PyFloat_FromDouble`
+#include <Python.h>
 #include <arcticdb/entity/types.hpp>
 #ifdef ARCTICDB_USING_CONDA
     #include <robin_hood.h>

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -11,6 +11,13 @@
 
 // For `PyObject` and `PyFloat_FromDouble`
 #include <Python.h>
+
+// Unset the definition of `copysign` that is defined in `Python.h` for Python < 3.8 on Windows.
+// See: https://github.com/python/cpython/pull/23326
+#if defined(_MSC_VER) && PY_VERSION_HEX < 0x03080000
+    #undef copysign
+#endif
+
 #include <arcticdb/entity/types.hpp>
 #ifdef ARCTICDB_USING_CONDA
     #include <robin_hood.h>


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Simplify headers inclusion of `entity/types.hpp` which is one of the most included headers (see https://github.com/man-group/ArcticDB/pull/1152) to improve build time.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
