### PR TITLE
Utility to analyze the size of various key types in a library

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -42,6 +42,13 @@ struct IndexKeyAndUpdateInfo{
     entity::AtomKey index_key;
     version_store::UpdateInfo update_info;
 };
+
+struct KeySizesInfo {
+    size_t count;
+    size_t compressed_size; // bytes
+    size_t uncompressed_size; // bytes
+};
+
 class LocalVersionedEngine : public VersionedEngine {
 
 public:
@@ -389,9 +396,9 @@ public:
         const StreamId& stream_id, 
         const WriteOptions& write_options);
 
-    std::unordered_map<KeyType, std::pair<size_t, size_t>> scan_object_sizes();
+    std::unordered_map<KeyType, KeySizesInfo> scan_object_sizes();
 
-    std::unordered_map<StreamId, std::unordered_map<KeyType, size_t>> scan_object_sizes_by_stream();
+    std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> scan_object_sizes_by_stream();
 
     std::shared_ptr<Store>& _test_get_store() { return store_; }
     void _test_set_validate_version_map() {

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -390,6 +390,9 @@ public:
         const WriteOptions& write_options);
 
     std::unordered_map<KeyType, std::pair<size_t, size_t>> scan_object_sizes();
+
+    std::unordered_map<StreamId, std::unordered_map<KeyType, size_t>> scan_object_sizes_by_stream();
+
     std::shared_ptr<Store>& _test_get_store() { return store_; }
     void _test_set_validate_version_map() {
         version_map()->set_validate(true);

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -544,6 +544,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
          .def("scan_object_sizes",
               &PythonVersionStore::scan_object_sizes,
             py::call_guard<SingleThreadMutexHolder>(), "Scan the sizes of object")
+        .def("scan_object_sizes_by_stream",
+             &PythonVersionStore::scan_object_sizes_by_stream,
+             py::call_guard<SingleThreadMutexHolder>(), "Scan the sizes of objects, grouped by stream ID.")
         .def("find_version",
              &PythonVersionStore::get_version_to_read,
              py::call_guard<SingleThreadMutexHolder>(), "Check if a specific stream has been written to previously")

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -381,6 +381,13 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def(py::init())
             .def_readwrite("row_filter",&UpdateQuery::row_filter);
 
+    py::class_<KeySizesInfo>(version, "KeySizesInfo")
+            .def(py::init())
+            .def_readonly("count", &KeySizesInfo::count)
+            .def_readonly("compressed_size", &KeySizesInfo::compressed_size)
+            .def_readonly("uncompressed_size", &KeySizesInfo::uncompressed_size)
+            .doc() = "Count of keys and their compressed and uncompressed sizes in bytes.";
+
     py::class_<PythonVersionStore>(version, "PythonVersionStore")
         .def(py::init([](const std::shared_ptr<storage::Library>& library, std::optional<std::string>) {
                 return PythonVersionStore(library);
@@ -545,12 +552,12 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
               &PythonVersionStore::scan_object_sizes,
               py::call_guard<SingleThreadMutexHolder>(),
               "Scan the compressed sizes of all objects in the library. Sizes are in bytes. Returns a dict "
-              "{KeyType: (n_keys_of_type, total_size_of_keys_in_bytes)}")
+              "{KeyType: KeySizesInfo}")
         .def("scan_object_sizes_by_stream",
              &PythonVersionStore::scan_object_sizes_by_stream,
              py::call_guard<SingleThreadMutexHolder>(),
              "Scan the compressed sizes of all objects in the library, grouped by stream ID and KeyType. Sizes are in bytes. "
-             "Returns a dict {symbol_id: {KeyType: size_in_bytes}")
+             "Returns a dict {symbol_id: {KeyType: KeySizesInfo}")
         .def("find_version",
              &PythonVersionStore::get_version_to_read,
              py::call_guard<SingleThreadMutexHolder>(), "Check if a specific stream has been written to previously")

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -543,10 +543,11 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::call_guard<SingleThreadMutexHolder>(), "Get the most recent update time for a list of stream ids")
          .def("scan_object_sizes",
               &PythonVersionStore::scan_object_sizes,
-            py::call_guard<SingleThreadMutexHolder>(), "Scan the sizes of object")
+            py::call_guard<SingleThreadMutexHolder>(), "Scan the sizes of all objects in the library. Sizes are in bytes.")
         .def("scan_object_sizes_by_stream",
              &PythonVersionStore::scan_object_sizes_by_stream,
-             py::call_guard<SingleThreadMutexHolder>(), "Scan the sizes of objects, grouped by stream ID.")
+             py::call_guard<SingleThreadMutexHolder>(),
+             "Scan the sizes of all objects in the library, grouped by stream ID. Sizes are in bytes.")
         .def("find_version",
              &PythonVersionStore::get_version_to_read,
              py::call_guard<SingleThreadMutexHolder>(), "Check if a specific stream has been written to previously")

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -543,11 +543,14 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::call_guard<SingleThreadMutexHolder>(), "Get the most recent update time for a list of stream ids")
          .def("scan_object_sizes",
               &PythonVersionStore::scan_object_sizes,
-            py::call_guard<SingleThreadMutexHolder>(), "Scan the sizes of all objects in the library. Sizes are in bytes.")
+              py::call_guard<SingleThreadMutexHolder>(),
+              "Scan the compressed sizes of all objects in the library. Sizes are in bytes. Returns a dict "
+              "{KeyType: (n_keys_of_type, total_size_of_keys_in_bytes)}")
         .def("scan_object_sizes_by_stream",
              &PythonVersionStore::scan_object_sizes_by_stream,
              py::call_guard<SingleThreadMutexHolder>(),
-             "Scan the sizes of all objects in the library, grouped by stream ID. Sizes are in bytes.")
+             "Scan the compressed sizes of all objects in the library, grouped by stream ID and KeyType. Sizes are in bytes. "
+             "Returns a dict {symbol_id: {KeyType: size_in_bytes}")
         .def("find_version",
              &PythonVersionStore::get_version_to_read,
              py::call_guard<SingleThreadMutexHolder>(), "Check if a specific stream has been written to previously")

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -56,7 +56,7 @@ def test_symbol_sizes_big(basic_store):
     assert sizes["sym"][KeyType.TABLE_INDEX].count == 1
 
     assert 50_000 < sizes["sym"][KeyType.TABLE_DATA].compressed_size < 85_000
