### PR TITLE
Support generators for metadata vectors again

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -5,7 +5,6 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-import copy
 import datetime
 import os
 import sys
@@ -1242,7 +1241,7 @@ class NativeVersionStore:
         if metadata_vector is None:
             metadata_vector = len(symbols) * [None]
         else:
-            metadata_vector = list(iter(metadata_vector))
+            metadata_vector = list(metadata_vector)
 
         for idx in range(len(symbols)):
             _handle_categorical_columns(symbols[idx], data_vector[idx], False)
@@ -1403,7 +1402,7 @@ class NativeVersionStore:
         if metadata_vector is None:
             metadata_vector = len(symbols) * [None]
         else:
-            metadata_vector = list(iter(metadata_vector))
+            metadata_vector = list(metadata_vector)
 
         for idx in range(len(symbols)):
             _handle_categorical_columns(symbols[idx], data_vector[idx])

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1342,7 +1342,7 @@ def test_batch_write(basic_store_tombstone_and_sync_passive):
         vitem = lmdb_version_store.read(sym)
         sequential_results[vitem.symbol] = vitem
     lmdb_version_store.batch_write(
-        list(multi_data.keys()), list(multi_data.values()), metadata_vector=list(metadata.values())
+        list(multi_data.keys()), list(multi_data.values()), metadata_vector=(metadata[sym] for sym in multi_data)
     )
     batch_results = lmdb_version_store.batch_read(list(multi_data.keys()))
     assert len(batch_results) == len(sequential_results)
@@ -2122,7 +2122,7 @@ def test_batch_append(basic_store_tombstone, three_col_df):
     metadata = {"sym1": {"key1": "val1"}, "sym2": None, "sym3": None}
 
     lmdb_version_store.batch_write(
-        list(multi_data.keys()), list(multi_data.values()), metadata_vector=list(metadata.values())
+        list(multi_data.keys()), list(multi_data.values()), metadata_vector=(metadata[sym] for sym in multi_data)
     )
 
     multi_append = {"sym1": three_col_df(10), "sym2": three_col_df(11), "sym3": three_col_df(12)}


### PR DESCRIPTION
Removed in #1444 but users of the V1 API may be relying on this behaviour