### PR TITLE
Pass unmodified argument by const& to FieldCollection::add_field

### DIFF
--- a/cpp/arcticdb/entity/field_collection.cpp
+++ b/cpp/arcticdb/entity/field_collection.cpp
@@ -10,7 +10,7 @@
 
 namespace arcticdb {
 
-std::string_view FieldCollection::add_field(TypeDescriptor type, std::string_view name) {
+std::string_view FieldCollection::add_field(const TypeDescriptor& type, std::string_view name) {
   const auto total_size = Field::calc_size(name);
   buffer_.ensure_bytes(total_size);
   auto field = reinterpret_cast<Field*>(buffer_.ptr());

--- a/cpp/arcticdb/entity/field_collection.hpp
+++ b/cpp/arcticdb/entity/field_collection.hpp
@@ -107,7 +107,7 @@ public:
         return add_field(field.type_, field.name_);
     }
 
-    std::string_view add_field(TypeDescriptor type, std::string_view name);
+    std::string_view add_field(const TypeDescriptor& type, std::string_view name);
 
     // Note that this is expensive and is primarily intended for testing, where drop_column
     // is a good way of creating dynamic schema from a large dataframe


### PR DESCRIPTION
Noticed while profiling for https://github.com/man-group/arcticdb-man/issues/62 that the allocation for passing this argument by copy was taking a noticable amount of time.