### PR TITLE
Bugfix 1209: Consistently return metadata from write, append, update, write_metadata, and batch versions thereof

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -809,6 +809,11 @@ class Library:
         prune_previous_versions
             Removes previous (non-snapshotted) versions from the database when True.
 
+        Returns
+        -------
+        VersionedItem
+            Structure containing metadata and version number of the written symbol in the store.
+
         Examples
         --------
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1342,7 +1342,7 @@ def test_batch_write(basic_store_tombstone_and_sync_passive):
         vitem = lmdb_version_store.read(sym)
         sequential_results[vitem.symbol] = vitem
     lmdb_version_store.batch_write(
-        list(multi_data.keys()), list(multi_data.values()), metadata_vector=(metadata[sym] for sym in multi_data)
+        list(multi_data.keys()), list(multi_data.values()), metadata_vector=list(metadata.values())
     )
     batch_results = lmdb_version_store.batch_read(list(multi_data.keys()))
     assert len(batch_results) == len(sequential_results)
@@ -2115,7 +2115,7 @@ def test_batch_append(basic_store_tombstone, three_col_df):
     metadata = {"sym1": {"key1": "val1"}, "sym2": None, "sym3": None}
 
     lmdb_version_store.batch_write(
-        list(multi_data.keys()), list(multi_data.values()), metadata_vector=(metadata[sym] for sym in multi_data)
+        list(multi_data.keys()), list(multi_data.values()), metadata_vector=list(metadata.values())
     )
 
     multi_append = {"sym1": three_col_df(10), "sym2": three_col_df(11), "sym3": three_col_df(12)}


### PR DESCRIPTION
Fixes #1209