### PR TITLE
Bugfix 1334: optimise version ref key access

### DIFF
--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -96,7 +96,6 @@ using VersionQueryType = std::variant<
 
 struct VersionQuery {
     VersionQueryType content_;
-    std::optional<bool> skip_compat_;
     std::optional<bool> iterate_on_failure_;
 
     void set_snap_name(const std::string& snap_name) {
@@ -109,10 +108,6 @@ struct VersionQuery {
 
     void set_version(SignedVersionId version) {
         content_ = SpecificVersionQuery{version};
-    }
-
-    void set_skip_compat(const std::optional<bool>& skip_compat) {
-        skip_compat_ = skip_compat;
     }
 
     void set_iterate_on_failure(const std::optional<bool>& iterate_on_failure) {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1720,11 +1720,6 @@ VersionedItem LocalVersionedEngine::sort_merge_internal(
     return versioned_item;
 }
 
-bool LocalVersionedEngine::has_stream(const StreamId & stream_id){
-    auto opt = get_latest_undeleted_version(store(), version_map(),  stream_id, VersionQuery{}, ReadOptions{});
-    return opt.has_value();
-}
-
 StorageLockWrapper LocalVersionedEngine::get_storage_lock(const StreamId& stream_id) {
     return StorageLockWrapper{stream_id, store_};
 }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -149,10 +149,6 @@ public:
         const StreamId& stream_id,
         const std::shared_ptr<InputTensorFrame>& frame) const override;
 
-    bool has_stream(
-        const StreamId & stream_id
-    ) override;
-
     void delete_tree(
         const std::vector<IndexTypeKey>& idx_to_be_deleted,
         const PreDeleteChecks& checks = default_pre_delete_checks

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -99,7 +99,6 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("set_snap_name", &VersionQuery::set_snap_name)
         .def("set_timestamp", &VersionQuery::set_timestamp)
         .def("set_version", &VersionQuery::set_version)
-        .def("set_skip_compat", &VersionQuery::set_skip_compat)
         .def("set_iterate_on_failure", &VersionQuery::set_iterate_on_failure);
 
     py::class_<ReadOptions>(version, "PythonVersionStoreReadOptions")

--- a/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
+++ b/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
@@ -34,7 +34,6 @@ template <typename Model>
 void check_latest_undeleted_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
     using namespace arcticdb;
     pipelines::VersionQuery version_query;
-    version_query.set_skip_compat(true),
     version_query.set_iterate_on_failure(true);
     auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, version_query, ReadOptions{});
     auto sut_version_id = prev ? prev->version_id() : 0;

--- a/cpp/arcticdb/version/test/test_stream_version_data.cpp
+++ b/cpp/arcticdb/version/test/test_stream_version_data.cpp
@@ -7,9 +7,9 @@ TEST(StreamVersionData, SpecificVersion) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false, false};
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false};
     stream_version_data.react(query_1);
-    VersionQuery query_2{SpecificVersionQuery{VersionId(4)}, false, false};
+    VersionQuery query_2{SpecificVersionQuery{VersionId(4)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_DOWNTO);
@@ -20,8 +20,8 @@ TEST(StreamVersionData, SpecificVersionReversed) {
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
 
-    StreamVersionData stream_version_data(VersionQuery{SpecificVersionQuery{VersionId(4)}, false, false});
-    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false, false};
+    StreamVersionData stream_version_data(VersionQuery{SpecificVersionQuery{VersionId(4)}, false});
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_DOWNTO);
@@ -33,9 +33,9 @@ TEST(StreamVersionData, Timestamp) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(12)}, false, false};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(12)}, false};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(4)}, false, false};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(4)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_FROM_TIME);
@@ -47,11 +47,11 @@ TEST(StreamVersionData, TimestampUnordered) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false, false};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(7)}, false, false};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(7)}, false};
     stream_version_data.react(query_2);
