### PR TITLE
Guard against numpy v2 to prevent breakage when it gets released

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     # conda-forge's package and feedstock browser.
     #
     # See: https://conda-forge.org/feedstock-outputs/
-    numpy
+    numpy <2 # To guard against numpy v2 when it gets released https://pythonspeed.com/articles/numpy-2/
     pandas
     attrs
     dataclasses ; python_version < '3.7'


### PR DESCRIPTION
We set `numpy <2` to prevent breakage when numpy v2 gets released. For context see [here](https://pythonspeed.com/articles/numpy-2/).

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
