### PR TITLE
[maint] Remove CMake which is not used

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -113,15 +113,6 @@
       "inherits": ["common_vcpkg", "linux"]
     },
     {
-      "name": "linux-debug-clang",
-      "inherits": ["common_vcpkg", "linux"],
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++",
-        "STATIC_LINK_STD_LIB": "OFF"
-      }
-    },
-    {
       "name": "linux-conda-debug",
       "inherits":  ["common_conda", "linux"]
     },
@@ -155,7 +146,6 @@
     {"name": "windows-cl-conda-debug",    "configurePreset": "windows-cl-conda-debug",    "targets": "arcticdb_ext" },
     {"name": "windows-cl-conda-release",  "configurePreset": "windows-cl-conda-release",  "targets": "arcticdb_ext" },
     {"name": "linux-debug",               "configurePreset": "linux-debug",               "targets": "arcticdb_ext" },
-    {"name": "linux-debug-clang",         "configurePreset": "linux-debug-clang",         "targets": "arcticdb_ext" },
     {"name": "linux-release",             "configurePreset": "linux-release",             "targets": "arcticdb_ext" },
     {"name": "linux-conda-debug",         "configurePreset": "linux-conda-debug",         "targets": "arcticdb_ext" },
     {"name": "linux-conda-release",       "configurePreset": "linux-conda-release",       "targets": "arcticdb_ext" },


### PR DESCRIPTION
Remove CMake clang preset as it's not used by CI and it's better to hande it via CMakeUserPresets

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
