### PR TITLE
Build time improvements

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -208,10 +208,13 @@ set(arcticdb_srcs
         entity/serialized_key.hpp
         entity/type_conversion.hpp
         entity/types.hpp
+        entity/types_proto.hpp
         entity/types-inl.hpp
         entity/variant_key.hpp
         entity/versioned_item.hpp
         entity/descriptor_item.hpp
+        entity/field_collection.hpp
+        entity/field_collection_proto.hpp
         log/log.hpp
         log/trace.hpp
         pipeline/column_mapping.hpp
@@ -371,11 +374,13 @@ set(arcticdb_srcs
         column_store/string_pool.cpp
         entity/data_error.cpp
         entity/field_collection.cpp
+        entity/field_collection_proto.cpp
         entity/key.cpp
         entity/merge_descriptors.cpp
         entity/metrics.cpp
         entity/performance_tracing.cpp
         entity/types.cpp
+        entity/types_proto.cpp
         log/log.cpp
         pipeline/column_stats.cpp
         pipeline/frame_slice.cpp

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -22,6 +22,7 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/util/constructors.hpp>
+#include <arcticdb/codec/codec.hpp>
 
 #include <type_traits>
 

--- a/cpp/arcticdb/column_store/chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.cpp
@@ -7,6 +7,8 @@
 
 #include <arcticdb/column_store/chunked_buffer.hpp>
 
+#include <optional>
+
 namespace arcticdb {
 
 template <size_t BlockSize>

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -8,17 +8,10 @@
 #pragma once
 
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/cursor.hpp>
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/entity/performance_tracing.hpp>
-#include <arcticdb/util/magic_num.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/column_store/memory_segment_impl.hpp>
-
-#include <google/protobuf/message.h>
-#include <google/protobuf/any.h>
-#include <google/protobuf/any.pb.h>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -9,8 +9,27 @@
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 
+#include <google/protobuf/any.h>
+#include <google/protobuf/any.pb.h>
+
 
 namespace arcticdb {
+
+    SegmentInMemoryImpl::SegmentInMemoryImpl() = default;
+
+    SegmentInMemoryImpl::SegmentInMemoryImpl( const StreamDescriptor& desc, size_t expected_column_size, bool presize, bool allow_sparse)
+        : descriptor_(std::make_shared<StreamDescriptor>(StreamDescriptor{ desc.id(), desc.index() }))
+        , allow_sparse_(allow_sparse)
+    {
+        on_descriptor_change(desc, expected_column_size, presize, allow_sparse);
+    }
+
+    SegmentInMemoryImpl::~SegmentInMemoryImpl()
+    {
+        ARCTICDB_TRACE(log::version(), "Destroying segment in memory");
+    }
+
+
 // Append any columns that exist both in this segment and in the 'other' segment onto the
 // end of the column in this segment. Any columns that exist in this segment but not in the
 // one being appended will be default-valued (or sparse) in this segment. Any columns in the
@@ -597,5 +616,23 @@ void SegmentInMemoryImpl::set_timeseries_descriptor(TimeseriesDescriptor&& tsd) 
     set_metadata(std::move(any));
 }
 
+void SegmentInMemoryImpl::set_metadata(google::protobuf::Any&& meta) {
+    util::check_arg(!metadata_, "Cannot override previously set metadata");
+    if (meta.ByteSizeLong())
+        metadata_ = std::make_unique<google::protobuf::Any>(std::move(meta));
+}
+
+void SegmentInMemoryImpl::override_metadata(google::protobuf::Any&& meta) {
+    if (meta.ByteSizeLong())
+        metadata_ = std::make_unique<google::protobuf::Any>(std::move(meta));
+}
+
+bool SegmentInMemoryImpl::has_metadata() const {
+    return static_cast<bool>(metadata_);
+}
+
+const google::protobuf::Any* SegmentInMemoryImpl::metadata() const {
+    return metadata_.get();
+}
 
 }

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -8,8 +8,7 @@
 #include <arcticdb/column_store/memory_segment_impl.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/entity/type_utils.hpp>
-#include <arcticdb/stream/index.hpp>
-#include <arcticdb/util/format_date.hpp>
+
 
 namespace arcticdb {
 // Append any columns that exist both in this segment and in the 'other' segment onto the
@@ -597,5 +596,6 @@ void SegmentInMemoryImpl::set_timeseries_descriptor(TimeseriesDescriptor&& tsd) 
     any.PackFrom(tsd.proto());
     set_metadata(std::move(any));
 }
+
 
 }

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/cursor.hpp>
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/preconditions.hpp>
@@ -18,17 +17,15 @@
 #include <arcticdb/util/magic_num.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/column_store/column_map.hpp>
-#include <arcticdb/pipeline/string_pool_utils.hpp>
-#include <arcticdb/util/format_date.hpp>
-#include <arcticdb/stream/index.hpp>
-#include <arcticdb/util/hash.hpp>
 #include <arcticdb/entity/stream_descriptor.hpp>
 
-#include <google/protobuf/message.h>
-#include <google/protobuf/any.h>
-#include <google/protobuf/any.pb.h>
 #include <boost/iterator/iterator_facade.hpp>
 #include <folly/container/Enumerate.h>
+
+namespace google::protobuf
+{
+    class Any;
+}
 
 namespace arcticdb {
 
@@ -372,21 +369,15 @@ public:
 
 
 
-    SegmentInMemoryImpl() = default;
+    SegmentInMemoryImpl();
 
     explicit SegmentInMemoryImpl(
-        const StreamDescriptor &desc,
+        const StreamDescriptor& desc,
         size_t expected_column_size,
         bool presize,
-        bool allow_sparse) :
-        descriptor_(std::make_shared<StreamDescriptor>(StreamDescriptor{desc.id(), desc.index()})),
-        allow_sparse_(allow_sparse) {
-        on_descriptor_change(desc, expected_column_size, presize, allow_sparse);
-    }
+        bool allow_sparse);
 
-    ~SegmentInMemoryImpl() {
-        ARCTICDB_TRACE(log::version(), "Destroying segment in memory");
-    }
+    ~SegmentInMemoryImpl();
 
     iterator begin() { return iterator{this}; }
 
@@ -726,24 +717,11 @@ public:
 
     StringPool &string_pool() { return *string_pool_; } //TODO protected
 
-    void set_metadata(google::protobuf::Any &&meta) {
-        util::check_arg(!metadata_, "Cannot override previously set metadata");
-        if (meta.ByteSizeLong())
-            metadata_ = std::make_unique<google::protobuf::Any>(std::move(meta));
-    }
+    void set_metadata(google::protobuf::Any&& meta);
+    void override_metadata(google::protobuf::Any&& meta);
+    bool has_metadata() const;
 
-    void override_metadata(google::protobuf::Any &&meta) {
-        if (meta.ByteSizeLong())
-            metadata_ = std::make_unique<google::protobuf::Any>(std::move(meta));
-    }
-
-    bool has_metadata() {
-        return static_cast<bool>(metadata_);
-    }
-
-    const google::protobuf::Any *metadata() const {
-        return metadata_.get();
-    }
+    const google::protobuf::Any* metadata() const;
 
     bool is_index_sorted() const;
 

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -56,14 +56,6 @@ inline void check_output_bitset(const arcticdb::util::BitSet& output,
 }
 } // namespace anon
 
