### PR TITLE
Build-time improvments: allocator.hpp, log.hpp, buffer.hpp

### DIFF
--- a/cpp/arcticdb/codec/encode_v1.cpp
+++ b/cpp/arcticdb/codec/encode_v1.cpp
@@ -7,6 +7,7 @@
 #include <arcticdb/codec/encode_common.hpp>
 #include <arcticdb/codec/typed_block_encoder_impl.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/util/configs_map.hpp>
 
 namespace arcticdb {
     void add_bitmagic_compressed_size(

--- a/cpp/arcticdb/codec/encode_v2.cpp
+++ b/cpp/arcticdb/codec/encode_v2.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/codec/typed_block_encoder_impl.hpp>
 #include <arcticdb/codec/magic_words.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/util/configs_map.hpp>
 
 
 namespace arcticdb {

--- a/cpp/arcticdb/codec/lz4.hpp
+++ b/cpp/arcticdb/codec/lz4.hpp
@@ -10,9 +10,7 @@
 #include <arcticdb/codec/core.hpp>
 #include <arcticdb/util/preconditions.hpp>
 
-#include <arcticdb/util/buffer.hpp>
 #include <arcticdb/util/hash.hpp>
-#include <arcticdb/util/dump_bytes.hpp>
 
 #include <lz4.h>
 #include <type_traits>

--- a/cpp/arcticdb/column_store/block.hpp
+++ b/cpp/arcticdb/column_store/block.hpp
@@ -9,17 +9,8 @@
 
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/magic_num.hpp>
-#include <arcticdb/util/allocator.hpp>
-#include <arcticdb/util/bitset.hpp>
 
-#include <cstdlib>
 #include <cstdint>
-#include <memory>
-#include <algorithm>
-#include <cassert>
-#include <cstring>
-#include <vector>
-#include <numeric>
 
 
 namespace arcticdb {

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -16,14 +16,7 @@
 
 #include <boost/container/small_vector.hpp>
 
-#include <cstdlib>
 #include <cstdint>
-#include <memory>
-#include <algorithm>
-#include <cassert>
-#include <cstring>
-#include <vector>
-#include <numeric>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -9,12 +9,12 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/buffer.hpp>
+#include <arcticdb/util/bitset.hpp>
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/column_store/block.hpp>
 
 #include <boost/iterator/iterator_facade.hpp>
 
-#include <cstdint>
 
 namespace arcticdb {
 using namespace arcticdb::entity;

--- a/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
@@ -6,6 +6,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <array>
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
 

--- a/cpp/arcticdb/entity/field_collection.cpp
+++ b/cpp/arcticdb/entity/field_collection.cpp
@@ -5,10 +5,7 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
-#include <arcticdb/util/buffer.hpp>
-#include <arcticdb/column_store/column_data.hpp>
 #include <arcticdb/entity/field_collection.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/entity/read_result.hpp
+++ b/cpp/arcticdb/entity/read_result.hpp
@@ -13,6 +13,7 @@
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/frame_and_descriptor.hpp>
 #include <arcticdb/pipeline//python_output_frame.hpp>
+#include <arcticdb/util/memory_tracing.hpp>
 
 #include <vector>
 

--- a/cpp/arcticdb/entity/serialized_key.hpp
+++ b/cpp/arcticdb/entity/serialized_key.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <string>
-#include <string_view>
 #include <arcticdb/util/preconditions.hpp>
 #include <limits>
 #include <arcticdb/entity/types.hpp>
@@ -16,10 +15,8 @@
 #include <arcticdb/entity/ref_key.hpp>
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/stream/index.hpp>
-#include <arcticdb/util/cursor.hpp>
 #include <arcticdb/util/buffer.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
-#include <arcticdb/util/variant.hpp>
 
 namespace arcticdb::entity {
 

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -17,9 +17,45 @@
 #include <arcticdb/util/configs_map.hpp>
 #include <filesystem>
 
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/async.h>
+#include <spdlog/async_logger.h>
+#include <spdlog/sinks/stdout_sinks.h>
+
+
+#include <logger.pb.h>
+
+#include <memory>
+#include <mutex>
+
 namespace arcticdb::log {
 
 static const char* DefaultLogPattern = "%Y%m%d %H:%M:%S.%f %t %L %n | %v";
+
+
+struct Loggers::Impl
+{
+
+    std::mutex config_mutex_;
+    std::unordered_map<std::string, spdlog::sink_ptr> sink_by_id_;
+    std::unique_ptr<spdlog::logger> unconfigured_ = std::make_unique<spdlog::logger>("arcticdb",
+        std::make_shared<spdlog::sinks::stderr_sink_mt>());
+    std::unique_ptr<spdlog::logger> root_;
+    std::unique_ptr<spdlog::logger> storage_;
+    std::unique_ptr<spdlog::logger> inmem_;
+    std::unique_ptr<spdlog::logger> memory_;
+    std::unique_ptr<spdlog::logger> codec_;
+    std::unique_ptr<spdlog::logger> version_;
+    std::unique_ptr<spdlog::logger> timings_;
+    std::unique_ptr<spdlog::logger> lock_;
+    std::unique_ptr<spdlog::logger> schedule_;
+    std::unique_ptr<spdlog::logger> message_;
+    std::unique_ptr<spdlog::logger> symbol_;
+    std::unique_ptr<spdlog::logger> snapshot_;
+    std::shared_ptr<spdlog::details::thread_pool> thread_pool_;
+    std::unique_ptr<spdlog::details::periodic_worker> periodic_worker_;
+};
+
 
 constexpr auto get_default_log_level() {
     return spdlog::level::info;
@@ -77,63 +113,67 @@ namespace fs = std::filesystem;
 
 using SinkConf = arcticdb::proto::logger::SinkConfig;
 
-Loggers::Loggers() {
-    unconfigured_->set_level(get_default_log_level());
+Loggers::Loggers()
+    : impl_(std::make_unique<Impl>())
+{
+    impl_->unconfigured_->set_level(get_default_log_level());
 }
+
+Loggers::~Loggers() = default;
 
 spdlog::logger &Loggers::logger_ref(std::unique_ptr<spdlog::logger> &src) {
     if (ARCTICDB_LIKELY(bool(src)))
         return *src;
 
-    return *unconfigured_;
+    return *impl_->unconfigured_;
 }
 
 spdlog::logger &Loggers::storage() {
-    return logger_ref(storage_);
+    return logger_ref(impl_->storage_);
 }
 
 spdlog::logger &Loggers::inmem() {
-    return logger_ref(inmem_);
+    return logger_ref(impl_->inmem_);
 }
 
 spdlog::logger &Loggers::codec() {
-    return logger_ref(codec_);
+    return logger_ref(impl_->codec_);
 }
 
 spdlog::logger &Loggers::version() {
-    return logger_ref(version_);
+    return logger_ref(impl_->version_);
 }
 
 spdlog::logger &Loggers::memory() {
-    return logger_ref(memory_);
+    return logger_ref(impl_->memory_);
 }
 
 spdlog::logger &Loggers::timings() {
-    return logger_ref(timings_);
+    return logger_ref(impl_->timings_);
 }
 
 spdlog::logger &Loggers::lock() {
-    return logger_ref(lock_);
+    return logger_ref(impl_->lock_);
 }
 
 spdlog::logger &Loggers::schedule() {
-    return logger_ref(schedule_);
+    return logger_ref(impl_->schedule_);
 }
 
 spdlog::logger &Loggers::message() {
-    return logger_ref(message_);
+    return logger_ref(impl_->message_);
 }
 
 spdlog::logger &Loggers::symbol() {
-    return logger_ref(symbol_);
+    return logger_ref(impl_->symbol_);
 }
 
 spdlog::logger &Loggers::snapshot() {
-    return logger_ref(snapshot_);
+    return logger_ref(impl_->snapshot_);
 }
 
 spdlog::logger &Loggers::root() {
-    return logger_ref(root_);
+    return logger_ref(impl_->root_);
 }
 
 void Loggers::flush_all() {
@@ -184,13 +224,13 @@ std::string make_parent_dir(const std::string &p_str, std::string_view def_p_str
 }
 }
 bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool force) {
-    auto lock = std::scoped_lock(config_mutex_);
-    if (!force && root_)
+    auto lock = std::scoped_lock(impl_->config_mutex_);
+    if (!force && impl_->root_)
         return false;
 
     // Configure async behavior
     if (conf.has_async()) {
-        thread_pool_ = std::make_shared<spdlog::details::thread_pool>(
+        impl_->thread_pool_ = std::make_shared<spdlog::details::thread_pool>(
             util::as_opt(conf.async().queue_size()).value_or(8192),
             util::as_opt(conf.async().thread_pool_size()).value_or(1)
         );
@@ -202,32 +242,32 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool
             case SinkConf::kConsole:
                 if (sink_conf.console().has_color()) {
                     if (sink_conf.console().std_err()) {
-                        sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
+                        impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
                     } else {
-                        sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+                        impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
                     }
                 } else {
                     if (sink_conf.console().std_err()) {
-                        sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stderr_sink_mt>());
+                        impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stderr_sink_mt>());
                     } else {
-                        sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stdout_sink_mt>());
+                        impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stdout_sink_mt>());
                     }
                 }
                 break;
             case SinkConf::kFile:
-                sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+                impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::basic_file_sink_mt>(
                     make_parent_dir(sink_conf.file().path(), "./arcticdb.basic.log")
                 ));
                 break;
             case SinkConf::kRotFile:
-                sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+                impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
                     make_parent_dir(sink_conf.rot_file().path(), "./arcticdb.rot.log"),
                     util::as_opt(sink_conf.rot_file().max_size_bytes()).value_or(64ULL* (1ULL<< 20)),
                     util::as_opt(sink_conf.rot_file().max_file_count()).value_or(8)
                 ));
                 break;
             case SinkConf::kDailyFile:
-                sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::daily_file_sink_mt>(
+                impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::daily_file_sink_mt>(
                     make_parent_dir(sink_conf.daily_file().path(), "./arcticdb.daily.log"),
                     util::as_opt(sink_conf.daily_file().utc_rotation_hour()).value_or(0),
                     util::as_opt(sink_conf.daily_file().utc_rotation_minute()).value_or(0)
@@ -253,22 +293,22 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool
         }
     };
 
-    check_and_configure("root", std::string(), root_);
-    check_and_configure("storage", "root", storage_);
-    check_and_configure("inmem", "root", inmem_);
-    check_and_configure("codec", "root", codec_);
-    check_and_configure("version", "root", version_);
-    check_and_configure("memory", "root", memory_);
-    check_and_configure("timings", "root", timings_);
-    check_and_configure("lock", "root", lock_);
-    check_and_configure("schedule", "root", schedule_);
-    check_and_configure("message", "root", message_);
-    check_and_configure("symbol", "root", symbol_);
-    check_and_configure("snapshot", "root", snapshot_);
+    check_and_configure("root", std::string(), impl_->root_);
+    check_and_configure("storage", "root", impl_->storage_);
+    check_and_configure("inmem", "root", impl_->inmem_);
+    check_and_configure("codec", "root", impl_->codec_);
+    check_and_configure("version", "root", impl_->version_);
+    check_and_configure("memory", "root", impl_->memory_);
+    check_and_configure("timings", "root", impl_->timings_);
+    check_and_configure("lock", "root", impl_->lock_);
+    check_and_configure("schedule", "root", impl_->schedule_);
+    check_and_configure("message", "root", impl_->message_);
+    check_and_configure("symbol", "root", impl_->symbol_);
+    check_and_configure("snapshot", "root", impl_->snapshot_);
 
 
     if (auto flush_sec = util::as_opt(conf.flush_interval_seconds()).value_or(1); flush_sec != 0) {
-        periodic_worker_ = std::make_unique<typename decltype(periodic_worker_)::element_type>(
+        impl_->periodic_worker_ = std::make_unique<typename decltype(impl_->periodic_worker_)::element_type>(
             [loggers = weak_from_this()]() {
                 if (auto l = loggers.lock()) {
                     l->flush_all();
@@ -284,17 +324,17 @@ void Loggers::configure_logger(
         std::unique_ptr<spdlog::logger> &logger) {
     std::vector<spdlog::sink_ptr> sink_ptrs;
     for (const auto& sink_id : conf.sink_ids()) {
-        if (auto it = sink_by_id_.find(sink_id); it != sink_by_id_.end()) {
+        if (auto it = impl_->sink_by_id_.find(sink_id); it != impl_->sink_by_id_.end()) {
             sink_ptrs.push_back(it->second);
         } else {
             throw std::invalid_argument(fmt::format("invalid sink_id {} for logger {}", sink_id, name));
         }
     }
     auto fq_name = fmt::format("arcticdb.{}", name);
-    if (thread_pool_) {
+    if (impl_->thread_pool_) {
         // async logger
         logger = std::make_unique<spdlog::async_logger>(fq_name, sink_ptrs.begin(), sink_ptrs.end(),
-                                                        thread_pool_, spdlog::async_overflow_policy::block);
+            impl_->thread_pool_, spdlog::async_overflow_policy::block);
     } else {
         logger = std::make_unique<spdlog::logger>(fq_name, sink_ptrs.begin(), sink_ptrs.end());
     }
@@ -305,7 +345,7 @@ void Loggers::configure_logger(
     else {
         logger->set_pattern(DefaultLogPattern);
     }
-    
+
     if (conf.level() != 0) {
         logger->set_level(static_cast<spdlog::level::level_enum>(conf.level() - 1));
     } else {

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -32,7 +32,6 @@ namespace arcticdb::log {
 
 static const char* DefaultLogPattern = "%Y%m%d %H:%M:%S.%f %t %L %n | %v";
 
-
 struct Loggers::Impl
 {
 
@@ -192,22 +191,23 @@ void Loggers::flush_all() {
 }
 
 
+static std::shared_ptr<Loggers> loggers_instance_;
+static std::once_flag loggers_init_flag_;
+
+
 std::shared_ptr<Loggers> Loggers::instance() {
-    std::call_once(Loggers::init_flag_, &Loggers::init);
-    return instance_;
+    std::call_once(loggers_init_flag_, &Loggers::init);
+    return loggers_instance_;
 }
 
 void Loggers::destroy_instance() {
-    Loggers::instance_.reset();
+    loggers_instance_.reset();
 }
 
 void Loggers::init() {
-    Loggers::instance_ = std::make_shared<Loggers>();
+    loggers_instance_ = std::make_shared<Loggers>();
 }
 
-
-std::shared_ptr<Loggers> Loggers::instance_;
-std::once_flag Loggers::init_flag_;
 
 namespace {
 std::string make_parent_dir(const std::string &p_str, std::string_view def_p_str) {

--- a/cpp/arcticdb/log/log.hpp
+++ b/cpp/arcticdb/log/log.hpp
@@ -37,9 +37,6 @@ class Loggers : public std::enable_shared_from_this<Loggers> {
     Loggers();
     ~Loggers();
 
-    static std::shared_ptr<Loggers> instance_;
-    static std::once_flag init_flag_;
-
     static void init();
     static std::shared_ptr<Loggers> instance();
     static void destroy_instance();

--- a/cpp/arcticdb/log/log.hpp
+++ b/cpp/arcticdb/log/log.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <memory>
 
 #include <spdlog/spdlog.h>
 
@@ -32,13 +33,13 @@ namespace arcticdb::proto {
 }
 
 namespace arcticdb::log {
-class Loggers : public std::enable_shared_from_this<Loggers> {
+class Loggers {
   public:
     Loggers();
     ~Loggers();
 
     static void init();
-    static std::shared_ptr<Loggers> instance();
+    static Loggers& instance();
     static void destroy_instance();
 
     /**
@@ -66,19 +67,13 @@ class Loggers : public std::enable_shared_from_this<Loggers> {
 
   private:
 
-    void configure_logger(const arcticdb::proto::logger::LoggerConfig &conf,
-                          const std::string &name,
-                          std::unique_ptr<spdlog::logger> &logger);
-
-    spdlog::logger &logger_ref(std::unique_ptr<spdlog::logger> &src);
 
     struct Impl;
     std::unique_ptr<Impl> impl_;
 
 };
 
-// N.B. If you add a new logger type here you need to add it to the dict of python loggers
-// in log.py
+
 spdlog::logger &storage();
 spdlog::logger &inmem();
 spdlog::logger &codec();

--- a/cpp/arcticdb/log/test/test_log.cpp
+++ b/cpp/arcticdb/log/test/test_log.cpp
@@ -7,6 +7,8 @@
 
 #include <arcticdb/log/log.hpp>
 
+#include <logger.pb.h>
+
 #include <gtest/gtest.h>
 #include <google/protobuf/text_format.h>
 #include <arcticdb/util/format_bytes.hpp>

--- a/cpp/arcticdb/log/test/test_log.cpp
+++ b/cpp/arcticdb/log/test/test_log.cpp
@@ -38,7 +38,7 @@ logger_by_id {
     )pb";
     arcticdb::proto::logger::LoggersConfig cfg;
     google::protobuf::TextFormat::ParseFromString(txt_conf, &cfg);
-    arcticdb::log::Loggers::instance()->configure(cfg);
+    arcticdb::log::Loggers::instance().configure(cfg);
     arcticdb::log::root().info("Some msg");
 }
 

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -32,6 +32,7 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <folly/SpinLock.h>
 #include <folly/gen/Base.h>
+#include <folly/concurrency/ConcurrentHashMap.h>
 
 namespace arcticdb::pipelines {
 

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -34,6 +34,8 @@
 #include <folly/portability/PThread.h>
 #include <mongocxx/exception/logic_error.hpp>
 
+#include <logger.pb.h>
+
 namespace py = pybind11;
 
 enum class LoggerId {

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -62,7 +62,7 @@ void register_log(py::module && log) {
     log.def("configure", [](const py::object & py_log_conf, bool force=false){
         arcticdb::proto::logger::LoggersConfig config;
         arcticdb::python_util::pb_from_python(py_log_conf, config);
-        return arcticdb::log::Loggers::instance()->configure(config, force);
+        return arcticdb::log::Loggers::instance().configure(config, force);
     }, py::arg("py_log_conf"), py::arg("force")=false);
 
      py::enum_<spdlog::level::level_enum>(log, "LogLevel")
@@ -142,7 +142,7 @@ void register_log(py::module && log) {
     });
 
     log.def("flush_all", [](){
-        arcticdb::log::Loggers::instance()->flush_all();
+        arcticdb::log::Loggers::instance().flush_all();
     });
 }
 

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -40,7 +40,7 @@ S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level) :
     }
     if (ec2_metadata_endpoint_reachable())
         return;
-    ARCTICDB_RUNTIME_DEBUG(log::Loggers::instance()->storage(),
+    ARCTICDB_RUNTIME_DEBUG(log::storage(),
         "Does not appear to be using AWS. Will set AWS_EC2_METADATA_DISABLED");
 #ifdef WIN32
     _putenv_s("AWS_EC2_METADATA_DISABLED", "true");

--- a/cpp/arcticdb/storage/s3/tcp_ping_ec2.hpp
+++ b/cpp/arcticdb/storage/s3/tcp_ping_ec2.hpp
@@ -19,7 +19,7 @@ struct RaiiSocket {
             if (out < 0) {
                 close(fd);
                 fd = invalid;
-                ARCTICDB_DEBUG(arcticdb::log::Loggers::instance()->storage(),
+                ARCTICDB_DEBUG(arcticdb::log::Loggers::instance().storage(),
                     "ec2_metadata step {} failed with {}. errno={}", step, out, errno);
             }
             return out;

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -9,9 +9,9 @@
 
 #include <arcticdb/storage/storage_factory.hpp>
 #include <arcticdb/storage/open_mode.hpp>
-#include <arcticdb/storage/failure_simulation.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/util/composite.hpp>
+#include <arcticdb/util/configs_map.hpp>
 
 #include <memory>
 #include <vector>

--- a/cpp/arcticdb/stream/merge_utils.hpp
+++ b/cpp/arcticdb/stream/merge_utils.hpp
@@ -3,6 +3,7 @@
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/util/memory_tracing.hpp>
 
 namespace arcticdb {
 inline void merge_string_column(

--- a/cpp/arcticdb/stream/segment_aggregator.hpp
+++ b/cpp/arcticdb/stream/segment_aggregator.hpp
@@ -10,6 +10,7 @@
 #include <arcticdb/stream/aggregator.hpp>
 #include <arcticdb/pipeline/frame_utils.hpp>
 #include <arcticdb/util/format_date.hpp>
+#include <arcticdb/util/memory_tracing.hpp>
 #include <arcticdb/pipeline/filter_segment.hpp>
 #include <arcticdb/stream/merge_utils.hpp>
 

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -15,6 +15,10 @@
 #include <arcticdb/version/de_dup_map.hpp>
 
 #include <folly/futures/Future.h>
+// FIXME: winnt.h is included by folly/futures/Future.h at some point and adds unwanted macros
+#ifdef DELETE
+#undef DELETE
+#endif
 
 namespace arcticdb::stream {
 

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -342,9 +342,9 @@ namespace arcticdb {
     }
 
 
-    template AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>;
-    template AllocatorImpl<InMemoryTracingPolicy, util::SysClock>;
-    template AllocatorImpl<NullTracingPolicy, util::LinearClock>;
-    template AllocatorImpl<NullTracingPolicy, util::SysClock>;
+    template class AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>;
+    template class AllocatorImpl<InMemoryTracingPolicy, util::SysClock>;
+    template class AllocatorImpl<NullTracingPolicy, util::LinearClock>;
+    template class AllocatorImpl<NullTracingPolicy, util::SysClock>;
 
 }

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -17,6 +17,8 @@
 
 namespace arcticdb {
 
+
+
     void TracingData::init() {
         TracingData::instance_ = std::make_shared<TracingData>();
     }
@@ -32,12 +34,6 @@ namespace arcticdb {
 
     std::shared_ptr<TracingData> TracingData::instance_;
     std::once_flag TracingData::init_flag_;
-
-    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>::free_count_;
-    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::LinearClock>::free_count_;
-
-    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::SysClock>::free_count_;
-    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::SysClock>::free_count_;
 
 
     struct TracingData::Impl
@@ -147,5 +143,208 @@ namespace arcticdb {
     }
 
 
+    namespace {
+        template<typename TracingPolicy, typename ClockType>
+        auto& free_count_of(){
+            static folly::ThreadCachedInt<uint32_t> free_count;
+            return free_count;
+        };
+    }
+
+    template<typename TracingPolicy, typename ClockType>
+    std::shared_ptr<AllocatorImpl<TracingPolicy, ClockType>> AllocatorImpl<TracingPolicy, ClockType>::instance_;
+
+    template<typename TracingPolicy, typename ClockType>
+    std::once_flag AllocatorImpl<TracingPolicy, ClockType>::init_flag_;
+
+
+    template<class TracingPolicy, class ClockType>
+    uint8_t* AllocatorImpl<TracingPolicy, ClockType>::get_alignment(size_t size) {
+#ifdef _WIN32
+        return  static_cast<uint8_t*>(_aligned_malloc(size, alignment));
+#else
+        return static_cast<uint8_t*>(std::malloc(size));
+#endif
+    }
+
+    template<class TracingPolicy, class ClockType>
+    entity::timestamp AllocatorImpl<TracingPolicy, ClockType>::current_timestamp() {
+        return ClockType::nanos_since_epoch();
+    }
+
+    template<class TracingPolicy, class ClockType>
+    uint8_t* AllocatorImpl<TracingPolicy, ClockType>::internal_alloc(size_t size) {
+        uint8_t* ret;
+#ifdef USE_SLAB_ALLOCATOR
+        std::call_once(slab_init_flag_, &init_slab);
+        if (size == page_size && use_slab_allocator) {
+            ARCTICDB_TRACE(log::codec(), "Doing slab allocation of page size");
+            ret = reinterpret_cast<uint8_t*>(page_size_slab_allocator_->allocate());
+        }
+        else {
+            ARCTICDB_TRACE(log::codec(), "Doing normal allocation of size {}", size);
+            ret = static_cast<uint8_t*>(std::malloc(size));
+        }
+#else
+        ret = static_cast<uint8_t*>(std::malloc(size));
+#endif
+        return ret;
+    }
+
+    template<class TracingPolicy, class ClockType>
+    void AllocatorImpl<TracingPolicy, ClockType>::internal_free(uint8_t* p) {
+#ifdef USE_SLAB_ALLOCATOR
+        std::call_once(slab_init_flag_, &init_slab);
+        auto raw_pointer = reinterpret_cast<SlabAllocatorType::pointer>(p);
+        if (use_slab_allocator && page_size_slab_allocator_->is_addr_in_slab(raw_pointer)) {
+            ARCTICDB_TRACE(log::codec(), "Doing slab free of address {}", uintptr_t(p));
+            page_size_slab_allocator_->deallocate(raw_pointer);
+        }
+        else {
+            ARCTICDB_TRACE(log::codec(), "Doing normal free of address {}", uintptr_t(p));
+            std::free(p);
+        }
+#else
+        std::free(p);
+        free_count_of<TracingPolicy, ClockType>().increment(1);
+        maybe_trim();
+#endif
+    }
+
+    template<class TracingPolicy, class ClockType>
+    uint8_t* AllocatorImpl<TracingPolicy, ClockType>::internal_realloc(uint8_t* p, std::size_t size) {
+        uint8_t* ret;
+#ifdef USE_SLAB_ALLOCATOR
+        std::call_once(slab_init_flag_, &init_slab);
+        auto raw_pointer = reinterpret_cast<SlabAllocatorType::pointer>(p);
+        if (use_slab_allocator && page_size_slab_allocator_->is_addr_in_slab(raw_pointer)) {
+            ARCTICDB_TRACE(log::codec(), "Doing slab realloc of address {} and size {}", uintptr_t(p), size);
+            if (size == page_size)
+                return p;
+            else {
+                page_size_slab_allocator_->deallocate(raw_pointer);
+                ret = static_cast<uint8_t*>(std::malloc(size));
+            }
+        }
+        else {
+            ARCTICDB_TRACE(log::codec(), "Doing normal realloc of address {} and size {}", uintptr_t(p), size);
+            if (use_slab_allocator && size == page_size) {
+                std::free(p);
+                ret = reinterpret_cast<uint8_t*>(page_size_slab_allocator_->allocate());
+            }
+            else {
+                ret = static_cast<uint8_t*>(std::realloc(p, size));
+            }
+        }
+#else
+        ret = static_cast<uint8_t*>(std::realloc(p, size));
+#endif
+        return ret;
+    }
+
+    template<class TracingPolicy, class ClockType>
+    void AllocatorImpl<TracingPolicy, ClockType>::init() {
+        instance_ = std::make_shared<AllocatorImpl>();
+    }
+
+
+    template<typename TracingPolicy, typename ClockType>
+    std::shared_ptr< AllocatorImpl<TracingPolicy, ClockType>>  AllocatorImpl<TracingPolicy, ClockType>::instance() {
+        std::call_once(AllocatorImpl<TracingPolicy, ClockType>::init_flag_, &AllocatorImpl<TracingPolicy, ClockType>::init);
+        return instance_;
+    }
+
+    template<typename TracingPolicy, typename ClockType>
+    void AllocatorImpl<TracingPolicy, ClockType>::destroy_instance() {
+        AllocatorImpl<TracingPolicy, ClockType>::instance_.reset();
+    }
+
+    template<typename TracingPolicy, typename ClockType>
+    std::pair<uint8_t*, entity::timestamp>
+    AllocatorImpl<TracingPolicy, ClockType>::alloc(size_t size, bool no_realloc ARCTICDB_UNUSED) {
+        util::check(size != 0, "Should not allocate zero bytes");
+        auto ts = current_timestamp();
+
+        uint8_t* ret = internal_alloc(size);
+        util::check(ret != nullptr, "Failed to allocate {} bytes", size);
+        TracingPolicy::track_alloc(std::make_pair(uintptr_t(ret), ts), size);
+        return { ret, ts };
+    }
+
+    template<typename TracingPolicy, typename ClockType>
+    void AllocatorImpl<TracingPolicy, ClockType>::trim() {
+        /* malloc_trim is a glibc extension not available on Windows.It is possible
+         * that we will end up with a larger memory footprint for not calling it, but
+         * there are no windows alternatives.
+         */
+#if defined(__linux__) && defined(__GLIBC__)
+        malloc_trim(0);
+#endif
+    }
+
+    template<class TracingPolicy, class ClockType>
+    void AllocatorImpl<TracingPolicy, ClockType>::maybe_trim() {
+        const uint32_t trim_count = ConfigsMap::instance()->get_int("Allocator.TrimCount", 250);
+        if (free_count_of<TracingPolicy, ClockType>().readFast() > trim_count && free_count_of<TracingPolicy, ClockType>().readFastAndReset() > trim_count)
+            trim();
+    }
+
+    template<typename TracingPolicy, typename ClockType>
+    std::pair<uint8_t*, entity::timestamp> AllocatorImpl<TracingPolicy, ClockType>::aligned_alloc(size_t size, bool no_realloc) {
+        util::check(size != 0, "Should not allocate zero bytes");
+        auto ts = current_timestamp();
+
+        util::check(size != 0, "Should not allocate zero bytes");
+        auto ret = internal_alloc(size);
+        util::check(ret != nullptr, "Failed to aligned allocate {} bytes", size);
+        TracingPolicy::track_alloc(std::make_pair(uintptr_t(ret), ts), size);
+        return std::make_pair(ret, ts);
+    }
+
+    template<class TracingPolicy, class ClockType>
+    std::pair<uint8_t*, entity::timestamp>
+    AllocatorImpl<TracingPolicy, ClockType>::realloc(std::pair<uint8_t*, entity::timestamp> ptr, size_t size) {
+        auto ret = internal_realloc(ptr.first, size);
+
+#ifdef ARCTICDB_TRACK_ALLOCS
+        ARCTICDB_TRACE(log::codec(), "Reallocating {} bytes from {} to {}",
+            util::MemBytes{ size },
+            uintptr_t(ptr.first),
+            uintptr_t(ret));
+#endif
+        auto ts = current_timestamp();
+        TracingPolicy::track_realloc(std::make_pair(uintptr_t(ptr.first), ptr.second), std::make_pair(uintptr_t(ret), ts), size);
+        return { ret, ts };
+    }
+
+    template<class TracingPolicy, class ClockType>
+    void AllocatorImpl<TracingPolicy, ClockType>::free(std::pair<uint8_t*, entity::timestamp> ptr) {
+        if (ptr.first == nullptr)
+            return;
+
+        TracingPolicy::track_free(std::make_pair(uintptr_t(ptr.first), ptr.second));
+        internal_free(ptr.first);
+    }
+
+    template<class TracingPolicy, class ClockType>
+    size_t AllocatorImpl<TracingPolicy, ClockType>::allocated_bytes() {
+        return TracingPolicy::total_bytes();
+    }
+
+    template<class TracingPolicy, class ClockType>
+    size_t AllocatorImpl<TracingPolicy, ClockType>::empty() {
+        return TracingPolicy::deallocated();
+    }
+
+    template<class TracingPolicy, class ClockType>
+    void AllocatorImpl<TracingPolicy, ClockType>::clear() {
+        TracingPolicy::clear();
+    }
+
+
+    template AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>;
+    template AllocatorImpl<InMemoryTracingPolicy, util::SysClock>;
+    template AllocatorImpl<NullTracingPolicy, util::LinearClock>;
+    template AllocatorImpl<NullTracingPolicy, util::SysClock>;
 
 }

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -295,7 +295,7 @@ namespace arcticdb {
     }
 
     template<typename TracingPolicy, typename ClockType>
-    std::pair<uint8_t*, entity::timestamp> AllocatorImpl<TracingPolicy, ClockType>::aligned_alloc(size_t size, bool no_realloc) {
+    std::pair<uint8_t*, entity::timestamp> AllocatorImpl<TracingPolicy, ClockType>::aligned_alloc(size_t size, bool no_realloc ARCTICDB_UNUSED) {
         util::check(size != 0, "Should not allocate zero bytes");
         auto ts = current_timestamp();
 

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -7,27 +7,145 @@
 
 #include <arcticdb/util/allocator.hpp>
 
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/util/memory_tracing.hpp>
+#include <arcticdb/util/clock.hpp>
+#include <folly/concurrency/ConcurrentHashMap.h>
+#include <folly/ThreadCachedInt.h>
+
+
 namespace arcticdb {
 
-void TracingData::init() {
-    TracingData::instance_ = std::make_shared<TracingData>();
-}
+    void TracingData::init() {
+        TracingData::instance_ = std::make_shared<TracingData>();
+    }
 
-std::shared_ptr<TracingData> TracingData::instance() {
-    std::call_once(TracingData::init_flag_, &TracingData::init);
-    return TracingData::instance_;
-}
+    std::shared_ptr<TracingData> TracingData::instance() {
+        std::call_once(TracingData::init_flag_, &TracingData::init);
+        return TracingData::instance_;
+    }
 
-void TracingData::destroy_instance() {
-    TracingData::instance_.reset();
-}
+    void TracingData::destroy_instance() {
+        TracingData::instance_.reset();
+    }
 
-std::shared_ptr<TracingData> TracingData::instance_;
-std::once_flag TracingData::init_flag_;
+    std::shared_ptr<TracingData> TracingData::instance_;
+    std::once_flag TracingData::init_flag_;
 
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>::free_count_;
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::LinearClock>::free_count_;
+    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>::free_count_;
+    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::LinearClock>::free_count_;
 
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::SysClock>::free_count_;
-template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::SysClock>::free_count_;
+    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<InMemoryTracingPolicy, util::SysClock>::free_count_;
+    template<> folly::ThreadCachedInt<uint32_t> AllocatorImpl<NullTracingPolicy, util::SysClock>::free_count_;
+
+
+    struct TracingData::Impl
+    {
+        folly::ConcurrentHashMap<AddrIdentifier, size_t> allocs_;
+        std::atomic<uint64_t> total_allocs_{ 0 };
+        std::atomic<uint64_t> total_irregular_allocs_{ 0 };
+        std::atomic<uint64_t> total_allocs_calls_{ 0 };
+
+    };
+
+    TracingData::TracingData() : impl_(std::make_unique<Impl>()) {}
+    TracingData::~TracingData() = default;
+
+    void TracingData::track_alloc(AddrIdentifier addr_ts, size_t size) {
+        //util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
+        impl_->allocs_.insert(std::make_pair(addr_ts, size));
+        impl_->total_allocs_ += size;
+        impl_->total_allocs_calls_++;
+        if (size != page_size) {
+            impl_->total_irregular_allocs_++;
+        }
+        ARCTICDB_TRACE(log::codec(), "Allocated {} to {}:{}, total allocation size {}, total irregular allocs {}/{}",
+            util::MemBytes{ size },
+            addr_ts.first,
+            addr_ts.second,
+            util::MemBytes{ total_allocs_ },
+            total_irregular_allocs_,
+            total_allocs_calls_);
+
+    }
+
+    void TracingData::track_free(AddrIdentifier addr_ts) {
+        //        util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
+        auto it = impl_->allocs_.find(addr_ts);
+        util::check(it != impl_->allocs_.end(), "Unrecognized address in free {}:{}", addr_ts.first, addr_ts.second);
+        util::check(impl_->total_allocs_ >= it->second,
+            "Request to free {}  from {}:{} when only {} remain",
+            it->second,
+            addr_ts.first,
+            addr_ts.second,
+            impl_->total_allocs_.load());
+        impl_->total_allocs_ -= it->second;
+        ARCTICDB_TRACE(log::codec(), "Freed {} at {}:{}, total allocation {}",
+            util::MemBytes{ it->second },
+            addr_ts.first,
+            addr_ts.second,
+            util::MemBytes{ impl_->total_allocs_.load() });
+        impl_->allocs_.erase(it);
+    }
+
+    void TracingData::track_realloc(AddrIdentifier old_addr, AddrIdentifier new_addr, size_t size) {
+        if (old_addr.first != 0)
+            track_free(old_addr);
+
+        track_alloc(new_addr, size);
+    }
+
+    size_t TracingData::total_bytes() const
+    {
+        return impl_->total_allocs_;
+    }
+
+    bool TracingData::all_freed() const
+    {
+        return impl_->allocs_.empty() && impl_->total_allocs_ == 0;
+    }
+
+    void TracingData::clear()
+    {
+        impl_->total_allocs_ = 0;
+        impl_->total_irregular_allocs_ = 0;
+        impl_->total_allocs_calls_ = 0;
+        impl_->allocs_.clear();
+    }
+
+    void InMemoryTracingPolicy::track_alloc(AddrIdentifier addr, size_t size) {
+        data().track_alloc(addr, size);
+    }
+
+    void InMemoryTracingPolicy::track_free(AddrIdentifier addr) {
+        data().track_free(addr);
+    }
+
+    void InMemoryTracingPolicy::track_realloc(AddrIdentifier old_addr, AddrIdentifier new_addr, size_t size) {
+        data().track_realloc(old_addr, new_addr, size);
+    }
+
+    size_t InMemoryTracingPolicy::total_bytes() {
+        return data().total_bytes();
+    }
+
+    bool InMemoryTracingPolicy::deallocated() {
+        auto& get_data = data();
+        bool all_freed = get_data.all_freed();
+        if (!all_freed) {
+            log::memory().warn("Allocator has not freed all data, {} bytes counted", get_data.impl_->total_allocs_);
+
+            for (auto alloc : get_data.impl_->allocs_)
+                log::memory().warn("Unfreed allocation: {}", uintptr_t(alloc.first.first));
+        }
+        return get_data.all_freed();
+    }
+
+    void InMemoryTracingPolicy::clear() {
+        data().clear();
+    }
+
+
+
 }

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -65,9 +65,9 @@ namespace arcticdb {
             util::MemBytes{ size },
             addr_ts.first,
             addr_ts.second,
-            util::MemBytes{ total_allocs_ },
-            total_irregular_allocs_,
-            total_allocs_calls_);
+            util::MemBytes{ impl_->total_allocs_ },
+            impl_->total_irregular_allocs_,
+            impl_->total_allocs_calls_);
 
     }
 

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -9,22 +9,6 @@
 
 namespace arcticdb {
 
-void SharedMemoryAllocator::init(){
-    SharedMemoryAllocator::instance_ = std::make_shared<SharedMemoryAllocator>();
-}
-
-std::shared_ptr<SharedMemoryAllocator> SharedMemoryAllocator::instance() {
-    std::call_once(SharedMemoryAllocator::init_flag_, &SharedMemoryAllocator::init);
-    return SharedMemoryAllocator::instance_;
-}
-
-void SharedMemoryAllocator::destroy_instance() {
-    SharedMemoryAllocator::instance_.reset();
-}
-
-std::shared_ptr<SharedMemoryAllocator> SharedMemoryAllocator::instance_;
-std::once_flag SharedMemoryAllocator::init_flag_;
-
 void TracingData::init() {
     TracingData::instance_ = std::make_shared<TracingData>();
 }

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <arcticdb/util/clock.hpp>
-#include <arcticdb/util/configs_map.hpp>
 
 
 #include <memory>
@@ -33,7 +32,7 @@ static constexpr uint64_t MEGABYTES = 1024 * KILOBYTES;
 static constexpr uint64_t GIGABYTES = 1024 * MEGABYTES;
 static constexpr uint64_t TERABYTES = 1024 * GIGABYTES;
 static constexpr uint64_t page_size = 4096; // 4KB
-static const bool use_slab_allocator = ConfigsMap::instance()->get_int("Allocator.UseSlabAllocator", 1);
+bool use_slab_allocator();
 
 
 static constexpr uint64_t ArcticNativeShmemSize = 30 * GIGABYTES;
@@ -127,7 +126,7 @@ private:
 
     static void init_slab() {
         static const size_t page_slab_capacity = ConfigsMap::instance()->get_int("Allocator.PageSlabCapacity", 1000 * 1000); // 4GB
-        if (use_slab_allocator) {
+        if (use_slab_allocator()) {
             page_size_slab_allocator_ = std::make_shared<SlabAllocatorType>(page_slab_capacity);
         }
     }

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -37,7 +37,6 @@ static const bool use_slab_allocator = ConfigsMap::instance()->get_int("Allocato
 
 
 static constexpr uint64_t ArcticNativeShmemSize = 30 * GIGABYTES;
-static const char *ArcticNativeShmemName = "arctic_native_temp";
 
 typedef std::pair<uintptr_t, entity::timestamp> AddrIdentifier;
 

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -181,10 +181,10 @@ using Allocator = AllocatorImpl<NullTracingPolicy>;
 #endif
 
 
-extern template AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>;
-extern template AllocatorImpl<InMemoryTracingPolicy, util::SysClock>;
-extern template AllocatorImpl<NullTracingPolicy, util::LinearClock>;
-extern template AllocatorImpl<NullTracingPolicy, util::SysClock>;
+extern template class AllocatorImpl<InMemoryTracingPolicy, util::LinearClock>;
+extern template class AllocatorImpl<InMemoryTracingPolicy, util::SysClock>;
+extern template class AllocatorImpl<NullTracingPolicy, util::LinearClock>;
+extern template class AllocatorImpl<NullTracingPolicy, util::SysClock>;
 
 
 } //namespace arcticdb

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -10,12 +10,8 @@
 #include <util/allocator.hpp>
 #include <util/constructors.hpp>
 
-#include <cstdlib>
 #include <cstdint>
 #include <memory>
-#include <algorithm>
-#include <cassert>
-#include <cstring>
 #include <variant>
 
 namespace arcticdb {
@@ -217,7 +213,7 @@ struct Buffer : public BaseBuffer<Buffer, true> {
     [[nodiscard]] uint8_t* preamble() {
         return data_;
     }
-    
+
     [[nodiscard]] size_t available() const {
         return capacity_ >= preamble_bytes_ ? capacity_ - preamble_bytes_ : 0;
     }

--- a/cpp/arcticdb/util/global_lifetimes.cpp
+++ b/cpp/arcticdb/util/global_lifetimes.cpp
@@ -24,7 +24,6 @@ namespace arcticdb {
 ModuleData::~ModuleData() {
     BufferPool::destroy_instance();
     TracingData::destroy_instance();
-    SharedMemoryAllocator::destroy_instance();
     Allocator::destroy_instance();
     PrometheusInstance::destroy_instance();
 #if defined(USE_REMOTERY)

--- a/cpp/arcticdb/util/random.h
+++ b/cpp/arcticdb/util/random.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <algorithm>
 #include <random>
+#include <array>
 #include <arcticdb/util/preconditions.hpp>
 
 /* The state must be seeded so that it is not all zero */

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -9,6 +9,9 @@
 
 #include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/preprocess.hpp>
+
+#include <arcticdb/util/bitset.hpp>
+
 #include <arcticdb/column_store/chunked_buffer.hpp>
 
 #include <bitmagic/bm.h>

--- a/cpp/arcticdb/util/test/test_tracing_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_tracing_allocator.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <arcticdb/util/allocator.hpp>
 #include <arcticdb/util/magic_num.hpp>
+#include <arcticdb/util/memory_tracing.hpp>
 
 TEST(Allocator, Tracing) {
     using AllocType = arcticdb::AllocatorImpl<arcticdb::InMemoryTracingPolicy>;

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -8,7 +8,6 @@
 #include <arcticdb/version/symbol_list.hpp>
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/entity/atom_key.hpp>
-#include <arcticdb/entity/ref_key.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/util/storage_lock.hpp>

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -7,16 +7,19 @@
 
 #pragma once
 
+
 #include <arcticdb/entity/types.hpp>
+
 #include <arcticdb/async/base_task.hpp>
 #include <arcticdb/version/version_map.hpp>
 
-#include <folly/Range.h>
+
+
 #include <folly/futures/Future.h>
 
-#include <cstdlib>
 #include <set>
-#include <mutex>
+
+
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/version/test/test_sorting_info_state_machine.cpp
+++ b/cpp/arcticdb/version/test/test_sorting_info_state_machine.cpp
@@ -7,13 +7,8 @@
 
 #include <gtest/gtest.h>
 
-#include <bitmagic/bm.h>
-#include <bitmagic/bmserial.h>
-#include <arcticdb/util/buffer.hpp>
-#include <arcticdb/util/bitset.hpp>
-
-#include <arcticdb/util/test/generators.hpp>
-#include <arcticdb/version/version_store_api.hpp>
+#include <arcticdb/entity/types.hpp>
+#include <arcticdb/version/version_utils.hpp>
 
 using namespace arcticdb;
 constexpr auto UNKNOWN = SortedValue::UNKNOWN;

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -12,6 +12,11 @@
  */
 #pragma once
 
+#include <shared_mutex>
+#include <unordered_set>
+#include <map>
+#include <deque>
+
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/stream/index.hpp>
@@ -19,7 +24,6 @@
 #include <arcticdb/stream/stream_writer.hpp>
 #include <arcticdb/stream/stream_source.hpp>
 #include <arcticdb/stream/stream_reader.hpp>
-#include <shared_mutex>
 #include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/storage/store.hpp>
@@ -31,9 +35,6 @@
 #include <arcticdb/version/version_utils.hpp>
 #include <arcticdb/util/lock_table.hpp>
 
-#include <unordered_set>
-#include <map>
-#include <deque>
 
 namespace arcticdb {
 


### PR DESCRIPTION
Reduces build-time of the whole project and most cpps in isolation.

I can't  make super reliable benchmarks but in general currently on Windows with MSVC/MSBuild with 12 jobs, hardware with 24 cores and 32GB and some other processes not active but still around, I get Build Insight build from-scratch:
- master: 6m33s
- this branch: 5m52s

Note that the difference stays stable but the actual numbers varies a lot, so it's just a general indication that build time have been reduced at least in my checks. For example, I had better times last week with the same computer but I did some system configuration tweaks on that computer in the weekend (it's my personal computer) and there migbht have been an impact.
I didn't check yet with 1 job as it's what's running on github's ci, neither did I check with ninja or on other platforms than Windows, but I can't reliably do these checks so we'll have to use some other reliable machine to be sure.
Note also that github's CI cannot be relied upon for build-time benchmark in my experience as depending on the machine performance can vary a lot (I once saw the same build on several branches take between 30 to 50 minutes, no stable build times.

We can see with Build Insights that allocator.hpp is not anymore a major source of build times:
master:
![image](https://github.com/man-group/ArcticDB/assets/142265/a31b915f-e578-4213-ae3f-c3ac1faa02ee)

this branch:
![image](https://github.com/man-group/ArcticDB/assets/142265/eed7222c-8bb0-4212-9c84-fafbef540ba1)


So I think we can go with that PR and I'll start another PR for `data_erro.hpp`.

Visual Studio also have an experimental feature clarifying how much each header is used, it helped me a lot here. I'll try to do a pass in another PR for cleaning up includes that are not actually used.