### PR TITLE
Switch from `arcticdb` to `adb` in python docstrings

### DIFF
--- a/docs/mkdocs/docs/api/index.md
+++ b/docs/mkdocs/docs/api/index.md
@@ -11,3 +11,9 @@ The API is structured into the following components:
 * [**Arctic**](arctic.md): Arctic is the primary API used for accessing and manipulating ArcticDB libraries.
 * [**Library**](library.md): The Library API enables reading and manipulating symbols inside ArcticDB libraries.
 * [**Query Builder**](query_builder.md): The QueryBuilder API enables the specification of complex queries, utilised in the Library API.
+
+Most of the code snippets in the API docs require importing `arcticdb` as `adb`:
+
+```python
+import arcticdb as adb
+```

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -163,9 +163,9 @@ class Arctic:
         Examples
         --------
 
-        >>> ac = Arctic('s3://MY_ENDPOINT:MY_BUCKET')  # Leave AWS to derive credential information
-        >>> ac = Arctic('s3://MY_ENDPOINT:MY_BUCKET?region=YOUR_REGION&access=ABCD&secret=DCBA') # Manually specify creds
-        >>> ac = Arctic('azure://CA_cert_path=/etc/ssl/certs/ca-certificates.crt;BlobEndpoint=https://arctic.blob.core.windows.net;Container=acblob;SharedAccessSignature=sp=sig')
+        >>> ac = adb.Arctic('s3://MY_ENDPOINT:MY_BUCKET')  # Leave AWS to derive credential information
+        >>> ac = adb.Arctic('s3://MY_ENDPOINT:MY_BUCKET?region=YOUR_REGION&access=ABCD&secret=DCBA') # Manually specify creds
+        >>> ac = adb.Arctic('azure://CA_cert_path=/etc/ssl/certs/ca-certificates.crt;BlobEndpoint=https://arctic.blob.core.windows.net;Container=acblob;SharedAccessSignature=sp=sig')
         >>> ac.create_library('travel_data')
         >>> ac.list_libraries()
         ['travel_data']
@@ -211,8 +211,8 @@ class Arctic:
         """
         Returns the library named ``name``.
 
-        This method can also be invoked through subscripting. ``Arctic('bucket').get_library("test")`` is equivalent to
-        ``Arctic('bucket')["test"]``.
+        This method can also be invoked through subscripting. ``adb.Arctic('bucket').get_library("test")`` is equivalent to
+        ``adb.Arctic('bucket')["test"]``.
 
         Parameters
         ----------
@@ -231,7 +231,7 @@ class Arctic:
 
         Examples
         --------
-        >>> arctic = Arctic('s3://MY_ENDPOINT:MY_BUCKET')
+        >>> arctic = adb.Arctic('s3://MY_ENDPOINT:MY_BUCKET')
         >>> arctic.create_library('test.library')
         >>> my_library = arctic.get_library('test.library')
         >>> my_library = arctic['test.library']
@@ -280,7 +280,7 @@ class Arctic:
 
         Examples
         --------
-        >>> arctic = Arctic('s3://MY_ENDPOINT:MY_BUCKET')
+        >>> arctic = adb.Arctic('s3://MY_ENDPOINT:MY_BUCKET')
         >>> arctic.create_library('test.library')
         >>> my_library = arctic['test.library']
 
@@ -350,7 +350,7 @@ class Arctic:
 
         Examples
         --------
-        >>> arctic = Arctic('s3://MY_ENDPOINT:MY_BUCKET')
+        >>> arctic = adb.Arctic('s3://MY_ENDPOINT:MY_BUCKET')
         >>> arctic.list_libraries()
         ['test.library']
 
@@ -367,7 +367,7 @@ class Arctic:
 
         Examples
         --------
-        >>> arctic = Arctic('s3://MY_ENDPOINT:MY_BUCKET')
+        >>> arctic = adb.Arctic('s3://MY_ENDPOINT:MY_BUCKET')
         >>> arctic.get_uri()
 
         Returns

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -412,8 +412,7 @@ class Library:
         2000-01-03       7
 
         WritePayload objects can be unpacked and used as parameters:
-
-        >>> w = WritePayload("symbol", df, metadata={'the': 'metadata'})
+        >>> w = adb.WritePayload("symbol", df, metadata={'the': 'metadata'})
         >>> lib.write(*w, staged=True)
         """
         if not isinstance(data, NORMALIZABLE_TYPES):
@@ -547,11 +546,10 @@ class Library:
         --------
 
         Writing a simple batch:
-
         >>> df_1 = pd.DataFrame({'column': [1,2,3]})
         >>> df_2 = pd.DataFrame({'column': [4,5,6]})
