### PR TITLE
Not allowing snapshotting tombstoned versions

### DIFF
--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -31,6 +31,12 @@ struct SymbolStatus {
     }
 };
 
+enum class BatchGetVersionOption {
+    LIVE_AND_TOMBSTONED_VER_REF_IN_OTHER_SNAPSHOT,
+    ALL_VER_FOUND_IN_STORAGE,
+    COUNT
+};
+
 template <typename Inputs, typename TaskSubmitter, typename ResultHandler>
 inline void submit_tasks_for_range(const Inputs& inputs, TaskSubmitter submitter, ResultHandler result_handler) {
     const auto window_size = async::TaskScheduler::instance()->io_thread_count() * 2;
@@ -178,23 +184,47 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_specific
     const std::shared_ptr<Store>& store,
     const std::shared_ptr<VersionMap>& version_map,
     const std::map<StreamId, VersionId>& sym_versions,
-    bool include_deleted = true) {
+    BatchGetVersionOption option = BatchGetVersionOption::ALL_VER_FOUND_IN_STORAGE) {
+    static_assert(static_cast<int>(BatchGetVersionOption::COUNT) == 2, "Update this function if new enum value added in BatchGetVersionOption");
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
     auto output = std::make_shared<std::unordered_map<StreamId, AtomKey>>();
-    auto mutex = std::make_shared<std::mutex>();
+    auto output_mutex = std::make_shared<std::mutex>();
+    auto tombstoned_vers = std::make_shared<std::vector<std::pair<StreamId, AtomKey>>>();
+    auto tombstoned_vers_mutex = std::make_shared<std::mutex>();
 
     MapRandomAccessWrapper wrapper{sym_versions};
     submit_tasks_for_range(wrapper, [store, version_map](auto& sym_version) {
             LoadParameter load_param{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(sym_version.second)};
             return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
         },
-        [output, include_deleted, mutex](auto sym_version, const std::shared_ptr<VersionMapEntry>& entry) {
-        auto index_key = find_index_key_for_version_id(sym_version.second, entry, include_deleted);
-        if (index_key) {
-            std::lock_guard lock{*mutex};
-            (*output)[sym_version.first] = *index_key;
+        [output, option, output_mutex, store, tombstoned_vers, tombstoned_vers_mutex]
+                    (auto sym_version, const std::shared_ptr<VersionMapEntry>& entry) {
+            auto version_details = find_index_key_for_version_id_and_tombstone_status(sym_version.second, entry);
+            if ((option == BatchGetVersionOption::ALL_VER_FOUND_IN_STORAGE && version_details.version_status_ == VersionStatus::TOMBSTONED) ||
+                        version_details.version_status_ == VersionStatus::LIVE) {
+                std::lock_guard lock{*output_mutex};
+                (*output)[sym_version.first] = version_details.key_.value();
+            }
+            else if (option == BatchGetVersionOption::LIVE_AND_TOMBSTONED_VER_REF_IN_OTHER_SNAPSHOT && version_details.version_status_ == VersionStatus::TOMBSTONED) {
+                // Need to allow tombstoned version but referenced in other snapshot(s) can be "re-snapshot"
+                log::version().warn("Version {} for symbol {} is tombstoned, need to check snapshots (this can be slow)", sym_version.second, sym_version.first);
+                std::lock_guard lock{*tombstoned_vers_mutex};
+                tombstoned_vers->emplace_back(sym_version.first, version_details.key_.value());
+            }
         }
-    });
+    );
+
+    if (!tombstoned_vers->empty()) {
+        const auto snap_map = get_master_snapshots_map(store);
+        for (const auto &tombstoned_ver : *tombstoned_vers) {
+            auto cit = snap_map.find(tombstoned_ver.first);
+            if (cit != snap_map.cend() && std::any_of(cit->second.cbegin(), cit->second.cend(), [tombstoned_ver, &sym_versions](const auto &key_and_snapshot_ids) {
+                return key_and_snapshot_ids.first.version_id() == sym_versions.at(tombstoned_ver.first);
+            }))
+                (*output)[tombstoned_ver.first] = tombstoned_ver.second;
+
+        }
+    }
 
     return output;
 }

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -427,7 +427,8 @@ void PythonVersionStore::snapshot(
     const SnapshotId &snap_name,
     const py::object &user_meta,
     const std::vector<StreamId> &skip_symbols,
-    std::map<StreamId, VersionId> &versions
+    std::map<StreamId, VersionId> &versions,
+    bool allow_partial_snapshot
     ) {
     ARCTICDB_SAMPLE(CreateSnapshot, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: snapshot");
@@ -454,15 +455,32 @@ void PythonVersionStore::snapshot(
         std::set_difference(all_symbols.begin(), all_symbols.end(), skip_symbols_set.begin(),
                 skip_symbols_set.end(), std::back_inserter(filtered_symbols));
 
-        if (filtered_symbols.empty()) {
-            log::version().warn("No valid symbols in the library, skipping creation for snapshot: {}", snap_name);
-            return;
-        }
+        missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
+            !filtered_symbols.empty(),
+            "No valid symbols in the library, skipping creation for snapshot: {}", snap_name
+        );
 
         auto sym_index_map = batch_get_latest_version(store(), version_map(), filtered_symbols, false);
         index_keys = utils::values(*sym_index_map);
     } else {
-        auto sym_index_map = batch_get_specific_version(store(), version_map(), versions);
+        auto sym_index_map = batch_get_specific_version(store(), version_map(), versions, BatchGetVersionOption::LIVE_AND_TOMBSTONED_VER_REF_IN_OTHER_SNAPSHOT);
+        if (allow_partial_snapshot) {
+            missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
+                !sym_index_map->empty(),
+                "None of the symbol-version pairs specified in versions exist, skipping creation for snapshot: {}",
+                snap_name
+            );
+        } else {
+            if (sym_index_map->size() != versions.size()) {
+                std::string error_msg = fmt::format("Snapshot {} will not be created. Specified symbol-version pairs do not exist in the library: ", snap_name);
+                for (const auto &kv : versions) {
+                    if (!sym_index_map->count(kv.first)) {
+                        error_msg += fmt::format("{}:{} ", kv.first, kv.second);
+                    }
+                }
+                missing_data::raise<ErrorCode::E_NO_SUCH_VERSION>(error_msg);
+            }
+        }
         index_keys = utils::values(*sym_index_map);
         auto missing = filter_keys_on_existence(
                 utils::copy_of_values_as<VariantKey>(*sym_index_map), store(), false);

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -239,7 +239,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         const SnapshotId &snap_name,
         const py::object &user_meta,
         const std::vector<StreamId> &skip_symbols,
-        std::map<StreamId, VersionId> &versions);
+        std::map<StreamId, VersionId> &versions,
+        bool allow_partial_snapshot);
 
     std::vector<std::pair<SnapshotId, py::object>> list_snapshots(const std::optional<bool> load_metadata);
 

