### PR TITLE
Docs that StorageFailureSimulator is not used in all stores

### DIFF
--- a/cpp/arcticdb/storage/failure_simulation.hpp
+++ b/cpp/arcticdb/storage/failure_simulation.hpp
@@ -110,6 +110,9 @@ public:
     }
 };
 
+// Note that StorageFailureSimulator currently is only used for the following storages:
+// - Mongo storage
+// - InMemoryStore (only in cpp tests)
 class StorageFailureSimulator {
 public:
     using ParamActionSequence = FailureTypeState::ActionSequence;


### PR DESCRIPTION
Minor PR to document that the StorageFailureSimulator is not used by all stores.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
