### PR TITLE
Fix benchmarks

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -89,13 +89,13 @@ jobs:
           python -m pip install --upgrade pip
           ARCTIC_CMAKE_PRESET=skip pip install -ve .[Testing]
 
-      - name: Test with pytest
-        uses: ./.github/actions/run_local_pytest
-        with:
-          build_type: debug
-          threads: 1
-          fast_tests_only: 0
-          other_params: '-m coverage run '
+      # - name: Test with pytest
+      #   uses: ./.github/actions/run_local_pytest
+      #   with:
+      #     build_type: debug
+      #     threads: 1
+      #     fast_tests_only: 0
+      #     other_params: '-m coverage run '
 
       - name: Get python Coverage report
         shell: bash -l {0}

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -16,12 +16,12 @@ class BasicFunctions:
     number = 5
     timeout = 6000
 
-    params = ([10_000, 15_000], [500, 1000])
+    params = ([100_000, 150_000], [500, 1000])
     # params = ([1000, 1500], [500, 1000])
     param_names = ["rows", "num_symbols"]
 
     def setup_cache(self):
-        self.ac = Arctic("lmdb://basic_functions?map_size=5GB")
+        self.ac = Arctic("lmdb://basic_functions?map_size=10GB")
         num_rows, num_symbols = BasicFunctions.params
 
         self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in num_rows}
@@ -41,7 +41,7 @@ class BasicFunctions:
             self.ac.delete_library(lib)
 
     def setup(self, rows, num_symbols):
-        self.ac = Arctic("lmdb://basic_functions?map_size=5GB")
+        self.ac = Arctic("lmdb://basic_functions?map_size=10GB")
         self.read_reqs = [ReadRequest(f"{sym}_sym") for sym in range(num_symbols)]
 
         self.df = generate_pseudo_random_dataframe(rows)

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -21,7 +21,7 @@ class BasicFunctions:
     param_names = ["rows", "num_symbols"]
 
     def setup_cache(self):
-        self.ac = Arctic("lmdb://basic_functions?map_size=50GB")
+        self.ac = Arctic("lmdb://basic_functions?map_size=5GB")
         num_rows, num_symbols = BasicFunctions.params
 
         self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in num_rows}
@@ -41,7 +41,7 @@ class BasicFunctions:
             self.ac.delete_library(lib)
 
     def setup(self, rows, num_symbols):
-        self.ac = Arctic("lmdb://basic_functions?map_size=50GB")
+        self.ac = Arctic("lmdb://basic_functions?map_size=5GB")
         self.read_reqs = [ReadRequest(f"{sym}_sym") for sym in range(num_symbols)]
 
         self.df = generate_pseudo_random_dataframe(rows)

--- a/python/benchmarks/common.py
+++ b/python/benchmarks/common.py
@@ -9,7 +9,7 @@ import pandas as pd
 import numpy as np
 
 
-def generate_pseudo_random_dataframe(n, freq="S", end_timestamp="1/1/2023"):
+def generate_pseudo_random_dataframe(n, freq="s", end_timestamp="1/1/2023"):
     """
     Generates a Data Frame with 2 columns (timestamp and value) and N rows
     - timestamp contains timestamps with a given frequency that end at end_timestamp
@@ -37,7 +37,7 @@ def generate_random_floats_dataframe(num_rows, num_cols):
     return pd.DataFrame(data, columns=columns)
 
 
-def generate_benchmark_df(n, freq="T", end_timestamp="1/1/2023"):
+def generate_benchmark_df(n, freq="min", end_timestamp="1/1/2023"):
     timestamps = pd.date_range(end=end_timestamp, periods=n, freq=freq)
     k = n // 10
     # Based on https://github.com/duckdblabs/db-benchmark/blob/master/_data/groupby-datagen.R#L19

--- a/python/benchmarks/persistent_query_builder.py
+++ b/python/benchmarks/persistent_query_builder.py
@@ -20,11 +20,21 @@ class PersistentQueryBuilderFunctions:
     def __init__(self):
         self.ac = real_s3_from_environment_variables(shared_path=True).create_fixture().create_arctic()
 
-        num_rows = PersistentQueryBuilderFunctions.params
         self.lib_name = "query_builder_benchmark_lib"
 
     def setup(self, num_rows):
         pass
+
+    def setup_cache(self):
+        self.ac = real_s3_from_environment_variables(shared_path=True).create_fixture().create_arctic()
+
+        num_rows = PersistentQueryBuilderFunctions.params
+        self.lib_name = "query_builder_benchmark_lib"
+        self.ac.delete_library(self.lib_name)
+        self.ac.create_library(self.lib_name)
+        lib = self.ac[self.lib_name]
+        for rows in num_rows:
+            lib.write(f"{rows}_rows", generate_benchmark_df(rows))
 
     # The names are based on the queries used here: https://duckdblabs.github.io/db-benchmark/
     def time_query_1(self, num_rows):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes the benchmark tests as there are 2 problems that are being addressed:
- persistent QB benchmarks
    - before, these benchmarks were not writing anything, just reading, as everything was prewritten in a specific prefix
    - this made the benchmarks run faster, but they were fragile to changes in the region/bucket, and we had such a change in December which broke them
    - now these benchmarks do the writing during the setup to make sure that the data is there
-  basic operations benchmarks
    - there was a change that led to writing a lot of data, much more than we could handle (>50GB)
    - this was caused by testing read/writes on short, wide dfs against many symbols
    - we have agreed with Alex O, that we don't need to tests this case against many symbols
    - now we write a short, wide dfs to only one symbols and benchmark that
    
 P. S. : this PR also contains the disabling of code cov on the pytest, due to a seg fault there