--- a/python/arcticdb/util/tasks.py
+++ b/python/arcticdb/util/tasks.py
@@ -170,7 +170,7 @@ def run_scenario(func, lib, with_snapshots, verbose):
         if verbose:
             print("Running function {} symbol {}".format(func.__name__, symbol))
         func(lib, symbol)
-        if with_snapshots:
+        if with_snapshots and lib.list_symbols():
             lib.snapshot("snapshot" + datetime.utcnow().isoformat())
             # clean up old snapshots - more than 3 hours old
             for s in lib.list_snapshots():

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2069,6 +2069,7 @@ class NativeVersionStore:
         metadata: Optional[Any] = None,
         skip_symbols: Optional[List[str]] = None,
         versions: Optional[Dict[str, int]] = None,
+        allow_partial_snapshot: Optional[bool] = False,
     ):
         """
         Create a named snapshot of the data within a library.
@@ -2077,6 +2078,8 @@ class NativeVersionStore:
         the snapshot. The symbols and versions contained within the snapshot will persist regardless of new symbols
         and versions written to the library post snapshot creation.
 
+        ``NoSuchVersionException`` will be thrown if no symbol exist in the library
+        
         Parameters
         ----------
         snap_name : `str`
@@ -2087,6 +2090,11 @@ class NativeVersionStore:
             Optional list of symbols to be excluded from the snapshot.
         versions: `Optional[Dict[str, int]]`, default=None
             Optional dictionary of versions of the symbols to include in the snapshot.
+        allow_partial_snapshot: Optional[bool], default=False
+            Changes the behaviour if either a symbol or the version of symbol specified in versions does not exist or has been deleted in the library:
+            - True: the snapshot will be created with all of the symbol-version pairs that do exist from the versions dict
+                    If none of the symbol-verison pairs exists, ``NoSuchVersionException`` will be thrown
+            - False: ``NoSuchVersionException`` will be thrown
         """
         if not skip_symbols:
             skip_symbols = []
@@ -2094,7 +2102,7 @@ class NativeVersionStore:
             versions = {}
         metadata = normalize_metadata(metadata) if metadata else None
 
-        self.version_store.snapshot(snap_name, metadata, skip_symbols, versions)
+        self.version_store.snapshot(snap_name, metadata, skip_symbols, versions, allow_partial_snapshot)
 
     def delete_snapshot(self, snap_name: str):
         """

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1285,6 +1285,9 @@ class Library:
         ------
         InternalException
             If a snapshot already exists with ``snapshot_name``. You must explicitly delete the pre-existing snapshot.
+        MissingDataException
+            If a symbol or the version of symbol specified in versions does not exist or has been deleted in the library,
+            or, the library has no symbol.
         """
         self._nvs.snapshot(snap_name=snapshot_name, metadata=metadata, skip_symbols=skip_symbols, versions=versions)
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -425,8 +425,11 @@ def test_negative_cases(basic_store, symbol):
     # To stay consistent with arctic this doesn't throw.
     basic_store.delete("does_not_exist")
 
