### PR TITLE
Fix version map cache invalidation policies

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -445,7 +445,7 @@ std::vector<std::variant<DescriptorItem, DataError>> LocalVersionedEngine::batch
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_error_.has_value(),
                                                     "ReadOptions::batch_throw_on_error_ should always be set here");
 
-    auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
+    auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries);
     std::vector<folly::Future<DescriptorItem>> descriptor_futures;
     for (auto&& [idx, version_fut]: folly::enumerate(version_futures)) {
         descriptor_futures.emplace_back(
@@ -1119,7 +1119,7 @@ std::vector<std::variant<ReadVersionOutput, DataError>> LocalVersionedEngine::te
     const ReadOptions &read_options) {
     py::gil_scoped_release release_gil;
 
-    auto versions = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
+    auto versions = batch_get_versions_async(store(), version_map(), stream_ids, version_queries);
     std::vector<folly::Future<ReadVersionOutput>> read_versions_futs;
     for (auto&& [idx, version] : folly::enumerate(versions)) {
         auto read_query = read_queries.empty() ? ReadQuery{} : read_queries[idx];
@@ -1664,7 +1664,7 @@ std::vector<std::variant<std::pair<VariantKey, std::optional<google::protobuf::A
     // This read option should always be set when calling batch_read_metadata
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(read_options.batch_throw_on_error_.has_value(),
                                                     "ReadOptions::batch_throw_on_error_ should always be set here");
-    auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries, read_options.read_previous_on_failure_);
+    auto version_futures = batch_get_versions_async(store(), version_map(), stream_ids, version_queries);
     std::vector<folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>>> metadata_futures;
     for (auto&& [idx, version]: folly::enumerate(version_futures)) {
         metadata_futures.emplace_back(get_metadata_async(std::move(version), stream_ids[idx], version_queries[idx]));

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -99,20 +99,17 @@ public:
 
     std::optional<VersionedItem> get_latest_version(
         const StreamId &stream_id,
-        const VersionQuery& version_query,
-        const ReadOptions& read_options);
+        const VersionQuery& version_query);
 
     std::optional<VersionedItem> get_specific_version(
         const StreamId &stream_id,
         SignedVersionId signed_version_id,
-        const VersionQuery& version_query,
-        const ReadOptions& read_options);
+        const VersionQuery& version_query);
 
     std::optional<VersionedItem> get_version_at_time(
         const StreamId& stream_id,
         timestamp as_of,
-        const VersionQuery& version_query,
-        const ReadOptions& read_options);
+        const VersionQuery& version_query);
 
     std::optional<VersionedItem> get_version_from_snapshot(
         const StreamId& stream_id,
@@ -125,8 +122,7 @@ public:
 
     std::optional<VersionedItem> get_version_to_read(
         const StreamId& stream_id,
-        const VersionQuery& version_query,
-        const ReadOptions& read_options
+        const VersionQuery& version_query
     );
 
     FrameAndDescriptor read_dataframe_internal(
@@ -142,8 +138,7 @@ public:
 
     DescriptorItem read_descriptor_internal(
             const StreamId& stream_id,
-            const VersionQuery& version_query,
-            const ReadOptions& read_options);
+            const VersionQuery& version_query);
 
     void write_parallel_frame(
         const StreamId& stream_id,
@@ -327,8 +322,7 @@ public:
 
     std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> read_metadata_internal(
         const StreamId& stream_id,
-        const VersionQuery& version_query,
-        const ReadOptions& read_options);
+        const VersionQuery& version_query);
 
     bool is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) override;
 

--- a/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
+++ b/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
@@ -23,7 +23,7 @@
 template <typename Model>
 void check_latest_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
     using namespace arcticdb;
-    auto prev = get_latest_version(sut.store_,sut.map_, symbol, pipelines::VersionQuery{}, ReadOptions{});
+    auto prev = get_latest_version(sut.store_,sut.map_, symbol, pipelines::VersionQuery{});
     auto sut_version_id = prev ? prev->version_id() : 0;
     auto model_prev = s0.get_latest_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
@@ -35,7 +35,7 @@ void check_latest_undeleted_versions(const Model&  s0, MapStorePair &sut, std::s
     using namespace arcticdb;
     pipelines::VersionQuery version_query;
     version_query.set_iterate_on_failure(true);
-    auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, version_query, ReadOptions{});
+    auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, version_query);
     auto sut_version_id = prev ? prev->version_id() : 0;
     auto model_prev = s0.get_latest_undeleted_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
@@ -224,7 +224,7 @@ struct GetAllVersions : rc::state::Command<Model, MapStorePair> {
     void run(const Model& s0, MapStorePair &sut) const override {
         auto model_versions = s0.get_all_versions(symbol_);
         using namespace arcticdb;
-        auto sut_version = get_all_versions(sut.store_, sut.map_, symbol_, pipelines::VersionQuery{}, ReadOptions{});
+        auto sut_version = get_all_versions(sut.store_, sut.map_, symbol_, pipelines::VersionQuery{});
         RC_ASSERT(model_versions.size() == sut_version.size());
 
         for(auto i = size_t{0}; i < model_versions.size(); ++i)

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -59,7 +59,7 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
     
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){
@@ -101,7 +101,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -113,7 +113,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     }
 
     // Now we can perform the actual batch query per timestamps
-    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){
@@ -150,7 +150,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
     }
 
     // Do query
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
     
     // Check results
     for(uint64_t i = 0; i < num_versions; i++){
@@ -183,7 +183,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     }
 
     // Do query
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -192,7 +192,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     }
 
     // Now we can perform the actual batch query per timestamps
