### PR TITLE
Allow different testing dependency version in pipeline

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -284,12 +284,11 @@ jobs:
           cmake -P cpp/CMake/CpuCount.cmake | sed 's/^-- //' | tee -a $GITHUB_ENV
           python -V
           cd "$RUNNER_TEMP" # Works for Windows-style paths as well
-          python -m pip install --force-reinstall *${{env.python_impl_name}}*.whl
+          python -m pip install --force-reinstall  $(ls *${{env.python_impl_name}}*.whl)[Testing] pytest-split
           if [[ -n "${{matrix.python_deps || ''}}" ]] ; then
             echo "Using deps ${{matrix.python_deps}}"
             python -m pip install --force-reinstall -r $GITHUB_WORKSPACE/build_tooling/${{matrix.python_deps}}
           fi
-          python -m pip install arcticdb[Testing]
           python -m pip uninstall -y pytest-cpp || true # No longer works on 3.6
           python -m pip list
           echo -e "${{matrix.envs || ''}}" | tee -a $GITHUB_ENV


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Partially forward porting https://github.com/man-group/ArcticDB/blob/1efea881d5357737acd483d57b47eb957e3b06d8/.github/workflows/build_steps.yml#L255 from https://github.com/man-group/ArcticDB/pull/1393
#### What does this implement or fix?
In old pipeline, testing dependency from another version of `arcticdb` will be installed with `python -m pip install arcticdb[Testing]`. It doesn't necessarily align with those specified in the freshly built wheel.
This PR is for addressing that.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
