### PR TITLE
S3 local delete failure raising meaningful error

### DIFF
--- a/cpp/arcticdb/storage/s3/mock_s3_client.cpp
+++ b/cpp/arcticdb/storage/s3/mock_s3_client.cpp
@@ -117,7 +117,7 @@ S3Result<DeleteOutput> MockS3Client::delete_objects(
     for (auto& s3_object_name : s3_object_names){
         auto maybe_error = has_failure_trigger(s3_object_name, S3Operation::DELETE_LOCAL);
         if (maybe_error.has_value()) {
-            output.failed_deletes.emplace_back(s3_object_name);
+            output.failed_deletes.push_back({s3_object_name, "Sample error message"});
         }
         else {
             s3_contents.erase({bucket_name, s3_object_name});

--- a/cpp/arcticdb/storage/s3/real_s3_client.cpp
+++ b/cpp/arcticdb/storage/s3/real_s3_client.cpp
@@ -28,6 +28,10 @@
 
 #include <boost/interprocess/streams/bufferstream.hpp>
 
+// GetMessage macro on windows shadows AWS's GetMessage:
+// https://github.com/aws/aws-sdk-cpp/issues/402
+#undef GetMessage
+
 namespace arcticdb::storage{
 
 using namespace object_store_utils;
@@ -187,11 +191,9 @@ S3Result<DeleteOutput> RealS3Client::delete_objects(
     }
     // AN-256: Per AWS S3 documentation, deleting non-exist objects is not an error, so not handling
     // RemoveOpts.ignores_missing_key_
-    std::vector<std::string> failed_deletes;
+    std::vector<FailedDelete> failed_deletes;
     for (const auto &failed_key: outcome.GetResult().GetErrors()) {
-        // TODO: We only use GetKey(), so we should use QUIET:
-        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
-        failed_deletes.emplace_back(failed_key.GetKey());
+        failed_deletes.push_back({failed_key.GetKey(), failed_key.GetMessage()});
     }
 
     DeleteOutput result = {failed_deletes};

--- a/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
@@ -50,8 +50,12 @@ struct ListObjectsOutput{
     std::optional<std::string> next_continuation_token;
 };
 
+struct FailedDelete{
+    std::string s3_object_name;
+    std::string error_message;
+};
 struct DeleteOutput{
-    std::vector<std::string> failed_deletes;
+    std::vector<FailedDelete> failed_deletes;
 };
 
 // An abstract class, which is responsible for sending the requests and parsing the responses from S3.

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -312,7 +312,7 @@ TEST_F(S3StorageFixture, test_remove) {
     // Remove 2 and local fail on 3
     ASSERT_THROW(
         remove_in_store(store, {"symbol_2", MockS3Client::get_failure_trigger("symbol_3", S3Operation::DELETE_LOCAL, Aws::S3::S3Errors::NETWORK_CONNECTION)}),
-        KeyNotFoundException);
+        UnexpectedS3ErrorException);
     remaining = std::set<std::string>{"symbol_3", "symbol_4"};
     ASSERT_EQ(list_in_store(store), remaining);
 


### PR DESCRIPTION
- Previously on a local delete failure we would have raised a KeyNotFoundException which is quite misleading
- Now we raise a E_UNEXCPETED_S3_ERROR with additional error messages

#### Reference Issues/PRs

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
