### PR TITLE
Bugfix 1278: filtering and projections on sparse columns

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -89,12 +89,13 @@ else()
     message(STATUS "NEW_FOLLY_DEPS" ${NEW_FOLLY_DEPS})
     list(REMOVE_ITEM NEW_FOLLY_DEPS "/usr/local/opt/openssl/include" )
     set_target_properties(Folly::folly_deps PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${NEW_FOLLY_DEPS}")
-
-    add_library(xxHash STATIC IMPORTED)
-    set_target_properties(xxHash PROPERTIES IMPORTED_LOCATION ${xxHash_LIBRARY})
-    set_target_properties(xxHash PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${xxHash_INCLUDE_DIR})
-
 endif()
+
+# Have to statically link xxhash as inlining causes non-deterministic hashing, and cannot dynamically link
+# # since `XXH_state_t` which we rely on is only available when statically linking.
+add_library(xxHash STATIC IMPORTED)
+set_target_properties(xxHash PROPERTIES IMPORTED_LOCATION ${xxHash_LIBRARY})
+set_target_properties(xxHash PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${xxHash_INCLUDE_DIR})
 
 # RocksDB can be manually excluded with set(ARCTICDB_INCLUDE_ROCKSDB 0)
 # Default is to include on PyPI builds and exclude on conda builds
@@ -195,6 +196,7 @@ set(arcticdb_srcs
         column_store/block.hpp
         column_store/chunked_buffer.hpp
         column_store/column_data.hpp
+        column_store/column_data_random_accessor.hpp
         column_store/column.hpp
         column_store/column_utils.hpp
         column_store/memory_segment.hpp
@@ -530,6 +532,7 @@ endif()
 set (arcticdb_core_libraries
         pybind11::module # Transitively includes Python::Module or Python::Python as appropriate
         arcticdb_proto
+        xxHash::xxHash
         prometheus-cpp::push
         prometheus-cpp::pull
         unordered_dense::unordered_dense
@@ -557,11 +560,7 @@ endif()
 # on their origin (i.e. vendored source or packages on conda-forge).
 if(${ARCTICDB_USING_CONDA})
 
-    # We must use dynamic libraries, except for xxHash, which must be statically linked.
-    # since `XXH_state_t` which we rely on is only available when statically linking.
-    # For all builds except linux conda's, we inline the functions so that xxhash does not need linking at all.
     list (APPEND arcticdb_core_libraries
-        xxHash::xxHash
         pcre
         msgpack-c
         ${LMDB_LIBRARIES}
@@ -759,6 +758,7 @@ if(${TEST})
             codec/test/test_codec.cpp
             column_store/test/ingestion_stress_test.cpp
             column_store/test/test_column.cpp
+            column_store/test/test_column_data_random_accessor.cpp
             column_store/test/test_index_filtering.cpp
             column_store/test/test_memory_segment.cpp
             entity/test/test_atom_key.cpp
@@ -774,6 +774,7 @@ if(${TEST})
             processing/test/test_clause.cpp
             processing/test/test_component_manager.cpp
             processing/test/test_expression.cpp
+            processing/test/test_filter_and_project_sparse.cpp
             processing/test/test_has_valid_type_promotion.cpp
             processing/test/test_operation_dispatch.cpp
             processing/test/test_set_membership.cpp
@@ -919,6 +920,7 @@ if(${TEST})
             column_store/test/rapidcheck_column_store.cpp
             column_store/test/rapidcheck_chunked_buffer.cpp
             column_store/test/rapidcheck_column.cpp
+            column_store/test/rapidcheck_column_data_random_accessor.cpp
             column_store/test/rapidcheck_column_map.cpp
             column_store/test/test_chunked_buffer.cpp
             stream/test/stream_test_common.cpp

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -91,8 +91,12 @@ class ChunkedBufferImpl {
     ChunkedBufferImpl() = default;
 
     explicit ChunkedBufferImpl(size_t size) {
-        if(size > 0)
+        if(size > 0) {
+            if (size > DefaultBlockSize) {
+                handle_transition_to_irregular();
+            }
             add_block(std::max(size, DefaultBlockSize), 0UL);
+        }
     }
 
     ChunkedBufferImpl &operator=(ChunkedBufferImpl &&other) noexcept {

--- a/cpp/arcticdb/column_store/column_data_random_accessor.hpp
+++ b/cpp/arcticdb/column_store/column_data_random_accessor.hpp
@@ -1,0 +1,192 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <folly/Poly.h>
+
+#include <arcticdb/column_store/column_data.hpp>
+
+namespace arcticdb {
+
+// Not handling regular sized until case, only skips one if statement in block_and_offset, cannot avoid branching completely
+enum class BlockStructure {
+    SINGLE,
+    REGULAR,
+    IRREGULAR
+};
+
+template<typename TDT>
+struct IChunkedBufferRandomAccessor {
+    template<class Base>
+    struct Interface : Base {
+        typename TDT::DataTypeTag::raw_type at(size_t idx) const { return folly::poly_call<0>(*this, idx); };
+    };
+
+    template<class T>
+    using Members = folly::PolyMembers<&T::at>;
+};
+
+template<typename TDT>
+using ChunkedBufferRandomAccessor = folly::Poly<IChunkedBufferRandomAccessor<TDT>>;
+
+template<typename TDT>
+class ChunkedBufferSingleBlockAccessor {
+    using RawType = typename TDT::DataTypeTag::raw_type;
+public:
+    ChunkedBufferSingleBlockAccessor(ColumnData* parent){
+        auto typed_block = parent->next<TDT>();
+        // Cache the base pointer of the block, as typed_block->data() has an if statement for internal vs external
+        base_ptr_ = reinterpret_cast<const RawType *>(typed_block->data());
+    }
+
+    RawType at(size_t idx) const {
+        return *(base_ptr_ + idx);
+    }
+private:
+    const RawType* base_ptr_;
+};
+
+template<typename TDT>
+class ChunkedBufferRegularBlocksAccessor {
+    using RawType = typename TDT::DataTypeTag::raw_type;
+public:
+    ChunkedBufferRegularBlocksAccessor(ColumnData* parent){
+        // Cache the base pointers of each block, as typed_block->data() has an if statement for internal vs external
+        base_ptrs_.reserve(parent->num_blocks());
+        while (auto typed_block = parent->next<TDT>()) {
+            base_ptrs_.emplace_back(reinterpret_cast<const RawType *>(typed_block->data()));
+        }
+    }
+
+    RawType at(size_t idx) const {
+        // quot is the block index, rem is the offset within the block
+        auto div = std::div(static_cast<long long>(idx), values_per_block_);
+        debug::check<ErrorCode::E_ASSERTION_FAILURE>(div.quot < static_cast<long long>(base_ptrs_.size()),
+                                                     "ColumnData::at called with out of bounds index");
+        return *(base_ptrs_[div.quot] + div.rem);
+    }
+private:
+    static constexpr auto values_per_block_ = BufferSize / sizeof(RawType);
+    std::vector<const RawType*> base_ptrs_;
+};
+
+template<typename TDT>
+class ChunkedBufferIrregularBlocksAccessor {
+    using RawType = typename TDT::DataTypeTag::raw_type;
+public:
+    ChunkedBufferIrregularBlocksAccessor(ColumnData* parent):
+            parent_(parent){
+    }
+
+    RawType at(size_t idx) const {
+        auto pos_bytes = idx * sizeof(RawType);
+        auto block_and_offset = parent_->buffer().block_and_offset(pos_bytes);
+        auto ptr = block_and_offset.block_->data();
+        ptr += block_and_offset.offset_;
+        return *reinterpret_cast<const RawType *>(ptr);
+    }
+private:
+    ColumnData* parent_;
+};
+
+template<typename TDT>
+struct IColumnDataRandomAccessor {
+    template<class Base>
+    struct Interface : Base {
+        typename TDT::DataTypeTag::raw_type at(size_t idx) const { return folly::poly_call<0>(*this, idx); };
+    };
+
+    template<class T>
+    using Members = folly::PolyMembers<&T::at>;
+};
+
+template<typename TDT>
+using ColumnDataRandomAccessor = folly::Poly<IColumnDataRandomAccessor<TDT>>;
+
+template<typename TDT, BlockStructure block_structure>
+class ColumnDataRandomAccessorSparse {
+    using RawType = typename TDT::DataTypeTag::raw_type;
+public:
+    ColumnDataRandomAccessorSparse(ColumnData* parent):
+    parent_(parent) {
+        parent_->bit_vector()->build_rs_index(&(bit_index_));
+        if constexpr (block_structure == BlockStructure::SINGLE) {
+            chunked_buffer_random_accessor_ = ChunkedBufferSingleBlockAccessor<TDT>(parent);
+        } else if constexpr (block_structure == BlockStructure::REGULAR) {
+            chunked_buffer_random_accessor_ = ChunkedBufferRegularBlocksAccessor<TDT>(parent);
+        } else {
+            // Irregular
+            chunked_buffer_random_accessor_ = ChunkedBufferIrregularBlocksAccessor<TDT>(parent);
+        }
+    }
+
+    RawType at(size_t idx) const {
+        debug::check<ErrorCode::E_ASSERTION_FAILURE>(parent_->bit_vector(),
+                                                     "ColumnData::at called with sparse true, but bit_vector_ == nullptr");
+        debug::check<ErrorCode::E_ASSERTION_FAILURE>(parent_->bit_vector()->size() > idx,
+                                                     "ColumnData::at called with sparse true, but index is out of range");
+        debug::check<ErrorCode::E_ASSERTION_FAILURE>(parent_->bit_vector()->get_bit(idx),
+                                                     "ColumnData::at called with sparse true, but selected bit is false");
+        // This is the same as using rank_corrected, but we always require the idx bit to be true, so do the -1 ourselves for efficiency
+        auto physical_offset = parent_->bit_vector()->rank(idx, bit_index_) - 1;
+        return chunked_buffer_random_accessor_.at(physical_offset);
+    }
+
+private:
+    ChunkedBufferRandomAccessor<TDT> chunked_buffer_random_accessor_;
+    ColumnData* parent_;
+    util::BitIndex bit_index_;
+};
+
+template<typename TDT, BlockStructure block_structure>
+class ColumnDataRandomAccessorDense {
+    using RawType = typename TDT::DataTypeTag::raw_type;
+public:
+    ColumnDataRandomAccessorDense(ColumnData* parent) {
+        if constexpr (block_structure == BlockStructure::SINGLE) {
+            chunked_buffer_random_accessor_ = ChunkedBufferSingleBlockAccessor<TDT>(parent);
+        } else if constexpr (block_structure == BlockStructure::REGULAR) {
+            chunked_buffer_random_accessor_ = ChunkedBufferRegularBlocksAccessor<TDT>(parent);
+        } else {
+            // Irregular
+            chunked_buffer_random_accessor_ = ChunkedBufferIrregularBlocksAccessor<TDT>(parent);
+        }
+    }
+
+    RawType at(size_t idx) const {
+        return chunked_buffer_random_accessor_.at(idx);
+    }
+
+private:
+    ChunkedBufferRandomAccessor<TDT> chunked_buffer_random_accessor_;
+};
+
+template<typename TDT>
+ColumnDataRandomAccessor<TDT> random_accessor(ColumnData* parent) {
+    bool sparse = parent->bit_vector() != nullptr;
+    if (parent->buffer().num_blocks() == 1) {
+        if (sparse) {
+            return ColumnDataRandomAccessorSparse<TDT, BlockStructure::SINGLE>(parent);
+        } else {
+            return ColumnDataRandomAccessorDense<TDT, BlockStructure::SINGLE>(parent);
+        }
+    } else if (parent->buffer().is_regular_sized()) {
+        if (sparse) {
+            return ColumnDataRandomAccessorSparse<TDT, BlockStructure::REGULAR>(parent);
+        } else {
+            return ColumnDataRandomAccessorDense<TDT, BlockStructure::REGULAR>(parent);
+        }
+    } else {
+        if (sparse) {
+            return ColumnDataRandomAccessorSparse<TDT, BlockStructure::IRREGULAR>(parent);
+        } else {
+            return ColumnDataRandomAccessorDense<TDT, BlockStructure::IRREGULAR>(parent);
+        }
+    }
+}
+}

--- a/cpp/arcticdb/column_store/test/rapidcheck_column_data_random_accessor.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column_data_random_accessor.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/column_store/column.hpp>
+#include <arcticdb/column_store/column_data_random_accessor.hpp>
+#include <arcticdb/util/test/rapidcheck.hpp>
+
+// Tricky to construct columns using a ChunkedBuffer with the testing size of 64 bytes, so only use rapidcheck for
+// single block tests, and test regualr and irregular accessors in test_column_data_random_accessor.cpp
+RC_GTEST_PROP(ColumnDataRandomAccessor, DenseSingleBlock, (const std::vector<int64_t> &input)) {
+    using namespace arcticdb;
+    RC_PRE(input.size() > 0u);
+    auto n = input.size();
+    using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
+    Column column(static_cast<TypeDescriptor>(TDT{}), n, true, false);
+    RC_ASSERT(column.num_blocks() == 1);
+    memcpy(column.ptr(), input.data(), n * sizeof(int64_t));
+
+    auto column_data = column.data();
+    auto accessor = random_accessor<TDT>(&column_data);
+    for (size_t idx = 0; idx < n; ++idx) {
+        RC_ASSERT(accessor.at(idx) == input[idx]);
+    }
+}
+
+RC_GTEST_PROP(ColumnDataRandomAccessor, SparseSingleBlock, (const std::vector<int64_t> &input)) {
+    using namespace arcticdb;
+    RC_PRE(input.size() > 0u);
+    auto n = input.size();
+    auto mask = *rc::gen::container<std::vector<bool>>(n, rc::gen::arbitrary<bool>());
+    // The last value in the bitset will always be true in a sparse column
+    mask[n - 1] = true;
+    auto on_bits = std::count(mask.begin(), mask.end(), true);
+    util::BitSet sparse_map;
+    for (size_t idx = 0; idx < mask.size(); ++idx) {
+        if (mask[idx]) {
+            sparse_map.set_bit(idx);
+        }
+    }
+
+    using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
+    Column column(static_cast<TypeDescriptor>(TDT{}), on_bits, true, true);
+    RC_ASSERT(column.num_blocks() == 1);
+    memcpy(column.ptr(), input.data(), on_bits * sizeof(int64_t));
+    column.set_sparse_map(std::move(sparse_map));
+
+    auto column_data = column.data();
+    auto accessor = random_accessor<TDT>(&column_data);
+    size_t input_idx{0};
+    for (size_t idx = 0; idx < n; ++idx) {
+        if (mask[idx]) {
+            RC_ASSERT(accessor.at(idx) == input[input_idx++]);
+        }
+    }
+}

--- a/cpp/arcticdb/column_store/test/test_column_data_random_accessor.cpp
+++ b/cpp/arcticdb/column_store/test/test_column_data_random_accessor.cpp
@@ -1,0 +1,107 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/column_store/column.hpp>
+#include <arcticdb/column_store/column_data_random_accessor.hpp>
+
+using namespace arcticdb;
+
+class ColumnDataRandomAccessorTest : public testing::Test {
+protected:
+    using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;
+    void SetUp() override {
+        input_data.resize(n);
+        std::iota(input_data.begin(), input_data.end(), 42);
+    }
+    // 3968 bytes == 496 int64s per block, so 3 blocks here
+    size_t n{1000};
+    std::vector<int64_t> input_data;
+    TypeDescriptor type_descriptor{static_cast<TypeDescriptor>(TDT{})};
+};
+
+// Note that dense and sparse single block accessors are tested in rapidcheck_column_data_random_accessor.cpp
+TEST_F(ColumnDataRandomAccessorTest, DenseRegularBlocks) {
+    Column column(type_descriptor, false);
+    for (auto& val: input_data) {
+        column.push_back<int64_t>(val);
+    }
+
+    ASSERT_TRUE(column.buffer().is_regular_sized());
+    ASSERT_EQ(column.num_blocks(), 3);
+
+    auto column_data = column.data();
+    auto accessor = random_accessor<TDT>(&column_data);
+    for (size_t idx = 0; idx < n; ++idx) {
+        ASSERT_EQ(accessor.at(idx), input_data[idx]);
+    }
+}
+
+TEST_F(ColumnDataRandomAccessorTest, SparseRegularBlocks) {
+    Column column(type_descriptor, true);
+    // Set every third value
+    for (size_t idx = 0; idx < n; ++idx) {
+        column.set_scalar<int64_t>(3 * idx, input_data[idx]);
+    }
+
+    ASSERT_TRUE(column.is_sparse());
+    ASSERT_TRUE(column.buffer().is_regular_sized());
+    ASSERT_EQ(column.num_blocks(), 3);
+
+    auto column_data = column.data();
+    auto accessor = random_accessor<TDT>(&column_data);
+    for (size_t idx = 0; idx < n; ++idx) {
+        ASSERT_EQ(accessor.at(3 * idx), input_data[idx]);
+    }
+}
+
+TEST_F(ColumnDataRandomAccessorTest, DenseIrregularBlocks) {
+    // Presize to 500 values forces irregular blocks
+    Column column(type_descriptor, n / 2, true, false);
+    ASSERT_EQ(column.num_blocks(), 1);
+    memcpy(column.ptr(), input_data.data(), (n / 2) * sizeof(int64_t));
+    column.set_row_data((n / 2) - 1);
+    for (size_t idx = n / 2; idx < n; ++idx) {
+        column.push_back<int64_t>(input_data[idx]);
+    }
+
+    ASSERT_FALSE(column.buffer().is_regular_sized());
+    ASSERT_EQ(column.num_blocks(), 3);
+
+    auto column_data = column.data();
+    auto accessor = random_accessor<TDT>(&column_data);
+    for (size_t idx = 0; idx < n; ++idx) {
+        ASSERT_EQ(accessor.at(idx), input_data[idx]);
+    }
+}
+
+TEST_F(ColumnDataRandomAccessorTest, SparseIrregularBlocks) {
+    // Presize to 500 values forces irregular blocks
+    Column column(type_descriptor, n / 2, true, true);
+    ASSERT_EQ(column.num_blocks(), 1);
+    memcpy(column.ptr(), input_data.data(), (n / 2) * sizeof(int64_t));
+    column.set_row_data((n / 2) - 1);
+    // Set every third value
+    for (size_t idx = n / 2; idx < n; ++idx) {
+        column.set_scalar<int64_t>(3 * idx, input_data[idx]);
+    }
+
+    ASSERT_TRUE(column.is_sparse());
+    ASSERT_FALSE(column.buffer().is_regular_sized());
+    ASSERT_EQ(column.num_blocks(), 3);
+
+    auto column_data = column.data();
+    auto accessor = random_accessor<TDT>(&column_data);
+    for (size_t idx = 0; idx < n; ++idx) {
+        if (idx < n / 2) {
+            ASSERT_EQ(accessor.at(idx), input_data[idx]);
+        } else {
+            ASSERT_EQ(accessor.at(3 * idx), input_data[idx]);
+        }
+    }
+}

--- a/cpp/arcticdb/processing/grouper.hpp
+++ b/cpp/arcticdb/processing/grouper.hpp
@@ -56,10 +56,10 @@ public:
                 if (std::isnan(key)) {
                     return std::nullopt;
                 } else {
-                    return hash<RawType>(&key, 1);
+                    return hash<RawType>(&key);
                 }
             } else {
-                return hash<RawType>(&key, 1);
+                return hash<RawType>(&key);
             }
         }
     private:

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -51,72 +51,67 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
             return EmptyResult{};
         } else if constexpr(std::is_same_v<Func, IsNotInOperator&&>) {
             return FullResult{};
-        } else {
-            internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unexpected operator passed to binary_membership");
         }
     }
-    util::BitSet output_bitset(column_with_strings.column_->row_count());
-    // If the value set is empty, then for IsInOperator, we are done
-    // For the IsNotInOperator, set all bits to 1
+    // If the value set is empty, we can short-circuit
     if (value_set.empty()) {
-        if constexpr(std::is_same_v<Func, IsNotInOperator&&>)
-            output_bitset.set();
-    } else {
-        details::visit_type(column_with_strings.column_->type().data_type(),[&] (auto col_desc_tag) {
-            using col_type_info = ScalarTypeInfo<decltype(col_desc_tag)>;
-            details::visit_type(value_set.base_type().data_type(), [&] (auto val_set_desc_tag) {
-                using val_set_type_info = ScalarTypeInfo<decltype(val_set_desc_tag)>;
-                if constexpr(is_sequence_type(col_type_info::data_type) && is_sequence_type(val_set_type_info::data_type)) {
-                    std::shared_ptr<std::unordered_set<std::string>> typed_value_set;
-                    if constexpr(is_fixed_string_type(col_type_info::data_type)) {
-                        auto width = column_with_strings.get_fixed_width_string_size();
-                        if (width.has_value()) {
-                            typed_value_set = value_set.get_fixed_width_string_set(*width);
-                        }
-                    } else {
-                        typed_value_set = value_set.get_set<std::string>();
-                    }
-                    auto offset_set = column_with_strings.string_pool_->get_offsets_for_column(typed_value_set, *column_with_strings.column_);
-                    Column::transform<typename col_type_info::TDT>(*column_with_strings.column_, output_bitset, [&func, &offset_set](auto input_value) -> bool {
-                        auto offset = static_cast<entity::position_t>(input_value);
-                        return func(offset, offset_set);
-                    });
-                } else if constexpr (is_bool_type(col_type_info::data_type) && is_bool_type(val_set_type_info::data_type)) {
-                    util::raise_rte("Binary membership not implemented for bools");
-                } else if constexpr (is_numeric_type(col_type_info::data_type) && is_numeric_type(val_set_type_info::data_type)) {
-                    using WideType = typename type_arithmetic_promoted_type<typename col_type_info::RawType, typename val_set_type_info::RawType, std::remove_reference_t<Func>>::type;
-                    auto typed_value_set = value_set.get_set<WideType>();
-                    Column::transform<typename col_type_info::TDT>(*column_with_strings.column_, output_bitset, [&func, &typed_value_set](auto input_value) -> bool {
-                        if constexpr (MembershipOperator::needs_uint64_special_handling<typename col_type_info::RawType, typename val_set_type_info::RawType>) {
-                            // Avoid narrowing conversion on *input_it:
-                            return func(input_value, *typed_value_set, UInt64SpecialHandlingTag{});
-                        } else {
-                            return func(static_cast<WideType>(input_value), *typed_value_set);
-                        }
-                    });
-                } else {
-                    util::raise_rte("Cannot check membership of {} in set of {} (possible categorical?)",
-                                    column_with_strings.column_->type(), value_set.base_type());
-                }
-            });
-        });
-    }
-
-    output_bitset.optimize();
-    auto pos = 0;
-
-    if(column_with_strings.column_->is_sparse()) {
-        const auto& sparse_map = column_with_strings.column_->opt_sparse_map().value();
-        util::BitSet replace(sparse_map.size());
-        auto it = sparse_map.first();
-        auto it_end = sparse_map.end();
-        while(it < it_end) {
-           replace.set(*it, output_bitset.test(pos++));
-            ++it;
+        if constexpr(std::is_same_v<Func, IsNotInOperator&&>) {
+            return FullResult{};
+        } else {
+            return EmptyResult{};
         }
     }
 
-    log::version().debug("Filtered segment of size {} down to {} bits", output_bitset.size(), output_bitset.count());
+    util::BitSet output_bitset;
+    constexpr auto sparse_missing_value_output = std::is_same_v<Func, IsNotInOperator&&>;
+    details::visit_type(column_with_strings.column_->type().data_type(),[&] (auto col_tag) {
+        using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
+        details::visit_type(value_set.base_type().data_type(), [&] (auto val_set_tag) {
+            using val_set_type_info = ScalarTypeInfo<decltype(val_set_tag)>;
+            if constexpr(is_sequence_type(col_type_info::data_type) && is_sequence_type(val_set_type_info::data_type)) {
+                std::shared_ptr<std::unordered_set<std::string>> typed_value_set;
+                if constexpr(is_fixed_string_type(col_type_info::data_type)) {
+                    auto width = column_with_strings.get_fixed_width_string_size();
+                    if (width.has_value()) {
+                        typed_value_set = value_set.get_fixed_width_string_set(*width);
+                    }
+                } else {
+                    typed_value_set = value_set.get_set<std::string>();
+                }
+                auto offset_set = column_with_strings.string_pool_->get_offsets_for_column(typed_value_set, *column_with_strings.column_);
+                Column::transform<typename col_type_info::TDT>(
+                        *column_with_strings.column_,
+                        output_bitset,
+                        sparse_missing_value_output,
+                        [&func, &offset_set](auto input_value) -> bool {
+                    auto offset = static_cast<entity::position_t>(input_value);
+                    return func(offset, offset_set);
+                });
+            } else if constexpr (is_bool_type(col_type_info::data_type) && is_bool_type(val_set_type_info::data_type)) {
+                util::raise_rte("Binary membership not implemented for bools");
+            } else if constexpr (is_numeric_type(col_type_info::data_type) && is_numeric_type(val_set_type_info::data_type)) {
+                using WideType = typename type_arithmetic_promoted_type<typename col_type_info::RawType,typename val_set_type_info::RawType, std::remove_reference_t<Func>>::type;
+                auto typed_value_set = value_set.get_set<WideType>();
+                Column::transform<typename col_type_info::TDT>(
+                        *column_with_strings.column_,
+                        output_bitset,
+                        sparse_missing_value_output,
+                        [&func, &typed_value_set](auto input_value) -> bool {
+                    if constexpr (MembershipOperator::needs_uint64_special_handling<typename col_type_info::RawType, typename val_set_type_info::RawType>) {
+                        // Avoid narrowing conversion on *input_it:
+                        return func(input_value, *typed_value_set, UInt64SpecialHandlingTag{});
+                    } else {
+                        return func(static_cast<WideType>(input_value), *typed_value_set);
+                    }
+                });
+            } else {
+                util::raise_rte("Cannot check membership of {} in set of {} (possible categorical?)",
+                                column_with_strings.column_->type(), value_set.base_type());
+            }
+        });
+    });
+
+    log::version().debug("Filtered column of size {} down to {} bits", column_with_strings.column_->last_row() + 1, output_bitset.count());
 
     return {std::move(output_bitset)};
 }
@@ -141,26 +136,37 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
     if (is_empty_type(left.column_->type().data_type()) || is_empty_type(right.column_->type().data_type())) {
         return EmptyResult{};
     }
-    util::check(left.column_->row_count() == right.column_->row_count(), "Columns with different row counts ({} and {}) in binary comparator", left.column_->row_count(), right.column_->row_count());
-    util::BitSet output_bitset(static_cast<util::BitSetSizeType>(left.column_->row_count()));
+    util::BitSet output_bitset;
+    constexpr auto sparse_missing_value_output = std::is_same_v<Func, NotEqualsOperator&&>;
 
-    details::visit_type(left.column_->type().data_type(), [&](auto left_desc_tag) {
-        using left_type_info = ScalarTypeInfo<decltype(left_desc_tag)>;
-        details::visit_type(right.column_->type().data_type(), [&](auto right_desc_tag) {
-            using right_type_info = ScalarTypeInfo<decltype(right_desc_tag)>;
+    details::visit_type(left.column_->type().data_type(), [&](auto left_tag) {
+        using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
+        details::visit_type(right.column_->type().data_type(), [&](auto right_tag) {
+            using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
             if constexpr(is_sequence_type(left_type_info::data_type) && is_sequence_type(right_type_info::data_type)) {
                 bool strip_fixed_width_trailing_nulls{false};
                 // If one or both columns are fixed width strings, we need to strip trailing null characters to get intuitive results
                 if constexpr (is_fixed_string_type(left_type_info::data_type) || is_fixed_string_type(right_type_info::data_type)) {
                     strip_fixed_width_trailing_nulls = true;
                 }
-                Column::transform<typename left_type_info::TDT, typename right_type_info::TDT>(*left.column_, *right.column_, output_bitset, [&func, &left, &right, strip_fixed_width_trailing_nulls] (auto left_value, auto right_value) -> bool {
-                    return func(left.string_at_offset(left_value, strip_fixed_width_trailing_nulls), right.string_at_offset(right_value, strip_fixed_width_trailing_nulls));
+                Column::transform<typename left_type_info::TDT, typename right_type_info::TDT>(
+                        *left.column_,
+                        *right.column_,
+                        output_bitset,
+                        sparse_missing_value_output,
+                        [&func, &left, &right, strip_fixed_width_trailing_nulls] (auto left_value, auto right_value) -> bool {
+                    return func(left.string_at_offset(left_value, strip_fixed_width_trailing_nulls),
+                                right.string_at_offset(right_value, strip_fixed_width_trailing_nulls));
                 });
             } else if constexpr ((is_numeric_type(left_type_info::data_type) && is_numeric_type(right_type_info::data_type)) ||
                                  (is_bool_type(left_type_info::data_type) && is_bool_type(right_type_info::data_type))) {
                 using comp = typename arcticdb::Comparable<typename left_type_info::RawType, typename right_type_info::RawType>;
-                Column::transform<typename left_type_info::TDT, typename right_type_info::TDT>(*left.column_, *right.column_, output_bitset, [&func] (auto left_value, auto right_value) -> bool {
+                Column::transform<typename left_type_info::TDT, typename right_type_info::TDT>(
+                        *left.column_,
+                        *right.column_,
+                        output_bitset,
+                        sparse_missing_value_output,
+                        [&func] (auto left_value, auto right_value) -> bool {
                     return func(static_cast<typename comp::left_type>(left_value), static_cast<typename comp::right_type>(right_value));
                 });
             } else {
@@ -168,7 +174,7 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
             }
         });
     });
-    ARCTICDB_DEBUG(log::version(), "Filtered segment of size {} down to {} bits", output_bitset.size(), output_bitset.count());
+    ARCTICDB_DEBUG(log::version(), "Filtered column of size {} down to {} bits", std::max(left.column_->last_row(), right.column_->last_row()) + 1, output_bitset.count());
 
     return VariantData{std::move(output_bitset)};
 }
@@ -178,12 +184,13 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
     if (is_empty_type(column_with_strings.column_->type().data_type())) {
         return EmptyResult{};
     }
-    util::BitSet output_bitset(static_cast<util::BitSetSizeType>(column_with_strings.column_->row_count()));
+    util::BitSet output_bitset;
+    constexpr auto sparse_missing_value_output = std::is_same_v<Func, NotEqualsOperator&&>;
 
-    details::visit_type(column_with_strings.column_->type().data_type(), [&](auto col_desc_tag) {
-        using col_type_info = ScalarTypeInfo<decltype(col_desc_tag)>;
-        details::visit_type(val.type().data_type(), [&](auto val_desc_tag) {
-            using val_type_info = ScalarTypeInfo<decltype(val_desc_tag)>;
+    details::visit_type(column_with_strings.column_->type().data_type(), [&](auto col_tag) {
+        using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
+        details::visit_type(val.type().data_type(), [&](auto val_tag) {
+            using val_type_info = ScalarTypeInfo<decltype(val_tag)>;
             if constexpr(is_sequence_type(col_type_info::data_type) && is_sequence_type(val_type_info::data_type)) {
                 std::optional<std::string> utf32_string;
                 std::string value_string;
@@ -199,7 +206,11 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                     value_string = std::string(*val.str_data(), val.len());
                 }
                 auto value_offset = column_with_strings.string_pool_->get_offset_for_column(value_string, *column_with_strings.column_);
-                Column::transform<typename col_type_info::TDT>(*column_with_strings.column_, output_bitset, [&func, value_offset](auto input_value) -> bool {
+                Column::transform<typename col_type_info::TDT>(
+                        *column_with_strings.column_,
+                        output_bitset,
+                        sparse_missing_value_output,
+                        [&func, value_offset](auto input_value) -> bool {
                     auto offset = static_cast<entity::position_t>(input_value);
                     if constexpr (arguments_reversed) {
                         return func(offset, value_offset);
@@ -213,7 +224,11 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                                                 typename arcticdb::Comparable<typename col_type_info::RawType, typename val_type_info::RawType>,
                                                 typename arcticdb::Comparable<typename val_type_info::RawType, typename col_type_info::RawType>>;
                 auto value = static_cast<typename comp::left_type>(*reinterpret_cast<const typename val_type_info::RawType *>(val.data_));
-                Column::transform<typename col_type_info::TDT>(*column_with_strings.column_, output_bitset, [&func, value](auto input_value) -> bool {
+                Column::transform<typename col_type_info::TDT>(
+                        *column_with_strings.column_,
+                        output_bitset,
+                        sparse_missing_value_output,
+                        [&func, value](auto input_value) -> bool {
                     if constexpr (arguments_reversed) {
                         return func(value, static_cast<typename comp::right_type>(input_value));
                     } else {
@@ -226,7 +241,7 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
             }
         });
     });
-    ARCTICDB_DEBUG(log::version(), "Filtered segment of size {} down to {} bits", output_bitset.size(), output_bitset.count());
+    ARCTICDB_DEBUG(log::version(), "Filtered column of size {} down to {} bits", column_with_strings.column_->last_row() + 1, output_bitset.count());
 
     return VariantData{std::move(output_bitset)};
 }
@@ -262,14 +277,14 @@ template <typename Func>
 VariantData binary_operator(const Value& left, const Value& right, Func&& func) {
     auto output_value = std::make_unique<Value>();
 
-    details::visit_type(left.type().data_type(), [&](auto left_desc_tag) {
-        using left_type_info = ScalarTypeInfo<decltype(left_desc_tag)>;
+    details::visit_type(left.type().data_type(), [&](auto left_tag) {
+        using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
         if constexpr(!is_numeric_type(left_type_info::data_type)) {
             util::raise_rte("Non-numeric type provided to binary operation: {}", left.type());
         }
         auto left_value = *reinterpret_cast<const typename left_type_info::RawType*>(left.data_);
-        details::visit_type(right.type().data_type(), [&](auto right_desc_tag) {
-            using right_type_info = ScalarTypeInfo<decltype(right_desc_tag)>;
+        details::visit_type(right.type().data_type(), [&](auto right_tag) {
+            using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
             if constexpr(!is_numeric_type(right_type_info::data_type)) {
                 util::raise_rte("Non-numeric type provided to binary operation: {}", right.type());
             }
@@ -287,25 +302,26 @@ VariantData binary_operator(const Column& left, const Column& right, Func&& func
     schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
             !is_empty_type(left.type().data_type()) && !is_empty_type(right.type().data_type()),
             "Empty column provided to binary operator");
-    util::check(left.row_count() == right.row_count(), "Columns with different row counts ({} and {}) in binary operator", left.row_count(), right.row_count());
     std::unique_ptr<Column> output_column;
 
-    details::visit_type(left.type().data_type(), [&](auto left_desc_tag) {
-        using left_type_info = ScalarTypeInfo<decltype(left_desc_tag)>;
+    details::visit_type(left.type().data_type(), [&](auto left_tag) {
+        using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
         if constexpr(!is_numeric_type(left_type_info::data_type)) {
             util::raise_rte("Non-numeric type provided to binary operation: {}", left.type());
         }
-        details::visit_type(right.type().data_type(), [&](auto right_desc_tag) {
-            using right_type_info = ScalarTypeInfo<decltype(right_desc_tag)>;
+        details::visit_type(right.type().data_type(), [&](auto right_tag) {
+            using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
             if constexpr(!is_numeric_type(right_type_info::data_type)) {
                 util::raise_rte("Non-numeric type provided to binary operation: {}", right.type());
             }
             using TargetType = typename type_arithmetic_promoted_type<typename left_type_info::RawType, typename right_type_info::RawType, std::remove_reference_t<decltype(func)>>::type;
             constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
-            output_column = std::make_unique<Column>(make_scalar_type(output_data_type), left.row_count(), true, false);
-            output_column->set_row_data(left.last_row());
+            output_column = std::make_unique<Column>(make_scalar_type(output_data_type), true);
             Column::transform<typename left_type_info::TDT, typename right_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
-                    left, right, *output_column, [&func] (auto left_value, auto right_value) -> TargetType {
+                    left,
+                    right,
+                    *output_column,
+                    [&func] (auto left_value, auto right_value) -> TargetType {
                         return func.apply(left_value, right_value);
                     });
         });
@@ -320,13 +336,13 @@ VariantData binary_operator(const Column& col, const Value& val, Func&& func) {
             "Empty column provided to binary operator");
     std::unique_ptr<Column> output_column;
 
-    details::visit_type(col.type().data_type(), [&](auto col_desc_tag) {
-        using col_type_info = ScalarTypeInfo<decltype(col_desc_tag)>;
+    details::visit_type(col.type().data_type(), [&](auto col_tag) {
+        using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
         if constexpr(!is_numeric_type(col_type_info::data_type)) {
             util::raise_rte("Non-numeric type provided to binary operation: {}", col.type());
         }
-        details::visit_type(val.type().data_type(), [&](auto val_desc_tag) {
-            using val_type_info = ScalarTypeInfo<decltype(val_desc_tag)>;
+        details::visit_type(val.type().data_type(), [&](auto val_tag) {
+            using val_type_info = ScalarTypeInfo<decltype(val_tag)>;
             if constexpr(!is_numeric_type(val_type_info::data_type)) {
                 util::raise_rte("Non-numeric type provided to binary operation: {}", val.type());
             }
@@ -335,16 +351,20 @@ VariantData binary_operator(const Column& col, const Value& val, Func&& func) {
             using ReversedTargetType = typename type_arithmetic_promoted_type<typename val_type_info::RawType, typename col_type_info::RawType, std::remove_reference_t<decltype(func)>>::type;
             if constexpr(arguments_reversed) {
                 constexpr auto output_data_type = data_type_from_raw_type<ReversedTargetType>();
-                output_column = std::make_unique<Column>(make_scalar_type(output_data_type), col.row_count(), true, false);
-                output_column->set_row_data(col.last_row());
-                Column::transform<typename col_type_info ::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(col, *output_column, [&func, raw_value](auto input_value) -> ReversedTargetType {
+                output_column = std::make_unique<Column>(make_scalar_type(output_data_type), true);
+                Column::transform<typename col_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
+                        col,
+                        *output_column,
+                        [&func, raw_value](auto input_value) -> ReversedTargetType {
                     return func.apply(raw_value, input_value);
                 });
             } else {
                 constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
-                output_column = std::make_unique<Column>(make_scalar_type(output_data_type), col.row_count(), true, false);
-                output_column->set_row_data(col.last_row());
-                Column::transform<typename col_type_info ::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(col, *output_column, [&func, raw_value](auto input_value) -> TargetType {
+                output_column = std::make_unique<Column>(make_scalar_type(output_data_type), true);
+                Column::transform<typename col_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
+                        col,
+                        *output_column,
+                        [&func, raw_value](auto input_value) -> TargetType {
                     return func.apply(input_value, raw_value);
                 });
             }

--- a/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
+++ b/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
@@ -1,0 +1,421 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <arcticdb/processing/processing_unit.hpp>
+#include <arcticdb/util/test/generators.hpp>
+
+using namespace arcticdb;
+
+class FilterProjectSparse : public testing::Test {
+protected:
+    void SetUp() override {
+        auto input_segment = generate_filter_and_project_testing_sparse_segment();
+        sparse_floats_1 = input_segment.column_ptr(input_segment.column_index("sparse_floats_1").value());
+        sparse_floats_2 = input_segment.column_ptr(input_segment.column_index("sparse_floats_2").value());
+        dense_floats_1 = input_segment.column_ptr(input_segment.column_index("dense_floats_1").value());
+        dense_floats_2 = input_segment.column_ptr(input_segment.column_index("dense_floats_2").value());
+        sparse_bools = input_segment.column_ptr(input_segment.column_index("sparse_bools").value());
+        proc_unit = ProcessingUnit(std::move(input_segment));
+        proc_unit.set_expression_context(expression_context);
+    }
+
+    std::shared_ptr<Column> unary_projection(std::string_view input_column_name, OperationType op) {
+        const std::string output_column("unary projection");
+        expression_context->root_node_name_ = ExpressionName(output_column);
+        auto expression_node = std::make_shared<ExpressionNode>(ColumnName(input_column_name), op);
+        expression_context->add_expression_node(output_column, expression_node);
+
+        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        return std::get<ColumnWithStrings>(variant_data).column_;
+    }
+
+    util::BitSet unary_filter(std::string_view input_column_name, OperationType op) {
+        const std::string root_node_name("unary filter");
+        expression_context->root_node_name_ = ExpressionName(root_node_name);
+        auto expression_node = std::make_shared<ExpressionNode>(ColumnName(input_column_name), op);
+        expression_context->add_expression_node(root_node_name, expression_node);
+
+        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        return std::get<util::BitSet>(variant_data);
+    }
+
+    util::BitSet binary_filter(std::string_view left_column_name,
+                               std::variant<std::string_view, double, std::unordered_set<double>> right_input,
+                               OperationType op) {
+        const std::string root_node_name("binary filter");
+        const std::string value_name("value");
+        const std::string value_set_name("value set");
+        expression_context->root_node_name_ = ExpressionName(root_node_name);
+        std::shared_ptr<ExpressionNode> expression_node;
+        util::variant_match(right_input,
+            [&](std::string_view right_column_name) {
+                expression_node = std::make_shared<ExpressionNode>(ColumnName(left_column_name), ColumnName(right_column_name), op);
+            },
+            [&](double value) {
+                expression_node = std::make_shared<ExpressionNode>(ColumnName(left_column_name), ValueName(value_name), op);
+                expression_context->add_value(value_name, std::make_shared<Value>(value, DataType::FLOAT64));
+            },
+            [&](std::unordered_set<double> value_set) {
+                expression_node = std::make_shared<ExpressionNode>(ColumnName(left_column_name), ValueSetName(value_set_name), op);
+                expression_context->add_value_set(value_set_name, std::make_shared<ValueSet>(std::make_shared<std::unordered_set<double>>(value_set)));
+            });
+        expression_context->add_expression_node(root_node_name, expression_node);
+
+        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        return std::get<util::BitSet>(variant_data);
+    }
+
+    std::shared_ptr<Column> binary_projection(std::string_view left_column_name,
+                                              std::variant<std::string_view, double> right_input,
+                                              OperationType op) {
+        const std::string output_column("binary filter");
+        const std::string value_name("value");
+        expression_context->root_node_name_ = ExpressionName(output_column);
+        std::shared_ptr<ExpressionNode> expression_node;
+        util::variant_match(right_input,
+                            [&](std::string_view right_column_name) {
+                                expression_node = std::make_shared<ExpressionNode>(ColumnName(left_column_name), ColumnName(right_column_name), op);
+                            },
+                            [&](double value) {
+                                expression_node = std::make_shared<ExpressionNode>(ColumnName(left_column_name), ValueName(value_name), op);
+                                expression_context->add_value(value_name, std::make_shared<Value>(value, DataType::FLOAT64));
+                            });
+        expression_context->add_expression_node(output_column, expression_node);
+
+        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        return std::get<ColumnWithStrings>(variant_data).column_;
+    }
+
+    ProcessingUnit proc_unit;
+    std::shared_ptr<ExpressionContext> expression_context{std::make_shared<ExpressionContext>()};
+    std::shared_ptr<Column> sparse_floats_1;
+    std::shared_ptr<Column> sparse_floats_2;
+    std::shared_ptr<Column> dense_floats_1;
+    std::shared_ptr<Column> dense_floats_2;
+    std::shared_ptr<Column> sparse_bools;
+};
+
+TEST_F(FilterProjectSparse, UnaryProjection) {
+    auto projected_column = unary_projection("sparse_floats_1", OperationType::NEG);
+
+    ASSERT_EQ(sparse_floats_1->last_row(), projected_column->last_row());
+    ASSERT_EQ(sparse_floats_1->row_count(), projected_column->row_count());
+    ASSERT_EQ(sparse_floats_1->opt_sparse_map(), projected_column->opt_sparse_map());
+
+    for (auto idx=0; idx< sparse_floats_1->row_count(); idx++) {
+        ASSERT_FLOAT_EQ(sparse_floats_1->reference_at<double>(idx), -projected_column->reference_at<double>(idx));
+    }
+}
+
+TEST_F(FilterProjectSparse, BoolColumnIdentity) {
+    auto bitset = unary_filter("sparse_bools", OperationType::IDENTITY);
+    for (auto idx = 0; idx <= sparse_bools->last_row(); idx++) {
+        auto opt_input_value = sparse_bools->scalar_at<bool>(idx);
+        if (opt_input_value.has_value() && *opt_input_value) {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BoolColumnNot) {
+    auto bitset = unary_filter("sparse_bools", OperationType::NOT);
+    for (auto idx = 0; idx <= sparse_bools->last_row(); idx++) {
+        auto opt_input_value = sparse_bools->scalar_at<bool>(idx);
+        if (opt_input_value.has_value() && *opt_input_value) {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        } else {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, IsNull) {
+    auto bitset = unary_filter("sparse_floats_2", OperationType::ISNULL);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_input_value = sparse_floats_2->scalar_at<double>(idx);
+        if (opt_input_value.has_value() && !std::isnan(*opt_input_value)) {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        } else {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, NotNull) {
+    auto bitset = unary_filter("sparse_floats_2", OperationType::NOTNULL);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_input_value = sparse_floats_2->scalar_at<double>(idx);
+        if (opt_input_value.has_value() && !std::isnan(*opt_input_value)) {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonIsIn) {
+    auto bitset = binary_filter("sparse_floats_2", std::unordered_set<double>{5.0}, OperationType::ISIN);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_input_value = sparse_floats_2->scalar_at<double>(idx);
+        if (opt_input_value.has_value() && *opt_input_value == double(5.0)) {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonIsNotIn) {
+    auto bitset = binary_filter("sparse_floats_2", std::unordered_set<double>{5.0}, OperationType::ISNOTIN);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_input_value = sparse_floats_2->scalar_at<double>(idx);
+        if (!opt_input_value.has_value() || *opt_input_value != double(5.0)) {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonColValEquals) {
+    auto bitset = binary_filter("sparse_floats_2", double{5.0}, OperationType::EQ);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_input_value = sparse_floats_2->scalar_at<double>(idx);
+        if (opt_input_value.has_value() && *opt_input_value == double(5.0)) {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonColValNotEqual) {
+    auto bitset = binary_filter("sparse_floats_2", double{5.0}, OperationType::NE);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_input_value = sparse_floats_2->scalar_at<double>(idx);
+        if (!opt_input_value.has_value() || *opt_input_value != double(5.0)) {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonSparseColSparseCol) {
+    auto bitset = binary_filter("sparse_floats_1", std::string_view{"sparse_floats_2"}, OperationType::LT);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_left_value = sparse_floats_1->scalar_at<double>(idx);
+        auto opt_right_value = sparse_floats_2->scalar_at<double>(idx);
+        if (opt_left_value.has_value() && opt_right_value.has_value()) {
+            ASSERT_EQ(*opt_left_value < *opt_right_value, bitset.get_bit(idx));
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonSparseColSparseColNotEqual) {
+    auto bitset = binary_filter("sparse_floats_1", std::string_view{"sparse_floats_2"}, OperationType::NE);
+    for (auto idx = 0; idx <= sparse_floats_2->last_row(); idx++) {
+        auto opt_left_value = sparse_floats_1->scalar_at<double>(idx);
+        auto opt_right_value = sparse_floats_2->scalar_at<double>(idx);
+        if (opt_left_value.has_value() && opt_right_value.has_value()) {
+            ASSERT_EQ(*opt_left_value != *opt_right_value, bitset.get_bit(idx));
+        } else {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonDenseColDenseCol) {
+    auto bitset = binary_filter("dense_floats_1", std::string_view{"dense_floats_2"}, OperationType::EQ);
+    for (auto idx = 0; idx <= dense_floats_2->last_row(); idx++) {
+        if (idx <= dense_floats_1->last_row()) {
+            auto opt_left_value = dense_floats_1->scalar_at<double>(idx);
+            auto opt_right_value = dense_floats_2->scalar_at<double>(idx);
+            if (opt_left_value.has_value() && opt_right_value.has_value()) {
+                ASSERT_EQ(*opt_left_value == *opt_right_value, bitset.get_bit(idx));
+            } else {
+                ASSERT_FALSE(bitset.get_bit(idx));
+            }
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonDenseColDenseColNotEqual) {
+    auto bitset = binary_filter("dense_floats_1", std::string_view{"dense_floats_2"}, OperationType::NE);
+    for (auto idx = 0; idx <= dense_floats_2->last_row(); idx++) {
+        if (idx <= dense_floats_1->last_row()) {
+            auto opt_left_value = dense_floats_1->scalar_at<double>(idx);
+            auto opt_right_value = dense_floats_2->scalar_at<double>(idx);
+            if (opt_left_value.has_value() && opt_right_value.has_value()) {
+                ASSERT_EQ(*opt_left_value != *opt_right_value, bitset.get_bit(idx));
+            } else {
+                ASSERT_TRUE(bitset.get_bit(idx));
+            }
+        } else {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonSparseColShorterThanDenseCol) {
+    auto bitset = binary_filter("sparse_floats_1", std::string_view{"dense_floats_1"}, OperationType::GT);
+    for (auto idx = 0; idx <= dense_floats_1->last_row(); idx++) {
+        if (idx <= sparse_floats_1->last_row()) {
+            auto opt_left_value = sparse_floats_1->scalar_at<double>(idx);
+            auto opt_right_value = dense_floats_1->scalar_at<double>(idx);
+            if (opt_left_value.has_value() && opt_right_value.has_value()) {
+                ASSERT_EQ(*opt_left_value > *opt_right_value, bitset.get_bit(idx));
+            } else {
+                ASSERT_FALSE(bitset.get_bit(idx));
+            }
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonSparseColShorterThanDenseColNotEqual) {
+    auto bitset = binary_filter("sparse_floats_1", std::string_view{"dense_floats_1"}, OperationType::NE);
+    for (auto idx = 0; idx <= sparse_floats_1->last_row(); idx++) {
+        auto opt_left_value = sparse_floats_1->scalar_at<double>(idx);
+        auto opt_right_value = dense_floats_1->scalar_at<double>(idx);
+        if (opt_left_value.has_value() && opt_right_value.has_value()) {
+            ASSERT_EQ(*opt_left_value != *opt_right_value, bitset.get_bit(idx));
+        } else {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonSparseColLongerThanDenseCol) {
+    auto bitset = binary_filter("dense_floats_1", std::string_view{"sparse_floats_1"}, OperationType::GT);
+    for (auto idx = 0; idx <= sparse_floats_1->last_row(); idx++) {
+        if (idx <= dense_floats_1->last_row()) {
+            auto opt_left_value = dense_floats_1->scalar_at<double>(idx);
+            auto opt_right_value = sparse_floats_1->scalar_at<double>(idx);
+            if (opt_left_value.has_value() && opt_right_value.has_value()) {
+                ASSERT_EQ(*opt_left_value > *opt_right_value, bitset.get_bit(idx));
+            } else {
+                ASSERT_FALSE(bitset.get_bit(idx));
+            }
+        } else {
+            ASSERT_FALSE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryComparisonSparseColLongerThanDenseColNotEqual) {
+    auto bitset = binary_filter("dense_floats_1", std::string_view{"sparse_floats_1"}, OperationType::NE);
+    for (auto idx = 0; idx <= sparse_floats_1->last_row(); idx++) {
+        auto opt_left_value = dense_floats_1->scalar_at<double>(idx);
+        auto opt_right_value = sparse_floats_1->scalar_at<double>(idx);
+        if (opt_left_value.has_value() && opt_right_value.has_value()) {
+            ASSERT_EQ(*opt_left_value != *opt_right_value, bitset.get_bit(idx));
+        } else {
+            ASSERT_TRUE(bitset.get_bit(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryArithmeticColVal) {
+    auto projected_column = binary_projection("sparse_floats_1", double{10.0}, OperationType::MUL);
+    ASSERT_EQ(sparse_floats_1->last_row(), projected_column->last_row());
+    ASSERT_EQ(sparse_floats_1->row_count(), projected_column->row_count());
+    ASSERT_EQ(sparse_floats_1->opt_sparse_map(), projected_column->opt_sparse_map());
+    for (auto idx=0; idx< sparse_floats_1->row_count(); idx++) {
+        ASSERT_FLOAT_EQ(10.0 * sparse_floats_1->reference_at<double>(idx), projected_column->reference_at<double>(idx));
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryArithmeticSparseColSparseCol) {
+    auto projected_column = binary_projection("sparse_floats_1", std::string_view{"sparse_floats_2"}, OperationType::MUL);
+    ASSERT_TRUE(projected_column->opt_sparse_map().has_value());
+    ASSERT_EQ(sparse_floats_1->sparse_map() & sparse_floats_2->sparse_map(), projected_column->sparse_map());
+    ASSERT_EQ(projected_column->row_count(), projected_column->sparse_map().count());
+
+    for (auto idx = 0; idx <= projected_column->last_row(); idx++) {
+        auto opt_left_value = sparse_floats_1->scalar_at<double>(idx);
+        auto opt_right_value = sparse_floats_2->scalar_at<double>(idx);
+        auto opt_projected_value = projected_column->scalar_at<double>(idx);
+        if (opt_left_value.has_value() && opt_right_value.has_value()) {
+            ASSERT_TRUE(opt_projected_value.has_value());
+            if (std::isnan(*opt_left_value * *opt_right_value)) {
+                ASSERT_TRUE(std::isnan(*opt_projected_value));
+            } else {
+                ASSERT_FLOAT_EQ(*opt_left_value * *opt_right_value, *projected_column->scalar_at<double>(idx));
+            }
+        } else {
+            ASSERT_FALSE(projected_column->has_value_at(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryArithmeticDenseColDenseCol) {
+    auto projected_column = binary_projection("dense_floats_1", std::string_view{"dense_floats_2"}, OperationType::MUL);
+    // dense_floats_1 has fewer values than dense_floats_2
+    ASSERT_EQ(dense_floats_1->last_row(), projected_column->last_row());
+    ASSERT_EQ(dense_floats_1->row_count(), projected_column->row_count());
+    ASSERT_FALSE(projected_column->opt_sparse_map().has_value());
+
+    for (auto idx=0; idx< dense_floats_1->last_row(); idx++) {
+        ASSERT_FLOAT_EQ(dense_floats_1->reference_at<double>(idx) * dense_floats_2->reference_at<double>(idx),
+                        projected_column->reference_at<double>(idx));
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryArithmeticSparseColShorterThanDenseCol) {
+    auto projected_column = binary_projection("sparse_floats_1", std::string_view{"dense_floats_1"}, OperationType::MUL);
+    ASSERT_TRUE(projected_column->opt_sparse_map().has_value());
+    ASSERT_EQ(*sparse_floats_1->opt_sparse_map(), *projected_column->opt_sparse_map());
+    ASSERT_EQ(projected_column->row_count(), projected_column->sparse_map().count());
+    for (auto idx = 0; idx <= projected_column->last_row(); idx++) {
+        auto opt_left_value = sparse_floats_1->scalar_at<double>(idx);
+        auto opt_right_value = dense_floats_1->scalar_at<double>(idx);
+        auto opt_projected_value = projected_column->scalar_at<double>(idx);
+        if (opt_left_value.has_value() && opt_right_value.has_value()) {
+            ASSERT_TRUE(opt_projected_value.has_value());
+            if (std::isnan(*opt_left_value * *opt_right_value)) {
+                ASSERT_TRUE(std::isnan(*opt_projected_value));
+            } else {
+                ASSERT_FLOAT_EQ(*opt_left_value * *opt_right_value, *projected_column->scalar_at<double>(idx));
+            }
+        } else {
+            ASSERT_FALSE(projected_column->has_value_at(idx));
+        }
+    }
+}
+
+TEST_F(FilterProjectSparse, BinaryArithmeticSparseColLongerThanDenseCol) {
+    auto projected_column = binary_projection("dense_floats_1", std::string_view{"sparse_floats_2"}, OperationType::MUL);
+    ASSERT_TRUE(projected_column->opt_sparse_map().has_value());
+    for (auto idx = 0; idx < dense_floats_1->row_count(); idx++) {
+        ASSERT_EQ(sparse_floats_2->sparse_map().get_bit(idx), projected_column->sparse_map().get_bit(idx));
+    }
+    ASSERT_EQ(projected_column->row_count(), projected_column->sparse_map().count());
+    for (auto idx = 0; idx <= projected_column->last_row(); idx++) {
+        auto opt_left_value = dense_floats_1->scalar_at<double>(idx);
+        auto opt_right_value = sparse_floats_2->scalar_at<double>(idx);
+        auto opt_projected_value = projected_column->scalar_at<double>(idx);
+        if (opt_left_value.has_value() && opt_right_value.has_value()) {
+            ASSERT_TRUE(opt_projected_value.has_value());
+            if (std::isnan(*opt_left_value * *opt_right_value)) {
+                ASSERT_TRUE(std::isnan(*opt_projected_value));
+            } else {
+                ASSERT_FLOAT_EQ(*opt_left_value * *opt_right_value, *projected_column->scalar_at<double>(idx));
+            }
+        } else {
+            ASSERT_FALSE(projected_column->has_value_at(idx));
+        }
+    }
+}

--- a/cpp/arcticdb/util/hash.hpp
+++ b/cpp/arcticdb/util/hash.hpp
@@ -12,23 +12,9 @@
 
 #include <folly/hash/Hash.h>
 
-// XXH_INLINE_ALL causes hashes to be non-deterministic with the linux conda build, needs investigating
-// https://github.com/man-group/ArcticDB/issues/1268
-#if defined(ARCTICDB_USING_CONDA) && defined(__linux__)
 #define XXH_STATIC_LINKING_ONLY
-#else
-// xxhash does some raw pointer manipulation that are safe, but compilers view as violating array bounds
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#define XXH_INLINE_ALL
-#endif
 #include <xxhash.h>
-#if defined(ARCTICDB_USING_CONDA) && defined(__linux__)
 #undef XXH_STATIC_LINKING_ONLY
-#else
-#undef XXH_INLINE_ALL
-#pragma GCC diagnostic pop
-#endif
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -68,6 +68,19 @@ namespace internal {
     constexpr auto raise = check<code>.raise;
 }
 
+namespace debug {
+#ifdef DEBUG_BUILD
+    template<ErrorCode code>
+    constexpr auto check = internal::check<code>;
+#else
+    template<ErrorCode code, typename...Args>
+    inline void check(ARCTICDB_UNUSED bool cond, ARCTICDB_UNUSED fmt::format_string<Args...> format, ARCTICDB_UNUSED Args&&...args) {}
+
+    template<ErrorCode code, typename FormatString, typename...Args>
+    inline void check(ARCTICDB_UNUSED bool cond, ARCTICDB_UNUSED FormatString format, ARCTICDB_UNUSED Args&&...args) {}
+#endif
+}
+
 namespace normalization {
 template<ErrorCode code>
 constexpr auto check = util::detail::Check<code, ErrorCategory::NORMALIZATION>{};

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -428,7 +428,7 @@ def test_mean_aggregation_float(local_object_version_store):
     assert_frame_equal(res.data, df)
 
 
-def test_mean_aggregation_float_nan(lmdb_version_store_v2):
+def test_mean_aggregation_float_nan(lmdb_version_store):
     df = DataFrame(
         {
             "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
@@ -439,9 +439,9 @@ def test_mean_aggregation_float_nan(lmdb_version_store_v2):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"to_mean": "mean"})
     symbol = "test_aggregation"
-    lmdb_version_store_v2.write(symbol, df)
+    lmdb_version_store.write(symbol, df)
 
-    res = lmdb_version_store_v2.read(symbol, query_builder=q)
+    res = lmdb_version_store.read(symbol, query_builder=q)
 
     df = pd.DataFrame({"to_mean": [(1.1 + 1.4 + 2.5) / 3, np.nan]}, index=["group_1", "group_2"])
     df.index.rename("grouping_column", inplace=True)


### PR DESCRIPTION
Fixes #1278 and https://github.com/man-group/arcticdb-man/issues/82

Makes filtering and projections work on sparse columns.