### PR TITLE
Bugfix/935/match pandas behviour when aggregating columns with nans

### DIFF
--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -213,7 +213,7 @@ public:
         }
 
         // Used to construct [c]end iterators
-        explicit ColumnDataIterator(ColumnData* parent, typename TDT::DataTypeTag::raw_type* end_ptr):
+        explicit ColumnDataIterator(ColumnData* parent, RawType* end_ptr):
                 parent_(parent) {
             data_.ptr_ = end_ptr;
         }
@@ -304,7 +304,7 @@ public:
         if(!data_->blocks().empty()) {
             auto block = data_->blocks().at(num_blocks() - 1);
             auto typed_block_data = next_typed_block<TDT>(block);
-            end_ptr = typed_block_data.data() + typed_block_data.row_count();
+            end_ptr = const_cast<RawType*>(typed_block_data.data() + typed_block_data.row_count());
         }
         return ColumnDataIterator<TDT, iterator_type, iterator_density, false>(this, end_ptr);
     }

--- a/cpp/arcticdb/processing/aggregation.cpp
+++ b/cpp/arcticdb/processing/aggregation.cpp
@@ -307,7 +307,7 @@ namespace
         SegmentInMemory res;
         if(!aggregated_.empty()) {
             constexpr auto dynamic_schema_data_type = DataType::FLOAT64;
-            using dynamic_schema_tdt = ScalarTagType<DataTypeTag<dynamic_schema_data_type>>;
+            using DynamicSchemaTDT = ScalarTagType<DataTypeTag<dynamic_schema_data_type>>;
             auto col = std::make_shared<Column>(make_scalar_type(dynamic_schema ? dynamic_schema_data_type: data_type_.value()), unique_values, true, false);
             auto column_data = col->data();
             col->set_row_data(unique_values - 1);
@@ -321,7 +321,7 @@ namespace
                     aggregated_.resize(new_size);
                     auto in_ptr = reinterpret_cast<MaybeValueType *>(aggregated_.data());
                     std::fill(in_ptr + prev_size, in_ptr + unique_values, MaybeValueType{});
-                    for (auto it = column_data.begin<dynamic_schema_tdt>(); it != column_data.end<dynamic_schema_tdt>(); ++it, ++in_ptr) {
+                    for (auto it = column_data.begin<DynamicSchemaTDT>(); it != column_data.end<DynamicSchemaTDT>(); ++it, ++in_ptr) {
                         *it = in_ptr->written_ ? static_cast<double>(in_ptr->value_)
                                                : std::numeric_limits<double>::quiet_NaN();
                     }

--- a/cpp/arcticdb/processing/aggregation.cpp
+++ b/cpp/arcticdb/processing/aggregation.cpp
@@ -436,7 +436,7 @@ void CountAggregatorData::aggregate(const std::optional<ColumnWithStrings>& inpu
             using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
             Column::for_each_enumerated<typename col_type_info::TDT>(*input_column->column_, [&groups, this](auto enumerating_it) {
                 if constexpr (is_floating_point_type(col_type_info::data_type)) {
-                    if (!std::isnan(static_cast<double>(enumerating_it.value()))) {
+                    if (ARCTICDB_LIKELY(!std::isnan(enumerating_it.value()))) {
                         auto& val = aggregated_[groups[enumerating_it.idx()]];
                         ++val;
                     }

--- a/cpp/arcticdb/processing/aggregation.cpp
+++ b/cpp/arcticdb/processing/aggregation.cpp
@@ -387,8 +387,15 @@ void MeanAggregatorData::aggregate(const std::optional<ColumnWithStrings>& input
             if constexpr(!is_sequence_type(col_type_info::data_type)) {
                 Column::for_each_enumerated<typename col_type_info::TDT>(*input_column->column_, [&groups, this](auto enumerating_it) {
                     auto& fraction = fractions_[groups[enumerating_it.idx()]];
-                    fraction.numerator_ += double(enumerating_it.value());
-                    ++fraction.denominator_;
+                    if constexpr ((is_floating_point_type(col_type_info ::data_type))) {
+                        if (ARCTICDB_LIKELY(!std::isnan(enumerating_it.value()))) {
+                            fraction.numerator_ += double(enumerating_it.value());
+                            ++fraction.denominator_;
+                        }
+                    } else {
+                        fraction.numerator_ += double(enumerating_it.value());
+                        ++fraction.denominator_;
+                    }
                 });
             } else {
                 util::raise_rte("String aggregations not currently supported");

--- a/cpp/arcticdb/processing/aggregation.cpp
+++ b/cpp/arcticdb/processing/aggregation.cpp
@@ -304,36 +304,30 @@ namespace
     ) {
         SegmentInMemory res;
         if(!aggregated_.empty()) {
-            if(dynamic_schema) {
-                details::visit_type(*data_type_, [&aggregated_, &res, &output_column_name, unique_values] (auto col_tag) {
-                    using RawType = typename decltype(col_tag)::DataTypeTag::raw_type;
-                    using MaybeValueType = MaybeValue<RawType, T>;
+            auto col = std::make_shared<Column>(make_scalar_type(dynamic_schema ? DataType::FLOAT64: data_type_.value()), unique_values, true, false);
+            auto column_data = col->data();
+            col->set_row_data(unique_values - 1);
+            res.add_column(scalar_field(dynamic_schema ? DataType::FLOAT64 : data_type_.value(), output_column_name.value), col);
+            details::visit_type(*data_type_, [&aggregated_, &column_data, unique_values, dynamic_schema] (auto col_tag) {
+                using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
+                using MaybeValueType = MaybeValue<typename col_type_info::RawType, T>;
+                if(dynamic_schema) {
                     auto prev_size = aggregated_.size() / sizeof(MaybeValueType);
                     auto new_size = sizeof(MaybeValueType) * unique_values;
                     aggregated_.resize(new_size);
-                    auto in_ptr =  reinterpret_cast<MaybeValueType*>(aggregated_.data());
+                    auto in_ptr = reinterpret_cast<MaybeValueType *>(aggregated_.data());
                     std::fill(in_ptr + prev_size, in_ptr + unique_values, MaybeValueType{});
-                    auto col = std::make_shared<Column>(make_scalar_type(DataType::FLOAT64), unique_values, true, false);
-                    auto out_ptr = reinterpret_cast<double*>(col->ptr());
-                    for(auto i = 0u; i < unique_values; ++i, ++in_ptr, ++out_ptr) {
-                        *out_ptr = in_ptr->written_ ? static_cast<double>(in_ptr->value_) : std::numeric_limits<double>::quiet_NaN();                }
-
-                    col->set_row_data(unique_values - 1);
-                    res.add_column(scalar_field(DataType::FLOAT64, output_column_name.value), col);
-                });
-            } else {
-                details::visit_type(*data_type_, [&aggregated_, &data_type_, &res, output_column_name, unique_values] (auto col_tag) {
-                    using RawType = typename decltype(col_tag)::DataTypeTag::raw_type;
-                    auto col = std::make_shared<Column>(make_scalar_type(data_type_.value()), unique_values, true, false);
-                    const auto* in_ptr =  reinterpret_cast<const MaybeValue<RawType, T>*>(aggregated_.data());
-                    auto out_ptr = reinterpret_cast<RawType*>(col->ptr());
-                    for(auto i = 0u; i < unique_values; ++i, ++in_ptr, ++out_ptr) {
-                        *out_ptr = in_ptr->value_;
+                    for (auto it = column_data.begin<ScalarTagType<DataTypeTag<DataType::FLOAT64>>>(); it != column_data.end<ScalarTagType<DataTypeTag<DataType::FLOAT64>>>(); ++it, ++in_ptr) {
+                        *it = in_ptr->written_ ? static_cast<double>(in_ptr->value_)
+                                               : std::numeric_limits<double>::quiet_NaN();
                     }
-                    col->set_row_data(unique_values - 1);
-                    res.add_column(scalar_field(data_type_.value(), output_column_name.value), col);
-                });
-            }
+                } else {
+                    auto in_ptr = reinterpret_cast<MaybeValueType*>(aggregated_.data());
+                    for (auto it = column_data.begin<typename col_type_info::TDT>(); it != column_data.end<typename col_type_info::TDT>(); ++it, ++in_ptr) {
+                        *it = in_ptr->value_;
+                    }
+                }
+            });
         }
         return res;
     }
@@ -410,14 +404,13 @@ SegmentInMemory MeanAggregatorData::finalize(const ColumnName& output_column_nam
     SegmentInMemory res;
     if(!fractions_.empty()) {
         fractions_.resize(unique_values);
-        auto pos = res.add_column(scalar_field(DataType::FLOAT64, output_column_name.value), fractions_.size(), true);
-        auto& column = res.column(pos);
-        auto ptr = reinterpret_cast<double*>(column.ptr());
-        column.set_row_data(fractions_.size() - 1);
-
-        for (auto idx = 0u; idx < fractions_.size(); ++idx) {
-            ptr[idx] = fractions_[idx].to_double();
-        }
+        auto col = std::make_shared<Column>(make_scalar_type(DataType::FLOAT64), fractions_.size(), true, false);
+        auto column_data = col->data();
+        std::transform(fractions_.cbegin(), fractions_.cend(), column_data.begin<ScalarTagType<DataTypeTag<DataType::FLOAT64>>>(), [](auto fraction) {
+            return fraction.to_double();
+        });
+        col->set_row_data(fractions_.size() - 1);
+        res.add_column(scalar_field(DataType::FLOAT64, output_column_name.value), col);
     }
     return res;
 }

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -400,103 +400,94 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
             auto partitioning_column = proc.get(ColumnName(grouping_column_));
             if (std::holds_alternative<ColumnWithStrings>(partitioning_column)) {
                 ColumnWithStrings col = std::get<ColumnWithStrings>(partitioning_column);
-                entity::details::visit_type(col.column_->type().data_type(),
-                                            [&proc_=proc, &grouping_map, &next_group_id, &aggregators_data, &string_pool, &col,
-                                             &num_unique, &grouping_data_type, this](auto data_type_tag) {
-                                                using DataTypeTagType = decltype(data_type_tag);
-                                                using RawType = typename DataTypeTagType::raw_type;
-                                                constexpr auto data_type = DataTypeTagType::data_type;
-                                                grouping_data_type = data_type;
-                                                std::vector<size_t> row_to_group;
-                                                row_to_group.reserve(col.column_->row_count());
-                                                auto input_data = col.column_->data();
-                                                auto hash_to_group = grouping_map.get<RawType>();
-                                                // For string grouping columns, keep a local map within this ProcessingUnit
-                                                // from offsets to groups, to avoid needless calls to col.string_at_offset and
-                                                // string_pool->get
-                                                // This could be slower in cases where there aren't many repeats in string
-                                                // grouping columns. Maybe track hit ratio of finds and stop using it if it is
-                                                // too low?
-                                                // Tested with 100,000,000 row dataframe with 100,000 unique values in the grouping column. Timings:
-                                                // 11.14 seconds without caching
-                                                // 11.01 seconds with caching
-                                                // Not worth worrying about right now
-                                                ankerl::unordered_dense::map<RawType, size_t> offset_to_group;
+                details::visit_type(col.column_->type().data_type(),
+                                    [&proc_=proc, &grouping_map, &next_group_id, &aggregators_data, &string_pool, &col,
+                                     &num_unique, &grouping_data_type, this](auto data_type_tag) {
+                                        using col_type_info = ScalarTypeInfo<decltype(data_type_tag)>;
+                                        grouping_data_type = col_type_info::data_type;
+                                        std::vector<size_t> row_to_group;
+                                        row_to_group.reserve(col.column_->row_count());
+                                        auto hash_to_group = grouping_map.get<typename col_type_info::RawType>();
+                                        // For string grouping columns, keep a local map within this ProcessingUnit
+                                        // from offsets to groups, to avoid needless calls to col.string_at_offset and
+                                        // string_pool->get
+                                        // This could be slower in cases where there aren't many repeats in string
+                                        // grouping columns. Maybe track hit ratio of finds and stop using it if it is
+                                        // too low?
+                                        // Tested with 100,000,000 row dataframe with 100,000 unique values in the grouping column. Timings:
+                                        // 11.14 seconds without caching
+                                        // 11.01 seconds with caching
+                                        // Not worth worrying about right now
+                                        ankerl::unordered_dense::map<typename col_type_info::RawType, size_t> offset_to_group;
 
-                                                const bool is_sparse = col.column_->is_sparse();
-                                                using optional_iter_type = std::optional<decltype(input_data.bit_vector()->first())>;
-                                                optional_iter_type iter = std::nullopt;
-                                                size_t previous_value_index = 0;
-                                                constexpr size_t missing_value_group_id = 0;
+                                        const bool is_sparse = col.column_->is_sparse();
+                                        if (is_sparse && next_group_id == 0) {
+                                            // We use 0 for the missing value group id
+                                            ++next_group_id;
+                                        }
+                                        ssize_t previous_value_index = 0;
+                                        constexpr size_t missing_value_group_id = 0;
 
-                                                if (is_sparse)
-                                                {
-                                                    iter = std::make_optional(input_data.bit_vector()->first());
-                                                    // We use 0 for the missing value group id
-                                                    next_group_id++;
-                                                }
-
-                                                while (auto block = input_data.next<ScalarTagType<DataTypeTagType>>()) {
-                                                    const auto row_count = block->row_count();
-                                                    auto ptr = block->data();
-                                                    for (size_t i = 0; i < row_count; ++i, ++ptr) {
-                                                        RawType val;
-                                                        if constexpr(is_sequence_type(data_type)) {
-                                                            auto offset = *ptr;
-                                                            if (auto it = offset_to_group.find(offset); it != offset_to_group.end()) {
-                                                                val = it->second;
+                                        Column::for_each_enumerated<typename col_type_info::TDT>(
+                                                *col.column_,
+                                                [&](auto enumerating_it) {
+                                                    typename col_type_info::RawType val;
+                                                    if constexpr(is_sequence_type(col_type_info::data_type)) {
+                                                        auto offset = enumerating_it.value();
+                                                        if (auto it = offset_to_group.find(offset); it != offset_to_group.end()) {
+                                                            val = it->second;
+                                                        } else {
+                                                            std::optional<std::string_view> str = col.string_at_offset(offset);
+                                                            if (str.has_value()) {
+                                                                val = string_pool->get(*str, true).offset();
                                                             } else {
-                                                                std::optional<std::string_view> str = col.string_at_offset(offset);
-                                                                if (str.has_value()) {
-                                                                    val = string_pool->get(*str, true).offset();
-                                                                } else {
-                                                                    val = offset;
-                                                                }
-                                                                RawType val_copy(val);
-                                                                offset_to_group.insert(std::make_pair<RawType, size_t>(std::forward<RawType>(offset), std::forward<RawType>(val_copy)));
+                                                                val = offset;
                                                             }
-                                                        } else {
-                                                            val = *ptr;
+                                                            typename col_type_info::RawType val_copy(val);
+                                                            offset_to_group.insert(std::make_pair<typename col_type_info::RawType, size_t>(std::forward<typename col_type_info::RawType>(offset), std::forward<typename col_type_info::RawType>(val_copy)));
                                                         }
-                                                        if (is_sparse) {
-                                                            for (size_t j = previous_value_index; j != *(iter.value()); ++j) {
-                                                                row_to_group.emplace_back(missing_value_group_id);
-                                                            }
-                                                            previous_value_index = *(iter.value()) + 1;
-                                                            ++(iter.value());
-                                                        }
+                                                    } else {
+                                                        val = enumerating_it.value();
+                                                    }
 
-                                                        if (auto it = hash_to_group->find(val); it == hash_to_group->end()) {
-                                                            row_to_group.emplace_back(next_group_id);
-                                                            auto group_id = next_group_id++;
-                                                            hash_to_group->insert(std::make_pair<RawType, size_t>(std::forward<RawType>(val), std::forward<RawType>(group_id)));
-                                                        } else {
-                                                            row_to_group.emplace_back(it->second);
+                                                    if (is_sparse) {
+                                                        for (auto j = previous_value_index; j != enumerating_it.idx(); ++j) {
+                                                            row_to_group.emplace_back(missing_value_group_id);
                                                         }
+                                                        previous_value_index = enumerating_it.idx() + 1;
+                                                    }
+
+                                                    if (auto it = hash_to_group->find(val); it == hash_to_group->end()) {
+                                                        row_to_group.emplace_back(next_group_id);
+                                                        auto group_id = next_group_id++;
+                                                        hash_to_group->insert(std::make_pair<typename col_type_info::RawType, size_t>(std::forward<typename col_type_info::RawType>(val), std::forward<typename col_type_info::RawType>(group_id)));
+                                                    } else {
+                                                        row_to_group.emplace_back(it->second);
                                                     }
                                                 }
+                                                );
 
-                                                // Marking all the last non-represented values as missing.
-                                                for (size_t i = row_to_group.size(); i <= size_t(col.column_->last_row()); ++i) {
-                                                    row_to_group.emplace_back(missing_value_group_id);
-                                                }
+                                        // Marking all the last non-represented values as missing.
+                                        for (size_t i = row_to_group.size(); i <= size_t(col.column_->last_row()); ++i) {
+                                            row_to_group.emplace_back(missing_value_group_id);
+                                        }
 
-                                                num_unique = next_group_id;
-                                                util::check(num_unique != 0, "Got zero unique values");
-                                                for (auto agg_data: folly::enumerate(aggregators_data)) {
-                                                    auto input_column_name = aggregators_.at(agg_data.index).get_input_column_name();
-                                                    auto input_column = proc_.get(input_column_name);
-                                                    std::optional<ColumnWithStrings> opt_input_column;
-                                                    if (std::holds_alternative<ColumnWithStrings>(input_column)) {
-                                                        auto column_with_strings = std::get<ColumnWithStrings>(input_column);
-                                                        // Empty columns don't contribute to aggregations
-                                                        if (!is_empty_type(column_with_strings.column_->type().data_type())) {
-                                                            opt_input_column.emplace(std::move(column_with_strings));
-                                                        }
-                                                    }
-                                                    agg_data->aggregate(opt_input_column, row_to_group, num_unique);
+                                        num_unique = next_group_id;
+                                        util::check(num_unique != 0, "Got zero unique values");
+                                        for (auto agg_data: folly::enumerate(aggregators_data)) {
+                                            auto input_column_name = aggregators_.at(agg_data.index).get_input_column_name();
+                                            auto input_column = proc_.get(input_column_name);
+                                            std::optional<ColumnWithStrings> opt_input_column;
+                                            if (std::holds_alternative<ColumnWithStrings>(input_column)) {
+                                                auto column_with_strings = std::get<ColumnWithStrings>(input_column);
+                                                // Empty columns don't contribute to aggregations
+                                                if (!is_empty_type(column_with_strings.column_->type().data_type())) {
+                                                    opt_input_column.emplace(std::move(column_with_strings));
                                                 }
-                                            });
+                                            }
+                                            agg_data->aggregate(opt_input_column, row_to_group, num_unique);
+                                        }
+                                    });
             } else {
                 util::raise_rte("Expected single column from expression");
             }

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -38,8 +38,8 @@ def test_group_on_float_column_with_nans(lmdb_version_store):
 
 # TODO: Add first and last once un-feature flagged
 # TODO: Test v2 encoding as well
-# @pytest.mark.parametrize("aggregator", ("sum", "min", "max", "mean", "ccccc"))
-@pytest.mark.parametrize("aggregator", ("mean",))
+# @pytest.mark.parametrize("aggregator", ("sum", "min", "max", "mean", "count"))
+@pytest.mark.parametrize("aggregator", ("count",))
 def test_aggregate_float_columns_with_nans(lmdb_version_store_v1, aggregator):
     lib = lmdb_version_store_v1
     sym = "test_aggregate_float_columns_with_nans"
@@ -51,6 +51,8 @@ def test_aggregate_float_columns_with_nans(lmdb_version_store_v1, aggregator):
     )
     lib.write(sym, df)
     expected = df.groupby("grouping_column").agg({"agg_column": aggregator})
+    if aggregator == "count":
+        expected = expected.astype(np.uint64)
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"agg_column": aggregator})
     received = lib.read(sym, query_builder=q).data

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -451,28 +451,6 @@ def test_mean_aggregation_float(local_object_version_store):
     assert_frame_equal(res.data, df)
 
 
-def test_mean_aggregation_float_nan(lmdb_version_store):
-    df = DataFrame(
-        {
-            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
-            "to_mean": [1.1, 1.4, 2.5, np.nan, 2.2],
-        },
-        index=np.arange(5),
-    )
-    q = QueryBuilder()
-    q = q.groupby("grouping_column").agg({"to_mean": "mean"})
-    symbol = "test_aggregation"
-    lmdb_version_store.write(symbol, df)
-
-    res = lmdb_version_store.read(symbol, query_builder=q)
-
-    df = pd.DataFrame({"to_mean": [(1.1 + 1.4 + 2.5) / 3, np.nan]}, index=["group_1", "group_2"])
-    df.index.rename("grouping_column", inplace=True)
-    res.data.sort_index(inplace=True)
-
-    assert_frame_equal(res.data, df)
-
-
 def test_max_minus_one(lmdb_version_store):
     symbol = "minus_one"
     lib = lmdb_version_store

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -37,11 +37,9 @@ def test_group_on_float_column_with_nans(lmdb_version_store):
 
 
 # TODO: Add first and last once un-feature flagged
-# TODO: Test v2 encoding as well
-# @pytest.mark.parametrize("aggregator", ("sum", "min", "max", "mean", "count"))
-@pytest.mark.parametrize("aggregator", ("count",))
-def test_aggregate_float_columns_with_nans(lmdb_version_store_v1, aggregator):
-    lib = lmdb_version_store_v1
+@pytest.mark.parametrize("aggregator", ("sum", "min", "max", "mean", "count"))
+def test_aggregate_float_columns_with_nans(lmdb_version_store, aggregator):
+    lib = lmdb_version_store
     sym = "test_aggregate_float_columns_with_nans"
     df = pd.DataFrame(
         {

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -49,6 +49,7 @@ def test_aggregate_float_columns_with_nans(lmdb_version_store, aggregator):
     )
     lib.write(sym, df)
     expected = df.groupby("grouping_column").agg({"agg_column": aggregator})
+    # We count in unsigned integers for obvious reasons
     if aggregator == "count":
         expected = expected.astype(np.uint64)
     q = QueryBuilder()


### PR DESCRIPTION
Fixes #935 

Also addresses two of the bullet points from #1439:

- AggregationClause::process x2
- aggregation.cpp all finalize methods