### PR TITLE
Bugfix arcticdb-man/62: Speedup reading wide dataframes that have no empty columns

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -696,7 +696,6 @@ class DataFrameNormalizer(_PandasNormalizer):
         columns, denormed_columns, data = _denormalize_columns(item, norm_meta, idx_type, n_indexes)
 
         if not self._skip_df_consolidation:
-            columns_dtype = {} if data is None else {name: np_array.dtype for name, np_array in data.items()}
             df = DataFrame(data, index=index, columns=columns)
 
             # Setting the columns' dtype manually, since pandas might just convert the dtype of some
@@ -710,17 +709,22 @@ class DataFrameNormalizer(_PandasNormalizer):
             #       }
             #       df = DataFrame(index=index, columns=columns_mapping, copy=False)
             #
-            for column_name, dtype in columns_dtype.items():
+            if not IS_PANDAS_TWO:
                 # TODO(jjerphan): Remove once pandas < 2 is not supported anymore.
-                if len(df[column_name]) == 0 and not IS_PANDAS_TWO and dtype in OBJECT_TOKENS:
-                    # Before Pandas 2.0, empty series' dtype was float, but as of Pandas 2.0. empty series' dtype became object.
-                    # See: https://github.com/pandas-dev/pandas/issues/17261
-                    # EMPTY type column are returned as pandas.Series with "object" dtype to match Pandas 2.0 default.
-                    # We cast it back to "float" so that it matches Pandas 1.0 default for empty series.
-                    # Pandas 0.X overrides the index of df to a RangeIndex if the index isn't explicitly provided here
+                # Before Pandas 2.0, empty series' dtype was float, but as of Pandas 2.0. empty series' dtype became object.
+                # See: https://github.com/pandas-dev/pandas/issues/17261
+                # EMPTY type column are returned as pandas.Series with "object" dtype to match Pandas 2.0 default.
+                # We cast it back to "float" so that it matches Pandas 1.0 default for empty series.
+                # Moreover, we explicitly provide the index otherwise Pandas 0.X overrides it for a RangeIndex
+                empty_columns_names = (
+                    [] if data is None else
+                    [
+                        name for name, np_array in data.items()
+                        if np_array.dtype in OBJECT_TOKENS and len(df[name]) == 0
+                    ]
+                )
+                for column_name in empty_columns_names:
                     df[column_name] = pd.Series([], index=index, dtype='float64')
-                else:
-                    df[column_name] = df[column_name].astype(dtype, copy=False)
 
         else:
             if index is not None:

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -31,6 +31,8 @@ class BasicFunctions:
             lib = self.ac[lib]
             for sym in range(num_symbols[-1]):
                 lib.write(f"{sym}_sym", self.dfs[rows])
+        for sym in range(num_symbols[-1]):
+            lib.write(f"{sym}_short_wide_sym", generate_random_floats_dataframe(5_000, 30_000))
 
     def teardown(self, rows, num_symbols):
         for lib in self.ac.list_libraries():
@@ -43,6 +45,7 @@ class BasicFunctions:
         self.read_reqs = [ReadRequest(f"{sym}_sym") for sym in range(num_symbols)]
 
         self.df = generate_pseudo_random_dataframe(rows)
+        self.df_short_wide = generate_random_floats_dataframe(5_000, 30_000)
 
     def get_fresh_lib(self):
         self.ac.delete_library("fresh_lib")
@@ -58,6 +61,16 @@ class BasicFunctions:
         lib = self.get_fresh_lib()
         for sym in range(num_symbols):
             lib.write(f"{sym}_sym", self.df)
+
+    def time_write_short_wide(self, rows, num_symbols):
+        lib = self.get_fresh_lib()
+        for sym in range(num_symbols):
+            lib.write(f"{sym}_short_wide_sym", self.df_short_wide)
+
+    def peakmem_write_short_wide(self, rows, num_symbols):
+        lib = self.get_fresh_lib()
+        for sym in range(num_symbols):
+            lib.write(f"{sym}_short_wide_sym", self.df_short_wide)
 
     def time_write_staged(self, rows, num_symbols):
         lib = self.get_fresh_lib()
@@ -94,6 +107,14 @@ class BasicFunctions:
     def peakmem_read(self, rows, num_symbols):
         lib = self.ac[get_prewritten_lib_name(rows)]
         [lib.read(f"{sym}_sym").data for sym in range(num_symbols)]
+
+    def time_read_short_wide(self, rows, num_symbols):
+        lib = self.ac[get_prewritten_lib_name(rows)]
+        [lib.read(f"{sym}_short_wide_sym").data for sym in range(num_symbols)]
+
+    def peakmem_read_short_wide(self, rows, num_symbols):
+        lib = self.ac[get_prewritten_lib_name(rows)]
+        [lib.read(f"{sym}_short_wide_sym").data for sym in range(num_symbols)]
 
     def time_read_batch(self, rows, num_symbols):
         lib = self.ac[get_prewritten_lib_name(rows)]

--- a/python/benchmarks/common.py
+++ b/python/benchmarks/common.py
@@ -25,6 +25,18 @@ def generate_pseudo_random_dataframe(n, freq="S", end_timestamp="1/1/2023"):
     return df
 
 
+def generate_random_floats_dataframe(num_rows, num_cols):
+    """
+    Generates a dataframe of random 64 bit floats with num_rows rows and num_cols columns.
+    Columns are named "col_n" for n in range(num_cols).
+    Row range indexed.
+    """
+    columns = [f"col_{n}" for n in range(num_cols)]
+    rng = np.random.default_rng()
+    data = rng.random((num_rows, num_cols), dtype=np.float64)
+    return pd.DataFrame(data, columns=columns)
+
+
 def generate_benchmark_df(n, freq="T", end_timestamp="1/1/2023"):
     timestamps = pd.date_range(end=end_timestamp, periods=n, freq=freq)
     k = n // 10


### PR DESCRIPTION
Closes https://github.com/man-group/arcticdb-man/issues/62

The modified for loop created a performance regression compared to the internal Man Group client when reading wide, shallow dataframes.

Also applied to the `4.0.x` branch in #1223.

Also adds a simple ASV benchmark to prevent similar performance regressions in the future.