### PR TITLE
Make benchmarks more stable

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -246,20 +246,20 @@ jobs:
         if: inputs.run_all_benchmarks == true
         shell: bash -el {0}
         run: |
-          python -m asv run -v --show-stderr HASHFILE:python/hashes_to_benchmark.txt
+          python -m asv run -v --show-stderr --strict HASHFILE:python/hashes_to_benchmark.txt
 
       - name: Benchmark only latest commit
         if: github.event_name != 'pull_request' && inputs.run_all_benchmarks == false
         shell: bash -el {0}
         run: |
-          python -m asv run -v --show-stderr HEAD^!
+          python -m asv run -v --show-stderr --strict HEAD^!
           git log HEAD^..HEAD --oneline -n1 --decorate=no | awk '{print $1;}' >> python/hashes_to_benchmark.txt
 
       - name: Benchmark against master
         if: github.event_name == 'pull_request' && inputs.run_all_benchmarks == false
         shell: bash -el {0}
         run: |
-          python -m asv continuous -v --show-stderr origin/master HEAD -f 1.15
+          python -m asv continuous -v --show-stderr --strict origin/master HEAD -f 1.15
 
       - name: Publish results
         if: github.event_name != 'pull_request' || github.ref == 'refs/heads/master'

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -21,7 +21,7 @@ class BasicFunctions:
     param_names = ["rows", "num_symbols"]
 
     def setup_cache(self):
-        self.ac = Arctic("lmdb://basic_functions?map_size=10GB")
+        self.ac = Arctic("lmdb://basic_functions?map_size=20GB")
         num_rows, num_symbols = BasicFunctions.params
 
         self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in num_rows}
@@ -41,7 +41,7 @@ class BasicFunctions:
             self.ac.delete_library(lib)
 
     def setup(self, rows, num_symbols):
-        self.ac = Arctic("lmdb://basic_functions?map_size=10GB")
+        self.ac = Arctic("lmdb://basic_functions?map_size=20GB")
         self.read_reqs = [ReadRequest(f"{sym}_sym") for sym in range(num_symbols)]
 
         self.df = generate_pseudo_random_dataframe(rows)

--- a/python/benchmarks/persistent_query_builder.py
+++ b/python/benchmarks/persistent_query_builder.py
@@ -5,20 +5,54 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+import os
+from arcticdb import Arctic
 from arcticdb.storage_fixtures.s3 import real_s3_from_environment_variables
 from arcticdb.version_store.processing import QueryBuilder
 
 from .common import *
 
 
+# We keep these functions here to make sure that every version of the benchmark
+# has access to the same functions for creating the AWS url and the real S3 credentials
+def real_s3_credentials(shared_path: bool = True):
+    endpoint = os.getenv("ARCTICDB_REAL_S3_ENDPOINT")
+    bucket = os.getenv("ARCTICDB_REAL_S3_BUCKET")
+    region = os.getenv("ARCTICDB_REAL_S3_REGION")
+    access_key = os.getenv("ARCTICDB_REAL_S3_ACCESS_KEY")
+    secret_key = os.getenv("ARCTICDB_REAL_S3_SECRET_KEY")
+    if shared_path:
+        path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX")
+    else:
+        path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX")
+
+    clear = str(os.getenv("ARCTICDB_REAL_S3_CLEAR")).lower() in ("true", "1")
+
+    return endpoint, bucket, region, access_key, secret_key, path_prefix, clear
+
+
+def get_real_s3_uri(shared_path: bool = True):
+    (
+        endpoint,
+        bucket,
+        region,
+        access_key,
+        secret_key,
+        path_prefix,
+        _,
+    ) = real_s3_credentials(shared_path)
+    aws_uri = f"s3s://{endpoint}:{bucket}?access={access_key}&secret={secret_key}&region={region}&path_prefix={path_prefix}"
+    return aws_uri
+
+
 class PersistentQueryBuilderFunctions:
     number = 2
     timeout = 6000
 
-    params = [10_000_000, 100_000_000]
+    params = [1_000_000, 10_000_000]
 
     def __init__(self):
-        self.ac = real_s3_from_environment_variables(shared_path=True).create_fixture().create_arctic()
+        self.ac = Arctic(get_real_s3_uri())
 
         self.lib_name = "query_builder_benchmark_lib"
 
@@ -26,7 +60,7 @@ class PersistentQueryBuilderFunctions:
         pass
 
     def setup_cache(self):
-        self.ac = real_s3_from_environment_variables(shared_path=True).create_fixture().create_arctic()
+        self.ac = Arctic(get_real_s3_uri())
 
         num_rows = PersistentQueryBuilderFunctions.params
         self.lib_name = "query_builder_benchmark_lib"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1311 

#### What does this implement or fix?
- Makes it so when a benchmark fails, asv will return a non 0 exit code, thus failing the build (this is done by adding the `--strict` flag)
- Explicitly add the code for creating a AWS URL to the benchmark code, so all versions can work with persistent storage
- Reduce the rows of the DFs used in benchmarking QB with AWS from [10_000_000, 100_000_000] to [1_000_000, 10_000_000], as there doesn't seem to be much benefit(performance scales linearly, as expected) but when testing with 100_000_000 rows, each run takes around **17m**, and also there is a large of cost to reading this much data, so frequently.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
