### PR TITLE
Docs: For top level imports x use direct arcticdb.x instead of full path to the object

### DIFF
--- a/docs/mkdocs/docs/api/library_types.md
+++ b/docs/mkdocs/docs/api/library_types.md
@@ -1,15 +1,15 @@
 ::: arcticdb.version_store.library.NormalizableType
 
-::: arcticdb.version_store.library.ReadInfoRequest
+::: arcticdb.ReadInfoRequest
 
-::: arcticdb.version_store.library.ReadRequest
+::: arcticdb.ReadRequest
 
 ::: arcticdb.version_store.library.SymbolDescription
 
 ::: arcticdb.version_store.library.SymbolVersion
 
-::: arcticdb.version_store.library.VersionedItem
+::: arcticdb.VersionedItem
 
 ::: arcticdb.version_store.library.VersionInfo
 
-::: arcticdb.version_store.library.WritePayload
+::: arcticdb.WritePayload


### PR DESCRIPTION
This patch updates the docs to import top level objects directly using `arcticdb.object` rather than using the full path to the `object`.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
