### PR TITLE
Bugfix 1460: preserve nanoseconds and timezones in date range from get info

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2553,7 +2553,6 @@ class NativeVersionStore:
         dit = self.version_store.read_descriptor(symbol, version_query)
         return self.is_pickled_descriptor(dit.timeseries_descriptor)
 
-
     @staticmethod
     def _does_not_have_date_range(desc, min_ts, max_ts):
         if desc.index.kind() != IndexKind.TIMESTAMP:
@@ -2567,7 +2566,7 @@ class NativeVersionStore:
 
         return False
 
-    def _get_time_range_from_ts(self, desc, min_ts, max_ts):
+    def _get_time_range_from_ts(self, desc, min_ts, max_ts, date_range_ns_precision):
         if self._does_not_have_date_range(desc, min_ts, max_ts):
             return datetime64("nat"), datetime64("nat")
         input_type = desc.normalization.WhichOneof("input_type")
@@ -2575,15 +2574,27 @@ class NativeVersionStore:
         if input_type == "df":
             index_metadata = desc.normalization.df.common
             tz = get_timezone_from_metadata(index_metadata)
-        if tz:
-            # If tz is provided, it is stored in UTC - hence needs to be localized to UTC before
-            # converting to the given tz
-            return (
-                _from_tz_timestamp(min_ts, "UTC").astimezone(pytz.timezone(tz)),
-                _from_tz_timestamp(max_ts, "UTC").astimezone(pytz.timezone(tz)),
-            )
+        if date_range_ns_precision:
+            # V2 API expects pandas timestamps with nanosecond precision
+            min_ts_pd = pd.Timestamp(min_ts)
+            max_ts_pd = pd.Timestamp(max_ts)
+            if tz:
+                # If tz is provided, it is stored in UTC - hence needs to be localized to UTC before converting to the
+                # given tz
+                min_ts_pd = min_ts_pd.tz_localize("UTC").tz_convert(tz)
+                max_ts_pd = max_ts_pd.tz_localize("UTC").tz_convert(tz)
+            return min_ts_pd, max_ts_pd
         else:
