### PR TITLE
conda-build: Adaptations for folly

### DIFF
--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-12
 
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -16,10 +16,6 @@
 #include <arcticdb/async/base_task.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 
-// Compilation fails on Mac if cstdio is not included prior to folly/Function.h due to a missing definition of memalign in folly/Memory.h
-#ifdef __APPLE__
-#include <cstdio>
-#endif
 #include <folly/executors/FutureExecutor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
@@ -71,7 +67,7 @@ public:
                 ARCTICDB_SAMPLE_THREAD();
               func();
             });
-
+    
   }
 // we use a modern version of folly when consuming dependencies from conda
 #ifdef ARCTICDB_USING_CONDA

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -16,6 +16,10 @@
 #include <arcticdb/async/base_task.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 
+// Compilation fails on Mac if cstdio is not included prior to folly/Function.h due to a missing definition of memalign in folly/Memory.h
+#ifdef __APPLE__
+#include <cstdio>
+#endif
 #include <folly/executors/FutureExecutor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
@@ -67,7 +71,7 @@ public:
                 ARCTICDB_SAMPLE_THREAD();
               func();
             });
-    
+
   }
 // we use a modern version of folly when consuming dependencies from conda
 #ifdef ARCTICDB_USING_CONDA

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -41,7 +41,7 @@ dependencies:
   #  - rocksdb
   # ArcticDB is currently incompatible with fmt 10
   - fmt < 10
-  - folly
+  - folly==2023.09.25.00
   # Vendored build dependencies (see `cpp/thirdparty` and `cpp/vcpkg.json`)
   # Versions must be kept in sync
   - xxhash==0.8.2


### PR DESCRIPTION
#### Reference Issues/PRs

See https://github.com/conda-forge/arcticdb-feedstock/pull/112.

#### What does this implement or fix?

Pin to `2023.09.25.00`, a stable version for consistency.

Downgrade workflow to `macos-12`, to avoid using CommandLineTools 15 as proposed by @joe-iddon in https://github.com/man-group/ArcticDB/issues/1322.

#### Any other comments?

#### Checklist