-    # Creating a snapshot in an empty library should not create it.
-    basic_store.snapshot("empty_snapshot")
+    
+    with pytest.raises(NoSuchVersionException):
+        basic_store.snapshot("empty_snapshot")
+    with pytest.raises(NoSuchVersionException):
+        basic_store.snapshot("empty_snapshot", versions={"non-exist-symbol":0})
     with pytest.raises(NoDataFoundException):
         basic_store.delete_snapshot("empty_snapshot")
 

--- a/python/tests/integration/arcticdb/version_store/test_snapshot.py
+++ b/python/tests/integration/arcticdb/version_store/test_snapshot.py
@@ -7,8 +7,10 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 import pytest
 import numpy as np
+import re
 
 from arcticdb_ext.exceptions import InternalException
+from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb_ext.storage import NoDataFoundException
 from arcticdb.util.test import distinct_timestamps
 
@@ -270,23 +272,6 @@ def test_read_symbol_with_ts_in_snapshot(store, request, sym):
     assert lib.read(sym, as_of=third_write_timestamps.after).version == 2
 
 
-def test_snapshot_random_versions_to_fail(basic_store_tombstone_and_pruning, sym):
-    lib = basic_store_tombstone_and_pruning
-    lib.write(sym, 0)
-    lib.snapshot("snap0")  # v0 of sym will be pruned after the second write
-    lib.write(sym, 1)
-    lib.write("sym2", 1)
-    # try creating a snapshot with a deleted version just in a snapshot
-
-    lib.snapshot("snap1", versions={sym: 0, "sym2": 0})
-    assert len(lib.list_versions(snapshot="snap1")) == len(lib.list_symbols(snapshot="snap1"))
-
-    # try creating a snapshot with a random version that never existed
-    lib.snapshot("snap2", versions={sym: 42, "sym2": 0})
-    assert lib.read("sym2", as_of="snap2").data == 1
-    assert len(lib.list_versions(snapshot="snap2")) == 1
-
-
 def test_add_to_snapshot_simple(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -439,3 +424,46 @@ def test_remove_from_snapshot_multiple(basic_store_tombstone_and_pruning):
     assert len(versions) == 1
     assert lib.read("s3", as_of="saved").data == 3
     assert lib.read("s2", as_of="saved").data == 2
+
+
+def test_snapshot_not_accept_tombstoned_key(basic_store_delayed_deletes_v1, sym):
+    lib = basic_store_delayed_deletes_v1
+    ver = lib.write(sym, 1).version
+    lib.write(sym, 2)
+    with pytest.raises(NoSuchVersionException, match=re.escape(f"{sym}:{ver}")): # sym contains square bracket...
+        lib.snapshot("s", versions={sym:ver})
+
+
+def test_snapshot_partially_valid_version_map(basic_store_delayed_deletes_v1):
+    lib = basic_store_delayed_deletes_v1
+    symA = "A"
+    symB = "B"
+
+    symA_ver1 = lib.write(symA, 1).version
+    lib.delete(symA)
+    symB_ver1 = lib.write(symB, 3).version
+    partial_valid_versions = {symA:symA_ver1, symB:symB_ver1}
+    with pytest.raises(NoSuchVersionException):
+        lib.snapshot("s", versions=partial_valid_versions)
+    assert len(lib.list_snapshots()) == 0
+
+    lib.snapshot("s", versions=partial_valid_versions, allow_partial_snapshot=True)
+    with pytest.raises(NoSuchVersionException):
+        lib.read(symA, as_of="s")
+    assert lib.read(symB, as_of="s").data == 3
+
+
+def test_snapshot_tombstoned_but_referenced_in_other_snapshot_version(basic_store_delayed_deletes_v1):
+    lib = basic_store_delayed_deletes_v1
+    symA = "A"
+    symB = "B"
+
+    symA_ver = lib.write(symA, 1).version
+    symB_ver = lib.write(symB, 1).version
+    lib.snapshot("s")
+    lib.delete(symA)
+    lib.delete(symB)
+    lib.snapshot("s2", versions={symA:symA_ver, symB:symB_ver})
+    assert lib.read(symA, as_of="s2").data == 1
+    assert lib.read(symB, as_of="s2").data == 1
+


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://github.com/man-group/ArcticDB/issues/1294
#### What does this implement or fix?
Not allowing tombstoned and not referenced by existing snapshot version being snapshotted

#### Any other comments?
Maybe a bit over engineered for the master snapshots map looping. Can roll back to commit [fix v2](https://github.com/man-group/ArcticDB/pull/1280/commits/3b3a155bba6be6c7b91ebab18972243dbf1363c6)

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
