### PR TITLE
Docs: For top level imports use `arcticdb.object` instead of using full path to `object`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ and diagrams are generated, even undocumented classes / functions. This gives ab
 
 Install
 ```
-pip install mkdocs-material mkdocs-jupyter mkdocstrings[python] black pybind11-stubgen mike
+pip3 install mkdocs-material mkdocs-jupyter 'mkdocstrings[python]' black pybind11-stubgen mike
 ```
 - mkdocs-material: theme
 - mkdocs-jupyter: jupyter notebook support
@@ -43,7 +43,7 @@ pip install arcticdb
 
 `mkdocstrings[python]` doesn't support python extensions very well, so create interface files (pyi) for the extensions first.
 ```
-cd python
+cd docs/mkdocs
 # TODO fix these errors!
 pybind11-stubgen arcticdb_ext.version_store --ignore-all-errors -o .
 ```

--- a/docs/mkdocs/docs/api/library_types.md
+++ b/docs/mkdocs/docs/api/library_types.md
@@ -1,15 +1,15 @@
 ::: arcticdb.version_store.library.NormalizableType
 
-::: arcticdb.version_store.library.ReadInfoRequest
+::: arcticdb.ReadInfoRequest
 
-::: arcticdb.version_store.library.ReadRequest
+::: arcticdb.ReadRequest
 
 ::: arcticdb.version_store.library.SymbolDescription
 
 ::: arcticdb.version_store.library.SymbolVersion
 
-::: arcticdb.version_store.library.VersionedItem
+::: arcticdb.VersionedItem
 
 ::: arcticdb.version_store.library.VersionInfo
 
-::: arcticdb.version_store.library.WritePayload
+::: arcticdb.WritePayload


### PR DESCRIPTION
This patch updates the mkdocs by directly import top level imports from `arcticdb` rather than using the full path to the imports which was done previously. The patch also fixes a mistake in the docs which was causing errors in building mkdocs locally.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
