### PR TITLE
Enable skipped test_partial_write_hashed 

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_engine.py
+++ b/python/tests/unit/arcticdb/version_store/test_engine.py
@@ -87,7 +87,6 @@ def test_partial_write_non_contiguous(version_store_factory, colnum, rownum, col
     nt.assert_array_equal(vit.data.values, expected.values)
 
 
-@pytest.mark.xfail(reason="Needs to be fixed by issue #316")
 @pytest.mark.parametrize("colnum,rownum,cols,tsbounds", gen_params())
 def test_partial_write_hashed(version_store_factory, colnum, rownum, cols, tsbounds):
     tz = "America/New_York"


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://github.com/man-group/ArcticDB/issues/316
#### What does this implement or fix?
Nothing is fixed. Just re-enabling the skipped test.
In the manual defragmentation PR, the container was changed from `bitmagic` to a simple `vector`
https://github.com/man-group/ArcticDB/pull/180
The PR was merged on 15th May and the related ticket was created on 2nd May. So it makes sense for @jjerphan to spot this issue at the time.

Per @poodlewars the test has been run 100 times locally and the issue has not re-appeared
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
