### PR TITLE
maint: Remove usage of `folly::enumerate`

### DIFF
--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -18,7 +18,6 @@
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/sparse_utils.hpp>
 
-#include <folly/container/Enumerate.h>
 // Compilation fails on Mac if cstdio is not included prior to folly/Function.h due to a missing definition of memalign in folly/Memory.h
 #ifdef __APPLE__
 #include <cstdio>

--- a/cpp/arcticdb/column_store/column_map.hpp
+++ b/cpp/arcticdb/column_store/column_map.hpp
@@ -12,8 +12,6 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/offset_string.hpp>
 
-#include <folly/container/Enumerate.h>
-
 #include <ankerl/unordered_dense.h>
 
 #include <optional>
@@ -55,8 +53,9 @@ public:
     }
 
     void set_from_descriptor(const StreamDescriptor& descriptor) {
-        for(const auto& field : folly::enumerate(descriptor.fields())) {
-            insert(field->name(), field.index);
+        for(size_t i = 0; i < descriptor.fields().size(); i++) {
+            const auto& field = descriptor.fields()[i];
+            insert(field.name(), i);
         }
     }
 

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -20,7 +20,6 @@
 #include <arcticdb/entity/stream_descriptor.hpp>
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <folly/container/Enumerate.h>
 
 namespace google::protobuf
 {
@@ -438,11 +437,13 @@ public:
     }
 
     void push_back(const Row &row) {
-        for (auto it : folly::enumerate(row)) {
-            it->visit([&it, that=this](const auto &val) {
+        size_t index = 0;
+        for (auto it: row) {
+            it.visit([&it, &index, that=this](const auto &val) {
                 if(val)
-                    that->set_scalar(it.index, val.value());
+                    that->set_scalar(index, val);
             });
+            index++;
         }
         end_row();
     }

--- a/cpp/arcticdb/column_store/test/benchmark_memory_segment.cpp
+++ b/cpp/arcticdb/column_store/test/benchmark_memory_segment.cpp
@@ -9,7 +9,6 @@
 
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
-#include <folly/container/Enumerate.h>
 
 #include <algorithm>
 

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -36,8 +36,9 @@ SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& 
             }
         }
     }
-    for (const auto& type_descriptor: folly::enumerate(type_descriptors)) {
-        merged.add_column(FieldRef{*type_descriptor, field_names.at(type_descriptor.index)}, 0, false);
+    for (size_t index = 0; index < type_descriptors.size(); index++) {
+        auto &type_descriptor = type_descriptors.at(index);
+        merged.add_column(FieldRef{type_descriptor, field_names.at(index)}, 0, false);
     }
     for (auto &segment : segments) {
         merged.append(segment);

--- a/cpp/arcticdb/pipeline/frame_slice_map.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice_map.hpp
@@ -27,13 +27,14 @@ struct FrameSliceMap {
             const auto& row_range = context_row.slice_and_key().slice_.row_range;
 
             const auto& fields = context_row.descriptor().fields();
-            for(const auto& field : folly::enumerate(fields)) {
-                if (!context_->is_in_filter_columns_set(field->name())) {
-                    ARCTICDB_DEBUG(log::version(), "{} not present in filtered columns, skipping", field->name());
+            for(size_t i = 0; i < fields.size(); i++) {
+                const auto& field = fields[i];
+                if (!context_->is_in_filter_columns_set(field.name())) {
+                    ARCTICDB_DEBUG(log::version(), "{} not present in filtered columns, skipping", field.name());
                     continue;
                 }
 
-                const entity::DataType row_range_type = field->type().data_type();
+                const entity::DataType row_range_type = field.type().data_type();
                 if(!dynamic_schema && !is_sequence_type(row_range_type)) {
                     // In case we end up with static schema and empty we must check the type of the whole column
                     // Because we could be reading an empty segment of a string column. Example: start with [None],
@@ -43,21 +44,21 @@ struct FrameSliceMap {
                     // TODO: This logic won't be needed when we move string handling into separate type handler
                     if(is_empty_type(row_range_type)) {
                         const entity::StreamDescriptor& descriptor = context_->descriptor();
-                        const size_t global_field_idx = descriptor.find_field(field->name()).value();
+                        const size_t global_field_idx = descriptor.find_field(field.name()).value();
                         const Field& global_field = descriptor.field(global_field_idx);
                         const entity::DataType global_field_type = global_field.type().data_type();
                         if(!is_sequence_type(global_field_type)) {
-                            ARCTICDB_DEBUG(log::version(), "{} not a string type in dynamic schema, skipping", field->name());
+                            ARCTICDB_DEBUG(log::version(), "{} not a string type in dynamic schema, skipping", field.name());
                             continue;
                         }
                     } else {
-                        ARCTICDB_DEBUG(log::version(), "{} not a string type in dynamic schema, skipping", field->name());
+                        ARCTICDB_DEBUG(log::version(), "{} not a string type in dynamic schema, skipping", field.name());
                         continue;
                     }
                 }
 
-                auto& column = columns_[field->name()];
-                ContextData data{context_row.index_, field.index};
+                auto& column = columns_[field.name()];
+                ContextData data{context_row.index_, i};
                 column.insert(std::make_pair(row_range, data));
             }
         }

--- a/cpp/arcticdb/pipeline/test/test_pipeline.cpp
+++ b/cpp/arcticdb/pipeline/test/test_pipeline.cpp
@@ -99,8 +99,10 @@ struct TestProjection {
         desc.add_field(fd);
         auto col_index = segment.add_column(fd, 0, false);
         auto& column = segment.column(col_index);
-        for(auto&& row : folly::enumerate(segment)) {
-            column.set_scalar(row.index, projection_func_(*row));
+        size_t row_index = 0;
+        for(const auto& row : segment) {
+            column.set_scalar(row_index, projection_func_(row));
+            ++row_index;
         }
         return segment;
     }

--- a/cpp/arcticdb/processing/processing_unit.cpp
+++ b/cpp/arcticdb/processing/processing_unit.cpp
@@ -16,7 +16,8 @@ void ProcessingUnit::apply_filter(
                                                     "ProcessingUnit::apply_filter requires all of segments, row_ranges, and col_ranges to be present");
     auto filter_down_stringpool = optimisation == PipelineOptimisation::MEMORY;
 
-    for (auto&& [idx, segment]: folly::enumerate(*segments_)) {
+    for (size_t idx = 0, segment_size = segments_.value().size(); idx < segment_size; idx++) {
+        auto&& segment = segments_->at(idx);
         auto seg = filter_segment(*segment,
                                   bitset,
                                   filter_down_stringpool);
@@ -33,7 +34,8 @@ void ProcessingUnit::truncate(size_t start_row, size_t end_row) {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(segments_.has_value() && row_ranges_.has_value() && col_ranges_.has_value(),
                                                     "ProcessingUnit::truncate requires all of segments, row_ranges, and col_ranges to be present");
 
-    for (auto&& [idx, segment]: folly::enumerate(*segments_)) {
+    for (size_t idx = 0, segment_size = segments_.value().size(); idx < segment_size; idx++) {
+        auto&& segment = segments_->at(idx);
         auto seg = segment->truncate(start_row, end_row, false);
         auto num_rows = seg.is_null() ? 0 : seg.row_count();
         row_ranges_->at(idx) = std::make_shared<pipelines::RowRange>(row_ranges_->at(idx)->first, row_ranges_->at(idx)->first + num_rows);

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -216,8 +216,8 @@ void do_remove_impl(Composite<VariantKey>&& ks,
         (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach(
             [&root_folder, b=std::move(bucketizer), delete_object_limit=delete_object_limit, &batch_counter, &to_delete, &submit_batch] (auto&& group) {//bypass incorrect 'set but no used" error for delete_object_limit
                 auto key_type_dir = key_type_folder(root_folder, group.key());
-                for (auto k : folly::enumerate(group.values())) {
-                    auto blob_name = object_path(b.bucketize(key_type_dir, *k), *k);
+                for (auto k : group.values()) {
+                    auto blob_name = object_path(b.bucketize(key_type_dir, k), k);
                     to_delete.emplace_back(std::move(blob_name));
                     if (++batch_counter == delete_object_limit) {
                         submit_batch(to_delete);

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -161,8 +161,8 @@ inline std::optional<Aws::Utils::Array<Aws::String>> parse_no_proxy_env_var(cons
         hosts.push_back(host);
     }
     Aws::Utils::Array<Aws::String> non_proxy_hosts{hosts.size()};
-    for (const auto& tmp: folly::enumerate(hosts)) {
-        non_proxy_hosts[tmp.index] = *tmp;
+    for (size_t i = 0; i < hosts.size(); i++) {
+        non_proxy_hosts[i] = hosts[i];
     }
     return non_proxy_hosts;
 }

--- a/cpp/arcticdb/util/composite.hpp
+++ b/cpp/arcticdb/util/composite.hpp
@@ -12,7 +12,6 @@
 #include <arcticdb/util/variant.hpp>
 
 #include <folly/Range.h>
-#include <folly/container/Enumerate.h>
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <variant>

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -228,8 +228,9 @@ std::unordered_map<SnapshotId, std::optional<VariantKey>> all_ref_keys(
     ) {
     std::unordered_map<SnapshotId, std::optional<VariantKey>> output;
     output.reserve(snap_names.size());
-    for(auto name : folly::enumerate(snap_names))
-        output.try_emplace(*name, ref_keys[name.index]);
+    for (size_t i = 0; i < snap_names.size(); i++) {
+        output.try_emplace(snap_names[i], ref_keys[i]);
+    }
 
     return output;
 }
@@ -241,9 +242,9 @@ std::unordered_map<SnapshotId, std::optional<VariantKey>> get_snapshot_keys_via_
     const std::shared_ptr<Store>& store
     ){
     std::unordered_map<SnapshotId, std::optional<VariantKey>> output;
-    for (auto snap : folly::enumerate(snap_names)) {
-        if (!ref_key_exists[snap.index])
-            output.try_emplace(*snap, std::nullopt);
+    for (size_t i = 0; i < snap_names.size(); i++) {
+        if (!ref_key_exists[i])
+            output.try_emplace(snap_names[i], std::nullopt);
     }
 
     store->iterate_type(KeyType::SNAPSHOT, [&output](VariantKey &&vk) {
@@ -251,9 +252,9 @@ std::unordered_map<SnapshotId, std::optional<VariantKey>> get_snapshot_keys_via_
             it->second = std::move(vk);
     });
 
-    for (auto snap : folly::enumerate(snap_names)) {
-        if (ref_key_exists[snap.index])
-            output.try_emplace(*snap, ref_keys[snap.index]);
+    for (size_t i = 0; i < snap_names.size(); i++) {
+        if (ref_key_exists[i])
+            output.try_emplace(snap_names[i], ref_keys[i]);
     }
     return output;
 }

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -74,7 +74,8 @@ std::vector<SymbolListEntry> load_previous_from_version_keys(
     auto res = folly::collect(batch_get_latest_undeleted_and_latest_versions_async(store, data.version_map_, stream_ids)).get();
 
     std::vector<SymbolListEntry> symbols;
-    for(auto&& [idx, opt_key_pair]: folly::enumerate(res)) {
+    for(size_t idx = 0, res_size = res.size(); idx < res_size; idx++) {
+        auto&& opt_key_pair = res[idx];
         const auto& [maybe_undeleted, _]  = opt_key_pair;
         if(maybe_undeleted) {
             const auto version_id = maybe_undeleted->version_id();

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -346,7 +346,8 @@ TEST_F(VersionStoreTest, StressBatchReadUncompressed) {
     ReadOptions read_options;
     read_options.set_batch_throw_on_error(true);
     auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, read_options);
-    for(auto&& [idx, version] : folly::enumerate(latest_versions)) {
+    for (size_t idx = 0; idx < latest_versions.size(); ++idx) {
+        auto& version = latest_versions[idx];
         auto expected = get_test_simple_frame(std::get<ReadResult>(version).item.symbol(), 10, idx);
         bool equal = expected.segment_ == std::get<ReadResult>(version).frame_data.frame();
         ASSERT_EQ(equal, true);

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -287,5 +287,4 @@ std::vector<folly::Future<std::optional<AtomKey>>> batch_get_versions_async(
     const std::vector<StreamId>& symbols,
     const std::vector<pipelines::VersionQuery>& version_queries);
 
-
 } //namespace arcticdb

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -443,7 +443,7 @@ void PythonVersionStore::snapshot(
     logger.set_level(spdlog::level::err);
     auto val = get_snapshot_key(store(), snap_name).has_value();
     logger.set_level(current_level);
-    
+
     util::check(!val, "Snapshot with name {} already exists", snap_name);
 
     auto index_keys = std::vector<AtomKey>();
@@ -797,10 +797,11 @@ std::vector<std::variant<ReadResult, DataError>> PythonVersionStore::batch_read(
     const std::vector<VersionQuery>& version_queries,
     std::vector<ReadQuery>& read_queries,
     const ReadOptions& read_options) {
-    
+
     auto read_versions_or_errors = batch_read_internal(stream_ids, version_queries, read_queries, read_options);
     std::vector<std::variant<ReadResult, DataError>> res;
-    for (auto&& [idx, read_version_or_error]: folly::enumerate(read_versions_or_errors)) {
+    for (size_t idx = 0; idx < read_versions_or_errors.size(); ++idx) {
+        auto& read_version_or_error = read_versions_or_errors[idx];
         util::variant_match(
                 read_version_or_error,
                 [&res] (ReadVersionOutput& read_version) {
@@ -1069,10 +1070,10 @@ std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> Pytho
                 results.push_back(std::move(res));
             }else{
                 auto res = std::make_pair(std::move(version), py::none());
-                results.push_back(std::move(res));   
+                results.push_back(std::move(res));
             }
         } else {
-            results.push_back(std::get<DataError>(std::move(metadata_or_error)));   
+            results.push_back(std::get<DataError>(std::move(metadata_or_error)));
         }
     }
     return results;
@@ -1089,7 +1090,7 @@ std::vector<std::variant<DescriptorItem, DataError>> PythonVersionStore::batch_r
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         const ReadOptions& read_options){
-    
+
     return batch_read_descriptor_internal(stream_ids, version_queries, read_options);
 }
 


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