-inline bool operator==(const Field::Proto& left, const Field::Proto& right) {
-    google::protobuf::util::MessageDifferencer diff;
-    return diff.Compare(left, right);
-}
-
-inline bool operator<(const Field::Proto& left, const Field::Proto& right) {
-    return left.name() < right.name();
-}
 
 class SegmentInMemoryImpl {
 public:

--- a/cpp/arcticdb/entity/atom_key.hpp
+++ b/cpp/arcticdb/entity/atom_key.hpp
@@ -10,10 +10,9 @@
 #include <arcticdb/entity/key.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/index_range.hpp>
-#include <arcticdb/util/string_utils.hpp>
 #include <variant>
+#include <optional>
 #include <fmt/format.h>
-#include <string_view>
 
 namespace arcticdb::entity {
 

--- a/cpp/arcticdb/entity/field_collection.hpp
+++ b/cpp/arcticdb/entity/field_collection.hpp
@@ -10,6 +10,7 @@
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <util/cursored_buffer.hpp>
 #include <util/buffer.hpp>
+#include <entity/types.hpp>
 #include <arcticdb/column_store/column_data.hpp>
 
 namespace arcticdb {
@@ -191,13 +192,6 @@ public:
     }
 };
 
-inline FieldCollection fields_from_proto(const arcticdb::proto::descriptors::StreamDescriptor& desc) {
-    FieldCollection output;
-    for(const auto& field : desc.fields())
-        output.add_field(type_desc_from_proto(field.type_desc()), field.name());
-
-    return output;
-}
 
 template <typename RangeType>
 FieldCollection fields_from_range(const RangeType& fields) {
@@ -206,13 +200,6 @@ FieldCollection fields_from_range(const RangeType& fields) {
         output.add({field.type(), field.name()});
     }
     return output;
-}
-
-inline void proto_from_fields(const FieldCollection& fields, arcticdb::proto::descriptors::StreamDescriptor& desc) {
-    for(const auto& field : fields) {
-        auto new_field = desc.add_fields();
-        new_field->MergeFrom(field_proto(field.type().data_type(), field.type().dimension(), field.name()));
-    }
 }
 
 

--- a/cpp/arcticdb/entity/field_collection_proto.cpp
+++ b/cpp/arcticdb/entity/field_collection_proto.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/entity/field_collection_proto.hpp>
+
+namespace arcticdb {
+
+
+FieldCollection fields_from_proto(const arcticdb::proto::descriptors::StreamDescriptor& desc) {
+    FieldCollection output;
+    for (const auto& field : desc.fields())
+        output.add_field(type_desc_from_proto(field.type_desc()), field.name());
+
+    return output;
+}
+
+
+void proto_from_fields(const FieldCollection& fields, arcticdb::proto::descriptors::StreamDescriptor& desc) {
+    for (const auto& field : fields) {
+        auto new_field = desc.add_fields();
+        new_field->MergeFrom(field_proto(field.type().data_type(), field.type().dimension(), field.name()));
+    }
+}
+
+
+}

--- a/cpp/arcticdb/entity/field_collection_proto.hpp
+++ b/cpp/arcticdb/entity/field_collection_proto.hpp
@@ -1,0 +1,19 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/entity/field_collection.hpp>
+#include <arcticdb/entity/types_proto.hpp>
+
+namespace arcticdb {
+
+FieldCollection fields_from_proto(const arcticdb::proto::descriptors::StreamDescriptor& desc);
+void proto_from_fields(const FieldCollection& fields, arcticdb::proto::descriptors::StreamDescriptor& desc);
+
+
+} //namespace arcticdb

--- a/cpp/arcticdb/entity/serialized_key.hpp
+++ b/cpp/arcticdb/entity/serialized_key.hpp
@@ -17,6 +17,7 @@
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/util/buffer.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
+#include <arcticdb/util/string_utils.hpp>
 
 namespace arcticdb::entity {
 

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -12,7 +12,7 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <folly/gen/Base.h>
 
-#include <arcticdb/entity/field_collection.hpp>
+#include <arcticdb/entity/field_collection_proto.hpp>
 #include <arcticdb/util/variant.hpp>
 
 namespace arcticdb::entity {

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -7,8 +7,13 @@
 
 #pragma once
 
-#include <arcticdb/entity/field_collection.hpp>
+
+#include <proto/arcticc/pb2/proto/descriptors.pb.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <folly/gen/Base.h>
+
+#include <arcticdb/entity/field_collection.hpp>
+#include <arcticdb/util/variant.hpp>
 
 namespace arcticdb::entity {
 

--- a/cpp/arcticdb/entity/types-inl.hpp
+++ b/cpp/arcticdb/entity/types-inl.hpp
@@ -127,62 +127,17 @@ struct formatter<arcticdb::entity::TypeDescriptor> {
 };
 
 template<>
-struct formatter<arcticdb::entity::Field> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    auto format(const arcticdb::entity::Field &fd, FormatContext &ctx) const {
-        if (!fd.name().empty())
-            return format_to(ctx.out(), "FD<name={}, type={}>", fd.name(), fd.type());
-        else
-            return format_to(ctx.out(), "FD<type={}>", fd.type());
-    }
-};
-
-template<>
-struct formatter<arcticdb::entity::IndexDescriptor> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    auto format(const arcticdb::entity::IndexDescriptor &idx, FormatContext &ctx) const {
-        return format_to(ctx.out(), "IDX<size={}, kind={}>", idx.field_count(), static_cast<char>(idx.type()));
-    }
-};
-template<>
 struct formatter<arcticdb::entity::StreamId> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    auto format(const arcticdb::entity::StreamId &tsid, FormatContext &ctx) const {
-        return std::visit([&ctx](auto &&val) {
+    auto format(const arcticdb::entity::StreamId& tsid, FormatContext& ctx) const {
+        return std::visit([&ctx](auto&& val) {
             return format_to(ctx.out(), "{}", val);
-        }, tsid);
+            }, tsid);
     }
 };
 
-template<>
-struct formatter<arcticdb::proto::descriptors::TypeDescriptor> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
-    template<typename FormatContext>
-    auto format(const arcticdb::proto::descriptors::TypeDescriptor& type_desc, FormatContext &ctx) const {
-        auto td = arcticdb::entity::type_desc_from_proto(type_desc);
-        return format_to(ctx.out(), "{}", td);
-    }
-};
-
-template<>
-struct formatter<arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    auto format(const arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor& field_desc, FormatContext &ctx) const {
-        return format_to(ctx.out(), "{}: {}", field_desc.name(), field_desc.type_desc());
-    }
-};
 }

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -24,13 +24,6 @@
 using ssize_t = SSIZE_T;
 #endif
 