-    assert 85_000 < sizes["sym"][KeyType.TABLE_DATA].uncompressed_size < 150_000
+    assert 60_000 < sizes["sym"][KeyType.TABLE_DATA].uncompressed_size < 150_000
     assert sizes["sym"][KeyType.TABLE_DATA].count == 1
 
 
@@ -70,7 +70,7 @@ def test_symbol_sizes_multiple_versions(basic_store):
     assert sizes["sym"][KeyType.VERSION].count == 2
     assert sizes["sym"][KeyType.TABLE_INDEX].count == 2
     assert sizes["sym"][KeyType.TABLE_DATA].count == 2
-    assert 150_000 < sizes["sym"][KeyType.TABLE_DATA].uncompressed_size < 250_000
+    assert 100_000 < sizes["sym"][KeyType.TABLE_DATA].uncompressed_size < 250_000
 
 
 def test_scan_object_sizes(basic_store):

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -1,0 +1,72 @@
+from arcticdb.util.test import sample_dataframe
+from arcticdb_ext.storage import KeyType
+
+
+def test_symbol_sizes(basic_store):
+    sizes = basic_store.version_store.scan_object_sizes_by_stream()
+    assert sizes == dict()
+
+    sym_names = []
+    for i in range(5):
+        df = sample_dataframe(100, i)
+        sym = "sym_{}".format(i)
+        sym_names.append(sym)
+        basic_store.write(sym, df)
+
+    sizes = basic_store.version_store.scan_object_sizes_by_stream()
+
+    assert len(sizes) == 5
+    for s in sym_names:
+        assert s in sizes
+
+    assert len(sizes["sym_0"]) == 3
+    assert sizes["sym_0"][KeyType.VERSION] < 1000
+    assert sizes["sym_0"][KeyType.TABLE_INDEX] < 5000
+    assert sizes["sym_0"][KeyType.TABLE_DATA] < 15000
+
+
+def test_symbol_sizes_big(basic_store):
+    df = sample_dataframe(1000)
+    basic_store.write("sym", df)
+
+    sizes = basic_store.version_store.scan_object_sizes_by_stream()
+
+    assert len(sizes) == 1
+    assert sizes["sym"][KeyType.VERSION] < 1000
+    assert sizes["sym"][KeyType.TABLE_INDEX] < 5000
+    assert 15_000 < sizes["sym"][KeyType.TABLE_DATA] < 100_000
+
+
+"""
+Manual testing lines up well:
+
+In [11]: lib._nvs.version_store.scan_object_sizes_by_stream()
+Out[11]: 
+{'sym': {<KeyType.VERSION: 4>: 1160,
+  <KeyType.TABLE_INDEX: 3>: 2506,
+  <KeyType.TABLE_DATA: 2>: 5553859}}
+
+In [12]: lib
+Out[12]: Library(Arctic(config=LMDB(path=/home/alex/source/ArcticDB/python/blah)), path=tst3, storage=lmdb_storage)
+
+(310) ➜  tst3 git:(size-by-symbol) ✗ du -h .  
+5.5M    .
+(310) ➜  tst3 git:(size-by-symbol) ✗ pwd 
+/home/alex/source/ArcticDB/python/blah/tst3
+"""
+
+
+def test_scan_object_sizes(basic_store):
+    df = sample_dataframe(1000)
+    basic_store.write("sym", df)
+
+    sizes = basic_store.version_store.scan_object_sizes()
+
+    assert len(sizes) == 5
+    assert sizes[KeyType.VERSION][1] < 1000
+    assert sizes[KeyType.TABLE_INDEX][1] < 5000
+    assert 15_000 < sizes[KeyType.TABLE_DATA][1] < 100_000
+
+    assert sizes[KeyType.VERSION][0] == 1
+    assert sizes[KeyType.TABLE_INDEX][0] == 1
+    assert sizes[KeyType.TABLE_DATA][0] == 1

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -4,7 +4,8 @@ from arcticdb_ext.storage import KeyType
 
 def test_symbol_sizes(basic_store):
     sizes = basic_store.version_store.scan_object_sizes_by_stream()
