### PR TITLE
Expose headers for consumers via arcticdb_core_static

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -110,3 +110,13 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/proto/arcticc/pb2/proto/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(arcticdb)
+
+# arcticdb_core_static is used by other projects so we expose the headers via `arcticdb/.../abc.hpp`.
+# We plan to introduce a new target that exposes only a "public" subset of headers from this project
+# soon instead, as exposing all headers is fragile for consumers.
+target_include_directories(arcticdb_core_static PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/proto/arcticc/pb2/proto/>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -151,6 +151,10 @@ folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair &&ks) overri
     return async::submit_io_task(WriteCompressedTask{std::move(ks), library_});
 }
 
+void write_compressed_sync(storage::KeySegmentPair &&ks) override {
+    library_->write(Composite<storage::KeySegmentPair>(std::move(ks)));
+}
+
 folly::Future<entity::VariantKey> update(const entity::VariantKey &key,
                                          SegmentInMemory &&segment,
                                          storage::UpdateOpts opts) override {
@@ -209,6 +213,13 @@ folly::Future<storage::KeySegmentPair> read_compressed(
         const entity::VariantKey &key,
         storage::ReadKeyOpts opts) override {
     return read_and_continue(key, library_, opts, PassThroughTask{});
+}
+
+storage::KeySegmentPair read_compressed_sync(
+        const entity::VariantKey& key,
+        storage::ReadKeyOpts opts
+        ) override {
+        return read_dispatch( key, library_, opts );
 }
 
 folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(const entity::VariantKey &key, storage::ReadKeyOpts opts) override {

--- a/cpp/arcticdb/pipeline/index_writer.hpp
+++ b/cpp/arcticdb/pipeline/index_writer.hpp
@@ -51,7 +51,7 @@ public:
         // ensure sorted by col group then row group, this is normally the case but in append scenario,
         // one will need to ensure that this holds, otherwise the assumptions in the read pipeline will be
         // broken.
-        ARCTICDB_DEBUG(log::version(), "Wriiting key {} to the index", key);
+        ARCTICDB_DEBUG(log::version(), "Writing key {} to the index", key);
         util::check_arg(!current_col_.has_value() || *current_col_ <= slice.col_range.first,
                         "expected increasing column group, last col range left value {}, arg {}",
                         current_col_.value_or(-1), slice.col_range

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -206,12 +206,23 @@ namespace arcticdb {
             throw std::runtime_error("Not implemented");
         }
 
+        storage::KeySegmentPair read_compressed_sync(
+                const entity::VariantKey&,
+                storage::ReadKeyOpts
+        ) override {
+            throw std::runtime_error("Not implemented");
+        }
+
         folly::Future<std::pair<VariantKey, SegmentInMemory>> read(const VariantKey& key, storage::ReadKeyOpts opts) override {
             // Anything read_sync() throws should be returned inside the Future, so:
             return folly::makeFutureWith([&](){ return read_sync(key, opts); });
         }
 
         folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&&) override {
+            util::raise_rte("Not implemented");
+        }
+
+        void write_compressed_sync(storage::KeySegmentPair&&) override {
             util::raise_rte("Not implemented");
         }
 

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -106,6 +106,8 @@ struct StreamSink {
 
     [[nodiscard]] virtual folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair&& ks) = 0;
 
+    virtual void write_compressed_sync(storage::KeySegmentPair&& ks) = 0;
+
     [[nodiscard]] virtual folly::Future<pipelines::SliceAndKey> async_write(
         folly::Future<std::tuple<PartialKey, SegmentInMemory, pipelines::FrameSlice>> &&input_fut,
         const std::shared_ptr<DeDupMap> &de_dup_map) = 0;

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -37,6 +37,11 @@ struct StreamSource {
         const entity::VariantKey &key,
         storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
+    virtual storage::KeySegmentPair read_compressed_sync(
+            const entity::VariantKey& key,
+            storage::ReadKeyOpts opts
+    ) = 0;
+
     virtual void iterate_type(
         KeyType type,
         const entity::IterateTypeVisitor& func,

--- a/python/arcticdb/util/tasks.py
+++ b/python/arcticdb/util/tasks.py
@@ -166,9 +166,10 @@ def get_symbol(func, lib):
 
 def run_scenario(func, lib, with_snapshots, verbose):
     try:
+        symbol = get_symbol(func, lib)
         if verbose:
-            print("Running function {}".format(func.__name__))
-        func(lib, get_symbol(func, lib))
+            print("Running function {} symbol {}".format(func.__name__, symbol))
+        func(lib, symbol)
         if with_snapshots:
             lib.snapshot("snapshot" + datetime.utcnow().isoformat())
             # clean up old snapshots - more than 3 hours old


### PR DESCRIPTION
This allows us to build projects, like the ArcticDB enterprise repo, on top of ArcticDB neatly.

Consumers can include ArcticDB as a git submodule with

```
add_subdirectory("ArcticDB/cpp")
```

then link against `arcticdb_core_static` and run code like this successfully,

```
#include <arcticdb/stream/index.hpp>

int main() {
    arcticdb::stream_descriptor(
            "version",
            arcticdb::stream::RowCountIndex(),
            {arcticdb::scalar_field(arcticdb::DataType::UINT64, "version")}
            );
    return 0;
}
```
.

This is really a stepping stone. Once we've finished a prototype for a consumer, we can start to pick apart a sensible set of "public" includes for ArcticDB to export, rather than all of them as it does here.