-// TODO: Forward declare further and move the inclusion of `descriptors.pb.h` in `types.cpp`.
-#include <descriptors.pb.h>
-
-namespace arcticdb::proto {
-    namespace descriptors = arcticc::pb2::descriptors_pb2;
-}
-
 namespace arcticdb::entity {
 
 enum class SortedValue : uint8_t {
@@ -39,32 +32,6 @@ enum class SortedValue : uint8_t {
     ASCENDING = 2,
     DESCENDING = 3,
 };
-
-inline arcticdb::proto::descriptors::SortedValue sorted_value_to_proto(SortedValue sorted) {
-    switch (sorted) {
-    case SortedValue::UNSORTED:
-        return arcticdb::proto::descriptors::SortedValue::UNSORTED;
-    case SortedValue::DESCENDING:
-        return arcticdb::proto::descriptors::SortedValue::DESCENDING;
-    case SortedValue::ASCENDING:
-        return arcticdb::proto::descriptors::SortedValue::ASCENDING;
-    default:
-        return arcticdb::proto::descriptors::SortedValue::UNKNOWN;
-    }
-}
-
-inline SortedValue sorted_value_from_proto(arcticdb::proto::descriptors::SortedValue sorted_proto) {
-    switch (sorted_proto) {
-    case arcticdb::proto::descriptors::SortedValue::UNSORTED:
-        return SortedValue::UNSORTED;
-    case arcticdb::proto::descriptors::SortedValue::DESCENDING:
-        return SortedValue::DESCENDING;
-    case arcticdb::proto::descriptors::SortedValue::ASCENDING:
-        return SortedValue::ASCENDING;
-    default:
-        return SortedValue::UNKNOWN;
-    }
-}
 
 using NumericId = int64_t;
 using StringId = std::string;
@@ -436,22 +403,11 @@ Dimension as_dim_checked(uint8_t d);
 
 struct TypeDescriptor;
 
-inline void set_data_type(DataType data_type, arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-    type_desc.set_size_bits(
-        static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
-            static_cast<std::uint8_t>(slice_bit_size(data_type))));
-    type_desc.set_value_type(
-        static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
-            static_cast<std::uint8_t>(slice_value_type(data_type))));
-}
-
 inline void set_data_type(DataType data_type, TypeDescriptor& type_desc);
 
 struct TypeDescriptor {
     DataType data_type_;
     Dimension dimension_;
-
-    using Proto = arcticdb::proto::descriptors::TypeDescriptor;
 
     TypeDescriptor(DataType dt, uint8_t dim) : data_type_(dt), dimension_(as_dim_checked(dim)) {}
     constexpr TypeDescriptor(DataType dt, Dimension dim) : data_type_(dt), dimension_(dim) {}
@@ -481,18 +437,6 @@ struct TypeDescriptor {
         return dimension_;
     }
 
-    explicit operator Proto() const {
-        return proto();
-    }
-
-    [[nodiscard]] Proto proto() const {
-        arcticdb::proto::descriptors::TypeDescriptor output;
-        output.set_dimension(static_cast<std::uint32_t>(dimension_));
-        set_data_type(data_type_, output);
-
-        return output;
-    }
-
     void set_size_bits(SizeBits new_size_bits) {
         data_type_ = combine_data_type(slice_value_type(data_type_), new_size_bits);
     }
@@ -501,6 +445,7 @@ struct TypeDescriptor {
         return get_byte_count(slice_bit_size(data_type_));
     }
 };
