### PR TITLE
Bugfix/1120/improve date range returned by get info for unordered and range indexed dataframes

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -21,7 +21,7 @@ from pandas import Timestamp, to_datetime, Timedelta
 from typing import Any, Optional, Union, List, Sequence, Tuple, Dict, Set
 from contextlib import contextmanager
 
-from arcticc.pb2.descriptors_pb2 import TypeDescriptor, SortedValue
+from arcticc.pb2.descriptors_pb2 import IndexDescriptor, TypeDescriptor, SortedValue
 from arcticc.pb2.storage_pb2 import LibraryConfig, EnvironmentConfigsMap
 from arcticdb.preconditions import check
 from arcticdb.supported_types import DateRangeInput, ExplicitlySupportedDates
@@ -2433,7 +2433,10 @@ class NativeVersionStore:
         return self.is_pickled_descriptor(dit.timeseries_descriptor)
 
     def _get_time_range_from_ts(self, desc, min_ts, max_ts):
-        if min_ts == None or max_ts == None:
+        if desc.stream_descriptor.index.kind != IndexDescriptor.Type.TIMESTAMP or \
+            desc.stream_descriptor.sorted == SortedValue.UNSORTED or \
+            min_ts is None or \
+            max_ts is None:
             return datetime64("nat"), datetime64("nat")
         input_type = desc.normalization.WhichOneof("input_type")
         tz = None

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -662,16 +662,46 @@ def test_get_info_version_no_columns_nat(basic_store):
     df["b"] = df["b"].astype("int64")
     basic_store.write(sym, df, dynamic_strings=True, coerce_columns={"a": float, "b": int, "c": str})
     info = basic_store.get_info(sym)
-    assert np.isnat(info["date_range"][0]) == True
-    assert np.isnat(info["date_range"][1]) == True
+    assert np.isnat(info["date_range"][0])
+    assert np.isnat(info["date_range"][1])
 
 
 def test_get_info_version_empty_nat(basic_store):
     sym = "test_get_info_version_empty_nat"
     basic_store.write(sym, pd.DataFrame())
     info = basic_store.get_info(sym)
-    assert np.isnat(info["date_range"][0]) == True
-    assert np.isnat(info["date_range"][1]) == True
+    assert np.isnat(info["date_range"][0])
+    assert np.isnat(info["date_range"][1])
+
+
+def test_get_info_non_timestamp_index_date_range(basic_store):
+    lib = basic_store
+    sym = "test_get_info_non_timestamp_index_date_range"
+    # Row-range indexed
+    lib.write(sym, pd.DataFrame({"col": [1, 2, 3]}))
+    info = lib.get_info(sym)
+    assert np.isnat(info["date_range"][0])
+    assert np.isnat(info["date_range"][1])
+    # int64 indexed
+    lib.write(sym, pd.DataFrame({"col": [1, 2, 3]}), index=pd.Index([4, 5, 6], dtype=np.int64))
+    info = lib.get_info(sym)
+    assert np.isnat(info["date_range"][0])
+    assert np.isnat(info["date_range"][1])
+
+
+def test_get_info_unsorted_timestamp_index_date_range(basic_store):
+    lib = basic_store
+    sym = "test_get_info_unsorted_timestamp_index_date_range"
+    lib.write(
+        sym,
+        pd.DataFrame(
+            {"col": [1, 2, 3]},
+            index=[pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-02")]
+        )
+    )
+    info = lib.get_info(sym)
+    assert np.isnat(info["date_range"][0])
+    assert np.isnat(info["date_range"][1])
 
 
 def test_update_times(basic_store):


### PR DESCRIPTION
Closes #1120 
`date_range` field of return values of `NativeVersionStore.get_info`, `Library.get_description`, and batch versions thereof now contain `NaT` if:

- the symbol is not timestamp indexed
- the symbol is timestamp indexed, but is known to be unsorted