### PR TITLE
Fix #1384 by refactoring `VersionMap` to include all combinations of `LoadType`s and whether to `include_deleted`

### DIFF
--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -96,7 +96,6 @@ using VersionQueryType = std::variant<
 
 struct VersionQuery {
     VersionQueryType content_;
-    std::optional<bool> iterate_on_failure_;
 
     void set_snap_name(const std::string& snap_name) {
         content_ = SnapshotVersionQuery{snap_name};
@@ -108,10 +107,6 @@ struct VersionQuery {
 
     void set_version(SignedVersionId version) {
         content_ = SpecificVersionQuery{version};
-    }
-
-    void set_iterate_on_failure(const std::optional<bool>& iterate_on_failure) {
-        iterate_on_failure_ = iterate_on_failure;
     }
 };
 

--- a/cpp/arcticdb/util/constants.hpp
+++ b/cpp/arcticdb/util/constants.hpp
@@ -19,7 +19,9 @@ constexpr auto string_nan = std::numeric_limits<position_t>::max() - 1;
 
 constexpr auto NaT = std::numeric_limits<timestamp>::min();
 
-static constexpr decltype(timestamp(0) - timestamp(0)) ONE_SECOND = 1'000'000'000;
+static constexpr decltype(timestamp(0) - timestamp(0)) ONE_MILLISECOND = 1'000'000;
+
+static constexpr decltype(timestamp(0) - timestamp(0)) ONE_SECOND = 1'000 * ONE_MILLISECOND;
 
 static constexpr decltype(timestamp(0) - timestamp(0)) ONE_MINUTE = 60 * ONE_SECOND;
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -864,9 +864,9 @@ folly::Future<folly::Unit> delete_trees_responsibly(
         {
             auto min_versions = min_versions_for_each_stream(orig_keys_to_delete);
             for (const auto& min : min_versions) {
-                auto load_strategy = load_type == LoadType::LOAD_DOWNTO
-                        ? LoadStrategy{load_type, LoadObjective::ANY, static_cast<SignedVersionId>(min.second)}
-                        : LoadStrategy{load_type, LoadObjective::ANY};
+                auto load_strategy = load_type == LoadType::DOWNTO
+                        ? LoadStrategy{load_type, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(min.second)}
+                        : LoadStrategy{load_type, LoadObjective::INCLUDE_DELETED};
                 const auto entry = version_map->check_reload(store, min.first, load_strategy, __FUNCTION__);
                 entry_map.try_emplace(std::move(min.first), entry);
             }

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -870,8 +870,8 @@ folly::Future<folly::Unit> delete_trees_responsibly(
             auto min_versions = min_versions_for_each_stream(orig_keys_to_delete);
             for (const auto& min : min_versions) {
                 auto load_param = load_type == LoadType::LOAD_DOWNTO
-                        ? LoadParameter{load_type, static_cast<SignedVersionId>(min.second)}
-                        : LoadParameter{load_type};
+                        ? LoadParameter{load_type, ToLoad::ANY, static_cast<SignedVersionId>(min.second)}
+                        : LoadParameter{load_type, ToLoad::ANY};
                 const auto entry = version_map->check_reload(store, min.first, load_param, __FUNCTION__);
                 entry_map.try_emplace(std::move(min.first), entry);
             }

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -870,8 +870,8 @@ folly::Future<folly::Unit> delete_trees_responsibly(
             auto min_versions = min_versions_for_each_stream(orig_keys_to_delete);
             for (const auto& min : min_versions) {
                 auto load_param = load_type == LoadType::LOAD_DOWNTO
-                        ? LoadParameter{load_type, ToLoad::ANY, static_cast<SignedVersionId>(min.second)}
-                        : LoadParameter{load_type, ToLoad::ANY};
+                        ? LoadParameter{load_type, LoadObjective::ANY, static_cast<SignedVersionId>(min.second)}
+                        : LoadParameter{load_type, LoadObjective::ANY};
                 const auto entry = version_map->check_reload(store, min.first, load_param, __FUNCTION__);
                 entry_map.try_emplace(std::move(min.first), entry);
             }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -112,18 +112,15 @@ public:
     ) override;
 
     std::optional<VersionedItem> get_latest_version(
-        const StreamId &stream_id,
-        const VersionQuery& version_query);
+        const StreamId &stream_id);
 
     std::optional<VersionedItem> get_specific_version(
         const StreamId &stream_id,
-        SignedVersionId signed_version_id,
-        const VersionQuery& version_query);
+        SignedVersionId signed_version_id);
 
     std::optional<VersionedItem> get_version_at_time(
         const StreamId& stream_id,
-        timestamp as_of,
-        const VersionQuery& version_query);
+        timestamp as_of);
 
     std::optional<VersionedItem> get_version_from_snapshot(
         const StreamId& stream_id,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -131,8 +131,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def(py::init())
         .def("set_snap_name", &VersionQuery::set_snap_name)
         .def("set_timestamp", &VersionQuery::set_timestamp)
-        .def("set_version", &VersionQuery::set_version)
-        .def("set_iterate_on_failure", &VersionQuery::set_iterate_on_failure);
+        .def("set_version", &VersionQuery::set_version);
 
     py::class_<ReadOptions>(version, "PythonVersionStoreReadOptions")
         .def(py::init())
@@ -715,10 +714,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
                 const std::optional<StreamId> & s_id,
                 const std::optional<SnapshotId> & snap_id,
                 const std::optional<bool>& latest,
-                const std::optional<bool>& iterate_on_failure,
                 const std::optional<bool>& skip_snapshots
                 ){
-                 return v.list_versions(s_id, snap_id, latest, iterate_on_failure, skip_snapshots);
+                 return v.list_versions(s_id, snap_id, latest, skip_snapshots);
              },
              py::call_guard<SingleThreadMutexHolder>(), "List all the version ids for this store.")
         .def("_compact_version_map",

--- a/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
+++ b/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
@@ -23,7 +23,7 @@
 template <typename Model>
 void check_latest_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
     using namespace arcticdb;
-    auto prev = get_latest_version(sut.store_,sut.map_, symbol, pipelines::VersionQuery{}).first;
+    auto prev = get_latest_version(sut.store_,sut.map_, symbol).first;
     auto sut_version_id = prev ? prev->version_id() : 0;
     auto model_prev = s0.get_latest_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
@@ -33,9 +33,7 @@ void check_latest_versions(const Model&  s0, MapStorePair &sut, std::string symb
 template <typename Model>
 void check_latest_undeleted_versions(const Model&  s0, MapStorePair &sut, std::string symbol) {
     using namespace arcticdb;
-    pipelines::VersionQuery version_query;
-    version_query.set_iterate_on_failure(true);
-    auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol, version_query);
+    auto prev = get_latest_undeleted_version(sut.store_, sut.map_, symbol);
     auto sut_version_id = prev ? prev->version_id() : 0;
     auto model_prev = s0.get_latest_undeleted_version(symbol);
     auto model_version_id = model_prev ? model_prev.value() : 0;
@@ -224,7 +222,7 @@ struct GetAllVersions : rc::state::Command<Model, MapStorePair> {
     void run(const Model& s0, MapStorePair &sut) const override {
         auto model_versions = s0.get_all_versions(symbol_);
         using namespace arcticdb;
-        auto sut_version = get_all_versions(sut.store_, sut.map_, symbol_, pipelines::VersionQuery{});
+        auto sut_version = get_all_versions(sut.store_, sut.map_, symbol_);
         RC_ASSERT(model_versions.size() == sut_version.size());
 
         for(auto i = size_t{0}; i < model_versions.size(); ++i)

--- a/cpp/arcticdb/version/test/test_stream_version_data.cpp
+++ b/cpp/arcticdb/version/test/test_stream_version_data.cpp
@@ -12,8 +12,9 @@ TEST(StreamVersionData, SpecificVersion) {
     VersionQuery query_2{SpecificVersionQuery{VersionId(4)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_param_.load_until_version_, 4);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_, 4);
 }
 
 TEST(StreamVersionData, SpecificVersionReversed) {
@@ -24,8 +25,9 @@ TEST(StreamVersionData, SpecificVersionReversed) {
     VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_param_.load_until_version_, 4);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_, 4);
 }
 
 TEST(StreamVersionData, Timestamp) {
@@ -38,8 +40,9 @@ TEST(StreamVersionData, Timestamp) {
     VersionQuery query_2{TimestampVersionQuery{timestamp(4)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_param_.load_from_time_, 4);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_, 4);
 }
 
 TEST(StreamVersionData, TimestampUnordered) {
@@ -54,8 +57,9 @@ TEST(StreamVersionData, TimestampUnordered) {
     VersionQuery query_3{TimestampVersionQuery{timestamp(4)}, false};
     stream_version_data.react(query_3);
     ASSERT_EQ(stream_version_data.count_, 3);
-    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_param_.load_from_time_, 3);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_, 3);
 }
 
 TEST(StreamVersionData, Latest) {
@@ -66,8 +70,9 @@ TEST(StreamVersionData, Latest) {
     VersionQuery query_1{std::monostate{}, false};
     stream_version_data.react(query_1);
     ASSERT_EQ(stream_version_data.count_, 1);
-    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_LATEST_UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_until_version_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_LATEST);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
 }
 
 TEST(StreamVersionData, SpecificToTimestamp) {
@@ -80,9 +85,10 @@ TEST(StreamVersionData, SpecificToTimestamp) {
     VersionQuery query_2{TimestampVersionQuery{timestamp(3)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_until_version_.has_value(), false);
-    ASSERT_EQ(stream_version_data.load_param_.load_from_time_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_ALL);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_.has_value(), false);
 }
 
 TEST(StreamVersionData, TimestampToSpecific) {
@@ -95,7 +101,8 @@ TEST(StreamVersionData, TimestampToSpecific) {
     VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_type_, LoadType::LOAD_UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_until_version_.has_value(), false);
-    ASSERT_EQ(stream_version_data.load_param_.load_from_time_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_ALL);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_.has_value(), false);
 }

--- a/cpp/arcticdb/version/test/test_stream_version_data.cpp
+++ b/cpp/arcticdb/version/test/test_stream_version_data.cpp
@@ -13,7 +13,7 @@ TEST(StreamVersionData, SpecificVersion) {
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_, 4);
 }
 
@@ -26,7 +26,7 @@ TEST(StreamVersionData, SpecificVersionReversed) {
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_, 4);
 }
 
@@ -41,7 +41,7 @@ TEST(StreamVersionData, Timestamp) {
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_, 4);
 }
 
@@ -58,7 +58,7 @@ TEST(StreamVersionData, TimestampUnordered) {
     stream_version_data.react(query_3);
     ASSERT_EQ(stream_version_data.count_, 3);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_, 3);
 }
 
@@ -71,7 +71,7 @@ TEST(StreamVersionData, Latest) {
     stream_version_data.react(query_1);
     ASSERT_EQ(stream_version_data.count_, 1);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_LATEST);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
 }
 
@@ -86,7 +86,7 @@ TEST(StreamVersionData, SpecificToTimestamp) {
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_ALL);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_.has_value(), false);
 }
@@ -102,7 +102,7 @@ TEST(StreamVersionData, TimestampToSpecific) {
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_ALL);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.to_load_, ToLoad::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
     ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_.has_value(), false);
 }

--- a/cpp/arcticdb/version/test/test_stream_version_data.cpp
+++ b/cpp/arcticdb/version/test/test_stream_version_data.cpp
@@ -12,8 +12,8 @@ TEST(StreamVersionData, SpecificVersion) {
     VersionQuery query_2{SpecificVersionQuery{VersionId(4)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::DOWNTO);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED_ONLY);
     ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_, 4);
 }
 
@@ -25,8 +25,8 @@ TEST(StreamVersionData, SpecificVersionReversed) {
     VersionQuery query_2{SpecificVersionQuery{VersionId(12)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::DOWNTO);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED_ONLY);
     ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_, 4);
 }
 
@@ -40,8 +40,8 @@ TEST(StreamVersionData, Timestamp) {
     VersionQuery query_2{TimestampVersionQuery{timestamp(4)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED_ONLY);
     ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_, 4);
 }
 
@@ -57,8 +57,8 @@ TEST(StreamVersionData, TimestampUnordered) {
     VersionQuery query_3{TimestampVersionQuery{timestamp(4)}};
     stream_version_data.react(query_3);
     ASSERT_EQ(stream_version_data.count_, 3);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED_ONLY);
     ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_, 3);
 }
 
@@ -70,8 +70,8 @@ TEST(StreamVersionData, Latest) {
     VersionQuery query_1{std::monostate{}};
     stream_version_data.react(query_1);
     ASSERT_EQ(stream_version_data.count_, 1);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_LATEST);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LATEST);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED_ONLY);
     ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_.has_value(), false);
 }
 
@@ -85,8 +85,8 @@ TEST(StreamVersionData, SpecificToTimestamp) {
     VersionQuery query_2{TimestampVersionQuery{timestamp(3)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_ALL);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::ALL);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED_ONLY);
     ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_.has_value(), false);
     ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_.has_value(), false);
 }
@@ -101,8 +101,8 @@ TEST(StreamVersionData, TimestampToSpecific) {
     VersionQuery query_2{SpecificVersionQuery{VersionId(12)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_ALL);
-    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::ALL);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED_ONLY);
     ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_.has_value(), false);
     ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_.has_value(), false);
 }

--- a/cpp/arcticdb/version/test/test_stream_version_data.cpp
+++ b/cpp/arcticdb/version/test/test_stream_version_data.cpp
@@ -7,27 +7,27 @@ TEST(StreamVersionData, SpecificVersion) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false};
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{SpecificVersionQuery{VersionId(4)}, false};
+    VersionQuery query_2{SpecificVersionQuery{VersionId(4)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_, 4);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_, 4);
 }
 
 TEST(StreamVersionData, SpecificVersionReversed) {
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
 
-    StreamVersionData stream_version_data(VersionQuery{SpecificVersionQuery{VersionId(4)}, false});
-    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false};
+    StreamVersionData stream_version_data(VersionQuery{SpecificVersionQuery{VersionId(4)}});
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_, 4);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_DOWNTO);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_, 4);
 }
 
 TEST(StreamVersionData, Timestamp) {
@@ -35,14 +35,14 @@ TEST(StreamVersionData, Timestamp) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(12)}, false};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(12)}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(4)}, false};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(4)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_, 4);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_, 4);
 }
 
 TEST(StreamVersionData, TimestampUnordered) {
@@ -50,16 +50,16 @@ TEST(StreamVersionData, TimestampUnordered) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(7)}, false};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(7)}};
     stream_version_data.react(query_2);
