### PR TITLE
LZ4 decoding empty type: move the segment buffer forward by the compressed data size for empty types

### DIFF
--- a/cpp/arcticdb/codec/codec-inl.hpp
+++ b/cpp/arcticdb/codec/codec-inl.hpp
@@ -91,6 +91,7 @@ std::size_t decode_ndarray(
             util::check(type_desc_tag.data_type() == DataType::EMPTYVAL,
                 "NDArray of type {} should not be of size 0!",
                 datatype_to_str(type_desc_tag.data_type()));
+            read_bytes = encoding_sizes::data_compressed_size(field);
             return;
         }
 


### PR DESCRIPTION
#### Reference Issues/PRs
There is a compatibility issue with columns containing empty types written in 4.0.x or earlier.
For version 4.0.x, the buffer was remaining behind the correct position which was causing an lz4 decoding error.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>
