### PR TITLE
Disable missing key warnings when expected

### DIFF
--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -180,11 +180,15 @@ inline void check_is_version(const AtomKey &key) {
 
 inline void read_symbol_ref(const std::shared_ptr<StreamSource>& store, const StreamId &stream_id, VersionMapEntry &entry) {
     std::pair<entity::VariantKey, SegmentInMemory> key_seg_pair;
+    // Trying to read a missing ref key is expected e.g. when writing a previously missing symbol.
+    // If the ref key is missing we keep the entry empty and should not raise warnings.
+    auto read_opts = storage::ReadKeyOpts{};
+    read_opts.dont_warn_about_missing_key=true;
     try {
-        key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION_REF});
+        key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION_REF}, read_opts);
     } catch (const storage::KeyNotFoundException&) {
         try {
-            key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION, true});
+            key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION, true}, read_opts);
         } catch (const storage::KeyNotFoundException&) {
             return;
         }


### PR DESCRIPTION
- Sets `opts.dont_warn_about_missing_key=true` when missing keys are expected (For example when writing a previously missing symbol it is expected to try to read a missing ref key)

#### Reference Issues/PRs

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
