### PR TITLE
Remove obsolete test log level environment variable

### DIFF
--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -180,15 +180,6 @@ def param_dict(fields, cases=None, xfail=None):
     return pytest.mark.parametrize(fields, params, ids=ids)
 
 
-def configure_test_logger(level="INFO"):
-    level = os.getenv("ARCTICC_TEST_LOG_LEVEL", level)
-    if os.getenv("ARCTICC_TEST_FILE_LOGGING"):
-        outputs = ["file", "console"]
-    else:
-        outputs = ["console"]
-    configure(get_test_logger_config(level=level, outputs=outputs), force=True)
-
-
 CustomThing = NamedTuple(
     "CustomThing",
     [

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -26,7 +26,7 @@ from arcticdb.storage_fixtures.s3 import MotoS3StorageFixtureFactory, real_s3_fr
 from arcticdb.storage_fixtures.mongo import auto_detect_server
 from arcticdb.storage_fixtures.in_memory import InMemoryStorageFixture
 from arcticdb.version_store._normalization import MsgPackNormalizer
-from arcticdb.util.test import configure_test_logger, create_df
+from arcticdb.util.test import create_df
 from tests.util.mark import (
     AZURE_TESTS_MARK,
     MONGO_TESTS_MARK,
@@ -39,8 +39,6 @@ hypothesis.settings.register_profile("ci_windows", max_examples=100)
 hypothesis.settings.register_profile("dev", max_examples=100)
 
 hypothesis.settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "dev"))
-
-configure_test_logger()
 
 # Use a smaller memory mapped limit for all tests
 MsgPackNormalizer.MMAP_DEFAULT_SIZE = 20 * (1 << 20)


### PR DESCRIPTION
…CDB_<stream>_loglevel

#### Reference Issues/PRs

#### What does this implement or fix?
Remove `ARCTICC_TEST_LOG_LEVEL` in favor of the standard `ARCTICDB_<stream>_loglevel`. The former is a legacy and is not documented.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
