### PR TITLE
Remove test parellism, and speed up test bottleneck

### DIFF
--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -7,16 +7,6 @@ echo Saving results to ${TEST_OUTPUT_DIR:="$(realpath "$tooling_dir/../cpp/out")
 
 [[ -e ${PARALLEL_TEST_ROOT:=/tmp/parallel_test} ]] && rm -rf $PARALLEL_TEST_ROOT
 
-if [[ -n "${ARCTICDB_PERSISTENT_STORAGE_TESTS}" ]]; then
-  # We want to run the pytests sequentially to avoid races
-  splits=1
-elif [[ -n "$TEST_PARALLELISM" ]]; then
-  splits=${TEST_PARALLELISM}}
-else
-  cpus=${CMAKE_BUILD_PARALLEL_LEVEL:-`nproc || echo 2`}
-  splits=$(($cpus * 15 / 10))
-fi
-
 catch=`{ which catchsegv 2>/dev/null || echo ; } | tail -n 1`
 
     set -o xtrace -o pipefail
@@ -28,7 +18,7 @@ catch=`{ which catchsegv 2>/dev/null || echo ; } | tail -n 1`
 
     export ARCTICDB_RAND_SEED=$RANDOM
 
-    $catch python -m pytest -n $splits $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
+    $catch python -m pytest $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
         "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#\2#"

--- a/python/tests/integration/arcticdb/version_store/test_symbol_list.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_list.py
@@ -307,12 +307,12 @@ class ScopedMaxDelta:
 @pytest.mark.parametrize("compaction_size", [2, 10, 200])
 @pytest.mark.parametrize("same_symbols", [True, False])
 def test_symbol_list_parallel_stress_with_delete(
-    s3_version_store_v1, list_freq, delete_freq, update_freq, compaction_size, same_symbols
+    lmdb_version_store_v1, list_freq, delete_freq, update_freq, compaction_size, same_symbols
 ):
     pd.set_option("display.max_rows", None)
     ScopedMaxDelta(compaction_size)
 
-    lib = s3_version_store_v1
+    lib = lmdb_version_store_v1
     num_pre_existing_symbols = 100
     num_symbols = 10
     num_workers = 5


### PR DESCRIPTION
Stops column stats tests from segfaulting by removing parallelism from the pytest runs in CI. This slows the build down from ~45 mins to ~1h, with the Windows integration tests the bottleneck at ~45 minutes. To alleviate some of this slowdown, the slowest test in a local run with 1 worker in each of the CPU and IO thread pools has been switched from S3 to lmdb, taking it from ~15 minutes to ~2 minutes locally.