### PR TITLE
fix: added __str__ with hidden account key to AzureLibraryAdapter

### DIFF
--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -62,7 +62,8 @@ class AzureLibraryAdapter(ArcticLibraryAdapter):
         super().__init__(uri, self._encoding_version)
 
     def __repr__(self):
-        return "azure(endpoint=%s, container=%s)" % (self._endpoint, self._container)
+        censored_endpoint = re.sub(r"AccountKey=.+?;", "AccountKey=...;", self._endpoint)
+        return "azure(endpoint=%s, container=%s)" % (censored_endpoint, self._container)
 
     @property
     def config_library(self):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -304,6 +304,12 @@ def test_delete_date_range(arctic_library):
     assert lib["symbol"].version == 1
 
 
+def test_azure_repr_body_censored(arctic_library):
+    ac_library_repr = repr(arctic_library)
+    if "AccountKey=" in ac_library_repr:
+        assert "AccountKey=..." in ac_library_repr.split(";")
+
+
 def _test_mongo_repr_body(mongo_storage: MongoDatabase):
     # The arctic_uri has the PrefixingLibraryAdapterDecorator logic in it, so use mongo_uri
     ac = Arctic(f"{mongo_storage.mongo_uri}/?maxPoolSize=10")


### PR DESCRIPTION
Hide sensitive data in AzureLibraryAdapter

#### Reference Issues/PRs
* #753

#### What does this implement or fix?
It adds \_\_str\_\_ method. \_\_str\_\_ () will take priority over \_\_repr\_\_ and will thus hide the sensitive information.
#### Any other comments?
I just removed the actual key from the string. If you want something more human readable that achieves the same goal, I can update the output.
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
