### PR TITLE
maint: Remove use of folly/system/ThreadName.h

### DIFF
--- a/cpp/arcticdb/entity/performance_tracing.cpp
+++ b/cpp/arcticdb/entity/performance_tracing.cpp
@@ -8,9 +8,9 @@
 
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/log/log.hpp>
-#include <folly/system/ThreadName.h>
 #include <arcticdb/util/preprocess.hpp>
 #include <arcticdb/util/pb_util.hpp>
+#include <arcticdb/util/storage_lock.hpp>
 
 std::shared_ptr<RemoteryInstance> RemoteryInstance::instance(){
     std::call_once(RemoteryInstance::init_flag_, &RemoteryInstance::init);
@@ -63,7 +63,7 @@ namespace arcticdb::detail {
         std::unordered_map<const char *, std::string> fqn_by_task_name_;
         std::string thread_name_;
 
-        ThreadNameCache():fqn_by_task_name_(),thread_name_(folly::getCurrentThreadName().value_or("Thread")){}
+        ThreadNameCache():fqn_by_task_name_(),thread_name_(fmt::format("{}", arcticdb::get_thread_id())){}
 
         std::string_view get_thread_name(const char * task_name){
             if(auto fqn_it = fqn_by_task_name_.find(task_name); fqn_it != fqn_by_task_name_.end()){

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -28,9 +28,9 @@
 #include <arcticdb/util/type_handler.hpp>
 #include <arcticdb/python/python_handlers.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
+#include <arcticdb/util/storage_lock.hpp>
 
 #include <pybind11/pybind11.h>
-#include <folly/system/ThreadName.h>
 #include <mongocxx/exception/logic_error.hpp>
 
 #include <logger.pb.h>
@@ -174,7 +174,7 @@ void register_termination_handler() {
             std::rethrow_exception(eptr);
         } catch (const std::exception &e) {
             arcticdb::log::root().error("Terminate called in thread {}: {}\n Aborting",
-                                        folly::getCurrentThreadName().value_or("Unknown"), e.what());
+                                        arcticdb::get_thread_id(), e.what());
             std::abort();
         }
     });


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes one item of the folly replacement plan, issue #1412.

#### What does this implement or fix?

This removes use of `folly/system/ThreadName.h`. It was used in two places to obtain a `std::string` name of a thread, and here is replaced with conversion of unique thread ID to a string using `fmt` via
```c++
fmt::format("{}", arcticdb::get_thread_id())
```

#### Any other comments?

This is used in two places, the first in the termination handler in `python_module.cpp` which I have manually tested. The second use is in the [Remotery](https://github.com/Celtoys/Remotery) which, as far as I can tell, is not tested in CI so I am not sure of the status of the Remotery support.
