### PR TITLE
Update .git-blame-ignore-revs for DataError implementation move

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 # Moving implementation from column.hpp to column.cpp
 # Reordering/removing some inclusions
 801cf4b6f0f9ec0a997311fbdc14639537d3bbb6
+
+# Moving implementation from data_error.hpp to data_error.cpp
+9e10e4b129eadba325db50ec1c683f3aeca1d6ea


### PR DESCRIPTION
Keep `DataError` implementation move to cpp file out of git blame