### PR TITLE
Add testing API to recreate a TaskScheduler

### DIFF
--- a/cpp/arcticdb/async/python_bindings.cpp
+++ b/cpp/arcticdb/async/python_bindings.cpp
@@ -23,6 +23,7 @@ void register_bindings(py::module &m) {
         }), "Number of threads used to execute tasks");
 
     async.def("print_scheduler_stats", &print_scheduler_stats);
+    async.def("reinit_task_scheduler", &TaskScheduler::init);  // for testing with new thread pool sizes
 }
 
 } // namespace arcticdb::async

--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -68,5 +68,3 @@ void print_scheduler_stats() {
 }
 
 } // namespace arcticdb
-
-

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -227,18 +227,6 @@ class TaskScheduler {
         return io_exec_;
     }
 
-    void re_init() {
-        ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Reinitializing task scheduler: {} {}", cpu_thread_count_, io_thread_count_);
-        ARCTICDB_RUNTIME_DEBUG(log::schedule(), "IO exec num threads: {}", io_exec_.numActiveThreads());
-        ARCTICDB_RUNTIME_DEBUG(log::schedule(), "CPU exec num threads: {}", cpu_exec_.numActiveThreads());
-        set_active_threads(0);
-        set_max_threads(0);
-        io_exec_.set_thread_factory(std::make_shared<InstrumentedNamedFactory>("IOPool"));
-        cpu_exec_.set_thread_factory(std::make_shared<InstrumentedNamedFactory>("CPUPool"));
-        io_exec_.setNumThreads(io_thread_count_);
-        cpu_exec_.setNumThreads(cpu_thread_count_);
-    }
-
     size_t cpu_thread_count() const {
         return cpu_thread_count_;
     }


### PR DESCRIPTION
Useful for testing as allows pytests to change thread pool sizes.

Used in enterprise repo.