### PR TITLE
Bugfix 902: Cannot filter on nans and nones

### DIFF
--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -397,8 +397,6 @@ struct DataTypeTag<DataType::__DT__> : public DataTypeTagBase { \
 }; \
 using TAG_##__DT__ = DataTypeTag<DataType::__DT__>;
 
-using timestamp = int64_t;
-
 
 DATA_TYPE_TAG(UINT8, std::uint8_t)
 DATA_TYPE_TAG(UINT16, std::uint16_t)

--- a/cpp/arcticdb/processing/operation_dispatch_unary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.cpp
@@ -69,8 +69,8 @@ VariantData dispatch_unary(const VariantData& left, OperationType operation) {
             return visit_unary_operator(left, NegOperator());
         case OperationType::ISNULL:
             return visit_unary_comparator(left, IsNullOperator());
-        case OperationType::ISNOTNULL:
-            return visit_unary_comparator(left, IsNotNullOperator());
+        case OperationType::NOTNULL:
+            return visit_unary_comparator(left, NotNullOperator());
         case OperationType::IDENTITY:
         case OperationType::NOT:
             return visit_unary_boolean(left, operation);

--- a/cpp/arcticdb/processing/operation_dispatch_unary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.cpp
@@ -67,6 +67,10 @@ VariantData dispatch_unary(const VariantData& left, OperationType operation) {
             return visit_unary_operator(left, AbsOperator());
         case OperationType::NEG:
             return visit_unary_operator(left, NegOperator());
+        case OperationType::ISNULL:
+            return visit_unary_comparator(left, IsNullOperator());
+        case OperationType::ISNOTNULL:
+            return visit_unary_comparator(left, IsNotNullOperator());
         case OperationType::IDENTITY:
         case OperationType::NOT:
             return visit_unary_boolean(left, operation);

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -115,30 +115,29 @@ VariantData unary_comparator(const Column& col, Func&& func) {
     auto output = std::make_shared<util::BitSet>(static_cast<util::BitSetSizeType>(col.row_count()));
 
     details::visit_type(col.type().data_type(), [&](auto col_desc_tag) {
-        using ColumnTagType =  decltype(col_desc_tag);
-        using DT = TypeDescriptorTag<decltype(col_desc_tag), DimensionTag<Dimension::Dim0>>;
-        using RawType = typename DT::DataTypeTag::raw_type;
+        using TDT = ScalarTagType<decltype(col_desc_tag)>;
+        using RawType = typename TDT::DataTypeTag::raw_type;
         // Right now this is equivalent to if constexpr (is_integer_type(ColumnTagType::data_type)), but that may change with the addition
         // of new types, so be defensive here
-        if constexpr (!(is_floating_point_type(ColumnTagType::data_type) ||
-                        is_sequence_type(ColumnTagType::data_type) ||
-                        is_time_type(ColumnTagType::data_type))) {
+        if constexpr (!(is_floating_point_type(TDT::DataTypeTag::data_type) ||
+                        is_sequence_type(TDT::DataTypeTag::data_type) ||
+                        is_time_type(TDT::DataTypeTag::data_type))) {
             internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Cannot perform null checks on {}", col.type());
         }
         auto column_data = col.data();
         util::BitSet::bulk_insert_iterator inserter(*output);
         auto pos = 0u;
-        while (auto block = column_data.next<DT>()) {
+        while (auto block = column_data.next<TDT>()) {
             auto ptr = reinterpret_cast<const RawType*>(block->data());
             const auto row_count = block->row_count();
             for (auto i = 0u; i < row_count; ++i, ++pos) {
-                if constexpr(is_floating_point_type(ColumnTagType::data_type)) {
+                if constexpr(is_floating_point_type(TDT::DataTypeTag::data_type)) {
                     if (func.apply(*ptr++))
                         inserter = pos;
-                } else if constexpr(is_sequence_type(ColumnTagType::data_type)) {
+                } else if constexpr(is_sequence_type(TDT::DataTypeTag::data_type)) {
                     if (func.template apply<StringTypeTag>(*ptr++))
                         inserter = pos;
-                } else if constexpr(is_time_type(ColumnTagType::data_type)) {
+                } else if constexpr(is_time_type(TDT::DataTypeTag::data_type)) {
                     if (func.template apply<TimeTypeTag>(*ptr++))
                         inserter = pos;
                 }

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -123,7 +123,7 @@ VariantData unary_comparator(const Column& col, Func&& func) {
         if constexpr (!(is_floating_point_type(ColumnTagType::data_type) ||
                         is_sequence_type(ColumnTagType::data_type) ||
                         is_time_type(ColumnTagType::data_type))) {
-            util::raise_rte("Cannot perform null checks on {}", col.type());
+            internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Cannot perform null checks on {}", col.type());
         }
         auto column_data = col.data();
         util::BitSet::bulk_insert_iterator inserter(*output);

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 
 #include <arcticdb/processing/signed_unsigned_comparison.hpp>
+#include <arcticdb/util/constants.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #ifdef ARCTICDB_USING_CONDA
     #include <robin_hood.h>
@@ -227,9 +228,10 @@ struct IsNullOperator {
 template<typename tag>
 bool apply(int64_t t) {
     if constexpr (std::is_same_v<tag, TimeTypeTag>) {
-        return t == util::NaT;
+        return t == NaT;
     } else if constexpr (std::is_same_v<tag, StringTypeTag>) {
-        return !is_a_string(t);
+        // Relies on string_nan == string_none - 1
+        return t >=  string_nan;
     }
 }
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
@@ -242,9 +244,10 @@ struct IsNotNullOperator {
 template<typename tag>
 bool apply(int64_t t) {
     if constexpr (std::is_same_v<tag, TimeTypeTag>) {
-        return t != util::NaT;
+        return t != NaT;
     } else if constexpr (std::is_same_v<tag, StringTypeTag>) {
-        return is_a_string(t);
+        // Relies on string_nan == string_none - 1
+        return t < string_nan;
     }
 }
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -225,7 +225,7 @@ struct TimeTypeTag{};
 struct StringTypeTag{};
 
 struct IsNullOperator {
-template<typename tag>
+template<typename tag, std::enable_if_t<std::is_same_v<tag, TimeTypeTag> || std::is_same_v<tag, StringTypeTag>, bool> = true>
 bool apply(int64_t t) {
     if constexpr (std::is_same_v<tag, TimeTypeTag>) {
         return t == NaT;
@@ -234,14 +234,14 @@ bool apply(int64_t t) {
         return t >=  string_nan;
     }
 }
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+template<typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 bool apply(T t) {
     return std::isnan(t);
 }
 };
 
 struct NotNullOperator {
-template<typename tag>
+template<typename tag, std::enable_if_t<std::is_same_v<tag, TimeTypeTag> || std::is_same_v<tag, StringTypeTag>, bool> = true>
 bool apply(int64_t t) {
     if constexpr (std::is_same_v<tag, TimeTypeTag>) {
         return t != NaT;
@@ -250,7 +250,7 @@ bool apply(int64_t t) {
         return t < string_nan;
     }
 }
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+template<typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 bool apply(T t) {
     return !std::isnan(t);
 }

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -28,7 +28,7 @@ enum class OperationType : uint8_t {
     NEG,
     // Comparison
     ISNULL,
-    ISNOTNULL,
+    NOTNULL,
     // Boolean
     IDENTITY,
     NOT,
@@ -240,7 +240,7 @@ bool apply(T t) {
 }
 };
 
-struct IsNotNullOperator {
+struct NotNullOperator {
 template<typename tag>
 bool apply(int64_t t) {
     if constexpr (std::is_same_v<tag, TimeTypeTag>) {

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -25,6 +25,9 @@ enum class OperationType : uint8_t {
     // Operator
     ABS,
     NEG,
+    // Comparison
+    ISNULL,
+    ISNOTNULL,
     // Boolean
     IDENTITY,
     NOT,
@@ -213,6 +216,32 @@ struct NegOperator {
 template<typename T, typename V = typename unary_arithmetic_promoted_type<T, NegOperator>::type>
 V apply(T t) {
     return -static_cast<V>(t);
+}
+};
+
+struct IsNullOperator {
+template<typename T>
+// StringPool::offset_t is an alias for int64_t, there needs to be logic in the calling function not to use this
+// operator with integer columns
+bool apply(StringPool::offset_t t) {
+    return !is_a_string(t);
+}
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+bool apply(T t) {
+    return std::isnan(t);
+}
+};
+
+struct IsNotNullOperator {
+template<typename T>
+// StringPool::offset_t is an alias for int64_t, there needs to be logic in the calling function not to use this
+// operator with integer columns
+bool apply(StringPool::offset_t t) {
+    return is_a_string(t);
+}
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+bool apply(T t) {
+    return !std::isnan(t);
 }
 };
 

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -252,7 +252,7 @@ bool apply(int64_t t) {
 }
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
 bool apply(T t) {
-    return std::isnan(t);
+    return !std::isnan(t);
 }
 };
 

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -220,7 +220,7 @@ V apply(T t) {
 }
 };
 
-// Needed for null and not bull operators as INT64, NANOSECONDS_UTC64, and all string columns hold int64_t values
+// Needed for null and not null operators as INT64, NANOSECONDS_UTC64, and all string columns hold int64_t values
 struct TimeTypeTag{};
 struct StringTypeTag{};
 

--- a/cpp/arcticdb/util/constants.hpp
+++ b/cpp/arcticdb/util/constants.hpp
@@ -11,6 +11,14 @@ namespace arcticdb {
 
 using timestamp = int64_t;
 
+using position_t = int64_t;
+
+constexpr auto string_none = std::numeric_limits<position_t>::max();
+
+constexpr auto string_nan = std::numeric_limits<position_t>::max() - 1;
+
+constexpr auto NaT = std::numeric_limits<timestamp>::min();
+
 static constexpr decltype(timestamp(0) - timestamp(0)) ONE_SECOND = 1'000'000'000;
 
 static constexpr decltype(timestamp(0) - timestamp(0)) ONE_MINUTE = 60 * ONE_SECOND;

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -25,6 +25,7 @@
 #endif
 
 #include <arcticdb/entity/types.hpp> // for entity::position_t
+#include <arcticdb/util/constants.hpp>
 
 namespace arcticdb {
 
@@ -45,9 +46,9 @@ public:
     StringPool *pool_;
 };
 
-constexpr OffsetString::offset_t not_a_string(){ return std::numeric_limits<OffsetString::offset_t>::max(); }
+constexpr OffsetString::offset_t not_a_string(){ return string_none; }
 
-constexpr OffsetString::offset_t nan_placeholder() { return not_a_string() - 1; }
+constexpr OffsetString::offset_t nan_placeholder() { return string_nan; }
 
 // Returns true if the provided offset does not represent None or NaN
 constexpr bool is_a_string(OffsetString::offset_t offset) {

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -11,6 +11,7 @@
 #include <arcticdb/util/preprocess.hpp>
 
 #include <arcticdb/util/bitset.hpp>
+#include <arcticdb/util/constants.hpp>
 
 #include <arcticdb/column_store/chunked_buffer.hpp>
 
@@ -20,8 +21,6 @@
 #include <cstdint>
 
 namespace arcticdb::util {
-
-constexpr timestamp NaT = std::numeric_limits<timestamp>::min();
 
 template <typename RawType>
 void densify_buffer_using_bitmap(const util::BitSet &block_bitset, arcticdb::ChunkedBuffer &dense_buffer, const uint8_t* sparse_ptr) {

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -21,7 +21,7 @@
 
 namespace arcticdb::util {
 
-constexpr auto NaT = 0x8000000000000000;
+constexpr timestamp NaT = std::numeric_limits<timestamp>::min();
 
 template <typename RawType>
 void densify_buffer_using_bitmap(const util::BitSet &block_bitset, arcticdb::ChunkedBuffer &dense_buffer, const uint8_t* sparse_ptr) {

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -311,7 +311,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .value("ABS", OperationType::ABS)
             .value("NEG", OperationType::NEG)
             .value("ISNULL", OperationType::ISNULL)
-            .value("ISNOTNULL", OperationType::ISNOTNULL)
+            .value("NOTNULL", OperationType::NOTNULL)
             .value("IDENTITY", OperationType::IDENTITY)
             .value("NOT", OperationType::NOT)
             .value("ADD", OperationType::ADD)

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -310,6 +310,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
     py::enum_<OperationType>(version, "OperationType")
             .value("ABS", OperationType::ABS)
             .value("NEG", OperationType::NEG)
+            .value("ISNULL", OperationType::ISNULL)
+            .value("ISNOTNULL", OperationType::ISNOTNULL)
             .value("IDENTITY", OperationType::IDENTITY)
             .value("NOT", OperationType::NOT)
             .value("ADD", OperationType::ADD)

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -214,7 +214,7 @@ class ExpressionNode:
         return self.notnull()
 
     def notnull(self):
-        return ExpressionNode.compose(self, _OperationType.NOTNULL, None)
+        return ExpressionNode.compose(self, _OperationType.ISNOTNULL, None)
 
     def __str__(self):
         return self.get_name()

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -214,7 +214,7 @@ class ExpressionNode:
         return self.notnull()
 
     def notnull(self):
-        return ExpressionNode.compose(self, _OperationType.ISNOTNULL, None)
+        return ExpressionNode.compose(self, _OperationType.NOTNULL, None)
 
     def __str__(self):
         return self.get_name()

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -306,6 +306,12 @@ class QueryBuilder:
 
     Supported filtering operations:
 
+    # isna, isnull, notna, and notnull - return all rows where a specified column is/is not NaN or None. isna is
+    equivalent to isnull, and notna is equivalent to notnull. I.e. no distinction is made between NaN and None values
+    in column types that support both (e.g. strings).
+
+        >>> q = q[q["col"].isna()]
+
     * Binary comparisons: <, <=, >, >=, ==, !=
 
     * Unary NOT: ~

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -204,6 +204,18 @@ class ExpressionNode:
         value_list = value_list_from_args(*args)
         return self._apply(value_list, _OperationType.ISNOTIN)
 
+    def isna(self):
+        return self.isnull()
+
+    def isnull(self):
+        return ExpressionNode.compose(self, _OperationType.ISNULL, None)
+
+    def notna(self):
+        return self.notnull()
+
+    def notnull(self):
+        return ExpressionNode.compose(self, _OperationType.NOTNULL, None)
+
     def __str__(self):
         return self.get_name()
 

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1975,6 +1975,24 @@ def test_filter_string_nans_col_col(lmdb_version_store):
     generic_filter_test_nans(lmdb_version_store, symbol, df, q, pandas_query)
 
 
+def test_filter_float_null_filtering(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    symbol = "test_filter_float_null_filtering"
+    # Nones are coerced to NaNs
+    df = pd.DataFrame(
+        {
+            "a": [0.0, 1.0, None, None, 4.0, np.nan, np.nan, 7.0, None, np.nan, 10.0]
+        },
+        index=np.arange(11)
+    )
+    lib.write(symbol, df)
+    q = QueryBuilder()
+    q = q[q["a"].isna()]
+    received_isna = lib.read(symbol, query_builder=q).data
+    expected_isna = df[df["a"].isna()]
+    assert_frame_equal(expected_isna, received_isna)
+
+
 def test_filter_batch_one_query(lmdb_version_store):
     sym1 = "sym1"
     sym2 = "sym2"

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1983,19 +1983,19 @@ def test_filter_null_filtering(lmdb_version_store, method, dtype):
     symbol = "test_filter_null_filtering"
     num_rows = 20
     if dtype in (np.float32, np.float64):
-        data = np.arange(20, dtype=dtype)
+        data = np.arange(num_rows, dtype=dtype)
         null_values = cycle([np.nan])
     elif dtype is np.datetime64:
         data = np.arange(np.datetime64("2024-01-01"), np.datetime64(f"2024-01-{num_rows + 1}"), np.timedelta64(1, "D")).astype("datetime64[ns]")
         null_values = cycle([np.datetime64("nat")])
     else: # str
-        data = [str(idx) for idx in range(20)]
+        data = [str(idx) for idx in range(num_rows)]
         null_values = cycle([None, np.nan])
     for idx in range(num_rows):
         if idx % 2 == 0:
             data[idx] = next(null_values)
 
-    df = pd.DataFrame({"a": data}, index=np.arange(20))
+    df = pd.DataFrame({"a": data}, index=np.arange(num_rows))
     lib.write(symbol, df)
 
     q = QueryBuilder()

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1978,8 +1978,8 @@ def test_filter_string_nans_col_col(lmdb_version_store):
 
 @pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
 @pytest.mark.parametrize("type", (np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64))
-def test_filter_int_null_filtering(lmdb_version_store_v1, method, type):
-    lib = lmdb_version_store_v1
+def test_filter_int_null_filtering(lmdb_version_store, method, type):
+    lib = lmdb_version_store
     symbol = "test_filter_int_null_filtering"
     data = np.arange(20, dtype=type)
     df = pd.DataFrame({"a": data}, index=np.arange(20))
@@ -1993,8 +1993,8 @@ def test_filter_int_null_filtering(lmdb_version_store_v1, method, type):
 
 @pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
 @pytest.mark.parametrize("dtype", (np.float32, np.float64, np.datetime64, str))
-def test_filter_null_filtering(lmdb_version_store_v1, method, dtype):
-    lib = lmdb_version_store_v1
+def test_filter_null_filtering(lmdb_version_store, method, dtype):
+    lib = lmdb_version_store
     symbol = "test_filter_null_filtering"
     num_rows = 20
     if dtype in (np.float32, np.float64):

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1977,21 +1977,6 @@ def test_filter_string_nans_col_col(lmdb_version_store):
 
 
 @pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
-@pytest.mark.parametrize("type", (np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64))
-def test_filter_int_null_filtering(lmdb_version_store, method, type):
-    lib = lmdb_version_store
-    symbol = "test_filter_int_null_filtering"
-    data = np.arange(20, dtype=type)
-    df = pd.DataFrame({"a": data}, index=np.arange(20))
-    lib.write(symbol, df)
-
-    q = QueryBuilder()
-    q = q[getattr(q["a"], method)()]
-    with pytest.raises(InternalException):
-        _ = lib.read(symbol, query_builder=q).data
-
-
-@pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
 @pytest.mark.parametrize("dtype", (np.float32, np.float64, np.datetime64, str))
 def test_filter_null_filtering(lmdb_version_store, method, dtype):
     lib = lmdb_version_store
@@ -2017,6 +2002,21 @@ def test_filter_null_filtering(lmdb_version_store, method, dtype):
     q = q[getattr(q["a"], method)()]
     received = lib.read(symbol, query_builder=q).data
     assert_frame_equal(df[getattr(df["a"], method)()], received)
+
+
+@pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
+@pytest.mark.parametrize("type", (np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64))
+def test_filter_null_filtering_int_raises(lmdb_version_store, method, type):
+    lib = lmdb_version_store
+    symbol = "test_filter_null_filtering_int_raises"
+    data = np.arange(20, dtype=type)
+    df = pd.DataFrame({"a": data}, index=np.arange(20))
+    lib.write(symbol, df)
+
+    q = QueryBuilder()
+    q = q[getattr(q["a"], method)()]
+    with pytest.raises(InternalException):
+        _ = lib.read(symbol, query_builder=q).data
 
 
 def test_filter_batch_one_query(lmdb_version_store):

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1981,7 +1981,7 @@ def test_filter_string_nans_col_col(lmdb_version_store):
 def test_filter_null_filtering(lmdb_version_store, method, dtype):
     lib = lmdb_version_store
     symbol = "test_filter_null_filtering"
-    num_rows = 20
+    num_rows = 5
     if dtype is np.int64:
         data = np.arange(num_rows, dtype=dtype)
         # These are the values used to represent:
@@ -1995,7 +1995,7 @@ def test_filter_null_filtering(lmdb_version_store, method, dtype):
         data = np.arange(num_rows, dtype=dtype)
         null_values = cycle([np.nan])
     elif dtype is np.datetime64:
-        data = np.arange(np.datetime64("2024-01-01"), np.datetime64(f"2024-01-{num_rows + 1}"), np.timedelta64(1, "D")).astype("datetime64[ns]")
+        data = np.arange(np.datetime64("2024-01-01"), np.datetime64(f"2024-01-0{num_rows + 1}"), np.timedelta64(1, "D")).astype("datetime64[ns]")
         null_values = cycle([np.datetime64("nat")])
     else: # str
         data = [str(idx) for idx in range(num_rows)]
@@ -2007,10 +2007,12 @@ def test_filter_null_filtering(lmdb_version_store, method, dtype):
     df = pd.DataFrame({"a": data}, index=np.arange(num_rows))
     lib.write(symbol, df)
 
+    expected = df[getattr(df["a"], method)()]
+
     q = QueryBuilder()
     q = q[getattr(q["a"], method)()]
     received = lib.read(symbol, query_builder=q).data
-    assert_frame_equal(df[getattr(df["a"], method)()], received)
+    assert_frame_equal(expected, received)
 
 
 def test_filter_batch_one_query(lmdb_version_store):

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1977,12 +1977,21 @@ def test_filter_string_nans_col_col(lmdb_version_store):
 
 
 @pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
-@pytest.mark.parametrize("dtype", (np.float32, np.float64, np.datetime64, str))
+@pytest.mark.parametrize("dtype", (np.int64, np.float32, np.float64, np.datetime64, str))
 def test_filter_null_filtering(lmdb_version_store, method, dtype):
     lib = lmdb_version_store
     symbol = "test_filter_null_filtering"
     num_rows = 20
-    if dtype in (np.float32, np.float64):
+    if dtype is np.int64:
+        data = np.arange(num_rows, dtype=dtype)
+        # These are the values used to represent:
+        # - NaT in timestamp columns
+        # - None in string columns
+        # - NaN in string columns
+        # respectively, so are most likely to cause issues
+        iinfo = np.iinfo(np.int64)
+        null_values = cycle([iinfo.min, iinfo.max, iinfo.max - 1])
+    elif dtype in (np.float32, np.float64):
         data = np.arange(num_rows, dtype=dtype)
         null_values = cycle([np.nan])
     elif dtype is np.datetime64:
@@ -2002,21 +2011,6 @@ def test_filter_null_filtering(lmdb_version_store, method, dtype):
     q = q[getattr(q["a"], method)()]
     received = lib.read(symbol, query_builder=q).data
     assert_frame_equal(df[getattr(df["a"], method)()], received)
-
-
-@pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
-@pytest.mark.parametrize("type", (np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64))
-def test_filter_null_filtering_int_raises(lmdb_version_store, method, type):
-    lib = lmdb_version_store
-    symbol = "test_filter_null_filtering_int_raises"
-    data = np.arange(20, dtype=type)
-    df = pd.DataFrame({"a": data}, index=np.arange(20))
-    lib.write(symbol, df)
-
-    q = QueryBuilder()
-    q = q[getattr(q["a"], method)()]
-    with pytest.raises(InternalException):
-        _ = lib.read(symbol, query_builder=q).data
 
 
 def test_filter_batch_one_query(lmdb_version_store):

--- a/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
@@ -405,26 +405,3 @@ def test_filter_null_filtering_dynamic(lmdb_version_store_dynamic_schema, method
     q = q[getattr(q["a"], method)()]
     received = lib.read(symbol, query_builder=q).data
     assert_frame_equal(df[getattr(df["a"], method)()], received)
-
-
-@pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
-@pytest.mark.parametrize("type", (np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64))
-def test_filter_null_filtering_int_raises_dynamic(lmdb_version_store_dynamic_schema, method, type):
-    lib = lmdb_version_store_dynamic_schema
-    symbol = "test_filter_null_filtering_int_raises_dynamic"
-    num_rows = 20
-    data = np.arange(num_rows, dtype=type)
-
-    df_0 = pd.DataFrame({"a": data, "b": data}, index=np.arange(num_rows))
-    lib.write(symbol, df_0)
-
-    df_1 = pd.DataFrame({"b": data}, index=np.arange(num_rows, 2 * num_rows))
-    lib.append(symbol, df_1)
-
-    df_2 = pd.DataFrame({"a": data, "b": data}, index=np.arange(2 * num_rows, 3 * num_rows))
-    lib.append(symbol, df_2)
-
-    q = QueryBuilder()
-    q = q[getattr(q["a"], method)()]
-    with pytest.raises(InternalException):
-        _ = lib.read(symbol, query_builder=q).data

--- a/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
@@ -404,7 +404,6 @@ def test_filter_null_filtering_dynamic(lmdb_version_store_dynamic_schema, method
     df_2 = pd.DataFrame({"a": data}, index=np.arange(2 * num_rows, 3 * num_rows))
     lib.append(symbol, df_2)
 
-    # Omit df_1 as we treat missing columns with dynamic schema as not passing any filtering checks
     df = pd.concat([df_0, df_1, df_2])
     expected = df[getattr(df["a"], method)()]
     # We backfill missing int columns with 0s to keep the original dtype, whereas Pandas promotes to float64 in concat

--- a/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
@@ -372,8 +372,8 @@ def test_filter_column_type_change(lmdb_version_store_dynamic_schema):
 
 @pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
 @pytest.mark.parametrize("dtype", (np.int64, np.float32, np.float64, np.datetime64, str))
-def test_filter_null_filtering_dynamic(lmdb_version_store_dynamic_schema_v1, method, dtype):
-    lib = lmdb_version_store_dynamic_schema_v1
+def test_filter_null_filtering_dynamic(lmdb_version_store_dynamic_schema, method, dtype):
+    lib = lmdb_version_store_dynamic_schema
     symbol = "lmdb_version_store_dynamic_schema"
     num_rows = 3
     if dtype is np.int64:

--- a/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
@@ -10,8 +10,10 @@ import sys
 from hypothesis import assume, given, settings
 from hypothesis.extra.pandas import column, data_frames, range_indexes
 import hypothesis.strategies as st
+from itertools import cycle
 import numpy as np
 import pandas as pd
+import pytest
 
 from arcticdb.util._versions import IS_PANDAS_TWO
 
@@ -31,6 +33,7 @@ from arcticdb.util.hypothesis import (
     numeric_type_strategies,
     string_strategy,
 )
+from arcticdb_ext.exceptions import InternalException
 
 
 def generic_dynamic_filter_test(version_store, symbol, df, arctic_query, pandas_query, dynamic_strings=True):
@@ -365,3 +368,63 @@ def test_filter_column_type_change(lmdb_version_store_dynamic_schema):
     received = lib.read(symbol, query_builder=q).data
     expected = pd.concat((df1, df2, df3)).query("col == 'a'")
     assert np.array_equal(expected, received)
+
+
+@pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
+@pytest.mark.parametrize("dtype", (np.float32, np.float64, np.datetime64, str))
+def test_filter_null_filtering_dynamic(lmdb_version_store_dynamic_schema, method, dtype):
+    lib = lmdb_version_store_dynamic_schema
+    symbol = "lmdb_version_store_dynamic_schema"
+    num_rows = 20
+    if dtype in (np.float32, np.float64):
+        data = np.arange(num_rows, dtype=dtype)
+        null_values = cycle([np.nan])
+    elif dtype is np.datetime64:
+        data = np.arange(np.datetime64("2024-01-01"), np.datetime64(f"2024-01-{num_rows + 1}"), np.timedelta64(1, "D")).astype("datetime64[ns]")
+        null_values = cycle([np.datetime64("nat")])
+    else: # str
+        data = [str(idx) for idx in range(num_rows)]
+        null_values = cycle([None, np.nan])
+    for idx in range(num_rows):
+        if idx % 2 == 0:
+            data[idx] = next(null_values)
+
+    df_0 = pd.DataFrame({"a": data, "b": data}, index=np.arange(num_rows))
+    lib.write(symbol, df_0)
+
+    df_1 = pd.DataFrame({"b": data}, index=np.arange(num_rows, 2 * num_rows))
+    lib.append(symbol, df_1)
+
+    df_2 = pd.DataFrame({"a": data, "b": data}, index=np.arange(2 * num_rows, 3 * num_rows))
+    lib.append(symbol, df_2)
+
+    # Omit df_1 as we treat missing columns with dynamic schema as not passing any filtering checks
+    df = pd.concat([df_0, df_2])
+
+    q = QueryBuilder()
+    q = q[getattr(q["a"], method)()]
+    received = lib.read(symbol, query_builder=q).data
+    assert_frame_equal(df[getattr(df["a"], method)()], received)
+
+
+@pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
+@pytest.mark.parametrize("type", (np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64))
+def test_filter_null_filtering_int_raises_dynamic(lmdb_version_store_dynamic_schema, method, type):
+    lib = lmdb_version_store_dynamic_schema
+    symbol = "test_filter_null_filtering_int_raises_dynamic"
+    num_rows = 20
+    data = np.arange(num_rows, dtype=type)
+
+    df_0 = pd.DataFrame({"a": data, "b": data}, index=np.arange(num_rows))
+    lib.write(symbol, df_0)
+
+    df_1 = pd.DataFrame({"b": data}, index=np.arange(num_rows, 2 * num_rows))
+    lib.append(symbol, df_1)
+
+    df_2 = pd.DataFrame({"a": data, "b": data}, index=np.arange(2 * num_rows, 3 * num_rows))
+    lib.append(symbol, df_2)
+
+    q = QueryBuilder()
+    q = q[getattr(q["a"], method)()]
+    with pytest.raises(InternalException):
+        _ = lib.read(symbol, query_builder=q).data

--- a/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
@@ -371,12 +371,18 @@ def test_filter_column_type_change(lmdb_version_store_dynamic_schema):
 
 
 @pytest.mark.parametrize("method", ("isna", "notna", "isnull", "notnull"))
-@pytest.mark.parametrize("dtype", (np.float32, np.float64, np.datetime64, str))
+@pytest.mark.parametrize("dtype", (np.int64, np.float32, np.float64, np.datetime64, str))
 def test_filter_null_filtering_dynamic(lmdb_version_store_dynamic_schema_v1, method, dtype):
     lib = lmdb_version_store_dynamic_schema_v1
     symbol = "lmdb_version_store_dynamic_schema"
     num_rows = 3
-    if dtype in (np.float32, np.float64):
+    if dtype is np.int64:
+        data = np.arange(num_rows, dtype=dtype)
+        # Cannot use int64 min/max here as with the static schema tests, as pd.concat with missing columns promotes the
+        # np.int64 columns to np.float64 columns, and astype(np.int64) on this produces incorrect results (presumably
+        # due to loss of precision)
+        null_values = cycle([100])
+    elif dtype in (np.float32, np.float64):
         data = np.arange(num_rows, dtype=dtype)
         null_values = cycle([np.nan])
     elif dtype is np.datetime64:
@@ -401,6 +407,10 @@ def test_filter_null_filtering_dynamic(lmdb_version_store_dynamic_schema_v1, met
     # Omit df_1 as we treat missing columns with dynamic schema as not passing any filtering checks
     df = pd.concat([df_0, df_1, df_2])
     expected = df[getattr(df["a"], method)()]
+    # We backfill missing int columns with 0s to keep the original dtype, whereas Pandas promotes to float64 in concat
+    # when an int column is missing
+    if dtype is np.int64:
+        expected = expected.fillna(0).astype(np.int64)
 
     q = QueryBuilder()
     q = q[getattr(q["a"], method)()]


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #902 

#### What does this implement or fix?

Implement `isna/isnull/notna/notnull` operators in the `QueryBuilder`. Notable decisions:

- `isna` is equivalent to `isnull` and `notna` is equivalent to `notnull`. In particular, that means that in string columns, which can contain both `NaN` and `None` values, no distinction is made between `NaN` and `None`. This is the same behaviour as Pandas.
- When applied to columns with integer dtypes, `isna/isnull` will always return empty dataframes, and `notna/notnull` will always return the same result as a plain `lib.read` call with no `QueryBuilder` provided.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
