### PR TITLE
Ignore .md files for github workflows

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -9,7 +9,8 @@ on:
     - cron: '0 0 * * *'
 
   pull_request:
-
+    paths-ignore:
+      - **/*.md
 jobs:
   cibw_docker_image:
     uses: ./.github/workflows/cibw_docker_image.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags: ["v**"]
     branches: ["master"]
+    paths-ignore:
+      - **/*.md
   pull_request:
     branches: ["**"]
     paths:
@@ -12,6 +14,8 @@ on:
       - python/**
       - setup.*
       - pyproject.toml
+    paths-ignore:
+      - **/*.md
   workflow_dispatch:
     inputs:
       persistent_storage:

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -3,13 +3,16 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - **/*.md
   # For Pull-Requests, this runs the CI on merge commit
   # of HEAD with the target branch instead on HEAD, allowing
   # testing against potential new states which might have
   # been introduced in the target branch last commits.
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
   pull_request:
-
+    paths-ignore:
+      - **/*.md
 jobs:
   start_ec2_runner:
     uses: ./.github/workflows/ec2_runner_jobs.yml


### PR DESCRIPTION
Previously GitHub workflows were unnecessarily running even when only docs were changed. This PR is to avoid running workflows when only docs are changed.