### PR TITLE
Bugfix 1207: Use pandas.Timestamp.max - 1 day in test_read_ts. Remove pointless snapshot. Improve error message when index key reading fails.

### DIFF
--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -716,7 +716,11 @@ std::optional<pipelines::index::IndexSegmentReader> get_index_segment_reader(
         index_key_seg = store->read_sync(version_info.key_);
     } catch (const std::exception& ex) {
         ARCTICDB_DEBUG(log::version(), "Key not found from versioned item {}: {}", version_info.key_, ex.what());
-        throw storage::NoDataFoundException(version_info.key_.id());
+        throw storage::NoDataFoundException(fmt::format("When trying to read version {} of symbol `{}`, failed to read key {}: {}",
+                                                        version_info.version(),
+                                                        version_info.symbol(),
+                                                        version_info.key_,
+                                                        ex.what()));
     }
 
     if (variant_key_type(index_key_seg.first) == KeyType::MULTI_KEY) {

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -971,7 +971,6 @@ def test_read_ts(basic_store):
     with distinct_timestamps(basic_store):
         basic_store.write("a", 3)  # v2
     basic_store.write("a", 4)  # v3
-    basic_store.snapshot("snap3")
 
     versions = basic_store.list_versions()
     assert len(versions) == 4
@@ -981,15 +980,15 @@ def test_read_ts(basic_store):
     assert vitem.version == 1
     assert vitem.data == 2
 
-    ts_for_v2 = sorted_versions_for_a[0]["date"]
-    vitem = basic_store.read("a", as_of=ts_for_v2)
+    ts_for_v0 = sorted_versions_for_a[0]["date"]
+    vitem = basic_store.read("a", as_of=ts_for_v0)
     assert vitem.version == 0
     assert vitem.data == 1
 
     with pytest.raises(NoDataFoundException):
         basic_store.read("a", as_of=pd.Timestamp(0))
 
-    brexit_almost_over = pd.Timestamp(np.iinfo(np.int64).max)  # Timestamp("2262-04-11 23:47:16.854775807")
+    brexit_almost_over = pd.Timestamp.max - pd.Timedelta(1, unit="day")  # Timestamp("2262-04-10 23:47:16.854775807")
     vitem = basic_store.read("a", as_of=brexit_almost_over)
     assert vitem.version == 3
     assert vitem.data == 4


### PR DESCRIPTION
Change "end of time" timestamp used in `test_read_ts` to 1 day before `pandas.Timestamp.max` which may fix issue.

In case it does not, improve the error message when an index key fails to be read.