### PR TITLE
Replace defragmentation logic with a simple read and write

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2785,15 +2785,11 @@ class NativeVersionStore:
         if self._lib_cfg.lib_desc.version.write_options.bucketize_dynamic:
             raise ArcticDbNotYetImplemented(f"Support for library with 'bucketize_dynamic' ON is not implemented yet")
 
-        result = self.version_store.defragment_symbol_data(symbol, segment_size)
-        return VersionedItem(
-            symbol=result.symbol,
-            library=self._library.library_path,
-            version=result.version,
-            metadata=None,
-            data=None,
-            host=self.env,
-        )
+        proto_cfg = self._lib_cfg.lib_desc.version.write_options
+        if segment_size and segment_size != self.resolve_defaults("segment_row_size", proto_cfg):
+            raise ArcticDbNotYetImplemented(f"Support for segment_size parameter is not implemented yet")
+
+        return self.write(symbol, self.read(symbol).data)
 
     def library(self):
         return self._library

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import datetime
 import os
 import sys
@@ -2785,11 +2786,18 @@ class NativeVersionStore:
         if self._lib_cfg.lib_desc.version.write_options.bucketize_dynamic:
             raise ArcticDbNotYetImplemented(f"Support for library with 'bucketize_dynamic' ON is not implemented yet")
 
-        proto_cfg = self._lib_cfg.lib_desc.version.write_options
-        if segment_size and segment_size != self.resolve_defaults("segment_row_size", proto_cfg):
-            raise ArcticDbNotYetImplemented(f"Support for segment_size parameter is not implemented yet")
+        if segment_size:
+            log.warning("The segment_size parameter has been deprecated. Specify using LibraryOptions instead.")
 
-        return self.write(symbol, self.read(symbol).data)
+        result = self.write(symbol, self.read(symbol).data)
+        return VersionedItem(
+            symbol=result.symbol,
+            library=self._library.library_path,
+            version=result.version,
+            metadata=None,
+            data=None,
+            host=self.env,
+        )
 
     def library(self):
         return self._library


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

> [!WARNING]
> **It was decided that this is overly cautious and our C++ implementation is robust enough.**
> **Superseded by a by #1163 which just fixes up the C++ layer.**

#### What does this implement or fix?

Implements the suggestion in PR #1158 to replace the defragmentation logic with a simple read and write in the Python layer.

> [!WARNING]  
> ### API Changes 
> We no longer support the `segment_size` parameter. Please use the library option if you need to change the `segment_row_size` for a particular library.

#### Any other comments?

- We still return a `VersionedItem` without the `.data` property, so that the API will remain consistent when we restore the C++ implementation.
- This implementation in the Python layer will be temporary because in the C++ layer we can avoid reading `TABLE_DATA` keys at all by skipping those that are already defragmented. This is especially important for defragmenting a few appends to very large symbols which do not fit in memory, for instance.
- Dynamic schema and empty types should be considered as potential issues with the Python read+write implementation. E.g. if a user managed to write a mix of `int` and `nan` as an `int` column then reading and writing that via Pandas would convert to a `float` column. It doesn't seem possible with the current API to be able to get data into a symbol of this format though at the moment. We should tests sufficient hypothesis tests for this.
- We could have an `optimise_memory_use` parameter to allow use of both versions. Eventually we'd deprecate this and everyone would use the C++ implementation.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
