### PR TITLE
Fix dynamic strings append to fixed strings issue

### DIFF
--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -136,4 +136,12 @@ std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vec
     const std::shared_ptr<Store>& store,
     const AtomKey& index_key);
 
+// Combines the stream descriptors of an existing index key and a new frame.
+// Can be used to get the metadata for [write_index] when updating or appending.
+TimeseriesDescriptor get_merged_tsd(
+    int row_count,
+    bool dynamic_schema,
+    const TimeseriesDescriptor& existing_tsd,
+    const std::shared_ptr<pipelines::InputTensorFrame>& new_frame);
+
 } //namespace arcticdb::pipelines::index

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -60,6 +60,20 @@ def test_append_string_of_different_sizes(lmdb_version_store):
     assert_frame_equal(vit.data, expected)
 
 
+def test_append_dynamic_schema_add_column(lmdb_version_store_dynamic_schema):
+    symbol = "symbol"
+    lib = lmdb_version_store_dynamic_schema
+    df_1 = pd.DataFrame(data={"a": [1.0, 2.0]}, index=pd.date_range("2018-01-01", periods=2))
+    df_2 = pd.DataFrame(data={"b": [3.0, 4.0]}, index=pd.date_range("2018-01-03", periods=2))
+
+    lib.write(symbol, df_1)
+    lib.append(symbol, df_2)
+
+    expected_df = pd.concat([df_1, df_2])
+    result_df = lib.read(symbol).data
+    assert_frame_equal(result_df, expected_df)
+
+
 def test_append_snapshot_delete(lmdb_version_store):
     symbol = "test_append_snapshot_delete"
     if sys.platform == "win32":

--- a/python/tests/unit/arcticdb/version_store/test_column_type_changes.py
+++ b/python/tests/unit/arcticdb/version_store/test_column_type_changes.py
@@ -43,18 +43,8 @@ def test_changing_numeric_type(version_store_factory, dynamic_schema):
         assert_frame_equal(expected_update, received_update)
 
 
-@pytest.mark.parametrize("dynamic_schema, dynamic_strings_first", [
-    (True, True),
-    (True, False),
-    pytest.param(False,
-                 True,
-                 marks=pytest.mark.xfail(
-                     reason="""Issue with appending/updating a dynamic string column with fixed-width strings
-                     https://github.com/man-group/ArcticDB/issues/1204"""
-                 )
-                 ),
-    (False, False),
-])
+@pytest.mark.parametrize("dynamic_schema", [True, False])
+@pytest.mark.parametrize("dynamic_strings_first", [True, False])
 def test_changing_string_type(version_store_factory, dynamic_schema, dynamic_strings_first):
     lib = version_store_factory(dynamic_strings=True, dynamic_schema=dynamic_schema)
     sym_append = "test_changing_string_type_append"

--- a/python/tests/unit/arcticdb/version_store/test_empty_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_writes.py
@@ -146,19 +146,34 @@ def test_empty_series(lmdb_version_store_dynamic_schema, sym):
     assert_series_equal(lmdb_version_store_dynamic_schema.read(sym).data, ser, check_index_type=False)
 
 
-@pytest.mark.parametrize("dtype", ["int64", "float64"])
-def test_append_empty_series(lmdb_version_store_dynamic_schema, sym, dtype):
-    ser = pd.Series([])
+@pytest.mark.parametrize("dtype, existing_empty, append_empty", [
+    ("int64", True, False),
+    ("float64", True, False),
+    ("float64", False, True),
+    ("float64", True, True),
+])
+def test_append_empty_series(lmdb_version_store_dynamic_schema, sym, dtype, existing_empty, append_empty):
+    empty_ser = pd.Series([])
+    non_empty_ser = pd.Series([1, 2, 3], dtype=dtype)
+    if existing_empty:
+        ser = empty_ser
+    else:
+        ser = non_empty_ser
     lmdb_version_store_dynamic_schema.write(sym, ser)
     assert not lmdb_version_store_dynamic_schema.is_symbol_pickled(sym)
 
     # ArcticDB stores empty columns under a dedicated `EMPTYVAL` type, so the types are not going to match with pandas
-    # until the first append.
-    assert_series_equal(lmdb_version_store_dynamic_schema.read(sym).data, ser, check_index_type=False)
+    # if the series is empty.
+    assert_series_equal(lmdb_version_store_dynamic_schema.read(sym).data, ser, check_index_type=(len(ser) > 0))
 
-    new_ser = pd.Series([1, 2, 3], dtype=dtype)
+    if append_empty:
+        new_ser = empty_ser
+    else:
+        new_ser = non_empty_ser
     lmdb_version_store_dynamic_schema.append(sym, new_ser)
-    assert_series_equal(lmdb_version_store_dynamic_schema.read(sym).data, new_ser)
+
+    result_ser = pd.concat([ser, new_ser])
+    assert_series_equal(lmdb_version_store_dynamic_schema.read(sym).data, result_ser, check_index_type=(len(result_ser) > 0))
 
 
 def test_entirely_empty_column(lmdb_version_store):


### PR DESCRIPTION
Abstracts out merging descriptors construction
- Deduplicates merging descriptors inside update and append
- Fixes fixed string to dynamic string conversion
- Fixes inconsistent column ordering with dynamic schema

#### Reference Issues/PRs
Fixes #1204
Fixes #1349 

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
