### PR TITLE
Adds a MockS3Client which can simulate s3 failures

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -415,6 +415,7 @@ set(arcticdb_srcs
         storage/s3/nfs_backed_storage.cpp
         storage/s3/s3_api.cpp
         storage/s3/real_s3_client.cpp
+        storage/s3/mock_s3_client.cpp
         storage/s3/s3_storage.cpp
         storage/s3/s3_storage_tool.cpp
         storage/storage_factory.cpp

--- a/cpp/arcticdb/storage/s3/mock_s3_client.cpp
+++ b/cpp/arcticdb/storage/s3/mock_s3_client.cpp
@@ -1,0 +1,168 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/storage/s3/mock_s3_client.hpp>
+#include <arcticdb/storage/s3/s3_client_wrapper.hpp>
+
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/util/pb_util.hpp>
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/util/buffer_pool.hpp>
+
+#include <arcticdb/storage/storage_utils.hpp>
+
+#include <aws/s3/S3Errors.h>
+
+namespace arcticdb::storage{
+
+using namespace object_store_utils;
+
+namespace s3 {
+
+std::string operation_to_string(S3Operation operation){
+    switch (operation) {
+        case S3Operation::HEAD: return "Head";
+        case S3Operation::GET: return "Get";
+        case S3Operation::PUT: return "Put";
+        case S3Operation::DELETE: return "Delete";
+        case S3Operation::DELETE_LOCAL: return "Delete_local";
+        case S3Operation::LIST: return "List";
+    }
+    util::raise_rte("Invalid s3 operation");
+}
+
+std::string MockS3Client::get_failure_trigger(
+        const std::string& s3_object_name,
+        S3Operation operation_to_fail,
+        Aws::S3::S3Errors error_to_fail_with) {
+    return fmt::format("{}#Failure_{}_{}", s3_object_name, operation_to_string(operation_to_fail), (int)error_to_fail_with);
+}
+
+std::optional<Aws::S3::S3Error> has_failure_trigger(const std::string& s3_object_name, S3Operation operation){
+    auto failure_string_for_operation = "#Failure_" + operation_to_string(operation) + "_";
+    auto position = s3_object_name.rfind(failure_string_for_operation);
+    if (position == std::string::npos) return std::nullopt;
+    try {
+        auto failure_code_string = s3_object_name.substr(position + failure_string_for_operation.size());
+        auto failure_code = Aws::S3::S3Errors(std::stoi(failure_code_string));
+        return Aws::S3::S3Error(Aws::Client::AWSError<Aws::S3::S3Errors>(failure_code, "Simulated error", "Simulated error message", true));
+    } catch (std::exception& e) {
+        return std::nullopt;
+    }
+}
+
+const auto not_found_error = Aws::S3::S3Error(Aws::Client::AWSError<Aws::S3::S3Errors>(Aws::S3::S3Errors::RESOURCE_NOT_FOUND, false));
+
+S3Result<std::monostate> MockS3Client::head_object(
+        const std::string& s3_object_name,
+        const std::string &bucket_name) const {
+    auto maybe_error = has_failure_trigger(s3_object_name, S3Operation::HEAD);
+    if (maybe_error.has_value()) {
+        return {maybe_error.value()};
+    }
+
+    if (s3_contents.find({bucket_name, s3_object_name}) == s3_contents.end()){
+        return {not_found_error};
+    }
+    return {std::monostate()};
+}
+
+
+S3Result<Segment> MockS3Client::get_object(
+        const std::string &s3_object_name,
+        const std::string &bucket_name) const {
+    auto maybe_error = has_failure_trigger(s3_object_name, S3Operation::GET);
+    if (maybe_error.has_value()) {
+        return {maybe_error.value()};
+    }
+
+    auto pos = s3_contents.find({bucket_name, s3_object_name});
+    if (pos == s3_contents.end()){
+        return {not_found_error};
+    }
+    return {pos->second};
+}
+
+S3Result<std::monostate> MockS3Client::put_object(
+        const std::string &s3_object_name,
+        Segment &&segment,
+        const std::string &bucket_name) {
+    auto maybe_error = has_failure_trigger(s3_object_name, S3Operation::PUT);
+    if (maybe_error.has_value()) {
+        return {maybe_error.value()};
+    }
+
+    s3_contents.insert_or_assign({bucket_name, s3_object_name}, std::move(segment));
+
+    return {std::monostate()};
+}
+
+S3Result<DeleteOutput> MockS3Client::delete_objects(
+        const std::vector<std::string>& s3_object_names,
+        const std::string& bucket_name) {
+    for (auto& s3_object_name : s3_object_names){
+        auto maybe_error = has_failure_trigger(s3_object_name, S3Operation::DELETE);
+        if (maybe_error.has_value()) {
+            return {maybe_error.value()};
+        }
+    }
+
+    DeleteOutput output;
+    for (auto& s3_object_name : s3_object_names){
+        auto maybe_error = has_failure_trigger(s3_object_name, S3Operation::DELETE_LOCAL);
+        if (maybe_error.has_value()) {
+            output.failed_deletes.emplace_back(s3_object_name);
+        }
+        else {
+            s3_contents.erase({bucket_name, s3_object_name});
+        }
+    }
+    return {output};
+}
+
+// Using a fixed page size since it's only being used for simple tests.
+// If we ever need to configure it we should move it to the s3 proto config instead.
+constexpr auto page_size = 10;
+S3Result<ListObjectsOutput> MockS3Client::list_objects(
+        const std::string& name_prefix,
+        const std::string& bucket_name,
+        const std::optional<std::string> continuation_token) const {
+    // Terribly inefficient but fine for tests.
+    auto matching_names = std::vector<std::string>();
+    for (auto& key : s3_contents){
+        if (key.first.first == bucket_name && key.first.second.rfind(name_prefix, 0) == 0){
+            matching_names.emplace_back(key.first.second);
+        }
+    }
+
+    auto start_from = 0u;
+    if (continuation_token.has_value()) {
+        start_from = std::stoi(continuation_token.value());
+    }
+
+    ListObjectsOutput output;
+    auto end_to = matching_names.size();
+    if (start_from + page_size < end_to){
+        end_to = start_from + page_size;
+        output.next_continuation_token = std::to_string(end_to);
+    }
+
+    for (auto i=start_from; i < end_to; ++i){
+        auto& s3_object_name = matching_names[i];
+
+        auto maybe_error = has_failure_trigger(s3_object_name, S3Operation::LIST);
+        if (maybe_error.has_value()) return {maybe_error.value()};
+
+        output.s3_object_names.emplace_back(s3_object_name);
+    }
+
+    return {output};
+}
+
+}
+
+}

--- a/cpp/arcticdb/storage/s3/mock_s3_client.hpp
+++ b/cpp/arcticdb/storage/s3/mock_s3_client.hpp
@@ -1,0 +1,75 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <aws/s3/S3Client.h>
+
+#include <arcticdb/storage/s3/s3_client_wrapper.hpp>
+
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/util/pb_util.hpp>
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/util/buffer_pool.hpp>
+
+#include <arcticdb/storage/object_store_utils.hpp>
+#include <arcticdb/storage/storage_utils.hpp>
+#include <arcticdb/entity/serialized_key.hpp>
+#include <arcticdb/util/exponential_backoff.hpp>
+#include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/composite.hpp>
+
+namespace arcticdb::storage::s3{
+
+enum class S3Operation{
+    HEAD,
+    GET,
+    PUT,
+    DELETE, // Triggers a global failure (i.e. delete_objects will fail for all objects if one of them triggers a delete failure)
+    DELETE_LOCAL, // Triggers a local failure (i.e. delete_objects will fail just for this object and succeed for the rest)
+    LIST
+};
+
+
+// A mock S3ClientWrapper which can simulate failures.
+// The MockS3Client stores the segments in memory to simulate regular S3 behavior for unit tests.
+// The MockS3Client can simulate storage failures by using the get_failure_trigger for s3_object_names.
+class MockS3Client : public S3ClientWrapper {
+public:
+    MockS3Client(){}
+
+    // Can be used to trigger a simulated failure inside MockS3Client. For example:
+    // auto object_to_trigger_put_failure = get_failure_trigger("test", S3Operation::PUT, Aws::S3::S3Errors::NETWORK_FAILURE);
+    // mock_s3_client.put_object(object_to_trigger_put_failure, segment, bucket_name); // This will return a network failure.
+    //
+    // The returned name looks like "{s3_object_name}#Failure_{operation_to_fail}_{error_to_fail_with}".
+    // For example: "symbol_1#Failure_Delete_99" will trigger a delete failure with code 99.
+    static std::string get_failure_trigger(const std::string& s3_object_name, S3Operation operation_to_fail, Aws::S3::S3Errors error_to_fail_with);
+
+    S3Result<std::monostate> head_object(const std::string& s3_object_name, const std::string& bucket_name) const override;
+
+    S3Result<Segment> get_object(const std::string& s3_object_name, const std::string& bucket_name) const override;
+
+    S3Result<std::monostate> put_object(
+            const std::string& s3_object_name,
+            Segment&& segment,
+            const std::string& bucket_name) override;
+
+    S3Result<DeleteOutput> delete_objects(
+            const std::vector<std::string>& s3_object_names,
+            const std::string& bucket_name) override;
+
+    S3Result<ListObjectsOutput> list_objects(
+            const std::string& prefix,
+            const std::string& bucket_name,
+            const std::optional<std::string> continuation_token) const override;
+private:
+    // Stores a mapping from pair<bucket_name, s3_name> to a Segment.
+    std::map<std::pair<std::string, std::string>, Segment> s3_contents;
+};
+
+}

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -7,8 +7,15 @@
 
 #include <gtest/gtest.h>
 #include <arcticdb/util/test/gtest_utils.hpp>
+#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/s3/s3_api.hpp>
 #include <arcticdb/storage/s3/s3_storage.hpp>
+#include <arcticdb/storage/s3/mock_s3_client.hpp>
+#include <arcticdb/storage/s3/detail-inl.hpp>
+#include <arcticdb/entity/protobufs.hpp>
+#include <arcticdb/entity/variant_key.hpp>
+#include <arcticdb/stream/test/stream_test_common.hpp>
+#include <arcticdb/codec/codec.hpp>
 
 #include <aws/core/Aws.h>
 
@@ -198,4 +205,138 @@ TEST_F(NoProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy) {
     expected_non_proxy_hosts[0] = "http://test-1.endpoint.com";
     expected_non_proxy_hosts[1] = "http://test-2.endpoint.com";
     ASSERT_EQ(ret_cfg.nonProxyHosts, expected_non_proxy_hosts);
+}
+
+using namespace arcticdb;
+using namespace storage;
+using namespace s3;
+
+proto::s3_storage::Config get_test_s3_config(){
+    auto config = proto::s3_storage::Config();
+    config.set_use_mock_storage_for_testing(true);
+    return config;
+}
+
+class S3StorageFixture : public testing::Test {
+protected:
+    S3StorageFixture():
+        store(LibraryPath("lib", '.'), OpenMode::DELETE, get_test_s3_config())
+    {}
+
+    S3Storage store;
+};
+
+VariantKey get_test_key(std::string name){
+    auto builder = atom_key_builder();
+    return builder.build<KeyType::TABLE_DATA>(name);
+}
+
+Segment get_test_segment(){
+    auto segment_in_memory = get_test_frame<arcticdb::stream::TimeseriesIndex>("symbol", {}, 10, 0).segment_;
+    auto codec_opts = proto::encoding::VariantCodec();
+    return encode_dispatch(std::move(segment_in_memory), codec_opts, EncodingVersion::V2);
+}
+
+void write_in_store(S3Storage& store, std::string symbol){
+    auto variant_key = get_test_key(symbol);
+    store.write(KeySegmentPair(std::move(variant_key), get_test_segment()));
+}
+
+bool exists_in_store(S3Storage& store, std::string symbol){
+    auto variant_key = get_test_key(symbol);
+    return store.key_exists(variant_key);
+}
+
+std::string read_in_store(S3Storage& store, std::string symbol){
+    auto variant_key = get_test_key(symbol);
+    auto opts = ReadKeyOpts{};
+    auto result = store.read(std::move(variant_key), opts);
+    return std::get<StringId>(result.atom_key().id());
+}
+
+void remove_in_store(S3Storage& store, std::vector<std::string> symbols){
+    auto to_remove = std::vector<VariantKey>();
+    for (auto& symbol : symbols){
+        to_remove.emplace_back(get_test_key(symbol));
+    }
+    auto opts = RemoveOpts();
+    store.remove(Composite(std::move(to_remove)), opts);
+}
+
+std::set<std::string> list_in_store(S3Storage& store){
+    auto keys = std::set<std::string>();
+    store.iterate_type(KeyType::TABLE_DATA, [&keys](VariantKey&& key){
+        auto atom_key = std::get<AtomKey>(key);
+        keys.emplace(std::get<StringId>(atom_key.id()));
+    });
+    return keys;
+}
+
+TEST_F(S3StorageFixture, test_key_exists){
+    write_in_store(store, "symbol");
+
+    ASSERT_TRUE(exists_in_store(store, "symbol"));
+    ASSERT_FALSE(exists_in_store(store, "symbol-not-present"));
+    ASSERT_THROW(
+        exists_in_store(store, MockS3Client::get_failure_trigger("symbol", S3Operation::HEAD, Aws::S3::S3Errors::NETWORK_CONNECTION)),
+        s3::detail::UnexpectedS3ErrorException);
+}
+
+TEST_F(S3StorageFixture, test_read){
+    write_in_store(store, "symbol");
+
+    ASSERT_EQ(read_in_store(store, "symbol"), "symbol");
+    ASSERT_THROW(read_in_store(store, "symbol-not-present"), KeyNotFoundException);
+    ASSERT_THROW(
+        read_in_store(store, MockS3Client::get_failure_trigger("symbol", S3Operation::GET, Aws::S3::S3Errors::THROTTLING)),
+        s3::detail::UnexpectedS3ErrorException);
+}
+
+TEST_F(S3StorageFixture, test_write){
+    write_in_store(store, "symbol");
+    ASSERT_THROW(
+        write_in_store(store, MockS3Client::get_failure_trigger("symbol", S3Operation::PUT, Aws::S3::S3Errors::NETWORK_CONNECTION)),
+        ArcticCategorizedException<ErrorCategory::INTERNAL>);
+}
+
+TEST_F(S3StorageFixture, test_remove) {
+    for (int i = 0; i < 5; ++i) {
+        write_in_store(store, fmt::format("symbol_{}", i));
+    }
+
+    // Remove 0 and 1
+    remove_in_store(store, {"symbol_0", "symbol_1"});
+    auto remaining = std::set<std::string>{"symbol_2", "symbol_3", "symbol_4"};
+    ASSERT_EQ(list_in_store(store), remaining);
+
+    // Remove 2 and local fail on 3
+    // TODO: Should raise an appropriate exception, we currently just silently fail to delete symbol_3.
+    remove_in_store(store, {"symbol_2", MockS3Client::get_failure_trigger("symbol_3", S3Operation::DELETE_LOCAL, Aws::S3::S3Errors::NETWORK_CONNECTION)});
+    remaining = std::set<std::string>{"symbol_3", "symbol_4"};
+    ASSERT_EQ(list_in_store(store), remaining);
+
+    // TODO: Should raise an appropriate exception, we currently raise a std::bad_variant_access
+    ASSERT_THROW(
+        remove_in_store(store, {"symbol_3", MockS3Client::get_failure_trigger("symbol_4", S3Operation::DELETE, Aws::S3::S3Errors::NETWORK_CONNECTION)}),
+        std::bad_variant_access);
+}
+
+TEST_F(S3StorageFixture, test_list) {
+    auto symbols = std::set<std::string>();
+    for (int i = 10; i < 25; ++i) {
+        auto symbol = fmt::format("symbol_{}", i);
+        write_in_store(store, symbol);
+        symbols.emplace(symbol);
+    }
+    ASSERT_EQ(list_in_store(store), symbols);
+
+    write_in_store(store, MockS3Client::get_failure_trigger("symbol_99", S3Operation::LIST, Aws::S3::S3Errors::NETWORK_CONNECTION));
+
+    auto incomplete_symbols = std::set<std::string>();
+    for (int i = 10; i < 20; ++i) {
+        auto symbol = fmt::format("symbol_{}", i);
+        incomplete_symbols.emplace(symbol);
+    }
+    // TODO: Should raise, we currently return an incomplete result which is bad.
+    ASSERT_EQ(list_in_store(store), incomplete_symbols);
 }

--- a/cpp/proto/arcticc/pb2/s3_storage.proto
+++ b/cpp/proto/arcticc/pb2/s3_storage.proto
@@ -22,4 +22,5 @@ message Config {
     bool https = 10;
     string region = 11;
     bool use_virtual_addressing = 12;
+    bool use_mock_storage_for_testing = 13;
 }


### PR DESCRIPTION
- Adds a config option to use the MockS3Client instead of the RealS3Client
- If a MockS3Client is created, one can simulate failures by passing the appropriate symbol name
- Adds tests which run various s3 storage failure scenarios
- The tests expose two issues with s3 which will be fixed in a follow up commit

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
