### PR TITLE
Bugfix 1182: Unskip test that is no longer flaky

### DIFF
--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1610,7 +1610,6 @@ def test_coercion_to_str_with_dynamic_strings(basic_store):
         sample_mock.assert_not_called()
 
 
-@pytest.mark.xfail(reason="Needs to be fixed by issue #496")
 def test_find_version(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_find_version"


### PR DESCRIPTION
Closes #1182

Git archaeology suggests this test has not been flaky for a while, and that it was mistakenly skipped, Evidence:

- Original bullet point in flaky tests epic linked to (now expired) [logs](https://github.com/man-group/ArcticDB/actions/runs/5556047996/job/15052956381?pr=604#step:9:633) from a build on 14/7/23, which had an [old implementation](https://github.com/man-group/ArcticDB/blob/e8b83c104256db2b902d718e88ac4032bfa826ea/python/tests/integration/arcticdb/version_store/test_basic_version_store.py#L1206-L1218) of this test, and said that the failure looked similar to `test_read_ts`, which also had an [old implementation](https://github.com/man-group/ArcticDB/blob/e8b83c104256db2b902d718e88ac4032bfa826ea/python/tests/integration/arcticdb/version_store/test_basic_version_store.py#L694-L731) using sleeps instead of the `distinct_timestamps` context manager now in use in both tests on `master`
- The `distinct_timestamps` context manager was added to `test_find_version` in a [PR](https://github.com/man-group/ArcticDB/pull/705) on 10/8/23, and the test was not marked as skipped at this point.
- The `xfail` mark was added in a [commit](https://github.com/man-group/ArcticDB/commit/b697a6c9d54ecb1235b9337925a4fe9274374084#diff-820e1d6f588509b49c8841acba4cc4c430a434a90a8fa483130ed6af36076048) titled "Reapply parts of the previous commit that isn't superseded without formatting to avoid conflicts", merged as part of [this PR](https://github.com/man-group/ArcticDB/pull/1054).
- However, none of the other commits in this PR removed the `xfail`, suggesting only the changes to `test_file_config.py` were intentional.

For additional safety, I [ran the test 1000 times](https://github.com/man-group/ArcticDB/actions/runs/7397826344) in all supported configurations in the CI, with no failures.