### PR TITLE
Restore mistake in #1315

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -202,30 +202,29 @@ void do_remove_impl(Composite<VariantKey>&& ks,
         static const size_t delete_object_limit =
             std::min(BATCH_SUBREQUEST_LIMIT, static_cast<size_t>(ConfigsMap::instance()->get_int("AzureStorage.DeleteBatchSize", BATCH_SUBREQUEST_LIMIT)));
 
-        unsigned int batch_counter = 0u;
-        auto submit_batch = [&azure_client, &request_timeout, &batch_counter](auto &to_delete) {
+        auto submit_batch = [&azure_client, &request_timeout](auto &to_delete) {
             try {
                 azure_client.delete_blobs(to_delete, request_timeout);
             }
             catch (const Azure::Core::RequestFailedException& e) {
                 raise_azure_exception(e);
             }
-            batch_counter = 0u;
+            to_delete.clear();
         };
 
         (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach(
-            [&root_folder, b=std::move(bucketizer), delete_object_limit=delete_object_limit, &batch_counter, &to_delete, &submit_batch] (auto&& group) {//bypass incorrect 'set but no used" error for delete_object_limit
+            [&root_folder, b=std::move(bucketizer), delete_object_limit=delete_object_limit, &to_delete, &submit_batch] (auto&& group) {//bypass incorrect 'set but no used" error for delete_object_limit
                 auto key_type_dir = key_type_folder(root_folder, group.key());
                 for (auto k : folly::enumerate(group.values())) {
                     auto blob_name = object_path(b.bucketize(key_type_dir, *k), *k);
                     to_delete.emplace_back(std::move(blob_name));
-                    if (++batch_counter == delete_object_limit) {
+                    if (to_delete.size() == delete_object_limit) {
                         submit_batch(to_delete);
                     }
                 }
             }
         );
-        if (batch_counter) {
+        if (!to_delete.empty()) {
             submit_batch(to_delete);
         }
 }

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -440,6 +440,15 @@ def test_write_batch_missing_keys_dedup(library_factory):
     assert_frame_equal(read_dataframe.data, df2)
 
 
+def test_delete_batch(library_factory, sym):
+    lib = library_factory(LibraryOptions(rows_per_segment=2))
+    df = pd.DataFrame({"y": np.arange(1000)})
+    lib.write(sym, df)
+    lib.delete(sym)
+    lib_tool = lib._nvs.library_tool()
+    assert not lib_tool.find_keys_for_id(KeyType.TABLE_DATA, sym)
+
+
 def test_append_batch(library_factory):
     lib = library_factory(LibraryOptions(rows_per_segment=10))
     assert lib._nvs._lib_cfg.lib_desc.version.write_options.segment_row_size == 10


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/man-group/ArcticDB/pull/1315/files#r1557428013
Batch delete container is needed to be manually cleared after each batch run.
The operation has been incorrectly removed in https://github.com/man-group/ArcticDB/pull/1315

#### What does this implement or fix?
Restore batch delete container clearing operation

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
