### PR TITLE
Skip workflow jobs when only .md docs are updated

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -9,7 +9,8 @@ on:
     - cron: '0 0 * * *'
 
   pull_request:
-
+    paths-ignore:
+      - "**/*.md"
 jobs:
   cibw_docker_image:
     uses: ./.github/workflows/cibw_docker_image.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   cibw_docker_image:
+    if: ${{ needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' }}
+    needs: [docs_only_check]
     uses: ./.github/workflows/cibw_docker_image.yml
     permissions: {packages: write}
     with:
@@ -40,7 +42,8 @@ jobs:
       force_update: false
 
   common_config:
-    needs: [cibw_docker_image]
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check, cibw_docker_image]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -95,7 +98,8 @@ jobs:
       windows_matrix: ${{toJson(matrix.windows_matrix)}}
 
   pre_seed_cleanup:
-    if: inputs.persistent_storage == true
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' && inputs.persistent_storage == true
+    needs: [docs_only_check]
     name: Cleanup persistent storages
     uses: ./.github/workflows/persistent_storage.yml
     secrets: inherit
@@ -103,8 +107,8 @@ jobs:
       job_type: cleanup
 
   persistent_storage_seed_linux:
-    needs: [common_config, pre_seed_cleanup]
-    if: inputs.persistent_storage == true
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' && inputs.persistent_storage == true
+    needs: [docs_only_check, common_config, pre_seed_cleanup]
     strategy:
       fail-fast: false
       matrix:
@@ -125,8 +129,8 @@ jobs:
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
 
   persistent_storage_seed_windows:
-    needs: [common_config, pre_seed_cleanup]
-    if: inputs.persistent_storage == true
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' && inputs.persistent_storage == true
+    needs: [docs_only_check, common_config, pre_seed_cleanup]
     strategy:
       fail-fast: false
       matrix:
@@ -147,7 +151,8 @@ jobs:
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
 
   cpp-test-linux:
-    needs: [cibw_docker_image, common_config]
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check, cibw_docker_image, common_config]
     name: Linux C++ Tests
     uses: ./.github/workflows/build_steps.yml
     secrets: inherit
@@ -160,7 +165,8 @@ jobs:
 
   build-python-wheels-linux:
     # Then use the cached compilation artifacts to build other python versions concurrently in cibuildwheels
-    needs: [cibw_docker_image, common_config]
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check, cibw_docker_image, common_config]
     strategy:
       fail-fast: false
       matrix:
@@ -199,7 +205,8 @@ jobs:
       pytest_xdist_mode: ${{matrix.pytest_xdist_mode}}
 
   cpp-test-windows:
-    needs: [common_config]
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check, common_config]
     name: Windows C++ Tests
     uses: ./.github/workflows/build_steps.yml
     secrets: inherit
@@ -209,7 +216,8 @@ jobs:
       matrix: ${{needs.common_config.outputs.windows_matrix}}
 
   build-python-wheels-windows:
-    needs: [common_config]
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check, common_config]
     strategy:
       fail-fast: false
       matrix:
@@ -227,8 +235,8 @@ jobs:
       persistent_storage: ${{ inputs.persistent_storage }}
 
   persistent_storage_verify_linux:
-    needs: [common_config, build-python-wheels-linux, build-python-wheels-windows]
-    if: inputs.persistent_storage == true
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' && inputs.persistent_storage == true
+    needs: [docs_only_check, common_config, build-python-wheels-linux, build-python-wheels-windows]
     strategy:
       fail-fast: false
       matrix:
@@ -249,8 +257,8 @@ jobs:
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
 
   persistent_storage_verify_windows:
