### PR TITLE
"Failed to find segment for key" to DEBUG message

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -225,8 +225,9 @@ public:
     }
 
     folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor(
-            const entity::VariantKey &key) override {
-        return read_and_continue(key, library_, storage::ReadKeyOpts{}, DecodeTimeseriesDescriptorTask{});
+            const entity::VariantKey &key,
+            storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) override {
+        return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
     }
 
     folly::Future<bool> key_exists(const entity::VariantKey &key) override {

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -261,12 +261,12 @@ namespace s3 {
                                                variant_key_view(k));
                             } else {
                                 auto &error = get_object_outcome.GetError();
-                                if (!opts.dont_warn_about_missing_key) {
-                                    log::storage().warn("Failed to find segment for key '{}' {}: {}",
-                                                        variant_key_view(k),
-                                                        error.GetExceptionName().c_str(),
-                                                        error.GetMessage().c_str());
-                                }
+                                log::storage().log(
+                                    opts.dont_warn_about_missing_key ? spdlog::level::debug : spdlog::level::warn,
+                                    "Failed to find segment for key '{}' {}: {}",
+                                    variant_key_view(k),
+                                    error.GetExceptionName().c_str(),
+                                    error.GetMessage().c_str());
 
                                 failed_reads.push_back(k);
                             }

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -369,7 +369,8 @@ namespace arcticdb {
 
 
         folly::Future<std::pair<std::variant<arcticdb::entity::AtomKeyImpl, arcticdb::entity::RefKey>, arcticdb::TimeseriesDescriptor>>
-        read_timeseries_descriptor(const entity::VariantKey& key) override {
+        read_timeseries_descriptor(const entity::VariantKey& key,
+                                   storage::ReadKeyOpts /*opts*/) override {
             return util::variant_match(key, [&](const AtomKey &ak) {
                 auto it = seg_by_atom_key_.find(ak);
                 if (it == seg_by_atom_key_.end())

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -331,12 +331,13 @@ std::pair<std::optional<AtomKey>, size_t> read_head(const std::shared_ptr<Stream
 std::pair<TimeseriesDescriptor, std::optional<SegmentInMemory>> get_descriptor_and_data(
     const std::shared_ptr<StreamSource>& store,
     const AtomKey& k,
-    bool load_data) {
+    bool load_data,
+    storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) {
     if(load_data) {
-        auto [key, seg] = store->read(k).get();
+        auto [key, seg] = store->read_sync(k, opts);
         return std::make_pair(TimeseriesDescriptor{seg.timeseries_proto(), seg.index_fields()}, std::make_optional<SegmentInMemory>(seg));
     } else {
-        auto [key, tsd] = store->read_timeseries_descriptor(k).get();
+        auto [key, tsd] = store->read_timeseries_descriptor(k, opts).get();
         return std::make_pair(std::move(tsd), std::nullopt);
     }
 }
@@ -352,7 +353,9 @@ AppendMapEntry create_entry(const arcticdb::proto::descriptors::TimeSeriesDescri
 }
 
 AppendMapEntry entry_from_key(const std::shared_ptr<StreamSource>& store, const AtomKey& key, bool load_data) {
-    auto [tsd, seg] = get_descriptor_and_data(store, key, load_data);
+    auto opts = storage::ReadKeyOpts{};
+    opts.dont_warn_about_missing_key = true;
+    auto [tsd, seg] = get_descriptor_and_data(store, key, load_data, opts);
     auto entry = create_entry(tsd.proto());
     auto descriptor = std::make_shared<StreamDescriptor>();
     auto desc = std::make_shared<StreamDescriptor>(tsd.as_stream_descriptor());

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -72,7 +72,8 @@ struct StreamSource {
         ) = 0;
 
     virtual folly::Future<std::pair<VariantKey, TimeseriesDescriptor>>
-        read_timeseries_descriptor(const entity::VariantKey& key) = 0;
+        read_timeseries_descriptor(const entity::VariantKey& key,
+                                   storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
 
 };


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Reading tick data is expected to produce these types of messages since we are reaching the end of the linked list. We should therefore downgrade these to just DEBUG from WARN as it is frustrating for users.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