+
 
 /// @brief Check if the type must contain data
 /// Some types are allowed not to have any data, e.g. empty arrays or the empty type (which by design denotes the
@@ -551,27 +496,6 @@ struct TypeDescriptorTag {
     }
 };
 
-inline DataType get_data_type(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-    return combine_data_type(
-        static_cast<ValueType>(static_cast<uint8_t >(type_desc.value_type())),
-        static_cast<SizeBits>(static_cast<uint8_t >(type_desc.size_bits()))
-        );
-}
-
-inline TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-    return {
-        combine_data_type(
-            static_cast<ValueType>(static_cast<uint8_t >(type_desc.value_type())),
-            static_cast<SizeBits>(static_cast<uint8_t >(type_desc.size_bits()))
-        ),
-        static_cast<Dimension>(static_cast<uint8_t>(type_desc.dimension()))
-    };
-}
-
-inline DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-    return type_desc_from_proto(type_desc).data_type();
-}
-
 template <typename DTT>
 using ScalarTagType = TypeDescriptorTag<DTT, DimensionTag<Dimension::Dim0>>;
 
@@ -581,93 +505,6 @@ struct ScalarTypeInfo {
     static constexpr auto data_type = TDT::DataTypeTag::data_type;
     using RawType = typename TDT::DataTypeTag::raw_type;
 };
-
-inline arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor field_proto(DataType dt, Dimension dim, std::string_view name) {
-    arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor output;
-    if(!name.empty())
-        output.set_name(name.data(), name.size());
-
-    auto output_desc = output.mutable_type_desc();
-    output_desc->set_dimension(static_cast<uint32_t>(dim));
-    output_desc->set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
-                                                  static_cast<std::uint8_t>(slice_bit_size(dt))));
-
-    output_desc->set_value_type(
-        static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
-            static_cast<std::uint8_t>(slice_value_type(dt))));
-
-    return output;
-}
-
-struct IndexDescriptor {
-        using Proto = arcticdb::proto::descriptors::IndexDescriptor;
-
-    Proto data_;
-    using Type = arcticdb::proto::descriptors::IndexDescriptor::Type;
-
-    static const Type UNKNOWN = arcticdb::proto::descriptors::IndexDescriptor_Type_UNKNOWN;
-    static const Type ROWCOUNT = arcticdb::proto::descriptors::IndexDescriptor_Type_ROWCOUNT;
-    static const Type STRING = arcticdb::proto::descriptors::IndexDescriptor_Type_STRING;
-    static const Type TIMESTAMP = arcticdb::proto::descriptors::IndexDescriptor_Type_TIMESTAMP;
-
-    using TypeChar = char;
-
-    IndexDescriptor() = default;
-    IndexDescriptor(size_t field_count, Type type) {
-        data_.set_kind(type);
-        data_.set_field_count(static_cast<uint32_t>(field_count));
-    }
-
-    explicit IndexDescriptor(arcticdb::proto::descriptors::IndexDescriptor data)
-        : data_(std::move(data)) {
-    }
-
-    bool uninitialized() const {
-        return data_.field_count() == 0 && data_.kind() == Type::IndexDescriptor_Type_UNKNOWN;
-    }
-
-    const Proto& proto() const  {
-        return data_;
-    }
-
-    size_t field_count() const {
-        return static_cast<size_t>(data_.field_count());
-    }
-
-    Type type() const {
-        return data_.kind();
-    }
-
-    void set_type(Type type) {
-        data_.set_kind(type);
-    }
-
-    ARCTICDB_MOVE_COPY_DEFAULT(IndexDescriptor)
-
-    friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right) {
-        return left.type() == right.type();
-    }
-};
-
-constexpr IndexDescriptor::TypeChar to_type_char(IndexDescriptor::Type type) {
-    switch (type) {
-    case IndexDescriptor::TIMESTAMP:return 'T';
-    case IndexDescriptor::ROWCOUNT:return 'R';
-    case IndexDescriptor::STRING:return 'S';
-    case IndexDescriptor::UNKNOWN:return 'U';
-    default:util::raise_rte("Unknown index type: {}", int(type));
-    }
-}
-
-constexpr IndexDescriptor::Type from_type_char(IndexDescriptor::TypeChar type) {
-    switch (type) {
-    case 'T': return IndexDescriptor::TIMESTAMP;
-    case 'R': return IndexDescriptor::ROWCOUNT;
-    case 'S': return IndexDescriptor::STRING;
-    case 'U': return IndexDescriptor::UNKNOWN;
-    default:util::raise_rte("Unknown index type: {}", int(type));
-    }
-}
 
 struct FieldRef {
     TypeDescriptor type_;
@@ -686,17 +523,6 @@ struct FieldRef {
     }
 };
 