-    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions_querying_with_timestamp = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_versions; i++){
@@ -231,7 +231,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
     }
 
     // do batch versions read
-    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
@@ -249,7 +249,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         }
     }
 
-    auto versions_querying_with_mix_types = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries, false)).get();
+    auto versions_querying_with_mix_types = folly::collect(batch_get_versions_async(store, version_map, stream_ids, version_queries)).get();
 
     // Do the checks
     for(uint64_t i = 0; i < num_streams; i++){

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -377,21 +377,21 @@ TEST(VersionStore, TestReadTimestampAt) {
 
   auto version_map = version_store._test_get_version_map();
   version_map->write_version(mock_store, key1);
-  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{}, ReadOptions{});
+  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{});
   ASSERT_EQ(key.value().content_hash(), 3);
 
   version_map->write_version(mock_store, key2);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{}, ReadOptions{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{});
   ASSERT_EQ(key.value().content_hash(), 3);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{}, ReadOptions{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{});
   ASSERT_EQ(key.value().content_hash(), 4);
 
   version_map->write_version(mock_store, key3);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{}, ReadOptions{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{});
   ASSERT_EQ(key.value().content_hash(), 3);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{}, ReadOptions{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{});
   ASSERT_EQ(key.value().content_hash(), 4);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(2), pipelines::VersionQuery{}, ReadOptions{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(2), pipelines::VersionQuery{});
   ASSERT_EQ(key.value().content_hash(), 5);
 }
 
@@ -409,7 +409,7 @@ TEST(VersionStore, TestReadTimestampAtInequality) {
 
   auto version_map = version_store._test_get_version_map();
   version_map->write_version(mock_store, key1);
-  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{}, ReadOptions{});
+  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{});
   ASSERT_EQ(static_cast<bool>(key), true);
   ASSERT_EQ(key.value().content_hash(), 3);
 }
@@ -534,7 +534,7 @@ TEST(VersionStore, UpdateAfter) {
         if(update_range.contains(i))
             expected += update_val;
 
-        auto val1 = seg.scalar_at<uint8_t >(i, 1);
+        auto val1 = seg.scalar_at<uint8_t>(i, 1);
         ASSERT_EQ(val1.value(), expected);
     }
 }

--- a/cpp/arcticdb/version/test/version_map_model.hpp
+++ b/cpp/arcticdb/version/test/version_map_model.hpp
@@ -36,7 +36,7 @@ struct MapStorePair {
 
     void write_version(const std::string &id) {
         log::version().info("MapStorePair, write version {}", id);
-        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{}, ReadOptions{});
+        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{});
         auto version_id = prev ? prev->version_id() + 1 : 0;
         map_->write_version(store_, make_test_index_key(id, version_id, KeyType::TABLE_INDEX));
     }
