### PR TITLE
Bugfix 1248 and 1249: compact_incomplete reject incomplete segments that overlap each other, or existing segments in the case of append

### DIFF
--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -849,7 +849,7 @@ void check_incompletes_index_ranges_dont_overlap(const std::shared_ptr<PipelineC
             if (next_it != unique_timestamp_ranges.end()) {
                 sorting::check<ErrorCode::E_UNSORTED_DATA>(
                         next_it->first >= it->second,
-                        "Cannot append staged segments to existing data as incomplete segment index values overlap one another: ({}, {}) ∩ ({}, {}) ≠ ∅",
+                        "Cannot append staged segments to existing data as incomplete segment index values overlap one another: ({}, {}) intersects ({}, {})",
                         it->first, it->second - 1, next_it->first, next_it->second - 1);
             }
         }
@@ -1209,7 +1209,6 @@ VersionedItem sort_merge_impl(
     auto num_versioned_rows = pipeline_context->total_rows_;
 
     read_incompletes_to_pipeline(store, pipeline_context, read_query, ReadOptions{}, convert_int_to_float, via_iteration, sparsify);
-    check_incompletes_index_ranges_dont_overlap(pipeline_context);
 
     std::vector<entity::VariantKey> delete_keys;
     for(auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -319,7 +319,6 @@ def test_parallel_non_timestamp_index(lmdb_version_store, append):
     assert_frame_equal(expected_df, read_df)
 
 
-@pytest.mark.xfail(reason="See https://github.com/man-group/ArcticDB/issues/1248")
 @pytest.mark.parametrize("append", (True, False))
 def test_parallel_overlapping_incomplete_segments(lmdb_version_store, append):
     lib = lmdb_version_store
@@ -335,11 +334,10 @@ def test_parallel_overlapping_incomplete_segments(lmdb_version_store, append):
     else:
         lib.write(sym, df_2, parallel=True)
         lib.write(sym, df_1, parallel=True)
-    with pytest.raises(Exception):
+    with pytest.raises(SortingException):
         lib.compact_incomplete(sym, append, False)
 
 
-@pytest.mark.xfail(reason="See https://github.com/man-group/ArcticDB/issues/1249")
 def test_parallel_append_overlapping_with_existing(lmdb_version_store):
     lib = lmdb_version_store
     sym = "test_parallel_append_overlapping_with_existing"
@@ -347,7 +345,7 @@ def test_parallel_append_overlapping_with_existing(lmdb_version_store):
     lib.write(sym, df_0)
     df_1 = pd.DataFrame({"col": [3, 4]}, index=[pd.Timestamp("2024-01-01T12"), pd.Timestamp("2024-01-03")])
     lib.append(sym, df_1, incomplete=True)
-    with pytest.raises(Exception):
+    with pytest.raises(SortingException):
         lib.compact_incomplete(sym, True, False)
 
 


### PR DESCRIPTION
Closes #1248 
Closes #1249