-inline void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id) {
-    std::visit([&pb_desc](auto &&arg) {
-        using IdType = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<IdType, NumericId>)
-            pb_desc.set_num_id(arg);
-        else if constexpr (std::is_same_v<IdType, StringId>)
-            pb_desc.set_str_id(arg);
-        else
-            util::raise_rte("Encoding unknown descriptor type");
-    }, id);
-}
 
 struct Field {
     uint32_t size_ = 0;
@@ -706,7 +532,7 @@ struct Field {
 
     ARCTICDB_NO_MOVE_OR_COPY(Field)
 
-    using Proto = arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor;
+
 
 private:
     explicit Field(const FieldRef& ref) {

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -9,20 +9,11 @@
 
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/constructors.hpp>
-#include <arcticdb/util/variant.hpp>
-#include <arcticdb/log/log.hpp>
-#include <google/protobuf/util/message_differencer.h>
 
-#include <fmt/format.h>
-
-#include <algorithm>
 #include <cstdint>
 #include <vector>
 #include <string>
-#include <exception>
 #include <type_traits>
-#include <iostream>
-#include <optional>
 #include <variant>
 
 

--- a/cpp/arcticdb/entity/types_proto.cpp
+++ b/cpp/arcticdb/entity/types_proto.cpp
@@ -21,4 +21,106 @@ namespace arcticdb::entity {
     }
 
 
+
+    arcticdb::proto::descriptors::SortedValue sorted_value_to_proto(SortedValue sorted) {
+        switch (sorted) {
+        case SortedValue::UNSORTED:
+            return arcticdb::proto::descriptors::SortedValue::UNSORTED;
+        case SortedValue::DESCENDING:
+            return arcticdb::proto::descriptors::SortedValue::DESCENDING;
+        case SortedValue::ASCENDING:
+            return arcticdb::proto::descriptors::SortedValue::ASCENDING;
+        default:
+            return arcticdb::proto::descriptors::SortedValue::UNKNOWN;
+        }
+    }
+
+    SortedValue sorted_value_from_proto(arcticdb::proto::descriptors::SortedValue sorted_proto) {
+        switch (sorted_proto) {
+        case arcticdb::proto::descriptors::SortedValue::UNSORTED:
+            return SortedValue::UNSORTED;
+        case arcticdb::proto::descriptors::SortedValue::DESCENDING:
+            return SortedValue::DESCENDING;
+        case arcticdb::proto::descriptors::SortedValue::ASCENDING:
+            return SortedValue::ASCENDING;
+        default:
+            return SortedValue::UNKNOWN;
+        }
+    }
+
+
+    void set_data_type(DataType data_type, arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        type_desc.set_size_bits(
+            static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
+                static_cast<std::uint8_t>(slice_bit_size(data_type))));
+        type_desc.set_value_type(
+            static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
+                static_cast<std::uint8_t>(slice_value_type(data_type))));
+    }
+
+
+    [[nodiscard]]
+    auto to_proto(const TypeDescriptor& desc)
+        -> arcticdb::proto::descriptors::TypeDescriptor
+    {
+        arcticdb::proto::descriptors::TypeDescriptor output;
+        output.set_dimension(static_cast<std::uint32_t>(desc.dimension_));
+        set_data_type(desc.data_type_, output);
+
+        return output;
+    }
+
+
+
+    DataType get_data_type(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        return combine_data_type(
+            static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
+            static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits()))
+        );
+    }
+
+    TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        return {
+            combine_data_type(
+                static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
+                static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits()))
+            ),
+            static_cast<Dimension>(static_cast<uint8_t>(type_desc.dimension()))
+        };
+    }
+
+    DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        return type_desc_from_proto(type_desc).data_type();
+    }
+
+
+    arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor field_proto(DataType dt, Dimension dim, std::string_view name) {
+        arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor output;
+        if (!name.empty())
+            output.set_name(name.data(), name.size());
+
+        auto output_desc = output.mutable_type_desc();
+        output_desc->set_dimension(static_cast<uint32_t>(dim));
+        output_desc->set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
+            static_cast<std::uint8_t>(slice_bit_size(dt))));
+
+        output_desc->set_value_type(
+            static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
+                static_cast<std::uint8_t>(slice_value_type(dt))));
+
+        return output;
+    }
+
+    void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id) {
+        std::visit([&pb_desc](auto&& arg) {
+            using IdType = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<IdType, NumericId>)
+                pb_desc.set_num_id(arg);
+            else if constexpr (std::is_same_v<IdType, StringId>)
+                pb_desc.set_str_id(arg);
+            else
+                util::raise_rte("Encoding unknown descriptor type");
+            }, id);
+    }
+
 } // namespace arcticdb

--- a/cpp/arcticdb/entity/types_proto.cpp
+++ b/cpp/arcticdb/entity/types_proto.cpp
@@ -1,0 +1,24 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/entity/types_proto.hpp>
+#include <google/protobuf/util/message_differencer.h>
+
+namespace arcticdb::entity {
+
+
+    bool operator==(const FieldProto& left, const FieldProto& right) {
+        google::protobuf::util::MessageDifferencer diff;
+        return diff.Compare(left, right);
+    }
+
+    bool operator<(const FieldProto& left, const FieldProto& right) {
+        return left.name() < right.name();
+    }
+
+
+} // namespace arcticdb

