### PR TITLE
Check TTL in do_lock

### DIFF
--- a/cpp/arcticdb/util/storage_lock.hpp
+++ b/cpp/arcticdb/util/storage_lock.hpp
@@ -117,7 +117,7 @@ class StorageLock {
         OnExit x{[that=this] () {
             that->mutex_.unlock();
         }};
-        if(!ref_key_exists(store)) {
+        if(!ref_key_exists(store) || ttl_expired(store)) {
             ts_= create_ref_key(store);
             auto lock_sleep = ConfigsMap::instance()->get_int("StorageLock.WaitMs", 200);
             std::this_thread::sleep_for(std::chrono::milliseconds(lock_sleep));
@@ -151,15 +151,8 @@ class StorageLock {
             sleep_ms(wait_ms);
             total_wait += wait_ms;
             wait_ms *= 2;
-            if (auto read_ts = read_timestamp(store); read_ts) {
-                // check TTL
-                auto ttl = ConfigsMap::instance()->get_int("StorageLock.TTL", DEFAULT_TTL_INTERVAL);
-                if (ClockType::coarse_nanos_since_epoch() - *read_ts > ttl) {
-                    log::lock().warn("StorageLock {} taken for more than TTL (default 1 day). Force releasing", name_);
-                    force_release_lock(name_, store);
-                    break;
-                }
-            }
+            if (ttl_expired(store))
+                break;
             if (timeout_ms && total_wait > *timeout_ms) {
                 ts_ = 0;
                 log::lock().info("Lock timed out, giving up after {}", wait_ms);
@@ -226,6 +219,19 @@ class StorageLock {
         } catch (const storage::KeyNotFoundException&) {
             return std::nullopt;
         }
+    }
+
+    bool ttl_expired(const std::shared_ptr<Store>& store) {
+        if (auto read_ts = read_timestamp(store); read_ts) {
+            // check TTL
+            auto ttl = ConfigsMap::instance()->get_int("StorageLock.TTL", DEFAULT_TTL_INTERVAL);
+            if (ClockType::coarse_nanos_since_epoch() - *read_ts > ttl) {
+                log::lock().warn("StorageLock {} taken for more than TTL (default 1 day). Force releasing", name_);
+                force_release_lock(name_, store);
+                return true;
+            }
+        }
+        return false;
     }
 };
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

The symbol list is protected by a storage lock, so only one writer can compact it at a time. This is implemented using a key of type `LOCK` of which there is almost at most one of in the storage backend. Writers will fail early if they see this key.

The method `lock()` implements a check for the TTL of the storage lock in case it was left locked by a failed write (default TTL is one day). But the `try_lock()` method used in the `list_symbols()` operation does not bother to check the TTL. This PR fixes that and adds another unit test.

The consequence of the previous behaviour was quite bad: libraries could get stuck in a permanent state of an uncompacted symbol list. So for tens of thousands of symbols, or frequent writers (each write inserts a new `__add__` to the symbol list), the `list_symbols()` method would grind to a halt since it would never be able to compact the symbols.

Already tested internally.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x ] Are API changes highlighted in the PR description?
 - [x ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
