### PR TITLE
Maximum space for docs text

### DIFF
--- a/docs/mkdocs/docs/stylesheets/extra.css
+++ b/docs/mkdocs/docs/stylesheets/extra.css
@@ -1,6 +1,10 @@
+/* Maximum space for text block */
+.md-grid {
+  max-width: 100%;
+}
+
 [data-md-color-scheme="arcticdb"] {
     --md-primary-fg-color:        #003f69;
     --md-primary-fg-color--light: #ECB7B7;
     --md-primary-fg-color--dark:  #90030C;
-  }
-  
+}


### PR DESCRIPTION
Fix issue where not all of docstring if visible in API docs.