### PR TITLE
Detailed error in case of S3's libcurl network failure

### DIFF
--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -114,7 +114,14 @@ namespace s3 {
             do_write_impl(std::move(kvs), root_folder, bucket_name, s3_client, std::move(bucketizer));
         }
 
-        struct UnexpectedS3ErrorException : public std::exception {
+        class UnexpectedS3ErrorException : public std::exception {
+        public:
+            UnexpectedS3ErrorException(const std::string& message):message(message){}
+            const char* what() const noexcept override {
+                return message.c_str();
+            }
+        private:
+            std::string message;
         };
 
         inline bool is_expected_error_type(Aws::S3::S3Errors err) {
@@ -127,21 +134,24 @@ namespace s3 {
 
         inline void raise_if_unexpected_error(const Aws::S3::S3Error& err){
             if (!is_expected_error_type(err.GetErrorType())) {
-                // We log a more detailed error explanation in case of NETWORK_CONNECTION errors to remedy #880.
+                std::string error_message;
+                // We create a more detailed error explanation in case of NETWORK_CONNECTION errors to remedy #880.
                 if (err.GetErrorType() == Aws::S3::S3Errors::NETWORK_CONNECTION){
-                    log::storage().error("Got an unexpected network error: {}. "
-                                         "This could be due to a connectivity issue or exhausted open sockets. "
-                                         "In case socket file descriptors are exhausted, consider increasing `ulimit -n`.",
-                                         err.GetMessage().c_str());
+                    error_message = fmt::format("Got an unexpected network error: {}. "
+                                                "This could be due to a connectivity issue or too many open Arctic instances. "
+                                                "Having more than one open Arctic instance is not advised, you should reuse them. "
+                                                "If you absolutely need many open Arctic instances, consider increasing `ulimit -n`.",
+                                                err.GetMessage().c_str());
                 }
                 else {
-                    log::storage().error("Got unexpected error: '{}' {}: {}",
-                                         int(err.GetErrorType()),
-                                         err.GetExceptionName().c_str(),
-                                         err.GetMessage().c_str());
+                    error_message = fmt::format("Got unexpected error: '{}' {}: {}",
+                                                int(err.GetErrorType()),
+                                                err.GetExceptionName().c_str(),
+                                                err.GetMessage().c_str());
                 }
 
-                throw UnexpectedS3ErrorException{};
+                log::storage().error(error_message);
+                throw UnexpectedS3ErrorException(error_message);
             }
         }
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #880

#### What does this implement or fix?
Previously on network connection failures we'd get an error message like `Got unexpected error: '99' : curlCode: 6, Couldn't resolve host name`.

Now we explain that this can be either caused by connection issues or by exhausted open sockets and suggests increasing `ulimit -n`.

#### Any other comments?
Didn't add a unit test since it's hard to reproduce in a unit test environment. So I tested locally as follows:
```
$ cat many_arctic.py
from arcticdb import Arctic

aas = []

for i in range(1000):
    print(i)
    arctic = Arctic("s3://172.22.107.88:test?port=9000&access=<ACCESS>&secret=<SECRET>")
    aas.append(arctic)
    arctic.has_library(f"lib_{i}")
$ ulimit -n 50
$ python many_arctic.py
0
1
2
3
4
5
6
7
8
[2024-01-23 16:35:53.717] [arcticdb] [error] Got an unexpected network error: curlCode: 7, Couldn't connect to server.
This could be due to a connectivity issue or exhausted open sockets. In case socket file descriptors are exhausted, consider increasing `ulimit -n`.
Traceback (most recent call last):
  File "/home/ivo/source/ArcticDB/python/many_arctic.py", line 9, in <module>
    arctic.has_library(f"lib_{i}")
  File "/home/ivo/source/ArcticDB/python/arcticdb/arctic.py", line 345, in has_library
    return self._library_manager.has_library(self._library_adapter.get_name_for_library_manager(name))
arcticdb_ext.exceptions.InternalException: arcticdb::storage::s3::detail::UnexpectedS3ErrorException(Got an unexpected network error: curlCode: 7, Couldn't connect to server. This could be due to a connectivity issue or too many open Arctic instances. Having more than one open Arctic instance is not advised, you should reuse them. If you absolutely need many open Arctic instances, consider increasing `ulimit -n`.)
```

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
