### PR TITLE
Feature flag to use WinInet client not WinHttp

### DIFF
--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -231,6 +231,12 @@ auto get_s3_config(const ConfigType& conf) {
             conf.max_connections();
     client_configuration.connectTimeoutMs = conf.connect_timeout() == 0 ? 30000 : conf.connect_timeout();
     client_configuration.requestTimeoutMs = conf.request_timeout() == 0 ? 200000 : conf.request_timeout();
+
+#ifdef _WIN32
+    // Use more modern WIN_INET rather than WINHTTP for better error messages
+    client_configuration.httpLibOverride = Aws::Http::TransferLibType::WIN_INET_CLIENT;
+#endif
+
     return client_configuration;
 }
 

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -232,10 +232,10 @@ auto get_s3_config(const ConfigType& conf) {
     client_configuration.connectTimeoutMs = conf.connect_timeout() == 0 ? 30000 : conf.connect_timeout();
     client_configuration.requestTimeoutMs = conf.request_timeout() == 0 ? 200000 : conf.request_timeout();
 
-#ifdef _WIN32
-    // Use more modern WIN_INET rather than WINHTTP for better error messages
-    client_configuration.httpLibOverride = Aws::Http::TransferLibType::WIN_INET_CLIENT;
-#endif
+    const bool use_win_inet = ConfigsMap::instance()->get_int("S3Storage.UseWinINet", 0);
+    if (use_win_inet) {
+        client_configuration.httpLibOverride = Aws::Http::TransferLibType::WIN_INET_CLIENT;
+    }
 
     return client_configuration;
 }

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -67,6 +67,21 @@ Values:
 * 0: Do not perform SSL verification.
 * 1: Perform SSL verification.
 
+### S3Storage.UseWinINet
+
+This setting only has an effect on the Windows operating system.
+
+Control whether the client should use the WinINet HTTP backend rather than the default WinHTTP backend.
+
+WinINet can provide better error messages in AWS SDK debug logs, for example for diagnosing SSL issues. See the logging
+configuration section below for notes on how to set up AWS SDK debug logs.
+
+The INet backend does not allow SSL verification to be disabled with the current AWS SDK.
+
+Values:
+* 0: Use WinHTTP
+* 1: Use WinINet
+
 ### VersionStore.NumCPUThreads and VersionStore.NumIOThreads
 
 ArcticDB uses two threadpools in order to manage computational resources:


### PR DESCRIPTION
This shows how to use WinInet client rather than WinHttp.

This gives better error messages in the AWS SDK logs for cert errors:

```
[DEBUG] 2024-01-31 11:02:44.560 WinInetSyncHttpClient [28240] amz-sdk-invocation-id: 15325992-86D2-49FF-B122-11A6CC210E4F

amz-sdk-request: attempt=1

authorization: AWS4-HMAC-SHA256 Credential=6pWBXggusk9MPFTpvj5G/20240131/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=5873b05fa185391c2d1b65ab337296164b313c979f26c00cde0640381cc46eac

content-type: application/xml

host: localhost:9000

user-agent: aws-sdk-cpp/1.11.201 ua/2.0 md/aws-crt#0.24.7 os/Windows#10.0.22621.2506 md/arch#AMD64 lang/c++#C++199711L md/MSVC#1937 cfg/retry-mode#default api/S3

x-amz-api-version: 2006-03-01

x-amz-content-sha256: UNSIGNED-PAYLOAD

x-amz-date: 20240131T110244Z


[WARN] 2024-01-31 11:02:44.579 WinInetSyncHttpClient [28240] Send request failed: The certificate authority is invalid or incorrect
```

Compared to WinHttp, which just says,

```
A security error occurred.
```

However, we can't merge this without a feature flag because the SSL verification disablement doesn't seem to work with this client, the AWS SDK logs:

```
[WARN] 2024-01-31 11:02:42.684 WinInetSyncHttpClient [28240] Turning ssl unknown ca verification off.
[FATAL] 2024-01-31 11:02:42.684 WinInetSyncHttpClient [28240] Failed to turn ssl cert ca verification off.
```

I've tested that this change does not affect Linux, even when the feature flag is set.