### PR TITLE
Add a global timeout for pytests

### DIFF
--- a/.github/actions/run_local_pytest/action.yml
+++ b/.github/actions/run_local_pytest/action.yml
@@ -18,7 +18,7 @@ runs:
         cd python
         ln -s ../cpp/out/linux-${{ inputs.build_type }}-build/arcticdb/arcticdb_ext.cpython-36m-x86_64-linux-gnu.so
         export ARCTICDB_RAND_SEED=$RANDOM
-        python ${{inputs.other_params}} -m pytest -n ${{ inputs.threads }} tests
+        python ${{inputs.other_params}} -m pytest --timeout=3600 -n ${{ inputs.threads }} tests
       env:
         TEST_OUTPUT_DIR: ${{ runner.temp }}
         ARCTICDB_FAST_TESTS_ONLY: ${{ inputs.fast_tests_only }}

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           cd python
           export ARCTICDB_RAND_SEED=$RANDOM
-          python -m pytest -n ${{ steps.cpu-cores.outputs.count }} -v tests
+          python -m pytest --timeout=3600 -n ${{ steps.cpu-cores.outputs.count }} -v tests
         env:
           ARCTICDB_USING_CONDA: 1
           # Use the Mongo created in the service container above to test against
@@ -160,7 +160,7 @@ jobs:
         run: |
           cd python
           export ARCTICDB_RAND_SEED=$RANDOM
-          python -m pytest -n ${{ steps.cpu-cores.outputs.count }} tests
+          python -m pytest --timeout=3600 -n ${{ steps.cpu-cores.outputs.count }} tests
         env:
           ARCTICDB_USING_CONDA: 1
 

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -18,7 +18,7 @@ catch=`{ which catchsegv 2>/dev/null || echo ; } | tail -n 1`
 
     export ARCTICDB_RAND_SEED=$RANDOM
 
-    $catch python -m pytest $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
+    $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
         "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#\2#"

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -73,6 +73,7 @@ dependencies:
   - hypothesis < 6.73
   - pytest-sugar
   - pytest-xdist
+  - pytest-timeout
   # Python dependencies (for tests only)
   - azure-storage-blob
   - azure-identity


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
We are experiencing tests in pytest that get stuck.
It is very hard to debug as they are just causing the overall CI step to timeout.
This change sets a global timeout for the pytests of 1 hour.
This way the stuck tests will fail faster (1 hours vs 6 hours) and it will be noted as a failed test se we can understand which tests exactly are stuck so we can fix them.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