-    assert sizes == dict()
+    assert len(sizes) == 1
+    assert "__symbols__" in sizes
 
     sym_names = []
     for i in range(5):
@@ -15,11 +16,9 @@ def test_symbol_sizes(basic_store):
 
     sizes = basic_store.version_store.scan_object_sizes_by_stream()
 
-    assert len(sizes) == 5
     for s in sym_names:
         assert s in sizes
 
-    assert len(sizes["sym_0"]) == 3
     assert sizes["sym_0"][KeyType.VERSION] < 1000
     assert sizes["sym_0"][KeyType.TABLE_INDEX] < 5000
     assert sizes["sym_0"][KeyType.TABLE_DATA] < 15000
@@ -31,7 +30,6 @@ def test_symbol_sizes_big(basic_store):
 
     sizes = basic_store.version_store.scan_object_sizes_by_stream()
 
-    assert len(sizes) == 1
     assert sizes["sym"][KeyType.VERSION] < 1000
     assert sizes["sym"][KeyType.TABLE_INDEX] < 5000
     assert 15_000 < sizes["sym"][KeyType.TABLE_DATA] < 100_000


### PR DESCRIPTION
The existing `scan_object_sizes` was not working as it was never actually submitting any work. It always gave the result that the library contained zero bytes. I've fixed it up here.

I've also introduced `scan_object_sizes_by_stream` so that users can figure out which symbols are using up space in their library.

I considered a map-reduce style approach in `scan_object_sizes_by_stream` rather than the mutex but decided against it as I was considered about memory use (or the probably needless complexity of batching reduce steps).