-        >>> payload_1 = WritePayload("symbol_1", df_1, metadata={'the': 'metadata'})
-        >>> payload_2 = WritePayload("symbol_2", df_2)
+        >>> payload_1 = adb.WritePayload("symbol_1", df_1, metadata={'the': 'metadata'})
+        >>> payload_2 = adb.WritePayload("symbol_2", df_2)
         >>> items = lib.write_batch([payload_1, payload_2])
         >>> lib.read("symbol_1").data
            column
@@ -1035,12 +1033,11 @@ class Library:
 
         Examples
         --------
-
         >>> lib.write("s1", pd.DataFrame())
         >>> lib.write("s2", pd.DataFrame({"col": [1, 2, 3]}))
         >>> lib.write("s2", pd.DataFrame(), prune_previous_versions=False)
         >>> lib.write("s3", pd.DataFrame())
-        >>> batch = lib.read_batch(["s1", ReadRequest("s2", as_of=0), "s3", ReadRequest("s2", as_of=1000)])
+        >>> batch = lib.read_batch(["s1", adb.ReadRequest("s2", as_of=0), "s3", adb.ReadRequest("s2", as_of=1000)])
         >>> batch[0].data.empty
         True
         >>> batch[1].data.empty
@@ -1049,8 +1046,7 @@ class Library:
         True
         >>> batch[3].symbol
         "s2"
-        >>> from arcticdb import DataError
-        >>> isinstance(batch[3], DataError)
+        >>> isinstance(batch[3], adb.DataError)
         True
         >>> batch[3].version_request_type
         VersionRequestType.SPECIFIC
@@ -1215,9 +1211,8 @@ class Library:
         --------
 
         Writing a simple batch:
-
-        >>> payload_1 = WriteMetadataPayload("symbol_1", {'the': 'metadata_1'})
-        >>> payload_2 = WriteMetadataPayload("symbol_2", {'the': 'metadata_2'})
+        >>> payload_1 = adb.WriteMetadataPayload("symbol_1", {'the': 'metadata_1'})
+        >>> payload_2 = adb.WriteMetadataPayload("symbol_2", {'the': 'metadata_2'})
         >>> items = lib.write_metadata_batch([payload_1, payload_2])
         >>> lib.read_metadata("symbol_1")
         {'the': 'metadata_1'}

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -279,8 +279,7 @@ class PythonRowRangeClause(NamedTuple):
 class QueryBuilder:
     """
     Build a query to process read results with. Syntax is designed to be similar to Pandas:
-
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q[q["a"] < 5] (equivalent to q = q[q.a < 5] provided the column name is also a valid Python variable name)
         >>> dataframe = lib.read(symbol, query_builder=q).data
 
@@ -314,12 +313,12 @@ class QueryBuilder:
 
     Boolean columns can be filtered on directly:
 
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q[q["boolean_column"]]
 
     and combined with other operations intuitively:
 
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q[(q["boolean_column_1"] & ~q["boolean_column_2"]) & (q["numeric_column"] > 0)]
 
     Arbitrary combinations of these expressions is possible, for example:
@@ -378,7 +377,7 @@ class QueryBuilder:
             index=np.arange(10),
         )
         >>> lib.write("expression", df)
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q.apply("ADJUSTED", q["ASK"] * q["VOL_ACC"] + 7)
         >>> lib.read("expression", query_builder=q).data
         VOL_ACC  ASK  VWAP  ADJUSTED
@@ -425,7 +424,6 @@ class QueryBuilder:
         Examples
         --------
         Average (mean) over two groups:
-
         >>> df = pd.DataFrame(
             {
                 "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
@@ -433,7 +431,7 @@ class QueryBuilder:
             },
             index=np.arange(5),
         )
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q.groupby("grouping_column").agg({"to_mean": "mean"})
         >>> lib.write("symbol", df)
         >>> lib.read("symbol", query_builder=q).data
@@ -450,7 +448,7 @@ class QueryBuilder:
             },
             index=np.arange(3),
         )
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q.groupby("grouping_column").agg({"to_max": "max"})
         >>> lib.write("symbol", df)
         >>> lib.read("symbol", query_builder=q).data
@@ -467,7 +465,7 @@ class QueryBuilder:
             },
             index=np.arange(3),
         )
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q.groupby("grouping_column").agg({"to_max": "max", "to_mean": "mean"})
         >>> lib.write("symbol", df)
         >>> lib.read("symbol", query_builder=q).data
@@ -554,8 +552,7 @@ class QueryBuilder:
 
         Examples
         --------
-
-        >>> q = QueryBuilder()
+        >>> q = adb.QueryBuilder()
         >>> q = q.date_range((pd.Timestamp("2000-01-01"), pd.Timestamp("2001-01-01")))
 
         Returns


### PR DESCRIPTION
This was missed in the previous [PR #1219](https://github.com/man-group/ArcticDB/pull/1219).