### PR TITLE
Only build on pull request events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build and Test
 on:
   push:
+    tags: ["v**"]
+    branches: ["master"]
+  pull_request:
     branches: ["**"]
-    tags: [v**]
     paths:
       - .github/workflows/*.yml
       - build_tooling/**


### PR DESCRIPTION
We're currently spending about $1500 USD per month on EC2 runners for our CI.

It probably isn't all necessary because currently we're building every push.

This changes it so that we build automatically when pull requests are:

- Opened
- Synchronized (ie, commits are pushed to the pull request)
- Reopened

It will still be possible to build your branch manually without a PR using the Github Actions UI.