-            return _from_tz_timestamp(min_ts, None), _from_tz_timestamp(max_ts, None)
+            # V1 API expects datetime.datetime with microsecond precision
+            if tz:
+                # If tz is provided, it is stored in UTC - hence needs to be localized to UTC before converting to the
+                # given tz
+                return (
+                    _from_tz_timestamp(min_ts, "UTC").astimezone(pytz.timezone(tz)),
+                    _from_tz_timestamp(max_ts, "UTC").astimezone(pytz.timezone(tz)),
+                )
+            else:
+                return _from_tz_timestamp(min_ts, None), _from_tz_timestamp(max_ts, None)
 
     def get_timerange_for_symbol(
         self, symbol: str, version: Optional[VersionQueryInput] = None, **kwargs
@@ -2616,7 +2627,8 @@ class NativeVersionStore:
         min_ts, max_ts = min(start_indices), max(end_indices)
         # to get timezone info
         dit = self.version_store.read_descriptor(symbol, version_query)
-        return self._get_time_range_from_ts(dit.timeseries_descriptor, min_ts, max_ts)
+        date_range_ns_precision = False
+        return self._get_time_range_from_ts(dit.timeseries_descriptor, min_ts, max_ts, date_range_ns_precision)
 
     def name(self):
         return self._lib_cfg.lib_desc.name
@@ -2647,7 +2659,13 @@ class NativeVersionStore:
     def open_mode(self):
         return self._open_mode
 
-    def _process_info(self, symbol: str, dit, as_of: Optional[VersionQueryInput] = None) -> Dict[str, Any]:
+    def _process_info(
+            self,
+            symbol: str,
+            dit,
+            as_of: VersionQueryInput,
+            date_range_ns_precision: bool,
+    ) -> Dict[str, Any]:
         timeseries_descriptor = dit.timeseries_descriptor
         columns = [f.name for f in timeseries_descriptor.fields]
         dtypes = [f.type for f in timeseries_descriptor.fields]
@@ -2695,7 +2713,7 @@ class NativeVersionStore:
             if timeseries_descriptor.normalization.df.has_synthetic_columns:
                 columns = pd.RangeIndex(0, len(columns))
 
-        date_range = self._get_time_range_from_ts(timeseries_descriptor, dit.start_index, dit.end_index)
+        date_range = self._get_time_range_from_ts(timeseries_descriptor, dit.start_index, dit.end_index, date_range_ns_precision)
         last_update = datetime64(dit.creation_ts, "ns")
         return {
             "col_names": {"columns": columns, "index": index, "index_dtype": index_dtype},
@@ -2710,7 +2728,12 @@ class NativeVersionStore:
             "sorted": sorted_value_name(timeseries_descriptor.sorted),
         }
 
-    def get_info(self, symbol: str, version: Optional[VersionQueryInput] = None) -> Dict[str, Any]:
+    def get_info(
+            self,
+            symbol: str,
+            version: Optional[VersionQueryInput] = None,
+            **kwargs
+    ) -> Dict[str, Any]:
         """
         Returns descriptive data for `symbol`.
 
@@ -2737,9 +2760,10 @@ class NativeVersionStore:
             - date_range, `tuple`
             - sorted, `str`
         """
+        date_range_ns_precision = kwargs.get("date_range_ns_precision", False)
         version_query = self._get_version_query(version)
         dit = self.version_store.read_descriptor(symbol, version_query)
-        return self._process_info(symbol, dit, version)
+        return self._process_info(symbol, dit, version, date_range_ns_precision)
 
     def batch_get_info(
         self, symbols: List[str], as_ofs: Optional[List[VersionQueryInput]] = None
@@ -2773,9 +2797,10 @@ class NativeVersionStore:
             - sorted, `str`
         """
         throw_on_error = True
-        return self._batch_read_descriptor(symbols, as_ofs, throw_on_error)
+        date_range_ns_precision = False
+        return self._batch_read_descriptor(symbols, as_ofs, throw_on_error, date_range_ns_precision)
 
-    def _batch_read_descriptor(self, symbols, as_ofs, throw_on_error):
+    def _batch_read_descriptor(self, symbols, as_ofs, throw_on_error, date_range_ns_precision):
         as_ofs_lists = []
         if as_ofs == None:
             as_ofs_lists = [None] * len(symbols)
@@ -2795,7 +2820,7 @@ class NativeVersionStore:
             if isinstance(dit, DataError):
                 description_results.append(dit)
             else:
-                description_results.append(self._process_info(symbol, dit, as_of))
+                description_results.append(self._process_info(symbol, dit, as_of, date_range_ns_precision))
         return description_results
 
     def write_metadata(

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -126,8 +126,7 @@ class SymbolDescription(NamedTuple):
     last_update_time : datetime.datetime
         The time of the last update to the symbol, in UTC.
     date_range : Tuple[Union[pandas.Timestamp], Union[pandas.Timestamp]]
-        The value of the index column in the first row of this symbol, and one nanosecond after the value of the index
-        column in the last row of this symbol. Both values will be NaT if:
+        The values of the index column in the first and last row of this symbol. Both values will be NaT if:
         - the symbol is not timestamp indexed
         - the symbol is timestamp indexed, but the sorted field of this class is UNSORTED (see below)
     sorted : str

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -941,7 +941,7 @@ def test_get_description(arctic_library):
     original_info = lib.get_description("symbol", as_of=0)
     # then
     assert [c[0] for c in info.columns] == ["column"]
-    assert info.date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=6, nanosecond=1))
+    assert info.date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=6))
     assert info.index[0] == ["named_index"]
     assert info.index_type == "index"
     assert info.row_count == 6
@@ -966,7 +966,7 @@ def test_get_description_date_range_tz(arctic_library, tz):
     assert isinstance(start_ts, pd.Timestamp)
     assert isinstance(end_ts, pd.Timestamp)
     assert start_ts == index[0]
-    assert end_ts == index[-1] + pd.Timedelta(1, unit="ns")
+    assert end_ts == index[-1]
 
 
 def test_tail(arctic_library):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -941,7 +941,7 @@ def test_get_description(arctic_library):
     original_info = lib.get_description("symbol", as_of=0)
     # then
     assert [c[0] for c in info.columns] == ["column"]
-    assert info.date_range == (datetime(2018, 1, 1, tzinfo=timezone.utc), datetime(2018, 1, 6, tzinfo=timezone.utc))
+    assert info.date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=6, nanosecond=1))
     assert info.index[0] == ["named_index"]
     assert info.index_type == "index"
     assert info.row_count == 6
@@ -950,6 +950,23 @@ def test_get_description(arctic_library):
     assert info.last_update_time.tz == pytz.UTC
     assert original_info.sorted == "ASCENDING"
     assert info.sorted == "ASCENDING"
+
+
+# See test_write_tz in test_normalization.py for the V1 API equivalent
+@pytest.mark.parametrize(
+    "tz", ["UTC", "Europe/Amsterdam"]
+)
+def test_get_description_date_range_tz(arctic_library, tz):
+    lib = arctic_library
+    sym = "test_get_description_date_range_tz"
+    index = index=pd.date_range(pd.Timestamp(0), periods=10, tz=tz)
+    df = pd.DataFrame(data={"col1": np.arange(10)}, index=index)
+    lib.write(sym, df)
+    start_ts, end_ts = lib.get_description(sym).date_range
+    assert isinstance(start_ts, pd.Timestamp)
+    assert isinstance(end_ts, pd.Timestamp)
+    assert start_ts == index[0]
+    assert end_ts == index[-1] + pd.Timedelta(1, unit="ns")
 
 
 def test_tail(arctic_library):

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -978,12 +978,7 @@ def test_get_description_batch_missing_keys(arctic_library):
     assert batch[1].error_category == ErrorCategory.STORAGE
 
     assert not isinstance(batch[2], DataError)
-    assert batch[2].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2018, 1, 1), datetime(2018, 1, 3)),
-        )
-    )
+    assert batch[2].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=3, nanosecond=1))
     assert [c[0] for c in batch[2].columns] == ["a"]
     assert batch[2].index[0] == ["named_index"]
     assert batch[2].index_type == "index"
@@ -1004,12 +999,7 @@ def test_get_description_batch_symbol_doesnt_exist(arctic_library):
 
     # Then
     assert not isinstance(batch[0], DataError)
-    assert batch[0].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
-        )
-    )
+    assert batch[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4, nanosecond=1))
     assert [c[0] for c in batch[0].columns] == ["a"]
     assert batch[0].index[0] == ["named_index"]
     assert batch[0].index_type == "index"
@@ -1041,12 +1031,7 @@ def test_get_description_batch_version_doesnt_exist(arctic_library):
 
     # Then
     assert not isinstance(batch[0], DataError)
-    assert batch[0].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
-        )
-    )
+    assert batch[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4, nanosecond=1))
     assert [c[0] for c in batch[0].columns] == ["a"]
     assert batch[0].index[0] == ["named_index"]
     assert batch[0].index_type == "index"
@@ -1146,43 +1131,13 @@ def test_get_description_batch(arctic_library):
         [ReadInfoRequest("symbol1", as_of=0), ReadInfoRequest("symbol2", as_of=0), ReadInfoRequest("symbol3", as_of=0)]
     )
 
-    assert infos[0].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2018, 1, 1), datetime(2018, 1, 6)),
-        )
-    )
-    assert infos[1].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2019, 1, 1), datetime(2019, 1, 6)),
-        )
-    )
-    assert infos[2].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2020, 1, 1), datetime(2020, 1, 6)),
-        )
-    )
+    assert infos[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=6, nanosecond=1))
+    assert infos[1].date_range == (pd.Timestamp(year=2019, month=1, day=1), pd.Timestamp(year=2019, month=1, day=6, nanosecond=1))
+    assert infos[2].date_range == (pd.Timestamp(year=2020, month=1, day=1), pd.Timestamp(year=2020, month=1, day=6, nanosecond=1))
 
-    assert original_infos[0].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
-        )
-    )
-    assert original_infos[1].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2019, 1, 1), datetime(2019, 1, 4)),
-        )
-    )
-    assert original_infos[2].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2020, 1, 1), datetime(2020, 1, 4)),
-        )
-    )
+    assert original_infos[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4, nanosecond=1))
+    assert original_infos[1].date_range == (pd.Timestamp(year=2019, month=1, day=1), pd.Timestamp(year=2019, month=1, day=4, nanosecond=1))
+    assert original_infos[2].date_range == (pd.Timestamp(year=2020, month=1, day=1), pd.Timestamp(year=2020, month=1, day=4, nanosecond=1))
 
     list_infos = list(zip(infos, original_infos))
     # then
@@ -1236,43 +1191,13 @@ def test_get_description_batch_multiple_versions(arctic_library):
     infos = infos_multiple_version[3:6]
     original_infos = infos_multiple_version[0:3]
 
-    assert infos[0].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2018, 1, 1), datetime(2018, 1, 6)),
-        )
-    )
-    assert infos[1].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2019, 1, 1), datetime(2019, 1, 6)),
-        )
-    )
-    assert infos[2].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2020, 1, 1), datetime(2020, 1, 6)),
-        )
-    )
+    assert infos[0].date_range == (pd.Timestamp("1/1/2018"), pd.Timestamp("1/6/2018") + pd.Timedelta(1, unit="ns"))
+    assert infos[1].date_range == (pd.Timestamp("1/1/2019"), pd.Timestamp("1/6/2019") + pd.Timedelta(1, unit="ns"))
+    assert infos[2].date_range == (pd.Timestamp("1/1/2020"), pd.Timestamp("1/6/2020") + pd.Timedelta(1, unit="ns"))
 
-    assert original_infos[0].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2018, 1, 1), datetime(2018, 1, 4)),
-        )
-    )
-    assert original_infos[1].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2019, 1, 1), datetime(2019, 1, 4)),
-        )
-    )
-    assert original_infos[2].date_range == tuple(
-        map(
-            lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x,
-            (datetime(2020, 1, 1), datetime(2020, 1, 4)),
-        )
-    )
+    assert original_infos[0].date_range == (pd.Timestamp("1/1/2018"), pd.Timestamp("1/4/2018") + pd.Timedelta(1, unit="ns"))
+    assert original_infos[1].date_range == (pd.Timestamp("1/1/2019"), pd.Timestamp("1/4/2019") + pd.Timedelta(1, unit="ns"))
+    assert original_infos[2].date_range == (pd.Timestamp("1/1/2020"), pd.Timestamp("1/4/2020") + pd.Timedelta(1, unit="ns"))
 
     list_infos = list(zip(infos, original_infos))
     # then
@@ -1310,14 +1235,11 @@ def test_read_description_batch_high_amount(arctic_library):
     for sym in range(num_symbols):
         for version in range(num_versions):
             idx = sym * num_versions + version
-            date_ramge_comp = (
-                datetime(start_year + sym, 1, start_day + version),
-                datetime(start_year + sym, 1, start_day + version + 3),
+            date_range_comp = (
+                pd.Timestamp(year=start_year + sym, month=1, day=start_day + version),
+                pd.Timestamp(year=start_year + sym, month=1, day=start_day + version + 3, nanosecond=1),
             )
-            date_range_comp_with_utc = tuple(
-                map(lambda x: x.replace(tzinfo=timezone.utc) if not np.isnat(np.datetime64(x)) else x, date_ramge_comp)
-            )
-            assert results_list[idx].date_range == date_range_comp_with_utc
+            assert results_list[idx].date_range == date_range_comp
             if version > 0:
                 assert results_list[idx].last_update_time > results_list[idx - 1].last_update_time
 

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -978,7 +978,7 @@ def test_get_description_batch_missing_keys(arctic_library):
     assert batch[1].error_category == ErrorCategory.STORAGE
 
     assert not isinstance(batch[2], DataError)
-    assert batch[2].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=3, nanosecond=1))
+    assert batch[2].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=3))
     assert [c[0] for c in batch[2].columns] == ["a"]
     assert batch[2].index[0] == ["named_index"]
     assert batch[2].index_type == "index"
@@ -999,7 +999,7 @@ def test_get_description_batch_symbol_doesnt_exist(arctic_library):
 
     # Then
     assert not isinstance(batch[0], DataError)
-    assert batch[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4, nanosecond=1))
+    assert batch[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4))
     assert [c[0] for c in batch[0].columns] == ["a"]
     assert batch[0].index[0] == ["named_index"]
     assert batch[0].index_type == "index"
@@ -1031,7 +1031,7 @@ def test_get_description_batch_version_doesnt_exist(arctic_library):
 
     # Then
     assert not isinstance(batch[0], DataError)
-    assert batch[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4, nanosecond=1))
+    assert batch[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4))
     assert [c[0] for c in batch[0].columns] == ["a"]
     assert batch[0].index[0] == ["named_index"]
     assert batch[0].index_type == "index"
@@ -1131,13 +1131,13 @@ def test_get_description_batch(arctic_library):
         [ReadInfoRequest("symbol1", as_of=0), ReadInfoRequest("symbol2", as_of=0), ReadInfoRequest("symbol3", as_of=0)]
     )
 
-    assert infos[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=6, nanosecond=1))
-    assert infos[1].date_range == (pd.Timestamp(year=2019, month=1, day=1), pd.Timestamp(year=2019, month=1, day=6, nanosecond=1))
-    assert infos[2].date_range == (pd.Timestamp(year=2020, month=1, day=1), pd.Timestamp(year=2020, month=1, day=6, nanosecond=1))
+    assert infos[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=6))
+    assert infos[1].date_range == (pd.Timestamp(year=2019, month=1, day=1), pd.Timestamp(year=2019, month=1, day=6))
+    assert infos[2].date_range == (pd.Timestamp(year=2020, month=1, day=1), pd.Timestamp(year=2020, month=1, day=6))
 
-    assert original_infos[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4, nanosecond=1))
-    assert original_infos[1].date_range == (pd.Timestamp(year=2019, month=1, day=1), pd.Timestamp(year=2019, month=1, day=4, nanosecond=1))
-    assert original_infos[2].date_range == (pd.Timestamp(year=2020, month=1, day=1), pd.Timestamp(year=2020, month=1, day=4, nanosecond=1))
+    assert original_infos[0].date_range == (pd.Timestamp(year=2018, month=1, day=1), pd.Timestamp(year=2018, month=1, day=4))
+    assert original_infos[1].date_range == (pd.Timestamp(year=2019, month=1, day=1), pd.Timestamp(year=2019, month=1, day=4))
+    assert original_infos[2].date_range == (pd.Timestamp(year=2020, month=1, day=1), pd.Timestamp(year=2020, month=1, day=4))
 
     list_infos = list(zip(infos, original_infos))
     # then
@@ -1191,13 +1191,13 @@ def test_get_description_batch_multiple_versions(arctic_library):
     infos = infos_multiple_version[3:6]
     original_infos = infos_multiple_version[0:3]
 
-    assert infos[0].date_range == (pd.Timestamp("1/1/2018"), pd.Timestamp("1/6/2018") + pd.Timedelta(1, unit="ns"))
-    assert infos[1].date_range == (pd.Timestamp("1/1/2019"), pd.Timestamp("1/6/2019") + pd.Timedelta(1, unit="ns"))
-    assert infos[2].date_range == (pd.Timestamp("1/1/2020"), pd.Timestamp("1/6/2020") + pd.Timedelta(1, unit="ns"))
+    assert infos[0].date_range == (pd.Timestamp("1/1/2018"), pd.Timestamp("1/6/2018"))
+    assert infos[1].date_range == (pd.Timestamp("1/1/2019"), pd.Timestamp("1/6/2019"))
+    assert infos[2].date_range == (pd.Timestamp("1/1/2020"), pd.Timestamp("1/6/2020"))
 
-    assert original_infos[0].date_range == (pd.Timestamp("1/1/2018"), pd.Timestamp("1/4/2018") + pd.Timedelta(1, unit="ns"))
-    assert original_infos[1].date_range == (pd.Timestamp("1/1/2019"), pd.Timestamp("1/4/2019") + pd.Timedelta(1, unit="ns"))
-    assert original_infos[2].date_range == (pd.Timestamp("1/1/2020"), pd.Timestamp("1/4/2020") + pd.Timedelta(1, unit="ns"))
+    assert original_infos[0].date_range == (pd.Timestamp("1/1/2018"), pd.Timestamp("1/4/2018"))
+    assert original_infos[1].date_range == (pd.Timestamp("1/1/2019"), pd.Timestamp("1/4/2019"))
+    assert original_infos[2].date_range == (pd.Timestamp("1/1/2020"), pd.Timestamp("1/4/2020"))
 
     list_infos = list(zip(infos, original_infos))
     # then
@@ -1237,7 +1237,7 @@ def test_read_description_batch_high_amount(arctic_library):
             idx = sym * num_versions + version
             date_range_comp = (
                 pd.Timestamp(year=start_year + sym, month=1, day=start_day + version),
-                pd.Timestamp(year=start_year + sym, month=1, day=start_day + version + 3, nanosecond=1),
+                pd.Timestamp(year=start_year + sym, month=1, day=start_day + version + 3),
             )
             assert results_list[idx].date_range == date_range_comp
             if version > 0:

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -6,6 +6,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 import datetime
+import sys
 from collections import namedtuple
 from unittest.mock import patch
 import numpy as np
@@ -127,17 +128,27 @@ def test_empty_df():
     assert_frame_equal(d, D)
 
 
+# See test_get_description_date_range_tz in test_arctic.py for the V2 API equivalent
 @pytest.mark.parametrize(
     "tz", ["UTC", "Europe/Amsterdam", pytz.UTC, pytz.timezone("Europe/Amsterdam"), du.tz.gettz("UTC")]
 )
 def test_write_tz(lmdb_version_store, sym, tz):
     assert tz is not None
-    df = pd.DataFrame(data={"col1": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10, tz=tz))
+    index = index=pd.date_range(pd.Timestamp(0), periods=10, tz=tz)
+    df = pd.DataFrame(data={"col1": np.arange(10)}, index=index)
     lmdb_version_store.write(sym, df)
     result = lmdb_version_store.read(sym).data
     assert_frame_equal(df, result)
     df_tz = df.index.tzinfo
     assert str(df_tz) == str(tz)
+    if tz == du.tz.gettz("UTC") and sys.version_info < (3, 7):
+        pytest.skip("Timezone files don't seem to have ever worked properly on Python 3.6")
+    start_ts, end_ts = lmdb_version_store.get_timerange_for_symbol(sym)
+    assert isinstance(start_ts, datetime.datetime)
+    assert isinstance(end_ts, datetime.datetime)
+    assert start_ts == index[0]
+    # datetime.datetime is microsecond precision, so don't need a +1ns in this assertion
+    assert end_ts == index[-1]
 
 
 def get_multiindex_df_with_tz(tz):

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -147,7 +147,6 @@ def test_write_tz(lmdb_version_store, sym, tz):
     assert isinstance(start_ts, datetime.datetime)
     assert isinstance(end_ts, datetime.datetime)
     assert start_ts == index[0]
-    # datetime.datetime is microsecond precision, so don't need a +1ns in this assertion
     assert end_ts == index[-1]
 
 


### PR DESCRIPTION
**THIS IS AN API CHANGE, AND SHOULD NOT BE MERGED UNTIL WE WANT TO BUMP THE MAJOR VERSION NUMBER FOR A MORE IMPORTANT FEATURE**
Fixes #1460 
Previously the `date_range` returned by `get_info[_batch]` was a `datetime.datetime`, which only has microsecond precision.
Now returns a `pandas.Timestamp` with nanosecond precision.
Also keeps the timezone information which was previously discarded for unknown reasons.