### PR TITLE
Introduce jitter in symbol list compaction threshold

### DIFF
--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd cpp/out/linux-conda-release-build/
-          make test
+          CTEST_OUTPUT_ON_FAILURE=1 make test
 
       - name: Install npm # Linux github runner image does not come with npm
         uses: actions/setup-node@v3.3.0
@@ -141,7 +141,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd cpp/out/darwin-conda-release-build/
-          make test
+          CTEST_OUTPUT_ON_FAILURE=1 make test
 
       - name: Install npm
         uses: actions/setup-node@v3.3.0

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -112,6 +112,15 @@
       "inherits": ["common_vcpkg", "linux"]
     },
     {
+      "name": "linux-debug-clang",
+      "inherits": ["common_vcpkg", "linux"],
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "STATIC_LINK_STD_LIB": "OFF"
+      }
+    },
+    {
       "name": "linux-conda-debug",
       "inherits":  ["common_conda", "linux"]
     },
@@ -145,6 +154,7 @@
     {"name": "windows-cl-conda-debug",    "configurePreset": "windows-cl-conda-debug",    "targets": "arcticdb_ext" },
     {"name": "windows-cl-conda-release",  "configurePreset": "windows-cl-conda-release",  "targets": "arcticdb_ext" },
     {"name": "linux-debug",               "configurePreset": "linux-debug",               "targets": "arcticdb_ext" },
+    {"name": "linux-debug-clang",         "configurePreset": "linux-debug-clang",         "targets": "arcticdb_ext" },
     {"name": "linux-release",             "configurePreset": "linux-release",             "targets": "arcticdb_ext" },
     {"name": "linux-conda-debug",         "configurePreset": "linux-conda-debug",         "targets": "arcticdb_ext" },
     {"name": "linux-conda-release",       "configurePreset": "linux-conda-release",       "targets": "arcticdb_ext" },

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -32,9 +32,9 @@ using CollectionType = std::vector<SymbolListEntry>;
 constexpr std::string_view version_string = "_v2_";
 constexpr NumericIndex version_identifier = std::numeric_limits<NumericIndex>::max();
 
-SymbolListData::SymbolListData(std::shared_ptr<VersionMap> version_map, entity::StreamId type_indicator) :
+SymbolListData::SymbolListData(std::shared_ptr<VersionMap> version_map, entity::StreamId type_indicator, uint32_t seed) :
     type_holder_(std::move(type_indicator)),
-    max_delta_(ConfigsMap::instance()->get_int("SymbolList.MaxDelta", 500)),
+    seed_(seed),
     version_map_(std::move(version_map)){
 }
 
