### PR TITLE
Fix SYMBOL_LIST Segment index out of bounds bug

### DIFF
--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -564,6 +564,7 @@ std::optional<std::string_view> SegmentInMemoryImpl::string_at(position_t row, p
     const auto& col_ref = column(col);
 
     if(is_fixed_string_type(td.data_type()) && col_ref.is_inflated()) {
+
         auto string_size = col_ref.bytes() / row_count();
         auto ptr = col_ref.data().buffer().ptr_cast<char>(row * string_size, string_size);
         return std::string_view(ptr, string_size);

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -128,17 +128,35 @@ MaybeCompaction last_compaction(const std::vector<AtomKey>& keys) {
     }
 }
 
+// The below string_at and scalar_at functions should be used for symbol list cache segments instead of the ones
+// provided in SegmentInMemory, because the symbol list structure is the only place where columns can have more entries
+// than the segment has rows. Hence, we need to bypass the checks inside SegmentInMemory's function and directly call the
+// Column's string_at and scalar_at.
+std::string string_at(const SegmentInMemory& seg, position_t row, position_t col){
+    auto offset = seg.column(col).scalar_at<position_t>(row);
+    util::check(offset.has_value(), "Symbol list trying to call string_at for missing row {}, column {}", row, col);
+    return std::string(seg.string_pool_ptr()->get_view(offset.value()));
+}
+
+template<typename T>
+T scalar_at(const SegmentInMemory& seg, position_t row, position_t col){
+    auto scalar = seg.column(col).scalar_at<T>(row);
+    util::check(scalar.has_value(), "Symbol list trying to call scalar_at for missing row {}, column {}", row, col);
+    return scalar.value();
+}
+
+
 StreamId stream_id_from_segment(
         DataType data_type,
         const SegmentInMemory& seg,
         position_t row_id,
         position_t column) {
     if (data_type == DataType::UINT64) {
-            auto num_id = seg.scalar_at<uint64_t>(row_id, column).value();
+            auto num_id = scalar_at<uint64_t>(seg, row_id, column);
             ARCTICDB_DEBUG(log::symbol(), "Reading numeric symbol {}", num_id);
             return safe_convert_to_numeric_id(num_id);
     } else {
-        auto sym = std::string(seg.string_at(row_id, column).value());
+        auto sym = string_at(seg, row_id, column);
         ARCTICDB_DEBUG(log::symbol(), "Reading string symbol '{}'", sym);
         return {std::move(sym)};
     }
@@ -183,8 +201,8 @@ std::vector<SymbolListEntry> read_new_style_list_from_storage(const SegmentInMem
 
     for(auto i = 0L; i < seg.column(0).row_count(); ++i) {
         auto stream_id = stream_id_from_segment(data_type, seg, i, 0);
-        auto reference_id = VersionId{seg.scalar_at<uint64_t>(i, 1).value()};
-        auto reference_time = timestamp{seg.scalar_at<int64_t>(i, 2).value()};
+        auto reference_id = VersionId{scalar_at<uint64_t>(seg, i, 1)};
+        auto reference_time = timestamp{scalar_at<int64_t>(seg, i, 2)};
         ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Reading added symbol {}: {}@{}", stream_id, reference_id, reference_time);
         output.emplace_back(stream_id, reference_id, reference_time, ActionType::ADD);
     }
@@ -195,8 +213,8 @@ std::vector<SymbolListEntry> read_new_style_list_from_storage(const SegmentInMem
 
         for (auto i = 0L; i < seg.column(3).row_count(); ++i) {
             auto stream_id = stream_id_from_segment(data_type, seg, i, 3);
-            auto reference_id = VersionId{seg.scalar_at<uint64_t>(i, 4).value()};
-            auto reference_time = timestamp{seg.scalar_at<int64_t>(i, 5).value()};
+            auto reference_id = VersionId{scalar_at<uint64_t>(seg, i, 4)};
+            auto reference_time = timestamp{scalar_at<int64_t>(seg, i, 5)};
             ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Reading deleted symbol {}: {}@{}", stream_id, reference_id, reference_time);
             output.emplace_back(stream_id, reference_id, reference_time, ActionType::DELETE);
         }


### PR DESCRIPTION
The check `row < row_count()` in `string_at` was problematic for symbol list entries because they have the exception that it is possible for a column to have more rows than segment rows.

That exception is because of the nature of the symbol list refactor in 4.2.0 which needed to remain backwards compatible with old readers.

This change bypasses the check for symbol list entries and directly
calls string_at or scalar_at of the Column.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