@@ -51,7 +51,7 @@ struct MapStorePair {
 
     void write_and_prune_previous(const std::string &id) {
         log::version().info("MapStorePair, write_and_prune_previous version {}", id);
-        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{}, ReadOptions{});
+        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{});
         auto version_id = prev ? prev->version_id() + 1 : 0;
 
         if(tombstones_)

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -14,8 +14,7 @@
 
 namespace arcticdb {
 
-inline void set_load_param_options(LoadParameter& load_param, const pipelines::VersionQuery& version_query, const ReadOptions& read_options) {
-    load_param.use_previous_ = read_options.read_previous_on_failure_.value_or(false);
+inline void set_load_param_options(LoadParameter& load_param, const pipelines::VersionQuery& version_query, const ReadOptions&) {
     load_param.iterate_on_failure_ = version_query.iterate_on_failure_.value_or(false);
 }
 

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -14,7 +14,7 @@
 
 namespace arcticdb {
 
-inline void set_load_param_options(LoadParameter& load_param, const pipelines::VersionQuery& version_query, const ReadOptions&) {
+inline void set_load_param_options(LoadParameter& load_param, const pipelines::VersionQuery &version_query) {
     load_param.iterate_on_failure_ = version_query.iterate_on_failure_.value_or(false);
 }
 
@@ -22,11 +22,10 @@ inline std::optional<AtomKey> get_latest_undeleted_version(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    const pipelines::VersionQuery& version_query,
-    const ReadOptions& read_options) {
+    const pipelines::VersionQuery& version_query) {
     ARCTICDB_RUNTIME_SAMPLE(GetLatestUndeletedVersion, 0)
     LoadParameter load_param{LoadType::LOAD_LATEST_UNDELETED};
-    set_load_param_options(load_param, version_query, read_options);
+    set_load_param_options(load_param, version_query);
     const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(false);
 }
@@ -35,11 +34,10 @@ inline std::optional<AtomKey> get_latest_version(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    const pipelines::VersionQuery& version_query,
-    const ReadOptions& read_options) {
+    const pipelines::VersionQuery& version_query) {
     ARCTICDB_SAMPLE(GetLatestVersion, 0)
     LoadParameter load_param{LoadType::LOAD_LATEST};
-    set_load_param_options(load_param, version_query, read_options);
+    set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(true);
 }
@@ -49,11 +47,10 @@ inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_i
         const std::shared_ptr<Store> &store,
         const std::shared_ptr<VersionMap> &version_map,
         const StreamId &stream_id,
-        const pipelines::VersionQuery& version_query,
-        const ReadOptions& read_options) {
+        const pipelines::VersionQuery& version_query) {
     ARCTICDB_SAMPLE(GetLatestUndeletedVersionAndHighestVersionId, 0)
     LoadParameter load_param{LoadType::LOAD_LATEST_UNDELETED};
-    set_load_param_options(load_param, version_query, read_options);
+        set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     auto latest_version = entry->get_first_index(true);
     auto latest_undeleted_version = entry->get_first_index(false);
@@ -65,12 +62,11 @@ inline std::vector<AtomKey> get_all_versions(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    const pipelines::VersionQuery& version_query,
-    const ReadOptions& read_option
+    const pipelines::VersionQuery& version_query
     ) {
     ARCTICDB_SAMPLE(GetAllVersions, 0)
     LoadParameter load_param{LoadType::LOAD_UNDELETED};
-    set_load_param_options(load_param, version_query, read_option);
+    set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_indexes(false);
 }
@@ -81,11 +77,10 @@ inline std::optional<AtomKey> get_specific_version(
         const StreamId &stream_id,
         SignedVersionId signed_version_id,
         const pipelines::VersionQuery& version_query,
-        const ReadOptions& read_option,
         bool include_deleted = false) {
     LoadParameter load_param{LoadType::LOAD_DOWNTO, signed_version_id};
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
-    set_load_param_options(load_param, version_query, read_option);
+    set_load_param_options(load_param, version_query);
     VersionId version_id;
     if (signed_version_id >= 0) {
         version_id = static_cast<VersionId>(signed_version_id);
@@ -141,7 +136,7 @@ inline bool has_undeleted_version(
     const StreamId &id) {
     pipelines::VersionQuery version_query;
     version_query.set_iterate_on_failure(false);
-    auto maybe_undeleted = get_latest_undeleted_version(store, version_map, id, version_query, ReadOptions{});
+    auto maybe_undeleted = get_latest_undeleted_version(store, version_map, id, version_query);
     return static_cast<bool>(maybe_undeleted);
 }
 
@@ -159,10 +154,9 @@ inline std::unordered_map<VersionId, bool> get_all_tombstoned_versions(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    const pipelines::VersionQuery& version_query,
-    const ReadOptions& read_option) {
+    const pipelines::VersionQuery& version_query) {
     LoadParameter load_param{LoadType::LOAD_ALL};
-    set_load_param_options(load_param, version_query, read_option);
+    set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::unordered_map<VersionId, bool> result;
     for (auto key: entry->get_tombstoned_indexes())
@@ -177,12 +171,11 @@ inline version_store::TombstoneVersionResult tombstone_version(
     const StreamId &stream_id,
     VersionId version_id,
     const pipelines::VersionQuery& version_query,
-    const ReadOptions& read_options,
     bool allow_tombstoning_beyond_latest_version=false,
     const std::optional<timestamp>& creation_ts=std::nullopt) {
     ARCTICDB_DEBUG(log::version(), "Tombstoning version {} for stream {}", version_id, stream_id);
     LoadParameter load_param{LoadType::LOAD_UNDELETED};
-    set_load_param_options(load_param, version_query, read_options);
+    set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     // Might as well do the previous/next version check while we find the required version_id.
     // But if entry is empty, it's possible the load failed (since iterate_on_failure=false above), so set the flag
@@ -203,7 +196,7 @@ inline version_store::TombstoneVersionResult tombstone_version(
             util::raise_rte("Version {} for symbol {} is already deleted", version_id, stream_id);
         } else {
             if (!allow_tombstoning_beyond_latest_version) {
-                auto latest_key = get_latest_version(store, version_map, stream_id, version_query, read_options);
+                auto latest_key = get_latest_version(store, version_map, stream_id, version_query);
                 if (!latest_key || latest_key->version_id() < version_id)
                     util::raise_rte("Can't delete version {} for symbol {} - it's higher than the latest version",
                             stream_id, version_id);
@@ -246,10 +239,9 @@ inline std::optional<AtomKey> load_index_key_from_time(
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
     timestamp from_time,
-    const pipelines::VersionQuery& version_query,
-    const ReadOptions& read_options) {
+    const pipelines::VersionQuery& version_query) {
     LoadParameter load_param{LoadType::LOAD_FROM_TIME, from_time};
-    set_load_param_options(load_param, version_query, read_options);
+    set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
     return get_index_key_from_time(from_time, indexes);
@@ -259,10 +251,9 @@ inline std::vector<AtomKey> get_index_and_tombstone_keys(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
-    const pipelines::VersionQuery& version_query,
-    const ReadOptions& read_options) {
+    const pipelines::VersionQuery& version_query) {
     LoadParameter load_param{LoadType::LOAD_ALL};
-    set_load_param_options(load_param, version_query, read_options);
+    set_load_param_options(load_param, version_query);
     const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::vector<AtomKey> res;
     std::copy_if(std::begin(entry->keys_), std::end(entry->keys_), std::back_inserter(res),

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -589,8 +589,7 @@ public:
                 break;
             case LoadType::LOAD_LATEST_UNDELETED:
                 if (requested_load_type == LoadType::LOAD_LATEST_UNDELETED
-                    || requested_load_type == LoadType::LOAD_LATEST
-                    || requested_load_type == LoadType::NOT_LOADED) {
+                    || requested_load_type == LoadType::LOAD_LATEST) {
                     return true;
                 }
 
@@ -613,7 +612,7 @@ public:
                     return opt_latest.has_value();
                 }
 
-                return requested_load_type == LoadType::NOT_LOADED;
+                return false;
             case LoadType::LOAD_FROM_TIME:
                 // Future: This case could be optimized: use cache if it is LOAD_FROM_TIME for earlier time or
                 // LOAD_DOWNTO for a version with an earlier timestamp

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -150,7 +150,9 @@ public:
         std::optional<VersionId> latest_version;
         LoadProgress load_progress;
         util::check(ref_entry.keys_.size() >= 2, "Invalid number of keys in ref entry: {}", ref_entry.keys_.size());
-        if (key_exists_in_ref_entry(load_params, ref_entry, std::nullopt, load_progress)) {
+        if (key_exists_in_ref_entry(load_params, ref_entry)) {
+            load_progress.loaded_until_ = ref_entry.loaded_until_;
+            load_progress.oldest_loaded_index_version_ = ref_entry.loaded_until_;
             entry->keys_.push_back(ref_entry.keys_[0]);
         } else {
             do {
@@ -537,7 +539,102 @@ public:
         folly::collect(key_futs).get();
     }
 
+    /**
+     * Public for testability only.
+     *
+     * @param stream_id symbol to check
+     * @param load_param the load type
+     * @return whether we have a cached entry suitable for the load type, so do not need to go to storage
+     */
+    bool has_cached_entry(const StreamId &stream_id, const LoadParameter& load_param) const {
+        LoadType requested_load_type = load_param.load_type_;
+        util::check(requested_load_type < LoadType::UNKNOWN, "Unexpected load type requested {}", requested_load_type);
+
+        load_param.validate();
+        MapType::const_iterator entry_it;
+        if(!find_entry(entry_it, stream_id)) {
+            return false;
+        }
+
+        const timestamp reload_interval = reload_interval_.value_or(
+                ConfigsMap::instance()->get_int("VersionMap.ReloadInterval", DEFAULT_RELOAD_INTERVAL));
+
+        const auto& entry = entry_it->second;
+        if (const timestamp cache_timing = now() - entry->last_reload_time_; cache_timing > reload_interval) {
+            ARCTICDB_DEBUG(log::version(),
+                           "Latest read time {} too long ago for last acceptable cached timing {} (cache period {}) for symbol {}",
+                           entry->last_reload_time_, cache_timing, reload_interval, stream_id);
+
+            return false;
+        }
+
+        if (requested_load_type == LoadType::NOT_LOADED) {
+            return true;
+        }
+
+        LoadType cached_load_type = entry->load_type_;
+
+        switch(cached_load_type) {
+            case LoadType::NOT_LOADED:
+                break;
+            case LoadType::LOAD_LATEST:
+                // Future: This case and LOAD_LATEST_UNDELETED could be optimized: use cache if request is
+                // LOAD_FROM_TIME for a later time than the cached entry.
+                if (requested_load_type == LoadType::LOAD_LATEST) {
+                    return true;
+                }
+                if (requested_load_type == LoadType::LOAD_DOWNTO) {
+                    return loaded_as_far_as_load_until(*entry, load_param);
+                }
+                break;
+            case LoadType::LOAD_LATEST_UNDELETED:
+                if (requested_load_type == LoadType::LOAD_LATEST_UNDELETED
+                    || requested_load_type == LoadType::LOAD_LATEST
+                    || requested_load_type == LoadType::NOT_LOADED) {
+                    return true;
+                }
+
+                if (requested_load_type == LoadType::LOAD_DOWNTO) {
+                    return loaded_as_far_as_load_until(*entry, load_param);
+                }
+                break;
+            case LoadType::LOAD_DOWNTO:
+                if (requested_load_type == LoadType::LOAD_DOWNTO) {
+                    return loaded_as_far_as_load_until(*entry, load_param);
+                }
+
+                if (requested_load_type == LoadType::LOAD_LATEST_UNDELETED) {
+                    auto opt_latest = entry->get_first_index(false);
+                    return opt_latest.has_value();
+                }
+
+                if (requested_load_type == LoadType::LOAD_LATEST) {
+                    auto opt_latest = entry->get_first_index(true);
+                    return opt_latest.has_value();
+                }
+
+                return requested_load_type == LoadType::NOT_LOADED;
+            case LoadType::LOAD_FROM_TIME:
+                // Future: This case could be optimized: use cache if it is LOAD_FROM_TIME for earlier time or
+                // LOAD_DOWNTO for a version with an earlier timestamp
+
+                // LOAD_FROM_TIME keeps looking till it finds an undeleted version, even that is earlier than the
+                // search time requested
+                return requested_load_type == LoadType::NOT_LOADED
+                    || requested_load_type == LoadType::LOAD_LATEST_UNDELETED
+                    || requested_load_type == LoadType::LOAD_LATEST;
+            case LoadType::LOAD_UNDELETED:
+                return requested_load_type != LoadType::LOAD_ALL;
+            case LoadType::LOAD_ALL:
+                return true;
+            default:
+                util::raise_rte("Unexpected load type in cache {}", cached_load_type);
+        }
+        return false;
+    }
+
 private:
+
     std::shared_ptr<VersionMapEntry> compact_entry(
             std::shared_ptr<Store> store,
             const StreamId& stream_id,
@@ -600,62 +697,34 @@ private:
         return true;
     }
 
-    bool has_cached_entry(const StreamId &stream_id, const LoadParameter& load_param) const {
-        load_param.validate();
-        MapType::const_iterator entry_it;
-        if(!find_entry(entry_it, stream_id))
-            return false;
-
-        const timestamp reload_interval = reload_interval_.value_or(ConfigsMap::instance()->get_int("VersionMap.ReloadInterval", DEFAULT_RELOAD_INTERVAL));
-
-        const auto& entry = entry_it->second;
-        if (const timestamp cache_timing = now() - entry->last_reload_time_; cache_timing > reload_interval) {
-            ARCTICDB_DEBUG(log::version(),
-                    "Latest read time {} too long ago for last acceptable cached timing {} (cache period {}) for symbol {}",
-                    entry->last_reload_time_, cache_timing, reload_interval, stream_id);
-
-            return false;
-        }
-
-        // TODO: Fix #587
-        if (entry->load_type_ < load_param.load_type_) {
-            ARCTICDB_DEBUG(log::version(), "Required load type {} exceeds existing load type {}, will reload {}",
-                           load_param.load_type_, entry->load_type_, stream_id);
-            return false;
-        }
-
-        if(entry->load_type_ == LoadType::LOAD_DOWNTO) {
-            if (load_param.load_type_ == LoadType::LOAD_UNDELETED) {
-                return false;
+    /**
+     * Whether entry contains as much of the version map as specified by load_param. Checks whether
+     * loaded_until_ in entry is earlier than that specified in load_param.
+     *
+     * @param entry the version map state to check
+     * @param load_param the load request to test for completeness
+     * @return true if and only if entry already contains data at least as far back as load_param requests
+     */
+    bool loaded_as_far_as_load_until(const VersionMapEntry& entry, const LoadParameter& load_param) const {
+        if (is_positive_version_query(load_param)) {
+            if (entry.loaded_until_ <= static_cast<VersionId>(load_param.load_until_.value())) {
+                ARCTICDB_DEBUG(log::version(), "Loaded as far as required value {}, have {}",
+                               load_param.load_until_.value(), entry.loaded_until_);
+                return true;
             }
-            if (load_param.load_type_ == LoadType::LOAD_DOWNTO ) {
-                if (is_positive_version_query(load_param)) {
-                    if (entry->loaded_until_ > static_cast<VersionId>(load_param.load_until_.value())) {
-                        ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {}",
-                                       load_param.load_until_.value(), entry->loaded_until_);
-                        return false;
-                    }
-                } else {
-                    auto opt_latest = entry->get_first_index(true);
-                    if (opt_latest.has_value()) {
-                        auto opt_version_id = get_version_id_negative_index(opt_latest->version_id(), *load_param.load_until_);
-                        if (opt_version_id.has_value() && entry->loaded_until_ > *opt_version_id) {
-                            ARCTICDB_DEBUG(log::version(), "Not loaded as far as required value {}, only have {} and there are {} total versions",
-                                           load_param.load_until_.value(), entry->loaded_until_, opt_latest->version_id());
-                            return false;
-                        }
-                    }
+        } else {
+            auto opt_latest = entry.get_first_index(true);
+            if (opt_latest.has_value()) {
+                auto opt_version_id = get_version_id_negative_index(opt_latest->version_id(),
+                                                                    *load_param.load_until_);
+                if (opt_version_id.has_value() && entry.loaded_until_ <= *opt_version_id) {
+                    ARCTICDB_DEBUG(log::version(), "Loaded as far as required value {}, have {} and there are {} total versions",
+                                   load_param.load_until_.value(), entry.loaded_until_, opt_latest->version_id());
+                    return true;
                 }
-
             }
         }
-
-        if(load_param.load_type_ == LoadType::LOAD_UNDELETED && !entry->tombstone_all_ &&
-           entry->load_type_ != LoadType::LOAD_UNDELETED)
-            return false;
-
-        ARCTICDB_DEBUG(log::version(), "{} Using cached entry for symbol {}", uintptr_t(this), stream_id);
-        return true;
+        return false;
     }
 
     std::shared_ptr<VersionMapEntry>& get_entry(const StreamId& stream_id) {

--- a/cpp/arcticdb/version/version_map_batch_methods.cpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.cpp
@@ -251,8 +251,7 @@ std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions_async(
     const std::shared_ptr<Store> &store,
     const std::shared_ptr<VersionMap> &version_map,
     const std::vector<StreamId> &symbols,
-    const std::vector<pipelines::VersionQuery> &version_queries,
-    const std::optional<bool> &use_previous_on_error) {
+    const std::vector<pipelines::VersionQuery> &version_queries) {
     ARCTICDB_SAMPLE(BatchGetVersion, 0)
     util::check(symbols.size() == version_queries.size(),
                 "Symbol and version query list mismatch: {} != {}",
@@ -293,13 +292,10 @@ std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions_async(
                     store
                 );
             },
-            [&version_entry_fut, &version_data, &symbol, &version_futures, use_previous_on_error, &store, &version_map](
+            [&version_entry_fut, &version_data, &symbol, &version_futures, &store, &version_map](
                 const auto &) {
                 const auto it = version_data.find(*symbol);
                 util::check(it != version_data.end(), "Missing version data for symbol {}", *symbol);
-
-                if (use_previous_on_error.value_or(false))
-                    it->second.load_param_.use_previous_ = true;
 
                 version_entry_fut = set_up_version_future(
                     *symbol,

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -255,8 +255,7 @@ std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions_async(
     const std::shared_ptr<Store>& store,
     const std::shared_ptr<VersionMap>& version_map,
     const std::vector<StreamId>& symbols,
-    const std::vector<pipelines::VersionQuery>& version_queries,
-    const std::optional<bool>& use_previous_on_error);
+    const std::vector<pipelines::VersionQuery>& version_queries);
 
 inline std::vector<folly::Future<folly::Unit>> batch_write_version(
     const std::shared_ptr<Store> &store,

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -327,7 +327,7 @@ struct VersionMapEntry {
     std::optional<AtomKey> head_;
     LoadType load_type_ = LoadType::NOT_LOADED;
     timestamp last_reload_time_ = 0;
-    VersionId loaded_until_ = 0;
+    VersionId loaded_until_ = std::numeric_limits<uint64_t>::max();
     std::deque<AtomKey> keys_;
     std::unordered_map<VersionId, AtomKey> tombstones_;
     std::optional<AtomKey> tombstone_all_;

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -20,23 +20,19 @@ namespace arcticdb {
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;
 
-enum class LoadType :
-        uint32_t {
+enum class LoadType : uint32_t {
     NOT_LOADED = 0,
-    LOAD_LATEST = 1,
-    LOAD_LATEST_UNDELETED = 2,
-    LOAD_DOWNTO = 3,
-    LOAD_UNDELETED = 4,
-    LOAD_FROM_TIME = 5,
-    LOAD_ALL = 6
+    LOAD_LATEST,
+    LOAD_LATEST_UNDELETED,
+    LOAD_DOWNTO,
+    LOAD_FROM_TIME,
+    LOAD_UNDELETED,
+    LOAD_ALL,
+    UNKNOWN
 };
 
 inline constexpr bool is_latest_load_type(LoadType load_type) {
     return load_type == LoadType::LOAD_LATEST || load_type == LoadType::LOAD_LATEST_UNDELETED;
-}
-
-inline constexpr bool is_partial_load_type(LoadType load_type) {
-    return load_type == LoadType::LOAD_DOWNTO || load_type == LoadType::LOAD_FROM_TIME;
 }
 
 struct LoadParameter {
@@ -62,7 +58,6 @@ struct LoadParameter {
     LoadType load_type_ = LoadType::NOT_LOADED;
     std::optional<SignedVersionId> load_until_ = std::nullopt;
     std::optional<timestamp> load_from_time_ = std::nullopt;
-    bool use_previous_ = false;
     bool iterate_on_failure_ = false;
 
     void validate() const {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -51,7 +51,7 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
     ARCTICDB_SAMPLE(WriteDataFrame, 0)
 
     ARCTICDB_DEBUG(log::version(), "write_dataframe_specific_version stream_id: {} , version_id: {}", stream_id, version_id);
-    if (auto version_key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id, VersionQuery{}, ReadOptions{}); version_key) {
+    if (auto version_key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id, VersionQuery{}); version_key) {
         log::version().warn("Symbol stream_id: {} already exists with version_id: {}", stream_id, version_id);
         return {std::move(*version_key)};
     }
@@ -212,7 +212,7 @@ VersionResultVector get_latest_versions_for_symbols(
 ) {
     VersionResultVector res;
     for (auto &s_id: stream_ids) {
-            const auto& opt_version_key = get_latest_undeleted_version(store, version_map, s_id, version_query, ReadOptions{});
+            const auto& opt_version_key = get_latest_undeleted_version(store, version_map, s_id, version_query);
             if (opt_version_key) {
                 res.emplace_back(
                     s_id,
@@ -237,7 +237,7 @@ VersionResultVector get_all_versions_for_symbols(
     VersionResultVector res;
     std::unordered_set<std::pair<StreamId, VersionId>> unpruned_versions;
     for (auto &s_id: stream_ids) {
-            auto all_versions = get_all_versions(store, version_map, s_id, VersionQuery{}, ReadOptions{});
+            auto all_versions = get_all_versions(store, version_map, s_id, VersionQuery{});
             unpruned_versions = {};
             for (const auto &entry: all_versions) {
                 unpruned_versions.emplace(s_id, entry.version_id());
@@ -510,7 +510,7 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     const std::vector<std::string>& partition_value
     ) {
     ARCTICDB_SAMPLE(WritePartitionedDataFrame, 0)
-    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
+    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{});
     auto version_id = get_next_version_from_key(maybe_prev);
 
     //    TODO: We are not actually partitioning stuff atm, just assuming a single partition is passed for now.
@@ -563,7 +563,7 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     ARCTICDB_SAMPLE(WriteVersionedMultiKey, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_composite_data");
-    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
+    auto maybe_prev = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{});
     auto version_id = get_next_version_from_key(maybe_prev);
     ARCTICDB_DEBUG(log::version(), "write_versioned_composite_data for stream_id: {} , version_id = {}", stream_id, version_id);
     // TODO: Assuming each sub key is always going to have the same version attached to it.
@@ -741,7 +741,7 @@ void PythonVersionStore::write_parallel(
 }
 
 std::unordered_map<VersionId, bool> PythonVersionStore::get_all_tombstoned_versions(const StreamId &stream_id) {
-    return ::arcticdb::get_all_tombstoned_versions(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
+    return ::arcticdb::get_all_tombstoned_versions(store(), version_map(), stream_id, VersionQuery{});
 }
 
 FrameAndDescriptor create_frame(const StreamId& target_id, SegmentInMemory seg, const ReadOptions& read_options) {
@@ -908,7 +908,7 @@ void PythonVersionStore::delete_version(
         const StreamId& stream_id,
         VersionId version_id) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_version");
-    auto result = ::arcticdb::tombstone_version(store(), version_map(), stream_id, version_id, VersionQuery{}, ReadOptions{});
+    auto result = ::arcticdb::tombstone_version(store(), version_map(), stream_id, version_id, VersionQuery{});
 
     if (!result.keys_to_delete.empty() && !cfg().write_options().delayed_deletes()) {
         delete_tree(result.keys_to_delete, result);
@@ -922,7 +922,7 @@ void PythonVersionStore::delete_version(
 void PythonVersionStore::fix_symbol_trees(const std::vector<StreamId>& symbols) {
     auto snaps = get_master_snapshots_map(store());
     for (const auto& sym : symbols) {
-        auto index_keys_from_symbol_tree = get_all_versions(store(), version_map(), sym, VersionQuery{}, ReadOptions{});
+        auto index_keys_from_symbol_tree = get_all_versions(store(), version_map(), sym, VersionQuery{});
         for(const auto& [key, map] : snaps[sym]) {
             index_keys_from_symbol_tree.push_back(key);
         }
@@ -951,7 +951,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
         return;
     }
 
-    auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, *prev_id, VersionQuery{}, ReadOptions{});
+    auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, *prev_id, VersionQuery{});
     auto [_, pruned_indexes] = version_map()->tombstone_from_key_or_all(store(), stream_id, previous);
     delete_unreferenced_pruned_indexes(pruned_indexes, *latest).get();
 }
@@ -1017,13 +1017,12 @@ py::object metadata_protobuf_to_pyobject(const std::optional<google::protobuf::A
 
 std::pair<VersionedItem, py::object> PythonVersionStore::read_metadata(
     const StreamId& stream_id,
-    const VersionQuery& version_query,
-    const ReadOptions& read_options
+    const VersionQuery& version_query
     ) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: read_metadata");
     ARCTICDB_SAMPLE(ReadMetadata, 0)
 
-    auto metadata = read_metadata_internal(stream_id, version_query, read_options);
+    auto metadata = read_metadata_internal(stream_id, version_query);
     if(!metadata.first.has_value())
         throw NoDataFoundException(fmt::format("read_metadata: version not found for symbol", stream_id));
 
@@ -1082,10 +1081,9 @@ std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> Pytho
 
 DescriptorItem PythonVersionStore::read_descriptor(
     const StreamId& stream_id,
-    const VersionQuery& version_query,
-    const ReadOptions& read_options
+    const VersionQuery& version_query
     ) {
-    return read_descriptor_internal(stream_id, version_query, read_options);
+    return read_descriptor_internal(stream_id, version_query);
 }
 
 std::vector<std::variant<DescriptorItem, DataError>> PythonVersionStore::batch_read_descriptor(
@@ -1102,7 +1100,7 @@ ReadResult PythonVersionStore::read_index(
     ) {
     ARCTICDB_SAMPLE(ReadIndex, 0)
 
-    auto version = get_version_to_read(stream_id, version_query, ReadOptions{});
+    auto version = get_version_to_read(stream_id, version_query);
     if(!version)
         throw NoDataFoundException(fmt::format("read_index: version not found for symbol '{}'", stream_id));
 
@@ -1111,7 +1109,7 @@ ReadResult PythonVersionStore::read_index(
 }
 
 std::vector<AtomKey> PythonVersionStore::get_version_history(const StreamId& stream_id) {
-    return get_index_and_tombstone_keys(store(), version_map(), stream_id, VersionQuery{}, ReadOptions{});
+    return get_index_and_tombstone_keys(store(), version_map(), stream_id, VersionQuery{});
 }
 
 void PythonVersionStore::_compact_version_map(const StreamId& id) {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -182,8 +182,7 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     std::pair<VersionedItem, py::object> read_metadata(
         const StreamId& stream_id,
-        const VersionQuery& version_query,
-        const ReadOptions& read_options
+        const VersionQuery& version_query
     );
 
     std::vector<std::variant<DescriptorItem, DataError>> batch_read_descriptor(
@@ -193,8 +192,7 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     DescriptorItem read_descriptor(
         const StreamId& stream_id,
-        const VersionQuery& version_query,
-        const ReadOptions& read_options);
+        const VersionQuery& version_query);
 
     ReadResult read_index(
         const StreamId& stream_id,

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -310,7 +310,7 @@ inline bool looking_for_undeleted(const LoadParameter& load_params, const std::s
     }
 }
 
-inline bool key_exists_in_ref_entry(const LoadParameter& load_params, const VersionMapEntry& ref_entry, const std::optional<AtomKey>&, LoadProgress&) {
+inline bool key_exists_in_ref_entry(const LoadParameter& load_params, const VersionMapEntry& ref_entry) {
     if (is_latest_load_type(load_params.load_type_) && is_index_key_type(ref_entry.keys_[0].type())) {
         ARCTICDB_DEBUG(log::version(), "Not following version chain as key for {} exists in ref entry", ref_entry.head_->id());
         return true;

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -192,6 +192,7 @@ inline void read_symbol_ref(const std::shared_ptr<StreamSource>& store, const St
 
     LoadProgress load_progress;
     entry.head_ = read_segment_with_keys(key_seg_pair.second, entry, load_progress);
+    entry.loaded_until_ = load_progress.loaded_until_;
 }
 
 inline void write_symbol_ref(std::shared_ptr<StreamSink> store,

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -19,10 +19,14 @@ from arcticdb_ext.storage import StorageOverride, S3Override, CONFIG_LIBRARY_NAM
 from arcticdb.encoding_version import EncodingVersion
 from collections import namedtuple
 from dataclasses import dataclass, fields
-from distutils.util import strtobool
 
 PARSED_QUERY = namedtuple("PARSED_QUERY", ["region"])
 USE_AWS_CRED_PROVIDERS_TOKEN = "_RBAC_"
+
+
+def strtobool(value: str) -> bool:
+  value = value.lower()
+  return value in ("y", "yes", "on", "1", "true", "t")
 
 
 @dataclass

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1761,8 +1761,7 @@ class NativeVersionStore:
         self, symbol: str, as_of: Optional[VersionQueryInput] = None, raise_on_missing: Optional[bool] = False, **kwargs
     ) -> Optional[VersionedItem]:
         version_query = self._get_version_query(as_of, **kwargs)
-        read_options = self._get_read_options(**kwargs)
-        version_handle = self.version_store.find_version(symbol, version_query, read_options)
+        version_handle = self.version_store.find_version(symbol, version_query)
 
         if version_handle is None and raise_on_missing:
             raise KeyError(f"Cannot find version for symbol={symbol},as_of={as_of}")
@@ -2321,8 +2320,7 @@ class NativeVersionStore:
             The data attribute will not be populated.
         """
         version_query = self._get_version_query(as_of, **kwargs)
-        read_options = self._get_read_options(**kwargs)
-        version_item, udm = self.version_store.read_metadata(symbol, version_query, read_options)
+        version_item, udm = self.version_store.read_metadata(symbol, version_query)
         meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
 
         return VersionedItem(
@@ -2399,8 +2397,7 @@ class NativeVersionStore:
             True if the symbol is pickled, False otherwise.
         """
         version_query = self._get_version_query(as_of, **kwargs)
-        read_options = self._get_read_options(**kwargs)
-        dit = self.version_store.read_descriptor(symbol, version_query, read_options)
+        dit = self.version_store.read_descriptor(symbol, version_query)
         return self.is_pickled_descriptor(dit.timeseries_descriptor)
 
     def _get_time_range_from_ts(self, desc, min_ts, max_ts):
@@ -2444,7 +2441,6 @@ class NativeVersionStore:
         """
         given_version = max([v["version"] for v in self.list_versions(symbol)]) if version is None else version
         version_query = self._get_version_query(given_version)
-        read_options = self._get_read_options(**kwargs)
 
         i = self.version_store.read_index(symbol, version_query)
         frame_data = ReadResult(*i).frame_data
@@ -2455,7 +2451,7 @@ class NativeVersionStore:
         start_indices, end_indices = index_data[0], index_data[1]
         min_ts, max_ts = min(start_indices), max(end_indices)
         # to get timezone info
-        dit = self.version_store.read_descriptor(symbol, version_query, read_options)
+        dit = self.version_store.read_descriptor(symbol, version_query)
         return self._get_time_range_from_ts(dit.timeseries_descriptor, min_ts, max_ts)
 
     def name(self):
@@ -2477,9 +2473,8 @@ class NativeVersionStore:
         `int`
             The number of rows in the specified revision of the symbol.
         """
-        read_options = self._get_read_options(**kwargs)
         version_query = self._get_version_query(as_of)
-        dit = self.version_store.read_descriptor(symbol, version_query, read_options)
+        dit = self.version_store.read_descriptor(symbol, version_query)
         return dit.timeseries_descriptor.total_rows
 
     def lib_cfg(self):
@@ -2579,8 +2574,7 @@ class NativeVersionStore:
             - sorted, `str`
         """
         version_query = self._get_version_query(version)
-        read_options = _PythonVersionStoreReadOptions()
-        dit = self.version_store.read_descriptor(symbol, version_query, read_options)
+        dit = self.version_store.read_descriptor(symbol, version_query)
         return self._process_info(symbol, dit, version)
 
     def batch_get_info(

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1983,7 +1983,7 @@ def test_snapshot_empty_segment(basic_store):
     assert lib.has_symbol("c") is False
 
 
-def test_columns_as_nparrary(basic_store, sym):
+def test_columns_as_nparray(basic_store, sym):
     lib = basic_store
     d = {"col1": [1, 2], "col2": [3, 4]}
     lib.write(sym, pd.DataFrame(data=d))


### PR DESCRIPTION
#### Reference Issues/PRs

This fixes issue #587 and is required to implement the Enterprise replication tool efficiently ( https://github.com/man-group/arcticdb-enterprise/pull/36#discussion_r1494741725 ).

#### What does this implement or fix?

The version map caching logic exists to stop us doing IO repeatedly for the same version map entries. Most of the old logic relied on an ordering:

```
if (entry->second->load_type_ < load_param.load_type_)
...
    NOT_LOADED = 0,
    LOAD_LATEST = 1,
    LOAD_LATEST_UNDELETED = 2,
    LOAD_DOWNTO = 3,
    LOAD_UNDELETED = 4,
    LOAD_FROM_TIME = 5,
    LOAD_ALL = 6
```

meaning "if a LOAD_FROM_TIME is live in the cache and a LOAD_UNDELETED is requested, just use the cache rather than performing IO".

This is incorrect in several cases. In particular:

- `LOAD_UNDELETED` should be below (i.e. have a higher value) than `LOAD_FROM_TIME`
- `LOAD_FROM_TIME` and `LOAD_DOWNTO` do not imply anything about one another.
- `LOAD_LATEST_UNDELETED` is not necessarily cached just because a `LOAD_DOWNTO` has already been performed.

The new logic abandons the idea of a priority ordering and does this case by case instead to calculate whether the cache is sufficient to answer a query. A limitation of this PR (though no worse than the status quo) is the logic for when the cache is populated with a LOAD_FROM_TIME request. This PR invalidates that cache for LOAD_FROM_TIME or LOAD_DOWN_TO requests even if they are for times or versions later than those loaded. This could be improved later.

Also, `follow_version_chain` was missing an update to the load progress state that the caching logic relies on in the case where the key being loaded is in the ref key, so we also fix that here.

The first commit also fixes a Python deprecation warning by removing distutils.strtobool.

I also remove the `read_previous_on_failure_` parameter since it was always false.