### PR TITLE
Fix publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         if: inputs.run_id <= 0
         with:
           node-version: 16
-      - run: npm install @actions/artifact
+      - run: npm install @actions/artifact@1
         if: inputs.run_id <= 0
       - id: download
         name: Fetch wheel artifacts
@@ -37,7 +37,7 @@ jobs:
             const client = new dhc.DownloadHttpClient();
             const artifactsResponse = await client.listArtifacts();
             for (const artifact of artifactsResponse.value) {
-                if (artifact.name.startsWith("build-metadata-follower-")) {
+                if (artifact.name.startsWith("build-metadata-build-")) {
                   console.log(`Downloading ${artifact.name} to ${cwd}`);
                   const itemsResponse = await client.getContainerItems(artifact.name, artifact.fileContainerResourceUrl);
                   // Must match "symbols" in build.yml
@@ -86,7 +86,7 @@ jobs:
             ${{steps.changelog.outputs.changelog}}
 
             ---
-            > The wheels are on [Pypi](https://pypi.org/project/arcticdb/). Below are for debugging:
+            > The wheels are on [PyPI](https://pypi.org/project/arcticdb/). Below are for debugging:
           files: ${{steps.compress.outcome == 'success' && env.SYMBOLS_ARTIFACT || ''}}
 
 
@@ -108,7 +108,7 @@ jobs:
         if: inputs.run_id <= 0
         with:
           node-version: 16
-      - run: npm install @actions/artifact
+      - run: npm install @actions/artifact@1
         if: inputs.run_id <= 0
       - name: Fetch wheel artifacts
         if: inputs.run_id <= 0


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

This fixes the `publish.yml` workflow. This can be triggered manually which works fine as it avoids using our custom node PyPI publish step, but due to the upgrade of `@actions/artifact` from v1 to v2 we have a dependency issue when the `publish.yml` workflow is called as the final step of the `build.yml` when doing a release.

Also fix the `symbols.tar.zst` debugging data which used to be added to [the releases page](https://github.com/man-group/ArcticDB/releases/) but has regressed since we updated our CI.

Also fix the release notes to use "PyPI" rather than "Pypi".

> [!WARNING]
> ~When merging, also manually make this commit on the `4.2.x` long term branch. We will still need to update `4.0.x` with the `@actions/artifact@1` change as well since we have node pinned to version `16` there too, despite the changes to the CI not having been backported to that branch.~
> As long as the [Tag and Release](https://github.com/man-group/ArcticDB/actions/workflows/tag.yml) workflow is run manually from the `master` branch when releasing a future `4.0.x` or `4.2.x` version, these changes will be used automatically. Currently it is recommended to run the workflow from the previous tag, but this seems to only be for generating the release notes correctly, so for these branches we can avoid having to backport this change. This should be communicated to those doing the release.

#### Any other comments?

Explanations:

The `@actions/artifact` package was outputting this during install:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@octokit/request-error@5.0.1',
npm WARN EBADENGINE   required: { node: '>= 18' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
```

This is because @actions/artifact v2 was released around 20:00 on 2023-12-12 (after Vasil's release), which brings in this dependency on @octokit/request-error@5.0.1 which clashes with our previously pinned node version.

See: https://www.npmjs.com/package/@actions/artifact?activeTab=dependencies
And: https://www.npmjs.com/package/@actions/artifact/v/1.1.2?activeTab=dependencies

Solution is to pin @actions/artifact to v1, and I've tested locally that `npm install @actions/artifact@1` is the correct way to do this.

---

For the `symbols.tar.zst` upload, this stopped working after [this commit](https://github.com/man-group/ArcticDB/commit/abdbb7f573d0f7f2b0659aed0d6cbc070e30f925) when we removed the follower jobs. As a side effect we saw old debug symbol info being uploaded on the release page which had presumably been cached in the CI workers (some are dated to Nov 1 for releases done in December).

We can explicitly see this from the CI logs:

E.g. v4.2.0 release ignores all artifacts (https://github.com/man-group/ArcticDB/actions/runs/7181334835/job/19559430285)
```
Ignoring build-metadata-build-python-wheels-linux-cp310
Ignoring build-metadata-build-python-wheels-linux-cp311
Ignoring build-metadata-build-python-wheels-linux-cp36
Ignoring build-metadata-build-python-wheels-linux-cp37
Ignoring build-metadata-build-python-wheels-linux-cp38
Ignoring build-metadata-build-python-wheels-linux-cp39
Ignoring build-metadata-build-python-wheels-windows-cp310
Ignoring build-metadata-build-python-wheels-windows-cp311
Ignoring build-metadata-build-python-wheels-windows-cp37
Ignoring build-metadata-build-python-wheels-windows-cp38
Ignoring build-metadata-build-python-wheels-windows-cp39
Ignoring build-metadata-cpp-tests-linux-default
Ignoring build-metadata-cpp-tests-windows-default
Ignoring pytest-linux-cp310-{hypothesis,nonreg,scripts}
Ignoring pytest-linux-cp310-integration
Ignoring pytest-linux-cp310-stress
Ignoring pytest-linux-cp310-unit
...
```

Previously it would do: (e.g. v4.1.0 release https://github.com/man-group/ArcticDB/actions/runs/6720429569/job/18272499301)
```
Ignoring build-metadata-cpp-tests-windows-default
Downloading build-metadata-follower-linux-cp310 to /home/runner/work/ArcticDB/ArcticDB
Total number of files that will be downloaded: 1
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
Downloading build-metadata-follower-linux-cp311 to /home/runner/work/ArcticDB/ArcticDB
Total number of files that will be downloaded: 1
Total file count: 1 ---- Processed file #0 (0.0%)
Total file count: 1 ---- Processed file #0 (0.0%)
...
```

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