-    VersionQuery query_3{TimestampVersionQuery{timestamp(4)}, false};
+    VersionQuery query_3{TimestampVersionQuery{timestamp(4)}};
     stream_version_data.react(query_3);
     ASSERT_EQ(stream_version_data.count_, 3);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_, 3);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_FROM_TIME);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_, 3);
 }
 
 TEST(StreamVersionData, Latest) {
@@ -67,12 +67,12 @@ TEST(StreamVersionData, Latest) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{std::monostate{}, false};
+    VersionQuery query_1{std::monostate{}};
     stream_version_data.react(query_1);
     ASSERT_EQ(stream_version_data.count_, 1);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_LATEST);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_LATEST);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_.has_value(), false);
 }
 
 TEST(StreamVersionData, SpecificToTimestamp) {
@@ -80,15 +80,15 @@ TEST(StreamVersionData, SpecificToTimestamp) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}, false};
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(3)}, false};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(3)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_ALL);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_ALL);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_.has_value(), false);
 }
 
 TEST(StreamVersionData, TimestampToSpecific) {
@@ -96,13 +96,13 @@ TEST(StreamVersionData, TimestampToSpecific) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}, false};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}, false};
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_type_, LoadType::LOAD_ALL);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_objective_, LoadObjective::UNDELETED);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_until_version_.has_value(), false);
-    ASSERT_EQ(stream_version_data.load_param_.load_strategy_.load_from_time_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::LOAD_ALL);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_objective_, LoadObjective::UNDELETED);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_until_version_.has_value(), false);
+    ASSERT_EQ(stream_version_data.load_strategy_.load_from_time_.has_value(), false);
 }

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -209,7 +209,7 @@ TEST(VersionMap, TestLoadsRefAndIteration) {
     version_map->load_via_iteration(store, id, entry_iteration);
 
     auto entry_ref = std::make_shared<VersionMapEntry>();
-    version_map->load_via_ref_key(store, id, LoadParameter{LoadType::LOAD_ALL}, entry_ref);
+    version_map->load_via_ref_key(store, id, LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, entry_ref);
 
     ASSERT_EQ(entry_iteration->head_, entry_ref->head_);
     ASSERT_EQ(entry_iteration->keys_.size(), entry_ref->keys_.size());
@@ -452,7 +452,7 @@ TEST(VersionMap, FixRefKeyTombstones) {
     auto key5 = atom_key_with_version(id, 1, 1696590624590123209);
     version_map->write_version(store, key5, key4);
     auto key6 = atom_key_with_version(id, 0, 1696590624612743245);
-    auto entry = version_map->check_reload(store, id, LoadParameter{LoadType::LOAD_LATEST},  __FUNCTION__);
+    auto entry = version_map->check_reload(store, id, LoadParameter{LoadType::LOAD_LATEST, ToLoad::ANY},  __FUNCTION__);
     version_map->journal_single_key(store, key5, entry->head_.value());
 
     auto valid = version_map->check_ref_key(store, id);
@@ -578,7 +578,7 @@ std::shared_ptr<VersionMapEntry> write_two_versions(std::shared_ptr<InMemoryStor
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadParameter{LoadType::NOT_LOADED},
+            LoadParameter{LoadType::NOT_LOADED, ToLoad::ANY},
             __FUNCTION__);
 
     auto key1 = atom_key_with_version(id, 0, 0);
@@ -586,6 +586,7 @@ std::shared_ptr<VersionMapEntry> write_two_versions(std::shared_ptr<InMemoryStor
     write_symbol_ref(store, key1, std::nullopt, entry->head_.value());
     auto key2 = atom_key_with_version(id, 1, 1);
     version_map->do_write(store, key2, entry);
+    // We override the symbol ref without a prev_key on purpose. This way we'll only load the version=1 from the ref key
     write_symbol_ref(store, key2, std::nullopt, entry->head_.value());
 
     return entry;
@@ -596,7 +597,7 @@ void write_alternating_deleted_undeleted(std::shared_ptr<InMemoryStore> store, s
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadParameter{LoadType::NOT_LOADED},
+            LoadParameter{LoadType::NOT_LOADED, ToLoad::ANY},
             __FUNCTION__);
 
     auto key1 = atom_key_with_version(id, 0, 0);
@@ -622,7 +623,95 @@ void write_alternating_deleted_undeleted(std::shared_ptr<InMemoryStore> store, s
     version_map->write_tombstone(store, VersionId{2}, id, entry, timestamp{3});
 }
 
-TEST(VersionMap, FollowingVersionChainEndEarly) {
+TEST(VersionMap, FollowingVersionChain){
+    // Set up the version chain v0(tombstone_all) <- v1 <- v2(tombstoned)
+    auto store = std::make_shared<InMemoryStore>();
+    auto version_map = std::make_shared<VersionMap>();
+    StreamId id{"test"};
+    write_alternating_deleted_undeleted(store, version_map, id);
+
+    auto check_strategy_loads_to = [&](LoadStrategy load_strategy, VersionId should_load_to){
+        auto ref_entry = VersionMapEntry{};
+        read_symbol_ref(store, id, ref_entry);
+        auto follow_result = std::make_shared<VersionMapEntry>();
+
+        version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
+        EXPECT_EQ(follow_result->loaded_with_progress_.oldest_loaded_index_version_, VersionId{should_load_to});
+    };
+
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(0)}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(-2)}, 1);
+    // DOWN_TO will not skip through tombstoned versions even when include_deleted=false
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(-1)}, 2);
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(0)}, 0);
+
+    // FROM_TIME when include_deleted=false will skip through deleted versions to go to the latest undeleted version before the timestamp.
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(10)}, 1);
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(0)}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(2)}, 2);
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(0)}, 0);
+
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_LATEST, ToLoad::ANY}, 2);
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED}, 1);
+
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_ALL, ToLoad::UNDELETED}, 0);
+}
+
+TEST(VersionMap, FollowingVersionChainWithCaching){
+    ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
+    // Set up the version chain v0(tombstone_all) <- v1 <- v2(tombstoned)
+    auto store = std::make_shared<InMemoryStore>();
+    auto version_map = std::make_shared<VersionMap>();
+    StreamId id{"test"};
+    write_alternating_deleted_undeleted(store, version_map, id);
+    // We create an empty version map after populating the versions
+    version_map = std::make_shared<VersionMap>();
+
+    auto check_loads_versions = [&](LoadParameter load_param, uint32_t should_load_any, uint32_t should_load_undeleted){
+        auto loaded = version_map->check_reload(store, id, load_param, __FUNCTION__);
+        EXPECT_EQ(loaded->get_indexes(true).size(), should_load_any);
+        EXPECT_EQ(loaded->get_indexes(false).size(), should_load_undeleted);
+    };
+
+    check_loads_versions(LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(-1)}, 1, 0);
+    // LOAD_FROM_TIME should not be cached by the LOAD_DOWNTO and should reload from storage up to the latest undeleted version, hence loading 2 versions, 1 of which is undeleted.
+    check_loads_versions(LoadParameter{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(10)}, 2, 1);
+    // LOAD_LATEST should be cached by the LOAD_FROM_TIME, so we still have the same 2 loaded versions
+    check_loads_versions(LoadParameter{LoadType::LOAD_LATEST, ToLoad::ANY}, 2, 1);
+    // This LOAD_FROM_TIME should still use the cached 2 versions
+    check_loads_versions(LoadParameter{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(1)}, 2, 1);
+
+    // We just get the entry to use for the tombstone and the write
+    auto entry = version_map->check_reload(
+            store,
+            id,
+            LoadParameter{LoadType::NOT_LOADED, ToLoad::ANY},
+            __FUNCTION__);
+    // We delete the only undeleted key
+    version_map->write_tombstone(store, VersionId{1}, id, entry, timestamp{4});
+
+    // LOAD_LATEST should still be cached, but the cached entry now needs to have no undeleted keys
+    check_loads_versions(LoadParameter{LoadType::LOAD_LATEST, ToLoad::ANY}, 2, 0);
+    // LOAD_FROM_TIME UNDELETED should no longer be cached even though we used the same request before because the undeleted key it went to got deleted. So it will load the entire version chain
+    check_loads_versions(LoadParameter{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(10)}, 3, 0);
+
+    // We add a new undeleted key
+    auto key4 = atom_key_with_version(id, 3, 5);
+    version_map->do_write(store, key4, entry);
+    write_symbol_ref(store, key4, std::nullopt, entry->head_.value());
+
+    // LOAD_LATEST should still be cached, but the cached entry now needs to have one more undeleted version
+    check_loads_versions(LoadParameter{LoadType::LOAD_LATEST, ToLoad::ANY}, 4, 1);
+
+    // We delete everything with a tombstone_all
+    version_map->delete_all_versions(store, id);
+
+    // LOAD_LATEST should still be cached, but now have no undeleted versions
+    check_loads_versions(LoadParameter{LoadType::LOAD_LATEST, ToLoad::ANY}, 4, 0);
+}
+
+TEST(VersionMap, FollowingVersionChainEndEarlyOnTombstoneAll) {
     auto store = std::make_shared<InMemoryStore>();
     auto version_map = std::make_shared<VersionMap>();
     StreamId id{"test"};
@@ -635,17 +724,29 @@ TEST(VersionMap, FollowingVersionChainEndEarly) {
     read_symbol_ref(store, id, ref_entry);
     auto follow_result = std::make_shared<VersionMapEntry>();
 
-    for (auto load_params: {
-        LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(0)},
-        LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(0)},
-        LoadParameter{LoadType::LOAD_UNDELETED},
-        LoadParameter{LoadType::LOAD_LATEST_UNDELETED}
+    for (auto load_strategy: {
+        LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(0)},
+        LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(0)},
+        LoadStrategy{LoadType::LOAD_ALL, ToLoad::UNDELETED},
+        LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED}
     }) {
         follow_result->clear();
-        version_map->follow_version_chain(store, ref_entry, follow_result, load_params);
-        // When loading with any of the specified load params we should end following the version chain early
+        version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
+        // When loading with any of the specified load strategies with include_deleted=false we should end following the version chain early
         // at version 1 because that's when we encounter the TOMBSTONE_ALL.
         EXPECT_EQ(follow_result->loaded_with_progress_.oldest_loaded_index_version_, VersionId{1});
+    }
+
+    for (auto load_strategy: {
+            LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(0)},
+            LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(0)},
+            LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}
+    }) {
+        follow_result->clear();
+        version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
+        // When loading with any of the specified load strategies with include_deleted=true we should continue to the beginning
+        // at version 0 even though it was deleted.
+        EXPECT_EQ(follow_result->loaded_with_progress_.oldest_loaded_index_version_, VersionId{0});
     }
 }
 
@@ -662,7 +763,7 @@ TEST(VersionMap, CacheInvalidation) {
         // Load to_load inside the clean version map cache
         clean_version_map->check_reload(store, id, to_load, __FUNCTION__);
         // Check whether to_check_if_cached is being cached by to_load
-        EXPECT_EQ(clean_version_map->has_cached_entry(id, to_check_if_cached), expected_outcome);
+        EXPECT_EQ(clean_version_map->has_cached_entry(id, to_check_if_cached.load_strategy_), expected_outcome);
     };
 
     auto check_all_caching = [&](const std::vector<LoadParameter>& to_load, const std::vector<LoadParameter>& to_check_if_cached, bool expected_result){
@@ -673,8 +774,8 @@ TEST(VersionMap, CacheInvalidation) {
         }
     };
 
-    auto load_all_param = LoadParameter{LoadType::LOAD_ALL};
-    auto load_all_undeleted_param = LoadParameter{LoadType::LOAD_UNDELETED};
+    auto load_all_param = LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY};
+    auto load_all_undeleted_param = LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED};
     check_caching(load_all_param, load_all_undeleted_param, true);
     check_caching(load_all_undeleted_param, load_all_param, false);
 
@@ -682,26 +783,27 @@ TEST(VersionMap, CacheInvalidation) {
     std::vector<LoadParameter> should_load_to_v[num_versions] = {
         // Different parameters which should all load to v0
         std::vector<LoadParameter>{
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(0)},
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(-3)},
-            LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(0)},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(0)},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(-3)},
+            LoadParameter{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(0)},
         },
 
         // Different parameters which should all load to v1
         std::vector<LoadParameter>{
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(1)},
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(-2)},
-            LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(1)},
-            LoadParameter{LoadType::LOAD_FROM_TIME,
-                          static_cast<timestamp>(2)}, // LOAD_FROM_TIME loads up to an undeleted version
-            LoadParameter{LoadType::LOAD_LATEST_UNDELETED},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(1)},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(-2)},
+            LoadParameter{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(1)},
+            LoadParameter{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED,
+                          static_cast<timestamp>(2)}, // when include_deleted=false LOAD_FROM_TIME searches for an undeleted version
+            LoadParameter{LoadType::LOAD_LATEST, ToLoad::UNDELETED},
         },
 
         // Different parameters which should all load to v2
         std::vector<LoadParameter>{
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(2)},
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(-1)},
-            LoadParameter{LoadType::LOAD_LATEST},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(2)},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(-1)},
+            LoadParameter{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(2)},
+            LoadParameter{LoadType::LOAD_LATEST, ToLoad::ANY},
         }
     };
 
@@ -735,24 +837,26 @@ TEST(VersionMap, CacheInvalidationWithTombstoneAfterLoad) {
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(1)},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(1)},
             __FUNCTION__);
 
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(1)}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(0)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(-1)}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(-2)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(1)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(0)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(-1)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(-2)}));
 
     // When - we delete version 1 and reload
     version_map->write_tombstone(store, VersionId{1}, id, entry);
 
     // Now when the cached version is deleted, we should invalidate the cache for load parameters which look for undeleted.
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(1)}));
-    //TODO: Add more undeleted checks
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::ANY}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::ANY, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(-1)}));
 
-    LoadParameter load_param{LoadType::LOAD_LATEST_UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::UNDELETED};
     const auto latest_undeleted_entry = version_map->check_reload(store, id, load_param, __FUNCTION__);
 
     // Then - version 0 should be returned
@@ -776,30 +880,30 @@ TEST(VersionMap, CacheInvalidationWithTombstoneAllAfterLoad) {
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(0)},
+            LoadParameter{LoadType::LOAD_DOWNTO, ToLoad::ANY, static_cast<SignedVersionId>(0)},
             __FUNCTION__);
 
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(0)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(-1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_DOWNTO, static_cast<SignedVersionId>(-2)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(0)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(-1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(-2)}));
 
     // When - we delete version 1
     auto tombstone_key = version_map->write_tombstone(store, VersionId{1}, id, entry);
 
     // We should not invalidate the cache because the version we loaded to is still undeleted
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(0)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(0)}));
 
     // When - we delete all versions without reloading
     version_map->write_tombstone_all_key_internal(store, tombstone_key, entry);
 
     // We should invalidate cached undeleted checks
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_LATEST_UNDELETED}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(1)}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadParameter{LoadType::LOAD_FROM_TIME, static_cast<timestamp>(0)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(1)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, static_cast<timestamp>(0)}));
 }
 
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -204,7 +204,7 @@ TEST(VersionMap, TestLoadsRefAndIteration) {
     version_map->load_via_iteration(store, id, entry_iteration);
 
     auto entry_ref = std::make_shared<VersionMapEntry>();
-    version_map->load_via_ref_key(store, id, LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, entry_ref);
+    version_map->load_via_ref_key(store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, entry_ref);
 
     ASSERT_EQ(entry_iteration->head_, entry_ref->head_);
     ASSERT_EQ(entry_iteration->keys_.size(), entry_ref->keys_.size());
@@ -418,7 +418,7 @@ TEST(VersionMap, FixRefKeyTombstones) {
     auto key5 = atom_key_with_version(id, 1, 1696590624590123209);
     version_map->write_version(store, key5, key4);
     auto key6 = atom_key_with_version(id, 0, 1696590624612743245);
-    auto entry = version_map->check_reload(store, id, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY}, __FUNCTION__);
+    auto entry = version_map->check_reload(store, id, LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);
     version_map->journal_single_key(store, key5, entry->head_.value());
 
     auto valid = version_map->check_ref_key(store, id);
@@ -544,7 +544,7 @@ std::shared_ptr<VersionMapEntry> write_two_versions(std::shared_ptr<InMemoryStor
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadStrategy{LoadType::NOT_LOADED, LoadObjective::ANY},
+            LoadStrategy{LoadType::NOT_LOADED, LoadObjective::INCLUDE_DELETED},
             __FUNCTION__);
 
     auto key1 = atom_key_with_version(id, 0, 0);
@@ -563,7 +563,7 @@ void write_alternating_deleted_undeleted(std::shared_ptr<InMemoryStore> store, s
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadStrategy{LoadType::NOT_LOADED, LoadObjective::ANY},
+            LoadStrategy{LoadType::NOT_LOADED, LoadObjective::INCLUDE_DELETED},
             __FUNCTION__);
 
     auto key1 = atom_key_with_version(id, 0, 0);
@@ -602,26 +602,26 @@ TEST(VersionMap, FollowingVersionChain){
         auto follow_result = std::make_shared<VersionMapEntry>();
 
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
-        EXPECT_EQ(follow_result->loaded_with_progress_.oldest_loaded_index_version_, VersionId{should_load_to});
+        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{should_load_to});
     };
 
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(0)}, 0);
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(-2)}, 1);
+    check_strategy_loads_to(LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(0)}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-2)}, 1);
     // DOWN_TO will not skip through tombstoned versions even when include_deleted=false
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(-1)}, 2);
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(0)}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(-1)}, 2);
+    check_strategy_loads_to(LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(0)}, 0);
 
     // FROM_TIME when include_deleted=false will skip through deleted versions to go to the latest undeleted version before the timestamp.
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(10)}, 1);
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(0)}, 0);
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(2)}, 2);
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(0)}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(10)}, 1);
+    check_strategy_loads_to(LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(0)}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(2)}, 2);
+    check_strategy_loads_to(LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(0)}, 0);
 
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY}, 2);
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}, 1);
+    check_strategy_loads_to(LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, 2);
+    check_strategy_loads_to(LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}, 1);
 
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, 0);
-    check_strategy_loads_to(LoadStrategy{LoadType::LOAD_ALL, LoadObjective::UNDELETED}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, 0);
+    check_strategy_loads_to(LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY}, 0);
 }
 
 TEST(VersionMap, FollowingVersionChainWithCaching){
@@ -640,41 +640,41 @@ TEST(VersionMap, FollowingVersionChainWithCaching){
         EXPECT_EQ(loaded->get_indexes(false).size(), should_load_undeleted);
     };
 
-    check_loads_versions(LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(-1)}, 1, 0);
-    // LOAD_FROM_TIME should not be cached by the LOAD_DOWNTO and should reload from storage up to the latest undeleted version, hence loading 2 versions, 1 of which is undeleted.
-    check_loads_versions(LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(10)}, 2, 1);
-    // LOAD_LATEST should be cached by the LOAD_FROM_TIME, so we still have the same 2 loaded versions
-    check_loads_versions(LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY}, 2, 1);
-    // This LOAD_FROM_TIME should still use the cached 2 versions
-    check_loads_versions(LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(1)}, 2, 1);
+    check_loads_versions(LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-1)}, 1, 0);
+    // FROM_TIME should not be cached by the DOWNTO and should reload from storage up to the latest undeleted version, hence loading 2 versions, 1 of which is undeleted.
+    check_loads_versions(LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(10)}, 2, 1);
+    // LATEST should be cached by the FROM_TIME, so we still have the same 2 loaded versions
+    check_loads_versions(LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, 2, 1);
+    // This FROM_TIME should still use the cached 2 versions
+    check_loads_versions(LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(1)}, 2, 1);
 
     // We just get the entry to use for the tombstone and the write
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadStrategy{LoadType::NOT_LOADED, LoadObjective::ANY},
+            LoadStrategy{LoadType::NOT_LOADED, LoadObjective::INCLUDE_DELETED},
             __FUNCTION__);
     // We delete the only undeleted key
     version_map->write_tombstone(store, VersionId{1}, id, entry, timestamp{4});
 
-    // LOAD_LATEST should still be cached, but the cached entry now needs to have no undeleted keys
-    check_loads_versions(LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY}, 2, 0);
-    // LOAD_FROM_TIME UNDELETED should no longer be cached even though we used the same request before because the undeleted key it went to got deleted. So it will load the entire version chain
-    check_loads_versions(LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(10)}, 3, 0);
+    // LATEST should still be cached, but the cached entry now needs to have no undeleted keys
+    check_loads_versions(LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, 2, 0);
+    // FROM_TIME UNDELETED_ONLY should no longer be cached even though we used the same request before because the undeleted key it went to got deleted. So it will load the entire version chain
+    check_loads_versions(LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(10)}, 3, 0);
 
     // We add a new undeleted key
     auto key4 = atom_key_with_version(id, 3, 5);
     version_map->do_write(store, key4, entry);
     write_symbol_ref(store, key4, std::nullopt, entry->head_.value());
 
-    // LOAD_LATEST should still be cached, but the cached entry now needs to have one more undeleted version
-    check_loads_versions(LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY}, 4, 1);
+    // LATEST should still be cached, but the cached entry now needs to have one more undeleted version
+    check_loads_versions(LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, 4, 1);
 
     // We delete everything with a tombstone_all
     version_map->delete_all_versions(store, id);
 
