### PR TITLE
build: Adapt protobuf compilation

### DIFF
--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           ARCTICDB_USING_CONDA: 1
           ARCTICDB_BUILD_CPP_TESTS: 1
+          ARCTICDB_PROTOC_VERS: "4"
 
       - name: Build C++ Tests
         shell: bash -l {0}
@@ -129,6 +130,7 @@ jobs:
         env:
           ARCTICDB_USING_CONDA: 1
           ARCTICDB_BUILD_CPP_TESTS: 1
+          ARCTICDB_PROTOC_VERS: "4"
 
       - name: Build C++ Tests
         shell: bash -l {0}

--- a/python/arcticc/pb2/__init__.py
+++ b/python/arcticc/pb2/__init__.py
@@ -4,6 +4,22 @@ import google.protobuf as _protobuf
 
 _proto_ver = _protobuf.__version__.split(".")[0]
 if _proto_ver in "34":
+
+    _python = _sys.version_info[:2]
+    if _python >= (3, 11) and _proto_ver == "3":
+        raise RuntimeError(
+            "Your environment uses protobuf 3 which does not officially support Python>=3.11.\n"
+            "Since the support of protobuf 3 for Python ended in 23Q2, we recommend adapting your environment\n"
+            "to use protobuf 4 before trying to downgrade to Python 3.10 to continue using protobuf 3.\n"
+            "For more information, see: https://protobuf.dev/support/version-support/#python"
+        )
+    elif _python <= (3, 6) and _proto_ver >= "4":
+        raise RuntimeError(
+            "Your environment uses protobuf 4 which does not support Python<=3.6.\n"
+            "We recommend updating your environment to use the minimum supported version of Python.\n"
+            "For more information, see: https://devguide.python.org/versions/#supported-versions"
+        )
+
     # Use the namespace package (https://peps.python.org/pep-0420) feature to select the pb2 files matching the protobuf
     _protos_path = _os.path.abspath(
         _os.path.join(_os.path.dirname(__file__), "..", "..", "arcticdb", "proto", _proto_ver, "arcticc", "pb2")

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,13 @@ class CompileProto(Command):
         python = sys.version_info[:2]
         print(f"\nProtoc compilation (into '{output_dir}') for versions '{self.proto_vers}':")
         for proto_ver in self.proto_vers:
-            if python >= (3, 11) and proto_ver == "3":
-                print(f"Python protobuf {proto_ver} is not officially supported on Python {python}. Skipping...") # e.g. https://pypi.org/project/protobuf/3.20.3/#files
-            elif python <= (3, 6) and proto_ver >= "4":
+            if not ARCTICDB_USING_CONDA and python >= (3, 11) and proto_ver == "3":
+                # No available on PyPI for this configuration.
+                # See the last release's: https://pypi.org/project/protobuf/3.20.3/#files
+                print(f"Python protobuf {proto_ver} is not officially supported on Python {python}. Skipping...")
+            elif not ARCTICDB_USING_CONDA and python <= (3, 6) and proto_ver >= "4":
+                # No available on PyPI for this configuration
+                # See the first release's: https://pypi.org/project/protobuf/4.21.1/#files
                 print(f"Python protobuf {proto_ver} do not run on Python {python}. Skipping...")
             else:
                 self._compile_one_version(proto_ver, os.path.join(output_dir, proto_ver))


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Currently the compilation of protobuf definitions is as follows:
 - for wheels, definitions are compiled for both protobuf 3 and protobuf 4 excepted at version support boundary (see the comments), causing problems at runtime.
 - for conda packages, definitions are compiled for protobuf 4 only. We can adapt the ArcticDB's feedstock to compile build for both protobuf 3 and protobuf 4.

This adapts the setup and adds a informative `RuntimeError` at version support boundary.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
