### PR TITLE
WIP: Changes to defragment_symbol_data API

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1030,8 +1030,9 @@ VersionedItem LocalVersionedEngine::compact_incomplete_dynamic(
 bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) {
     auto update_info = get_latest_undeleted_version_and_next_version_id(
             store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
+    auto options = get_write_options();
     auto pre_defragmentation_info = get_pre_defragmentation_info(
-        store(), stream_id, update_info, get_write_options(), segment_size.value_or(cfg_.write_options().segment_row_size()));
+        store(), stream_id, update_info, options, segment_size.value_or(options.segment_row_size));
     return is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction);
 }
 
@@ -1042,9 +1043,10 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& strea
     auto update_info = get_latest_undeleted_version_and_next_version_id(
         store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
 
+    auto options = get_write_options();
     auto versioned_item = defragment_symbol_data_impl(
-            store(), stream_id, update_info, get_write_options(),
-            segment_size.has_value() ? *segment_size : cfg_.write_options().segment_row_size());
+            store(), stream_id, update_info, options,
+            segment_size.has_value() ? *segment_size : options.segment_row_size);
 
     version_map_->write_version(store_, versioned_item.key_);
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1362,8 +1362,10 @@ VersionedItem defragment_symbol_data_impl(
         const WriteOptions& options,
         size_t segment_size) {
     auto pre_defragmentation_info = get_pre_defragmentation_info(store, stream_id, update_info, options, segment_size);
-    util::check(is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction) && pre_defragmentation_info.append_after.has_value(), "Nothing to compact in defragment_symbol_data");
-
+    if (!(is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction) && pre_defragmentation_info.append_after.has_value())) {
+        log::version().info("Nothing to compact in defragment_symbol_data");
+        return update_info.previous_index_key_.value();
+    }
     // in the new index segment, we will start appending after this value
     std::vector<folly::Future<VariantKey>> fut_vec;
     std::vector<FrameSlice> slices;

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1363,11 +1363,7 @@ VersionedItem defragment_symbol_data_impl(
         size_t segment_size) {
     auto pre_defragmentation_info = get_pre_defragmentation_info(store, stream_id, update_info, options, segment_size);
     util::check(is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction) && pre_defragmentation_info.append_after.has_value(), "Nothing to compact in defragment_symbol_data");
-    
-    std::vector<entity::VariantKey> delete_keys;
-    for(auto sk = std::next(pre_defragmentation_info.pipeline_context->begin(), pre_defragmentation_info.append_after.value()); sk != pre_defragmentation_info.pipeline_context->end(); ++sk) {
-        delete_keys.emplace_back(sk->slice_and_key().key());
-    }
+
     // in the new index segment, we will start appending after this value
     std::vector<folly::Future<VariantKey>> fut_vec;
     std::vector<FrameSlice> slices;
@@ -1402,7 +1398,6 @@ VersionedItem defragment_symbol_data_impl(
             pre_defragmentation_info.append_after.value(),
             std::nullopt);
     
-    store->remove_keys(delete_keys).get();
     return vit;
 }
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2785,7 +2785,14 @@ class NativeVersionStore:
         if self._lib_cfg.lib_desc.version.write_options.bucketize_dynamic:
             raise ArcticDbNotYetImplemented(f"Support for library with 'bucketize_dynamic' ON is not implemented yet")
 
+        if segment_size is not None:
+            # TODO: Document this above and also in library.py
+            log.warn("The segment_size parameter is deprecated and will be removed in a future version."
+                     "Specify using LibraryOptions instead.")
+
         result = self.version_store.defragment_symbol_data(symbol, segment_size)
