### PR TITLE
build: Disable compilers' extensions

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -8,6 +8,9 @@ enable_testing()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# We do not need any compilers' extensions, so we disable them.
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 option(
     ARCTICDB_USING_CONDA
     "Whether ArcticDB's build system relies on conda for resolving its dependencies."


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?

Compilers extensions are not needed as mentioned by @Klaim.

This PR disables them to be sure the C++ standard only is used.

#### Any other comments?