-    // LOAD_LATEST should still be cached, but now have no undeleted versions
-    check_loads_versions(LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY}, 4, 0);
+    // LATEST should still be cached, but now have no undeleted versions
+    check_loads_versions(LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, 4, 0);
 }
 
 TEST(VersionMap, FollowingVersionChainEndEarlyOnTombstoneAll) {
@@ -691,28 +691,28 @@ TEST(VersionMap, FollowingVersionChainEndEarlyOnTombstoneAll) {
     auto follow_result = std::make_shared<VersionMapEntry>();
 
     for (auto load_strategy: {
-        LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(0)},
-        LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(0)},
-        LoadStrategy{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
-        LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}
+        LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(0)},
+        LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(0)},
+        LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY},
+        LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}
     }) {
         follow_result->clear();
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
         // When loading with any of the specified load strategies with include_deleted=false we should end following the version chain early
         // at version 1 because that's when we encounter the TOMBSTONE_ALL.
-        EXPECT_EQ(follow_result->loaded_with_progress_.oldest_loaded_index_version_, VersionId{1});
+        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{1});
     }
 
     for (auto load_strategy: {
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(0)},
-            LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(0)},
-            LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(0)},
+            LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(0)},
+            LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}
     }) {
         follow_result->clear();
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
         // When loading with any of the specified load strategies with include_deleted=true we should continue to the beginning
         // at version 0 even though it was deleted.
-        EXPECT_EQ(follow_result->loaded_with_progress_.oldest_loaded_index_version_, VersionId{0});
+        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{0});
     }
 }
 
@@ -740,8 +740,8 @@ TEST(VersionMap, CacheInvalidation) {
         }
     };
 
-    auto load_all_param = LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY};
-    auto load_all_undeleted_param = LoadStrategy{LoadType::LOAD_ALL, LoadObjective::UNDELETED};
+    auto load_all_param = LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED};
+    auto load_all_undeleted_param = LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY};
     check_caching(load_all_param, load_all_undeleted_param, true);
     check_caching(load_all_undeleted_param, load_all_param, false);
 
@@ -749,27 +749,27 @@ TEST(VersionMap, CacheInvalidation) {
     std::vector<LoadStrategy> should_load_to_v[num_versions] = {
         // Different parameters which should all load to v0
         std::vector<LoadStrategy>{
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(0)},
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(-3)},
-            LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(0)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(0)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-3)},
+            LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(0)},
         },
 
         // Different parameters which should all load to v1
         std::vector<LoadStrategy>{
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(1)},
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(-2)},
-            LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(1)},
-            LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED,
-                          static_cast<timestamp>(2)}, // when include_deleted=false LOAD_FROM_TIME searches for an undeleted version
-            LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(1)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-2)},
+            LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(1)},
+            LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY,
+                         static_cast<timestamp>(2)}, // when include_deleted=false FROM_TIME searches for an undeleted version
+            LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY},
         },
 
         // Different parameters which should all load to v2
         std::vector<LoadStrategy>{
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(2)},
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(-1)},
-            LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(2)},
-            LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(2)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-1)},
+            LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(2)},
+            LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED},
         }
     };
 
@@ -779,7 +779,7 @@ TEST(VersionMap, CacheInvalidation) {
             check_all_caching(should_load_to_v[i], should_load_to_v[j], i<=j);
         }
 
-        // LOAD_ALL and LOAD_UNDELETED because they both load to v0 (UNDELETED will load v0 because only there it will load
+        // ALL and LOAD_UNDELETED because they both load to v0 (UNDELETED_ONLY will load v0 because only there it will load
         check_all_caching({load_all_param, load_all_undeleted_param}, should_load_to_v[i], true);
         check_all_caching(should_load_to_v[i], {load_all_param, load_all_undeleted_param}, false);
     }
@@ -803,26 +803,26 @@ TEST(VersionMap, CacheInvalidationWithTombstoneAfterLoad) {
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(1)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(1)},
             __FUNCTION__);
 
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(1)}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(0)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(-1)}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(-2)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(1)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(0)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(-1)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(-2)}));
 
     // When - we delete version 1 and reload
     version_map->write_tombstone(store, VersionId{1}, id, entry);
 
     // Now when the cached version is deleted, we should invalidate the cache for load parameters which look for undeleted.
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::ANY}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::ANY, static_cast<timestamp>(1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(-1)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(-1)}));
 
-    LoadStrategy load_strategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED};
+    LoadStrategy load_strategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY};
     const auto latest_undeleted_entry = version_map->check_reload(store, id, load_strategy, __FUNCTION__);
 
     // Then - version 0 should be returned
@@ -846,30 +846,30 @@ TEST(VersionMap, CacheInvalidationWithTombstoneAllAfterLoad) {
     auto entry = version_map->check_reload(
             store,
             id,
-            LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::ANY, static_cast<SignedVersionId>(0)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(0)},
             __FUNCTION__);
 
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(0)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(-1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(-2)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(0)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(-1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(-2)}));
 
     // When - we delete version 1
     auto tombstone_key = version_map->write_tombstone(store, VersionId{1}, id, entry);
 
     // We should not invalidate the cache because the version we loaded to is still undeleted
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(1)}));
-    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(0)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(1)}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(0)}));
 
     // When - we delete all versions without reloading
     version_map->write_tombstone_all_key_internal(store, tombstone_key, entry);
 
     // We should invalidate cached undeleted checks
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(1)}));
-    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, static_cast<timestamp>(0)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(1)}));
+    ASSERT_FALSE(version_map->has_cached_entry(id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(0)}));
 }
 
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -57,7 +57,7 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
         }
     }
 
@@ -99,7 +99,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
         }
     }
 
@@ -111,7 +111,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     for(uint64_t i = 0; i < num_streams; i++){
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
-            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false});
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}});
         }
     }
 
@@ -149,7 +149,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.emplace_back("stream_0");
-        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}});
     }
 
     // Do query
@@ -182,7 +182,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.emplace_back("stream_0");
-        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}, false});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}});
     }
 
     // Do query
@@ -191,7 +191,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
     for(uint64_t i = 0; i < num_versions; i++){
-        version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts())}, false});
+        version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts())}});
     }
 
     // Now we can perform the actual batch query per timestamps
@@ -229,7 +229,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
         }
     }
 
@@ -244,11 +244,11 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}, false});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}, false});
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}});
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{std::monostate{}, false});
+            version_queries.emplace_back(VersionQuery{std::monostate{}});
         }
     }
 

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -136,7 +136,7 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     auto ref_entry = std::make_shared<VersionMapEntry>();
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry);
-    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, ref_entry);
+    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, ref_entry);
 
     EXPECT_EQ(std::string(iter_entry->head_.value().view()), std::string(ref_entry->head_.value().view()));
     ASSERT_EQ(iter_entry->keys_.size(), ref_entry->keys_.size());
@@ -151,7 +151,7 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     auto ref_entry_compact = std::make_shared<VersionMapEntry>();
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry_compact);
-    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, arcticdb::ToLoad::ANY}, ref_entry_compact);
+    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, arcticdb::LoadObjective::ANY}, ref_entry_compact);
 
     EXPECT_EQ(std::string(iter_entry_compact->head_.value().view()), std::string(ref_entry_compact->head_.value().view()));
     ASSERT_EQ(iter_entry_compact->keys_.size(), ref_entry_compact->keys_.size());

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -390,21 +390,21 @@ TEST(VersionStore, TestReadTimestampAt) {
 
   auto version_map = version_store._test_get_version_map();
   version_map->write_version(mock_store, key1, std::nullopt);
-  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{});
+  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(0));
   ASSERT_EQ(key.value().content_hash(), 3);
 
   version_map->write_version(mock_store, key2, key1);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0));
   ASSERT_EQ(key.value().content_hash(), 3);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1));
   ASSERT_EQ(key.value().content_hash(), 4);
 
   version_map->write_version(mock_store, key3, key2);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0), pipelines::VersionQuery{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(0));
   ASSERT_EQ(key.value().content_hash(), 3);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(1));
   ASSERT_EQ(key.value().content_hash(), 4);
-  key = load_index_key_from_time(mock_store, version_map, id, timestamp(2), pipelines::VersionQuery{});
+  key = load_index_key_from_time(mock_store, version_map, id, timestamp(2));
   ASSERT_EQ(key.value().content_hash(), 5);
 }
 
@@ -422,7 +422,7 @@ TEST(VersionStore, TestReadTimestampAtInequality) {
 
   auto version_map = version_store._test_get_version_map();
   version_map->write_version(mock_store, key1, std::nullopt);
-  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(1), pipelines::VersionQuery{});
+  auto key = load_index_key_from_time(mock_store, version_map, id, timestamp(1));
   ASSERT_EQ(static_cast<bool>(key), true);
   ASSERT_EQ(key.value().content_hash(), 3);
 }

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -136,7 +136,7 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     auto ref_entry = std::make_shared<VersionMapEntry>();
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry);
-    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, ref_entry);
+    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, ref_entry);
 
     EXPECT_EQ(std::string(iter_entry->head_.value().view()), std::string(ref_entry->head_.value().view()));
     ASSERT_EQ(iter_entry->keys_.size(), ref_entry->keys_.size());
@@ -151,7 +151,7 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     auto ref_entry_compact = std::make_shared<VersionMapEntry>();
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry_compact);
-    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, arcticdb::LoadObjective::ANY}, ref_entry_compact);
+    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::ALL, arcticdb::LoadObjective::INCLUDE_DELETED}, ref_entry_compact);
 
     EXPECT_EQ(std::string(iter_entry_compact->head_.value().view()), std::string(ref_entry_compact->head_.value().view()));
     ASSERT_EQ(iter_entry_compact->keys_.size(), ref_entry_compact->keys_.size());

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -136,7 +136,7 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     auto ref_entry = std::make_shared<VersionMapEntry>();
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry);
-    version_map->load_via_ref_key(mock_store, stream_id, LoadParameter{LoadType::LOAD_ALL}, ref_entry);
+    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, ref_entry);
 
     EXPECT_EQ(std::string(iter_entry->head_.value().view()), std::string(ref_entry->head_.value().view()));
     ASSERT_EQ(iter_entry->keys_.size(), ref_entry->keys_.size());