-    needs: [common_config, build-python-wheels-windows, build-python-wheels-linux]
-    if: inputs.persistent_storage == true
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' && inputs.persistent_storage == true
+    needs: [docs_only_check, common_config, build-python-wheels-windows, build-python-wheels-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -271,24 +279,73 @@ jobs:
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
     
   post_verify_cleanup:
-    needs: [persistent_storage_verify_windows, persistent_storage_verify_linux]
-    if: inputs.persistent_storage == true
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' && inputs.persistent_storage == true
+    needs: [ docs_only_check, persistent_storage_verify_windows, persistent_storage_verify_linux]
     name: Cleanup persistent storages
     uses: ./.github/workflows/persistent_storage.yml
     secrets: inherit
     with:
       job_type: cleanup
 
+  docs_only_check:
+    name: Check for docs-only change
+    outputs:
+      docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
+      - id: files
+        name: Get changed files
+        uses: tj-actions/changed-files@v23.1
+        with:
+          files_ignore: /**/*.md|README.md #change this to docs paths
+          files_ignore_separator: '|'
+      - id: docs_only_check
+        if: steps.files.outputs.any_changed != 'true'
+        name: Check for docs-only changes
+        run: echo "docs_only=DOCS_ONLY" >> "$GITHUB_OUTPUT"
+
+  set_can_merge_docs_only:
+    if: needs.docs_only_check.outputs.docs_only == 'DOCS_ONLY'
+    needs: [ docs_only_check ]
+    outputs:
+      merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - id: set_merge_ok
+        run: echo "merge_ok=true" >> "$GITHUB_OUTPUT"
+
+  set_can_merge_not_docs_only:
+    if: |
+      always() &&
+      !failure() &&
+      !cancelled() &&
+      needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check, cpp-test-linux, cpp-test-windows, build-python-wheels-linux, build-python-wheels-windows, persistent_storage_verify_linux, persistent_storage_verify_windows]
+    outputs:
+      merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: set_merge_ok
+        run: echo "merge_ok=true" >> "$GITHUB_OUTPUT"
+
   can_merge:
-    needs: [cpp-test-linux, cpp-test-windows, build-python-wheels-linux, build-python-wheels-windows, persistent_storage_verify_linux, persistent_storage_verify_windows]
+    needs: [set_can_merge_docs_only, set_can_merge_not_docs_only]
     if: |
       always() &&
       !failure() &&
       !cancelled()
     runs-on: ubuntu-latest
     steps:
-      - run: echo Dummy job to simplify PR merge checks configuration
-      # FUTURE: add some test stats/reporting
+      - run: "can_merge_docs_only=\"${{ needs.set_can_merge_docs_only.outputs.merge_ok\
+            \ }}\"\ncan_merge_not_docs_only=\"${{ needs.set_can_merge_not_docs_only.outputs.merge_ok\
+            \ }}\"\nif [[ \"${can_merge_docs_only}\" == \"true\" || \"${can_merge_not_docs_only}\"\
+            \ == \"true\" ]]; then\n    echo \"Merge OK\"\n    exit 0\nelse\n    echo\
+            \ \"Merge NOT OK\"\n    exit 1\nfi\n"
 
   publish:
     needs: [common_config, can_merge]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches: ["**"]
     paths:
       - .github/workflows/*.yml
+      - /**/*.md
       - build_tooling/**
       - cpp/**
       - python/**

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   start_ec2_runner:
+    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check]
     uses: ./.github/workflows/ec2_runner_jobs.yml
     secrets: inherit
     permissions: write-all
@@ -19,10 +21,37 @@ jobs:
       job_type: start
 
   linux:
+    needs: [ set_linux_docs_only, set_linux_not_docs_only ]
     if: |
       always() &&
       !cancelled()
-    needs: [start_ec2_runner]
+    runs-on: ubuntu-latest
+    steps:
+      - run: "linux_docs_only=\"${{ needs.set_linux_docs_only.outputs.linux_ok\
+              \ }}\"\nlinux_not_docs_only=\"${{ needs.set_linux_not_docs_only.outputs.linux_ok\
+              \ }}\"\nif [[ \"${linux_docs_only}\" == \"true\" || \"${linux_not_docs_only}\"\
+              \ == \"true\" ]]; then\n    echo \"LINUX PASS\"\n    exit 0\nelse\n    echo\
+              \ \"LINUX test FAIL\"\n    exit 1\nfi\n"
+
+  set_linux_docs_only:
+    if: needs.docs_only_check.outputs.docs_only == 'DOCS_ONLY'
+    needs: [docs_only_check]
+    outputs:
+      linux_ok: ${{ steps.set_linux_ok.outputs.linux_ok }}
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - id: set_linux_ok
+        run: echo "linux_ok=true" >> $GITHUB_OUTPUT
+
+  set_linux_not_docs_only:
+    if: |
+      always() &&
+      !cancelled() && 
+      needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check, start_ec2_runner]
+    outputs:
+      linux_ok: ${{ steps.set_linux_ok.outputs.linux_ok }}
     runs-on: ${{ needs.start_ec2_runner.result != 'failure' && needs.start_ec2_runner.outputs.label || 'ubuntu-latest'}}
     services:
       mongodb:
@@ -82,10 +111,12 @@ jobs:
           python -m pytest -n ${{ steps.cpu-cores.outputs.count }} tests
         env:
           ARCTICDB_USING_CONDA: 1
+      - id: set_linux_ok
+        run: echo "linux_ok=true" >> $GITHUB_OUTPUT
 
   stop-ec2-runner:
-    needs: [start_ec2_runner, linux]
-    if: ${{ always() }}
+    needs: [ docs_only_check, start_ec2_runner, linux]
+    if: ${{ always() && needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY' }}
     uses: ./.github/workflows/ec2_runner_jobs.yml
     secrets: inherit
     permissions: write-all
@@ -95,6 +126,48 @@ jobs:
       ec2-instance-id: ${{ needs.start_ec2_runner.outputs.ec2-instance-id }}
 
   macos:
+    needs: [ set_macos_docs_only, set_macos_not_docs_only ]
+    if: |
+      always() &&
+      !cancelled()
+    strategy:
+      matrix:
+        include:
+          - os: macos-13
+
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: "macos_docs_only=\"${{ needs.set_macos_docs_only.outputs.macos_ok\
+              \ }}\"\nmacos_not_docs_only=\"${{ needs.set_macos_not_docs_only.outputs.macos_ok\
+              \ }}\"\nif [[ \"${macos_docs_only}\" == \"true\" || \"${macos_not_docs_only}\"\
+              \ == \"true\" ]]; then\n    echo \"MACOS PASS\"\n    exit 0\nelse\n    echo\
+              \ \" MACOS test FAIL\"\n    exit 1\nfi\n"
+
+  set_macos_docs_only:
+    if: needs.docs_only_check.outputs.docs_only == 'DOCS_ONLY'
+    needs: [docs_only_check]
+    outputs:
+      macos_ok: ${{ steps.set_macos_ok.outputs.macos_ok }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-13
+
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - id: set_macos_ok
+        run: echo "macos_ok=true" >> $GITHUB_OUTPUT
+
+  set_macos_not_docs_only:
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    needs: [docs_only_check]
+    outputs:
+      macos_ok: ${{ steps.set_macos_ok.outputs.macos_ok }}
     strategy:
       matrix:
         include:
@@ -159,4 +232,26 @@ jobs:
           python -m pytest -n ${{ steps.cpu-cores.outputs.count }} tests
         env:
           ARCTICDB_USING_CONDA: 1
+      - id: set_macos_ok
+        run: echo "macos_ok=true" >> $GITHUB_OUTPUT
 
+  docs_only_check:
+    name: Check for docs-only change
+    outputs:
+      docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
+      - id: files
+        name: Get changed files
+        uses: tj-actions/changed-files@v23.1
+        with:
+          files_ignore: /**/*.md|README.md #change this to docs paths
+          files_ignore_separator: '|'
+      - id: docs_only_check
+        if: steps.files.outputs.any_changed != 'true'
+        name: Check for docs-only changes
+        run: echo "docs_only=DOCS_ONLY" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Previously GitHub workflows were unnecessarily running even when only docs were changed. This PR is to avoid running slow workflow jobs when only docs are changed.

The solution is implemented according to the guidelines on the following page 

https://blog.pantsbuild.org/skipping-github-actions-jobs-without-breaking-branch-protection/

For testing the changes you can try the following commits

b77f245: this is to test that if you change the files that you want to ignore, GitHub workflows skips all the checks. In this test we ignore all `.yml` files as these are the only files changed in this PR. In fact it skips all the checks

53407d6: this is to test that if you change files to ignore and other files too, then GitHub workflows will run all the required tests. e.g. if you change a `.md` and a `.py` file you would expect all the checks to run. For this test the paths to ignore are set to `*/build.yml`. As this PR changes multiple `.yml` files including `build.yml` we can test the expected behaviour.