--- a/cpp/arcticdb/entity/types_proto.hpp
+++ b/cpp/arcticdb/entity/types_proto.hpp
@@ -24,94 +24,22 @@ namespace arcticdb::entity {
 
 
 
-    inline arcticdb::proto::descriptors::SortedValue sorted_value_to_proto(SortedValue sorted) {
-        switch (sorted) {
-        case SortedValue::UNSORTED:
-            return arcticdb::proto::descriptors::SortedValue::UNSORTED;
-        case SortedValue::DESCENDING:
-            return arcticdb::proto::descriptors::SortedValue::DESCENDING;
-        case SortedValue::ASCENDING:
-            return arcticdb::proto::descriptors::SortedValue::ASCENDING;
-        default:
-            return arcticdb::proto::descriptors::SortedValue::UNKNOWN;
-        }
-    }
+    arcticdb::proto::descriptors::SortedValue sorted_value_to_proto(SortedValue sorted);
 
-    inline SortedValue sorted_value_from_proto(arcticdb::proto::descriptors::SortedValue sorted_proto) {
-        switch (sorted_proto) {
-        case arcticdb::proto::descriptors::SortedValue::UNSORTED:
-            return SortedValue::UNSORTED;
-        case arcticdb::proto::descriptors::SortedValue::DESCENDING:
-            return SortedValue::DESCENDING;
-        case arcticdb::proto::descriptors::SortedValue::ASCENDING:
-            return SortedValue::ASCENDING;
-        default:
-            return SortedValue::UNKNOWN;
-        }
-    }
+    SortedValue sorted_value_from_proto(arcticdb::proto::descriptors::SortedValue sorted_proto);
 
 
-    inline void set_data_type(DataType data_type, arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-        type_desc.set_size_bits(
-            static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
-                static_cast<std::uint8_t>(slice_bit_size(data_type))));
-        type_desc.set_value_type(
-            static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
-                static_cast<std::uint8_t>(slice_value_type(data_type))));
-    }
+    void set_data_type(DataType data_type, arcticdb::proto::descriptors::TypeDescriptor& type_desc);
 
 
-    [[nodiscard]]
-    inline auto to_proto(const TypeDescriptor& desc)
-        -> arcticdb::proto::descriptors::TypeDescriptor
-    {
-        arcticdb::proto::descriptors::TypeDescriptor output;
-        output.set_dimension(static_cast<std::uint32_t>(desc.dimension_));
-        set_data_type(desc.data_type_, output);
+    DataType get_data_type(const arcticdb::proto::descriptors::TypeDescriptor& type_desc);
 
-        return output;
-    }
+    TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc);
+
+    DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc);
 
 
-
-    inline DataType get_data_type(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-        return combine_data_type(
-            static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
-            static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits()))
-        );
-    }
-
-    inline TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-        return {
-            combine_data_type(
-                static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
-                static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits()))
-            ),
-            static_cast<Dimension>(static_cast<uint8_t>(type_desc.dimension()))
-        };
-    }
-
-    inline DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
-        return type_desc_from_proto(type_desc).data_type();
-    }
-
-
-    inline arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor field_proto(DataType dt, Dimension dim, std::string_view name) {
-        arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor output;
-        if (!name.empty())
-            output.set_name(name.data(), name.size());
-
-        auto output_desc = output.mutable_type_desc();
-        output_desc->set_dimension(static_cast<uint32_t>(dim));
-        output_desc->set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
-            static_cast<std::uint8_t>(slice_bit_size(dt))));
-
-        output_desc->set_value_type(
-            static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
-                static_cast<std::uint8_t>(slice_value_type(dt))));
-
-        return output;
-    }
+    arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor field_proto(DataType dt, Dimension dim, std::string_view name);
 
 
 
@@ -160,7 +88,7 @@ namespace arcticdb::entity {
 
         ARCTICDB_MOVE_COPY_DEFAULT(IndexDescriptor)
 
-            friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right) {
+        friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right) {
             return left.type() == right.type();
         }
     };
@@ -185,17 +113,7 @@ namespace arcticdb::entity {
         }
     }
 
-    inline void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id) {
-        std::visit([&pb_desc](auto&& arg) {
-            using IdType = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<IdType, NumericId>)
-                pb_desc.set_num_id(arg);
-            else if constexpr (std::is_same_v<IdType, StringId>)
-                pb_desc.set_str_id(arg);
-            else
-                util::raise_rte("Encoding unknown descriptor type");
-            }, id);
-    }
+    void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id);
 
 } // namespace arcticdb::entity
 