-    VersionQuery query_3{TimestampVersionQuery{timestamp(4)}, false, false};
+    VersionQuery query_3{TimestampVersionQuery{timestamp(4)}, false};
     stream_version_data.react(query_3);
     ASSERT_EQ(stream_version_data.count_, 3);
     ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_FROM_TIME);
@@ -63,7 +63,7 @@ TEST(StreamVersionData, Latest) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{std::monostate{}, false, false};
+    VersionQuery query_1{std::monostate{}, false};
     stream_version_data.react(query_1);
     ASSERT_EQ(stream_version_data.count_, 1);
     ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_LATEST_UNDELETED);
@@ -75,9 +75,9 @@ TEST(StreamVersionData, SpecificToTimestamp) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false, false};
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(3)}, false, false};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(3)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_UNDELETED);
@@ -90,9 +90,9 @@ TEST(StreamVersionData, TimestampToSpecific) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false, false};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false};
     stream_version_data.react(query_1);
-    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false, false};
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_UNDELETED);

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -54,7 +54,7 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
         }
     }
 
@@ -96,7 +96,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
         }
     }
 
@@ -108,7 +108,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     for(uint64_t i = 0; i < num_streams; i++){
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
-            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false, false});
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false});
         }
     }
 
@@ -146,7 +146,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.emplace_back(StreamId{"stream_0"});
-        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false});
     }
 
     // Do query
@@ -179,7 +179,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.emplace_back(StreamId{"stream_0"});
-        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false, false});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false});
     }
 
     // Do query
@@ -188,7 +188,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
     for(uint64_t i = 0; i < num_versions; i++){
-        version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts())}, false, false});
+        version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts())}, false});
     }
 
     // Now we can perform the actual batch query per timestamps
@@ -226,7 +226,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
         }
     }
 