@@ -556,7 +556,37 @@ StreamDescriptor delete_symbol_stream_descriptor(const StreamId& stream_id, cons
 }
 
 bool SymbolList::needs_compaction(const LoadResult& load_result) const {
-    return load_result.symbol_list_keys_.size() > data_.max_delta_ || !load_result.maybe_previous_compaction;
+    if (!load_result.maybe_previous_compaction) {
+        log::version().debug("Symbol list: needs_compaction=[true] as no previous compaction");
+        return true;
+    }
+
+    uint64_t n_keys = load_result.symbol_list_keys_.size();
+    if (auto fixed = ConfigsMap::instance()->get_int("SymbolList.MaxDelta")) {
+        auto result = n_keys > fixed.value();
+        log::version().debug("Symbol list: Fixed draw for compaction. needs_compaction=[{}] n_keys=[{}], MaxDelta=[{}]",
+                             result, n_keys, fixed.value());
+        return result;
+    }
+
+    int64_t min = ConfigsMap::instance()->get_int("SymbolList.MinCompactionThreshold", 300);
+    int64_t max = ConfigsMap::instance()->get_int("SymbolList.MaxCompactionThreshold", 700);
+    util::check(max >= min, "Bad configuration, min compaction threshold=[{}] > max compaction threshold=[{}]", min, max);
+
+    uint32_t seed;
+    if (data_.seed_ == 0) {
+        seed = std::random_device{}();
+    } else {
+        seed = data_.seed_;
+    }
+
+    std::mt19937 gen = std::mt19937{seed};
+    std::uniform_int_distribution<int64_t> distrib(min, max);
+    auto draw = distrib(gen);
+    auto result = n_keys > draw;
+    log::version().debug("Symbol list: Random draw for compaction. needs_compaction=[{}] n_keys=[{}], draw=[{}]",
+                         result, n_keys, draw);
+    return result;
 }
 
 void write_symbol_at(

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -149,8 +149,9 @@ ProblematicResult is_problematic(const std::vector<SymbolEntryData>& updated, ti
 class SymbolList {
     SymbolListData data_;
   public:
-    explicit SymbolList(std::shared_ptr<VersionMap> version_map, entity::StreamId type_indicator = entity::StringId()) :
-        data_(std::move(version_map), std::move(type_indicator)) {
+    explicit SymbolList(std::shared_ptr<VersionMap> version_map, entity::StreamId type_indicator = entity::StringId(),
+                        uint32_t seed = 0) :
+        data_(std::move(version_map), std::move(type_indicator), seed) {
     }
 
     std::set<entity::StreamId> load(const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store, bool no_compaction);

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -28,11 +28,12 @@ class Store;
 
 struct SymbolListData {
     entity::StreamId type_holder_;
-    uint64_t max_delta_ = 0;
+    uint32_t seed_;
     std::shared_ptr<VersionMap> version_map_;
     std::atomic<bool> warned_expected_slowdown_ = false;
 
-    explicit SymbolListData(std::shared_ptr<VersionMap> version_map, entity::StreamId type_indicator = entity::StringId());
+    explicit SymbolListData(std::shared_ptr<VersionMap> version_map, entity::StreamId type_indicator = entity::StringId(),
+                            uint32_t seed = 0);
 };
 
 constexpr std::string_view CompactionId = "__symbols__";

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -726,12 +726,12 @@ TEST_F(SymbolListSuite, CompactionThreshold) {
     std::shared_ptr<VersionMap> version_map = std::make_shared<VersionMap>();
     auto symbol_list = SymbolList{version_map};
     auto state = std::make_shared<SymbolListState>(store, version_map);
-    symbol_list.load(store, false);
+    symbol_list.get_symbols(store, false);
 
     // when
-    symbol_list.add_symbol(store, "1");
-    symbol_list.add_symbol(store, "2");
-    symbol_list.add_symbol(store, "3");
+    SymbolList::add_symbol(store, "1", 0);
+    SymbolList::add_symbol(store, "2", 0);
+    SymbolList::add_symbol(store, "3", 0);
 
     // then
     auto symbols = symbol_list.get_symbol_set(store);
@@ -750,13 +750,13 @@ TEST_F(SymbolListSuite, CompactionThresholdMaxDeltaWins) {
     std::shared_ptr<InMemoryStore> store = std::make_shared<InMemoryStore>();
     std::shared_ptr<VersionMap> version_map = std::make_shared<VersionMap>();
     auto symbol_list = SymbolList{version_map};
-    symbol_list.load(store, false);
+    symbol_list.get_symbols(store, false);
 
     // when
-    symbol_list.add_symbol(store, "1");
+    SymbolList::add_symbol(store, "1", 0);
 
     // then
-    symbol_list.load(store, false);
+    symbol_list.get_symbols(store, false);
     {
         std::vector<VariantKey> keys;
         store->iterate_type(entity::KeyType::SYMBOL_LIST, [&keys](auto &&k) { keys.push_back(k); });
@@ -764,10 +764,10 @@ TEST_F(SymbolListSuite, CompactionThresholdMaxDeltaWins) {
     }
 
     // when
-    symbol_list.add_symbol(store, "2");
+    SymbolList::add_symbol(store, "2", 0);
 
     // then
-    symbol_list.load(store, false);
+    symbol_list.get_symbols(store, false);
     {
         std::vector<VariantKey> keys;
         store->iterate_type(entity::KeyType::SYMBOL_LIST, [&keys](auto &&k) { keys.push_back(k); });
@@ -783,13 +783,13 @@ TEST_F(SymbolListSuite, CompactionThresholdRandomChoice) {
     std::shared_ptr<InMemoryStore> store = std::make_shared<InMemoryStore>();
     std::shared_ptr<VersionMap> version_map = std::make_shared<VersionMap>();
     auto symbol_list = SymbolList{version_map, StringId(), 1};
-    symbol_list.load(store, false);
+    symbol_list.get_symbols(store, false);
 
     // when
     for (int i = 0; i < 5; i++) {
-    symbol_list.add_symbol(store, fmt::format("sym{}", i));
+      SymbolList::add_symbol(store, fmt::format("sym{}", i), 0);
     }
-    symbol_list.load(store, false);
+    symbol_list.get_symbols(store, false);
 
     // then
     std::vector<VariantKey> keys;

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -777,7 +777,7 @@ TEST_F(SymbolListSuite, CompactionThresholdMaxDeltaWins) {
 
 TEST_F(SymbolListSuite, CompactionThresholdRandomChoice) {
     // given
-    // Compaction thresholds [1, 10] form random choice, seeded with value 1 => choice of threshold is 5
+    // Compaction thresholds [1, 10] form random choice, seeded with value 1 => choice of threshold is 5 (or 6 on Mac)
     ScopedConfig min("SymbolList.MinCompactionThreshold", 1);
     ScopedConfig max("SymbolList.MaxCompactionThreshold", 10);
     std::shared_ptr<InMemoryStore> store = std::make_shared<InMemoryStore>();
@@ -786,7 +786,7 @@ TEST_F(SymbolListSuite, CompactionThresholdRandomChoice) {
     symbol_list.get_symbols(store, false);
 
     // when
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 6; i++) {
       SymbolList::add_symbol(store, fmt::format("sym{}", i), 0);
     }
     symbol_list.get_symbols(store, false);


### PR DESCRIPTION
Add symbol list jitter feature.

Port of internal PR #1087

Introduce jitter to avoid storm of writers to the symbol list cache when
the compaction threshold is tripped.

Will backport to 4.0.x once merged.

Also includes:
- A clang preset
- Better C++ test output for Conda (in this case to help debug a Mac failure without a Mac to work on)