@@ -151,7 +151,7 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     auto ref_entry_compact = std::make_shared<VersionMapEntry>();
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry_compact);
-    version_map->load_via_ref_key(mock_store, stream_id, LoadParameter{LoadType::LOAD_ALL}, ref_entry_compact);
+    version_map->load_via_ref_key(mock_store, stream_id, LoadStrategy{LoadType::LOAD_ALL, arcticdb::ToLoad::ANY}, ref_entry_compact);
 
     EXPECT_EQ(std::string(iter_entry_compact->head_.value().view()), std::string(ref_entry_compact->head_.value().view()));
     ASSERT_EQ(iter_entry_compact->keys_.size(), ref_entry_compact->keys_.size());

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -33,7 +33,7 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
     const StreamId& stream_id
     ) {
     std::deque<AtomKey> output;
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
+    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
     output.assign(std::begin(indexes), std::end(indexes));
 
@@ -49,7 +49,7 @@ std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<S
     log::version().debug("Version map pruning previous versions for stream {}", key.id());
 
     std::vector<AtomKey> output;
-    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL},  __FUNCTION__);
+    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY},  __FUNCTION__);
 
     auto old_entry = *entry;
     entry->clear();

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -33,7 +33,7 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
     const StreamId& stream_id
     ) {
     std::deque<AtomKey> output;
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
+    auto entry = version_map->check_reload(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
     output.assign(std::begin(indexes), std::end(indexes));
 
@@ -49,7 +49,7 @@ std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<S
     log::version().debug("Version map pruning previous versions for stream {}", key.id());
 
     std::vector<AtomKey> output;
-    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
+    auto entry = version_map->check_reload(store, key.id(), LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
 
     auto old_entry = *entry;
     entry->clear();

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -33,7 +33,7 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
     const StreamId& stream_id
     ) {
     std::deque<AtomKey> output;
-    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
+    auto entry = version_map->check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
     output.assign(std::begin(indexes), std::end(indexes));
 
@@ -49,7 +49,7 @@ std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<S
     log::version().debug("Version map pruning previous versions for stream {}", key.id());
 
     std::vector<AtomKey> output;
-    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY},  __FUNCTION__);
+    auto entry = version_map->check_reload(store, key.id(), LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
 
     auto old_entry = *entry;
     entry->clear();

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -33,7 +33,7 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
     const StreamId& stream_id
     ) {
     std::deque<AtomKey> output;
-    auto entry = version_map->check_reload(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
+    auto entry = version_map->check_reload(store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
     output.assign(std::begin(indexes), std::end(indexes));
 
@@ -49,7 +49,7 @@ std::vector<AtomKey> backwards_compat_write_and_prune_previous(std::shared_ptr<S
     log::version().debug("Version map pruning previous versions for stream {}", key.id());
 
     std::vector<AtomKey> output;
-    auto entry = version_map->check_reload(store, key.id(), LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
+    auto entry = version_map->check_reload(store, key.id(), LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);
 
     auto old_entry = *entry;
     entry->clear();

--- a/cpp/arcticdb/version/test/version_map_model.hpp
+++ b/cpp/arcticdb/version/test/version_map_model.hpp
@@ -36,7 +36,7 @@ struct MapStorePair {
 
     void write_version(const std::string &id) {
         ARCTICDB_DEBUG(log::version(), "MapStorePair, write version {}", id);
-        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{}).first;
+        auto prev = get_latest_version(store_, map_, id).first;
         auto version_id = prev ? prev->version_id() + 1 : 0;
         map_->write_version(store_, make_test_index_key(id, version_id, KeyType::TABLE_INDEX), prev);
     }
@@ -51,7 +51,7 @@ struct MapStorePair {
 
     void write_and_prune_previous(const std::string &id) {
         ARCTICDB_DEBUG(log::version(), "MapStorePair, write_and_prune_previous version {}", id);
-        auto prev = get_latest_version(store_, map_, id, pipelines::VersionQuery{}).first;
+        auto prev = get_latest_version(store_, map_, id).first;
         auto version_id = prev ? prev->version_id() + 1 : 0;
 
         if(tombstones_)

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -188,7 +188,6 @@ inline version_store::TombstoneVersionResult tombstone_version(
             is_live_index_type_key // Entry could be cached with deleted keys even if LOAD_UNDELETED
             );
 
-    AtomKey tombstone;
     if (res.keys_to_delete.empty()) {
         // It is possible to have a tombstone key without a corresponding index_key
         // This scenario can happen in case of DR sync
@@ -202,13 +201,12 @@ inline version_store::TombstoneVersionResult tombstone_version(
                             stream_id, version_id);
             }
             // We will write a tombstone key even when the index_key is not found
-            tombstone = version_map->write_tombstone(store, version_id, stream_id, entry, creation_ts);
+            version_map->write_tombstone(store, version_id, stream_id, entry, creation_ts);
         }
     } else {
-        tombstone = version_map->write_tombstone(store, res.keys_to_delete[0], stream_id, entry, creation_ts);
+        version_map->write_tombstone(store, res.keys_to_delete[0], stream_id, entry, creation_ts);
     }
 
-    entry->tombstones_.try_emplace(version_id, std::move(tombstone));
     if (version_map->validate())
         entry->validate();
 

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -24,7 +24,7 @@ inline std::optional<AtomKey> get_latest_undeleted_version(
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
     ARCTICDB_RUNTIME_SAMPLE(GetLatestUndeletedVersion, 0)
-    LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_LATEST, LoadObjective::UNDELETED};
     set_load_param_options(load_param, version_query);
     const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(false).first;
@@ -36,7 +36,7 @@ inline std::pair<std::optional<AtomKey>, bool> get_latest_version(
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
     ARCTICDB_SAMPLE(GetLatestVersion, 0)
-    LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::ANY};
+    LoadParameter load_param{LoadType::LOAD_LATEST, LoadObjective::ANY};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(true);
@@ -49,7 +49,7 @@ inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_i
         const StreamId &stream_id,
         const pipelines::VersionQuery& version_query) {
     ARCTICDB_SAMPLE(GetLatestUndeletedVersionAndHighestVersionId, 0)
-    LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_LATEST, LoadObjective::UNDELETED};
         set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     auto latest_version = entry->get_first_index(true).first;
@@ -65,7 +65,7 @@ inline std::vector<AtomKey> get_all_versions(
     const pipelines::VersionQuery& version_query
     ) {
     ARCTICDB_SAMPLE(GetAllVersions, 0)
-    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_ALL, LoadObjective::UNDELETED};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_indexes(false);
@@ -78,7 +78,7 @@ inline std::optional<AtomKey> get_specific_version(
         SignedVersionId signed_version_id,
         const pipelines::VersionQuery& version_query,
         bool include_deleted = false) {
-    LoadParameter load_param{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, signed_version_id};
+    LoadParameter load_param{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, signed_version_id};
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     set_load_param_options(load_param, version_query);
     VersionId version_id;
@@ -155,7 +155,7 @@ inline std::unordered_map<VersionId, bool> get_all_tombstoned_versions(
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
-    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::ANY};
+    LoadParameter load_param{LoadType::LOAD_ALL, LoadObjective::ANY};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::unordered_map<VersionId, bool> result;
@@ -174,7 +174,7 @@ inline version_store::TombstoneVersionResult tombstone_version(
     bool allow_tombstoning_beyond_latest_version=false,
     const std::optional<timestamp>& creation_ts=std::nullopt) {
     ARCTICDB_DEBUG(log::version(), "Tombstoning version {} for stream {}", version_id, stream_id);
-    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_ALL, LoadObjective::UNDELETED};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     // Might as well do the previous/next version check while we find the required version_id.
@@ -238,7 +238,7 @@ inline std::optional<AtomKey> load_index_key_from_time(
     const StreamId &stream_id,
     timestamp from_time,
     const pipelines::VersionQuery& version_query) {
-    LoadParameter load_param{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, from_time};
+    LoadParameter load_param{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, from_time};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
@@ -250,7 +250,7 @@ inline std::vector<AtomKey> get_index_and_tombstone_keys(
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
-    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::ANY};
+    LoadParameter load_param{LoadType::LOAD_ALL, LoadObjective::ANY};
     set_load_param_options(load_param, version_query);
     const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::vector<AtomKey> res;

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -24,7 +24,7 @@ inline std::optional<AtomKey> get_latest_undeleted_version(
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
     ARCTICDB_RUNTIME_SAMPLE(GetLatestUndeletedVersion, 0)
-    LoadParameter load_param{LoadType::LOAD_LATEST_UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::UNDELETED};
     set_load_param_options(load_param, version_query);
     const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(false).first;
@@ -36,7 +36,7 @@ inline std::pair<std::optional<AtomKey>, bool> get_latest_version(
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
     ARCTICDB_SAMPLE(GetLatestVersion, 0)
-    LoadParameter load_param{LoadType::LOAD_LATEST};
+    LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::ANY};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_first_index(true);
@@ -49,7 +49,7 @@ inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_i
         const StreamId &stream_id,
         const pipelines::VersionQuery& version_query) {
     ARCTICDB_SAMPLE(GetLatestUndeletedVersionAndHighestVersionId, 0)
-    LoadParameter load_param{LoadType::LOAD_LATEST_UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::UNDELETED};
         set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     auto latest_version = entry->get_first_index(true).first;
@@ -65,7 +65,7 @@ inline std::vector<AtomKey> get_all_versions(
     const pipelines::VersionQuery& version_query
     ) {
     ARCTICDB_SAMPLE(GetAllVersions, 0)
-    LoadParameter load_param{LoadType::LOAD_UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::UNDELETED};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     return entry->get_indexes(false);
@@ -78,7 +78,7 @@ inline std::optional<AtomKey> get_specific_version(
         SignedVersionId signed_version_id,
         const pipelines::VersionQuery& version_query,
         bool include_deleted = false) {
-    LoadParameter load_param{LoadType::LOAD_DOWNTO, signed_version_id};
+    LoadParameter load_param{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, signed_version_id};
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     set_load_param_options(load_param, version_query);
     VersionId version_id;
@@ -155,7 +155,7 @@ inline std::unordered_map<VersionId, bool> get_all_tombstoned_versions(
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
-    LoadParameter load_param{LoadType::LOAD_ALL};
+    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::ANY};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::unordered_map<VersionId, bool> result;
@@ -174,7 +174,7 @@ inline version_store::TombstoneVersionResult tombstone_version(
     bool allow_tombstoning_beyond_latest_version=false,
     const std::optional<timestamp>& creation_ts=std::nullopt) {
     ARCTICDB_DEBUG(log::version(), "Tombstoning version {} for stream {}", version_id, stream_id);
-    LoadParameter load_param{LoadType::LOAD_UNDELETED};
+    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::UNDELETED};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     // Might as well do the previous/next version check while we find the required version_id.
@@ -238,7 +238,7 @@ inline std::optional<AtomKey> load_index_key_from_time(
     const StreamId &stream_id,
     timestamp from_time,
     const pipelines::VersionQuery& version_query) {
-    LoadParameter load_param{LoadType::LOAD_FROM_TIME, from_time};
+    LoadParameter load_param{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, from_time};
     set_load_param_options(load_param, version_query);
     auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
@@ -250,7 +250,7 @@ inline std::vector<AtomKey> get_index_and_tombstone_keys(
     const std::shared_ptr<VersionMap> &version_map,
     const StreamId &stream_id,
     const pipelines::VersionQuery& version_query) {
-    LoadParameter load_param{LoadType::LOAD_ALL};
+    LoadParameter load_param{LoadType::LOAD_ALL, ToLoad::ANY};
     set_load_param_options(load_param, version_query);
     const auto entry = version_map->check_reload(store, stream_id, load_param, __FUNCTION__);
     std::vector<AtomKey> res;

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -235,7 +235,7 @@ public:
     }
 
     void write_version(std::shared_ptr<Store> store, const AtomKey &key, const std::optional<AtomKey>& previous_key) {
-        LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::ANY};
+        LoadParameter load_param{LoadType::LOAD_LATEST, LoadObjective::ANY};
         auto entry = check_reload(store, key.id(), load_param,  __FUNCTION__);
 
         do_write(store, key, entry);
@@ -259,7 +259,7 @@ public:
         auto entry = check_reload(
             store,
             stream_id,
-            LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
+            LoadParameter{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
             __FUNCTION__);
         auto output = tombstone_from_key_or_all_internal(store, stream_id, first_key_to_tombstone, entry);
 
@@ -273,7 +273,7 @@ public:
     }
 
     std::string dump_entry(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
-        const auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
+        const auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
         return entry->dump();
     }
 
@@ -285,7 +285,7 @@ public:
         auto entry = check_reload(
                 store,
                 key.id(),
-                LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
+                LoadParameter{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
                 __FUNCTION__);
         auto [_, result] = tombstone_from_key_or_all_internal(store, key.id(), previous_key, entry);
 
@@ -324,7 +324,7 @@ public:
         // This method has no API, and is not tested in the rapidcheck tests, but could easily be enabled there.
         // It compacts the version map but skips any keys which have been deleted (to free up space).
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
-        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
+        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
         if (!requires_compaction(entry))
             return;
 
@@ -439,7 +439,7 @@ public:
 
     void compact(std::shared_ptr<Store> store, const StreamId& stream_id) {
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
-        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
+        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
         if (entry->empty()) {
             log::version().warn("Entry is empty in compact");
             return;
@@ -461,7 +461,7 @@ public:
 
     void overwrite_symbol_tree(
             std::shared_ptr<Store> store, const StreamId& stream_id, const std::vector<AtomKey>& index_keys) {
-        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
+        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, LoadObjective::ANY}, __FUNCTION__);
         auto old_entry = *entry;
         if (!index_keys.empty()) {
             entry->keys_.assign(std::begin(index_keys), std::end(index_keys));
@@ -775,7 +775,7 @@ private:
         }
         if (iterate_on_failure && entry->empty()) {
             (void) load_via_iteration(store, stream_id, entry);
-            entry->load_strategy_ = LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY};
+            entry->load_strategy_ = LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY};
         }
 
         util::check(entry->keys_.empty() || entry->head_, "Non-empty VersionMapEntry should set head");
@@ -841,7 +841,7 @@ public:
 
         try {
             auto entry_ref = std::make_shared<VersionMapEntry>();
-            load_via_ref_key(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, entry_ref);
+            load_via_ref_key(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, entry_ref);
             entry_ref->validate();
         } catch (const std::exception& err) {
             log::version().warn(
@@ -854,7 +854,7 @@ public:
 
     bool indexes_sorted(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
         auto entry_ref = std::make_shared<VersionMapEntry>();
-        load_via_ref_key(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, entry_ref);
+        load_via_ref_key(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, LoadObjective::ANY}, entry_ref);
         auto indexes = entry_ref->get_indexes(true);
         return std::is_sorted(std::cbegin(indexes), std::cend(indexes), [] (const auto& l, const auto& r) {
             return l > r;
@@ -945,7 +945,7 @@ private:
             entry = check_reload(
                     store,
                     stream_id,
-                    LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
+                    LoadParameter{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
                     __FUNCTION__);
         }
 

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -108,7 +108,7 @@ class VersionMapImpl {
      */
     using MapType =  std::map<StreamId, std::shared_ptr<VersionMapEntry>>;
 
-    static constexpr uint64_t DEFAULT_CLOCK_UNSYNC_TOLERANCE = ONE_SECOND * 2;
+    static constexpr uint64_t DEFAULT_CLOCK_UNSYNC_TOLERANCE = ONE_MILLISECOND * 200;
     static constexpr uint64_t DEFAULT_RELOAD_INTERVAL = ONE_SECOND * 2;
     MapType map_;
     bool validate_ = false;

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -146,7 +146,7 @@ public:
         const std::shared_ptr<Store>& store,
         const VersionMapEntry& ref_entry,
         const std::shared_ptr<VersionMapEntry>& entry,
-        const LoadParameter& load_params) const {
+        const LoadStrategy& load_strategy) const {
         auto next_key = ref_entry.head_;
         entry->head_ = ref_entry.head_;
 
@@ -159,7 +159,7 @@ public:
             cached_penultimate_index = ref_entry.keys_[1];
         }
 
-        if (key_exists_in_ref_entry(load_params, ref_entry, cached_penultimate_index)) {
+        if (key_exists_in_ref_entry(load_strategy, ref_entry, cached_penultimate_index)) {
             load_progress = ref_entry.loaded_with_progress_;
             entry->keys_.push_back(ref_entry.keys_[0]);
             if(cached_penultimate_index)
@@ -171,10 +171,10 @@ public:
                 next_key = read_segment_with_keys(seg, entry, load_progress);
                 set_latest_version(entry, latest_version);
             } while (next_key
-            && !loaded_until_version_id(load_params, load_progress, latest_version)
-            && !loaded_until_timestamp(load_params, load_progress)
-            && load_latest_ongoing(load_params, entry)
-            && looking_for_undeleted(load_params, entry, load_progress));
+            && !loaded_until_version_id(load_strategy, load_progress, latest_version)
+            && !loaded_until_timestamp(load_strategy, load_progress)
+            && load_latest_ongoing(load_strategy, entry)
+            && looking_for_undeleted(load_strategy, entry, load_progress));
         }
         entry->loaded_with_progress_ = load_progress;
     }
@@ -182,9 +182,9 @@ public:
     void load_via_ref_key(
         std::shared_ptr<Store> store,
         const StreamId& stream_id,
-        const LoadParameter& load_params,
+        const LoadStrategy& load_strategy,
         const std::shared_ptr<VersionMapEntry>& entry) {
-        load_params.validate();
+        load_strategy.validate();
         static const auto max_trial_config = ConfigsMap::instance()->get_int("VersionMap.MaxReadRefTrials", 2);
         auto max_trials = max_trial_config;
         while (true) {
@@ -194,7 +194,7 @@ public:
                 if (ref_entry.empty())
                     return;
 
-                follow_version_chain(store, ref_entry, entry, load_params);
+                follow_version_chain(store, ref_entry, entry, load_strategy);
                 break;
             } catch (const std::exception &err) {
                 if (--max_trials <= 0) {
@@ -235,7 +235,7 @@ public:
     }
 
     void write_version(std::shared_ptr<Store> store, const AtomKey &key, const std::optional<AtomKey>& previous_key) {
-        LoadParameter load_param{LoadType::LOAD_LATEST};
+        LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::ANY};
         auto entry = check_reload(store, key.id(), load_param,  __FUNCTION__);
 
         do_write(store, key, entry);
@@ -259,7 +259,7 @@ public:
         auto entry = check_reload(
             store,
             stream_id,
-            LoadParameter{LoadType::LOAD_UNDELETED},
+            LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
             __FUNCTION__);
         auto output = tombstone_from_key_or_all_internal(store, stream_id, first_key_to_tombstone, entry);
 
@@ -273,7 +273,7 @@ public:
     }
 
     std::string dump_entry(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
-        const auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
+        const auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
         return entry->dump();
     }
 
@@ -285,7 +285,7 @@ public:
         auto entry = check_reload(
                 store,
                 key.id(),
-                LoadParameter{LoadType::LOAD_UNDELETED},
+                LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
                 __FUNCTION__);
         auto [_, result] = tombstone_from_key_or_all_internal(store, key.id(), previous_key, entry);
 
@@ -324,7 +324,7 @@ public:
         // This method has no API, and is not tested in the rapidcheck tests, but could easily be enabled there.
         // It compacts the version map but skips any keys which have been deleted (to free up space).
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
-        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
+        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
         if (!requires_compaction(entry))
             return;
 
@@ -439,7 +439,7 @@ public:
 
     void compact(std::shared_ptr<Store> store, const StreamId& stream_id) {
         ARCTICDB_DEBUG(log::version(), "Version map compacting versions for stream {}", stream_id);
-        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
+        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
         if (entry->empty()) {
             log::version().warn("Entry is empty in compact");
             return;
@@ -461,7 +461,7 @@ public:
 
     void overwrite_symbol_tree(
             std::shared_ptr<Store> store, const StreamId& stream_id, const std::vector<AtomKey>& index_keys) {
-        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, __FUNCTION__);
+        auto entry = check_reload(store, stream_id, LoadParameter{LoadType::LOAD_ALL, ToLoad::ANY}, __FUNCTION__);
         auto old_entry = *entry;
         if (!index_keys.empty()) {
             entry->keys_.assign(std::begin(index_keys), std::end(index_keys));
@@ -484,11 +484,11 @@ public:
         const char* function ARCTICDB_UNUSED) {
         ARCTICDB_DEBUG(log::version(), "Check reload in function {} for id {}", function, stream_id);
 
-        if (has_cached_entry(stream_id, load_param)) {
+        if (has_cached_entry(stream_id, load_param.load_strategy_)) {
             return get_entry(stream_id);
         }
 
-        return storage_reload(store, stream_id, load_param, load_param.iterate_on_failure_);
+        return storage_reload(store, stream_id, load_param.load_strategy_, load_param.iterate_on_failure_);
     }
 
     /**
@@ -548,13 +548,13 @@ public:
      *
      * @param stream_id symbol to check
      * @param load_param the load type
-     * @return whether we have a cached entry suitable for the load type, so do not need to go to storage
+     * @return whether we have a cached entry suitable for the load strategy, so do not need to go to storage
      */
-    bool has_cached_entry(const StreamId &stream_id, const LoadParameter& load_param) const {
-        LoadType requested_load_type = load_param.load_type_;
+    bool has_cached_entry(const StreamId &stream_id, const LoadStrategy& requested_load_strategy) const {
+        LoadType requested_load_type = requested_load_strategy.load_type_;
         util::check(requested_load_type < LoadType::UNKNOWN, "Unexpected load type requested {}", requested_load_type);
 
-        load_param.validate();
+        requested_load_strategy.validate();
         MapType::const_iterator entry_it;
         if(!find_entry(entry_it, stream_id)) {
             return false;
@@ -572,35 +572,37 @@ public:
             return false;
         }
 
-        LoadType cached_load_type = entry->load_type_;
+        LoadType cached_load_type = entry->load_strategy_.load_type_;
 
         switch (requested_load_type) {
             case LoadType::NOT_LOADED:
                 return true;
             case LoadType::LOAD_LATEST: {
-                // If entry has at least one index we have the latest value cached
-                auto opt_latest = entry->get_first_index(true).first;
-                return opt_latest.has_value();
-            }
-            case LoadType::LOAD_LATEST_UNDELETED: {
-                // If entry has at least one undeleted index we have the latest_undeleted cached
-                // This check can be slow if we have thousands of deleted versions before the first undeleted. If that is
-                // ever a problem we can just store a boolean if we have an undeleted version.
-                auto opt_latest = entry->get_first_index(false).first;
+                // If entry has at least one (maybe undeleted) index we have the latest value cached
+
+                // This check can be slow if we have thousands of deleted versions before the first undeleted and we're
+                // looking for an undeleted version. If that is ever a problem we can just store a boolean whether
+                // we have an undeleted version.
+                auto opt_latest = entry->get_first_index(requested_load_strategy.should_include_deleted()).first;
                 return opt_latest.has_value();
             }
             case LoadType::LOAD_DOWNTO:
                 // We check whether the oldest loaded version is before or at the requested one
-                return loaded_as_far_as_version_id(*entry, load_param.load_until_version_.value());
-            case LoadType::LOAD_FROM_TIME:
-                // We check whether the earliest loaded timestamp is before or at the requested on
-                return entry->loaded_with_progress_.earliest_loaded_undeleted_timestamp_ <= load_param.load_from_time_.value();
-            case LoadType::LOAD_UNDELETED:
-                // We can have all undeleteded versions cached when cache was loaded by either loading all or all undeleted.
-                return cached_load_type==LoadType::LOAD_ALL || cached_load_type==LoadType::LOAD_UNDELETED;
+                return loaded_as_far_as_version_id(*entry, requested_load_strategy.load_until_version_.value());
+            case LoadType::LOAD_FROM_TIME: {
+                // We check whether the cached (deleted or undeleted) timestamp is before or at the requested one
+                auto cached_timestamp = requested_load_strategy.should_include_deleted() ?
+                                        entry->loaded_with_progress_.earliest_loaded_timestamp_ :
+                                        entry->loaded_with_progress_.earliest_loaded_undeleted_timestamp_;
+                return cached_timestamp <= requested_load_strategy.load_from_time_.value();
+            }
             case LoadType::LOAD_ALL:
-                // We can have all versions cached only when cache was loaded by loading all versions.
-                return cached_load_type==LoadType::LOAD_ALL;
+                // We can use cache when it was populated by a LOAD_ALL call, in which case it is only unsafe to use
+                // when the cache is of undeleted versions and the request is for all versions
+                if (cached_load_type==LoadType::LOAD_ALL){
+                    return entry->load_strategy_.should_include_deleted() || !requested_load_strategy.should_include_deleted();
+                }
+                return false;
             default:
                 util::raise_rte("Unexpected load type in cache {}", cached_load_type);
         }
@@ -740,7 +742,7 @@ private:
     std::shared_ptr<VersionMapEntry> storage_reload(
         std::shared_ptr<Store> store,
         const StreamId& stream_id,
-        const LoadParameter& load_param,
+        const LoadStrategy& load_strategy,
         bool iterate_on_failure) {
         /*
          * Goes to the storage for a given symbol, and recreates the VersionMapEntry from preferably the ref key
@@ -753,13 +755,13 @@ private:
         const auto clock_unsync_tolerance = ConfigsMap::instance()->get_int("VersionMap.UnsyncTolerance",
                                                                             DEFAULT_CLOCK_UNSYNC_TOLERANCE);
         entry->last_reload_time_ = Clock::nanos_since_epoch() - clock_unsync_tolerance;
-        entry->load_type_ = LoadType::NOT_LOADED; // FUTURE: to make more thread-safe with #368
+        entry->load_strategy_ = LoadStrategy{LoadType::NOT_LOADED}; // FUTURE: to make more thread-safe with #368
 
         try {
             auto temp = std::make_shared<VersionMapEntry>(*entry);
-            load_via_ref_key(store, stream_id, load_param, temp);
+            load_via_ref_key(store, stream_id, load_strategy, temp);
             std::swap(*entry, *temp);
-            entry->load_type_ = load_param.load_type_;
+            entry->load_strategy_ = load_strategy;
         }
         catch (const std::runtime_error &err) {
             (void)err;
@@ -773,7 +775,7 @@ private:
         }
         if (iterate_on_failure && entry->empty()) {
             (void) load_via_iteration(store, stream_id, entry);
-            entry->load_type_ = LoadType::LOAD_ALL;
+            entry->load_strategy_ = LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY};
         }
 
         util::check(entry->keys_.empty() || entry->head_, "Non-empty VersionMapEntry should set head");
@@ -839,7 +841,7 @@ public:
 
         try {
             auto entry_ref = std::make_shared<VersionMapEntry>();
-            load_via_ref_key(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, entry_ref);
+            load_via_ref_key(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, entry_ref);
             entry_ref->validate();
         } catch (const std::exception& err) {
             log::version().warn(
@@ -852,7 +854,7 @@ public:
 
     bool indexes_sorted(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
         auto entry_ref = std::make_shared<VersionMapEntry>();
-        load_via_ref_key(store, stream_id, LoadParameter{LoadType::LOAD_ALL}, entry_ref);
+        load_via_ref_key(store, stream_id, LoadStrategy{LoadType::LOAD_ALL, ToLoad::ANY}, entry_ref);
         auto indexes = entry_ref->get_indexes(true);
         return std::is_sorted(std::cbegin(indexes), std::cend(indexes), [] (const auto& l, const auto& r) {
             return l > r;
@@ -943,7 +945,7 @@ private:
             entry = check_reload(
                     store,
                     stream_id,
-                    LoadParameter{LoadType::LOAD_UNDELETED},
+                    LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
                     __FUNCTION__);
         }
 

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -171,10 +171,10 @@ public:
                 next_key = read_segment_with_keys(seg, entry, load_progress);
                 set_latest_version(entry, latest_version);
             } while (next_key
-            && !loaded_until_version_id(load_strategy, load_progress, latest_version)
-            && !loaded_until_timestamp(load_strategy, load_progress)
-            && load_latest_ongoing(load_strategy, entry)
-            && looking_for_undeleted(load_strategy, entry, load_progress));
+            && continue_when_loading_version(load_strategy, load_progress, latest_version)
+            && continue_when_loading_from_time(load_strategy, load_progress)
+            && continue_when_loading_latest(load_strategy, entry)
+            && continue_when_loading_undeleted(load_strategy, entry, load_progress));
         }
         entry->loaded_with_progress_ = load_progress;
     }

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -1023,6 +1023,7 @@ private:
             return index_to_tombstone(k, stream_id, creation_ts.value_or(store->current_timestamp()));
         });
         do_write(store, tombstone,  entry);
+        entry->tombstones_.try_emplace(tombstone.version_id(), tombstone);
         if(log_changes_)
             log_tombstone(store, tombstone.id(), tombstone.version_id());
 

--- a/cpp/arcticdb/version/version_map_batch_methods.cpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.cpp
@@ -20,59 +20,18 @@ void StreamVersionData::react(const pipelines::VersionQuery &version_query) {
 }
 
 void StreamVersionData::do_react(std::monostate) {
-    if (load_param_.load_type_ == LoadType::NOT_LOADED)
-        load_param_ = LoadParameter{LoadType::LOAD_LATEST_UNDELETED};
-
     ++count_;
+    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED});
 }
 
 void StreamVersionData::do_react(const pipelines::SpecificVersionQuery &specific_version) {
     ++count_;
-    switch (load_param_.load_type_) {
-    case LoadType::NOT_LOADED:
-        [[fallthrough]];
-    case LoadType::LOAD_LATEST_UNDELETED:
-        load_param_ = LoadParameter{LoadType::LOAD_DOWNTO, specific_version.version_id_};
-        break;
-    case LoadType::LOAD_DOWNTO:
-        util::check(load_param_.load_until_version_.has_value(),
-                    "Expect LOAD_DOWNTO to have version specified");
-        if ((specific_version.version_id_ >= 0 && is_positive_version_query(load_param_)) ||
-            (specific_version.version_id_ < 0 && load_param_.load_until_version_.value() < 0)) {
-            load_param_.load_until_version_ = std::min(load_param_.load_until_version_.value(), specific_version.version_id_);
-        } else {
-            load_param_ = LoadParameter{LoadType::LOAD_UNDELETED};
-        }
-        break;
-    case LoadType::LOAD_FROM_TIME:
-        [[fallthrough]];
-    case LoadType::LOAD_UNDELETED:
-        load_param_ = LoadParameter{LoadType::LOAD_UNDELETED};
-        break;
-    default:util::raise_rte("Unexpected load state {} applying specific version query", load_param_.load_type_);
-    }
+    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, specific_version.version_id_});
 }
 
 void StreamVersionData::do_react(const pipelines::TimestampVersionQuery &timestamp_query) {
     ++count_;
-    switch (load_param_.load_type_) {
-    case LoadType::NOT_LOADED:
-        [[fallthrough]];
-    case LoadType::LOAD_LATEST_UNDELETED:
-        load_param_ = LoadParameter{LoadType::LOAD_FROM_TIME, timestamp_query.timestamp_};
-        break;
-    case LoadType::LOAD_FROM_TIME:
-        util::check(load_param_.load_from_time_.has_value(),
-                    "Expect LOAD_TO_TIME to have timestamp specified");
-        load_param_.load_from_time_ = std::min(load_param_.load_from_time_.value(), timestamp_query.timestamp_);
-        break;
-    case LoadType::LOAD_DOWNTO:
-        [[fallthrough]];
-    case LoadType::LOAD_UNDELETED:
-        load_param_ = LoadParameter{LoadType::LOAD_UNDELETED};
-        break;
-    default:util::raise_rte("Unexpected load state {} applying specific version query", load_param_.load_type_);
-    }
+    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, timestamp_query.timestamp_});
 }
 
 void StreamVersionData::do_react(const pipelines::SnapshotVersionQuery &snapshot_query) {

--- a/cpp/arcticdb/version/version_map_batch_methods.cpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.cpp
@@ -21,17 +21,17 @@ void StreamVersionData::react(const pipelines::VersionQuery &version_query) {
 
 void StreamVersionData::do_react(std::monostate) {
     ++count_;
-    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_LATEST, ToLoad::UNDELETED});
+    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED});
 }
 
 void StreamVersionData::do_react(const pipelines::SpecificVersionQuery &specific_version) {
     ++count_;
-    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, specific_version.version_id_});
+    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, specific_version.version_id_});
 }
 
 void StreamVersionData::do_react(const pipelines::TimestampVersionQuery &timestamp_query) {
     ++count_;
-    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_FROM_TIME, ToLoad::UNDELETED, timestamp_query.timestamp_});
+    load_param_.load_strategy_ = union_of_undeleted_strategies(load_param_.load_strategy_, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, timestamp_query.timestamp_});
 }
 
 void StreamVersionData::do_react(const pipelines::SnapshotVersionQuery &snapshot_query) {

--- a/cpp/arcticdb/version/version_map_batch_methods.cpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.cpp
@@ -21,17 +21,17 @@ void StreamVersionData::react(const pipelines::VersionQuery &version_query) {
 
 void StreamVersionData::do_react(std::monostate) {
     ++count_;
-    load_strategy_ = union_of_undeleted_strategies(load_strategy_, LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED});
+    load_strategy_ = union_of_undeleted_strategies(load_strategy_, LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY});
 }
 
 void StreamVersionData::do_react(const pipelines::SpecificVersionQuery &specific_version) {
     ++count_;
-    load_strategy_ = union_of_undeleted_strategies(load_strategy_, LoadStrategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, specific_version.version_id_});
+    load_strategy_ = union_of_undeleted_strategies(load_strategy_, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, specific_version.version_id_});
 }
 
 void StreamVersionData::do_react(const pipelines::TimestampVersionQuery &timestamp_query) {
     ++count_;
-    load_strategy_ = union_of_undeleted_strategies(load_strategy_, LoadStrategy{LoadType::LOAD_FROM_TIME, LoadObjective::UNDELETED, timestamp_query.timestamp_});
+    load_strategy_ = union_of_undeleted_strategies(load_strategy_, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, timestamp_query.timestamp_});
 }
 
 void StreamVersionData::do_react(const pipelines::SnapshotVersionQuery &snapshot_query) {

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -69,13 +69,13 @@ inline std::shared_ptr<std::unordered_map<StreamId, SymbolStatus>> batch_check_l
     const std::shared_ptr<VersionMap> &version_map,
     const std::shared_ptr<std::vector<StreamId>> &symbols) {
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
-    const LoadParameter load_param{LoadType::LOAD_LATEST, LoadObjective::UNDELETED};
+    const LoadStrategy load_strategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED};
     auto output = std::make_shared<std::unordered_map<StreamId, SymbolStatus>>();
     auto mutex = std::make_shared<std::mutex>();
 
     submit_tasks_for_range(*symbols,
-        [store, version_map, &load_param](auto &symbol) {
-          return async::submit_io_task(CheckReloadTask{store, version_map, symbol, load_param});
+        [store, version_map, &load_strategy](auto &symbol) {
+          return async::submit_io_task(CheckReloadTask{store, version_map, symbol, load_strategy});
         },
         [output, mutex](const auto& id, const std::shared_ptr<VersionMapEntry> &entry) {
           auto index_key = entry->get_first_index(false).first;
@@ -105,13 +105,13 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_latest_v
     const std::vector<StreamId> &stream_ids,
     bool include_deleted) {
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
-    const LoadParameter load_param{LoadType::LOAD_LATEST, include_deleted ? LoadObjective::ANY : LoadObjective::UNDELETED};
+    const LoadStrategy load_strategy{LoadType::LOAD_LATEST, include_deleted ? LoadObjective::ANY : LoadObjective::UNDELETED};
     auto output = std::make_shared<std::unordered_map<StreamId, AtomKey>>();
     auto mutex = std::make_shared<std::mutex>();
 
     submit_tasks_for_range(stream_ids,
-            [store, version_map, &load_param](auto& stream_id) {
-                return async::submit_io_task(CheckReloadTask{store, version_map, stream_id, load_param});
+            [store, version_map, &load_strategy](auto& stream_id) {
+                return async::submit_io_task(CheckReloadTask{store, version_map, stream_id, load_strategy});
             },
             [output, include_deleted, mutex](auto id, auto entry) {
                 auto [index_key, deleted] = entry->get_first_index(include_deleted);
@@ -134,7 +134,7 @@ inline std::vector<folly::Future<std::pair<std::optional<AtomKey>, std::optional
         vector_fut.push_back(async::submit_io_task(CheckReloadTask{store,
                                                                    version_map,
                                                                    stream_id,
-                                                                   LoadParameter{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
+                                                                   LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
                                  .thenValue([](const std::shared_ptr<VersionMapEntry>& entry){
                                      return std::make_pair(entry->get_first_index(false).first, entry->get_first_index(true).first);
                                  }));
@@ -152,7 +152,7 @@ inline std::vector<folly::Future<version_store::UpdateInfo>> batch_get_latest_un
         vector_fut.push_back(async::submit_io_task(CheckReloadTask{store,
                                                      version_map,
                                                      stream_id,
-                                                     LoadParameter{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
+                                                     LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
         .thenValue([](auto entry){
             auto latest_version = entry->get_first_index(true).first;
             auto latest_undeleted_version = entry->get_first_index(false).first;
@@ -199,8 +199,8 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_specific
 
     MapRandomAccessWrapper wrapper{sym_versions};
     submit_tasks_for_range(wrapper, [store, version_map](auto& sym_version) {
-            LoadParameter load_param{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(sym_version.second)};
-            return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
+            LoadStrategy load_strategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(sym_version.second)};
+            return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_strategy});
         },
         [output, option, output_mutex, store, tombstoned_vers, tombstoned_vers_mutex]
                     (auto sym_version, const std::shared_ptr<VersionMapEntry>& entry) {
@@ -252,8 +252,8 @@ inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKe
 
     submit_tasks_for_range(wrapper, [store, version_map](auto sym_version) {
                 auto first_version = *std::min_element(std::begin(sym_version.second), std::end(sym_version.second));
-                LoadParameter load_param{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(first_version)};
-                return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
+                LoadStrategy load_strategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(first_version)};
+                return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_strategy});
             },
 
             [output, &sym_versions, include_deleted, mutex](auto sym_version, const std::shared_ptr<VersionMapEntry>& entry) {
@@ -273,11 +273,11 @@ inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKe
 }
 
 // [StreamVersionData] is used to combine different [VersionQuery]s for a stream_id into a list of needed snapshots and
-// a single [LoadParameter] which will query the union of all version queries.
+// a single [LoadStrategy] which will query the union of all version queries.
 // It only ever produces load parameters where to_load=UNDELETED.
 struct StreamVersionData {
     size_t count_ = 0;
-    LoadParameter load_param_ = LoadParameter{LoadType::NOT_LOADED, LoadObjective::UNDELETED};
+    LoadStrategy load_strategy_ = LoadStrategy{LoadType::NOT_LOADED, LoadObjective::UNDELETED};
     boost::container::small_vector<SnapshotId, 1> snapshots_;
 
     explicit StreamVersionData(const pipelines::VersionQuery& version_query);

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -69,7 +69,7 @@ inline std::shared_ptr<std::unordered_map<StreamId, SymbolStatus>> batch_check_l
     const std::shared_ptr<VersionMap> &version_map,
     const std::shared_ptr<std::vector<StreamId>> &symbols) {
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
-    const LoadParameter load_param{LoadType::LOAD_LATEST, ToLoad::UNDELETED};
+    const LoadParameter load_param{LoadType::LOAD_LATEST, LoadObjective::UNDELETED};
     auto output = std::make_shared<std::unordered_map<StreamId, SymbolStatus>>();
     auto mutex = std::make_shared<std::mutex>();
 
@@ -105,7 +105,7 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_latest_v
     const std::vector<StreamId> &stream_ids,
     bool include_deleted) {
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
-    const LoadParameter load_param{LoadType::LOAD_LATEST, include_deleted ? ToLoad::ANY : ToLoad::UNDELETED};
+    const LoadParameter load_param{LoadType::LOAD_LATEST, include_deleted ? LoadObjective::ANY : LoadObjective::UNDELETED};
     auto output = std::make_shared<std::unordered_map<StreamId, AtomKey>>();
     auto mutex = std::make_shared<std::mutex>();
 
@@ -134,7 +134,7 @@ inline std::vector<folly::Future<std::pair<std::optional<AtomKey>, std::optional
         vector_fut.push_back(async::submit_io_task(CheckReloadTask{store,
                                                                    version_map,
                                                                    stream_id,
-                                                                   LoadParameter{LoadType::LOAD_LATEST, ToLoad::UNDELETED}})
+                                                                   LoadParameter{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
                                  .thenValue([](const std::shared_ptr<VersionMapEntry>& entry){
                                      return std::make_pair(entry->get_first_index(false).first, entry->get_first_index(true).first);
                                  }));
@@ -152,7 +152,7 @@ inline std::vector<folly::Future<version_store::UpdateInfo>> batch_get_latest_un
         vector_fut.push_back(async::submit_io_task(CheckReloadTask{store,
                                                      version_map,
                                                      stream_id,
-                                                     LoadParameter{LoadType::LOAD_LATEST, ToLoad::UNDELETED}})
+                                                     LoadParameter{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
         .thenValue([](auto entry){
             auto latest_version = entry->get_first_index(true).first;
             auto latest_undeleted_version = entry->get_first_index(false).first;
@@ -199,7 +199,7 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_specific
 
     MapRandomAccessWrapper wrapper{sym_versions};
     submit_tasks_for_range(wrapper, [store, version_map](auto& sym_version) {
-            LoadParameter load_param{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(sym_version.second)};
+            LoadParameter load_param{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(sym_version.second)};
             return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
         },
         [output, option, output_mutex, store, tombstoned_vers, tombstoned_vers_mutex]
@@ -252,7 +252,7 @@ inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKe
 
     submit_tasks_for_range(wrapper, [store, version_map](auto sym_version) {
                 auto first_version = *std::min_element(std::begin(sym_version.second), std::end(sym_version.second));
-                LoadParameter load_param{LoadType::LOAD_DOWNTO, ToLoad::UNDELETED, static_cast<SignedVersionId>(first_version)};
+                LoadParameter load_param{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(first_version)};
                 return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_param});
             },
 
@@ -277,7 +277,7 @@ inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKe
 // It only ever produces load parameters where to_load=UNDELETED.
 struct StreamVersionData {
     size_t count_ = 0;
-    LoadParameter load_param_ = LoadParameter{LoadType::NOT_LOADED, ToLoad::UNDELETED};
+    LoadParameter load_param_ = LoadParameter{LoadType::NOT_LOADED, LoadObjective::UNDELETED};
     boost::container::small_vector<SnapshotId, 1> snapshots_;
 
     explicit StreamVersionData(const pipelines::VersionQuery& version_query);

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -69,7 +69,7 @@ inline std::shared_ptr<std::unordered_map<StreamId, SymbolStatus>> batch_check_l
     const std::shared_ptr<VersionMap> &version_map,
     const std::shared_ptr<std::vector<StreamId>> &symbols) {
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
-    const LoadStrategy load_strategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED};
+    const LoadStrategy load_strategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY};
     auto output = std::make_shared<std::unordered_map<StreamId, SymbolStatus>>();
     auto mutex = std::make_shared<std::mutex>();
 
@@ -105,7 +105,7 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_latest_v
     const std::vector<StreamId> &stream_ids,
     bool include_deleted) {
     ARCTICDB_SAMPLE(BatchGetLatestVersion, 0)
-    const LoadStrategy load_strategy{LoadType::LOAD_LATEST, include_deleted ? LoadObjective::ANY : LoadObjective::UNDELETED};
+    const LoadStrategy load_strategy{LoadType::LATEST, include_deleted ? LoadObjective::INCLUDE_DELETED : LoadObjective::UNDELETED_ONLY};
     auto output = std::make_shared<std::unordered_map<StreamId, AtomKey>>();
     auto mutex = std::make_shared<std::mutex>();
 
@@ -134,7 +134,7 @@ inline std::vector<folly::Future<std::pair<std::optional<AtomKey>, std::optional
         vector_fut.push_back(async::submit_io_task(CheckReloadTask{store,
                                                                    version_map,
                                                                    stream_id,
-                                                                   LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
+                                                                   LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}})
                                  .thenValue([](const std::shared_ptr<VersionMapEntry>& entry){
                                      return std::make_pair(entry->get_first_index(false).first, entry->get_first_index(true).first);
                                  }));
@@ -152,7 +152,7 @@ inline std::vector<folly::Future<version_store::UpdateInfo>> batch_get_latest_un
         vector_fut.push_back(async::submit_io_task(CheckReloadTask{store,
                                                      version_map,
                                                      stream_id,
-                                                     LoadStrategy{LoadType::LOAD_LATEST, LoadObjective::UNDELETED}})
+                                                     LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}})
         .thenValue([](auto entry){
             auto latest_version = entry->get_first_index(true).first;
             auto latest_undeleted_version = entry->get_first_index(false).first;
@@ -199,7 +199,7 @@ inline std::shared_ptr<std::unordered_map<StreamId, AtomKey>> batch_get_specific
 
     MapRandomAccessWrapper wrapper{sym_versions};
     submit_tasks_for_range(wrapper, [store, version_map](auto& sym_version) {
-            LoadStrategy load_strategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(sym_version.second)};
+            LoadStrategy load_strategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(sym_version.second)};
             return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_strategy});
         },
         [output, option, output_mutex, store, tombstoned_vers, tombstoned_vers_mutex]
@@ -252,7 +252,7 @@ inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKe
 
     submit_tasks_for_range(wrapper, [store, version_map](auto sym_version) {
                 auto first_version = *std::min_element(std::begin(sym_version.second), std::end(sym_version.second));
-                LoadStrategy load_strategy{LoadType::LOAD_DOWNTO, LoadObjective::UNDELETED, static_cast<SignedVersionId>(first_version)};
+                LoadStrategy load_strategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(first_version)};
                 return async::submit_io_task(CheckReloadTask{store, version_map, sym_version.first, load_strategy});
             },
 
@@ -274,10 +274,10 @@ inline std::shared_ptr<std::unordered_map<std::pair<StreamId, VersionId>, AtomKe
 
 // [StreamVersionData] is used to combine different [VersionQuery]s for a stream_id into a list of needed snapshots and
 // a single [LoadStrategy] which will query the union of all version queries.
-// It only ever produces load parameters where to_load=UNDELETED.
+// It only ever produces load parameters where to_load=UNDELETED_ONLY.
 struct StreamVersionData {
     size_t count_ = 0;
-    LoadStrategy load_strategy_ = LoadStrategy{LoadType::NOT_LOADED, LoadObjective::UNDELETED};
+    LoadStrategy load_strategy_ = LoadStrategy{LoadType::NOT_LOADED, LoadObjective::UNDELETED_ONLY};
     boost::container::small_vector<SnapshotId, 1> snapshots_;
 
     explicit StreamVersionData(const pipelines::VersionQuery& version_query);

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -132,6 +132,12 @@ inline AtomKey get_tombstone_all_key(const AtomKey &latest, timestamp creation_t
         .build(latest.id(), KeyType::TOMBSTONE_ALL);
 }
 
+struct LoadProgress {
+    VersionId oldest_loaded_index_version_ = std::numeric_limits<VersionId>::max();
+    timestamp earliest_loaded_timestamp_ = std::numeric_limits<timestamp>::max();
+    timestamp earliest_loaded_undeleted_timestamp_ = std::numeric_limits<timestamp>::max();
+};
+
 struct VersionMapEntry {
     /*
       VersionMapEntry is all the data we have in-memory about each stream_id in the version map which in its essence
@@ -167,6 +173,7 @@ struct VersionMapEntry {
         tombstones_.clear();
         tombstone_all_.reset();
         keys_.clear();
+        loaded_with_progress_ = LoadProgress{};
     }
 
     bool empty() const {
@@ -184,6 +191,7 @@ struct VersionMapEntry {
         swap(left.tombstone_all_, right.tombstone_all_);
         swap(left.head_, right.head_);
         swap(left.load_type_, right.load_type_);
+        swap(left.loaded_with_progress_, right.loaded_with_progress_);
     }
 
     // Below four functions used to return optional<AtomKey> of the tombstone, but copying keys is expensive and only
@@ -358,7 +366,7 @@ struct VersionMapEntry {
     std::optional<AtomKey> head_;
     LoadType load_type_ = LoadType::NOT_LOADED;
     timestamp last_reload_time_ = 0;
-    VersionId loaded_until_ = std::numeric_limits<uint64_t>::max();
+    LoadProgress loaded_with_progress_;
     std::deque<AtomKey> keys_;
     std::unordered_map<VersionId, AtomKey> tombstones_;
     std::optional<AtomKey> tombstone_all_;

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -134,6 +134,7 @@ inline AtomKey get_tombstone_all_key(const AtomKey &latest, timestamp creation_t
 
 struct LoadProgress {
     VersionId oldest_loaded_index_version_ = std::numeric_limits<VersionId>::max();
+    VersionId oldest_loaded_undeleted_index_version_ = std::numeric_limits<VersionId>::max();
     timestamp earliest_loaded_timestamp_ = std::numeric_limits<timestamp>::max();
     timestamp earliest_loaded_undeleted_timestamp_ = std::numeric_limits<timestamp>::max();
 };

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -54,7 +54,7 @@ struct VersionDetails {
 // load_type: Describes up to which point in the chain we need to go.
 // load_objective: Whether to include tombstoned versions
 struct LoadStrategy {
-    explicit LoadStrategy(LoadType load_type, LoadObjective load_objective = LoadObjective::ANY) :
+    explicit LoadStrategy(LoadType load_type, LoadObjective load_objective) :
             load_type_(load_type), load_objective_(load_objective) {
     }
 
@@ -149,17 +149,6 @@ inline LoadStrategy union_of_undeleted_strategies(const LoadStrategy& left, cons
     return LoadStrategy{LoadType::LOAD_ALL, LoadObjective::UNDELETED};
 }
 
-// LoadParameter is just a LoadStrategy and a boolean specified from VersionQuery.iterate_on_failure defaulting to false.
-struct LoadParameter {
-    LoadParameter(const LoadStrategy& load_strategy) : load_strategy_(load_strategy) {}
-    LoadParameter(LoadType load_type, LoadObjective load_objective) : load_strategy_(load_type, load_objective) {}
-    LoadParameter(LoadType load_type, LoadObjective load_objective, int64_t load_from_time_or_until) :
-        load_strategy_(load_type, load_objective, load_from_time_or_until) {}
-
-    LoadStrategy load_strategy_;
-    bool iterate_on_failure_ = false;
-};
-
 template<typename T>
 bool deque_is_unique(std::deque<T> vec) {
     sort(vec.begin(), vec.end());
@@ -252,7 +241,7 @@ struct VersionMapEntry {
         tombstone_all_.reset();
         keys_.clear();
         loaded_with_progress_ = LoadProgress{};
-        load_strategy_ = LoadStrategy{LoadType::NOT_LOADED};
+        load_strategy_ = LoadStrategy{LoadType::NOT_LOADED, LoadObjective::ANY};
     }
 
     bool empty() const {
@@ -443,7 +432,7 @@ struct VersionMapEntry {
     }
 
     std::optional<AtomKey> head_;
-    LoadStrategy load_strategy_ = LoadStrategy{LoadType::NOT_LOADED };
+    LoadStrategy load_strategy_ = LoadStrategy{LoadType::NOT_LOADED, LoadObjective::ANY};
     timestamp last_reload_time_ = 0;
     LoadProgress loaded_with_progress_;
     std::deque<AtomKey> keys_;

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -23,10 +23,8 @@ using namespace arcticdb::stream;
 enum class LoadType : uint32_t {
     NOT_LOADED = 0,
     LOAD_LATEST,
-    LOAD_LATEST_UNDELETED,
     LOAD_DOWNTO,
     LOAD_FROM_TIME,
-    LOAD_UNDELETED,
     LOAD_ALL,
     UNKNOWN
 };
@@ -34,6 +32,12 @@ enum class LoadType : uint32_t {
 inline constexpr bool is_partial_load_type(LoadType load_type) {
     return load_type == LoadType::LOAD_DOWNTO || load_type == LoadType::LOAD_FROM_TIME;
 }
+
+// Used to specify whether we want to load all or only undeleted versions
+enum class ToLoad : uint32_t {
+    ANY,
+    UNDELETED
+};
 
 enum class VersionStatus {
     LIVE,
@@ -46,17 +50,16 @@ struct VersionDetails {
     VersionStatus version_status_;
 };
 
-inline constexpr bool is_latest_load_type(LoadType load_type) {
-    return load_type == LoadType::LOAD_LATEST || load_type == LoadType::LOAD_LATEST_UNDELETED;
-}
-
-struct LoadParameter {
-    explicit LoadParameter(LoadType load_type) :
-        load_type_(load_type) {
+// The LoadStrategy describes how to load versions from the version chain. It consists of:
+// load_type: Describes up to which point in the chain we need to go.
+// to_load: Whether to include tombstoned versions
+struct LoadStrategy {
+    explicit LoadStrategy(LoadType load_type, ToLoad to_load = ToLoad::ANY) :
+        load_type_(load_type), to_load_(to_load) {
     }
 
-    LoadParameter(LoadType load_type, int64_t load_from_time_or_until) :
-        load_type_(load_type) {
+    LoadStrategy(LoadType load_type, ToLoad to_load, int64_t load_from_time_or_until) :
+        load_type_(load_type), to_load_(to_load) {
         switch(load_type_) {
             case LoadType::LOAD_FROM_TIME:
                 load_from_time_ = load_from_time_or_until;
@@ -65,22 +68,96 @@ struct LoadParameter {
                 load_until_version_ = load_from_time_or_until;
                 break;
             default:
-                internal::raise<ErrorCode::E_ASSERTION_FAILURE>("LoadParameter constructor with load_from_time_or_until parameter {} provided invalid load_type {}",
+                internal::raise<ErrorCode::E_ASSERTION_FAILURE>("LoadStrategy constructor with load_from_time_or_until parameter {} provided invalid load_type {}",
                                                                 load_from_time_or_until, static_cast<uint32_t>(load_type));
         }
     }
 
     LoadType load_type_ = LoadType::NOT_LOADED;
+    ToLoad to_load_ = ToLoad::ANY;
     std::optional<SignedVersionId> load_until_version_ = std::nullopt;
     std::optional<timestamp> load_from_time_ = std::nullopt;
-    bool iterate_on_failure_ = false;
+
+    bool should_include_deleted() const {
+        switch (to_load_) {
+            case ToLoad::ANY:
+                return true;
+            case ToLoad::UNDELETED:
+                return false;
+            default:
+                util::raise_rte("Invalid to_load: {}", to_load_);
+        }
+    }
 
     void validate() const {
-        util::check((load_type_ == LoadType::LOAD_DOWNTO) == load_until_version_.has_value(),
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>((load_type_ == LoadType::LOAD_DOWNTO) == load_until_version_.has_value(),
                     "Invalid load parameter: load_type {} with load_util {}", int(load_type_), load_until_version_.value_or(VersionId{}));
-        util::check((load_type_ == LoadType::LOAD_FROM_TIME) == load_from_time_.has_value(),
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>((load_type_ == LoadType::LOAD_FROM_TIME) == load_from_time_.has_value(),
             "Invalid load parameter: load_type {} with load_from_time_ {}", int(load_type_), load_from_time_.value_or(timestamp{}));
     }
+};
+
+
+inline bool is_undeleted_strategy_subset(const LoadStrategy& left, const LoadStrategy& right){
+    switch (left.load_type_) {
+        case LoadType::NOT_LOADED:
+            return true;
+        case LoadType::LOAD_LATEST:
+            // LOAD_LATEST is not a subset of LOAD_DOWNTO because LOAD_DOWNTO may not reach the latest undeleted version.
+            return right.load_type_ != LoadType::NOT_LOADED && right.load_type_ != LoadType::LOAD_DOWNTO;
+        case LoadType::LOAD_DOWNTO:
+            if (right.load_type_ == LoadType::LOAD_ALL) {
+                return true;
+            }
+            if (right.load_type_ == LoadType::LOAD_DOWNTO && ((left.load_until_version_.value()>=0) == (right.load_until_version_.value()>=0))) {
+                // Left is subset of right only when the [load_until]s have same sign and left's version is >= right's version
+                return left.load_until_version_.value() >= right.load_until_version_.value();
+            }
+            break;
+        case LoadType::LOAD_FROM_TIME:
+            if (right.load_type_ == LoadType::LOAD_ALL){
+                return true;
+            }
+            if (right.load_type_ == LoadType::LOAD_FROM_TIME){
+                return left.load_from_time_.value() >= right.load_from_time_.value();
+            }
+            break;
+        case LoadType::LOAD_ALL:
+            return right.load_type_ == LoadType::LOAD_ALL;
+        default:
+            util::raise_rte("Invalid load type: {}", left.load_type_);
+    }
+    return false;
+}
+
+// Returns a strategy which is guaranteed to load all versions requested by left and right.
+// Works only on strategies with include_deleted=false.
+inline LoadStrategy union_of_undeleted_strategies(const LoadStrategy& left, const LoadStrategy& right){
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(!left.should_include_deleted(), "Trying to produce a union of undeleted strategies but left strategy includes deleted.");
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(!right.should_include_deleted(), "Trying to produce a union of undeleted strategies but right strategy includes deleted.");
+    if (is_undeleted_strategy_subset(left, right)){
+        return right;
+    }
+    if (is_undeleted_strategy_subset(right, left)){
+        return left;
+    }
+    // If none is subset of the other, then we should load all versions. We can't be less conservative because we can't
+    // know where to load to with strategies which have a different load type. E.g. for LOAD_FROM_TIME and LOAD_DOWNTO
+    // we can't know where to read to unless we know the version chain.
+    // A possible workaround for this is to restructure loading the version chain to get a set of LoadStrategies and stop
+    // searching only when all of them are satisfied.
+    return LoadStrategy{LoadType::LOAD_ALL, ToLoad::UNDELETED};
+}
+
+// LoadParameter is just a LoadStrategy and a boolean specified from VersionQuery.iterate_on_failure defaulting to false.
+struct LoadParameter {
+    LoadParameter(const LoadStrategy& load_strategy) : load_strategy_(load_strategy) {}
+    LoadParameter(LoadType load_type, ToLoad to_load) : load_strategy_(load_type, to_load) {}
+    LoadParameter(LoadType load_type, ToLoad to_load, int64_t load_from_time_or_until) :
+        load_strategy_(load_type, to_load, load_from_time_or_until) {}
+
+    LoadStrategy load_strategy_;
+    bool iterate_on_failure_ = false;
 };
 
 template<typename T>
@@ -144,9 +221,9 @@ struct VersionMapEntry {
       VersionMapEntry is all the data we have in-memory about each stream_id in the version map which in its essence
       is a map of StreamId: VersionMapEntry. It's created from the linked-list-like structure that we have in the
       storage, where the head_ points to the latest version and keys_ are basically all the index/version keys
-      loaded in memory in a deque - based on the load_type.
+      loaded in memory in a deque - based on the load_strategy.
 
-      load_type signifies the current state of the in memory structure vs the state on disk, where LOAD_LATEST will
+      load_strategy signifies the current state of the in memory structure vs the state on disk, where LOAD_LATEST will
       just load the latest version, and LOAD_ALL loads everything in memory by going through the linked list on disk.
 
       It also contains a map of version_ids and the tombstone key corresponding to it iff it has been pruned or
@@ -162,6 +239,7 @@ struct VersionMapEntry {
         if (keys_.empty())
             return;
 
+        // Sorting by creation_ts is safe from clock skew because we don't support parallel writes to the same symbol.
         std::sort(std::begin(keys_), std::end(keys_), [](const AtomKey &l, const AtomKey &r) {
             return l.creation_ts() > r.creation_ts();
         });
@@ -169,12 +247,12 @@ struct VersionMapEntry {
 
     void clear() {
         head_.reset();
-        load_type_ = LoadType::NOT_LOADED;
         last_reload_time_ = 0;
         tombstones_.clear();
         tombstone_all_.reset();
         keys_.clear();
         loaded_with_progress_ = LoadProgress{};
+        load_strategy_ = LoadStrategy{LoadType::NOT_LOADED};
     }
 
     bool empty() const {
@@ -191,7 +269,7 @@ struct VersionMapEntry {
         swap(left.last_reload_time_, right.last_reload_time_);
         swap(left.tombstone_all_, right.tombstone_all_);
         swap(left.head_, right.head_);
-        swap(left.load_type_, right.load_type_);
+        swap(left.load_strategy_, right.load_strategy_);
         swap(left.loaded_with_progress_, right.loaded_with_progress_);
     }
 
@@ -365,7 +443,7 @@ struct VersionMapEntry {
     }
 
     std::optional<AtomKey> head_;
-    LoadType load_type_ = LoadType::NOT_LOADED;
+    LoadStrategy load_strategy_ = LoadStrategy{LoadType::NOT_LOADED };
     timestamp last_reload_time_ = 0;
     LoadProgress loaded_with_progress_;
     std::deque<AtomKey> keys_;
@@ -452,24 +530,38 @@ namespace fmt {
         template<typename ParseContext>
         constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
-    template<typename FormatContext>
-    auto format(arcticdb::LoadType l, FormatContext &ctx) const {
-        switch(l) {
-        case arcticdb::LoadType::NOT_LOADED:
-            return fmt::format_to(ctx.out(), "NOT_LOADED");
-        case arcticdb::LoadType::LOAD_LATEST:
-            return fmt::format_to(ctx.out(), "LOAD_LATEST");
-        case arcticdb::LoadType::LOAD_LATEST_UNDELETED:
-            return fmt::format_to(ctx.out(), "LOAD_LATEST_UNDELETED");
-        case arcticdb::LoadType::LOAD_DOWNTO:
-            return fmt::format_to(ctx.out(), "LOAD_DOWNTO");
-        case arcticdb::LoadType::LOAD_UNDELETED:
-            return fmt::format_to(ctx.out(), "LOAD_UNDELETED");
-        case arcticdb::LoadType::LOAD_ALL:
-            return fmt::format_to(ctx.out(), "LOAD_ALL");
-        default:
-            arcticdb::util::raise_rte("Unrecognized load type {}", int(l));
+        template<typename FormatContext>
+        auto format(arcticdb::LoadType l, FormatContext &ctx) const {
+            switch (l) {
+                case arcticdb::LoadType::NOT_LOADED:
+                    return fmt::format_to(ctx.out(), "NOT_LOADED");
+                case arcticdb::LoadType::LOAD_LATEST:
+                    return fmt::format_to(ctx.out(), "LOAD_LATEST");
+                case arcticdb::LoadType::LOAD_DOWNTO:
+                    return fmt::format_to(ctx.out(), "LOAD_DOWNTO");
+                case arcticdb::LoadType::LOAD_ALL:
+                    return fmt::format_to(ctx.out(), "LOAD_ALL");
+                default:
+                    arcticdb::util::raise_rte("Unrecognized load type {}", int(l));
+            }
         }
-    }
-};
+    };
+
+    template<>
+    struct formatter<arcticdb::ToLoad> {
+        template<typename ParseContext>
+        constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+        template<typename FormatContext>
+        auto format(arcticdb::ToLoad l, FormatContext &ctx) const {
+            switch (l) {
+                case arcticdb::ToLoad::ANY:
+                    return fmt::format_to(ctx.out(), "ANY");
+                case arcticdb::ToLoad::UNDELETED:
+                    return fmt::format_to(ctx.out(), "UNDELETED");
+                default:
+                    arcticdb::util::raise_rte("Unrecognized to load {}", int(l));
+            }
+        }
+    };
 }

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1156,6 +1156,7 @@ std::vector<SliceAndKey> PythonVersionStore::list_incompletes(const StreamId& st
 }
 
 void PythonVersionStore::clear(const bool continue_on_error) {
+    version_map()->flush();
     if (store()->fast_delete()) {
         // Most storage backends have a fast deletion method for a db/collection equivalent, eg. drop() for mongo and
         // lmdb and iterating each key is always going to be suboptimal.

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -966,7 +966,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
     const std::shared_ptr<VersionMapEntry>& entry = version_map()->check_reload(
             store(),
             stream_id,
-            LoadParameter{LoadType::LOAD_UNDELETED},
+            LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
             __FUNCTION__);
     storage::check<ErrorCode::E_SYMBOL_NOT_FOUND>(!entry->empty(), "Symbol {} is not found", stream_id);
     auto [latest, deleted] = entry->get_first_index(false);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -966,7 +966,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
     const std::shared_ptr<VersionMapEntry>& entry = version_map()->check_reload(
             store(),
             stream_id,
-            LoadParameter{LoadType::LOAD_ALL, ToLoad::UNDELETED},
+            LoadParameter{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
             __FUNCTION__);
     storage::check<ErrorCode::E_SYMBOL_NOT_FOUND>(!entry->empty(), "Symbol {} is not found", stream_id);
     auto [latest, deleted] = entry->get_first_index(false);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -961,7 +961,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
     const std::shared_ptr<VersionMapEntry>& entry = version_map()->check_reload(
             store(),
             stream_id,
-            LoadStrategy{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
+            LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY},
             __FUNCTION__);
     storage::check<ErrorCode::E_SYMBOL_NOT_FOUND>(!entry->empty(), "Symbol {} is not found", stream_id);
     auto [latest, deleted] = entry->get_first_index(false);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -52,7 +52,7 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
     ARCTICDB_SAMPLE(WriteDataFrame, 0)
 
     ARCTICDB_DEBUG(log::version(), "write_dataframe_specific_version stream_id: {} , version_id: {}", stream_id, version_id);
-    if (auto version_key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id, VersionQuery{}); version_key) {
+    if (auto version_key = ::arcticdb::get_specific_version(store(), version_map(), stream_id, version_id); version_key) {
         log::version().warn("Symbol stream_id: {} already exists with version_id: {}", stream_id, version_id);
         return {std::move(*version_key)};
     }
@@ -190,12 +190,11 @@ VersionResultVector get_latest_versions_for_symbols(
     const std::shared_ptr<Store>& store,
     const std::shared_ptr<VersionMap>& version_map,
     const std::set<StreamId>& stream_ids,
-    SymbolVersionToSnapshotMap& snapshots_for_symbol,
-    const VersionQuery& version_query
+    SymbolVersionToSnapshotMap& snapshots_for_symbol
 ) {
     VersionResultVector res;
     for (auto &s_id: stream_ids) {
-            const auto& opt_version_key = get_latest_undeleted_version(store, version_map, s_id, version_query);
+            const auto& opt_version_key = get_latest_undeleted_version(store, version_map, s_id);
             if (opt_version_key) {
                 res.emplace_back(
                     s_id,
@@ -220,7 +219,7 @@ VersionResultVector get_all_versions_for_symbols(
     VersionResultVector res;
     std::unordered_set<std::pair<StreamId, VersionId>> unpruned_versions;
     for (auto &s_id: stream_ids) {
-            auto all_versions = get_all_versions(store, version_map, s_id, VersionQuery{});
+            auto all_versions = get_all_versions(store, version_map, s_id);
             unpruned_versions = {};
             for (const auto &entry: all_versions) {
                 unpruned_versions.emplace(s_id, entry.version_id());
@@ -252,7 +251,6 @@ VersionResultVector PythonVersionStore::list_versions(
     const std::optional<StreamId> &stream_id,
     const std::optional<SnapshotId> &snap_name,
     const std::optional<bool>& latest_only,
-    const std::optional<bool>& iterate_on_failure,
     const std::optional<bool>& skip_snapshots) {
     ARCTICDB_SAMPLE(ListVersions, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: list_versions");
@@ -276,11 +274,8 @@ VersionResultVector PythonVersionStore::list_versions(
             return list_versions_for_snapshot(stream_ids, snap_name, *versions_for_snapshots, snapshots_for_symbol);
     }
 
-    VersionQuery version_query;
-    version_query.set_iterate_on_failure(iterate_on_failure);
-
    if(opt_false(latest_only))
-       return get_latest_versions_for_symbols(store(), version_map(), stream_ids, snapshots_for_symbol, version_query);
+       return get_latest_versions_for_symbols(store(), version_map(), stream_ids, snapshots_for_symbol);
    else
        return get_all_versions_for_symbols(store(), version_map(), stream_ids, snapshots_for_symbol, creation_ts_for_version_symbol);
 }
@@ -515,7 +510,7 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     const std::vector<std::string>& partition_value
     ) {
     ARCTICDB_SAMPLE(WritePartitionedDataFrame, 0)
-    auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{});
+    auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id);
     auto version_id = get_next_version_from_key(maybe_prev);
 
     //    TODO: We are not actually partitioning stuff atm, just assuming a single partition is passed for now.
@@ -568,7 +563,7 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     ARCTICDB_SAMPLE(WriteVersionedMultiKey, 0)
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_composite_data");
-    auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{});
+    auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id);
     auto version_id = get_next_version_from_key(maybe_prev);
     ARCTICDB_DEBUG(log::version(), "write_versioned_composite_data for stream_id: {} , version_id = {}", stream_id, version_id);
     // TODO: Assuming each sub key is always going to have the same version attached to it.
@@ -765,7 +760,7 @@ void PythonVersionStore::write_parallel(
 }
 
 std::unordered_map<VersionId, bool> PythonVersionStore::get_all_tombstoned_versions(const StreamId &stream_id) {
-    return ::arcticdb::get_all_tombstoned_versions(store(), version_map(), stream_id, VersionQuery{});
+    return ::arcticdb::get_all_tombstoned_versions(store(), version_map(), stream_id);
 }
 
 FrameAndDescriptor create_frame(const StreamId& target_id, SegmentInMemory seg, const ReadOptions& read_options) {
@@ -934,7 +929,7 @@ void PythonVersionStore::delete_version(
         const StreamId& stream_id,
         VersionId version_id) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: delete_version");
-    auto result = ::arcticdb::tombstone_version(store(), version_map(), stream_id, version_id, VersionQuery{});
+    auto result = ::arcticdb::tombstone_version(store(), version_map(), stream_id, version_id);
 
     if (!result.keys_to_delete.empty() && !cfg().write_options().delayed_deletes()) {
         delete_tree(result.keys_to_delete, result);
@@ -948,7 +943,7 @@ void PythonVersionStore::delete_version(
 void PythonVersionStore::fix_symbol_trees(const std::vector<StreamId>& symbols) {
     auto snaps = get_master_snapshots_map(store());
     for (const auto& sym : symbols) {
-        auto index_keys_from_symbol_tree = get_all_versions(store(), version_map(), sym, VersionQuery{});
+        auto index_keys_from_symbol_tree = get_all_versions(store(), version_map(), sym);
         for(const auto& [key, map] : snaps[sym]) {
             index_keys_from_symbol_tree.push_back(key);
         }
@@ -966,7 +961,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
     const std::shared_ptr<VersionMapEntry>& entry = version_map()->check_reload(
             store(),
             stream_id,
-            LoadParameter{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
+            LoadStrategy{LoadType::LOAD_ALL, LoadObjective::UNDELETED},
             __FUNCTION__);
     storage::check<ErrorCode::E_SYMBOL_NOT_FOUND>(!entry->empty(), "Symbol {} is not found", stream_id);
     auto [latest, deleted] = entry->get_first_index(false);
@@ -977,7 +972,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
         return;
     }
 
-    auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, *prev_id, VersionQuery{});
+    auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, *prev_id);
     auto [_, pruned_indexes] = version_map()->tombstone_from_key_or_all(store(), stream_id, previous);
     delete_unreferenced_pruned_indexes(std::move(pruned_indexes), *latest).get();
 }
@@ -1140,7 +1135,7 @@ ReadResult PythonVersionStore::read_index(
 }
 
 std::vector<AtomKey> PythonVersionStore::get_version_history(const StreamId& stream_id) {
-    return get_index_and_tombstone_keys(store(), version_map(), stream_id, VersionQuery{});
+    return get_index_and_tombstone_keys(store(), version_map(), stream_id);
 }
 
 void PythonVersionStore::_compact_version_map(const StreamId& id) {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -264,7 +264,6 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::optional<StreamId> &stream_id,
         const std::optional<SnapshotId>& snap_name,
         const std::optional<bool> &latest_only,
-        const std::optional<bool>& iterate_on_failure,
         const std::optional<bool>& skip_snapshots);
 
     // Batch methods

--- a/cpp/arcticdb/version/version_store_objects.hpp
+++ b/cpp/arcticdb/version/version_store_objects.hpp
@@ -43,8 +43,8 @@ struct PreDeleteChecks {
     std::unordered_set<IndexTypeKey> could_share_data {};
 
     LoadType calc_load_type() const {
-        if (prev_version) return LoadType::LOAD_ALL;
-        if (version_visible | next_version) return LoadType::LOAD_DOWNTO;
+        if (prev_version) return LoadType::ALL;
+        if (version_visible | next_version) return LoadType::DOWNTO;
         return LoadType::NOT_LOADED;
     }
 };

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -107,21 +107,21 @@ struct CheckReloadTask : async::BaseTask {
     const std::shared_ptr<Store> store_;
     const std::shared_ptr<VersionMap> version_map_;
     const StreamId stream_id_;
-    const LoadParameter load_param_;
+    const LoadStrategy load_strategy_;
 
     CheckReloadTask(
         std::shared_ptr<Store> store,
         std::shared_ptr<VersionMap> version_map,
         StreamId stream_id,
-        LoadParameter load_param) :
+        LoadStrategy load_strategy) :
         store_(std::move(store)),
         version_map_(std::move(version_map)),
         stream_id_(std::move(stream_id)),
-        load_param_(load_param) {
+        load_strategy_(load_strategy) {
     }
 
     std::shared_ptr<VersionMapEntry> operator()() const {
-        return version_map_->check_reload(store_, stream_id_, load_param_, __FUNCTION__);
+        return version_map_->check_reload(store_, stream_id_, load_strategy_, __FUNCTION__);
     }
 };
 

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -70,6 +70,7 @@ inline std::optional<AtomKey> read_segment_with_keys(
     ssize_t row = 0;
     std::optional<AtomKey> next;
     VersionId oldest_loaded_index = std::numeric_limits<VersionId>::max();
+    VersionId oldest_loaded_undeleted_index = std::numeric_limits<VersionId>::max();
     timestamp earliest_loaded_timestamp = std::numeric_limits<timestamp>::max();
     timestamp earliest_loaded_undeleted_timestamp = std::numeric_limits<timestamp>::max();
 
@@ -80,10 +81,12 @@ inline std::optional<AtomKey> read_segment_with_keys(
         if (is_index_key_type(key.type())) {
             entry.keys_.push_back(key);
             oldest_loaded_index = std::min(oldest_loaded_index, key.version_id());
-
             earliest_loaded_timestamp = std::min(earliest_loaded_timestamp, key.creation_ts());
-            if(!entry.is_tombstoned(key))
+
+            if(!entry.is_tombstoned(key)) {
+                oldest_loaded_undeleted_index = std::min(oldest_loaded_undeleted_index, key.version_id());
                 earliest_loaded_undeleted_timestamp = std::min(earliest_loaded_timestamp, key.creation_ts());
+            }
 
         } else if (key.type() == KeyType::TOMBSTONE) {
             entry.tombstones_.try_emplace(key.version_id(), key);
@@ -102,6 +105,7 @@ inline std::optional<AtomKey> read_segment_with_keys(
     }
     util::check(row == ssize_t(seg.row_count()), "Unexpected ordering in journal segment");
     load_progress.oldest_loaded_index_version_ = std::min(load_progress.oldest_loaded_index_version_, oldest_loaded_index);
+    load_progress.oldest_loaded_undeleted_index_version_ = std::min(load_progress.oldest_loaded_undeleted_index_version_, oldest_loaded_undeleted_index);
     load_progress.earliest_loaded_timestamp_ = std::min(load_progress.earliest_loaded_timestamp_, earliest_loaded_timestamp);
     load_progress.earliest_loaded_undeleted_timestamp_ = std::min(load_progress.earliest_loaded_undeleted_timestamp_, earliest_loaded_undeleted_timestamp);
     return next;

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -228,21 +228,21 @@ inline std::optional<VersionId> get_version_id_negative_index(VersionId latest, 
 
 std::unordered_map<StreamId, size_t> get_num_version_entries(const std::shared_ptr<Store> &store, size_t batch_size);
 
-inline bool is_positive_version_query(const LoadParameter& load_params) {
-    return load_params.load_until_version_.value() >= 0;
+inline bool is_positive_version_query(const LoadStrategy& load_strategy) {
+    return load_strategy.load_until_version_.value() >= 0;
 }
 
-inline bool loaded_until_version_id(const LoadParameter &load_params, const LoadProgress& load_progress, const std::optional<VersionId>& latest_version) {
-    if (!load_params.load_until_version_)
+inline bool loaded_until_version_id(const LoadStrategy &load_strategy, const LoadProgress& load_progress, const std::optional<VersionId>& latest_version) {
+    if (!load_strategy.load_until_version_)
         return false;
 
-    if (is_positive_version_query(load_params)) {
-        if (load_progress.oldest_loaded_index_version_ > static_cast<VersionId>(*load_params.load_until_version_)) {
+    if (is_positive_version_query(load_strategy)) {
+        if (load_progress.oldest_loaded_index_version_ > static_cast<VersionId>(*load_strategy.load_until_version_)) {
             return false;
         }
     } else {
         if (latest_version.has_value()) {
-            if (auto opt_version_id = get_version_id_negative_index(*latest_version, *load_params.load_until_version_);
+            if (auto opt_version_id = get_version_id_negative_index(*latest_version, *load_strategy.load_until_version_);
                 opt_version_id && load_progress.oldest_loaded_index_version_ > *opt_version_id) {
                     return false;
             }
@@ -253,7 +253,7 @@ inline bool loaded_until_version_id(const LoadParameter &load_params, const Load
     ARCTICDB_DEBUG(log::version(),
                    "Exiting load downto because loaded to version {} for request {} with {} total versions",
                    load_progress.oldest_loaded_index_version_,
-                   *load_params.load_until_version_,
+                   *load_strategy.load_until_version_,
                    latest_version.value()
                   );
     return true;
@@ -271,28 +271,32 @@ static constexpr timestamp nanos_to_seconds(timestamp nanos) {
     return nanos / timestamp(10000000000);
 }
 
-inline bool loaded_until_timestamp(const LoadParameter &load_params, const LoadProgress& load_progress) {
-    if (!load_params.load_from_time_ || load_progress.earliest_loaded_undeleted_timestamp_ > *load_params.load_from_time_)
+inline bool loaded_until_timestamp(const LoadStrategy &load_strategy, const LoadProgress& load_progress) {
+    if (!load_strategy.load_from_time_)
+        return false;
+
+    auto loaded_deleted_or_undeleted_timestamp = load_strategy.should_include_deleted() ? load_progress.earliest_loaded_timestamp_ : load_progress.earliest_loaded_undeleted_timestamp_;
+
+    if (loaded_deleted_or_undeleted_timestamp > *load_strategy.load_from_time_)
         return false;
 
     ARCTICDB_DEBUG(log::version(),
                    "Exiting load from timestamp because request {} <= {}",
-                   *load_params.load_from_time_,
-                   load_progress.earliest_loaded_undeleted_timestamp_);
+                   loaded_deleted_or_undeleted_timestamp,
+                   *load_strategy.load_from_time_);
     return true;
 }
 
-inline bool load_latest_ongoing(const LoadParameter &load_params, const std::shared_ptr<VersionMapEntry> &entry) {
-    if (!(load_params.load_type_ == LoadType::LOAD_LATEST_UNDELETED && entry->get_first_index(false).first) &&
-        !(load_params.load_type_ == LoadType::LOAD_LATEST && entry->get_first_index(true).first))
+inline bool load_latest_ongoing(const LoadStrategy &load_strategy, const std::shared_ptr<VersionMapEntry> &entry) {
+    if (!(load_strategy.load_type_ == LoadType::LOAD_LATEST && entry->get_first_index(load_strategy.should_include_deleted()).first))
         return true;
 
-    ARCTICDB_DEBUG(log::version(), "Exiting because we found a non-deleted index in load latest");
+    ARCTICDB_DEBUG(log::version(), "Exiting because we found the latest version with include_deleted: {}", load_strategy.should_include_deleted());
     return false;
 }
 
-inline bool looking_for_undeleted(const LoadParameter& load_params, const std::shared_ptr<VersionMapEntry>& entry, const LoadProgress& load_progress) {
-    if(!(load_params.load_type_ == LoadType::LOAD_UNDELETED || load_params.load_type_ == LoadType::LOAD_LATEST_UNDELETED)) {
+inline bool looking_for_undeleted(const LoadStrategy& load_strategy, const std::shared_ptr<VersionMapEntry>& entry, const LoadProgress& load_progress) {
+    if(load_strategy.should_include_deleted()) {
         return true;
     }
 
@@ -313,25 +317,25 @@ inline bool looking_for_undeleted(const LoadParameter& load_params, const std::s
     }
 }
 
-inline bool penultimate_key_contains_required_version_id(const AtomKey& key, const LoadParameter& load_params) {
-    if(is_positive_version_query(load_params)) {
-        return key.version_id() <= static_cast<VersionId>(load_params.load_until_version_.value());
+inline bool penultimate_key_contains_required_version_id(const AtomKey& key, const LoadStrategy& load_strategy) {
+    if(is_positive_version_query(load_strategy)) {
+        return key.version_id() <= static_cast<VersionId>(load_strategy.load_until_version_.value());
     } else {
-        return *load_params.load_until_version_ == -1;
+        return *load_strategy.load_until_version_ == -1;
     }
 }
 
-inline bool key_exists_in_ref_entry(const LoadParameter& load_params, const VersionMapEntry& ref_entry, std::optional<AtomKey>& cached_penultimate_key) {
-    if (is_latest_load_type(load_params.load_type_) && is_index_key_type(ref_entry.keys_[0].type()))
+inline bool key_exists_in_ref_entry(const LoadStrategy& load_strategy, const VersionMapEntry& ref_entry, std::optional<AtomKey>& cached_penultimate_key) {
+    if (load_strategy.load_type_ == LoadType::LOAD_LATEST && is_index_key_type(ref_entry.keys_[0].type()))
         return true;
 
-    if(cached_penultimate_key && is_partial_load_type(load_params.load_type_)) {
-        load_params.validate();
-        if(load_params.load_type_ == LoadType::LOAD_DOWNTO && penultimate_key_contains_required_version_id(*cached_penultimate_key, load_params)) {
+    if(cached_penultimate_key && is_partial_load_type(load_strategy.load_type_)) {
+        load_strategy.validate();
+        if(load_strategy.load_type_ == LoadType::LOAD_DOWNTO && penultimate_key_contains_required_version_id(*cached_penultimate_key, load_strategy)) {
             return true;
         }
 
-        if(load_params.load_type_ == LoadType::LOAD_FROM_TIME &&cached_penultimate_key->creation_ts() <= load_params.load_from_time_.value()) {
+        if(load_strategy.load_type_ == LoadType::LOAD_FROM_TIME && cached_penultimate_key->creation_ts() <= load_strategy.load_from_time_.value()) {
             return true;
         }
     }

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -232,22 +232,26 @@ inline bool is_positive_version_query(const LoadStrategy& load_strategy) {
     return load_strategy.load_until_version_.value() >= 0;
 }
 
-inline bool loaded_until_version_id(const LoadStrategy &load_strategy, const LoadProgress& load_progress, const std::optional<VersionId>& latest_version) {
+inline bool continue_when_loading_version(const LoadStrategy& load_strategy, const LoadProgress& load_progress, const std::optional<VersionId>& latest_version) {
     if (!load_strategy.load_until_version_)
-        return false;
+        // Should continue when not loading down to a version
+        return true;
 
     if (is_positive_version_query(load_strategy)) {
         if (load_progress.oldest_loaded_index_version_ > static_cast<VersionId>(*load_strategy.load_until_version_)) {
-            return false;
+            // Should continue when version was not reached
+            return true;
         }
     } else {
         if (latest_version.has_value()) {
             if (auto opt_version_id = get_version_id_negative_index(*latest_version, *load_strategy.load_until_version_);
                 opt_version_id && load_progress.oldest_loaded_index_version_ > *opt_version_id) {
-                    return false;
+                    // Should continue when version was not reached
+                    return true;
             }
         } else {
-            return false;
+            // Should continue if not yet reached any index key
+            return true;
         }
     }
     ARCTICDB_DEBUG(log::version(),
@@ -256,7 +260,7 @@ inline bool loaded_until_version_id(const LoadStrategy &load_strategy, const Loa
                    *load_strategy.load_until_version_,
                    latest_version.value()
                   );
-    return true;
+    return false;
 }
 
 inline void set_latest_version(const std::shared_ptr<VersionMapEntry>& entry, std::optional<VersionId>& latest_version) {
@@ -271,23 +275,23 @@ static constexpr timestamp nanos_to_seconds(timestamp nanos) {
     return nanos / timestamp(10000000000);
 }
 
-inline bool loaded_until_timestamp(const LoadStrategy &load_strategy, const LoadProgress& load_progress) {
+inline bool continue_when_loading_from_time(const LoadStrategy &load_strategy, const LoadProgress& load_progress) {
     if (!load_strategy.load_from_time_)
-        return false;
+        return true;
 
     auto loaded_deleted_or_undeleted_timestamp = load_strategy.should_include_deleted() ? load_progress.earliest_loaded_timestamp_ : load_progress.earliest_loaded_undeleted_timestamp_;
 
     if (loaded_deleted_or_undeleted_timestamp > *load_strategy.load_from_time_)
-        return false;
+        return true;
 
     ARCTICDB_DEBUG(log::version(),
                    "Exiting load from timestamp because request {} <= {}",
                    loaded_deleted_or_undeleted_timestamp,
                    *load_strategy.load_from_time_);
-    return true;
+    return false;
 }
 
-inline bool load_latest_ongoing(const LoadStrategy &load_strategy, const std::shared_ptr<VersionMapEntry> &entry) {
+inline bool continue_when_loading_latest(const LoadStrategy& load_strategy, const std::shared_ptr<VersionMapEntry> &entry) {
     if (!(load_strategy.load_type_ == LoadType::LOAD_LATEST && entry->get_first_index(load_strategy.should_include_deleted()).first))
         return true;
 
@@ -295,26 +299,29 @@ inline bool load_latest_ongoing(const LoadStrategy &load_strategy, const std::sh
     return false;
 }
 
-inline bool looking_for_undeleted(const LoadStrategy& load_strategy, const std::shared_ptr<VersionMapEntry>& entry, const LoadProgress& load_progress) {
-    if(load_strategy.should_include_deleted()) {
+inline bool continue_when_loading_undeleted(const LoadStrategy& load_strategy, const std::shared_ptr<VersionMapEntry>& entry, const LoadProgress& load_progress) {
+    if (load_strategy.should_include_deleted()){
         return true;
     }
 
     if(entry->tombstone_all_) {
-        const bool is_deleted_by_tombstone_all = entry->tombstone_all_->version_id() >= load_progress.oldest_loaded_index_version_;
-        if(is_deleted_by_tombstone_all) {
+        // We need the check below because it is possible to have a tombstone_all which doesn't cover all version keys after it.
+        // For example when we use prune_previous_versions (without write) we write a tombstone_all key which applies to keys
+        // before the previous one. So it's possible the version chain can look like:
+        // v0 <- v1 <- v2 <- tombstone_all(version=1)
+        // In this case we need to terminate at v1.
+        const bool is_deleted_by_tombstone_all =
+                entry->tombstone_all_->version_id() >= load_progress.oldest_loaded_index_version_;
+        if (is_deleted_by_tombstone_all) {
             ARCTICDB_DEBUG(
-                log::version(),
-                "Exiting because tombstone all key deletes all versions beyond: {} and the oldest loaded index has version: {}",
-                entry->tombstone_all_->version_id(),
-                load_progress.oldest_loaded_index_version_);
+                    log::version(),
+                    "Exiting because tombstone all key deletes all versions beyond: {} and the oldest loaded index has version: {}",
+                    entry->tombstone_all_->version_id(),
+                    load_progress.oldest_loaded_index_version_);
             return false;
-        } else {
-            return true;
         }
-    } else {
-        return true;
     }
+    return true;
 }
 
 inline bool penultimate_key_contains_required_version_id(const AtomKey& key, const LoadStrategy& load_strategy) {

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -190,7 +190,7 @@ inline void read_symbol_ref(const std::shared_ptr<StreamSource>& store, const St
 
     LoadProgress load_progress;
     entry.head_ = read_segment_with_keys(key_seg_pair.second, entry, load_progress);
-    entry.loaded_with_progress_ = load_progress;
+    entry.load_progress_ = load_progress;
 }
 
 inline void write_symbol_ref(std::shared_ptr<StreamSink> store,
@@ -292,7 +292,7 @@ inline bool continue_when_loading_from_time(const LoadStrategy &load_strategy, c
 }
 
 inline bool continue_when_loading_latest(const LoadStrategy& load_strategy, const std::shared_ptr<VersionMapEntry> &entry) {
-    if (!(load_strategy.load_type_ == LoadType::LOAD_LATEST && entry->get_first_index(load_strategy.should_include_deleted()).first))
+    if (!(load_strategy.load_type_ == LoadType::LATEST && entry->get_first_index(load_strategy.should_include_deleted()).first))
         return true;
 
     ARCTICDB_DEBUG(log::version(), "Exiting because we found the latest version with include_deleted: {}", load_strategy.should_include_deleted());
@@ -333,16 +333,16 @@ inline bool penultimate_key_contains_required_version_id(const AtomKey& key, con
 }
 
 inline bool key_exists_in_ref_entry(const LoadStrategy& load_strategy, const VersionMapEntry& ref_entry, std::optional<AtomKey>& cached_penultimate_key) {
-    if (load_strategy.load_type_ == LoadType::LOAD_LATEST && is_index_key_type(ref_entry.keys_[0].type()))
+    if (load_strategy.load_type_ == LoadType::LATEST && is_index_key_type(ref_entry.keys_[0].type()))
         return true;
 
     if(cached_penultimate_key && is_partial_load_type(load_strategy.load_type_)) {
         load_strategy.validate();
-        if(load_strategy.load_type_ == LoadType::LOAD_DOWNTO && penultimate_key_contains_required_version_id(*cached_penultimate_key, load_strategy)) {
+        if(load_strategy.load_type_ == LoadType::DOWNTO && penultimate_key_contains_required_version_id(*cached_penultimate_key, load_strategy)) {
             return true;
         }
 
-        if(load_strategy.load_type_ == LoadType::LOAD_FROM_TIME && cached_penultimate_key->creation_ts() <= load_strategy.load_from_time_.value()) {
+        if(load_strategy.load_type_ == LoadType::FROM_TIME && cached_penultimate_key->creation_ts() <= load_strategy.load_from_time_.value()) {
             return true;
         }
     }

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1986,6 +1986,7 @@ class NativeVersionStore:
         symbol: Optional[str] = None,
         snapshot: Optional[str] = None,
         latest_only: Optional[bool] = False,
+        iterate_on_failure: Optional[bool] = False,
         skip_snapshots: Optional[bool] = False,
     ) -> List[Dict]:
         """
@@ -2000,6 +2001,8 @@ class NativeVersionStore:
         latest_only : `bool`
             Only include the latest version for each returned symbol. Has no effect if `snapshot` argument is also
             specified.
+        iterate_on_failure: `bool`
+            DEPRECATED: Passing this doesn't change behavior
         skip_snapshots: `bool`
             Don't populate version list with snapshot information.
             Can improve performance significantly if there are many snapshots.
@@ -2026,6 +2029,9 @@ class NativeVersionStore:
         `List[Dict]`
             List of dictionaries describing the discovered versions in the library.
         """
+        if iterate_on_failure:
+            log.warning("The iterate_on_failure argument is deprecated and will soon be removed. It's safe to remove since it doesn't change behavior.")
+
         if latest_only and snapshot and not NativeVersionStore._warned_about_list_version_latest_only_and_snapshot:
             log.warning("latest_only has no effect when snapshot is specified")
             NativeVersionStore._warned_about_list_version_latest_only_and_snapshot = True
@@ -2315,7 +2321,7 @@ class NativeVersionStore:
             log.info("Done deleting version: {}".format(str(v_info["version"])))
 
     def has_symbol(
-        self, symbol: str, as_of: Optional[VersionQueryInput] = None
+        self, symbol: str, as_of: Optional[VersionQueryInput] = None, iterate_on_failure: Optional[bool] = False
     ) -> bool:
         """
         Return True if the 'symbol' exists in this library AND the symbol isn't deleted in the specified as_of.
@@ -2327,12 +2333,16 @@ class NativeVersionStore:
             symbol name
         as_of : `Optional[VersionQueryInput]`, default=None
             See documentation of `read` method for more details.
+        iterate_on_failure: `Optional[bool]`, default=False
+            DEPRECATED: Passing this doesn't change behavior
 
         Returns
         -------
         `bool`
             True if the symbol exists as_of the specified revision, False otherwise.
         """
+        if iterate_on_failure:
+            log.warning("The iterate_on_failure argument is deprecated and will soon be removed. It's safe to remove since it doesn't change behavior.")
 
         return (
             self._find_version(symbol, as_of=as_of, raise_on_missing=False)

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1499,7 +1499,6 @@ class NativeVersionStore:
 
     def _get_version_query(self, as_of: VersionQueryInput, **kwargs):
         version_query = _PythonVersionStoreVersionQuery()
-        version_query.set_iterate_on_failure(_assume_false("iterate_on_failure", kwargs))
 
         if isinstance(as_of, str):
             version_query.set_snap_name(as_of)
@@ -1987,7 +1986,6 @@ class NativeVersionStore:
         symbol: Optional[str] = None,
         snapshot: Optional[str] = None,
         latest_only: Optional[bool] = False,
-        iterate_on_failure: Optional[bool] = False,
         skip_snapshots: Optional[bool] = False,
     ) -> List[Dict]:
         """
@@ -2002,8 +2000,6 @@ class NativeVersionStore:
         latest_only : `bool`
             Only include the latest version for each returned symbol. Has no effect if `snapshot` argument is also
             specified.
-        iterate_on_failure: `bool`
-            Iterate the type in the storage if the top-level key isn't present.
         skip_snapshots: `bool`
             Don't populate version list with snapshot information.
             Can improve performance significantly if there are many snapshots.
@@ -2034,7 +2030,7 @@ class NativeVersionStore:
             log.warning("latest_only has no effect when snapshot is specified")
             NativeVersionStore._warned_about_list_version_latest_only_and_snapshot = True
 
-        result = self.version_store.list_versions(symbol, snapshot, latest_only, iterate_on_failure, skip_snapshots)
+        result = self.version_store.list_versions(symbol, snapshot, latest_only, skip_snapshots)
         return [
             {
                 "symbol": version_result[0],
@@ -2319,7 +2315,7 @@ class NativeVersionStore:
             log.info("Done deleting version: {}".format(str(v_info["version"])))
 
     def has_symbol(
-        self, symbol: str, as_of: Optional[VersionQueryInput] = None, iterate_on_failure: Optional[bool] = False
+        self, symbol: str, as_of: Optional[VersionQueryInput] = None
     ) -> bool:
         """
         Return True if the 'symbol' exists in this library AND the symbol isn't deleted in the specified as_of.
@@ -2331,8 +2327,6 @@ class NativeVersionStore:
             symbol name
         as_of : `Optional[VersionQueryInput]`, default=None
             See documentation of `read` method for more details.
-        iterate_on_failure: `Optional[bool]`, default=False
-            Iterate the type in the storage if the top-level key isn;t present
 
         Returns
         -------
@@ -2341,7 +2335,7 @@ class NativeVersionStore:
         """
 
         return (
-            self._find_version(symbol, as_of=as_of, raise_on_missing=False, iterate_on_failure=iterate_on_failure)
+            self._find_version(symbol, as_of=as_of, raise_on_missing=False)
             is not None
         )
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1566,7 +1566,6 @@ class Library:
             symbol=symbol,
             snapshot=snapshot,
             latest_only=latest_only,
-            iterate_on_failure=False,
             skip_snapshots=skip_snapshots,
         )
         return {


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1384 

#### What does this implement or fix?
The #1384 bug also applies to `as_of=<VERSION_ID>` it is just not seen in the repro because it is not looking for an old enough version.

The bug is that we perform the check on `TOMBSTONE_ALL` only for `LOAD_UNDELETED` and `LOAD_LATEST_UNDELETED`. However `LOAD_DOWNTO` and `LOAD_FROM_TIME` should also only work on undeleted versions when querying with `as_of`.

As discussed we would like to have the ability to both load deleted and undeleted with `LOAD_DOWNTO` and `LOAD_FROM_TIME`. This essentially leaves us with the full cartesian product of possible load types and whether to include deleted or not.

This the majority of this change is to do the refactor to extract the `include_deleted` out of the load type and ensure correctness.

The PR is split in several commits, each one of which should be reviewed separately. The commits have detailed descriptions but in a few words the commits do the following:
- Introduce a failing cpp test to demonstrate #1384 
- Moves entry updates when tombstoning inside `write_tombstone`
- Revamp version map caching logic to simplify the checks and to make less unnecessary cache misses
- Fix cache invalidation when tombstoning
- Refactor the `LoadType` into a `LoadStrategy` which encapsulates the `LoadType`, `include_deleted` and the timestamp or version for `LOAD_DOWNTO` and `LOAD_FROM_TIME`. This fixes the #1384 bug and provides new functionality 
- Small refactor with renames to make the logic inside `follow_version_chain` clearer.
- Decrease the default `unsync_tolerance` because previously we were ~always skipping the cache and deeming it outdated. Also fixes a bug where we don't clear the cache when clearing the storage.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
