### PR TITLE
Add __contains__ to Arctic class, to support lib in arctic

### DIFF
--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -205,6 +205,9 @@ class Arctic:
     def __repr__(self):
         return "Arctic(config=%r)" % self._library_adapter
 
+    def __contains__(self, name: str):
+        return self.has_library(name)
+
     def get_library(
         self, name: str, create_if_missing: Optional[bool] = False, library_options: Optional[LibraryOptions] = None
     ) -> Library:

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -47,6 +47,7 @@ def test_library_creation_deletion(arctic_client):
 
     assert ac.list_libraries() == ["pytest_test_lib"]
     assert ac.has_library("pytest_test_lib")
+    assert "pytest_test_lib" in ac
     if "mongo" in arctic_client.get_uri():
         # The mongo fixture uses PrefixingLibraryAdapterDecorator which leaks in this one case
         assert ac["pytest_test_lib"].name.endswith(".pytest_test_lib")
@@ -61,6 +62,7 @@ def test_library_creation_deletion(arctic_client):
     with pytest.raises(LibraryNotFound):
         _lib = ac["pytest_test_lib"]
     assert not ac.has_library("pytest_test_lib")
+    assert "pytest_test_lib" not in ac
 
 
 def test_get_library(arctic_client):


### PR DESCRIPTION
TLDR: add ability to test for a library using

`lib in arctic`
and
`lib not in arctic`

A full description of the fix is in this issue

https://github.com/man-group/ArcticDB/issues/1295