### PR TITLE
Revert "build: Update to fmt 10 (#1427)"

### DIFF
--- a/cpp/arcticdb/storage/single_file_storage.hpp
+++ b/cpp/arcticdb/storage/single_file_storage.hpp
@@ -63,7 +63,7 @@ struct formatter<arcticdb::storage::KeyData> {
 
     template<typename FormatContext>
     auto format(const arcticdb::storage::KeyData &k, FormatContext &ctx) const {
-        return format_to(ctx.out(), "{}:{}", k.key_offset_, k.key_size_);
+        return fmt::format_to(ctx.out(), "{}:{}", k.key_offset_, k.key_size_);
     }
 };
 

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -15,7 +15,6 @@
 #include <folly/concurrency/ConcurrentHashMap.h>
 #include <folly/ThreadCachedInt.h>
 
-#include <fmt/std.h>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -5,6 +5,8 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
+#include <variant>
+#include <cstdint>
 #include <arcticdb/version/symbol_list.hpp>
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/entity/atom_key.hpp>

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -149,7 +149,7 @@
     { "name": "boost-winapi", "version": "1.80.0#1" },
     { "name": "curl", "version": "8.4.0" },
     { "name": "double-conversion", "version": "3.2.1" },
-    { "name": "fmt", "version": "10.2.1" },
+    { "name": "fmt", "version": "9.1.0#1" },
     { "name": "folly", "version-string": "2022.10.31.00#3" },
     { "name": "gflags", "version": "2.2.2#5" },
     { "name": "glog", "version": "0.6.0#2" },
@@ -165,7 +165,7 @@
     { "name": "protobuf", "version": "3.21.8" },
     { "name": "rapidcheck", "version": "2021-12-20" },
     { "name": "s2n", "version": "1.3.5" },
-    { "name": "spdlog", "version": "1.13.0" },
+    { "name": "spdlog", "version": "1.11.0" },
     { "name": "xxhash", "version": "0.8.2" },
     { "name": "zlib", "version": "1.2.13" },
     { "name": "zstd", "version": "1.5.2" }

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -39,7 +39,8 @@ dependencies:
   - azure-storage-blobs-cpp
   # RocksDB is not supported on the conda build at the moment
   #  - rocksdb
-  - fmt
+  # ArcticDB is currently incompatible with fmt 10
+  - fmt < 10
   - folly==2023.09.25.00
   - unordered_dense
   # Vendored build dependencies (see `cpp/thirdparty` and `cpp/vcpkg.json`)


### PR DESCRIPTION
This reverts commit 75b14e14b433770a118e111ae7bcd31931797672.

Upgrading to fmt 10 breaks MSVS builds. Abseil package fails to build.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
