### PR TITLE
Multiple segments within the same block: storage and library refactoring

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -264,6 +264,8 @@ set(arcticdb_srcs
         storage/constants.hpp
         storage/common.hpp
         storage/config_resolvers.hpp
+        storage/coalesced/multi_segment_header.hpp
+        storage/coalesced/multi_segment_utils.hpp
         storage/failure_simulation.hpp
         storage/library.hpp
         storage/library_index.hpp
@@ -276,6 +278,10 @@ set(arcticdb_srcs
         storage/mongo/mongo_instance.hpp
         storage/mongo/mongo_storage.hpp
         storage/object_store_utils.hpp
+        storage/file/file_store.hpp
+        storage/file/mapped_file_storage.hpp
+        storage/file/file_store.hpp
+        storage/single_file_storage.hpp
         storage/s3/nfs_backed_storage.hpp
         storage/s3/s3_client_wrapper.hpp
         storage/s3/s3_storage_tool.hpp
@@ -288,6 +294,7 @@ set(arcticdb_srcs
         stream/aggregator-inl.hpp
         stream/append_map.hpp
         stream/merge_utils.hpp
+        stream/piloted_clock.hpp
         stream/index_aggregator.hpp
         stream/index.hpp
         stream/merge.hpp
@@ -326,6 +333,7 @@ set(arcticdb_srcs
         util/magic_num.hpp
         util/movable_priority_queue.hpp
         util/movable_priority_queue.hpp
+        util/memory_mapped_file.hpp
         util/name_validation.hpp
         util/offset_string.hpp
         util/offset_string.hpp
@@ -424,6 +432,7 @@ set(arcticdb_srcs
         storage/library_manager.cpp
         storage/azure/azure_storage.cpp
         storage/lmdb/lmdb_storage.cpp
+        storage/file/mapped_file_storage.cpp
         storage/mongo/mongo_client.cpp
         storage/mongo/mongo_instance.cpp
         storage/mongo/mongo_storage.cpp
@@ -441,6 +450,7 @@ set(arcticdb_srcs
         storage/azure/azure_mock_client.cpp
         stream/aggregator.cpp
         stream/append_map.cpp
+        stream/piloted_clock.cpp
         toolbox/library_tool.cpp
         util/allocator.cpp
         util/buffer_pool.cpp
@@ -448,6 +458,7 @@ set(arcticdb_srcs
         util/decimal.cpp
         util/error_code.cpp
         util/global_lifetimes.cpp
+        util/memory_mapped_file.hpp
         util/name_validation.cpp
         util/offset_string.cpp
         util/offset_string.cpp

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -321,7 +321,7 @@ std::vector<folly::Future<bool>> batch_key_exists(
             const std::shared_ptr<DeDupMap> &de_dup_map) override {
         using KeyOptSegment = std::pair<VariantKey, std::optional<Segment>>;
         return std::move(input_fut).thenValue([this] (auto&& input) {
-            auto [key, seg, slice] = std::move(input);
+            auto [key, seg, slice] = std::forward<decltype(input)>(input);
             auto key_seg = EncodeAtomTask{
                 std::move(key),
                 ClockType::nanos_since_epoch(),

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -43,7 +43,7 @@ TEST(Async, SinkBasic) {
 
     auto seg = ac::SegmentInMemory();
     aa::EncodeAtomTask enc{
-        ac::entity::KeyType::GENERATION, 6, 123, 456, 457, 999, std::move(seg), codec_opt, ac::EncodingVersion::V2
+        ac::entity::KeyType::GENERATION, ac::entity::VersionId{6}, ac::entity::NumericId{123}, ac::entity::NumericId{456}, ac::timestamp{457}, {ac::entity::NumericIndex{999}}, std::move(seg), codec_opt, ac::EncodingVersion::V2
     };
 
     auto v = sched.submit_cpu_task(std::move(enc)).via(&aa::io_executor()).thenValue(aa::WriteSegmentTask{lib}).get();
@@ -52,7 +52,7 @@ TEST(Async, SinkBasic) {
     auto default_content_hash = h.digest();
 
     ASSERT_EQ(ac::entity::atom_key_builder().gen_id(6).start_index(456).end_index(457).creation_ts(999)
-                  .content_hash(default_content_hash).build(123, ac::entity::KeyType::GENERATION),
+        .content_hash(default_content_hash).build(ac::entity::NumericId{123}, ac::entity::KeyType::GENERATION),
               to_atom(v)
     );
 }
@@ -75,8 +75,8 @@ TEST(Async, DeDupTest) {
 
     std::vector<std::pair<ast::StreamSink::PartialKey, ac::SegmentInMemory>> key_segments;
 
-    key_segments.emplace_back(ast::StreamSink::PartialKey{ac::entity::KeyType::TABLE_DATA, 1, "", 0, 1}, seg);
-    key_segments.emplace_back(ast::StreamSink::PartialKey{ac::entity::KeyType::TABLE_DATA, 2, "", 1, 2}, seg);
+    key_segments.emplace_back(ast::StreamSink::PartialKey{ ac::entity::KeyType::TABLE_DATA, 1, "", ac::entity::NumericIndex{0}, ac::entity::NumericIndex{1} }, seg);
+    key_segments.emplace_back(ast::StreamSink::PartialKey{ ac::entity::KeyType::TABLE_DATA, 2, "", ac::entity::NumericIndex{1}, ac::entity::NumericIndex{2} }, seg);
 
     ac::HashAccum h;
     auto default_content_hash = h.digest();

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -44,6 +44,17 @@ constexpr TypeDescriptor encoded_blocks_type_desc() {
     };
 }
 
+SizeResult max_compressed_size_dispatch(
+    const SegmentInMemory& in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    EncodingVersion encoding_version) {
+    if(encoding_version == EncodingVersion::V2) {
+        return max_compressed_size_v2(in_mem_seg, codec_opts);
+    } else {
+        return max_compressed_size_v1(in_mem_seg, codec_opts);
+    }
+}
+
 Segment encode_dispatch(
     SegmentInMemory&& in_mem_seg,
     const arcticdb::proto::encoding::VariantCodec &codec_opts,
@@ -131,8 +142,7 @@ std::optional<google::protobuf::Any> decode_metadata_from_segment(const Segment 
     const uint8_t* data = segment.buffer().data();
 
     const auto begin = data;
-    const auto has_magic_numbers = EncodingVersion(hdr.encoding_version()) == EncodingVersion::V2;
-    if(has_magic_numbers)
+    if(const auto has_magic_numbers = EncodingVersion(hdr.encoding_version()) == EncodingVersion::V2; has_magic_numbers)
         util::check_magic<MetadataMagic>(data);
 
     return decode_metadata(hdr, data, begin);
@@ -211,7 +221,7 @@ std::optional<FieldCollection> decode_descriptor_fields(
 }
 
 std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>> decode_timeseries_descriptor(
-    arcticdb::proto::encoding::SegmentHeader& hdr,
+    const arcticdb::proto::encoding::SegmentHeader& hdr,
     const uint8_t* data,
     const uint8_t* begin,
     const uint8_t* end) {
@@ -328,8 +338,7 @@ void decode_v2(
         data += encoding_sizes::field_compressed_size(hdr.descriptor_field());
 
     util::check_magic<IndexMagic>(data);
-    auto index_fields = decode_index_fields(hdr, data, begin, end);
-    if(index_fields)
+    if(auto index_fields = decode_index_fields(hdr, data, begin, end); index_fields)
         res.set_index_fields(std::make_shared<FieldCollection>(std::move(*index_fields)));
 
     util::check(hdr.has_column_fields(), "Expected column fields in v2 encoding");
@@ -337,15 +346,14 @@ void decode_v2(
     if (data!=end) {
         auto encoded_fields_buffer = decode_encoded_fields(hdr, encoded_fields_ptr, begin);
         const auto fields_size = desc.fields().size();
-        //util::check(fields_size == static_cast<size_t>(hdr.fields_size()), "Mismatch between descriptor and header field size: {} != {}", fields_size, hdr.fields_size());
         const auto start_row = res.row_count();
         EncodedFieldCollection encoded_fields(std::move(encoded_fields_buffer));
         const auto seg_row_count = fields_size ? ssize_t(encoded_fields.at(0).ndarray().items_count()) : 0L;
         res.init_column_map();
 
-        for (std::size_t i = 0; i < static_cast<size_t>(fields_size); ++i) {
+        for (std::size_t i = 0; i < fields_size; ++i) {
             const auto& encoded_field = encoded_fields.at(i);
-            //log::version().debug("{}", dump_bytes(begin, (data - begin) + encoding_sizes::field_compressed_size(*encoded_field), 100u));
+            log::version().debug("{}", dump_bytes(begin, (data - begin) + encoding_sizes::field_compressed_size(encoded_field), 100u));
             const auto& field_name = desc.fields(i).name();
             util::check(data!=end, "Reached end of input block with {} fields to decode", fields_size-i);
             if(auto col_index = res.column_index(field_name)) {
@@ -363,7 +371,8 @@ void decode_v2(
 
         res.set_row_data(static_cast<ssize_t>(start_row + seg_row_count-1));
         res.set_compacted(segment.header().compacted());
-    }}
+    }
+}
 
 void decode_v1(
     const Segment& segment,
@@ -518,7 +527,7 @@ void encode_sparse_map(
         util::check(!is_empty_type(column_data.type().data_type()), "Empty typed columns should not have sparse maps");
         ARCTICDB_DEBUG(log::codec(), "Sparse map count = {} pos = {}", column_data.bit_vector()->count(), pos);
         const size_t sparse_bm_bytes = encode_bitmap(*column_data.bit_vector(), out, pos);
-        util::variant_match(variant_field, [&](auto field) {
+        util::variant_match(variant_field, [sparse_bm_bytes](auto field) {
             field->mutable_ndarray()->set_sparse_map_bytes(static_cast<int>(sparse_bm_bytes));
         });
     }

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -353,7 +353,6 @@ void decode_v2(
 
         for (std::size_t i = 0; i < fields_size; ++i) {
             const auto& encoded_field = encoded_fields.at(i);
-            log::version().debug("{}", dump_bytes(begin, (data - begin) + encoding_sizes::field_compressed_size(encoded_field), 100u));
             const auto& field_name = desc.fields(i).name();
             util::check(data!=end, "Reached end of input block with {} fields to decode", fields_size-i);
             if(auto col_index = res.column_index(field_name)) {

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -11,6 +11,7 @@
 #include <arcticdb/codec/segment.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/entity/types.hpp>
+#include <arcticdb/codec/encode_common.hpp>
 
 namespace arcticdb {
 
@@ -18,6 +19,12 @@ using ShapesBlockTDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, Dimension
 
 Segment encode_dispatch(
     SegmentInMemory&& in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    EncodingVersion encoding_version);
+
+
+SizeResult max_compressed_size_dispatch(
+    const SegmentInMemory& in_mem_seg,
     const arcticdb::proto::encoding::VariantCodec &codec_opts,
     EncodingVersion encoding_version);
 

--- a/cpp/arcticdb/codec/encode_common.hpp
+++ b/cpp/arcticdb/codec/encode_common.hpp
@@ -19,195 +19,205 @@
 
 namespace arcticdb {
 
-    /// @brief This should be the block data type descriptor when the shapes array is encoded as a block
-    using ShapesBlockTDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension::Dim0>>;
+/// @brief This should be the block data type descriptor when the shapes array is encoded as a block
+using ShapesBlockTDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension::Dim0>>;
 
-    using ByteArrayTDT = TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension::Dim1>>;
+using ByteArrayTDT = TypeDescriptorTag<DataTypeTag<DataType::UINT8>, DimensionTag<Dimension::Dim1>>;
 
-    template<template<typename> class TypedBlock, class TD, EncodingVersion encoder_version>
-    struct TypedBlockEncoderImpl;
+template<template<typename> class TypedBlock, class TD, EncodingVersion encoder_version>
+struct TypedBlockEncoderImpl;
 
-    template<EncodingVersion v, typename VersionedColumnEncoder>
-    struct EncodingPolicyType {
-        static constexpr EncodingVersion version = v;
-        using ColumnEncoder = VersionedColumnEncoder;
-    };
+template<EncodingVersion v, typename VersionedColumnEncoder>
+struct EncodingPolicyType {
+    static constexpr EncodingVersion version = v;
+    using ColumnEncoder = VersionedColumnEncoder;
+};
 
-    template<typename EncodingPolicyType>
-    struct BytesEncoder {
-        using Encoder = TypedBlockEncoderImpl<TypedBlockData, ByteArrayTDT, EncodingPolicyType::version>;
-        using BytesBlock = TypedBlockData<ByteArrayTDT>;
-        using ShapesEncoder = TypedBlockEncoderImpl<TypedBlockData, ShapesBlockTDT, EncodingPolicyType::version>;
+template<typename EncodingPolicyType>
+struct BytesEncoder {
+    using Encoder = TypedBlockEncoderImpl<TypedBlockData, ByteArrayTDT, EncodingPolicyType::version>;
+    using BytesBlock = TypedBlockData<ByteArrayTDT>;
+    using ShapesEncoder = TypedBlockEncoderImpl<TypedBlockData, ShapesBlockTDT, EncodingPolicyType::version>;
 
-        template<typename EncodedFieldType>
-        static void encode(
-            const ChunkedBuffer& data,
-            const arcticdb::proto::encoding::VariantCodec& codec_opts,
-            Buffer& out_buffer,
-            std::ptrdiff_t& pos,
-            EncodedFieldType* encoded_field
-        ) {
-            if constexpr(EncodingPolicyType::version == EncodingVersion::V1) {
-                const auto bytes_count = static_cast<shape_t>(data.bytes());
-                auto typed_block = BytesBlock(
-                    data.data(),
-                    &bytes_count,
-                    bytes_count,
-                    1u,
-                    data.block_and_offset(0).block_);
-                Encoder::encode(codec_opts, typed_block, *encoded_field, out_buffer, pos);
-            } else if constexpr(EncodingPolicyType::version == EncodingVersion::V2) {
-                // On Man's Mac build servers size_t and ssize_t are long rather than long long but the shape TDT
-                // expects int64 (long long).
-                const size_t row_count = 1;
-                const auto shapes_data = static_cast<ShapesBlockTDT::DataTypeTag::raw_type>(data.bytes());
-                auto shapes_block = TypedBlockData<ShapesBlockTDT>(&shapes_data,
-                    nullptr,
-                    sizeof(shape_t),
-                    row_count,
-                    data.block_and_offset(0).block_);
-                const auto bytes_count = static_cast<shape_t>(data.bytes());
-                auto data_block = BytesBlock(data.data(),
-                    &bytes_count,
-                    static_cast<shape_t>(bytes_count),
-                    row_count,
-                    data.block_and_offset(0).block_);
-                ShapesEncoder::encode_shapes(codec::default_shapes_codec(), shapes_block, *encoded_field, out_buffer, pos);
-                Encoder::encode_values(codec_opts, data_block, *encoded_field, out_buffer, pos);
-                auto* field_nd_array = encoded_field->mutable_ndarray();
-                const auto total_items_count = field_nd_array->items_count() + row_count;
-                field_nd_array->set_items_count(total_items_count);
-            } else {
-                static_assert(std::is_same_v<decltype(EncodingPolicyType::version), void>, "Unknown encoding version");
-            }
-        }
-
-        static size_t
-        max_compressed_size(const arcticdb::proto::encoding::VariantCodec& codec_opts, shape_t data_size) {
-            const shape_t shapes_bytes = sizeof(shape_t);
-            const auto values_block = BytesBlock(data_size, &data_size);
-            if constexpr(EncodingPolicyType::version == EncodingVersion::V1) {
-                const auto shapes_block = BytesBlock(shapes_bytes, &shapes_bytes);
-                return Encoder::max_compressed_size(codec_opts, values_block) +
-                       Encoder::max_compressed_size(codec_opts, shapes_block);
-            } else if constexpr(EncodingPolicyType::version == EncodingVersion::V2) {
-                const auto shapes_block = TypedBlockData<ShapesBlockTDT>(shapes_bytes, &shapes_bytes);
-                return Encoder::max_compressed_size(codec_opts, values_block) +
-                       ShapesEncoder::max_compressed_size(codec::default_shapes_codec(), shapes_block);
-            } else {
-                static_assert(std::is_same_v<decltype(EncodingPolicyType::version), void>, "Unknown encoding version");
-            }
-        }
-    };
-
-    struct SizeResult {
-        size_t max_compressed_bytes_;
-        size_t uncompressed_bytes_;
-        shape_t encoded_blocks_bytes_;
-    };
-
-    template<typename EncodingPolicyType>
-    void calc_metadata_size(
-        const SegmentInMemory& in_mem_seg,
-        const arcticdb::proto::encoding::VariantCodec& codec_opts,
-        SizeResult& result
+    template<typename EncodedFieldType>
+    static void encode(
+        const ChunkedBuffer &data,
+        const arcticdb::proto::encoding::VariantCodec &codec_opts,
+        Buffer &out_buffer,
+        std::ptrdiff_t &pos,
+        EncodedFieldType *encoded_field
     ) {
-        if(in_mem_seg.metadata()) {
-            const auto metadata_bytes = static_cast<shape_t>(in_mem_seg.metadata()->ByteSizeLong());
-            result.uncompressed_bytes_ += metadata_bytes + sizeof(shape_t);
-            result.max_compressed_bytes_ += BytesEncoder<EncodingPolicyType>::max_compressed_size(codec_opts, metadata_bytes);
-            ARCTICDB_TRACE(log::codec(), "Metadata requires {} max_compressed_bytes", result.max_compressed_bytes_);
-        }
-    }
-
-    template<typename EncodingPolicyType>
-    void calc_columns_size(
-        const SegmentInMemory& in_mem_seg,
-        const arcticdb::proto::encoding::VariantCodec& codec_opts,
-        SizeResult& result
-    ) {
-        for (std::size_t c = 0; c < in_mem_seg.num_columns(); ++c) {
-            auto column_data = in_mem_seg.column_data(c);
-            const auto [uncompressed, required] = EncodingPolicyType::ColumnEncoder::max_compressed_size(codec_opts,
-                column_data);
-            result.uncompressed_bytes_ += uncompressed;
-            result.max_compressed_bytes_ += required;
-            ARCTICDB_TRACE(log::codec(),
-                "Column {} requires {} max_compressed_bytes, total {}",
-                c,
-                required,
-                result.max_compressed_bytes_);
-        }
-    }
-
-    template<typename EncodingPolicyType>
-    void calc_string_pool_size(
-        const SegmentInMemory& in_mem_seg,
-        const arcticdb::proto::encoding::VariantCodec& codec_opts,
-        SizeResult& result
-    ) {
-        if(in_mem_seg.has_string_pool()) {
-            auto string_col = in_mem_seg.string_pool_data();
-            const auto [uncompressed, required] = EncodingPolicyType::ColumnEncoder::max_compressed_size(codec_opts,
-                string_col);
-            result.uncompressed_bytes_ += uncompressed;
-            result.max_compressed_bytes_ += required;
-            ARCTICDB_TRACE(log::codec(),
-                "String pool requires {} max_compressed_bytes, total {}",
-                required,
-                result.max_compressed_bytes_);
-        }
-    }
-
-    template<typename EncodingPolicyType>
-    void encode_metadata(
-        const SegmentInMemory& in_mem_seg,
-        arcticdb::proto::encoding::SegmentHeader& segment_header,
-        const arcticdb::proto::encoding::VariantCodec& codec_opts,
-        Buffer& out_buffer,
-        std::ptrdiff_t& pos
-    ) {
-        if(in_mem_seg.metadata()) {
-            const auto bytes_count = static_cast<shape_t>(in_mem_seg.metadata()->ByteSizeLong());
-            ARCTICDB_TRACE(log::codec(), "Encoding {} bytes of metadata", bytes_count);
-            auto encoded_field = segment_header.mutable_metadata_field();
-
-            constexpr int max_stack_alloc = 1 << 11;
-            bool malloced{false};
-            uint8_t* meta_ptr{nullptr};
-            if(bytes_count > max_stack_alloc) {
-                meta_ptr = reinterpret_cast<uint8_t*>(malloc(bytes_count));
-                malloced = true;
-            } else {
-                meta_ptr = reinterpret_cast<uint8_t*>(alloca(bytes_count));
-            }
-            ChunkedBuffer meta_buffer;
-            meta_buffer.add_external_block(meta_ptr, bytes_count, 0u);
-            google::protobuf::io::ArrayOutputStream aos(&meta_buffer[0], static_cast<int>(bytes_count));
-            in_mem_seg.metadata()->SerializeToZeroCopyStream(&aos);
-            BytesEncoder<EncodingPolicyType>::encode(meta_buffer, codec_opts, out_buffer, pos, encoded_field);
-            ARCTICDB_DEBUG(log::codec(), "Encoded metadata to position {}", pos);
-            if(malloced)
-                free(meta_ptr);
+        if constexpr (EncodingPolicyType::version == EncodingVersion::V1) {
+            const auto bytes_count = static_cast<shape_t>(data.bytes());
+            auto typed_block = BytesBlock(
+                data.data(),
+                &bytes_count,
+                bytes_count,
+                1u,
+                data.block_and_offset(0).block_);
+            Encoder::encode(codec_opts, typed_block, *encoded_field, out_buffer, pos);
+        } else if constexpr (EncodingPolicyType::version == EncodingVersion::V2) {
+            // On Man's Mac build servers size_t and ssize_t are long rather than long long but the shape TDT
+            // expects int64 (long long).
+            const size_t row_count = 1;
+            const auto shapes_data = static_cast<ShapesBlockTDT::DataTypeTag::raw_type>(data.bytes());
+            auto shapes_block = TypedBlockData<ShapesBlockTDT>(&shapes_data,
+                                                               nullptr,
+                                                               sizeof(shape_t),
+                                                               row_count,
+                                                               data.block_and_offset(0).block_);
+            const auto bytes_count = static_cast<shape_t>(data.bytes());
+            auto data_block = BytesBlock(data.data(),
+                                         &bytes_count,
+                                         static_cast<shape_t>(bytes_count),
+                                         row_count,
+                                         data.block_and_offset(0).block_);
+            ShapesEncoder::encode_shapes(codec::default_shapes_codec(), shapes_block, *encoded_field, out_buffer, pos);
+            Encoder::encode_values(codec_opts, data_block, *encoded_field, out_buffer, pos);
+            auto *field_nd_array = encoded_field->mutable_ndarray();
+            const auto total_items_count = field_nd_array->items_count() + row_count;
+            field_nd_array->set_items_count(total_items_count);
         } else {
-            ARCTICDB_DEBUG(log::codec(), "Not encoding any metadata");
+            static_assert(std::is_same_v<decltype(EncodingPolicyType::version), void>, "Unknown encoding version");
         }
     }
 
-    template<typename EncodingPolicyType>
-    void encode_string_pool(
-        const SegmentInMemory& in_mem_seg,
-        arcticdb::proto::encoding::SegmentHeader& segment_header,
-        const arcticdb::proto::encoding::VariantCodec& codec_opts,
-        Buffer& out_buffer,
-        std::ptrdiff_t& pos
-    ) {
-        if(in_mem_seg.has_string_pool()) {
-            ARCTICDB_TRACE(log::codec(), "Encoding string pool to position {}", pos);
-            auto* encoded_field = segment_header.mutable_string_pool_field();
-            auto col = in_mem_seg.string_pool_data();
-            EncodingPolicyType::ColumnEncoder::encode(codec_opts, col, encoded_field, out_buffer, pos);
-            ARCTICDB_TRACE(log::codec(), "Encoded string pool to position {}", pos);
+    static size_t
+    max_compressed_size(const arcticdb::proto::encoding::VariantCodec &codec_opts, shape_t data_size) {
+        const shape_t shapes_bytes = sizeof(shape_t);
+        const auto values_block = BytesBlock(data_size, &data_size);
+        if constexpr (EncodingPolicyType::version == EncodingVersion::V1) {
+            const auto shapes_block = BytesBlock(shapes_bytes, &shapes_bytes);
+            return Encoder::max_compressed_size(codec_opts, values_block) +
+                Encoder::max_compressed_size(codec_opts, shapes_block);
+        } else if constexpr (EncodingPolicyType::version == EncodingVersion::V2) {
+            const auto shapes_block = TypedBlockData<ShapesBlockTDT>(shapes_bytes, &shapes_bytes);
+            return Encoder::max_compressed_size(codec_opts, values_block) +
+                ShapesEncoder::max_compressed_size(codec::default_shapes_codec(), shapes_block);
+        } else {
+            static_assert(std::is_same_v<decltype(EncodingPolicyType::version), void>, "Unknown encoding version");
         }
+    }
+};
+
+struct SizeResult {
+    size_t max_compressed_bytes_;
+    size_t uncompressed_bytes_;
+    shape_t encoded_blocks_bytes_;
+};
+
+template<typename EncodingPolicyType>
+void calc_metadata_size(
+    const SegmentInMemory &in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    SizeResult &result
+) {
+    if (in_mem_seg.metadata()) {
+        const auto metadata_bytes = static_cast<shape_t>(in_mem_seg.metadata()->ByteSizeLong());
+        result.uncompressed_bytes_ += metadata_bytes + sizeof(shape_t);
+        result.max_compressed_bytes_ +=
+            BytesEncoder<EncodingPolicyType>::max_compressed_size(codec_opts, metadata_bytes);
+        ARCTICDB_TRACE(log::codec(), "Metadata requires {} max_compressed_bytes", result.max_compressed_bytes_);
     }
 }
+
+template<typename EncodingPolicyType>
+void calc_columns_size(
+    const SegmentInMemory &in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    SizeResult &result
+) {
+    for (std::size_t c = 0; c < in_mem_seg.num_columns(); ++c) {
+        auto column_data = in_mem_seg.column_data(c);
+        const auto [uncompressed, required] = EncodingPolicyType::ColumnEncoder::max_compressed_size(codec_opts,
+                                                                                                     column_data);
+        result.uncompressed_bytes_ += uncompressed;
+        result.max_compressed_bytes_ += required;
+        ARCTICDB_TRACE(log::codec(),
+                       "Column {} requires {} max_compressed_bytes, total {}",
+                       c,
+                       required,
+                       result.max_compressed_bytes_);
+    }
+}
+
+template<typename EncodingPolicyType>
+void calc_string_pool_size(
+    const SegmentInMemory &in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    SizeResult &result
+) {
+    if (in_mem_seg.has_string_pool()) {
+        auto string_col = in_mem_seg.string_pool_data();
+        const auto [uncompressed, required] = EncodingPolicyType::ColumnEncoder::max_compressed_size(codec_opts,
+                                                                                                     string_col);
+        result.uncompressed_bytes_ += uncompressed;
+        result.max_compressed_bytes_ += required;
+        ARCTICDB_TRACE(log::codec(),
+                       "String pool requires {} max_compressed_bytes, total {}",
+                       required,
+                       result.max_compressed_bytes_);
+    }
+}
+
+template<typename EncodingPolicyType>
+void encode_metadata(
+    const SegmentInMemory &in_mem_seg,
+    arcticdb::proto::encoding::SegmentHeader &segment_header,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    Buffer &out_buffer,
+    std::ptrdiff_t &pos
+) {
+    if (in_mem_seg.metadata()) {
+        const auto bytes_count = static_cast<shape_t>(in_mem_seg.metadata()->ByteSizeLong());
+        ARCTICDB_TRACE(log::codec(), "Encoding {} bytes of metadata", bytes_count);
+        auto encoded_field = segment_header.mutable_metadata_field();
+
+        constexpr int max_stack_alloc = 1 << 11;
+        bool malloced{false};
+        uint8_t *meta_ptr{nullptr};
+        if (bytes_count > max_stack_alloc) {
+            meta_ptr = reinterpret_cast<uint8_t *>(malloc(bytes_count));
+            malloced = true;
+        } else {
+            meta_ptr = reinterpret_cast<uint8_t *>(alloca(bytes_count));
+        }
+        ChunkedBuffer meta_buffer;
+        meta_buffer.add_external_block(meta_ptr, bytes_count, 0u);
+        google::protobuf::io::ArrayOutputStream aos(&meta_buffer[0], static_cast<int>(bytes_count));
+        in_mem_seg.metadata()->SerializeToZeroCopyStream(&aos);
+        BytesEncoder<EncodingPolicyType>::encode(meta_buffer, codec_opts, out_buffer, pos, encoded_field);
+        ARCTICDB_DEBUG(log::codec(), "Encoded metadata to position {}", pos);
+        if (malloced)
+            free(meta_ptr);
+    } else {
+        ARCTICDB_DEBUG(log::codec(), "Not encoding any metadata");
+    }
+}
+
+template<typename EncodingPolicyType>
+void encode_string_pool(
+    const SegmentInMemory &in_mem_seg,
+    arcticdb::proto::encoding::SegmentHeader &segment_header,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    Buffer &out_buffer,
+    std::ptrdiff_t &pos
+) {
+    if (in_mem_seg.has_string_pool()) {
+        ARCTICDB_TRACE(log::codec(), "Encoding string pool to position {}", pos);
+        auto *encoded_field = segment_header.mutable_string_pool_field();
+        auto col = in_mem_seg.string_pool_data();
+        EncodingPolicyType::ColumnEncoder::encode(codec_opts, col, encoded_field, out_buffer, pos);
+        ARCTICDB_TRACE(log::codec(), "Encoded string pool to position {}", pos);
+    }
+}
+
+[[nodiscard]] SizeResult max_compressed_size_v1(
+    const SegmentInMemory &in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts);
+
+[[nodiscard]] SizeResult max_compressed_size_v2(
+    const SegmentInMemory &in_mem_seg,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts);
+
+} //namespace arcticdb

--- a/cpp/arcticdb/codec/encode_v1.cpp
+++ b/cpp/arcticdb/codec/encode_v1.cpp
@@ -88,7 +88,7 @@ namespace arcticdb {
 
     using EncodingPolicyV1 = EncodingPolicyType<EncodingVersion::V1, ColumnEncoderV1>;
 
-    [[nodiscard]] static SizeResult max_compressed_size_v1(
+    [[nodiscard]] SizeResult max_compressed_size_v1(
         const SegmentInMemory& in_mem_seg,
         const arcticdb::proto::encoding::VariantCodec& codec_opts
     ) {
@@ -142,7 +142,7 @@ namespace arcticdb {
         ARCTICDB_DEBUG(log::codec(), "Setting buffer bytes to {}", pos);
         out_buffer->set_bytes(pos);
         tsd->set_out_bytes(pos);
-        ARCTICDB_DEBUG(log::codec(), "Encoded header: {}", tsd->DebugString());
+        ARCTICDB_TRACE(log::codec(), "Encoded header: {}", tsd->DebugString());
         if(!segment_header->has_metadata_field())
             ARCTICDB_DEBUG(log::codec(), "No metadata field");
         ARCTICDB_DEBUG(log::codec(), "Block count {} header size {} ratio {}",

--- a/cpp/arcticdb/codec/encoded_field.hpp
+++ b/cpp/arcticdb/codec/encoded_field.hpp
@@ -231,6 +231,8 @@ struct EncodedField {
     uint64_t items_count_ = 0u;
     std::array<EncodedBlock, 1> blocks_;
 
+    static constexpr size_t MinimumSize = sizeof(type_) + sizeof(shapes_count_) + sizeof(values_count_) + sizeof(sparse_map_bytes_) + sizeof(items_count_);
+
     static constexpr EncodedFieldType kNdarray = EncodedFieldType::kNdarray;
 
     static constexpr size_t Size =

--- a/cpp/arcticdb/codec/encoded_field_collection.hpp
+++ b/cpp/arcticdb/codec/encoded_field_collection.hpp
@@ -36,11 +36,11 @@ public:
     }
 
     [[nodiscard]] const EncodedField &at(size_t pos) const {
-        return *(buffer_.ptr_cast<EncodedField>(get_offset(pos), sizeof(EncodedField)));
+        return *(buffer_.ptr_cast<EncodedField>(get_offset(pos), EncodedField::MinimumSize));
     }
 
     [[nodiscard]] EncodedField &at(size_t pos) {
-        return *(buffer_.ptr_cast<EncodedField>(get_offset(pos), sizeof(EncodedField)));
+        return *(buffer_.ptr_cast<EncodedField>(get_offset(pos), EncodedField::MinimumSize));
     }
 
     [[nodiscard]] size_t size() const {

--- a/cpp/arcticdb/codec/encoding_sizes.hpp
+++ b/cpp/arcticdb/codec/encoding_sizes.hpp
@@ -56,8 +56,8 @@ template <typename NDArrayEncodedFieldType> std::size_t shape_compressed_size(co
     switch (field.encoding_case()) {
         case EncodedFieldType::kNdarray:
             return ndarray_field_compressed_size(field.ndarray());
-            default:
-                util::raise_error_msg("Unsupported encoding {}", field);
+        default:
+            util::raise_error_msg("Unsupported encoding {}", field);
     }
 }
 
@@ -75,8 +75,8 @@ std::size_t segment_compressed_size(const FieldCollectionType &fields) {
       /*  case arcticdb::proto::encoding::EncodedField::kDictionary:
             total += compressed_size(field.dictionary());
             break;*/
-            default:
-                util::raise_rte("Unsupported encoding in {}",  util::format(field));
+        default:
+            util::raise_rte("Unsupported encoding in {}",  util::format(field));
         }
     }
     return total;

--- a/cpp/arcticdb/codec/test/test_codec.cpp
+++ b/cpp/arcticdb/codec/test/test_codec.cpp
@@ -48,6 +48,7 @@ namespace arcticdb {
             std::variant<EncodedField*, arcticdb::proto::encoding::EncodedField*> variant_field,
             Buffer& out,
             std::ptrdiff_t& pos_in_buffer);
+
         static void encode_blocks(
             const arcticdb::proto::encoding::VariantCodec &codec_opts,
             ColumnData& column_data,
@@ -450,7 +451,7 @@ TEST(SegmentEncoderTest, StressTestString) {
     SegmentsSink sink;
     auto index = as::TimeseriesIndex::default_index();
     as::FixedSchema schema{
-        index.create_stream_descriptor(123, {
+        index.create_stream_descriptor(NumericId{123}, {
             scalar_field(DataType::ASCII_DYNAMIC64, "col_1"),
             scalar_field(DataType::ASCII_DYNAMIC64, "col_2"),
             scalar_field(DataType::ASCII_DYNAMIC64, "col_3"),

--- a/cpp/arcticdb/column_store/chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.cpp
@@ -75,6 +75,9 @@ template <size_t BlockSize>
 ChunkedBufferImpl<BlockSize> truncate(const ChunkedBufferImpl<BlockSize>& input, size_t start_byte, size_t end_byte) {
     ARCTICDB_DEBUG(log::version(), "Truncating buffer of size {} between bytes {} and {}", input.bytes(), start_byte, end_byte);
     const auto output_size = start_byte >= end_byte ? 0 : end_byte - start_byte;
+    if(input.num_blocks() == 0 || output_size == 0)
+        return {};
+
     // This is trivially extendable to use presized_in_blocks, but there is no use case for this right now, and
     // copy_frame_data_to_buffer expects a contiguous buffer
     auto output = ChunkedBufferImpl<BlockSize>::presized(output_size);

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -224,7 +224,7 @@ public:
             // Check cpp/arcticdb/column_store/column_utils.hpp::array_at and cpp/arcticdb/column_store/column.hpp::Column
             data_(expected_rows * entity::sizeof_datatype(type), presize),
             type_(type),
-            allow_sparse_(allow_sparse){
+            allow_sparse_(allow_sparse) {
         ARCTICDB_TRACE(log::inmem(), "Creating column with descriptor {}", type);
     }
 
@@ -794,6 +794,7 @@ private:
 
     bool inflated_ = false;
     bool allow_sparse_ = false;
+
     std::optional<util::BitMagic> sparse_map_;
     util::MagicNum<'D', 'C', 'o', 'l'> magic_;
 }; //class Column

--- a/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
+++ b/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
@@ -41,7 +41,7 @@ TEST(IngestionStress, ScalarInt) {
 
     const auto index = as::TimeseriesIndex::default_index();
     as::FixedSchema schema{
-        index.create_stream_descriptor(123, fields_from_range(std::move(columns))), index
+        index.create_stream_descriptor(NumericId{123}, fields_from_range(std::move(columns))), index
     };
 
     SegmentsSink sink;

--- a/cpp/arcticdb/column_store/test/test_index_filtering.cpp
+++ b/cpp/arcticdb/column_store/test/test_index_filtering.cpp
@@ -53,8 +53,8 @@ std::pair<TimeseriesDescriptor , std::vector<SliceAndKey>> get_sample_slice_and_
                         version_id,
                         i,
                         col_range,
-                        IndexValue{start_val},
-                        IndexValue{end_val},
+                        IndexValue{NumericIndex{start_val}},
+                        IndexValue{NumericIndex{end_val}},
                         KeyType::TABLE_DATA
                     }
                 }
@@ -93,7 +93,7 @@ TEST(IndexFilter, Static) {
     auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor{isr.tsd().as_stream_descriptor()});
 
     ReadQuery read_query{};
-    read_query.row_filter = IndexRange{25, 65};
+    read_query.row_filter = IndexRange{ NumericIndex{25}, NumericIndex{65} };
 
     auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(
         read_query,
@@ -129,7 +129,7 @@ TEST(IndexFilter, Dynamic) {
     auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor(isr.tsd().as_stream_descriptor()));
 
     ReadQuery read_query{};
-    read_query.row_filter = IndexRange{25, 65};
+    read_query.row_filter = IndexRange{ NumericIndex{25}, NumericIndex{65} };
 
     auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(
         read_query,
@@ -165,7 +165,7 @@ TEST(IndexFilter, StaticMulticolumn) {
     auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor(isr.tsd().as_stream_descriptor()));
 
     ReadQuery read_query{};
-    read_query.row_filter = IndexRange{25, 65};
+    read_query.row_filter = IndexRange{ NumericIndex{25}, NumericIndex{65} };
 
     auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(
         read_query,
@@ -205,7 +205,7 @@ TEST(IndexFilter, MultiColumnSelectAll) {
     auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor{isr.tsd().as_stream_descriptor()});
 
     ReadQuery read_query{};
-    read_query.row_filter = IndexRange{0, 100};
+    read_query.row_filter = IndexRange{ NumericIndex{0}, NumericIndex{100} };
 
     auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(
         read_query,
@@ -240,7 +240,7 @@ TEST(IndexFilter, StaticMulticolumnFilterColumns) {
     auto pipeline_context = std::make_shared<PipelineContext>(StreamDescriptor{isr.tsd().as_stream_descriptor()});
 
     ReadQuery read_query{};
-    read_query.row_filter = IndexRange{25, 65};
+    read_query.row_filter = IndexRange{ NumericIndex{25}, NumericIndex{65} };
     read_query.columns = std::vector<std::string> {"col_10", "col_91"};
 
     auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(

--- a/cpp/arcticdb/entity/key.hpp
+++ b/cpp/arcticdb/entity/key.hpp
@@ -275,7 +275,10 @@ auto foreach_key_type_write_precedence(Function&& func) {
         func(KeyType(type));
     }
 }
-
+inline KeyType key_type_from_int(int type_num) {
+    util::check(type_num > 0 && type_num < int(KeyType::UNDEFINED), "Unrecognized key type number {}", type_num);
+    return KeyType(type_num);
+}
 
 } // namespace arcticdb::entity
 

--- a/cpp/arcticdb/entity/protobufs.hpp
+++ b/cpp/arcticdb/entity/protobufs.hpp
@@ -16,6 +16,7 @@
 #include <rocksdb_storage.pb.h>
 #include <nfs_backed_storage.pb.h>
 #include <azure_storage.pb.h>
+#include <mapped_file_storage.pb.h>
 #include <config.pb.h>
 #include <utils.pb.h>
 
@@ -24,6 +25,7 @@ namespace arcticdb::proto {
     namespace storage = arcticc::pb2::storage_pb2;
     namespace s3_storage = arcticc::pb2::s3_storage_pb2;
     namespace lmdb_storage = arcticc::pb2::lmdb_storage_pb2;
+    namespace mapped_file_storage = arcticc::pb2::mapped_file_storage_pb2;
     namespace mongo_storage = arcticc::pb2::mongo_storage_pb2;
     namespace memory_storage = arcticc::pb2::in_memory_storage_pb2;
     namespace rocksdb_storage = arcticc::pb2::rocksdb_storage_pb2;

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -42,8 +42,8 @@ struct StreamDescriptor {
 
     void set_id(const StreamId& id) {
         util::variant_match(id,
-                            [that=this] (const StringId& str) { that->data_->set_str_id(str); },
-                            [that=this] (const NumericId& n) { that->data_->set_num_id(n); });
+                            [this] (const StringId& str) { data_->set_str_id(str); },
+                            [this] (const NumericId& n) { data_->set_num_id(n); });
     }
 
     static StreamId id_from_proto(const Proto& proto) {

--- a/cpp/arcticdb/entity/test/test_atom_key.cpp
+++ b/cpp/arcticdb/entity/test/test_atom_key.cpp
@@ -26,8 +26,8 @@ TEST(Key, Basic) {
     timestamp creation_ts(34534);
     ContentHash content_hash(2734);
     KeyType numeric_data_key_type(KeyType::TABLE_DATA);
-    IndexValue timestamp_start(33);
-    IndexValue timestamp_end(57);
+    IndexValue timestamp_start(NumericId{33});
+    IndexValue timestamp_end(NumericId{57});
     AtomKey construct_numeric_key
         (numeric_id, version_id, creation_ts, content_hash, timestamp_start, timestamp_end, numeric_data_key_type);
 
@@ -108,7 +108,7 @@ struct AlternativeFormat {
 TEST(Key, Formatting) {
 
     AtomKey k{
-        StreamId{999},
+        StreamId{NumericId{999}},
         VersionId(123),
         timestamp(123000000LL),
         0x789456321ULL,
@@ -122,7 +122,7 @@ TEST(Key, Formatting) {
 
     auto k3 = atom_key_builder().gen_id(123).creation_ts(123000000)
         .start_index(timestamp(122000000)).end_index(timestamp(122000999))
-        .content_hash(0x789456321).build<KeyType::TABLE_DATA>(999);
+        .content_hash(0x789456321).build<KeyType::TABLE_DATA>(NumericId{999});
 
     ASSERT_EQ(k3, k2);
 

--- a/cpp/arcticdb/entity/test/test_key_serialization.cpp
+++ b/cpp/arcticdb/entity/test/test_key_serialization.cpp
@@ -30,8 +30,8 @@ TEST(KeySerialize, RoundtripStringidNumericIndex) {
     auto key_type = KeyType::TABLE_INDEX;
     auto version_id = VersionId(26);
     auto content_hash = 0xBADF00D;
-    auto start_index = IndexValue(1234);
-    auto end_index = IndexValue(4321);
+    auto start_index = IndexValue(NumericIndex{1234});
+    auto end_index = IndexValue(NumericIndex{4321});
 
     auto key = atom_key_builder().version_id(version_id)
         .creation_ts(version_id)
@@ -61,12 +61,12 @@ TEST(KeySerialize, RoundtripNumericIdNumericIndex) {
     using namespace arcticdb;
     using namespace arcticdb::entity;
 
-    auto stream_id = StreamId(4753);
+    auto stream_id = StreamId(NumericId{ 753});
     auto key_type = KeyType::TABLE_DATA;
     auto version_id = VersionId(26);
     auto content_hash = 0xBADF00D;
-    auto start_index = IndexValue(1234);
-    auto end_index = IndexValue(4321);
+    auto start_index = IndexValue(NumericIndex{1234});
+    auto end_index = IndexValue(NumericIndex{4321});
 
     auto key = atom_key_builder().version_id(version_id)
         .creation_ts(version_id)
@@ -152,8 +152,8 @@ TEST(SerializeNumber, SignedNumbers) {
     auto key_type = KeyType::TABLE_DATA;
     auto version_id = VersionId(26);
     auto content_hash = 0xBADF00D;
-    auto start_index = IndexValue(-123456789);
-    auto end_index = IndexValue(-987654321);
+    auto start_index = IndexValue(NumericIndex{-123456789});
+    auto end_index = IndexValue(NumericIndex{-987654321});
 
     auto key = atom_key_builder().version_id(version_id)
         .creation_ts(version_id)
@@ -179,8 +179,8 @@ TEST(KeySerialize, RoundtripStringidSpecialCharacter) {
     auto key_type = KeyType::TABLE_INDEX;
     auto version_id = VersionId(26);
     auto content_hash = 0xBADF00D;
-    auto start_index = IndexValue(1234);
-    auto end_index = IndexValue(4321);
+    auto start_index = IndexValue(NumericIndex{ 234});
+    auto end_index = IndexValue(NumericIndex{4321});
 
     auto key = atom_key_builder().version_id(version_id)
         .creation_ts(version_id)

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -34,8 +34,9 @@ enum class SortedValue : uint8_t {
 };
 
 using NumericId = int64_t;
+using UnsignedId = uint64_t;
 using StringId = std::string;
-using VariantId = std::variant<NumericId, StringId>;
+using VariantId = std::variant<NumericId, StringId, UnsignedId>;
 using StreamId = VariantId;
 using SnapshotId = VariantId;
 using VersionId = uint64_t;
@@ -60,7 +61,7 @@ constexpr size_t UNICODE_WIDTH = sizeof(UnicodeType);
 constexpr size_t ASCII_WIDTH = 1;
 //TODO: Fix unicode width for windows
 #ifndef _WIN32
-    static_assert(UNICODE_WIDTH == 4, "Only support python platforms where unicode width is 4");
+static_assert(UNICODE_WIDTH == 4, "Only support python platforms where unicode width is 4");
 #endif
 
 // Beware, all the enum values of the field must match exactly the values
@@ -99,13 +100,13 @@ enum class ValueType : uint8_t {
 // Sequence types are composed of more than one element
 constexpr bool is_sequence_type(ValueType v){
     return uint8_t(v) >= uint8_t(ValueType::ASCII_FIXED) &&
-    uint8_t(v) <= uint8_t(ValueType::ASCII_DYNAMIC);
+        uint8_t(v) <= uint8_t(ValueType::ASCII_DYNAMIC);
 }
 
 constexpr bool is_numeric_type(ValueType v){
     return v == ValueType::NANOSECONDS_UTC ||
-    (uint8_t(v) >= uint8_t(ValueType::UINT) &&
-    uint8_t(v) <= uint8_t(ValueType::FLOAT));
+        (uint8_t(v) >= uint8_t(ValueType::UINT) &&
+            uint8_t(v) <= uint8_t(ValueType::FLOAT));
 }
 
 constexpr bool is_floating_point_type(ValueType v){
@@ -146,20 +147,20 @@ enum class SizeBits : uint8_t {
 
 constexpr SizeBits get_size_bits(uint8_t size) {
     switch (size) {
-        case 2:return SizeBits::S16;
-        case 4:return SizeBits::S32;
-        case 8:return SizeBits::S64;
-        default:return SizeBits::S8;
+    case 2:return SizeBits::S16;
+    case 4:return SizeBits::S32;
+    case 8:return SizeBits::S64;
+    default:return SizeBits::S8;
     }
 }
 
 [[nodiscard]] constexpr int get_byte_count(SizeBits size_bits) {
     switch(size_bits) {
-        case SizeBits::S8: return 1;
-        case SizeBits::S16: return 2;
-        case SizeBits::S32: return 4;
-        case SizeBits::S64: return 8;
-        default: util::raise_rte("Unknown size bits");
+    case SizeBits::S8: return 1;
+    case SizeBits::S16: return 2;
+    case SizeBits::S32: return 4;
+    case SizeBits::S64: return 8;
+    default: util::raise_rte("Unknown size bits");
     }
 }
 
@@ -190,6 +191,7 @@ enum class DataType : uint8_t {
     UTF_DYNAMIC64 = detail::combine_val_bits(ValueType::UTF_DYNAMIC, SizeBits::S64),
     EMPTYVAL = detail::combine_val_bits(ValueType::EMPTY, SizeBits::S64),
     BOOL_OBJECT8 = detail::combine_val_bits(ValueType::BOOL_OBJECT, SizeBits::S8),
+#undef DT_COMBINE
     UNKNOWN = 0,
 };
 
@@ -289,10 +291,10 @@ static_assert(get_type_size(DataType::UINT64) == 8);
 
 constexpr  ValueType get_value_type(char specifier) noexcept {
     switch(specifier){
-        case 'u': return ValueType::UINT; //  unsigned integer
-        case 'i': return ValueType::INT; //  signed integer
-        case 'f': return ValueType::FLOAT; //  floating-point
-        case 'b': return ValueType::BOOL; //  boolean
+    case 'u': return ValueType::UINT; //  unsigned integer
+    case 'i': return ValueType::INT; //  signed integer
+    case 'f': return ValueType::FLOAT; //  floating-point
+    case 'b': return ValueType::BOOL; //  boolean
         // NOTE: this is safe as of Pandas < 2.0 because `datetime64` _always_ has been using nanosecond resolution,
         // i.e. Pandas < 2.0 _always_ provides `datetime64[ns]` and ignores any other resolution.
         // Yet, this has changed in Pandas 2.0 and other resolution can be used,
@@ -300,21 +302,21 @@ constexpr  ValueType get_value_type(char specifier) noexcept {
         // See: https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#construction-with-datetime64-or-timedelta64-dtype-with-unsupported-resolution
         // TODO: for the support of Pandas>=2.0, convert any `datetime` to `datetime64[ns]` before-hand and do not
         // rely uniquely on the resolution-less 'M' specifier if it this doable.
-        case 'M': return ValueType::NANOSECONDS_UTC; //  datetime // numpy doesn't support the buffer protocol for datetime64
-        case 'U': return ValueType::UTF8_FIXED; //  Unicode
-        case 'S': return ValueType::ASCII_FIXED; //  (byte-)string
-        case 'O': return ValueType::BYTES; // Fishy, an actual type might be better
-        default:
-            return ValueType::UNKNOWN_VALUE_TYPE;    // Unknown
+    case 'M': return ValueType::NANOSECONDS_UTC; //  datetime // numpy doesn't support the buffer protocol for datetime64
+    case 'U': return ValueType::UTF8_FIXED; //  Unicode
+    case 'S': return ValueType::ASCII_FIXED; //  (byte-)string
+    case 'O': return ValueType::BYTES; // Fishy, an actual type might be better
+    default:
+        return ValueType::UNKNOWN_VALUE_TYPE;    // Unknown
     }
 }
 
 constexpr char get_dtype_specifier(ValueType vt){
     switch(vt){
-        case ValueType::UINT: return 'u';
-        case ValueType::INT:  return 'i';
-        case ValueType::FLOAT: return 'f';
-        case ValueType::BOOL: return 'b';
+    case ValueType::UINT: return 'u';
+    case ValueType::INT:  return 'i';
+    case ValueType::FLOAT: return 'f';
+    case ValueType::BOOL: return 'b';
         // NOTE: this is safe as of Pandas < 2.0 because `datetime64` _always_ has been using nanosecond resolution,
         // i.e. Pandas < 2.0 _always_ provides `datetime64[ns]` and ignores any other resolution.
         // Yet, this has changed in Pandas 2.0 and other resolution can be used,
@@ -322,13 +324,13 @@ constexpr char get_dtype_specifier(ValueType vt){
         // See: https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#construction-with-datetime64-or-timedelta64-dtype-with-unsupported-resolution
         // TODO: for the support of Pandas>=2.0, convert any `datetime` to `datetime64[ns]` before-hand and do not
         // rely uniquely on the resolution-less 'M' specifier if it this doable.
-        case ValueType::NANOSECONDS_UTC: return 'M';
-        case ValueType::UTF8_FIXED: return 'U';
-        case ValueType::ASCII_FIXED: return 'S';
-        case ValueType::BYTES: return 'O';
-        case ValueType::EMPTY: return 'O';
-        default:
-            return 'x';
+    case ValueType::NANOSECONDS_UTC: return 'M';
+    case ValueType::UTF8_FIXED: return 'U';
+    case ValueType::ASCII_FIXED: return 'S';
+    case ValueType::BYTES: return 'O';
+    case ValueType::EMPTY: return 'O';
+    default:
+        return 'x';
     }
 }
 
@@ -461,7 +463,7 @@ constexpr bool must_contain_data(TypeDescriptor td) {
 /// @important Be sure to match this with the type handler registry in: cpp/arcticdb/python/python_module.cpp#register_type_handlers
 constexpr bool is_numpy_array(TypeDescriptor td) {
     return (is_numeric_type(td.data_type()) || is_bool_type(td.data_type()) || is_empty_type(td.data_type())) &&
-           (td.dimension() == Dimension::Dim1);
+        (td.dimension() == Dimension::Dim1);
 }
 
 constexpr bool is_pyobject_type(TypeDescriptor td) {
@@ -552,7 +554,7 @@ public:
     }
 
     static size_t calc_size(std::string_view name) {
-      return sizeof(type_) + sizeof(size_) + std::max(NameSize, name.size());
+        return sizeof(type_) + sizeof(size_) + std::max(NameSize, name.size());
     }
 
     [[nodiscard]] std::string_view name() const {
@@ -597,7 +599,7 @@ public:
 struct FieldWrapper {
     std::vector<uint8_t> data_;
     FieldWrapper(TypeDescriptor type, std::string_view name) :
-    data_(Field::calc_size(name)) {
+        data_(Field::calc_size(name)) {
         mutable_field().set(type, name);
     }
 

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -65,8 +65,8 @@ struct InputTensorFrame {
         // Fill index range
         // Note RowCountIndex will normally have an index field count of 0
         if(num_rows == 0) {
-            index_range.start_  = IndexValue{0};
-            index_range.end_ = IndexValue{0};
+            index_range.start_ = IndexValue{ NumericIndex{0} };
+            index_range.end_ = IndexValue{ NumericIndex{0} };
         } else if (desc.index().field_count() == 1) {
             visit_field(desc.field(0), [&](auto &&tag) {
                 using DT = std::decay_t<decltype(tag)>;
@@ -83,7 +83,7 @@ struct InputTensorFrame {
                     throw std::runtime_error("Unsupported non-integral index type");
                 });
         } else {
-            index_range.start_  = IndexValue{0};
+            index_range.start_ = IndexValue{ NumericIndex{0} };
             index_range.end_ = IndexValue{static_cast<timestamp>(num_rows) - 1};
         }
     }

--- a/cpp/arcticdb/pipeline/test/test_query.cpp
+++ b/cpp/arcticdb/pipeline/test/test_query.cpp
@@ -17,7 +17,7 @@ TEST(BitsetForIndex, DynamicSchemaStrictlyBefore) {
     TestContainer container;
     container.seg().set_range(3, 4);
     container.seg().set_range(5, 7);
-    IndexRange rg(0, 2);
+    IndexRange rg(NumericIndex{0}, NumericIndex{2});
     auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ(bitset->count(), 0);
 }
@@ -28,7 +28,7 @@ TEST(BitsetForIndex, DynamicSchemaStrictlyAfter) {
     TestContainer container;
     container.seg().set_range(0, 2);
     container.seg().set_range(3, 4);
-    IndexRange rg(5, 7);
+    IndexRange rg(NumericIndex{ 5 }, NumericIndex{7});
     auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ(bitset->count(), 0);
 }
@@ -39,7 +39,7 @@ TEST(BitsetForIndex, DynamicSchemaMiddle) {
    TestContainer container;
    container.seg().set_range(0, 2);
    container.seg().set_range(5, 7);
-   IndexRange rg(3, 4);
+   IndexRange rg(NumericIndex{3}, NumericIndex{4});
    auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
    ASSERT_EQ(bitset->count(), 0);
 }
@@ -50,7 +50,7 @@ TEST(BitsetForIndex, DynamicSchemaOverlapBegin) {
     TestContainer container;
     container.seg().set_range(2, 4);
     container.seg().set_range(5, 7);
-    IndexRange rg(1, 3);
+    IndexRange rg(NumericIndex{1}, NumericIndex{3});
     auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ((*bitset)[0], true);
     ASSERT_EQ(bitset->count(), 1);
@@ -62,7 +62,7 @@ TEST(BitsetForIndex, DynamicSchemaOverlapEnd) {
     TestContainer container;
     container.seg().set_range(2, 4);
     container.seg().set_range(5, 7);
-    IndexRange rg(6, 8);
+    IndexRange rg(NumericIndex{ 6 }, NumericIndex{8});
     auto bitset = build_bitset_for_index<TestContainer, TimeseriesIndex>(container, rg, true, false, std::unique_ptr<util::BitSet>{});
     ASSERT_EQ((*bitset)[1], true);
     ASSERT_EQ(bitset->count(), 1);

--- a/cpp/arcticdb/pipeline/write_options.hpp
+++ b/cpp/arcticdb/pipeline/write_options.hpp
@@ -23,8 +23,7 @@ struct WriteOptions {
                 opt.dynamic_schema(),
                 opt.ignore_sort_order(),
                 opt.bucketize_dynamic(),
-                opt.max_num_buckets() > 0 ? size_t(opt.max_num_buckets()) : def.max_num_buckets,
-                opt.compact_incomplete_dedup_rows()
+                opt.max_num_buckets() > 0 ? size_t(opt.max_num_buckets()) : def.max_num_buckets
         };
     }
 
@@ -37,6 +36,6 @@ struct WriteOptions {
     bool ignore_sort_order = false;
     bool bucketize_dynamic = false;
     size_t max_num_buckets = 150;
-    bool compact_incomplete_dedup_rows = false;
+    bool sparsify_floats = false;
 };
 } //namespace arcticdb

--- a/cpp/arcticdb/storage/coalesced/multi_segment_header.hpp
+++ b/cpp/arcticdb/storage/coalesced/multi_segment_header.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <arcticdb/storage/key_segment_pair.hpp>
+#include <arcticdb/entity/stream_descriptor.hpp>
+#include <arcticdb/stream/index.hpp>
+#include <arcticdb/stream/schema.hpp>
+#include <arcticdb/entity/types.hpp>
+#include <arcticdb/storage/coalesced/multi_segment_utils.hpp>
+
+namespace arcticdb::storage {
+
+enum class MultiSegmentFields : uint32_t {
+    time_symbol,
+    stream_id,
+    version_id,
+    start_index,
+    end_index,
+    creation_ts,
+    content_hash,
+    index_type,
+    id_type,
+    key_type,
+    offset,
+    size
+};
+
+inline StreamDescriptor multi_segment_descriptor(StreamId stream_id) {
+    return stream_descriptor(std::move(stream_id), stream::RowCountIndex(), {
+        scalar_field(DataType::INT64, "time_symbol"),
+        scalar_field(DataType::UINT64, "stream_id"),
+        scalar_field(DataType::UINT64, "version_id"),
+        scalar_field(DataType::UINT64, "start_index"),
+        scalar_field(DataType::UINT64, "end_index"),
+        scalar_field(DataType::UINT64, "creation_ts"),
+        scalar_field(DataType::UINT64, "content_hash"),
+        scalar_field(DataType::UINT8, "index_type"),
+        scalar_field(DataType::UINT8, "id_type"),
+        scalar_field(DataType::UINT32, "key_type"),
+        scalar_field(DataType::UINT64, "offset"),
+        scalar_field(DataType::UINT64, "size")
+    });
+}
+
+template <typename FieldType>
+std::pair<size_t, size_t> get_offset_and_size(size_t pos, const SegmentInMemory& segment) {
+    auto result = std::make_pair(
+        segment.scalar_at<uint64_t>(pos, as_pos(FieldType::offset)).value(),
+        segment.scalar_at<uint64_t>(pos, as_pos(FieldType::size)).value());
+    ARCTICDB_DEBUG(log::storage(), "At pos {}, multi segment header found offset and size {}:{}", result.first, result.second);
+    return result;
+}
+
+class MultiSegmentHeader {
+    SegmentInMemory segment_;
+    std::mutex mutex_;
+public:
+    using TimeSymbolTag = ScalarTagType<DataTypeTag<DataType::INT64>>;
+
+    explicit MultiSegmentHeader(StreamId id) :
+        segment_(multi_segment_descriptor(std::move(id))) {}
+
+    explicit MultiSegmentHeader(SegmentInMemory segment) :
+        segment_(std::move(segment)) {
+    }
+
+    MultiSegmentHeader() = default;
+
+    void set_segment(SegmentInMemory&& segment) {
+        segment_ = std::move(segment);
+    }
+
+    void initalize(StreamId id, size_t num_rows) {
+        segment_ = SegmentInMemory{multi_segment_descriptor(std::move(id)), num_rows, false};
+    }
+
+    void add_key_and_offset(const AtomKey &key, uint64_t offset, uint64_t size) {
+        auto time_sym = time_symbol_from_key(key).data();
+        std::lock_guard lock(mutex_);
+        ARCTICDB_DEBUG(log::storage(), "Adding key {} with offset {} and {} bytes, time_sym: {}", key, offset, size, time_sym);
+        segment_.set_scalar(as_pos(MultiSegmentFields::time_symbol), time_sym);
+        set_key<MultiSegmentFields>(key, segment_);
+        segment_.set_scalar(as_pos(MultiSegmentFields::offset), offset);
+        segment_.set_scalar(as_pos(MultiSegmentFields::size), size);
+        segment_.end_row();
+    }
+
+    void sort() {
+        segment_.sort(0);
+    }
+
+    [[nodiscard]] const SegmentInMemory& segment() const {
+        return segment_;
+    }
+
+    SegmentInMemory&& detach_segment() {
+        return std::move(segment_);
+    }
+
+    [[nodiscard]] std::optional<std::pair<size_t, size_t>> get_offset_for_key(const AtomKey& key) const {
+        ARCTICDB_DEBUG(log::storage(), "Multi segment header searching for key {}", key);
+        const auto& time_symbol_column = segment_.column(0);
+        const auto time_symbol = time_symbol_from_key(key);
+        auto start_pos = std::lower_bound(time_symbol_column.begin<TimeSymbolTag>(), time_symbol_column.end<TimeSymbolTag>(), time_symbol.data());
+        if(start_pos == time_symbol_column.end<TimeSymbolTag>()) {
+            ARCTICDB_DEBUG(log::storage(), "Reached end of column looking for symbol {}", key);
+            return std::nullopt;
+        }
+
+        ARCTICDB_DEBUG(log::storage(), "Start pos for time symbol {} is {}", time_symbol.data(), start_pos.get_offset());
+        const auto& creation_ts_column = segment_.column(as_pos(MultiSegmentFields::creation_ts));
+        using CreationTsTag = ScalarTagType<DataTypeTag<DataType::UINT64>>;
+        auto creation_it = creation_ts_column.begin<CreationTsTag>();
+        creation_it.advance(start_pos.get_offset());
+        auto creation_ts_pos = std::lower_bound(creation_it, creation_ts_column.end<CreationTsTag>(), key.creation_ts());
+        if(creation_ts_pos == creation_ts_column.end<CreationTsTag>()) {
+            ARCTICDB_DEBUG(log::storage(), "Reached end of column looking for timestamp {}", key.creation_ts());
+            return std::nullopt;
+        }
+
+        ARCTICDB_DEBUG(log::storage(), "Starting at creation timestamp {} at offset {}", *creation_ts_pos, creation_ts_pos.get_offset());
+        while(*creation_ts_pos == static_cast<uint64_t>(key.creation_ts())) {
+            const auto creation_ts_offset = creation_ts_pos.get_offset();
+            if(const auto found_key = get_key<MultiSegmentFields>(creation_ts_offset, segment_); found_key == key) {
+                ARCTICDB_DEBUG(log::storage(), "Got key {} from multi-segment header", key);
+                return get_offset_and_size<MultiSegmentFields>(creation_ts_offset, segment_);
+            }
+
+            ++creation_ts_pos;
+        }
+        ARCTICDB_DEBUG(log::storage(), "Failed to find offset for key {}", key);
+        return std::nullopt;
+    }
+};
+
+} //namespace arcticdb::storage

--- a/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
+++ b/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <arcticdb/entity/key.hpp>
+#include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/entity/types.hpp>
+
+/*
+ * Contains similar functions to stream_utils.hpp but assumes that many keys are mixed in together, so we can't guarantee that
+ * either the id types or the index types will be the same, so we track those with a uint8_t column.
+ */
+namespace arcticdb {
+
+static constexpr uint64_t NumericMask = 0x7FFFFF;
+static constexpr uint64_t NumericFlag = uint64_t(1) << 31;
+static_assert(NumericFlag > NumericMask);
+
+template<typename StorageType>
+uint64_t get_symbol_prefix(const entity::StreamId& stream_id) {
+    using InternalType = uint64_t;
+    static_assert(sizeof(StorageType) <= sizeof(InternalType));
+    constexpr size_t end = sizeof(InternalType);
+    constexpr size_t begin = sizeof(InternalType) - sizeof(StorageType);
+    StorageType data{};
+    util::variant_match(stream_id,
+        [&data] (const entity::StringId& string_id) {
+            auto* target = reinterpret_cast<char*>(&data);
+            for(size_t p = begin, i = 0; p < end && i < string_id.size(); ++p, ++i) {
+                const auto c = string_id[i];
+                util::check(c < 127, "Out of bounds character {}", c);
+                target[p] = c;
+            }
+        },
+        [&data] (const entity::NumericId& numeric_id) {
+            util::check(numeric_id < static_cast<entity::NumericId>(NumericMask), "Numeric id too large: {}", numeric_id);
+            data &= NumericFlag;
+            data &= numeric_id;
+        }
+    );
+    return data;
+}
+
+enum class IdType : uint8_t {
+    String,
+    Numeric
+};
+
+struct TimeSymbol {
+    using IndexDataType = uint64_t;
+
+    IndexDataType data_ = 0UL;
+
+    TimeSymbol(const entity::StreamId& stream_id, entity::timestamp time) {
+        set_data(stream_id, time);
+    }
+
+    [[nodiscard]] IndexDataType data() const {
+        return data_;
+    }
+
+    friend bool operator<(const TimeSymbol& left, const TimeSymbol& right) {
+        return left.data() < right.data();
+    }
+
+private:
+    void set_data(const entity::StreamId& stream_id, entity::timestamp time) {
+        time <<= 32;
+        auto prefix = get_symbol_prefix<uint32_t>(stream_id);
+        data_ = time | prefix;
+    }
+};
+
+inline TimeSymbol time_symbol_from_key(const AtomKey& key) {
+    return {key.id(), key.creation_ts()};
+}
+template <typename FieldType>
+position_t as_pos(FieldType id_type) {
+    return static_cast<position_t>(id_type);
+}
+
+template <typename FieldType>
+StreamId get_id(position_t pos, const SegmentInMemory& segment) {
+    auto id_type = IdType(segment.scalar_at<uint8_t>(pos, as_pos(FieldType::id_type)).value());
+    const auto id = segment.scalar_at<uint64_t>(pos, as_pos(FieldType::stream_id));
+    switch(id_type) {
+    case IdType::String:
+        return StreamId{std::string{segment.const_string_pool().get_const_view(id.value())}};
+    case IdType::Numeric:
+        return StreamId{static_cast<NumericId>(id.value())};
+    default:
+        util::raise_rte("Unknown id type {}", static_cast<int>(id_type));
+    }
+}
+
+template <typename FieldType>
+IndexValue get_index(position_t pos, FieldType field, const SegmentInMemory& segment) {
+    auto index_type = VariantType(segment.scalar_at<uint8_t>(pos, as_pos(FieldType::index_type)).value());
+    const auto index = segment.scalar_at<uint64_t>(pos, as_pos(field));
+    switch(index_type) {
+    case VariantType::STRING_TYPE:
+        return StreamId{std::string{segment.const_string_pool().get_const_view(index.value())}};
+    case VariantType::NUMERIC_TYPE:
+        return StreamId{static_cast<NumericId>(index.value())};
+    default:
+        util::raise_rte("Unknown index type {} in multi_segment", static_cast<int>(index_type));
+    }
+}
+
+template <typename FieldType>
+entity::AtomKey get_key(position_t pos, const SegmentInMemory& segment) {
+    const auto id = get_id<FieldType>(pos, segment);
+    const auto key_type_num = segment.scalar_at<int32_t>(pos, as_pos(FieldType::key_type)).value();
+    const auto key_type = entity::key_type_from_int(key_type_num);
+    const auto version_id = segment.scalar_at<uint64_t>(pos, as_pos(FieldType::version_id)).value();
+    const auto content_hash = segment.scalar_at<uint64_t>(pos, as_pos(FieldType::content_hash)).value();
+    const auto creation_ts = segment.scalar_at<uint64_t>(pos, as_pos(FieldType::creation_ts)).value();
+    const auto start_index = get_index(pos, FieldType::start_index, segment);
+    const auto end_index = get_index(pos, FieldType::end_index, segment);
+
+    auto key = atom_key_builder()
+        .version_id(version_id)
+        .content_hash(content_hash)
+        .creation_ts(creation_ts)
+        .start_index(start_index)
+        .end_index(end_index)
+        .build(id, key_type);
+
+    return key;
+}
+
+template <typename FieldType>
+void set_index(const IndexValue &index, FieldType field, SegmentInMemory& segment, bool set_type) {
+    util::variant_match(index,
+        [&segment, field, set_type](const StringIndex &string_index) {
+            auto offset = segment.string_pool().get(std::string_view(string_index));
+            segment.set_scalar<uint64_t>(as_pos(field), offset.offset());
+            if(set_type)
+                segment.set_scalar<uint8_t>(as_pos(FieldType::index_type),
+                                         static_cast<uint8_t>(VariantType::STRING_TYPE));
+        },
+        [&segment, field, set_type](const NumericIndex &numeric_index) {
+            segment.set_scalar<uint64_t>(as_pos(field), numeric_index);
+            if(set_type)
+                segment.set_scalar<uint8_t>(as_pos(FieldType::index_type),
+                                         static_cast<uint8_t>(VariantType::NUMERIC_TYPE));
+        });
+}
+
+template <typename FieldType>
+void set_id(const AtomKey &key, SegmentInMemory& segment) {
+    util::variant_match(key.id(),
+        [&segment](const StringId &string_id) {
+            auto offset = segment.string_pool().get(std::string_view(string_id));
+            segment.set_scalar<uint64_t>(as_pos(FieldType::stream_id), offset.offset());
+            segment.set_scalar<uint8_t>(as_pos(FieldType::id_type),
+                                         static_cast<uint8_t>(IdType::String));
+        },
+        [&segment](const NumericId &numeric_id) {
+            segment.set_scalar<uint64_t>(as_pos(FieldType::stream_id), numeric_id);
+            segment.set_scalar<uint8_t>(as_pos(FieldType::id_type),
+                                         static_cast<uint8_t>(IdType::Numeric));
+        });
+}
+
+template <typename FieldType>
+void set_key(const AtomKey& key, SegmentInMemory& segment) {
+    set_id<FieldType>(key, segment);
+    segment.set_scalar(as_pos(FieldType::version_id), key.version_id());
+    set_index(key.start_index(), FieldType::start_index, segment, true);
+    set_index(key.end_index(), FieldType::end_index, segment, false);
+    segment.set_scalar(as_pos(FieldType::creation_ts), key.creation_ts());
+    segment.set_scalar(as_pos(FieldType::content_hash), key.content_hash());
+    segment.set_scalar<int32_t>(as_pos(FieldType::key_type), static_cast<int32_t>(key.type()));
+}
+
+} //namespace arcticdb

--- a/cpp/arcticdb/storage/config_cache.hpp
+++ b/cpp/arcticdb/storage/config_cache.hpp
@@ -78,7 +78,7 @@ class ConfigCache {
         auto &descriptor = *maybe_descriptor;
 
         util::check(!descriptor.storage_ids_.empty(), "Can't configure library with no storage ids");
-        std::vector<std::unique_ptr<Storage>> storages;
+        std::vector<std::shared_ptr<Storage>> storages;
         for (const auto& storage_name : descriptor.storage_ids_) {
             // Otherwise see if we have the storage config.
             arcticdb::proto::storage::VariantStorage storage_conf;

--- a/cpp/arcticdb/storage/file/file_store.hpp
+++ b/cpp/arcticdb/storage/file/file_store.hpp
@@ -1,0 +1,147 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/entity/types.hpp>
+#include <arcticdb/codec/codec.hpp>
+#include <arcticdb/storage/coalesced/multi_segment_header.hpp>
+#include <arcticdb/codec/default_codecs.hpp>
+#include <arcticdb/version/version_core.hpp>
+#include <arcticdb/storage/storage.hpp>
+#include <arcticdb/storage/storage_options.hpp>
+#include <arcticdb/util/optional_defaults.hpp>
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/codec/segment.hpp>
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/storage/file/mapped_file_storage.hpp>
+#include <arcticdb/storage/single_file_storage.hpp>
+#include <arcticdb/storage/library.hpp>
+#include <arcticdb/storage/library_path.hpp>
+#include <arcticdb/stream/piloted_clock.hpp>
+#include <arcticdb/version/version_core.hpp>
+#include <arcticdb/entity/serialized_key.hpp>
+
+namespace arcticdb {
+
+
+size_t max_data_size(
+    const std::vector<std::tuple<stream::StreamSink::PartialKey, SegmentInMemory, FrameSlice>>& items,
+    const arcticdb::proto::encoding::VariantCodec& codec_opts,
+    EncodingVersion encoding_version) {
+    auto max_file_size = 0UL;
+    for(const auto& item : items) {
+        const auto& [pk, seg, slice] = item;
+        max_file_size += max_compressed_size_dispatch(seg, codec_opts, encoding_version).max_compressed_bytes_;
+    }
+    return max_file_size;
+}
+
+struct FileFooter {
+    uint64_t index_offset_;
+    uint64_t footer_offset_;
+};
+
+void write_dataframe_to_file_internal(
+    const StreamId &stream_id,
+    const std::shared_ptr<pipelines::InputTensorFrame> &frame,
+    const std::string& path,
+    const WriteOptions &options,
+    const arcticdb::proto::encoding::VariantCodec &codec_opts,
+    EncodingVersion encoding_version
+) {
+    ARCTICDB_SAMPLE(WriteDataFrameToFile, 0)
+    py::gil_scoped_release release_gil;
+    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_dataframe_to_file");
+    frame->set_bucketize_dynamic(options.bucketize_dynamic);
+    auto slicing = get_slicing_policy(options, *frame);
+    auto partial_key = pipelines::IndexPartialKey{frame->desc.id(), VersionId{0}};
+    ARCTICDB_SUBSAMPLE_DEFAULT(SliceFrame)
+    auto slices = slice(*frame, slicing);
+    ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
+
+    auto slice_and_rowcount = get_slice_and_rowcount(slices);
+    const size_t write_window = ConfigsMap::instance()->get_int("VersionStore.BatchWriteWindow",
+                                                              static_cast<int64_t>(2 * async::TaskScheduler::instance()->io_thread_count()));
+    auto key_seg_futs = folly::collect(folly::window(std::move(slice_and_rowcount),
+         [frame, slicing, key = std::move(partial_key),
+             sparsify_floats = options.sparsify_floats](auto &&slice) {
+             return async::submit_cpu_task(pipelines::WriteToSegmentTask(
+                 frame,
+                 slice.first,
+                 slicing,
+                 get_partial_key_gen(frame, key),
+                 slice.second,
+                 frame->index,
+                 sparsify_floats));
+         },
+         write_window)).via(&async::io_executor());
+    auto segments = std::move(key_seg_futs).get();
+
+    auto data_size = max_data_size(segments, codec_opts, encoding_version);
+    ARCTICDB_DEBUG(log::version(), "Estimated max data size: {}", data_size);
+    auto config = storage::file::pack_config(path, data_size, segments.size(), stream_id, stream::get_descriptor_from_index(frame->index), encoding_version, codec_opts);
+
+    storage::LibraryPath lib_path{std::string{"file"}, fmt::format("{}", stream_id)};
+    auto library = create_library(lib_path, storage::OpenMode::WRITE, {std::move(config)});
+    auto store = std::make_shared<async::AsyncStore<PilotedClock>>(library, codec_opts, encoding_version);
+    auto dedup_map = std::make_shared<DeDupMap>();
+    size_t batch_size = ConfigsMap::instance()->get_int("FileWrite.BatchSize", 50);
+    auto index_fut = folly::collect(folly::window(segments, [store, dedup_map] (auto key_seg) {
+        return store->async_write(key_seg, dedup_map);
+    }, batch_size)).via(&async::io_executor())
+    .thenValue([&frame, stream_id, store] (auto&& slice_and_keys) {
+        return index::write_index(frame, std::forward<decltype(slice_and_keys)>(slice_and_keys), IndexPartialKey{stream_id, VersionId{0}}, store);
+    });
+    // TODO include key size and key offset in max size calculation
+    auto index_key = std::move(index_fut).get();
+    auto serialized_key = to_serialized_key(index_key);
+    auto single_file_store = library->get_single_file_storage().value();
+    const auto offset = single_file_store->get_offset();
+    single_file_store->write_raw(reinterpret_cast<const uint8_t*>(serialized_key.c_str()), serialized_key.size());
+    single_file_store->finalize(storage::KeyData{offset, serialized_key.size()});
+}
+
+version_store::ReadVersionOutput read_dataframe_from_file_internal(
+        const StreamId& stream_id,
+        const std::string& path,
+        ReadQuery& read_query,
+        const ReadOptions& read_options,
+        const arcticdb::proto::encoding::VariantCodec &codec_opts) {
+    auto config = storage::file::pack_config(path, codec_opts);
+    storage::LibraryPath lib_path{std::string{"file"}, fmt::format("{}", stream_id)};
+    auto library = create_library(lib_path, storage::OpenMode::WRITE, {std::move(config)});
+    auto store = std::make_shared<async::AsyncStore<PilotedClock>>(library, codec::default_lz4_codec(), EncodingVersion::V1);
+
+    auto single_file_storage = library->get_single_file_storage().value();
+
+    using namespace arcticdb::storage;
+    const auto data_end = single_file_storage->get_bytes() - sizeof(KeyData);
+    auto key_data = *reinterpret_cast<KeyData*>(single_file_storage->read_raw(data_end, sizeof(KeyData)));
+
+    auto index_key = from_serialized_atom_key(single_file_storage->read_raw(key_data.key_offset_, key_data.key_size_), KeyType::TABLE_INDEX);
+    VersionedItem versioned_item(index_key);
+    const auto header_offset = key_data.key_offset_ + key_data.key_size_;
+    ARCTICDB_DEBUG(log::storage(), "Got header offset at {}", header_offset);
+    single_file_storage->load_header(header_offset, data_end - header_offset);
+
+    using namespace arcticdb::pipelines;
+    auto pipeline_context = std::make_shared<PipelineContext>();
+
+    pipeline_context->stream_id_ = stream_id;
+
+    version_store::read_indexed_keys_to_pipeline(store, pipeline_context, versioned_item, read_query, read_options);
+
+    version_store::modify_descriptor(pipeline_context, read_options);
+    generate_filtered_field_descriptors(pipeline_context, read_query.columns);
+    ARCTICDB_DEBUG(log::version(), "Fetching data to frame");
+    auto buffers = std::make_shared<BufferHolder>();
+    auto frame = version_store::do_direct_read_or_process(store, read_query, read_options, pipeline_context, buffers);
+    ARCTICDB_DEBUG(log::version(), "Reduce and fix columns");
+    reduce_and_fix_columns(pipeline_context, frame, read_options);
+    FrameAndDescriptor frame_and_descriptor{frame, timeseries_descriptor_from_pipeline_context(pipeline_context, {}, pipeline_context->bucketize_dynamic_), {}, buffers};
+    return {std::move(versioned_item), std::move(frame_and_descriptor)};
+}
+} //namespace arcticdb

--- a/cpp/arcticdb/storage/file/mapped_file_storage.cpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.cpp
@@ -1,0 +1,155 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+#include <arcticdb/storage/file/mapped_file_storage.hpp>
+
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/entity/atom_key.hpp>
+#include <arcticdb/storage/constants.hpp>
+#include <arcticdb/storage/library_path.hpp>
+#include <arcticdb/storage/open_mode.hpp>
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/storage/storage.hpp>
+#include <arcticdb/storage/storage_options.hpp>
+#include <arcticdb/codec/codec.hpp>
+#include <arcticdb/entity/serialized_key.hpp>
+
+namespace arcticdb::storage::file {
+
+MappedFileStorage::MappedFileStorage(const LibraryPath &lib, OpenMode mode, Config conf) :
+    SingleFileStorage(lib, mode),
+    config_(std::move(conf)) {
+    init();
+}
+
+void MappedFileStorage::do_write_raw(const uint8_t* data, size_t bytes) {
+    ARCTICDB_DEBUG(log::storage(), "Writing {} bytes to mapped file storage at offset {}", bytes, offset_);
+    memcpy(file_.data() + offset_, data, bytes);
+    offset_ += bytes;
+}
+
+void MappedFileStorage::init() {
+    ARCTICDB_DEBUG(log::storage(), "Creating file with config {}", config_.DebugString());
+    if (config_.bytes() > 0) {
+        ARCTICDB_DEBUG(log::storage(), "Creating new mapped file storage at path {}", config_.path());
+        multi_segment_header_.initalize(StreamId{NumericId{0}}, config_.items_count());
+        auto data_size = config_.bytes() + max_compressed_size_dispatch(multi_segment_header_.segment(),
+            config_.codec_opts(),
+            EncodingVersion{
+            static_cast<uint16_t>(config_.encoding_version())}).max_compressed_bytes_;
+        StreamId id = config_.has_str_id() ? StreamId{} : NumericId{};
+        data_size += entity::max_key_size(id, IndexDescriptor{config_.index()});
+        file_.create_file(config_.path(), data_size);
+    } else {
+        ARCTICDB_DEBUG(log::storage(), "Opening existing mapped file storage at path {}", config_.path());
+        file_.open_file(config_.path());
+    }
+}
+
+SegmentInMemory MappedFileStorage::read_segment(size_t offset, size_t bytes) const  {
+    auto index_segment = Segment::from_bytes(file_.data() + offset, bytes);
+    return decode_segment(std::move(index_segment));
+}
+
+void MappedFileStorage::do_load_header(size_t header_offset, size_t header_size) {
+    auto header = read_segment(header_offset, header_size);
+    ARCTICDB_DEBUG(log::storage(), "Loaded mapped file header of size {}", header.row_count());
+    multi_segment_header_.set_segment(std::move(header));
+}
+
+uint64_t MappedFileStorage::get_data_offset(const Segment& seg, size_t header_size) {
+    ARCTICDB_SAMPLE(MappedFileStorageGetOffset, 0)
+    std::lock_guard lock{offset_mutex_};
+    const auto segment_size = seg.total_segment_size(header_size);
+    ARCTICDB_DEBUG(log::storage(), "Mapped file storage returning offset {} and adding {} bytes", offset_, segment_size);
+    const auto previous_offset = offset_;
+    offset_ += segment_size;
+    return previous_offset;
+}
+
+uint64_t MappedFileStorage::write_segment(Segment&& seg) {
+    auto segment = std::move(seg);
+    const auto header_size = segment.segment_header_bytes_size();
+    auto offset = get_data_offset(segment, header_size);
+    auto* data = file_.data() + offset;
+    ARCTICDB_SUBSAMPLE(FileStorageMemCpy, 0)
+    ARCTICDB_DEBUG(log::storage(), "Mapped file storage writing segment of size {} at offset {}",  segment.total_segment_size(header_size), offset);
+    segment.write_to(data, header_size);
+    return offset;
+}
+
+void MappedFileStorage::do_write(Composite<KeySegmentPair>&& kvs) {
+    ARCTICDB_SAMPLE(MappedFileStorageWriteValues, 0)
+    auto key_values = std::move(kvs);
+    key_values.broadcast([this] (auto key_seg) {
+        const auto size = key_seg.segment().total_segment_size();
+        const auto offset = write_segment(std::move(key_seg.segment()));
+        multi_segment_header_.add_key_and_offset(key_seg.atom_key(), offset, size);
+    });
+}
+
+void MappedFileStorage::do_update(Composite<KeySegmentPair>&&, UpdateOpts) {
+    util::raise_rte("Update not implemented for file storages");
+}
+
+void MappedFileStorage::do_read(Composite<VariantKey>&& ks, const ReadVisitor& visitor, storage::ReadKeyOpts) {
+    ARCTICDB_SAMPLE(MappedFileStorageRead, 0)
+    auto keys = std::move(ks);
+    keys.broadcast([&visitor, this] (const auto& key) {
+        auto maybe_offset = multi_segment_header_.get_offset_for_key(to_atom(key));
+        util::check(maybe_offset.has_value(), "Failed to find key {} in file", key);
+        auto [offset, bytes] = std::move(maybe_offset.value());
+        auto segment = Segment::from_bytes(file_.data() + offset, bytes);
+        visitor(key, std::move(segment));
+    });
+}
+
+bool MappedFileStorage::do_key_exists(const VariantKey& key) {
+    ARCTICDB_SAMPLE(MappedFileStorageKeyExists, 0)
+    return multi_segment_header_.get_offset_for_key(to_atom(key)) != std::nullopt;
+}
+
+void MappedFileStorage::do_remove(Composite<VariantKey>&&, RemoveOpts) {
+    util::raise_rte("Remove not implemented for file storages");
+}
+
+bool MappedFileStorage::do_fast_delete() {
+    util::raise_rte("Fast delete not implemented for file storage - just delete the file");
+}
+
+void MappedFileStorage::do_finalize(KeyData key_data)  {
+    multi_segment_header_.sort();
+    auto header_segment = encode_dispatch(multi_segment_header_.detach_segment(),
+                                          config_.codec_opts(),
+                                          EncodingVersion{static_cast<uint16_t>(config_.encoding_version())});
+    write_segment(std::move(header_segment));
+    auto pos = reinterpret_cast<KeyData*>(file_.data() + offset_);
+    *pos = key_data;
+    ARCTICDB_DEBUG(log::storage(), "Finalizing mapped file, writing key data {}", *pos);
+    offset_ += sizeof(KeyData);
+    file_.truncate(offset_);
+}
+
+uint8_t* MappedFileStorage::do_read_raw(size_t offset, size_t bytes) {
+    util::check(offset + bytes <= file_.bytes(), "Can't read {} bytes from {} in file of size {},",
+                                                 bytes, offset, file_.bytes());
+    ARCTICDB_DEBUG(log::storage(), "Mapped file storage returning raw offset {} for {} bytes", offset, bytes);
+    return file_.data() + offset;
+}
+
+void MappedFileStorage::do_iterate_type(KeyType, const IterateTypeVisitor&, const std::string&) {
+   util::raise_rte("Iterate type not implemented for file storage");
+}
+
+size_t MappedFileStorage::do_get_offset() const {
+    return offset_;
+}
+
+size_t MappedFileStorage::do_get_bytes() const {
+    return file_.bytes();
+}
+} // namespace arcticdb::storage
+

--- a/cpp/arcticdb/storage/file/mapped_file_storage.hpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.hpp
@@ -1,0 +1,110 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/storage/single_file_storage.hpp>
+#include <arcticdb/storage/storage_factory.hpp>
+#include <arcticdb/entity/protobufs.hpp>
+#include <arcticdb/util/composite.hpp>
+#include <arcticdb/util/memory_mapped_file.hpp>
+#include <arcticdb/storage/coalesced/multi_segment_header.hpp>
+
+namespace fs = std::filesystem;
+
+namespace arcticdb::storage::file {
+
+class MappedFileStorage final : public SingleFileStorage {
+  public:
+    using Config = arcticdb::proto::mapped_file_storage::Config;
+
+    MappedFileStorage(const LibraryPath &lib, OpenMode mode, Config conf);
+
+    ~MappedFileStorage() override = default;
+
+  private:
+    void do_write_raw(const uint8_t* data, size_t bytes) override;
+
+    void do_write(Composite<KeySegmentPair>&& kvs) override;
+
+    [[noreturn]] void do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts) override;
+
+    void do_read(Composite<VariantKey>&& ks, const ReadVisitor& visitor, storage::ReadKeyOpts opts) override;
+
+    [[noreturn]] void do_remove(Composite<VariantKey>&& ks, RemoveOpts opts) override;
+
+    bool do_supports_prefix_matching() const override {
+        return false;
+    };
+
+    std::string do_key_path(const VariantKey&) const override { return {}; }
+
+    [[noreturn]] bool do_fast_delete() override;
+
+    [[noreturn]] void do_iterate_type(KeyType key_type, const IterateTypeVisitor& visitor, const std::string &prefix) override;
+
+    bool do_key_exists(const VariantKey & key) override;
+
+    size_t do_get_offset() const override;
+
+    void do_finalize(KeyData key_data) override;
+
+    uint64_t get_data_offset(const Segment& seg, size_t header_size);
+
+    void do_load_header(size_t header_offset, size_t header_size) override;
+
+    uint64_t write_segment(Segment&& seg);
+
+    uint8_t* do_read_raw(size_t offset, size_t bytes) override;
+
+    size_t do_get_bytes() const override;
+
+    void init();
+
+    SegmentInMemory read_segment(size_t offset, size_t bytes) const;
+
+    std::mutex offset_mutex_;
+    size_t offset_ = 0UL;
+    Config config_;
+    MemoryMappedFile file_;
+    storage::MultiSegmentHeader multi_segment_header_;
+};
+
+inline arcticdb::proto::storage::VariantStorage pack_config(
+        const std::string& path,
+        size_t file_size,
+        size_t items_count,
+        const StreamId& id,
+        const IndexDescriptor& index_desc,
+        EncodingVersion encoding_version,
+        const arcticdb::proto::encoding::VariantCodec& codec_opts) {
+    arcticdb::proto::storage::VariantStorage output;
+    arcticdb::proto::mapped_file_storage::Config cfg;
+    cfg.set_path(path);
+    cfg.set_bytes(file_size);
+    cfg.set_items_count(items_count);
+    util::variant_match(id,
+                            [&cfg] (const StringId& str) { cfg.set_str_id(str); },
+                            [&cfg] (const NumericId& n) { cfg.set_num_id(n); });
+    cfg.mutable_index()->CopyFrom(index_desc.proto()),
+    cfg.set_encoding_version(static_cast<uint32_t>(encoding_version));
+    cfg.mutable_codec_opts()->CopyFrom(codec_opts);
+    util::pack_to_any(cfg, *output.mutable_config());
+    return output;
+}
+
+inline arcticdb::proto::storage::VariantStorage pack_config(
+    const std::string& path,
+    const arcticdb::proto::encoding::VariantCodec& codec_opts) {
+    arcticdb::proto::storage::VariantStorage output;
+    arcticdb::proto::mapped_file_storage::Config cfg;
+    cfg.set_path(path);
+    cfg.mutable_codec_opts()->CopyFrom(codec_opts);
+    util::pack_to_any(cfg, *output.mutable_config());
+    return output;
+}
+} //namespace arcticdb::storage::file

--- a/cpp/arcticdb/storage/file/mapped_file_storage.hpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.hpp
@@ -43,7 +43,7 @@ class MappedFileStorage final : public SingleFileStorage {
 
     std::string do_key_path(const VariantKey&) const override { return {}; }
 
-    [[noreturn]] bool do_fast_delete() override;
+    bool do_fast_delete() override;
 
     [[noreturn]] void do_iterate_type(KeyType key_type, const IterateTypeVisitor& visitor, const std::string &prefix) override;
 

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -16,6 +16,7 @@
 #include <arcticdb/storage/open_mode.hpp>
 #include <arcticdb/storage/storages.hpp>
 #include <arcticdb/storage/failure_simulation.hpp>
+#include <arcticdb/storage/single_file_storage.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/composite.hpp>
 
@@ -23,6 +24,7 @@
 #include <folly/concurrency/ConcurrentHashMap.h>
 #include <boost/core/noncopyable.hpp>
 #include <filesystem>
+
 
 
 #ifdef _WIN32
@@ -109,6 +111,10 @@ class Library {
         storages_->remove(std::move(ks), opts);
     }
 
+    std::optional<std::shared_ptr<SingleFileStorage>> get_single_file_storage() const {
+        return storages_->get_single_file_storage();
+    }
+
     bool fast_delete() {
         return storages_->fast_delete();
     }
@@ -161,8 +167,8 @@ class Library {
     bool storage_fallthrough_ = false;
 };
 
-inline Library create_library(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::VariantStorage>& storage_configs) {
-    return Library{library_path, create_storages(library_path, mode, storage_configs)};
+inline std::shared_ptr<Library> create_library(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::VariantStorage>& storage_configs) {
+    return std::make_shared<Library>(library_path, create_storages(library_path, mode, storage_configs));
 }
 
 }

--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -47,7 +47,7 @@ class DefaultStringViewable : public std::shared_ptr<std::string> {
     DefaultStringViewable operator=(const DefaultStringViewable&) = delete;
 
   private:
-    HashedValue hash_;
+   HashedValue hash_;
 };
 
 inline bool operator==(const DefaultStringViewable &l, const DefaultStringViewable &r) {

--- a/cpp/arcticdb/storage/single_file_storage.hpp
+++ b/cpp/arcticdb/storage/single_file_storage.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <arcticdb/storage/storage.hpp>
+
+namespace arcticdb::storage {
+
+struct KeyData {
+    uint64_t key_offset_;
+    uint64_t key_size_;
+};
+
+class SingleFileStorage : public Storage {
+public:
+
+    SingleFileStorage(const LibraryPath &lib, OpenMode mode) :
+        Storage(lib, mode) {}
+
+    void write_raw(const uint8_t* data, size_t bytes) {
+        do_write_raw(data, bytes);
+    }
+
+    uint8_t* read_raw(size_t offset, size_t bytes) {
+        return do_read_raw(offset, bytes);
+    }
+
+    size_t get_offset() const {
+        return do_get_offset();
+    }
+
+    size_t get_bytes() const {
+        return do_get_bytes();
+    }
+
+    void finalize(KeyData key_data) {
+        do_finalize(key_data);
+    }
+
+    void load_header(size_t header_offset, size_t header_size) {
+        return do_load_header(header_offset, header_size);
+    }
+
+private:
+    virtual uint8_t* do_read_raw(size_t offset, size_t bytes) = 0;
+
+    virtual size_t do_get_bytes() const = 0;
+
+    virtual void do_write_raw(const uint8_t* data, size_t bytes) = 0;
+
+    virtual size_t do_get_offset() const = 0;
+
+    virtual void do_finalize(KeyData) = 0;
+
+    virtual void do_load_header(size_t header_offset, size_t header_size) = 0;
+};
+} //namespace arcticdb::storage
+
+
+namespace fmt {
+template<>
+struct formatter<arcticdb::storage::KeyData> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    auto format(const arcticdb::storage::KeyData &k, FormatContext &ctx) const {
+        return format_to(ctx.out(), "{}:{}", k.key_offset_, k.key_size_);
+    }
+};
+
+} //namespace fmt
+

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -12,54 +12,47 @@
 #include <arcticdb/storage/azure/azure_storage.hpp>
 #include <arcticdb/storage/s3/s3_storage.hpp>
 #include <arcticdb/storage/s3/nfs_backed_storage.hpp>
+#include <arcticdb/storage/file/mapped_file_storage.hpp>
 #include <arcticdb/util/pb_util.hpp>
 
 namespace arcticdb::storage {
 
-std::unique_ptr<Storage> create_storage(
+std::shared_ptr<Storage> create_storage(
     const LibraryPath &library_path,
     OpenMode mode,
     const arcticdb::proto::storage::VariantStorage &storage_descriptor) {
 
-    std::unique_ptr<Storage> storage;
+    std::shared_ptr<Storage> storage;
     auto type_name = util::get_arcticdb_pb_type_name(storage_descriptor.config());
 
     if (type_name == s3::S3Storage::Config::descriptor()->full_name()) {
         s3::S3Storage::Config s3_config;
         storage_descriptor.config().UnpackTo(&s3_config);
-        storage = std::make_unique<s3::S3Storage>(
-                s3::S3Storage(library_path, mode, s3_config)
-        );
+        storage = std::make_shared<s3::S3Storage>(library_path, mode, s3_config);
     } else if (type_name == lmdb::LmdbStorage::Config::descriptor()->full_name()) {
         lmdb::LmdbStorage::Config lmbd_config;
         storage_descriptor.config().UnpackTo(&lmbd_config);
-        storage = std::make_unique<lmdb::LmdbStorage>(
-                lmdb::LmdbStorage(library_path, mode, lmbd_config)
-        );
+        storage = std::make_shared<lmdb::LmdbStorage>(library_path, mode, lmbd_config);
     } else if (type_name == mongo::MongoStorage::Config::descriptor()->full_name()) {
         mongo::MongoStorage::Config mongo_config;
         storage_descriptor.config().UnpackTo(&mongo_config);
-        storage = std::make_unique<mongo::MongoStorage>(
-                mongo::MongoStorage(library_path, mode, mongo_config)
-        );
+        storage = std::make_shared<mongo::MongoStorage>(library_path, mode, mongo_config);
     } else if (type_name == memory::MemoryStorage::Config::descriptor()->full_name()) {
         memory::MemoryStorage::Config memory_config;
         storage_descriptor.config().UnpackTo(&memory_config);
-        storage = std::make_unique<memory::MemoryStorage>(
-                memory::MemoryStorage(library_path, mode, memory_config)
-        );
+        storage = std::make_shared<memory::MemoryStorage>(library_path, mode, memory_config);
     } else if (type_name == nfs_backed::NfsBackedStorage::Config::descriptor()->full_name()) {
         nfs_backed::NfsBackedStorage::Config nfs_backed_config;
         storage_descriptor.config().UnpackTo(&nfs_backed_config);
-        storage = std::make_unique<nfs_backed::NfsBackedStorage>(
-                nfs_backed::NfsBackedStorage(library_path, mode, nfs_backed_config)
-        );
+        storage = std::make_shared<nfs_backed::NfsBackedStorage>(library_path, mode, nfs_backed_config);
     } else if (type_name == azure::AzureStorage::Config::descriptor()->full_name()) {
         azure::AzureStorage::Config azure_config;
         storage_descriptor.config().UnpackTo(&azure_config);
-        storage = std::make_unique<azure::AzureStorage  >(
-            azure::AzureStorage(library_path, mode, azure_config)
-        );
+        storage = std::make_shared<azure::AzureStorage >(library_path, mode, azure_config);
+    } else if (type_name == file::MappedFileStorage::Config::descriptor()->full_name()) {
+        file::MappedFileStorage::Config mapped_config;
+        storage_descriptor.config().UnpackTo(&mapped_config);
+        storage = std::make_shared<file::MappedFileStorage >(library_path, mode, mapped_config);
     } else
         throw std::runtime_error(fmt::format("Unknown config type {}", type_name));
 

--- a/cpp/arcticdb/storage/storage_factory.hpp
+++ b/cpp/arcticdb/storage/storage_factory.hpp
@@ -16,7 +16,7 @@
 namespace arcticdb {
     namespace storage {
 
-        std::unique_ptr<Storage> create_storage(
+        std::shared_ptr<Storage> create_storage(
                 const LibraryPath& library_path,
                 OpenMode mode,
                 const arcticdb::proto::storage::VariantStorage &storage_config);

--- a/cpp/arcticdb/storage/test/test_embedded.cpp
+++ b/cpp/arcticdb/storage/test/test_embedded.cpp
@@ -94,7 +94,7 @@ TEST_P(SimpleTestSuite, ConstructDestruct) {
 
 TEST_P(SimpleTestSuite, Example) {
     std::unique_ptr<as::Storage> storage = GetParam().new_backend();
-    ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(999);
+    ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(NumericId{999});
 
     as::KeySegmentPair kv(k);
     kv.segment().header().set_start_ts(1234);
@@ -182,7 +182,7 @@ TEST_P(SimpleTestSuite, Strings) {
 
     std::unique_ptr<as::Storage> storage = GetParam().new_backend();
 
-    ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(999);
+    ac::entity::AtomKey k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(NumericId{999});
     auto save_k = k;
     as::KeySegmentPair kv(std::move(k), std::move(seg));
     kv.segment().header().set_start_ts(1234);

--- a/cpp/arcticdb/storage/test/test_mongo_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_mongo_storage.cpp
@@ -91,7 +91,7 @@ TEST(MongoStorage, ClientSession) {
                          });
     ASSERT_TRUE(executed);
 
-    ac::entity::AtomKey numeric_k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::STREAM_GROUP>(999);
+    ac::entity::AtomKey numeric_k = ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::STREAM_GROUP>(ac::entity::NumericId{999});
     as::KeySegmentPair numeric_kv(numeric_k);
     numeric_kv.segment().header().set_start_ts(7890);
 

--- a/cpp/arcticdb/storage/test/test_multi_segment.cpp
+++ b/cpp/arcticdb/storage/test/test_multi_segment.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+#include <arcticdb/storage/coalesced/multi_segment_aggregator.hpp>
+
+
+TEST(MultiSegment, Roundtrip) {
+
+}

--- a/cpp/arcticdb/stream/index.hpp
+++ b/cpp/arcticdb/stream/index.hpp
@@ -101,7 +101,7 @@ public:
     template<typename SegmentType>
     static IndexValue start_value_for_segment(const SegmentType &segment) {
         if (segment.row_count() == 0)
-            return {0};
+            return { NumericIndex{0} };
         auto first_ts = segment.template scalar_at<timestamp>(0, 0).value();
         return {first_ts};
     }
@@ -110,7 +110,7 @@ public:
     static IndexValue end_value_for_segment(const SegmentType &segment) {
         auto row_count = segment.row_count();
         if (row_count == 0)
-            return {0};
+            return { NumericIndex{0} };
         auto last_ts = segment.template scalar_at<timestamp>(row_count - 1, 0).value();
         return {last_ts};
     }
@@ -118,7 +118,7 @@ public:
     template<typename SegmentType>
     static IndexValue start_value_for_keys_segment(const SegmentType &segment) {
         if (segment.row_count() == 0)
-            return {0};
+            return { NumericIndex{0} };
         auto start_index_id = int(pipelines::index::Fields::start_index);
         auto first_ts = segment.template scalar_at<timestamp>(0, start_index_id).value();
         return {first_ts};
@@ -128,7 +128,7 @@ public:
     static IndexValue end_value_for_keys_segment(const SegmentType &segment) {
         auto row_count = segment.row_count();
         if (row_count == 0)
-            return {0};
+            return { NumericIndex{0} };
         auto end_index_id = int(pipelines::index::Fields::end_index);
         auto last_ts = segment.template scalar_at<timestamp>(row_count - 1, end_index_id).value();
         return {last_ts};
@@ -207,7 +207,7 @@ public:
     template<typename SegmentType>
     static IndexValue start_value_for_keys_segment(const SegmentType &segment) {
         if (segment.row_count() == 0)
-            return {0};
+            return { NumericIndex{0} };
         auto start_index_id = int(pipelines::index::Fields::start_index);
         auto string_index = segment.string_at(0, start_index_id).value();
         return {std::string{string_index}};
@@ -217,7 +217,7 @@ public:
     static IndexValue end_value_for_keys_segment(const SegmentType &segment) {
         auto row_count = segment.row_count();
         if (row_count == 0)
-            return {0};
+            return { NumericIndex{0} };
         auto end_index_id = int(pipelines::index::Fields::end_index);
         auto string_index = segment.string_at(row_count - 1, end_index_id).value();
         return {std::string{string_index}};

--- a/cpp/arcticdb/stream/piloted_clock.cpp
+++ b/cpp/arcticdb/stream/piloted_clock.cpp
@@ -1,0 +1,5 @@
+#include <arcticdb/stream/piloted_clock.hpp>
+
+namespace arcticdb {
+std::atomic<entity::timestamp> PilotedClock::time_;
+}

--- a/cpp/arcticdb/stream/piloted_clock.hpp
+++ b/cpp/arcticdb/stream/piloted_clock.hpp
@@ -1,0 +1,17 @@
+#include <arcticdb/entity/types.hpp>
+#include <arcticdb/util/preprocess.hpp>
+
+namespace arcticdb {
+
+struct PilotedClock {
+    static std::atomic<entity::timestamp> time_;
+    static entity::timestamp nanos_since_epoch() {
+        return PilotedClock::time_++;
+    }
+
+    static void reset() {
+        PilotedClock::time_ = 0;
+    }
+};
+
+} //namespace arcticdb

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -24,8 +24,10 @@
 #include <arcticdb/storage/lmdb/lmdb_storage.hpp>
 #include <arcticdb/version/version_store_api.hpp>
 #include <arcticdb/stream/index.hpp>
-#include <filesystem>
 #include <arcticdb/entity/protobufs.hpp>
+#include <arcticdb/stream/piloted_clock.hpp>
+
+#include <filesystem>
 
 namespace fg = folly::gen;
 
@@ -69,16 +71,6 @@ SegmentInMemory fill_test_index_segment(const StreamId &tsid, TsIndexKeyGen &&ts
     return seg;
 }
 
-struct PilotedClock {
-    static std::atomic<timestamp> time_;
-    static timestamp nanos_since_epoch() ARCTICDB_UNUSED {
-        return PilotedClock::time_++;
-    }
-
-    static void reset() ARCTICDB_UNUSED {
-        PilotedClock::time_ = 0;
-    }
-};
 
 inline auto get_simple_data_descriptor(const StreamId &id) {
     return TimeseriesIndex::default_index().create_stream_descriptor(

--- a/cpp/arcticdb/stream/test/test_aggregator.cpp
+++ b/cpp/arcticdb/stream/test/test_aggregator.cpp
@@ -24,7 +24,7 @@ struct SegmentsSink {
 TEST(Aggregator, BasicAndSegmenting) {
     const auto index = as::TimeseriesIndex::default_index();
     as::FixedSchema schema{
-        index.create_stream_descriptor(123, {
+        index.create_stream_descriptor(NumericId{123}, {
             scalar_field(DataType::UINT8, "uint8"),
         }), index
     };

--- a/cpp/arcticdb/stream/test/test_row_builder.cpp
+++ b/cpp/arcticdb/stream/test/test_row_builder.cpp
@@ -21,7 +21,7 @@ TEST(RowBuilder, Basic) {
     using namespace arcticdb;
     const auto index = as::TimeseriesIndex::default_index();
     as::FixedSchema schema{
-        index.create_stream_descriptor(123, {
+        index.create_stream_descriptor(NumericId{123}, {
             arcticdb::scalar_field(DataType::UINT8, "bbb"),
             arcticdb::scalar_field(DataType::INT8, "AAA"),
         }), index

--- a/cpp/arcticdb/stream/test/test_types.cpp
+++ b/cpp/arcticdb/stream/test/test_types.cpp
@@ -41,7 +41,7 @@ TEST(TickStreamDesc, FromFields) {
     using namespace arcticdb::entity;
     using namespace arcticdb;
     StreamDescriptor tsd{stream_descriptor(
-        123,
+        NumericId{123},
         stream::TimeseriesIndex::default_index(),
         {
             scalar_field(DataType::UINT8, "uint8"),

--- a/cpp/arcticdb/util/memory_mapped_file.hpp
+++ b/cpp/arcticdb/util/memory_mapped_file.hpp
@@ -1,0 +1,240 @@
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/util/constructors.hpp>
+#include <arcticdb/log/log.hpp>
+
+#ifdef WIN32
+
+#include "Windows.h"
+#include "winerror.h"
+
+namespace arcticdb {
+
+    class MemoryMappedFile {
+    private:
+        HANDLE file_ = INVALID_HANDLE_VALUE;
+        HANDLE map_ = nullptr;
+        size_t length_ = 0;
+        uint8_t* data_ = nullptr;
+
+    public:
+        MemoryMappedFile() = default;
+
+        size_t get_file_size(const std::string& file_path) {
+            LARGE_INTEGER size;
+            HANDLE h = CreateFile(file_path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (h == INVALID_HANDLE_VALUE) {
+                util::raise_rte("Failed to get file size");
+            }
+            if (!GetFileSizeEx(h, &size)) {
+                CloseHandle(h);
+                util::raise_rte("Failed to get file size");
+            }
+            CloseHandle(h);
+            return static_cast<size_t>(size.QuadPart);
+        }
+
+        void open_file(const std::string& filepath) {
+            length_ = get_file_size(filepath);
+            file_ = CreateFile(filepath.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (file_ == INVALID_HANDLE_VALUE) {
+                util::raise_rte("Error opening file for reading");
+            }
+
+            map_ = CreateFileMapping(file_, nullptr, PAGE_READONLY, 0, 0, nullptr);
+            if (!map_) {
+                CloseHandle(file_);
+                util::raise_rte("Error creating file mapping");
+            }
+
+            data_ = static_cast<uint8_t*>(MapViewOfFile(map_, FILE_MAP_READ, 0, 0, length_));
+            if (!data_) {
+                CloseHandle(map_);
+                CloseHandle(file_);
+                util::raise_rte("Error mapping view of file");
+            }
+        }
+
+        void create_file(const std::string& filepath, size_t size) {
+            length_ = size;
+            file_ = CreateFile(filepath.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (file_ == INVALID_HANDLE_VALUE) {
+                util::raise_rte("Error opening file for writing");
+            }
+
+            map_ = CreateFileMapping(file_, nullptr, PAGE_READWRITE, 0, static_cast<DWORD>(size), nullptr);
+            if (!map_) {
+                CloseHandle(file_);
+                util::raise_rte("Error creating file mapping");
+            }
+
+            data_ = static_cast<uint8_t*>(MapViewOfFile(map_, FILE_MAP_WRITE, 0, 0, size));
+            if (!data_) {
+                CloseHandle(map_);
+                CloseHandle(file_);
+                util::raise_rte("Error mapping view of file");
+            }
+        }
+
+        void unmap() {
+            if (data_) {
+                if (!UnmapViewOfFile(data_)) {
+                    log::storage().warn("Failed to unmap view of file");
+                }
+                data_ = nullptr;
+            }
+            if (map_) {
+                CloseHandle(map_);
+                map_ = nullptr;
+            }
+        }
+
+        void truncate(size_t new_size) {
+            unmap();
+            if (file_ != INVALID_HANDLE_VALUE) {
+                // Set file pointer to the new truncated size
+                LARGE_INTEGER li;
+                li.QuadPart = new_size;
+                li.LowPart = SetFilePointer(file_, li.LowPart, &li.HighPart, FILE_BEGIN);
+                if (li.LowPart == INVALID_SET_FILE_POINTER && GetLastError() != 0UL) {
+                    util::raise_rte("Error setting file pointer");
+                }
+                // Truncate the file
+                if (!SetEndOfFile(file_)) {
+                    util::raise_rte("Error truncating file");
+                }
+            }
+        }
+
+        ~MemoryMappedFile() {
+            unmap();
+            if (file_ != INVALID_HANDLE_VALUE) {
+                CloseHandle(file_);
+            }
+        }
+
+        [[nodiscard]] uint8_t* data() const {
+            return data_;
+        }
+
+        [[nodiscard]] size_t bytes() const {
+            return length_;
+        }
+    };
+
+}//namespace arcticdb
+
+#else
+#include <iostream>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+namespace arcticdb {
+
+class MemoryMappedFile {
+private:
+    int fd_ = -1;
+    size_t length_ = 0;
+    uint8_t *data_ = nullptr;
+
+public:
+    ARCTICDB_NO_MOVE_OR_COPY(MemoryMappedFile)
+
+    MemoryMappedFile() = default;
+
+    size_t get_file_size(const std::string& file_path) {
+        struct stat sb;
+        auto result = stat(file_path.c_str(), &sb);
+        util::check(result != -1, "Failed to stat file");
+        return static_cast<size_t>(sb.st_size);
+    }
+
+    void open_file(const std::string &filepath) {
+        length_ = get_file_size(filepath);
+        // Open file
+        fd_ = open(filepath.c_str(), O_RDONLY);
+        util::check(fd_ != -1, "Error opening file for reading");
+
+        // Map file into memory
+        ARCTICDB_DEBUG(log::storage(), "Memory-mapped file at path {} with length {}", filepath, length_);
+        data_ = static_cast<uint8_t *>(mmap(nullptr, length_, PROT_READ, MAP_SHARED, fd_, 0));
+        if (data_ == MAP_FAILED) {
+            close(fd_);
+            util::raise_rte("Error mmapping the file");
+        }
+    }
+
+    void create_file(const std::string &filepath, size_t size) {
+        length_ = size;
+        // Open file
+        fd_ = open(filepath.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+        util::check(fd_ != -1, "Error opening file for writing");
+
+        auto result = lseek(fd_, static_cast<long>(length_ - 1), SEEK_SET);
+        if (result == -1) {
+            close(fd_);
+            util::raise_rte("Failed to extend memory mapped file: {}", result);
+        }
+
+        result = write(fd_, "", 1);
+        if (result == -1) {
+            close(fd_);
+            util::raise_rte("Error writing last byte of the file: {}", result);
+        }
+
+        // Map file into memory
+        data_ = static_cast<uint8_t *>(mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0));
+        if (data_ == MAP_FAILED) {
+            close(fd_);
+            util::raise_rte("Error mmapping the file");
+        }
+        ARCTICDB_DEBUG(log::storage(), "Created memory mapped file at {} with size {}", filepath, length_);
+    }
+
+    void unmap() {
+        if (data_ != nullptr) {
+            auto result = msync(data_, length_, MS_SYNC);
+            if(result == -1) {
+                log::storage().warn("Could not sync the file to disk: {}", result);
+            } else {
+                result = munmap(data_, length_);
+                if (result == -1)
+                    log::storage().warn("Error un-mmapping the file");
+            }
+        }
+    }
+
+    void truncate(size_t new_size) {
+        length_ = new_size;
+        unmap();
+
+        auto result = ftruncate(fd_, new_size);
+        util::check(result != -1, "Error truncating file");
+
+        data_ = nullptr;
+        ARCTICDB_DEBUG(log::storage(), "Truncated memory-mapped file to size {}", length_);
+    }
+
+
+    ~MemoryMappedFile() {
+        unmap();
+
+        ARCTICDB_DEBUG(log::storage(), "Closing memory-mapped file of length {}", length_);
+        if (fd_ != -1)
+            close(fd_);
+
+    }
+
+    [[nodiscard]] uint8_t *data() const {
+        return data_;
+    }
+
+    [[nodiscard]] size_t bytes() const {
+        return length_;
+    }
+};
+
+} //namespace arcticdb
+
+#endif

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -23,15 +23,20 @@
 #include <arcticdb/python/gil_lock.hpp>
 
 namespace arcticdb::version_store {
+
 template<class ClockType>
 LocalVersionedEngine::LocalVersionedEngine(
         const std::shared_ptr<storage::Library>& library,
         const ClockType&) :
     store_(std::make_shared<async::AsyncStore<ClockType>>(library, codec::default_lz4_codec(), encoding_version(library->config()))),
     symbol_list_(std::make_shared<SymbolList>(version_map_)){
+    initialize(library);
+}
+
+void LocalVersionedEngine::initialize(const std::shared_ptr<storage::Library>& library) {
     configure(library->config());
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Created versioned engine at {} for library path {}  with config {}", uintptr_t(this),
-                         library->library_path(), [&cfg=cfg_]{  return util::format(cfg); });
+                           library->library_path(), [&cfg=cfg_]{  return util::format(cfg); });
 #ifdef USE_REMOTERY
     auto temp = RemoteryInstance::instance();
 #endif
@@ -1816,6 +1821,7 @@ void LocalVersionedEngine::force_release_lock(const StreamId& name) {
 WriteOptions LocalVersionedEngine::get_write_options() const  {
     return  WriteOptions::from_proto(cfg().write_options());
 }
+
 
 std::shared_ptr<VersionMap> LocalVersionedEngine::_test_get_version_map() {
     return version_map();

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -52,11 +52,14 @@ struct KeySizesInfo {
 class LocalVersionedEngine : public VersionedEngine {
 
 public:
+    LocalVersionedEngine() = default;
+
     template<class ClockType = util::SysClock>
     explicit LocalVersionedEngine(
         const std::shared_ptr<storage::Library>& library,
-        const ClockType& = util::SysClock{} // Only used to allow the template variable to be inferred
-        );
+        const ClockType& = ClockType{});
+
+
 
     virtual ~LocalVersionedEngine() = default;
 
@@ -442,6 +445,7 @@ protected:
         const std::vector<VersionQuery>& version_queries);
 
 private:
+    void initialize(const std::shared_ptr<storage::Library>& library);
 
     std::shared_ptr<Store> store_;
     arcticdb::proto::storage::VersionStoreConfig cfg_;

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -112,6 +112,12 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("set_batch_throw_on_error", &ReadOptions::set_batch_throw_on_error)
         .def_property_readonly("incompletes", &ReadOptions::get_incompletes);
 
+    version.def("write_dataframe_to_file", &write_dataframe_to_file);
+    version.def("read_dataframe_from_file",
+        [] (StreamId sid, const std::string(path), ReadQuery& read_query){
+            return adapt_read_df(read_dataframe_from_file(sid, path, read_query));
+        });
+
     using FrameDataWrapper = arcticdb::pipelines::FrameDataWrapper;
     py::class_<FrameDataWrapper, std::shared_ptr<FrameDataWrapper>>(version, "FrameDataWrapper")
             .def_property_readonly("data", &FrameDataWrapper::data);

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -684,7 +684,7 @@ folly::Future<VariantKey> write_symbols(
         segment = write_entries_to_symbol_segment(stream_id, type_holder, symbols);
     }
 
-    return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, 0, 0, std::move(segment));
+    return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, NumericIndex{ 0 }, NumericIndex{ 0 }, std::move(segment));
 }
 
 folly::Future<std::vector<Store::RemoveKeyResultType>> delete_keys(

--- a/cpp/arcticdb/version/test/symbol_list_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/symbol_list_backwards_compat.hpp
@@ -135,7 +135,7 @@ folly::Future<VariantKey> backwards_compat_write(
         any.PackFrom(metadata);
         list_segment.set_metadata(std::move(any));
     }
-    return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, 0, 0, std::move(list_segment));
+    return store->write(KeyType::SYMBOL_LIST, 0, stream_id, creation_ts, NumericIndex{0}, NumericIndex{0}, std::move(list_segment));
 }
 
 void backwards_compat_write_journal(const std::shared_ptr<Store>& store, const StreamId& symbol, std::string action) {

--- a/cpp/arcticdb/version/test/test_snapshot.cpp
+++ b/cpp/arcticdb/version/test/test_snapshot.cpp
@@ -29,7 +29,7 @@ TEST(SnapshotCreate, Basic) {
     InstanceUri instance_uri("localhost");
     auto library_path = LibraryPath::from_delim_path("test.test", '.');
     auto temp_path = std::filesystem::temp_directory_path();
-    auto library = std::make_shared<Library>(create_library(library_path, OpenMode::WRITE, arcticdb::storage::lmdb::pack_config(temp_path)));
+    auto library = create_library(library_path, OpenMode::WRITE, arcticdb::storage::lmdb::pack_config(temp_path));
     auto version_store = std::make_shared<version_store::PythonVersionStore>(library);
     auto store = version_store->_test_get_store();
 

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -923,7 +923,7 @@ TEST_P(SymbolListRace, Run) {
                 store->remove_keys(get_symbol_list_keys(), {});
             }
             if (add_new2) {
-                store->write(KeyType::SYMBOL_LIST, 0, StringId{CompactionId}, PilotedClock::nanos_since_epoch(), 0, 0,
+                store->write(KeyType::SYMBOL_LIST, 0, StringId{ CompactionId }, PilotedClock::nanos_since_epoch(), NumericIndex{0}, NumericIndex{0},
                         SegmentInMemory{});
             }
             if (add_other2) {

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -327,8 +327,8 @@ void write_old_style_journal_entry(const AtomKey &key, std::shared_ptr<StreamSin
         store->write(KeyType::VERSION_JOURNAL,
                           key.version_id(),
                           key.id(),
-                          IndexValue(0),
-                          IndexValue(0),
+                          IndexValue(NumericIndex{0}),
+                          IndexValue(NumericIndex{0}),
                           std::move(segment)).wait();
     });
     journal_agg.add_key(key);

--- a/cpp/arcticdb/version/test/version_map_model.hpp
+++ b/cpp/arcticdb/version/test/version_map_model.hpp
@@ -18,9 +18,9 @@ namespace arcticdb {
 AtomKey make_test_index_key(std::string id,
                            VersionId version_id,
                            KeyType key_type,
-                           const IndexValue& index_start = 0,
-                           const IndexValue& index_end = 0,
-                           timestamp creation_ts = PilotedClock::nanos_since_epoch()) {
+    const IndexValue& index_start = NumericIndex{0},
+    const IndexValue& index_end = NumericIndex{0},
+     timestamp creation_ts = PilotedClock::nanos_since_epoch()) {
     return atom_key_builder().version_id(version_id).start_index(index_start).end_index(index_end).creation_ts(
             creation_ts)
         .content_hash(0).build(id, key_type);

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -135,6 +135,18 @@ struct PredefragmentationInfo{
     size_t segments_need_compaction;
     std::optional<size_t> append_after;
 };
+SegmentInMemory prepare_output_frame(
+    std::vector<SliceAndKey>&& items,
+    const std::shared_ptr<PipelineContext>& pipeline_context,
+    const std::shared_ptr<Store>& store,
+    const ReadOptions& read_options);
+
+SegmentInMemory do_direct_read_or_process(
+    const std::shared_ptr<Store>& store,
+    ReadQuery& read_query,
+    const ReadOptions& read_options,
+    const std::shared_ptr<PipelineContext>& pipeline_context,
+    const std::shared_ptr<BufferHolder>& buffers);
 
 PredefragmentationInfo get_pre_defragmentation_info(
         const std::shared_ptr<Store>& store,

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -390,8 +390,8 @@ public:
                     KeyType::VERSION,
                     key.version_id(),
                     key.id(),
-                    IndexValue(0),
-                    IndexValue(0)
+                    IndexValue(NumericIndex{0}),
+                    IndexValue(NumericIndex{0})
             };
 
             journal_key = store->write_sync(pk, std::forward<decltype(segment)>(segment));
@@ -759,8 +759,8 @@ private:
                     KeyType::VERSION,
                     version_id,
                     stream_id,
-                    IndexValue(0),
-                    IndexValue(0)};
+                    IndexValue(NumericIndex{0}),
+                    IndexValue(NumericIndex{0}) };
 
             journal_key = to_atom(store->write_sync(pk, std::forward<decltype(segment)>(segment)));
         });

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -106,8 +106,8 @@ inline AtomKey index_to_tombstone(VersionId version_id, const StreamId& stream_i
         .version_id(version_id)
         .creation_ts(creation_ts)
         .content_hash(0)
-        .start_index(0)
-        .end_index(0)
+        .start_index(NumericIndex{0}) // TODO why not the one from the index key?
+        .end_index(NumericIndex{0})
         .build(stream_id, KeyType::TOMBSTONE);
 }
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -63,9 +63,9 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     VersionedItem write_versioned_dataframe(
         const StreamId& stream_id,
-        const py::tuple &item,
-        const py::object &norm,
-        const py::object & user_meta,
+        const py::tuple& item,
+        const py::object& norm,
+        const py::object& user_meta,
         bool prune_previous_versions,
         bool allow_sparse,
         bool validate_index);
@@ -327,9 +327,22 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     std::vector<AtomKey> get_version_history(const StreamId& stream_id);
 
+
 private:
     void delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key);
 };
+
+void write_dataframe_to_file(
+    const StreamId& stream_id,
+    const std::string& path,
+    const py::tuple& item,
+    const py::object& norm,
+    const py::object& user_meta);
+
+ReadResult read_dataframe_from_file(
+    const StreamId &stream_id,
+    const std::string& path,
+    ReadQuery& read_query);
 
 struct ManualClockVersionStore : PythonVersionStore {
     ManualClockVersionStore(const std::shared_ptr<storage::Library>& library) :

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -38,8 +38,8 @@ inline entity::VariantKey write_multi_index_entry(
         multi_key_fut = store->write(KeyType::MULTI_KEY,
                                      version_id,  // version_id
                                      stream_id,
-                                     0,  // start_index
-                                     0,  // end_index
+                                     NumericIndex{0},  // start_index
+                                     NumericIndex{0},  // end_index
                                      std::forward<decltype(segment)>(segment)).wait();
     });
 

--- a/cpp/proto/arcticc/pb2/descriptors.proto
+++ b/cpp/proto/arcticc/pb2/descriptors.proto
@@ -60,7 +60,7 @@ message IndexDescriptor {
         ROWCOUNT = 82; // 'R'
         STRING = 83; // 'S'
         TIMESTAMP = 84; //  'T'
-
+        TIME_SYMBOL = 85; // 'U'
     }
     uint32 field_count = 1;
     Type kind = 2;

--- a/cpp/proto/arcticc/pb2/mapped_file_storage.proto
+++ b/cpp/proto/arcticc/pb2/mapped_file_storage.proto
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+*/
+syntax = "proto3";
+
+package arcticc.pb2.mapped_file_storage_pb2;
+
+import "arcticc/pb2/encoding.proto";
+import "arcticc/pb2/descriptors.proto";
+
+message Config {
+    string path = 1;
+    uint64 bytes = 2;
+    uint64 items_count = 3;
+    uint32 encoding_version = 4;
+
+    oneof id
+    {
+        uint64 num_id = 5;
+        string str_id = 6;
+    }
+
+    arcticc.pb2.descriptors_pb2.IndexDescriptor index = 7;
+    arcticc.pb2.encoding_pb2.VariantCodec codec_opts = 8;
+}
+
+

--- a/cpp/proto/arcticc/pb2/proto/CMakeLists.txt
+++ b/cpp/proto/arcticc/pb2/proto/CMakeLists.txt
@@ -14,6 +14,7 @@ SET(PROTO_IN_FILES
         s3_storage.proto
         azure_storage.proto
         nfs_backed_storage.proto
+        mapped_file_storage.proto
         logger.proto
         )
 


### PR DESCRIPTION
Work in progress to store multiple individual segments in one larger, indexed block.

Also adds a single-file-store abstraction and a memory-mapped implementation. N.B. this is for research purposes around data formats, multi-symbol storage and compression, and is not currently exposed to users.

Also some minor memory refactoring to the chunked buffer class in the case where no data is to be written (i.e. in empty types)