### PR TITLE
Adds python tests which simulate s3 storage exceptions

### DIFF
--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -225,6 +225,7 @@ def get_s3_proto(
     is_https=False,
     region=None,
     use_virtual_addressing=False,
+    use_mock_storage_for_testing=None,
 ):
     env = cfg.env_by_id[env_name]
     s3 = S3Config()
@@ -240,6 +241,8 @@ def get_s3_proto(
         s3.https = is_https
     if use_virtual_addressing is not None:
         s3.use_virtual_addressing = use_virtual_addressing
+    if use_mock_storage_for_testing is not None:
+        s3.use_mock_storage_for_testing = use_mock_storage_for_testing
     # adding time to prefix - so that the s3 root folder is unique and we can delete and recreate fast
     if with_prefix:
         if isinstance(with_prefix, str):
@@ -270,6 +273,7 @@ def add_s3_library_to_env(
     is_https=False,
     region=None,
     use_virtual_addressing=False,
+    use_mock_storage_for_testing=None,
 ):
     env = cfg.env_by_id[env_name]
     if with_prefix and isinstance(with_prefix, str) and (with_prefix.endswith("/") or "//" in with_prefix):
@@ -290,6 +294,7 @@ def add_s3_library_to_env(
         is_https=is_https,
         region=region,
         use_virtual_addressing=use_virtual_addressing,
+        use_mock_storage_for_testing=use_mock_storage_for_testing,
     )
 
     _add_lib_desc_to_env(env, lib_name, sid, description)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -22,7 +22,7 @@ from functools import partial
 from arcticdb.storage_fixtures.api import StorageFixture
 from arcticdb.storage_fixtures.azure import AzuriteStorageFixtureFactory
 from arcticdb.storage_fixtures.lmdb import LmdbStorageFixture
-from arcticdb.storage_fixtures.s3 import MotoS3StorageFixtureFactory, real_s3_from_environment_variables
+from arcticdb.storage_fixtures.s3 import MotoS3StorageFixtureFactory, real_s3_from_environment_variables, mock_s3_with_error_simulation
 from arcticdb.storage_fixtures.mongo import auto_detect_server
 from arcticdb.storage_fixtures.in_memory import InMemoryStorageFixture
 from arcticdb.version_store._normalization import MsgPackNormalizer
@@ -109,6 +109,17 @@ def s3_storage_factory():
 @pytest.fixture
 def s3_storage(s3_storage_factory):
     with s3_storage_factory.create_fixture() as f:
+        yield f
+
+
+@pytest.fixture
+def mock_s3_storage_with_error_simulation_factory():
+    return mock_s3_with_error_simulation()
+
+
+@pytest.fixture
+def mock_s3_storage_with_error_simulation(mock_s3_storage_with_error_simulation_factory):
+    with mock_s3_storage_with_error_simulation_factory.create_fixture() as f:
         yield f
 
 
@@ -217,6 +228,11 @@ def s3_store_factory(lib_name, s3_storage):
 
 
 @pytest.fixture
+def mock_s3_store_with_error_simulation_factory(lib_name, mock_s3_storage_with_error_simulation):
+    return mock_s3_storage_with_error_simulation.create_version_store_factory(lib_name)
+
+
+@pytest.fixture
 def real_s3_store_factory(lib_name, real_s3_storage):
     return real_s3_storage.create_version_store_factory(lib_name)
 
@@ -246,6 +262,11 @@ def real_s3_version_store(real_s3_store_factory):
 @pytest.fixture(scope="function")
 def real_s3_version_store_dynamic_schema(real_s3_store_factory):
     return real_s3_store_factory(dynamic_strings=True, dynamic_schema=True)
+
+
+@pytest.fixture
+def mock_s3_store_with_error_simulation(mock_s3_store_with_error_simulation_factory):
+    return mock_s3_store_with_error_simulation_factory()
 
 
 @pytest.fixture

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -1,0 +1,27 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import pytest
+import pandas as pd
+
+from arcticdb import Arctic
+from arcticdb_ext.exceptions import StorageException
+
+
+def test_s3_storage_failures(mock_s3_store_with_error_simulation):
+    lib = mock_s3_store_with_error_simulation
+    symbol_fail_write = "symbol#Failure_Put_99_0"
+    symbol_fail_read = "symbol#Failure_Get_17_0"
+    df = pd.DataFrame({"a": list(range(100))}, index=list(range(100)))
+
+    with pytest.raises(StorageException, match="Unexpected network error: S3Error#99"):
+        lib.write(symbol_fail_write, df)
+
+    lib.write(symbol_fail_read, df)
+    with pytest.raises(StorageException, match="Unexpected error: S3Error#17"):
+        lib.read(symbol_fail_read)


### PR DESCRIPTION
- Adds a mock_s3_store_with_error_simulation python fixture
- Adds a test to verify s3 exceptions are properly displayed in the python layer

#### Reference Issues/PRs
This is a minor follow up to #1281 to add a small test in the python layer to verify exceptions are raised correctly.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
