### PR TITLE
Stop defragment_symbol_data deleting table data keys

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1031,7 +1031,7 @@ bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::
     auto update_info = get_latest_undeleted_version_and_next_version_id(
             store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
     auto pre_defragmentation_info = get_pre_defragmentation_info(
-        store(), stream_id, update_info, get_write_options(), segment_size.value_or(cfg_.write_options().segment_row_size()));
+        store(), stream_id, update_info, get_write_options(), segment_size);
     return is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction);
 }
 
@@ -1043,8 +1043,7 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& strea
         store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
 
     auto versioned_item = defragment_symbol_data_impl(
-            store(), stream_id, update_info, get_write_options(),
-            segment_size.has_value() ? *segment_size : cfg_.write_options().segment_row_size());
+            store(), stream_id, update_info, get_write_options(), segment_size);
 
     version_map_->write_version(store_, versioned_item.key_);
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -141,7 +141,7 @@ PredefragmentationInfo get_pre_defragmentation_info(
         const StreamId& stream_id,
         const UpdateInfo& update_info,
         const WriteOptions& options,
-        size_t segment_size);
+        std::optional<size_t> segment_size);
 
 bool is_symbol_fragmented_impl(size_t segments_need_compaction);
 
@@ -150,7 +150,7 @@ VersionedItem defragment_symbol_data_impl(
         const StreamId& stream_id,
         const UpdateInfo& update_info,
         const WriteOptions& options,
-        size_t segment_size);
+        std::optional<size_t> segment_size);
         
 VersionedItem sort_merge_impl(
     const std::shared_ptr<Store>& store,

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -502,3 +502,37 @@ def test_read_incomplete_no_warning(s3_store_factory, sym, get_stderr):
         assert err.count("D arcticdb.storage | Failed to find segment for key") == 1
     finally:
         set_log_level()
+
+
+def test_defragment_read_prev_versions(sym, lmdb_version_store):
+    start_time, end_time = pd.to_datetime(("1990-1-1", "1995-1-1"))
+    cols = ["a", "b", "c", "d"]
+    index = pd.date_range(start_time, end_time, freq="D")
+    original_df = pd.DataFrame(np.random.randn(len(index), len(cols)), index=index, columns=cols)
+    lmdb_version_store.write(sym, original_df)
+    expected_dfs = [original_df]
+
+    for idx in range(100):
+        update_start = end_time + pd.to_timedelta(idx, "days")
+        update_end = update_start + pd.to_timedelta(10, "days")
+        update_index = pd.date_range(update_start, update_end, freq="D")
+        update_df = pd.DataFrame(np.random.randn(len(update_index), len(cols)), index=update_index, columns=cols)
+        lmdb_version_store.update(sym, update_df)
+        next_expected_df = expected_dfs[-1].reindex(expected_dfs[-1].index.union(update_df.index))
+        next_expected_df.loc[update_df.index] = update_df
+        expected_dfs.append(next_expected_df)
+
+    assert_frame_equal(lmdb_version_store.read(sym).data, expected_dfs[-1])
+    assert len(lmdb_version_store.list_versions(sym)) == 101
+    assert len(expected_dfs) == 101
+    for version_id, expected_df in enumerate(expected_dfs):
+        assert_frame_equal(lmdb_version_store.read(sym, as_of=version_id).data, expected_df)
+
+    assert lmdb_version_store.is_symbol_fragmented(sym)
+    lmdb_version_store.defragment_symbol_data(sym)
+    assert len(lmdb_version_store.list_versions(sym)) == 102
+
+    assert_frame_equal(lmdb_version_store.read(sym).data, expected_dfs[-1])
+    assert_frame_equal(lmdb_version_store.read(sym, as_of=0).data, expected_dfs[0])
+    for version_id, expected_df in enumerate(expected_dfs):
+        assert_frame_equal(lmdb_version_store.read(sym, as_of=version_id).data, expected_df)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

> [!WARNING]
>**EDIT: Superseeded by a fix in #1163 which doesn't deprecate the `segment_size` parameter.**

Fixes #1157 

#### What does this implement or fix?

In `defragment_symbol_data_impl`, we retrieve all the `TABLE_DATA` keys from the previous version (which have already been loaded to the pipeline context) with these lines:

```C++
    std::vector<entity::VariantKey> delete_keys;
    for(auto sk = std::next(pre_defragmentation_info.pipeline_context->begin(), pre_defragmentation_info.append_after.value()); sk != pre_defragmentation_info.pipeline_context->end(); ++sk) {
        delete_keys.emplace_back(sk->slice_and_key().key());
    }
```

and then delete them

```C++
store->remove_keys(delete_keys).get();
```

This is sensible for the `compact_incomplete` API, but not the right thing to do here given that these `delete_keys` are `TABLE_DATA` keys referenced by the previous version, and likely many of the earlier versions.

This PR removes deleting any keys in the call to `defragment_symbol_data`.

Note that we don't respect a `prune_previous` at all with this API (yet).

#### Any other comments?

We might need to replace this with a more robust `lib.read` followed by `lib.write` temporarily. This would be until we sort out this method to write the new `TABLE_DATA` keys in batches and therefore take advantage of the fact that in the C++ layer we could avoid loading all the `TABLE_DATA` keys into memory at once, but discard them as they are deduped and formed into a new `TABLE_DATA` key. The advantage therefore of the C++ logic would be to reduce overall memory usage of this operation. If the symbol is large enough that after defragmenting there still requires multiple `TABLE_DATA` keys then the C++ layer could certainly be made to be more efficient in terms of threading and storage I/O.

**Edit: This was done in #1159, but decided unnecessarily cautious to revert to just the Python layer.**

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
