### PR TITLE
Clean and reorganize `OffsetString` and `StringPool`

### DIFF
--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -5,6 +5,7 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 #include <arcticdb/codec/codec.hpp>
+#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/stream/protobuf_mappings.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/codec/default_codecs.hpp>

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -7,6 +7,7 @@
 
 #include <arcticdb/column_store/column.hpp>
 
+#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/util/offset_string.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -123,13 +123,13 @@ void Column::string_array_prologue(ssize_t row_offset, size_t num_strings) {
     shapes_.ensure<shape_t>();
     auto shape_cursor = reinterpret_cast<shape_t *>(shapes_.ptr());
     *shape_cursor = shape_t(num_strings);
-    data_.ensure<StringPool::offset_t>(num_strings);
+    data_.ensure<entity::position_t>(num_strings);
 }
 
 void Column::string_array_epilogue(size_t num_strings) {
     data_.commit();
     shapes_.commit();
-    update_offsets(num_strings * sizeof(StringPool::offset_t));
+    update_offsets(num_strings * sizeof(entity::position_t));
     ++last_logical_row_;
 }
 
@@ -139,7 +139,7 @@ void Column::set_string_array(ssize_t row_offset,
                         char *input,
                         StringPool &string_pool) {
     string_array_prologue(row_offset, num_strings);
-    auto data_ptr = reinterpret_cast<StringPool::offset_t*>(data_.ptr());
+    auto data_ptr = reinterpret_cast<entity::position_t*>(data_.ptr());
     for (size_t i = 0; i < num_strings; ++i) {
         auto off = string_pool.get(std::string_view(input, string_size));
         *data_ptr++ = off.offset();
@@ -150,7 +150,7 @@ void Column::set_string_array(ssize_t row_offset,
 
 void Column::set_string_list(ssize_t row_offset, const std::vector<std::string> &input, StringPool &string_pool) {
     string_array_prologue(row_offset, input.size());
-    auto data_ptr = reinterpret_cast<StringPool::offset_t *>(data_.ptr());
+    auto data_ptr = reinterpret_cast<entity::position_t*>(data_.ptr());
     for (const auto &str : input) {
         auto off = string_pool.get(str.data());
         *data_ptr++ = off.offset();

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -7,6 +7,8 @@
 
 #include <arcticdb/column_store/column.hpp>
 
+#include <arcticdb/util/offset_string.hpp>
+
 namespace arcticdb {
 
 // Column operators

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -387,7 +387,7 @@ void Column::set_shapes_buffer(size_t row_count) {
 // The following two methods inflate (reduplicate) numpy string arrays that are potentially multi-dimensional,
 // i.e where the value is not a string but an array of strings
 void Column::inflate_string_array(
-        const TensorType<OffsetString::offset_t> &string_refs,
+        const TensorType<position_t> &string_refs,
         CursoredBuffer<ChunkedBuffer> &data,
         CursoredBuffer<Buffer> &shapes,
         std::vector<position_t> &offsets,
@@ -421,7 +421,7 @@ void Column::inflate_string_arrays(const StringPool &string_pool) {
     CursoredBuffer<Buffer> shapes;
     std::vector<position_t> offsets;
     for (position_t row = 0; row < row_count(); ++row) {
-        auto string_refs = tensor_at<OffsetString::offset_t>(row).value();
+        auto string_refs = tensor_at<position_t>(row).value();
         inflate_string_array(string_refs, data, shapes, offsets, string_pool);
     }
 

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -67,6 +67,7 @@ struct JiveTable {
 };
 
 class Column;
+class StringPool;
 
 template <typename T>
 JiveTable create_jive_table(const Column& col);

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -9,7 +9,6 @@
 
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/column_store/column_data.hpp>
-#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/entity/native_tensor.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/entity/types.hpp>

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -16,7 +16,6 @@
 #include <arcticdb/util/bitset.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
 #include <arcticdb/util/flatten_utils.hpp>
-#include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/sparse_utils.hpp>
 
@@ -420,7 +419,7 @@ public:
 
     // The following two methods inflate (reduplicate) numpy string arrays that are potentially multi-dimensional,
     // i.e where the value is not a string but an array of strings
-    void inflate_string_array(const TensorType<OffsetString::offset_t> &string_refs,
+    void inflate_string_array(const TensorType<position_t> &string_refs,
                               CursoredBuffer<ChunkedBuffer> &data,
                               CursoredBuffer<Buffer> &shapes,
                               std::vector<position_t> &offsets,

--- a/cpp/arcticdb/column_store/column_map.hpp
+++ b/cpp/arcticdb/column_store/column_map.hpp
@@ -7,10 +7,11 @@
 
 #pragma once
 
-#include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/entity/stream_descriptor.hpp>
+#include <arcticdb/entity/types.hpp>
+#include <arcticdb/util/offset_string.hpp>
+
 #include <folly/container/Enumerate.h>
 
 #ifdef ARCTICDB_USING_CONDA
@@ -19,8 +20,8 @@
     #include <arcticdb/util/third_party/robin_hood.hpp>
 #endif
 
-#include <string>
-#include <unordered_map>
+#include <optional>
+#include <string_view>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -157,7 +157,7 @@ public:
         impl_->set_string_at(col, row, str, size);
     }
 
-    void set_no_string_at(position_t col, position_t row, OffsetString::offset_t placeholder) {
+    void set_no_string_at(position_t col, position_t row, position_t placeholder) {
         impl_->set_no_string_at(col, row, placeholder);
     }
 

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -11,7 +11,6 @@
 #include <arcticdb/util/cursor.hpp>
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/util/magic_num.hpp>
 #include <arcticdb/util/constructors.hpp>

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <arcticdb/column_store/memory_segment_impl.hpp>
+#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/util/format_date.hpp>

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -162,7 +162,7 @@ std::shared_ptr<SegmentInMemoryImpl> SegmentInMemoryImpl::filter(const util::Bit
     auto output_string_pool = filter_down_stringpool ? std::make_shared<StringPool>() : string_pool_;
     // Map from offsets in the input stringpool to offsets in the output stringpool
     // Only used if filter_down_stringpool is true
-    robin_hood::unordered_flat_map<StringPool::offset_t, StringPool::offset_t> input_to_output_offsets;
+    robin_hood::unordered_flat_map<entity::position_t, entity::position_t> input_to_output_offsets;
     // Prepopulate with None and NaN placeholder values to avoid an if statement in a tight loop later
     input_to_output_offsets.insert(robin_hood::pair(not_a_string(), not_a_string()));
     input_to_output_offsets.insert(robin_hood::pair(nan_placeholder(), nan_placeholder()));
@@ -235,7 +235,7 @@ std::shared_ptr<SegmentInMemoryImpl> SegmentInMemoryImpl::filter(const util::Bit
                                     auto str = string_pool_->get_const_view(value);
                                     auto output_string_pool_offset = output_string_pool->get(str, false).offset();
                                     *output_ptr = output_string_pool_offset;
-                                    input_to_output_offsets.insert(robin_hood::pair(StringPool::offset_t(value), std::move(output_string_pool_offset)));
+                                    input_to_output_offsets.insert(robin_hood::pair(entity::position_t(value), std::move(output_string_pool_offset)));
                                 }
                             } else {
                                 *output_ptr = value;
@@ -269,7 +269,7 @@ std::shared_ptr<SegmentInMemoryImpl> SegmentInMemoryImpl::filter(const util::Bit
                                     auto str = string_pool_->get_const_view(value);
                                     auto output_string_pool_offset = output_string_pool->get(str, false).offset();
                                     *output_ptr = output_string_pool_offset;
-                                    input_to_output_offsets.insert(robin_hood::pair(StringPool::offset_t(value), std::move(output_string_pool_offset)));
+                                    input_to_output_offsets.insert(robin_hood::pair(entity::position_t(value), std::move(output_string_pool_offset)));
                                 }
                             } else {
                                 *output_ptr = value;
@@ -527,7 +527,7 @@ std::optional<std::string_view> SegmentInMemoryImpl::string_at(position_t row, p
         return std::string_view(ptr, string_size);
     } else {
 
-        auto offset = col_ref.scalar_at<StringPool::offset_t>(row);
+        auto offset = col_ref.scalar_at<entity::position_t>(row);
         if (offset != std::nullopt && *offset != not_a_string() && *offset != nan_placeholder())
             return string_pool_->get_view(*offset);
         else

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -10,7 +10,6 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/cursor.hpp>
 #include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/preconditions.hpp>
 

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -529,7 +529,7 @@ public:
         column_unchecked(col).set_scalar(row, ofstr.offset());
     }
 
-    void set_no_string_at(position_t col, position_t row, OffsetString::offset_t placeholder) {
+    void set_no_string_at(position_t col, position_t row, position_t placeholder) {
         column_unchecked(col).set_scalar(row, placeholder);
     }
 

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -11,6 +11,7 @@
 #include <arcticdb/util/cursor.hpp>
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
+#include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/preconditions.hpp>
 
 #include <arcticdb/entity/timeseries_descriptor.hpp>

--- a/cpp/arcticdb/column_store/segment_utils.hpp
+++ b/cpp/arcticdb/column_store/segment_utils.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/string_pool.hpp>
 #ifdef ARCTICDB_USING_CONDA
     #include <robin_hood.h>
 #else
@@ -17,14 +16,14 @@
 #include <arcticdb/util/configs_map.hpp>
 
 namespace arcticdb {
-robin_hood::unordered_set<StringPool::offset_t> unique_values_for_string_column(const Column &column) {
+robin_hood::unordered_set<entity::position_t> unique_values_for_string_column(const Column &column) {
     auto column_data = column.data();
-    return column_data.type().visit_tag([&](auto type_desc_tag) -> robin_hood::unordered_set<StringPool::offset_t> {
+    return column_data.type().visit_tag([&](auto type_desc_tag) -> robin_hood::unordered_set<entity::position_t> {
         using TDT = decltype(type_desc_tag);
         using DTT = typename TDT::DataTypeTag;
         if constexpr(is_sequence_type(DTT::data_type)) {
             using RawType = typename TDT::DataTypeTag::raw_type;
-            robin_hood::unordered_set<StringPool::offset_t> output;
+            robin_hood::unordered_set<entity::position_t> output;
             // Guessing that unique values is a third of the column length
             static auto map_reserve_ratio = ConfigsMap::instance()->get_int("UniqueColumns.AllocationRatio", 3);
             output.reserve(column.row_count() / map_reserve_ratio);

--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -17,13 +17,126 @@
 #include <pybind11/pybind11.h>
 
 namespace arcticdb {
-py::buffer_info StringPool::as_buffer_info() const {
-    return py::buffer_info{
-        (void *) block_.at(0).data(),
-        1,
-        py::format_descriptor<char>::format(),
-        ssize_t(block_.at(0).size())
+
+/*****************
+ * StringBlock *
+*****************/
+
+StringBlock::StringBlock(StringBlock &&that) noexcept
+    : data_(std::move(that.data_))
+{}
+
+StringBlock& StringBlock::operator=(StringBlock &&that) noexcept {
+    data_ = std::move(that.data_);
+    return *this;
+}
+
+StringBlock StringBlock::clone() const {
+    StringBlock output;
+    output.data_ = data_.clone();
+    return output;
+}
+
+position_t StringBlock::insert(const char *str, size_t size) {
+    auto bytes_required = StringHead::calc_size(size);
+    auto ptr = data_.ensure_aligned_bytes(bytes_required);
+    reinterpret_cast<StringHead*>(ptr)->copy(str, size);
+    data_.commit();
+    return data_.cursor_pos() - bytes_required;
+}
+
+std::string_view StringBlock::at(position_t pos) {
+    auto head(head_at(pos));
+    return {head->data(), head->size()};
+}
+
+std::string_view StringBlock::const_at(position_t pos) const {
+    auto head(const_head_at(pos));
+    return {head->data(), head->size()};
+}
+
+void StringBlock::reset() {
+    data_.reset();
+}
+
+void StringBlock::clear() {
+    data_.clear();
+}
+
+void StringBlock::allocate(size_t size) {
+    data_.ensure_bytes(size);
+}
+
+[[nodiscard]] position_t StringBlock::cursor_pos() const {
+    return data_.cursor_pos();
+}
+
+void StringBlock::advance(size_t size) {
+    data_.advance(size);
+}
+
+[[nodiscard]] size_t StringBlock::size() const {
+    return data_.size<uint8_t>();
+}
+
+[[nodiscard]] const ChunkedBuffer& StringBlock::buffer() const {
+    return data_.buffer();
+}
+
+uint8_t* StringBlock::pos_data(size_t required_size) {
+    return data_.pos_cast<uint8_t>(required_size);
+}
+
+/*****************
+ *  StringPool  *
+*****************/
+
+std::shared_ptr<StringPool> StringPool::clone() const {
+    auto output = std::make_shared<StringPool>();
+    output->block_ = block_.clone();
+    output->map_ = map_;
+    output->shapes_ = shapes_.clone();
+    return output;
+}
+
+StringPool& StringPool::operator=(StringPool &&that) noexcept {
+    if (this != &that) {
+        block_ = std::move(that.block_);
+        map_ = std::move(that.map_);
+        shapes_ = std::move(that.shapes_);
+    }
+    return *this;
+}
+
+ColumnData StringPool::column_data() const {
+    return {
+        &block_.buffer(),
+        &shapes_.buffer(),
+        string_pool_descriptor().type(),
+        nullptr
     };
+}
+
+shape_t* StringPool::allocate_shapes(size_t size) {
+    shapes_.ensure_bytes(size);
+    return shapes_.pos_cast<shape_t>(size);
+}
+
+uint8_t* StringPool::allocate_data(size_t size) {
+    block_.allocate(size);
+    return block_.pos_data(size);
+}
+
+void StringPool::advance_data(size_t size) {
+    block_.advance(size);
+}
+
+void StringPool::advance_shapes(size_t) {
+    // Not used
+}
+
+void StringPool::set_allow_sparse(bool) {
+    // Not used
 }
 
 OffsetString StringPool::get(std::string_view s, bool deduplicate) {
@@ -54,12 +167,45 @@ OffsetString StringPool::get(const char *data, size_t size, bool deduplicate) {
     return str;
 }
 
+const ChunkedBuffer& StringPool::data() const {
+    return block_.buffer();
+}
+
 std::string_view StringPool::get_view(offset_t o) {
     return block_.at(o);
 }
 
 std::string_view StringPool::get_const_view(offset_t o) const {
     return block_.const_at(o);
+}
+
+void StringPool::clear() {
+    map_.clear();
+    block_.clear();
+}
+
+const Buffer& StringPool::shapes() const {
+    auto& blocks = block_.buffer().blocks();
+    shapes_.ensure_bytes(blocks.size() * sizeof(shape_t));
+    auto ptr = shapes_.buffer().ptr_cast<shape_t>(0, sizeof(shape_t));
+    for(auto& block : blocks) {
+        *ptr++ = static_cast<shape_t>(block->bytes());
+    }
+    ARCTICDB_TRACE(log::inmem(), "String pool shapes array has {} blocks", blocks.size());
+    return shapes_.buffer();
+}
+
+size_t StringPool::size() const {
+    return block_.size();
+}
+
+py::buffer_info StringPool::as_buffer_info() const {
+    return py::buffer_info{
+        (void *) block_.at(0).data(),
+        1,
+        py::format_descriptor<char>::format(),
+        ssize_t(block_.at(0).size())
+    };
 }
 
 std::optional<position_t> StringPool::get_offset_for_column(std::string_view string, const Column& column) {

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -7,18 +7,16 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <unordered_set>
+
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/cursor.hpp>
 #include <arcticdb/util/buffer.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/column_store/column_data.hpp>
-
-#include <string_view>
-#include <unordered_map>
-#include <cstddef>
-#include <cstdint>
-#include <mutex>
 
 namespace pybind11 {
     struct buffer_info;
@@ -42,6 +40,10 @@ static FieldRef string_pool_descriptor() {
     static std::string_view name{ "__string_pool__" };
     return FieldRef{type, name};
 }
+
+/*****************
+ * StringBlock *
+*****************/
 
 class StringBlock {
     friend class StringPool;
@@ -73,46 +75,38 @@ class StringBlock {
 
   public:
     StringBlock() = default;
-    StringBlock(StringBlock &&that) noexcept :
-        data_(std::move(that.data_)) {
-    }
-
-    StringBlock &operator=(StringBlock &&that) noexcept {
-        data_ = std::move(that.data_);
-        return *this;
-    }
-
-    StringBlock &operator=(const StringBlock &) = delete;
-
+    StringBlock(StringBlock &&that) noexcept;
     StringBlock(const StringBlock &) = delete;
 
-    [[nodiscard]] StringBlock clone() const {
-        StringBlock output;
-        output.data_ = data_.clone();
-        return output;
-    }
+    StringBlock& operator=(StringBlock &&that) noexcept;
+    StringBlock& operator=(const StringBlock &) = delete;
 
-    position_t insert(const char *str, size_t size) {
-        auto bytes_required = StringHead::calc_size(size);
-        auto ptr = data_.ensure_aligned_bytes(bytes_required);
-        reinterpret_cast<StringHead*>(ptr)->copy(str, size);
-        data_.commit();
-        return data_.cursor_pos() - bytes_required;
-    }
+    [[nodiscard]] StringBlock clone() const;
 
-    std::string_view at(position_t pos) {
-        auto head(head_at(pos));
-        return {head->data(), head->size()};
-    }
+    position_t insert(const char *str, size_t size);
 
-    [[nodiscard]] std::string_view const_at(position_t pos) const {
-        auto head(const_head_at(pos));
-        return {head->data(), head->size()};
-    }
+    std::string_view at(position_t pos);
+    [[nodiscard]] std::string_view const_at(position_t pos) const;
 
-    StringHead *head_at(position_t pos) {
+    void reset();
+
+    void clear();
+
+    void allocate(size_t size);
+
+    [[nodiscard]] position_t cursor_pos() const;
+
+    void advance(size_t size);
+
+    [[nodiscard]] size_t size() const;
+
+    [[nodiscard]] const ChunkedBuffer &buffer() const;
+
+    uint8_t * pos_data(size_t required_size);
+
+    StringHead* head_at(position_t pos) {
         auto data = data_.buffer().ptr_cast<uint8_t>(pos, sizeof(StringHead));
-        return reinterpret_cast<StringHead *>(data);
+        return reinterpret_cast<StringHead*>(data);
     }
 
     [[nodiscard]] const StringHead* const_head_at(position_t pos) const {
@@ -122,43 +116,15 @@ class StringBlock {
         return reinterpret_cast<const StringHead *>(data);
     }
 
-    void reset() {
-        data_.reset();
-    }
-
-    void clear() {
-        data_.clear();
-    }
-
-    void allocate(size_t size) {
-        data_.ensure_bytes(size);
-    }
-
-    [[nodiscard]] position_t cursor_pos() const {
-        return data_.cursor_pos();
-    }
-
-    void advance(size_t size) {
-        data_.advance(size);
-    }
-
-    [[nodiscard]] size_t size() const {
-        return data_.size<uint8_t>();
-    }
-
-    [[nodiscard]] const ChunkedBuffer &buffer() const {
-        return data_.buffer();
-    }
-
-    uint8_t * pos_data(size_t required_size) {
-        return data_.pos_cast<uint8_t>(required_size);
-    }
-
   private:
     CursoredBuffer<ChunkedBuffer> data_;
 };
 
 class OffsetString;
+
+/*****************
+ *  StringPool  *
+*****************/
 
 class StringPool {
   public:
@@ -172,84 +138,37 @@ class StringPool {
     StringPool(const StringPool &) = delete;
     StringPool(StringPool &&that) = delete;
 
-    std::shared_ptr<StringPool> clone() const {
-        auto output = std::make_shared<StringPool>();
-        output->block_ = block_.clone();
-        output->map_ = map_;
-        output->shapes_ = shapes_.clone();
-        return output;
-    }
+    std::shared_ptr<StringPool> clone() const;
 
-    StringPool &operator=(StringPool &&that) noexcept {
-        if (this != &that) {
-            block_ = std::move(that.block_);
-            map_ = std::move(that.map_);
-            shapes_ = std::move(that.shapes_);
-        }
-        return *this;
-    }
+    StringPool &operator=(StringPool &&that) noexcept;
 
+    ColumnData column_data() const;
 
-    ColumnData column_data() const {
-        return {
-          &block_.buffer(),
-          &shapes_.buffer(),
-          string_pool_descriptor().type(),
-          nullptr
-        };
-    }
+    shape_t *allocate_shapes(size_t size);
+    uint8_t *allocate_data(size_t size);
 
-    OffsetString get(const char *data, size_t size, bool deduplicate = true);
+    void advance_data(size_t size);
 
-    shape_t *allocate_shapes(size_t size) {
-        shapes_.ensure_bytes(size);
-        return shapes_.pos_cast<shape_t>(size);
-    }
+    // Neither used nor defined
+    void advance_shapes(size_t);
 
-    uint8_t *allocate_data(size_t size) {
-        block_.allocate(size);
-        return block_.pos_data(size);
-    }
-
-    void advance_shapes(size_t) {
-        // Not used
-    }
-
-    void advance_data(size_t size) {
-        block_.advance(size);
-    }
-
-    void set_allow_sparse(bool) {
-        // Not used
-    }
+    // Neither used nor defined
+    void set_allow_sparse(bool);
 
     OffsetString get(std::string_view s, bool deduplicate = true);
+    OffsetString get(const char *data, size_t size, bool deduplicate = true);
 
-    const ChunkedBuffer &data() const {
-        return block_.buffer();
-    }
+    const ChunkedBuffer &data() const;
 
     std::string_view get_view(offset_t o);
 
     std::string_view get_const_view(offset_t o) const;
 
-    void clear() {
-        map_.clear();
-        block_.clear();
-    }
+    void clear();
 
-    const auto &shapes() const {
-        auto& blocks = block_.buffer().blocks();
-        shapes_.ensure_bytes(blocks.size() * sizeof(shape_t));
-        auto ptr = shapes_.buffer().ptr_cast<shape_t>(0, sizeof(shape_t));
-        for(auto& block : blocks) {
-            *ptr++ = static_cast<shape_t>(block->bytes());
-        }
-        ARCTICDB_TRACE(log::inmem(), "String pool shapes array has {} blocks", blocks.size());
-        return shapes_.buffer();
-    }
+    const Buffer& shapes() const;
 
-    size_t size() const { return block_.size(); }
+    size_t size() const;
 
     py::buffer_info as_buffer_info() const;
 

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -31,6 +31,7 @@ namespace py = pybind11;
 #endif
 
 namespace arcticdb {
+
 class StringPool;
 class Column;
 

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -36,7 +36,7 @@ class StringPool;
 class Column;
 
 
-static FieldRef string_pool_descriptor() {
+static FieldRef ARCTICDB_UNUSED string_pool_descriptor() {
     static TypeDescriptor type{ DataType::UINT8, Dimension::Dim1 };
     static std::string_view name{ "__string_pool__" };
     return FieldRef{type, name};

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -143,8 +143,8 @@ std::optional<convert::StringEncodingError> aggregator_set_data(
                 // been processed, on the assumption that if a column has one such string it will probably have many.
                 std::optional<ScopedGILLock> scoped_gil_lock;
                 auto& column = agg.segment().column(col);
-                column.allocate_data(rows_to_write * sizeof(StringPool::offset_t));
-                auto out_ptr = reinterpret_cast<StringPool::offset_t*>(column.buffer().data());
+                column.allocate_data(rows_to_write * sizeof(entity::position_t));
+                auto out_ptr = reinterpret_cast<entity::position_t*>(column.buffer().data());
                 auto& string_pool = agg.segment().string_pool();
                 for (size_t s = 0; s < rows_to_write; ++s, ++ptr_data) {
                     if (*ptr_data == none.ptr()) {

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -19,6 +19,7 @@
 #include <arcticdb/python/python_types.hpp>
 #include <arcticdb/python/python_to_tensor_frame.hpp>
 #include <arcticdb/pipeline/string_pool_utils.hpp>
+#include <arcticdb/util/offset_string.hpp>
 #include <util/flatten_utils.hpp>
 #include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/entity/type_utils.hpp>

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -9,6 +9,7 @@
 
 #include <arcticdb/codec/encoding_sizes.hpp>
 #include <arcticdb/codec/codec.hpp>
+#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/pipeline/read_frame.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -689,7 +689,7 @@ public:
                     [&] (std::string_view sv) {
                         std::memcpy(dst_, sv.data(), sv.size());
                 },
-                [&] (StringPool::offset_t ) {
+                [&] (entity::position_t ) {
                     memset(dst_, 0, column_width_);
                 });
             dst_ += column_width_;
@@ -725,7 +725,7 @@ public:
                                     util::check(success, "Failed to convert utf8 to utf32 for string {}", sv);
                                     memcpy(dst_, buf_, column_width_);
                                 },
-                                [&] (StringPool::offset_t ) {
+                                [&] (entity::position_t ) {
                                     memset(dst_, 0, column_width_);
                                 });
 
@@ -798,7 +798,7 @@ class DynamicStringReducer : public StringReducer {
     };
 
     template<typename StringCreator, typename LockPolicy>
-    void assign_strings_shared(size_t end, const StringPool::offset_t* ptr_src, bool has_type_conversion, const StringPool& string_pool) {
+    void assign_strings_shared(size_t end, const entity::position_t* ptr_src, bool has_type_conversion, const StringPool& string_pool) {
         LockPolicy::lock(*lock_);
         auto none = std::make_unique<py::none>(py::none{});
         LockPolicy::unlock(*lock_);
@@ -837,12 +837,12 @@ class DynamicStringReducer : public StringReducer {
 
 
     template<typename StringCreator, typename LockPolicy>
-    void assign_strings_local(size_t end, const StringPool::offset_t* ptr_src, bool has_type_conversion, const StringPool& string_pool) {
+    void assign_strings_local(size_t end, const entity::position_t* ptr_src, bool has_type_conversion, const StringPool& string_pool) {
         LockPolicy::lock(*lock_);
         auto none = std::make_unique<py::none>(py::none{});
         LockPolicy::unlock(*lock_);
         size_t none_count = 0u;
-        robin_hood::unordered_flat_map<StringPool::offset_t, std::pair<PyObject*, folly::SpinLock>> local_map;
+        robin_hood::unordered_flat_map<entity::position_t, std::pair<PyObject*, folly::SpinLock>> local_map;
         local_map.reserve(end - row_);
         // TODO this is no good for non-contigous blocks, but we currently expect
         // output data to be contiguous
@@ -886,7 +886,7 @@ class DynamicStringReducer : public StringReducer {
         bool has_type_conversion,
         bool is_utf,
         size_t end,
-        const StringPool::offset_t* ptr_src,
+        const entity::position_t* ptr_src,
         const StringPool& string_pool) {
         auto string_constructor = get_string_constructor(has_type_conversion, is_utf);
 
@@ -922,7 +922,7 @@ public:
         std::shared_ptr<PyObject> py_nan,
         std::shared_ptr<LockType> lock,
         bool do_lock) :
-        StringReducer(column, context, std::move(frame), frame_field, sizeof(StringPool::offset_t)),
+        StringReducer(column, context, std::move(frame), frame_field, sizeof(entity::position_t)),
         ptr_dest_(reinterpret_cast<PyObject**>(dst_)),
         unique_string_map_(std::move(unique_string_map)),
         py_nan_(py_nan),
@@ -1065,7 +1065,7 @@ struct ReduceColumnTask : async::BaseTask {
             column.default_initialize_rows(0, frame_.row_count(), false);
             bool dynamic_type = is_dynamic_string_type(field_type);
             if(dynamic_type) {
-                EmptyDynamicStringReducer reducer(column, frame_, frame_field, sizeof(StringPool::offset_t), lock_);
+                EmptyDynamicStringReducer reducer(column, frame_, frame_field, sizeof(entity::position_t), lock_);
                 reducer.reduce(frame_.row_count());
             }
         } else {

--- a/cpp/arcticdb/pipeline/string_pool_utils.hpp
+++ b/cpp/arcticdb/pipeline/string_pool_utils.hpp
@@ -11,7 +11,7 @@
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/util/offset_string.hpp>
 
-#include <string>
+#include <string_view>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/pipeline/string_pool_utils.hpp
+++ b/cpp/arcticdb/pipeline/string_pool_utils.hpp
@@ -21,22 +21,22 @@ namespace pipelines {
 }
 
 inline auto get_offset_string_at(size_t offset, const ChunkedBuffer& src) {
-    return *(src.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t), sizeof(StringPool::offset_t)));
+    return *(src.ptr_cast<typename entity::position_t>(offset * sizeof(entity::position_t), sizeof(entity::position_t)));
 }
 
 inline auto get_offset_ptr_at(size_t offset, const ChunkedBuffer& src) {
-    return src.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t), sizeof(StringPool::offset_t));
+    return src.ptr_cast<typename entity::position_t>(offset * sizeof(entity::position_t), sizeof(entity::position_t));
 }
 
-inline void set_offset_string_at(size_t offset, ChunkedBuffer& target,  StringPool::offset_t str) {
-    *(target.ptr_cast<typename StringPool::offset_t>(offset * sizeof(StringPool::offset_t), sizeof(StringPool::offset_t))) = str;
+inline void set_offset_string_at(size_t offset, ChunkedBuffer& target,  entity::position_t str) {
+    *(target.ptr_cast<typename entity::position_t>(offset * sizeof(entity::position_t), sizeof(entity::position_t))) = str;
 }
 
-inline auto get_string_from_pool(StringPool::offset_t offset_val, const StringPool& string_pool) {
+inline auto get_string_from_pool(entity::position_t offset_val, const StringPool& string_pool) {
     return string_pool.get_const_view(offset_val);
 }
 
-inline std::variant<std::string_view, StringPool::offset_t> get_string_from_buffer(size_t offset, const ChunkedBuffer& src, const StringPool& string_pool) {
+inline std::variant<std::string_view, entity::position_t> get_string_from_buffer(size_t offset, const ChunkedBuffer& src, const StringPool& string_pool) {
     auto offset_val = get_offset_string_at(offset, src);
     if (offset_val == nan_placeholder() || offset_val == not_a_string())
         return offset_val;
@@ -49,7 +49,7 @@ size_t first_context_row(const pipelines::SliceAndKey& slice_and_key, size_t fir
 position_t get_offset_string(const pipelines::PipelineContextRow& context_row, ChunkedBuffer &src, std::size_t first_row_in_frame);
 
 inline size_t get_first_string_size(size_t num_rows, ChunkedBuffer &src, std::size_t first_row_in_frame, const StringPool& string_pool) {
-    StringPool::offset_t offset_val{0};
+    entity::position_t offset_val{0};
 
     for(auto row = 0u; row < num_rows; ++row) {
         offset_val = get_offset_string_at(first_row_in_frame + row, src);

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -5,6 +5,7 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
+#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/entity/native_tensor.hpp>
 #include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
@@ -17,6 +18,7 @@
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/stream/aggregator.hpp>
 #include <arcticdb/entity/protobufs.hpp>
+#include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/python/python_types.hpp>
 #include <arcticdb/pipeline/frame_utils.hpp>

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -222,7 +222,7 @@ void update_string_columns(const SegmentInMemory& original, SegmentInMemory outp
                                         auto off_str = output.string_pool().get(sv);
                                         set_offset_string_at(row, target, off_str.offset());
                                     },
-                                    [&] (StringPool::offset_t offset) {
+                                    [&] (entity::position_t offset) {
                                         set_offset_string_at(row, target, offset);
                                     });
 

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -7,9 +7,14 @@
 
 #include <vector>
 #include <variant>
-#include <arcticdb/processing/processing_unit.hpp>
+
 #include <folly/Poly.h>
+
+#include <arcticdb/processing/processing_unit.hpp>
+#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/util/composite.hpp>
+#include <arcticdb/util/offset_string.hpp>
+
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
@@ -20,6 +25,7 @@
 #else
     #include <arcticdb/util/third_party/robin_hood.hpp>
 #endif
+
 namespace arcticdb {
 
 using namespace pipelines;

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -5,6 +5,9 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
+#include <arcticdb/column_store/column.hpp>
+#include <arcticdb/column_store/string_pool.hpp>
+#include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/processing/operation_types.hpp>
@@ -12,6 +15,39 @@
 #include <arcticdb/processing/operation_dispatch_unary.hpp>
 
 namespace arcticdb {
+
+[[nodiscard]] std::optional<std::string_view> ColumnWithStrings::string_at_offset(entity::position_t offset, bool strip_fixed_width_trailing_nulls) const {
+    if (UNLIKELY(!column_ || !string_pool_))
+        return std::nullopt;
+    util::check(!column_->is_inflated(), "Unexpected inflated column in filtering");
+    if (!is_a_string(offset)) {
+        return std::nullopt;
+    }
+    std::string_view raw = string_pool_->get_view(offset);
+    if (strip_fixed_width_trailing_nulls && is_fixed_string_type(column_->type().data_type())) {
+        auto char_width = is_utf_type(slice_value_type(column_->type().data_type())) ? UNICODE_WIDTH : ASCII_WIDTH;
+        const std::string_view null_char_view("\0\0\0\0", char_width);
+        while(!raw.empty() && raw.substr(raw.size() - char_width) == null_char_view) {
+            raw.remove_suffix(char_width);
+        }
+    }
+    return raw;
+}
+
+[[nodiscard]] std::optional<size_t> ColumnWithStrings::get_fixed_width_string_size() const {
+    if (!column_ || !string_pool_)
+        return std::nullopt;
+
+    util::check(!column_->is_inflated(), "Unexpected inflated column in filtering");
+    for(position_t i = 0; i < column_->row_count(); ++i) {
+        auto offset = column_->scalar_at<entity::position_t>(i);
+        if (offset != std::nullopt) {
+            std::string_view raw = string_pool_->get_view(*offset);
+            return raw.size();
+        }
+    }
+    return std::nullopt;
+}
 
 ExpressionNode::ExpressionNode(VariantNode left, VariantNode right, OperationType op) :
     left_(std::move(left)),

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -10,13 +10,11 @@
 #include <memory>
 
 #include <arcticdb/util/bitset.hpp>
-#include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/string_wrapping_value.hpp>
 #include <arcticdb/processing/operation_types.hpp>
 #include <arcticdb/pipeline/value.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
-#include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/string_pool.hpp>
+
 
 namespace arcticdb {
 
@@ -35,7 +33,8 @@ using ExpressionName = util::StringWrappingValue<ExpressionNameTag>;
 using VariantNode = std::variant<std::monostate, ColumnName, ValueName, ValueSetName, ExpressionName>;
 
 struct ProcessingUnit;
-class Store;
+class Column;
+class StringPool;
 
 /*
  * Wrapper class combining a column with the string pool containing strings for that column
@@ -58,38 +57,9 @@ struct ColumnWithStrings {
         string_pool_(string_pool) {
     }
 
-    [[nodiscard]] std::optional<std::string_view> string_at_offset(StringPool::offset_t offset, bool strip_fixed_width_trailing_nulls=false) const {
-        if (UNLIKELY(!column_ || !string_pool_))
-            return std::nullopt;
-        util::check(!column_->is_inflated(), "Unexpected inflated column in filtering");
-        if (!is_a_string(offset)) {
-            return std::nullopt;
-        }
-        std::string_view raw = string_pool_->get_view(offset);
-        if (strip_fixed_width_trailing_nulls && is_fixed_string_type(column_->type().data_type())) {
-            auto char_width = is_utf_type(slice_value_type(column_->type().data_type())) ? UNICODE_WIDTH : ASCII_WIDTH;
-            const std::string_view null_char_view("\0\0\0\0", char_width);
-            while(!raw.empty() && raw.substr(raw.size() - char_width) == null_char_view) {
-                raw.remove_suffix(char_width);
-            }
-        }
-        return raw;
-    }
+    [[nodiscard]] std::optional<std::string_view> string_at_offset(entity::position_t offset, bool strip_fixed_width_trailing_nulls=false) const;
 
-    [[nodiscard]] std::optional<size_t> get_fixed_width_string_size() const {
-        if (!column_ || !string_pool_)
-            return std::nullopt;
-
-        util::check(!column_->is_inflated(), "Unexpected inflated column in filtering");
-        for(position_t i = 0; i < column_->row_count(); ++i) {
-            auto offset = column_->scalar_at<StringPool::offset_t>(i);
-            if (offset != std::nullopt) {
-                std::string_view raw = string_pool_->get_view(*offset);
-                return raw.size();
-            }
-        }
-        return std::nullopt;
-    }
+    [[nodiscard]] std::optional<size_t> get_fixed_width_string_size() const;
 };
 
 struct FullResult {};

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -85,7 +85,7 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                     util::BitSet::bulk_insert_iterator inserter(*output);
                     auto pos = 0u;
                     while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
-                        auto ptr = reinterpret_cast<const StringPool::offset_t*>(block->data());
+                        auto ptr = reinterpret_cast<const entity::position_t*>(block->data());
                         const auto row_count = block->row_count();
                         for (auto i = 0u; i < row_count; ++i, ++pos) {
                             auto offset = *ptr++;
@@ -196,7 +196,7 @@ VariantData binary_comparator(const Value& val, const ColumnWithStrings& column_
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
                 while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
-                    auto ptr = reinterpret_cast<const StringPool::offset_t*>(block->data());
+                    auto ptr = reinterpret_cast<const entity::position_t*>(block->data());
                     const auto row_count = block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         auto offset = *ptr++;
@@ -335,7 +335,7 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                 util::BitSet::bulk_insert_iterator inserter(*output);
                 auto pos = 0u;
                 while (auto block = column_data.next<TypeDescriptorTag<ColumnTagType, DimensionTag<entity::Dimension::Dim0>>>()) {
-                    auto ptr = reinterpret_cast<const StringPool::offset_t*>(block->data());
+                    auto ptr = reinterpret_cast<const entity::position_t*>(block->data());
                     const auto row_count = block->row_count();
                     for (auto i = 0u; i < row_count; ++i, ++pos) {
                         auto offset = *ptr++;

--- a/cpp/arcticdb/python/python_utils.hpp
+++ b/cpp/arcticdb/python/python_utils.hpp
@@ -15,7 +15,6 @@
 #include <arcticdb/entity/index_range.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/stream/stream_reader.hpp>
-#include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/variant.hpp>
 
 namespace py = pybind11;
@@ -50,7 +49,7 @@ class ARCTICDB_VISIBILITY_HIDDEN PyRowRef : public py::tuple {
                         auto str_arr = segment.string_array_at(row_pos, col).value();
                         set_col(col, py::array(from_string_array(str_arr)));
                     } else if (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64) {
-                        auto string_refs = segment.tensor_at<OffsetString::offset_t>(row_pos, col).value();
+                        auto string_refs = segment.tensor_at<entity::position_t>(row_pos, col).value();
                         std::vector<std::string_view> output;
                         for (ssize_t i = 0; i < string_refs.size(); ++i)
                             output.emplace_back(view_at(string_refs.at(i)));
@@ -68,7 +67,7 @@ class ARCTICDB_VISIBILITY_HIDDEN PyRowRef : public py::tuple {
     }
 
   private:
-    std::string_view view_at(OffsetString::offset_t o) {
+    std::string_view view_at(entity::position_t o) {
         return row_ref_.segment().string_pool().get_view(o);
     }
 

--- a/cpp/arcticdb/python/reader.hpp
+++ b/cpp/arcticdb/python/reader.hpp
@@ -32,7 +32,7 @@ public:
         return segment_.row_count();
     }
 
-    std::string_view view_at(OffsetString::offset_t o) {
+    std::string_view view_at(entity::position_t o) {
         return segment_.string_pool().get_view(o);
     }
 
@@ -75,7 +75,7 @@ public:
                     }
                     else if (T::DataTypeTag::data_type == DataType::ASCII_DYNAMIC64)
                     {
-                        auto string_refs = segment_.tensor_at<OffsetString::offset_t>(row, col).value();
+                        auto string_refs = segment_.tensor_at<entity::position_t>(row, col).value();
                         std::vector<std::string_view > output;
                         for(ssize_t i = 0; i < string_refs.size(); ++i )
                             output.emplace_back(view_at(string_refs.at(i)));

--- a/cpp/arcticdb/stream/aggregator.hpp
+++ b/cpp/arcticdb/stream/aggregator.hpp
@@ -236,7 +236,7 @@ class Aggregator {
         segment_.set_string_at(col, row, val, size);
     }
 
-    void set_no_string_at(position_t col, position_t row, OffsetString::offset_t placeholder) {
+    void set_no_string_at(position_t col, position_t row, position_t placeholder) {
         segment_.set_no_string_at(col, row, placeholder);
     }
 

--- a/cpp/arcticdb/stream/merge_utils.hpp
+++ b/cpp/arcticdb/stream/merge_utils.hpp
@@ -13,12 +13,12 @@ inline void merge_string_column(
     CursoredBuffer<ChunkedBuffer>& output,
     bool verify
 ) {
-    using OffsetType = StringPool::offset_t;
+    using OffsetType = entity::position_t;
     constexpr auto offset_size =  sizeof(OffsetType);
     auto num_strings = src_buffer.bytes() / offset_size;
     for(auto row = 0ULL; row < num_strings; ++row) {
         auto offset = get_offset_string_at(row, src_buffer);
-        StringPool::offset_t new_value;
+        entity::position_t new_value;
         if (offset != not_a_string() && offset != nan_placeholder()) {
             auto sv = get_string_from_pool(offset, *src_pool);
             new_value = merged_pool->get(sv).offset();

--- a/cpp/arcticdb/util/cursor.hpp
+++ b/cpp/arcticdb/util/cursor.hpp
@@ -10,7 +10,6 @@
 #include <cstdlib>
 #include <cstdint>
 #include <memory>
-#include <vector>
 
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/constructors.hpp>

--- a/cpp/arcticdb/util/offset_string.cpp
+++ b/cpp/arcticdb/util/offset_string.cpp
@@ -9,5 +9,24 @@
 #include <arcticdb/column_store/string_pool.hpp>
 
 namespace arcticdb {
-OffsetString::operator std::string_view() const { return pool_->get_view(offset()); }
+
+OffsetString::OffsetString(OffsetString::offset_t offset, StringPool *pool)
+    : offset_(offset)
+    , pool_(pool)
+{}
+
+OffsetString::operator std::string_view() const {
+    return pool_->get_view(offset());
+}
+
+OffsetString::offset_t OffsetString::offset() const {
+    return offset_;
+}
+
+// Given a set of string pool offsets, removes any that represent None or NaN
+void remove_nones_and_nans(robin_hood::unordered_set<OffsetString::offset_t>& offsets) {
+    offsets.erase(not_a_string());
+    offsets.erase(nan_placeholder());
+}
+
 } //namespace arcticdb

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -18,12 +18,13 @@
     #undef copysign
 #endif
 
-#include <arcticdb/entity/types.hpp>
 #ifdef ARCTICDB_USING_CONDA
     #include <robin_hood.h>
 #else
     #include <arcticdb/util/third_party/robin_hood.hpp>
 #endif
+
+#include <arcticdb/entity/types.hpp> // for entity::position_t
 
 namespace arcticdb {
 
@@ -33,32 +34,29 @@ class OffsetString {
 public:
     using offset_t = entity::position_t;
 
-    explicit OffsetString(offset_t offset, StringPool *pool) :
-        offset_(offset), pool_(pool) {}
+    explicit OffsetString(offset_t offset, StringPool *pool);
 
     explicit operator std::string_view() const;
 
-    [[nodiscard]] offset_t offset() const { return offset_; }
+    [[nodiscard]] offset_t offset() const;
 
   private:
     entity::position_t offset_;
     StringPool *pool_;
 };
 
-inline constexpr OffsetString::offset_t not_a_string() { return std::numeric_limits<OffsetString::offset_t>::max(); }
+constexpr OffsetString::offset_t not_a_string(){ return std::numeric_limits<OffsetString::offset_t>::max(); }
 
-inline constexpr OffsetString::offset_t nan_placeholder() { return not_a_string() - 1; }
+constexpr OffsetString::offset_t nan_placeholder() { return not_a_string() - 1; }
 
 // Returns true if the provided offset does not represent None or NaN
-inline constexpr bool is_a_string(OffsetString::offset_t offset) {
+constexpr bool is_a_string(OffsetString::offset_t offset) {
     return offset < nan_placeholder();
 }
 
 // Given a set of string pool offsets, removes any that represent None or NaN
-inline void remove_nones_and_nans(robin_hood::unordered_set<OffsetString::offset_t>& offsets) {
-    offsets.erase(not_a_string());
-    offsets.erase(nan_placeholder());
-}
+void remove_nones_and_nans(robin_hood::unordered_set<OffsetString::offset_t>& offsets);
+
 
 template <typename LockPtrType>
 inline PyObject* create_py_nan(LockPtrType& lock) {

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -14,7 +14,6 @@
 
 #include <arcticdb/column_store/chunked_buffer.hpp>
 
-#include <bitmagic/bm.h>
 #include <bitmagic/bmserial.h>
 
 #include <algorithm>


### PR DESCRIPTION
- [x] Move definitions to `cpp` files
- [x] Remove unnecessary headers inclusions
- [x] Remove `OffsetString::offset_t` and  `StringPool::offset_t` in favor of `entity::position_t` (same thing, different names). This will avoid including `offset_string.hpp` and `string_pool.hpp` just for these while `types.hpp` is already there
- [ ] Define types in a specific file to be included where needed instead of the whole `types.hpp` (to be done in an upcoming PR)