### PR TITLE
Link against python explicitly in order to make MSVS builds work

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -94,7 +94,8 @@
       "installDir": "${sourceDir}/out/install",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "/MP",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-static"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+        "ARCTICDB_PYTHON_EXPLICIT_LINK": "ON"
       }
     },
 

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -516,6 +516,14 @@ set (arcticdb_core_libraries
         Azure::azure-storage-blobs
 )
 
+if(${ARCTICDB_PYTHON_EXPLICIT_LINK})
+    # Even though python is transitive dependency MSVS builds fail if we don't link against python explicitly
+    # TODO: Figure out why
+    list(APPEND arcticdb_core_libraries
+        Python::Python
+    )
+endif()
+
 # Dependencies expose different names of their libraries depending
 # on their origin (i.e. vendored source or packages on conda-forge).
 if(${ARCTICDB_USING_CONDA})


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
MSVS builds fail because they can't find python. We get Python as transitive dependency via pybind11, however debug MSVS builds (by default) require all dependencies to be build in debug and pybind11's python is in release. Thus adding explicit linkage will use the library found via find_package.
#### Any other comments?
Debug python symbols can be installed via python installer.
While having debug python is nice the binary becomes huge and it takes quite a lot of time to load the DLL. In future we should add option to work with release python in MSVS.
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