--- a/cpp/arcticdb/entity/types_proto.hpp
+++ b/cpp/arcticdb/entity/types_proto.hpp
@@ -1,0 +1,252 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/entity/types.hpp>
+
+#include <descriptors.pb.h>
+
+namespace arcticdb::proto {
+    namespace descriptors = arcticc::pb2::descriptors_pb2;
+}
+
+namespace arcticdb::entity {
+
+    using FieldProto = arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor;
+
+    bool operator==(const FieldProto& left, const FieldProto& right);
+    bool operator<(const FieldProto& left, const FieldProto& right);
+
+
+
+    inline arcticdb::proto::descriptors::SortedValue sorted_value_to_proto(SortedValue sorted) {
+        switch (sorted) {
+        case SortedValue::UNSORTED:
+            return arcticdb::proto::descriptors::SortedValue::UNSORTED;
+        case SortedValue::DESCENDING:
+            return arcticdb::proto::descriptors::SortedValue::DESCENDING;
+        case SortedValue::ASCENDING:
+            return arcticdb::proto::descriptors::SortedValue::ASCENDING;
+        default:
+            return arcticdb::proto::descriptors::SortedValue::UNKNOWN;
+        }
+    }
+
+    inline SortedValue sorted_value_from_proto(arcticdb::proto::descriptors::SortedValue sorted_proto) {
+        switch (sorted_proto) {
+        case arcticdb::proto::descriptors::SortedValue::UNSORTED:
+            return SortedValue::UNSORTED;
+        case arcticdb::proto::descriptors::SortedValue::DESCENDING:
+            return SortedValue::DESCENDING;
+        case arcticdb::proto::descriptors::SortedValue::ASCENDING:
+            return SortedValue::ASCENDING;
+        default:
+            return SortedValue::UNKNOWN;
+        }
+    }
+
+
+    inline void set_data_type(DataType data_type, arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        type_desc.set_size_bits(
+            static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
+                static_cast<std::uint8_t>(slice_bit_size(data_type))));
+        type_desc.set_value_type(
+            static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
+                static_cast<std::uint8_t>(slice_value_type(data_type))));
+    }
+
+
+    [[nodiscard]]
+    inline auto to_proto(const TypeDescriptor& desc)
+        -> arcticdb::proto::descriptors::TypeDescriptor
+    {
+        arcticdb::proto::descriptors::TypeDescriptor output;
+        output.set_dimension(static_cast<std::uint32_t>(desc.dimension_));
+        set_data_type(desc.data_type_, output);
+
+        return output;
+    }
+
+
+
+    inline DataType get_data_type(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        return combine_data_type(
+            static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
+            static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits()))
+        );
+    }
+
+    inline TypeDescriptor type_desc_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        return {
+            combine_data_type(
+                static_cast<ValueType>(static_cast<uint8_t>(type_desc.value_type())),
+                static_cast<SizeBits>(static_cast<uint8_t>(type_desc.size_bits()))
+            ),
+            static_cast<Dimension>(static_cast<uint8_t>(type_desc.dimension()))
+        };
+    }
+
+    inline DataType data_type_from_proto(const arcticdb::proto::descriptors::TypeDescriptor& type_desc) {
+        return type_desc_from_proto(type_desc).data_type();
+    }
+
+
+    inline arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor field_proto(DataType dt, Dimension dim, std::string_view name) {
+        arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor output;
+        if (!name.empty())
+            output.set_name(name.data(), name.size());
+
+        auto output_desc = output.mutable_type_desc();
+        output_desc->set_dimension(static_cast<uint32_t>(dim));
+        output_desc->set_size_bits(static_cast<arcticdb::proto::descriptors::TypeDescriptor_SizeBits>(
+            static_cast<std::uint8_t>(slice_bit_size(dt))));
+
+        output_desc->set_value_type(
+            static_cast<arcticdb::proto::descriptors::TypeDescriptor_ValueType>(
+                static_cast<std::uint8_t>(slice_value_type(dt))));
+
+        return output;
+    }
+
+
+
+    struct IndexDescriptor {
+        using Proto = arcticdb::proto::descriptors::IndexDescriptor;
+
+        Proto data_;
+        using Type = arcticdb::proto::descriptors::IndexDescriptor::Type;
+
+        static const Type UNKNOWN = arcticdb::proto::descriptors::IndexDescriptor_Type_UNKNOWN;
+        static const Type ROWCOUNT = arcticdb::proto::descriptors::IndexDescriptor_Type_ROWCOUNT;
+        static const Type STRING = arcticdb::proto::descriptors::IndexDescriptor_Type_STRING;
+        static const Type TIMESTAMP = arcticdb::proto::descriptors::IndexDescriptor_Type_TIMESTAMP;
+
+        using TypeChar = char;
+
+        IndexDescriptor() = default;
+        IndexDescriptor(size_t field_count, Type type) {
+            data_.set_kind(type);
+            data_.set_field_count(static_cast<uint32_t>(field_count));
+        }
+
+        explicit IndexDescriptor(arcticdb::proto::descriptors::IndexDescriptor data)
+            : data_(std::move(data)) {
+        }
+
+        bool uninitialized() const {
+            return data_.field_count() == 0 && data_.kind() == Type::IndexDescriptor_Type_UNKNOWN;
+        }
+
+        const Proto& proto() const {
+            return data_;
+        }
+
+        size_t field_count() const {
+            return static_cast<size_t>(data_.field_count());
+        }
+
+        Type type() const {
+            return data_.kind();
+        }
+
+        void set_type(Type type) {
+            data_.set_kind(type);
+        }
+
+        ARCTICDB_MOVE_COPY_DEFAULT(IndexDescriptor)
+
+            friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right) {
+            return left.type() == right.type();
+        }
+    };
+
+    constexpr IndexDescriptor::TypeChar to_type_char(IndexDescriptor::Type type) {
+        switch (type) {
+        case IndexDescriptor::TIMESTAMP:return 'T';
+        case IndexDescriptor::ROWCOUNT:return 'R';
+        case IndexDescriptor::STRING:return 'S';
+        case IndexDescriptor::UNKNOWN:return 'U';
+        default:util::raise_rte("Unknown index type: {}", int(type));
+        }
+    }
+
+    constexpr IndexDescriptor::Type from_type_char(IndexDescriptor::TypeChar type) {
+        switch (type) {
+        case 'T': return IndexDescriptor::TIMESTAMP;
+        case 'R': return IndexDescriptor::ROWCOUNT;
+        case 'S': return IndexDescriptor::STRING;
+        case 'U': return IndexDescriptor::UNKNOWN;
+        default:util::raise_rte("Unknown index type: {}", int(type));
+        }
+    }
+
+    inline void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id) {
+        std::visit([&pb_desc](auto&& arg) {
+            using IdType = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<IdType, NumericId>)
+                pb_desc.set_num_id(arg);
+            else if constexpr (std::is_same_v<IdType, StringId>)
+                pb_desc.set_str_id(arg);
+            else
+                util::raise_rte("Encoding unknown descriptor type");
+            }, id);
+    }
+
+} // namespace arcticdb::entity
+
+
+namespace fmt {
+
+    template<>
+    struct formatter<arcticdb::proto::descriptors::TypeDescriptor> {
+        template<typename ParseContext>
+        constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+
+        template<typename FormatContext>
+        auto format(const arcticdb::proto::descriptors::TypeDescriptor& type_desc, FormatContext& ctx) const {
+            auto td = arcticdb::entity::type_desc_from_proto(type_desc);
+            return format_to(ctx.out(), "{}", td);
+        }
+    };
+
+    template<>
+    struct formatter<arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor> {
+        template<typename ParseContext>
+        constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+
+        template<typename FormatContext>
+        auto format(const arcticdb::proto::descriptors::StreamDescriptor_FieldDescriptor& field_desc, FormatContext& ctx) const {
+            return format_to(ctx.out(), "{}: {}", field_desc.name(), field_desc.type_desc());
+        }
+    };
+
+    template<>
+    struct formatter<arcticdb::entity::IndexDescriptor> {
+        template<typename ParseContext>
+        constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+
+        template<typename FormatContext>
+        auto format(const arcticdb::entity::IndexDescriptor& idx, FormatContext& ctx) const {
+            return format_to(ctx.out(), "IDX<size={}, kind={}>", idx.field_count(), static_cast<char>(idx.type()));
+        }
+    };
+
+    template<>
+    struct formatter<arcticdb::entity::Field> {
+        template<typename ParseContext>
+        constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+
+        template<typename FormatContext>
+        auto format(const arcticdb::entity::Field& fd, FormatContext& ctx) const {
+            if (!fd.name().empty())
+                return format_to(ctx.out(), "FD<name={}, type={}>", fd.name(), fd.type());
+            else
+                return format_to(ctx.out(), "FD<type={}>", fd.type());
+        }
+    };
+}

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -12,6 +12,7 @@
 #include <arcticdb/entity/versioned_item.hpp>
 #include <arcticdb/pipeline/pipeline_common.hpp>
 #include <arcticdb/entity/variant_key.hpp>
