### PR TITLE
Minor improvement on analysis flow

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -4,6 +4,9 @@ on:
     inputs:
       run_all_benchmarks:
         type: boolean
+      force_publish_result:
+        description: Force publish result (requries admin access)
+        type: boolean
 
   schedule: # Schdeule the job to run at 12 a.m. daily
     - cron: '0 0 * * *'
@@ -262,14 +265,13 @@ jobs:
           python -m asv continuous -v --show-stderr origin/master HEAD -f 1.15
 
       - name: Publish results
-        if: github.event_name != 'pull_request' || github.ref == 'refs/heads/master'
+        if: inputs.force_publish_result == true || github.event_name == 'schedule'
         shell: bash -el {0}
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
 
           git fetch --tags --all
-          git pull
 
           python -m asv publish -v
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://github.com/man-group/ArcticDB/issues/1289

#### What does this implement or fix?
[Existing](https://github.com/man-group/ArcticDB/blob/35013a3ed7f4ea0da5f04b321554935c336d4a8a/.github/workflows/analysis_workflow.yml#L265) triggers for starting the workflow:
1. Schedule - target `master` branch, always publish as `github.ref == 'refs/heads/master'`
2. Manual - target branch depends on selection, always publish as the `github.event_name == 'workflow_dispatch'` (`github.event_name != 'pull_request'`)
3. [Pull request ](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)- target merge branch (`ref/pull...`), always not publish as `github.event_name == 'pull_request'`

Shortfall:
1. Manual run always trigger publish result
2. Manual run on tag will fail to publish, as the flow will try to `git pull`

Goals:
1. Make manual run on tag works again
2. Can control whether publish or not while running the flow manually

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
