### PR TITLE
Add a way to enable/disable silencing of errors when deleting a library

### DIFF
--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -78,7 +78,7 @@ inline void delete_all_for_stream(const std::shared_ptr<Store>& store, const Str
     foreach_key_type([&store, &stream_id, continue_on_error] (KeyType key_type) { delete_keys_of_type_for_stream(store, stream_id, key_type, continue_on_error); });
 }
 
-inline void delete_all(const std::shared_ptr<Store>& store, bool continue_on_error) {
+inline void delete_all(const std::shared_ptr<Store>& store, bool continue_on_error = true) {
     foreach_key_type([&store, continue_on_error] (KeyType key_type) {
         ARCTICDB_DEBUG(log::version(), "Deleting keys of type {}", key_type);
         delete_all_keys_of_type(key_type, store, continue_on_error);

--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -78,7 +78,7 @@ inline void delete_all_for_stream(const std::shared_ptr<Store>& store, const Str
     foreach_key_type([&store, &stream_id, continue_on_error] (KeyType key_type) { delete_keys_of_type_for_stream(store, stream_id, key_type, continue_on_error); });
 }
 
-inline void delete_all(const std::shared_ptr<Store>& store, bool continue_on_error = true) {
+inline void delete_all(const std::shared_ptr<Store>& store, bool continue_on_error) {
     foreach_key_type([&store, continue_on_error] (KeyType key_type) {
         ARCTICDB_DEBUG(log::version(), "Deleting keys of type {}", key_type);
         delete_all_keys_of_type(key_type, store, continue_on_error);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1729,8 +1729,8 @@ StorageLockWrapper LocalVersionedEngine::get_storage_lock(const StreamId& stream
     return StorageLockWrapper{stream_id, store_};
 }
 
-void LocalVersionedEngine::delete_storage() {
-    delete_all(store_, true);
+void LocalVersionedEngine::delete_storage(const bool continue_on_error) {
+    delete_all(store_, continue_on_error);
 }
 
 void LocalVersionedEngine::configure(const storage::LibraryDescriptor::VariantStoreConfig & cfg){

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -333,7 +333,7 @@ public:
     
     StorageLockWrapper get_storage_lock(const StreamId& stream_id) override;
 
-    void delete_storage() override;
+    void delete_storage(const bool continue_on_error = true) override;
 
     void configure(
         const storage::LibraryDescriptor::VariantStoreConfig & cfg) final;

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -510,6 +510,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::call_guard<SingleThreadMutexHolder>(), "Get a list of all the versions for a symbol which are tombstoned")
         .def("delete_storage",
              &PythonVersionStore::delete_storage,
+             py::arg("continue_on_error") = true,
              py::call_guard<SingleThreadMutexHolder>(), "Delete everything. Don't use this unless you want to delete everything")
         .def("write_versioned_dataframe",
              &PythonVersionStore::write_versioned_dataframe,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -497,6 +497,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             py::call_guard<SingleThreadMutexHolder>(),  "Remove an item from a snapshot")
         .def("clear",
              &PythonVersionStore::clear,
+             py::arg("continue_on_error") = true,
              py::call_guard<SingleThreadMutexHolder>(), "Delete everything. Don't use this unless you want to delete everything")
         .def("empty",
              &PythonVersionStore::empty,

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1126,7 +1126,7 @@ std::vector<SliceAndKey> PythonVersionStore::list_incompletes(const StreamId& st
     return get_incomplete(store(), stream_id, unspecified_range(), 0u, true, false);
 }
 
-void PythonVersionStore::clear() {
+void PythonVersionStore::clear(const bool continue_on_error) {
     if (store()->fast_delete()) {
         // Most storage backends have a fast deletion method for a db/collection equivalent, eg. drop() for mongo and
         // lmdb and iterating each key is always going to be suboptimal.
@@ -1134,7 +1134,7 @@ void PythonVersionStore::clear() {
         return;
     }
 
-    delete_all(store(), true);
+    delete_all(store(), continue_on_error);
 }
 
 bool PythonVersionStore::empty() {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -312,7 +312,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::optional<bool>& use_symbol_list = std::nullopt,
         const std::optional<bool>& all_symbols = std::nullopt);
 
-    void clear();
+    void clear(const bool continue_on_error = true);
     bool empty();
     void force_delete_symbol(const StreamId& stream_id);
 

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -159,7 +159,7 @@ public:
     virtual StorageLockWrapper get_storage_lock(
         const StreamId& stream_id) = 0;
 
-    virtual void delete_storage() = 0;
+    virtual void delete_storage(const bool continue_on_error = true) = 0;
 
     virtual void configure(
         const storage::LibraryDescriptor::VariantStoreConfig & cfg) = 0;


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?
When trying to delete a library using delete_library(), if the user doesn't have write access to the lib, deleting the content fails, but this is not raising an exception.

This PR introduces a way to enable/disable this silencing of errors when deleting a library.