+#include <arcticdb/stream/index.hpp>
 
 #include <folly/futures/Future.h>
 

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -27,6 +27,7 @@
 #include <arcticdb/version/version_utils.hpp>
 #include <arcticdb/entity/merge_descriptors.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
+#include <arcticdb/util/format_date.hpp>
 
 #include <pybind11/pybind11.h>
 

--- a/cpp/arcticdb/processing/test/test_has_valid_type_promotion.cpp
+++ b/cpp/arcticdb/processing/test/test_has_valid_type_promotion.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <arcticdb/entity/types.hpp>
+#include <arcticdb/entity/types_proto.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 
 TEST(HasValidTypePromotion, DifferentDimensions) {

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -15,6 +15,7 @@
 #include <arcticdb/storage/storage_exceptions.hpp>
 #include <arcticdb/storage/open_mode.hpp>
 #include <arcticdb/storage/storages.hpp>
+#include <arcticdb/storage/failure_simulation.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/composite.hpp>
 

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -22,6 +22,7 @@
 #include <mongocxx/model/replace_one.hpp>
 #include <mongocxx/config/version.hpp>
 #include <arcticdb/util/composite.hpp>
+#include <arcticdb/storage/failure_simulation.hpp>
 
 namespace arcticdb::storage::mongo {
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -1,24 +1,14 @@
 #pragma once
-#include <arcticdb/codec/codec.hpp>
+
+#include <functional>
+
 #include <arcticdb/entity/key.hpp>
-#include <arcticdb/entity/ref_key.hpp>
-#include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/variant_key.hpp>
-#include <arcticdb/storage/common.hpp>
 #include <arcticdb/storage/library_path.hpp>
 #include <arcticdb/storage/open_mode.hpp>
-#include <arcticdb/storage/failure_simulation.hpp>
-#include <arcticdb/storage/storage_options.hpp>
-#include <arcticdb/util/type_traits.hpp>
 #include <arcticdb/storage/key_segment_pair.hpp>
+#include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/util/composite.hpp>
-#include <arcticdb/entity/protobufs.hpp>
-#include <boost/callable_traits.hpp>
-#include <type_traits>
-#include <iterator>
-#include <array>
-#include <string_view>
-#include <storage/key_segment_pair.hpp>
 #include <util/composite.hpp>
 
 namespace arcticdb::storage {

--- a/cpp/arcticdb/stream/merge_utils.hpp
+++ b/cpp/arcticdb/stream/merge_utils.hpp
@@ -5,6 +5,8 @@
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/util/memory_tracing.hpp>
 
+#include <arcticdb/pipeline/string_pool_utils.hpp>
+
 namespace arcticdb {
 inline void merge_string_column(
     ChunkedBuffer& src_buffer,

--- a/cpp/arcticdb/stream/protobuf_mappings.hpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/entity/types.hpp>
+#include <arcticdb/entity/types_proto.hpp>
 
 #include <google/protobuf/text_format.h>
 

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <memory>
 #include <variant>
+#include <optional>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -375,17 +375,6 @@ inline SortedValue deduce_sorted(SortedValue existing_frame, SortedValue input_f
     return final_state;
 }
 
-inline FrameAndDescriptor frame_and_descriptor_from_segment(SegmentInMemory&& seg) {
-    TimeseriesDescriptor tsd;
-    auto& tsd_proto = tsd.mutable_proto();
-    tsd_proto.set_total_rows(seg.row_count());
-    const auto& seg_descriptor = seg.descriptor();
-    tsd_proto.mutable_stream_descriptor()->CopyFrom(seg_descriptor.proto());
-    if(seg.descriptor().index().type() == IndexDescriptor::ROWCOUNT)
-        ensure_rowcount_norm_meta(*tsd_proto.mutable_normalization(), seg_descriptor.id());
-    else
-        ensure_timeseries_norm_meta(*tsd.mutable_proto().mutable_normalization(), seg_descriptor.id(), false);
-    return {SegmentInMemory(std::move(seg)), tsd, {}, {}};
-}
+FrameAndDescriptor frame_and_descriptor_from_segment(SegmentInMemory&& seg);
 
 } // namespace arcticdb


### PR DESCRIPTION
This set of changes attempts to reduce the total build-time of ArcticDB C++ code.

After many experiments I ended up going with the following strategy:
- reduce the inclusion of protobuf headers in headers which are used everywhere (notably `types.hpp`)
- reduce inclusions in general (still a lot of not-used includes)
- reduce code appearing in headers by moving the implementations in translation units where it seems trivial and harmless