### PR TITLE
Do not compile wheel build on EC2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,6 @@ jobs:
       cmake_preset_type: ${{needs.common_config.outputs.cmake_preset_type_resolved}}
       cibw_image_tag: ${{needs.cibw_docker_image.outputs.tag}}
       matrix: ${{needs.common_config.outputs.linux_matrix}}
-      compile-override: compile-on-ec2
 
   build-python-wheels-linux:
     # Then use the cached compilation artifacts to build other python versions concurrently in cibuildwheels
@@ -187,7 +186,6 @@ jobs:
       matrix: ${{toJson(matrix.matrix_override)}}
       python_deps_ids: ${{toJson(matrix.python_deps_ids)}}
       persistent_storage: ${{inputs.persistent_storage}}
-      compile-override: compile-on-ec2
       pytest_xdist_mode: ${{matrix.pytest_xdist_mode}}
 
   cpp-test-windows:


### PR DESCRIPTION
While still working on stopping for Conda.

See also PR #1302 which is working on doing this for Conda too.
