### PR TITLE
maint: Replace use of folly getCurrentThreadId with STL

### DIFF
--- a/cpp/arcticdb/util/storage_lock.hpp
+++ b/cpp/arcticdb/util/storage_lock.hpp
@@ -14,9 +14,9 @@
 #include <arcticdb/util/exponential_backoff.hpp>
 #include <arcticdb/util/configs_map.hpp>
 
-#include <folly/system/ThreadId.h>
-
+#include <fmt/std.h>
 #include <mutex>
+#include <thread>
 
 namespace arcticdb {
 
@@ -66,8 +66,8 @@ struct StorageLockTimeout : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
-inline uint64_t get_thread_id() {
-    return folly::getCurrentThreadID();
+inline std::thread::id get_thread_id() noexcept {
+    return std::this_thread::get_id();
 }
 
 template <class ClockType = util::SysClock>


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?

This is work to assist @jjerphan in removing use of folly in the ArcticDB code base.

The change here is to remove use of `folly::getCurrentThreadID()` in `get_thread_id()`, replacing it with use of `std::this_thread::get_id()`.

This replaces #1408 and is submitted from a branch of the main repo rather than my fork so that CI runs automatically.

#### Any other comments?

The folly implementation is much more complicated as there are different implementation for the 3 major OSes:

https://github.com/facebook/folly/blob/69a1b93df285457cd0799a6898e2e5390a09cd73/folly/system/ThreadId.cpp#L29-L37

The different implementations are not required as the STL C++11 solution should work on all OSes. Following
 https://github.com/man-group/ArcticDB/pull/1408#discussion_r1521142399 the solution here returns a `std::thread::id` rather than a `uint64_t` and this is formatted correctly in log messages (the only use of thread ID) by including `<fmt/std.h>`.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
