### PR TITLE
Fix recurse_segment forward declaration to match the signature of its implementation

### DIFF
--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -116,7 +116,7 @@ inline std::unordered_set<AtomKey> get_data_keys_set(
 
 std::unordered_set<AtomKey> recurse_segment(const std::shared_ptr<stream::StreamSource>& store,
                                             SegmentInMemory segment,
-                                            std::optional<VersionId> version_id);
+                                            const std::optional<VersionId>& version_id);
 
 /* Given a [multi-]index key, returns a set containing the top level [multi-]index key itself, and all of the
  * multi-index, index, and data keys referenced by this [multi-]index key.


### PR DESCRIPTION
See the implementation on line 133 of this file.

The mismatch was causing issues resolving the symbol in the `arcticdb-enterprise` build.

I'm not sure how it works in ArcticDB, but seems pretty clearly wrong.