### PR TITLE
Docs: Set `max-wdith` to none to auto increase width of the middle section on the website

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -2,7 +2,7 @@ name: Docs Build
 on:
   workflow_dispatch:
     inputs:
-      version: { type: string, required: false, description: "The version to build (used in git and pypi). git-tag='v{version}-docs'.  If not specified then use master and wheel from the last successful build."}
+      version: { type: string, required: false, description: "The version to build (used in git and pypi). git-tag='v{version}-docs'.  If not specified then use selected branch and wheel from the last successful build."}
       latest: { type: boolean, required: false, description: Alias this version as the 'latest' stable docs.  This should be set for the latest stable release.}
       deploy: { type: boolean, required: false, description: Push the built docs to the docs-pages branch on github.}
       
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.3.0
         with:
-          ref: ${{inputs.version && format('v{0}-docs', inputs.version) || 'master'}}
+          ref: ${{inputs.version && format('v{0}-docs', inputs.version) || github.ref}}
 
       - name: Fetch docs-pages branch
         if: ${{inputs.deploy}}
@@ -37,7 +37,7 @@ jobs:
           name: wheel-${{env.PY_IMPL}}-manylinux_x86_64
           workflow: build.yml
           workflow_conclusion: success
-          branch: master
+          branch: ${{github.ref}}
 
       - name: Install documentation dependencies (including ArcticDB)
         run: |

--- a/docs/mkdocs/docs/stylesheets/extra.css
+++ b/docs/mkdocs/docs/stylesheets/extra.css
@@ -3,4 +3,7 @@
     --md-primary-fg-color--light: #ECB7B7;
     --md-primary-fg-color--dark:  #90030C;
   }
-  
+
+.md-grid {
+    max-width: none;
+}


### PR DESCRIPTION
Currently, no matter how wide the screen gets, the middle section of the [website](https://arcticdb-docs.pages.dev/latest/api/arctic/), which contains the main documentation, always remains fixed to a maximum of `61rem`. This PR sets the `max-width` to `none` to auto increase the width as the screen gets wider.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
