### PR TITLE
maint: Revert #1496

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -73,13 +73,6 @@ jobs:
         with:
           submodules: recursive # Just in case a dep has its own third-party deps
 
-      # See: https://github.com/actions/runner-images/issues/9680#issuecomment-2051917949
-      - name: HOTFIX Setup CMake 3.29.2
-        if: matrix.os == 'windows'
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.29.2'
-
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.3
         with:


### PR DESCRIPTION
#### Reference Issues/PRs
This reverts commit 74f993285492f25875297aa9c09ebf6ea60d3f90 after [the publication of a new image containing CMake 3.29.2](https://github.com/actions/runner-images/releases/tag/win22/20240414.1).