+        # TODO: We should consider returning a containing object to return whether defrag was carried out
+        # See https://github.com/man-group/ArcticDB/issues/699 for where this was suggested
         return VersionedItem(
             symbol=result.symbol,
             library=self._library.library_path,

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -544,5 +544,7 @@ def test_defragment_no_work_to_do(sym, lmdb_version_store):
     lmdb_version_store.write(sym, df)
     assert_frame_equal(lmdb_version_store.read(sym).data, df)
     assert list(lmdb_version_store.list_versions(sym))[0]["version"] == 0
-    with pytest.raises(InternalException):
-        lmdb_version_store.defragment_symbol_data(sym)
+    versioned_item = lmdb_version_store.defragment_symbol_data(sym)
+    assert_frame_equal(lmdb_version_store.read(sym).data, df)
+    assert versioned_item.version == 0
+    assert list(lmdb_version_store.list_versions(sym))[0]["version"] == 0

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -502,3 +502,47 @@ def test_read_incomplete_no_warning(s3_store_factory, sym, get_stderr):
         assert err.count("D arcticdb.storage | Failed to find segment for key") == 1
     finally:
         set_log_level()
+
+
+def test_defragment_read_prev_versions(sym, lmdb_version_store):
+    start_time, end_time = pd.to_datetime(("1990-1-1", "1995-1-1"))
+    cols = ["a", "b", "c", "d"]
+    index = pd.date_range(start_time, end_time, freq="D")
+    original_df = pd.DataFrame(np.random.randn(len(index), len(cols)), index=index, columns=cols)
+    lmdb_version_store.write(sym, original_df)
+    expected_dfs = [original_df]
+
+    for idx in range(100):
+        update_start = end_time + pd.to_timedelta(idx, "days")
+        update_end = update_start + pd.to_timedelta(10, "days")
+        update_index = pd.date_range(update_start, update_end, freq="D")
+        update_df = pd.DataFrame(np.random.randn(len(update_index), len(cols)), index=update_index, columns=cols)
+        lmdb_version_store.update(sym, update_df)
+        next_expected_df = expected_dfs[-1].reindex(expected_dfs[-1].index.union(update_df.index))
+        next_expected_df.loc[update_df.index] = update_df
+        expected_dfs.append(next_expected_df)
+
+    assert_frame_equal(lmdb_version_store.read(sym).data, expected_dfs[-1])
+    assert len(lmdb_version_store.list_versions(sym)) == 101
+    assert len(expected_dfs) == 101
+    for version_id, expected_df in enumerate(expected_dfs):
+        assert_frame_equal(lmdb_version_store.read(sym, as_of=version_id).data, expected_df)
+
+    assert lmdb_version_store.is_symbol_fragmented(sym)
+    versioned_item = lmdb_version_store.defragment_symbol_data(sym)
+    assert versioned_item.version == 101
+    assert len(lmdb_version_store.list_versions(sym)) == 102
+
+    assert_frame_equal(lmdb_version_store.read(sym).data, expected_dfs[-1])
+    assert_frame_equal(lmdb_version_store.read(sym, as_of=0).data, expected_dfs[0])
+    for version_id, expected_df in enumerate(expected_dfs):
+        assert_frame_equal(lmdb_version_store.read(sym, as_of=version_id).data, expected_df)
+
+
+def test_defragment_no_work_to_do(sym, lmdb_version_store):
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    lmdb_version_store.write(sym, df)
+    assert_frame_equal(lmdb_version_store.read(sym).data, df)
+    assert list(lmdb_version_store.list_versions(sym))[0]["version"] == 0
+    with pytest.raises(InternalException):
+        lmdb_version_store.defragment_symbol_data(sym)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Fixes #699 

> [!WARNING]  
> ### API Changes 
> - Calling `defragment_symbol_data` on a symbol which does not need defragmenting now logs an `INFO` message and returns the latest version in the `VersionedItem`. Previously an error was thrown. Use `is_symbol_fragmented` if you would like to know beforehand if calling `defragment_symbol_data` will need to do work.
> - The `segment_size` parameter to `defragment_symbol_data` is now deprecated. Its use will still be respected, but this will be removed entirely in later versions. Use the relevant parameter in [`LibraryOptions`](https://docs.arcticdb.io/latest/api/arctic/#arcticdb.LibraryOptions) instead.

TODO: This PR should also get rid of the `segment_size` parameter entirely. Possible it should be deprecated. (see old commit on the #1159 for details.)

TODO: Update documentation

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
