### PR TITLE
Abstract AzureClientWrapper out of azure_storage.cpp

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -444,7 +444,10 @@ set(arcticdb_srcs
         version/version_utils.cpp
         version/symbol_list.cpp
         version/version_map_batch_methods.cpp
-        )
+        storage/azure/azure_client_wrapper.hpp
+        storage/azure/azure_real_client.hpp
+        storage/azure/azure_real_client.cpp
+)
 
 if(${ARCTICDB_INCLUDE_ROCKSDB})
     list (APPEND arcticdb_srcs

--- a/cpp/arcticdb/storage/azure/azure_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_wrapper.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <azure/core/http/curl_transport.hpp>
+#include <azure/core.hpp>
+#include <azure/storage/blobs.hpp>
+
+#include <arcticdb/storage/storage_utils.hpp>
+
+
+namespace arcticdb::storage::azure {
+
+    // An abstract class, which is responsible for sending the requests and parsing the responses from Azure.
+    // It can be derived as either a real connection to Azure or a mock used for unit tests.
+class AzureClientWrapper {
+public:
+    using Config = arcticdb::proto::azure_storage::Config;
+    virtual void write_blob(
+            const std::string& blob_name,
+            Segment&& segment,
+            const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
+            unsigned int request_timeout) = 0;
+
+    virtual Segment read_blob(
+            const std::string& blob_name,
+            const Azure::Storage::Blobs::DownloadBlobToOptions& download_option,
+            unsigned int request_timeout) = 0;
+
+    virtual void delete_blobs(
+            const std::vector<std::string>& blob_names,
+            unsigned int request_timeout) = 0;
+
+    virtual Azure::Storage::Blobs::ListBlobsPagedResponse list_blobs(const std::string& prefix) = 0;
+
+    virtual bool blob_exists(const std::string& blob_name) = 0;
+
+    virtual ~AzureClientWrapper() = default;
+};
+
+}
+
+

--- a/cpp/arcticdb/storage/azure/azure_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_wrapper.hpp
@@ -16,6 +16,8 @@
 
 namespace arcticdb::storage::azure {
 
+static const size_t BATCH_SUBREQUEST_LIMIT = 256; //https://github.com/Azure/azure-sdk-for-python/blob/767facc39f2487504bcde4e627db16a79f96b297/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py#L1608
+
     // An abstract class, which is responsible for sending the requests and parsing the responses from Azure.
     // It can be derived as either a real connection to Azure or a mock used for unit tests.
 class AzureClientWrapper {

--- a/cpp/arcticdb/storage/azure/azure_real_client.cpp
+++ b/cpp/arcticdb/storage/azure/azure_real_client.cpp
@@ -84,6 +84,11 @@ Segment RealAzureClient::read_blob(
 void RealAzureClient::delete_blobs(
         const std::vector<std::string>& blob_names,
         unsigned int request_timeout) {
+
+    util::check(blob_names.size() <= BATCH_SUBREQUEST_LIMIT,
+                "Azure delete batch size {} exceeds maximum permitted batch size of {}",
+                blob_names.size(),
+                BATCH_SUBREQUEST_LIMIT);
     auto batch = container_client.CreateBatch();
 
     for (auto& blob_name: blob_names) {

--- a/cpp/arcticdb/storage/azure/azure_real_client.cpp
+++ b/cpp/arcticdb/storage/azure/azure_real_client.cpp
@@ -1,0 +1,115 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+
+#include <azure/core/http/curl_transport.hpp>
+#include <azure/core.hpp>
+#include <azure/storage/blobs.hpp>
+
+#include <arcticdb/storage/storage_utils.hpp>
+#include <arcticdb/storage/azure/azure_real_client.hpp>
+#include <arcticdb/storage/azure/azure_client_wrapper.hpp>
+#include <arcticdb/storage/object_store_utils.hpp>
+
+namespace arcticdb::storage {
+using namespace object_store_utils;
+namespace azure {
+using namespace Azure::Storage;
+using namespace Azure::Storage::Blobs;
+
+Azure::Core::Context get_context(unsigned int request_timeout){
+    Azure::Core::Context requestContext; //TODO: Maybe can be static but need to be careful with its shared_ptr and ContextSharedState
+    return requestContext.WithDeadline(std::chrono::system_clock::now() + std::chrono::milliseconds(request_timeout));
+}
+
+
+RealAzureClient::RealAzureClient(const Config &conf) :
+container_client(BlobContainerClient::CreateFromConnectionString(conf.endpoint(), conf.container_name(), get_client_options(conf))) { }
+
+Azure::Storage::Blobs::BlobClientOptions RealAzureClient::get_client_options(const Config &conf) {
+    BlobClientOptions client_options;
+    if (!conf.ca_cert_path().empty()) {//WARNING: Setting ca_cert_path will force Azure sdk uses libcurl as backend support, instead of winhttp
+        Azure::Core::Http::CurlTransportOptions curl_transport_options;
+        curl_transport_options.CAInfo = conf.ca_cert_path();
+        client_options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_transport_options);
+    }
+    return client_options;
+}
+
+void RealAzureClient::write_blob(
+        const std::string& blob_name,
+        Segment&& segment,
+        const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
+        unsigned int request_timeout) {
+
+    std::shared_ptr<Buffer> tmp;
+    auto hdr_size = segment.segment_header_bytes_size();
+    auto [dst, write_size] = segment.try_internal_write(tmp, hdr_size);
+    util::check(arcticdb::Segment::FIXED_HEADER_SIZE + hdr_size + segment.buffer().bytes() <= write_size,
+                "Size disparity, fixed header size {} + variable header size {} + buffer size {}  >= total size {}",
+                arcticdb::Segment::FIXED_HEADER_SIZE,
+                hdr_size,
+                segment.buffer().bytes(),
+                write_size);
+    ARCTICDB_SUBSAMPLE(AzureStorageUploadObject, 0)
+    auto blob_client = container_client.GetBlockBlobClient(blob_name);
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Writing key '{}' with {} bytes of data",
+                           blob_name,
+                           segment.total_segment_size(hdr_size));
+    blob_client.UploadFrom(dst, write_size, upload_option, get_context(request_timeout));
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Wrote key '{}' with {} bytes of data",
+                           blob_name,
+                           segment.total_segment_size(hdr_size));
+}
+
+Segment RealAzureClient::read_blob(
+        const std::string& blob_name,
+        const Azure::Storage::Blobs::DownloadBlobToOptions& download_option,
+        unsigned int request_timeout) {
+
+    ARCTICDB_DEBUG(log::storage(), "Looking for blob {}", blob_name);
+    auto blob_client = container_client.GetBlockBlobClient(blob_name);
+    auto properties = blob_client.GetProperties(Azure::Storage::Blobs::GetBlobPropertiesOptions{}, get_context(request_timeout)).Value;
+    std::shared_ptr<Buffer> buffer = std::make_shared<Buffer>(properties.BlobSize);
+    blob_client.DownloadTo(buffer->preamble(), buffer->available(), download_option, get_context(request_timeout));
+    ARCTICDB_SUBSAMPLE(AzureStorageVisitSegment, 0)
+
+    return Segment::from_buffer(std::move(buffer));
+}
+
+void RealAzureClient::delete_blobs(
+        const std::vector<std::string>& blob_names,
+        unsigned int request_timeout) {
+    auto batch = container_client.CreateBatch();
+
+    for (auto& blob_name: blob_names) {
+        ARCTICDB_RUNTIME_DEBUG(log::storage(), "Removing azure blob with key {}", blob_names);
+        batch.DeleteBlob(blob_name);
+    }
+
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Submitting DeleteBlob batch");
+    ARCTICDB_SUBSAMPLE(AzureStorageDeleteObjects, 0)
+    container_client.SubmitBatch(batch, Azure::Storage::Blobs::SubmitBlobBatchOptions(), get_context(request_timeout));//To align with s3 behaviour, deleting non-exist objects is not an error, so not handling response
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Submitted DeleteBlob batch");
+}
+
+ListBlobsPagedResponse RealAzureClient::list_blobs(const std::string& prefix) {
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Searching for objects with prefix {}", prefix);
+    Azure::Storage::Blobs::ListBlobsOptions options;
+    options.Prefix = prefix;
+    return container_client.ListBlobs(options);
+}
+
+bool RealAzureClient::blob_exists(const std::string& blob_name) {
+    auto blob_client = container_client.GetBlockBlobClient(blob_name);
+    auto properties = blob_client.GetProperties().Value;
+    return properties.ETag.HasValue();
+}
+
+}
+
+}

--- a/cpp/arcticdb/storage/azure/azure_real_client.hpp
+++ b/cpp/arcticdb/storage/azure/azure_real_client.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <azure/core/http/curl_transport.hpp>
+#include <azure/core.hpp>
+#include <azure/storage/blobs.hpp>
+
+#include <arcticdb/storage/storage_utils.hpp>
+#include <arcticdb/storage/azure/azure_client_wrapper.hpp>
+
+namespace arcticdb::storage::azure {
+class RealAzureClient : public AzureClientWrapper {
+private:
+    Azure::Storage::Blobs::BlobContainerClient container_client;
+
+    static Azure::Storage::Blobs::BlobClientOptions get_client_options(const Config &conf);
+public:
+
+    explicit RealAzureClient(const Config &conf);
+
+    void write_blob(
+            const std::string& blob_name,
+            Segment&& segment,
+            const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
+            unsigned int request_timeout) override;
+
+    Segment read_blob(
+            const std::string& blob_name,
+            const Azure::Storage::Blobs::DownloadBlobToOptions& download_option,
+            unsigned int request_timeout) override;
+
+    void delete_blobs(
+            const std::vector<std::string>& blob_names,
+            unsigned int request_timeout) override;
+
+    bool blob_exists(const std::string& blob_name) override;
+
+    Azure::Storage::Blobs::ListBlobsPagedResponse list_blobs(const std::string& prefix) override;
+};
+}

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -46,8 +46,6 @@ namespace fg = folly::gen;
 
 namespace detail {
 
-static const size_t BATCH_SUBREQUEST_LIMIT = 256; //https://github.com/Azure/azure-sdk-for-python/blob/767facc39f2487504bcde4e627db16a79f96b297/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py#L1608
-
 template<class KeyBucketizer>
 void do_write_impl(
     Composite<KeySegmentPair>&& kvs,

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -10,6 +10,7 @@
 #include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/storage_factory.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
+#include <arcticdb/storage/azure/azure_client_wrapper.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/composite.hpp>
@@ -29,11 +30,6 @@ class AzureStorage final : public Storage {
     using Config = arcticdb::proto::azure_storage::Config;
 
     AzureStorage(const LibraryPath &lib, OpenMode mode, const Config &conf);
-
-    /**
-     * Full object path in Azure bucket.
-     */
-    std::string get_key_path(const VariantKey& key) const;
 
   protected:
     void do_write(Composite<KeySegmentPair>&& kvs) final;
@@ -59,7 +55,8 @@ class AzureStorage final : public Storage {
     std::string do_key_path(const VariantKey&) const final { return {}; };
 
   private:
-    Azure::Storage::Blobs::BlobContainerClient container_client_;
+    std::unique_ptr<AzureClientWrapper> azure_client_;
+
     std::string root_folder_;
     unsigned int request_timeout_;
     Azure::Storage::Blobs::UploadBlockBlobFromOptions upload_option_;


### PR DESCRIPTION
This is a refactor which should not modify behavior.

The refactor abstracts away building the requests and parsing the responses from Azure behind an abstract class `AzureClientWrapper`. The refactor is written similar to how #1274 is for S3.

`RealAzureClient` (derives `AzureClientWrapper`) is implemented by moving the Azure Client logic from `azure_storage.cpp`. `AzureClientWrapper` will then be used to add `MockAzureClient` class which would be used to simulate azure erros.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
