### PR TITLE
GitHub Workflows: Make can_merge run for all files to allow any changes to be mergeable.

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -9,6 +9,8 @@ on:
     - cron: '0 0 * * *'
 
   pull_request:
+    paths-ignore:
+    - "**/*.md"
 
 jobs:
   cibw_docker_image:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,6 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["**"]
-    paths:
-      - .github/workflows/*.yml
-      - build_tooling/**
-      - cpp/**
-      - python/**
-      - setup.*
-      - pyproject.toml
   workflow_dispatch:
     inputs:
       persistent_storage:


### PR DESCRIPTION
This is from #1269. Skipping the builds for docs required significant changes. For now it is better to run the builds for all updates to ensure that if docs are updated and approved there is no need for an admin to force merge the branch.