@@ -241,11 +241,11 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false, false});
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false});
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{std::monostate{}, false, false});
+            version_queries.emplace_back(VersionQuery{std::monostate{}, false});
         }
     }
 

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -16,7 +16,6 @@ namespace arcticdb {
 
 inline void set_load_param_options(LoadParameter& load_param, const pipelines::VersionQuery& version_query, const ReadOptions& read_options) {
     load_param.use_previous_ = read_options.read_previous_on_failure_.value_or(false);
-    load_param.skip_compat_ = version_query.skip_compat_.value_or(true);
     load_param.iterate_on_failure_ = version_query.iterate_on_failure_.value_or(false);
 }
 
@@ -142,7 +141,6 @@ inline bool has_undeleted_version(
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &id) {
     pipelines::VersionQuery version_query;
-    version_query.set_skip_compat(true),
     version_query.set_iterate_on_failure(false);
     auto maybe_undeleted = get_latest_undeleted_version(store, version_map, id, version_query, ReadOptions{});
     return static_cast<bool>(maybe_undeleted);

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -891,27 +891,6 @@ public:
     }
 
 private:
-    // Backwards compat stuff
-    AtomKey rewrite_old_journal_keys(std::shared_ptr<Store> store, const StreamId &stream_id, const std::shared_ptr<VersionMapEntry>& entry) {
-        util::check(!entry->keys_.empty(), "Can't rewrite empty version journal entry");
-        auto version_id = entry->keys_[0].version_id();
-        entry->head_ = std::make_optional(write_entry_to_storage(store, stream_id, version_id, entry));
-        write_symbol_ref(store, *entry->keys_.cbegin(), std::nullopt, entry->head_.value());
-        return entry->head_.value();
-    }
-
-    std::shared_ptr<VersionMapEntry> load_from_old_journal_keys(std::shared_ptr<StreamSource> store, const StreamId &stream_id) {
-        ARCTICDB_DEBUG(log::version(), "Attempting to iterate old journal keys");
-        auto match_stream_id = [&stream_id](const AtomKey &k) { return k.id() == stream_id; };
-        auto old_entry = build_version_map_entry_with_predicate_iteration(store, match_stream_id, stream_id,
-                                                                          {KeyType::VERSION_JOURNAL});
-        auto index_keys = old_entry->get_indexes(false);
-        std::sort(index_keys.begin(), index_keys.end(), std::greater<>());
-        auto entry = std::make_shared<VersionMapEntry>();
-        entry->keys_.assign(index_keys.begin(), index_keys.end());
-        return entry;
-    }
-
     std::pair<VersionId, std::vector<AtomKey>> tombstone_from_key_or_all_internal(std::shared_ptr<Store> store,
                                                             const StreamId& stream_id,
                                                             std::optional<AtomKey> first_key_to_tombstone = std::nullopt,

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -63,7 +63,6 @@ struct LoadParameter {
     std::optional<SignedVersionId> load_until_ = std::nullopt;
     std::optional<timestamp> load_from_time_ = std::nullopt;
     bool use_previous_ = false;
-    bool skip_compat_ = true;
     bool iterate_on_failure_ = false;
 
     void validate() const {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -960,13 +960,13 @@ void PythonVersionStore::delete_all_versions(const StreamId& stream_id) {
     ARCTICDB_SAMPLE(DeleteAllVersions, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_all_versions");
-    if (!has_stream(stream_id)) {
-        log::version().warn("Symbol: {} does not exist.", stream_id);
-        return;
-    }
 
     try {
         auto [version_id, all_index_keys] = version_map()->delete_all_versions(store(), stream_id);
+        if (all_index_keys.empty()) {
+            log::version().warn("Nothing to delete for symbol '{}'", stream_id);
+            return;
+        }
         if (cfg().symbol_list())
             symbol_list().remove_symbol(store(), stream_id, version_id);
 

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -178,32 +178,20 @@ inline void check_is_version(const AtomKey &key) {
     util::check(key.type() == KeyType::VERSION, "Expected version key type but got {}", key);
 }
 
-inline std::optional<RefKey> get_symbol_ref_key(
-    const std::shared_ptr<StreamSource> &store,
-    const StreamId &stream_id) {
-    auto ref_key = RefKey{stream_id, KeyType::VERSION_REF};
-    if (store->key_exists_sync(ref_key))
-        return std::make_optional(std::move(ref_key));
-
-    // Old style ref_key
-    ARCTICDB_DEBUG(log::version(), "Ref key {} not found, trying old style ref key", ref_key);
-    ref_key = RefKey{stream_id, KeyType::VERSION, true};
-    if (!store->key_exists_sync(ref_key))
-        return std::nullopt;
-
-    ARCTICDB_DEBUG(log::version(), "Found old-style ref key", ref_key);
-    return std::make_optional(std::move(ref_key));
-}
-
 inline void read_symbol_ref(const std::shared_ptr<StreamSource>& store, const StreamId &stream_id, VersionMapEntry &entry) {
-    auto maybe_ref_key = get_symbol_ref_key(store, stream_id);
-    if (!maybe_ref_key)
-        return;
-
-    auto [key, seg] = store->read_sync(*maybe_ref_key);
+    std::pair<entity::VariantKey, SegmentInMemory> key_seg_pair;
+    try {
+        key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION_REF});
+    } catch (const storage::KeyNotFoundException&) {
+        try {
+            key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION, true});
+        } catch (const storage::KeyNotFoundException&) {
+            return;
+        }
+    }
 
     LoadProgress load_progress;
-    entry.head_ = read_segment_with_keys(seg, entry, load_progress);
+    entry.head_ = read_segment_with_keys(key_seg_pair.second, entry, load_progress);
 }
 
 inline void write_symbol_ref(std::shared_ptr<StreamSink> store,

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -84,10 +84,6 @@ public:
         const StreamId& stream_id,
         const std::shared_ptr<InputTensorFrame>& frame) const = 0;
 
-    virtual bool has_stream(
-        const StreamId & stream_id
-    ) = 0;
-
     /**
      * Delete the given index keys, and their associated data excluding those shared with keys not in the argument.
      *

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1447,7 +1447,6 @@ class NativeVersionStore:
 
     def _get_version_query(self, as_of: VersionQueryInput, **kwargs):
         version_query = _PythonVersionStoreVersionQuery()
-        version_query.set_skip_compat(_assume_true("skip_compat", kwargs))
         version_query.set_iterate_on_failure(_assume_false("iterate_on_failure", kwargs))
 
         if isinstance(as_of, str):

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -22,6 +22,5 @@ def test_s3_storage_failures(mock_s3_store_with_error_simulation):
     with pytest.raises(StorageException, match="Unexpected network error: S3Error#99"):
         lib.write(symbol_fail_write, df)
 
-    lib.write(symbol_fail_read, df)
     with pytest.raises(StorageException, match="Unexpected error: S3Error#17"):
         lib.read(symbol_fail_read)

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -10,13 +10,11 @@ import pandas as pd
 import datetime
 import pytest
 import sys
-import time
 
 from arcticdb.util.test import assert_frame_equal, assert_series_equal
 from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.util.date import DateRange
-
 
 def test_read_keys(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -10,11 +10,20 @@ import pandas as pd
 import datetime
 import pytest
 import sys
+import time
 
 from arcticdb.util.test import assert_frame_equal, assert_series_equal
 from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.util.date import DateRange
+
+def test_version_ref_key_access(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_version_ref_key_access"
+    lib.write(sym, 1)
+    time.sleep(10)
+    print("Write completed", flush=True)
+    lib.read(sym)
 
 def test_read_keys(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -21,9 +21,15 @@ def test_version_ref_key_access(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_version_ref_key_access"
     lib.write(sym, 1)
-    time.sleep(10)
+    lib.write(sym, 2)
     print("Write completed", flush=True)
-    lib.read(sym)
+    time.sleep(10)
+    lib.delete(sym)
+    # lib.delete(sym)
+    # lib.delete("non-existent sym")
+    # lib_tool = lib.library_tool()
+    # for key_type in lib_tool.key_types():
+    #     print(lib_tool.find_keys_for_symbol(key_type, sym))
 
 def test_read_keys(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -17,19 +17,6 @@ from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.util.date import DateRange
 
-def test_version_ref_key_access(lmdb_version_store_v1):
-    lib = lmdb_version_store_v1
-    sym = "test_version_ref_key_access"
-    lib.write(sym, 1)
-    lib.write(sym, 2)
-    print("Write completed", flush=True)
-    time.sleep(10)
-    lib.delete(sym)
-    # lib.delete(sym)
-    # lib.delete("non-existent sym")
-    # lib_tool = lib.library_tool()
-    # for key_type in lib_tool.key_types():
-    #     print(lib_tool.find_keys_for_symbol(key_type, sym))
 
 def test_read_keys(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1334 

#### What does this implement or fix?
Main functional change is to `read_symbol_ref` in `version_utils.hpp`. There was an old style of version chain entry point which used a `VERSION` key of type reference (rather than atom), as opposed to a `VERSION_REF` key. The old implementation did a HEAD request on both of these keys, and then read the one that exists. This introduced 1 or 2 tiny IOs, when the same information could be obtained by attempting to GET the relevant keys, and handling the key not existing as appropriate.

Now reading and deleting operations only ever read the version ref key once. Modifying operations still read the key twice, to account for the fact that other changes could have been made to the symbol between the latest version being identified, and being ready to write the new version ref key back.
The only exception is if `write_metadata` is called with a symbol name that has never existed. This case should be rare, and the code change to reduce this to 2 reads in line with other modifying operations would make the general `write` path harder to read.

The remaining changes are to strip out attempts to read `VERSION_JOURNAL` keys, as these should all have been replaced with `VERSION_REF` keys by the (also now deleted) `rewrite_old_journal_keys` a long time go.