### PR TITLE
Refactor: Move mongo client errors handling into mongo_storage.cpp

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -464,6 +464,7 @@ set(arcticdb_srcs
         version/version_utils.cpp
         version/symbol_list.cpp
         version/version_map_batch_methods.cpp
+        storage/mongo/mongo_client_wrapper.hpp
 )
 
 if(${ARCTICDB_INCLUDE_ROCKSDB})

--- a/cpp/arcticdb/storage/mongo/mongo_client.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.hpp
@@ -32,7 +32,7 @@ class MongoClient : public MongoClientWrapper {
         const std::string &collection_name,
         storage::KeySegmentPair&& kv) override;
 
-    std::optional<int> update_segment(
+    UpdateResult update_segment(
         const std::string &database_name,
         const std::string &collection_name,
         storage::KeySegmentPair&& kv,
@@ -43,16 +43,15 @@ class MongoClient : public MongoClientWrapper {
         const std::string &collection_name,
         const entity::VariantKey &key) override;
 
-    std::optional<int> remove_keyvalue(
+    DeleteResult remove_keyvalue(
         const std::string &database_name,
         const std::string &collection_name,
         const entity::VariantKey &key) override;
 
-    void iterate_type(
+    std::vector<VariantKey> list_keys(
         const std::string &database_name,
         const std::string &collection_name,
         KeyType key_type,
-        folly::Function<void(entity::VariantKey &&)>&& visitor,
         const std::optional<std::string> &prefix
         ) override;
 

--- a/cpp/arcticdb/storage/mongo/mongo_client.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.hpp
@@ -9,13 +9,14 @@
 #include <fmt/format.h>
 
 #include <arcticdb/storage/storage.hpp>
+#include <arcticdb/storage/mongo/mongo_client_wrapper.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 
 namespace arcticdb::storage::mongo {
 
 class MongoClientImpl;
 
-class MongoClient {
+class MongoClient : public MongoClientWrapper {
     using Config = arcticdb::proto::mongo_storage::Config;
   public:
     explicit MongoClient(
@@ -24,28 +25,28 @@ class MongoClient {
         uint64_t max_pool_size,
         uint64_t selection_timeout_ms);
 
-    ~MongoClient();
+    ~MongoClient() override;
 
-    void write_segment(
+    bool write_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& kv);
+        storage::KeySegmentPair&& kv) override;
 
-    void update_segment(
+    std::optional<int> update_segment(
         const std::string &database_name,
         const std::string &collection_name,
         storage::KeySegmentPair&& kv,
-        bool upsert);
+        bool upsert) override;
 
-    storage::KeySegmentPair read_segment(
+    std::optional<KeySegmentPair> read_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        const entity::VariantKey &key);
+        const entity::VariantKey &key) override;
 
-    void remove_keyvalue(
+    std::optional<int> remove_keyvalue(
         const std::string &database_name,
         const std::string &collection_name,
-        const entity::VariantKey &key);
+        const entity::VariantKey &key) override;
 
     void iterate_type(
         const std::string &database_name,
@@ -53,20 +54,20 @@ class MongoClient {
         KeyType key_type,
         folly::Function<void(entity::VariantKey &&)>&& visitor,
         const std::optional<std::string> &prefix
-        );
+        ) override;
 
     void ensure_collection(
         std::string_view database_name,
-        std::string_view collection_name);
+        std::string_view collection_name) override;
 
     void drop_collection(
             std::string database_name,
-            std::string collection_name);
+            std::string collection_name) override;
 
     bool key_exists(
         const std::string &database_name,
         const std::string &collection_name,
-        const  entity::VariantKey &key);
+        const  entity::VariantKey &key) override;
 
 private:
     MongoClientImpl* client_;

--- a/cpp/arcticdb/storage/mongo/mongo_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client_wrapper.hpp
@@ -13,8 +13,10 @@
 
 namespace arcticdb::storage::mongo {
 
+// modified_count set to null_opt signals update failed (mongo docs are unclear on what error causes this)
 struct UpdateResult { std::optional<int> modified_count; };
 
+// delete_count set to null_opt signals delete failed (mongo docs are unclear on what error causes this)
 struct DeleteResult { std::optional<int> delete_count; };
 
 class MongoClientWrapper {

--- a/cpp/arcticdb/storage/mongo/mongo_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client_wrapper.hpp
@@ -1,0 +1,78 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+#include <fmt/format.h>
+
+#include <arcticdb/storage/storage.hpp>
+#include <arcticdb/entity/protobufs.hpp>
+
+namespace arcticdb::storage::mongo {
+
+template<class Output, class Result>
+struct MongoResult{
+    std::variant<Output, Result> result;
+
+    [[nodiscard]] bool is_success() const {
+        return std::holds_alternative<Output>(result);
+    }
+
+    Result& get_error(){
+        return std::get<Result>(result);
+    }
+    Output& get_output(){
+        return std::get<Output>(result);
+    }
+};
+
+class MongoClientWrapper {
+public:
+    virtual ~MongoClientWrapper() = default;
+
+    virtual bool write_segment(
+            const std::string &database_name,
+            const std::string &collection_name,
+            storage::KeySegmentPair&& kv) = 0;
+
+    virtual std::optional<int> update_segment(
+            const std::string &database_name,
+            const std::string &collection_name,
+            storage::KeySegmentPair&& kv,
+            bool upsert) = 0;
+
+    virtual std::optional<KeySegmentPair> read_segment(
+            const std::string &database_name,
+            const std::string &collection_name,
+            const entity::VariantKey &key) = 0;
+
+    virtual std::optional<int> remove_keyvalue(
+            const std::string &database_name,
+            const std::string &collection_name,
+            const entity::VariantKey &key) = 0;
+
+    virtual void iterate_type(
+            const std::string &database_name,
+            const std::string &collection_name,
+            KeyType key_type,
+            folly::Function<void(entity::VariantKey &&)>&& visitor,
+            const std::optional<std::string> &prefix) = 0;
+
+    virtual void ensure_collection(
+            std::string_view database_name,
+            std::string_view collection_name) = 0;
+
+    virtual void drop_collection(
+            std::string database_name,
+            std::string collection_name) = 0;
+
+    virtual bool key_exists(
+            const std::string &database_name,
+            const std::string &collection_name,
+            const  entity::VariantKey &key) = 0;
+};
+
+}

--- a/cpp/arcticdb/storage/mongo/mongo_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client_wrapper.hpp
@@ -13,21 +13,9 @@
 
 namespace arcticdb::storage::mongo {
 
-template<class Output, class Result>
-struct MongoResult{
-    std::variant<Output, Result> result;
+struct UpdateResult { std::optional<int> modified_count; };
 
-    [[nodiscard]] bool is_success() const {
-        return std::holds_alternative<Output>(result);
-    }
-
-    Result& get_error(){
-        return std::get<Result>(result);
-    }
-    Output& get_output(){
-        return std::get<Output>(result);
-    }
-};
+struct DeleteResult { std::optional<int> delete_count; };
 
 class MongoClientWrapper {
 public:
@@ -38,7 +26,7 @@ public:
             const std::string &collection_name,
             storage::KeySegmentPair&& kv) = 0;
 
-    virtual std::optional<int> update_segment(
+    virtual UpdateResult update_segment(
             const std::string &database_name,
             const std::string &collection_name,
             storage::KeySegmentPair&& kv,
@@ -49,16 +37,15 @@ public:
             const std::string &collection_name,
             const entity::VariantKey &key) = 0;
 
-    virtual std::optional<int> remove_keyvalue(
+    virtual DeleteResult remove_keyvalue(
             const std::string &database_name,
             const std::string &collection_name,
             const entity::VariantKey &key) = 0;
 
-    virtual void iterate_type(
+    virtual std::vector<VariantKey> list_keys(
             const std::string &database_name,
             const std::string &collection_name,
             KeyType key_type,
-            folly::Function<void(entity::VariantKey &&)>&& visitor,
             const std::optional<std::string> &prefix) = 0;
 
     virtual void ensure_collection(

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -35,7 +35,9 @@ void MongoStorage::do_write(Composite<KeySegmentPair>&& kvs) {
     (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
         for (auto &kv : group.values()) {
             auto collection = collection_name(kv.key_type());
-            client_->write_segment(db_, collection, std::move(kv));
+            std::string potential_error_msg = fmt::format("Mongo error while putting key {}", kv.key_view());
+            auto success = client_->write_segment(db_, collection, std::move(kv));
+            util::check(success, potential_error_msg);
         }
     });
 }
@@ -49,7 +51,10 @@ void MongoStorage::do_update(Composite<KeySegmentPair>&& kvs, UpdateOpts opts) {
     (fg::from(kvs.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
         for (auto &kv : group.values()) {
             auto collection = collection_name(kv.key_type());
-            client_->update_segment(db_, collection, std::move(kv), opts.upsert_);
+            std::string potential_error_msg = fmt::format("Mongo error while updating key {}", kv.key_view());
+            auto modified_count = client_->update_segment(db_, collection, std::move(kv), opts.upsert_);
+            util::check(modified_count.has_value(), potential_error_msg);
+            util::check(opts.upsert_ || modified_count > 0, "update called with upsert=false but key does not exist");
         }
     });
 }
@@ -62,12 +67,22 @@ void MongoStorage::do_read(Composite<VariantKey>&& ks, const ReadVisitor& visito
 
     (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
         for (auto &k : group.values()) {
-                auto collection = collection_name(variant_key_type(k));
+            auto collection = collection_name(variant_key_type(k));
+            try {
                 auto kv = client_->read_segment(db_, collection, k);
-                if(kv.has_segment())
-                    visitor(k, std::move(kv.segment()));
+                // later we should add the key to failed_reads in this case
+                if(!kv.has_value()) {
+                    throw std::runtime_error(fmt::format("Missing key in mongo: {}", k));
+                }
+                if (kv.value().has_segment())
+                    visitor(k, std::move(kv.value().segment()));
                 else
-                   failed_reads.push_back(k);
+                    failed_reads.push_back(k);
+            }
+            catch(const std::exception &ex) {
+                log::storage().info("Segment read error: {}", ex.what());
+                throw storage::KeyNotFoundException{Composite<VariantKey>{VariantKey{k}}};
+            }
         }
     });
 
@@ -91,7 +106,12 @@ void MongoStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
     (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach([&](auto &&group) {
         for (auto &k : group.values()) {
             auto collection = collection_name(variant_key_type(k));
-            client_->remove_keyvalue(db_, collection, k);
+            auto deleted_count = client_->remove_keyvalue(db_, collection, k);
+            if (deleted_count) {
+                util::warn(deleted_count == 1, "Expect to delete a single document with key {}",
+                           k);
+            } else
+                throw std::runtime_error(fmt::format("Mongo error deleting data for key {}", k));
         }
     });
 }
@@ -105,7 +125,13 @@ void MongoStorage::do_iterate_type(KeyType key_type, const IterateTypeVisitor& v
 
 bool MongoStorage::do_key_exists(const VariantKey& key) {
     auto collection = collection_name(variant_key_type(key));
-    return client_->key_exists(db_, collection, key);
+    try {
+        return client_->key_exists(db_, collection, key);
+    }
+    catch(const std::exception& ex) {
+        log::storage().error(fmt::format("Key exists error: {}", ex.what()));
+        throw;
+    }
 }
 
 


### PR DESCRIPTION
This is a refactor and it does not change the existing behaviour. Currently error handling is done in `mongo_client.cpp`. We want to avoid that because later a mock client shall be created which will be used instead of `MongoClient` to simulate mongo errors. For this reason the errors should be handled in `mongo_storage.cpp`. Error simulation via  a mock client is needed to perform exception normlization similar to other storages such as S3 and Azure.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
