### PR TITLE
Use same region for S3 and EC2 to avoid data transfer costs

### DIFF
--- a/.github/actions/set_persistent_storage_env_vars/action.yml
+++ b/.github/actions/set_persistent_storage_env_vars/action.yml
@@ -1,9 +1,9 @@
 name: 'Set Persistent storages env variables'
 description: 'Set the necessary variables for Persistent storage tests'
 inputs:
-  bucket:            {default: 'arcticdb-ci-test-bucket-01', type: string, description: The name of the S3 bucket that we will test against}
-  endpoint:          {default: 's3.eu-west-2.amazonaws.com', type: string, description: The address of the S3 endpoint}
-  region:            {default: 'eu-west-2', type: string, description: The S3 region of the bucket}
+  bucket:            {default: 'arcticdb-ci-test-bucket-02', type: string, description: The name of the S3 bucket that we will test against}
+  endpoint:          {default: 's3.eu-west-1.amazonaws.com', type: string, description: The address of the S3 endpoint}
+  region:            {default: 'eu-west-1', type: string, description: The S3 region of the bucket}
   aws_access_key:    {required: true, type: string, description: The value for the AWS Access key}      
   aws_secret_key:    {required: true, type: string, description: The value for the AWS Secret key}
   strategy_branch:   {default: 'ignore', type: string, description: a unique combination of the parameters for the given job strategy branch, e.g. linux_cp36} 

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -11,11 +11,6 @@ on:
       python_deps_ids:   {default: '[""]', type: string, description: build-python-wheels test matrix parameter. JSON string.}
       python3:           {default: -1, type: number, description: Python 3 minor version}
       persistent_storage:      {default: "false", type: string, description: Specifies whether the python tests should tests against real storages e.g. AWS S3  }
-      # TODO: Maybe we should add these as GitHub variables
-      bucket:            {default: 'arcticdb-ci-test-bucket-01', type: string, description: The name of the S3 bucket that we will test against}
-      endpoint:          {default: 's3.eu-west-2.amazonaws.com', type: string, description: The address of the S3 endpoint}
-      region:            {default: 'eu-west-2', type: string, description: The S3 region of the bucket}
-      clear:             {default: 1, type: number, description: Controls wheather we will clear the libraries in the versions stores that we test against}
 jobs:
   start_ec2_runner:
     if: inputs.compile-override == 'compile-on-ec2'

--- a/.github/workflows/persistent_storage.yml
+++ b/.github/workflows/persistent_storage.yml
@@ -8,9 +8,9 @@ on:
       python3:           {default: -1, type: number, description: Python 3 minor version}
       arcticdb_version:  {default: "", type: string, description: The version of ArcticDB that will be installed and used for seed/verify }
       # TODO: Maybe we should add these as GitHub variables
-      bucket:            {default: 'arcticdb-ci-test-bucket-01', type: string, description: The name of the S3 bucket that we will test against}
-      endpoint:          {default: 's3.eu-west-2.amazonaws.com', type: string, description: The address of the S3 endpoint}
-      region:            {default: 'eu-west-2', type: string, description: The S3 region of the bucket}
+      bucket:            {default: 'arcticdb-ci-test-bucket-02', type: string, description: The name of the S3 bucket that we will test against}
+      endpoint:          {default: 's3.eu-west-1.amazonaws.com', type: string, description: The address of the S3 endpoint}
+      region:            {default: 'eu-west-1', type: string, description: The S3 region of the bucket}
       clear:             {default: 0, type: number, description: Controls wheather we will clear the libraries in the versions stores that we test against}      
 jobs:
   setup:


### PR DESCRIPTION
We paid about $800 on transfer costs in November this year, forming the huge majority of our S3 related costs.

The root cause seems to be data transfer costs between eu-west-2 (London), to eu-west-1 (Ireland).

I can only think that this would be transfers between our EC2 workers (eu-west-1) and our S3 storage (eu-west-2). Transfers in the same region should be free, so it's possible we can eliminate this cost completely.
