### PR TITLE
Disable ec2 runners on PR

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -240,9 +240,9 @@ jobs:
           echo /opt/python/cp36-cp36m/bin >> $GITHUB_PATH
 
       - name: Install ASV
-        shell: bash
+        shell: bash -el {0}
         run: |
-          git config --global --add safe.directory .
+          git config --global --add safe.directory ${{github.event_name == 'schedule' && '.' || '/__w/ArcticDB/ArcticDB'}}
           python -m pip install --upgrade pip
           pip install asv virtualenv
           python -m asv machine -v --yes --machine ArcticDB-Runner-Medium

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -192,6 +192,7 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   start_ec2_runner:
+    if: github.event_name == 'schedule'
     uses: ./.github/workflows/ec2_runner_jobs.yml
     secrets: inherit
     with:
@@ -199,8 +200,9 @@ jobs:
 
   benchmark_linux_medium:
     timeout-minutes: 1200
+    if: always() # We want to run this job even if the previous job fails/does not run
     needs: [start_ec2_runner, cibw_docker_image]
-    runs-on: ${{ needs.start_ec2_runner.outputs.label }}
+    runs-on: ${{ needs.start_ec2_runner.outputs.label || 'ubuntu-latest' }}
     container:
       image: ${{needs.cibw_docker_image.outputs.tag}}
     permissions:
@@ -288,7 +290,7 @@ jobs:
 
   stop-ec2-runner:
     needs: [start_ec2_runner, benchmark_linux_medium]
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name != 'schedule' }}
     uses: ./.github/workflows/ec2_runner_jobs.yml
     secrets: inherit
     with:

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -200,9 +200,9 @@ jobs:
 
   benchmark_linux_medium:
     timeout-minutes: 1200
-    if: always() # We want to run this job even if the previous job fails/does not run
+    if: github.event_name == 'schedule'
     needs: [start_ec2_runner, cibw_docker_image]
-    runs-on: ${{ needs.start_ec2_runner.outputs.label || 'ubuntu-latest' }}
+    runs-on: ${{ needs.start_ec2_runner.outputs.label }}
     container:
       image: ${{needs.cibw_docker_image.outputs.tag}}
     permissions:
@@ -242,7 +242,7 @@ jobs:
       - name: Install ASV
         shell: bash -el {0}
         run: |
-          git config --global --add safe.directory ${{github.event_name == 'schedule' && '.' || '/__w/ArcticDB/ArcticDB'}}
+          git config --global --add safe.directory .
           python -m pip install --upgrade pip
           pip install asv virtualenv
           python -m asv machine -v --yes --machine ArcticDB-Runner-Medium
@@ -290,7 +290,7 @@ jobs:
 
   stop-ec2-runner:
     needs: [start_ec2_runner, benchmark_linux_medium]
-    if: ${{ always() && github.event_name != 'schedule' }}
+    if: github.event_name == 'schedule'
     uses: ./.github/workflows/ec2_runner_jobs.yml
     secrets: inherit
     with:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Makes it so ec2 runners are used for benchmarks only during the scheduled runs

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
