### PR TITLE
bugfix/1336: on s3 and azure add delimiter in iterate_type when prefix is empty to avoid KeyType::LOG_COMPACTED when KeyType::LOG is queried

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -229,32 +229,33 @@ void do_remove_impl(Composite<VariantKey>&& ks,
         }
 }
 
-auto default_prefix_handler() {
-    return [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
-        return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
-    };
+std::string prefix_handler(const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
+    return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
 }
 
-template<class KeyBucketizer, class PrefixHandler>
+template<class KeyBucketizer>
 void do_iterate_type_impl(KeyType key_type,
     const IterateTypeVisitor& visitor,
     const std::string& root_folder,
     AzureClientWrapper& azure_client,
     KeyBucketizer&& bucketizer,
-    PrefixHandler&& prefix_handler = default_prefix_handler(),
     const std::string& prefix = std::string{}) {
         ARCTICDB_SAMPLE(AzureStorageIterateType, 0)
         auto key_type_dir = key_type_folder(root_folder, key_type);
+        const auto path_to_key_size = key_type_dir.size() + 1 + bucketizer.bucketize_length(key_type);
+        // if prefix is empty, add / to avoid matching both log and logc when key_type_dir is {root_folder}/log
+        if (prefix.empty()) {
+            key_type_dir += "/";
+        }
 
         KeyDescriptor key_descriptor(prefix,
             is_ref_key_class(key_type) ? IndexDescriptor::UNKNOWN : IndexDescriptor::TIMESTAMP, FormatType::TOKENIZED);
         auto key_prefix = prefix_handler(prefix, key_type_dir, key_descriptor, key_type);
-        const auto root_folder_size = key_type_dir.size() + 1 + bucketizer.bucketize_length(key_type);
 
         try {
             for (auto page = azure_client.list_blobs(key_prefix); page.HasPage(); page.MoveToNextPage()) {
                 for (const auto& blob : page.Blobs) {
-                    auto key = blob.Name.substr(root_folder_size);
+                    auto key = blob.Name.substr(path_to_key_size);
                     ARCTICDB_TRACE(log::version(), "Got object_list: {}, key: {}", blob.Name, key);
                     auto k = variant_key_from_bytes(
                                 reinterpret_cast<uint8_t*>(key.data()),
@@ -316,11 +317,7 @@ void AzureStorage::do_remove(Composite<VariantKey>&& ks, RemoveOpts) {
 }
 
 void AzureStorage::do_iterate_type(KeyType key_type, const IterateTypeVisitor& visitor, const std::string &prefix) {
-    auto prefix_handler = [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor key_descriptor, KeyType) {
-        return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
-    };
-
-    detail::do_iterate_type_impl(key_type, visitor, root_folder_, *azure_client_, FlatBucketizer{}, std::move(prefix_handler), prefix);
+    detail::do_iterate_type_impl(key_type, visitor, root_folder_, *azure_client_, FlatBucketizer{}, prefix);
 }
 
 bool AzureStorage::do_key_exists(const VariantKey& key) {

--- a/cpp/arcticdb/storage/test/common.hpp
+++ b/cpp/arcticdb/storage/test/common.hpp
@@ -14,9 +14,9 @@
 
 namespace arcticdb::storage {
 
-inline VariantKey get_test_key(std::string name) {
+inline VariantKey get_test_key(std::string name, entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
     auto builder = arcticdb::atom_key_builder();
-    return builder.build<arcticdb::entity::KeyType::TABLE_DATA>(name);
+    return builder.build(name, key_type);
 }
 
 inline Segment get_test_segment() {
@@ -25,44 +25,55 @@ inline Segment get_test_segment() {
     return encode_dispatch(std::move(segment_in_memory), codec_opts, arcticdb::EncodingVersion::V2);
 }
 
-inline void write_in_store(Storage &store, std::string symbol) {
-    auto variant_key = get_test_key(symbol);
+inline void write_in_store(Storage &store, std::string symbol, entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
+    auto variant_key = get_test_key(symbol, key_type);
     store.write(KeySegmentPair(std::move(variant_key), get_test_segment()));
 }
 
-inline void update_in_store(Storage &store, std::string symbol) {
-    auto variant_key = get_test_key(symbol);
+inline void update_in_store(Storage &store, std::string symbol, entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
+    auto variant_key = get_test_key(symbol, key_type);
     store.update(KeySegmentPair(std::move(variant_key), get_test_segment()), arcticdb::storage::UpdateOpts{});
 }
 
-inline bool exists_in_store(Storage &store, std::string symbol) {
-    auto variant_key = get_test_key(symbol);
+inline bool exists_in_store(Storage &store, std::string symbol, entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
+    auto variant_key = get_test_key(symbol, key_type);
     return store.key_exists(variant_key);
 }
 
-inline std::string read_in_store(Storage &store, std::string symbol) {
-    auto variant_key = get_test_key(symbol);
+inline std::string read_in_store(Storage &store, std::string symbol, entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
+    auto variant_key = get_test_key(symbol, key_type);
     auto opts = ReadKeyOpts{};
     auto result = store.read(std::move(variant_key), opts);
     return std::get<StringId>(result.atom_key().id());
 }
 
-inline void remove_in_store(Storage &store, std::vector<std::string> symbols) {
+inline void remove_in_store(Storage &store, std::vector<std::string> symbols, entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
     auto to_remove = std::vector<VariantKey>();
     for (auto &symbol: symbols) {
-        to_remove.emplace_back(get_test_key(symbol));
+        to_remove.emplace_back(get_test_key(symbol, key_type));
     }
     auto opts = RemoveOpts();
     store.remove(Composite(std::move(to_remove)), opts);
 }
 
-inline std::set<std::string> list_in_store(Storage &store) {
+inline std::set<std::string> list_in_store(Storage &store, entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
     auto keys = std::set<std::string>();
-    store.iterate_type(KeyType::TABLE_DATA, [&keys](VariantKey &&key) {
+    store.iterate_type(key_type, [&keys](VariantKey &&key) {
         auto atom_key = std::get<AtomKey>(key);
         keys.emplace(std::get<StringId>(atom_key.id()));
     });
     return keys;
+}
+
+inline std::set<std::string> populate_store(Storage &store, std::string_view symbol_prefix, int start, int end,
+                                            entity::KeyType key_type = entity::KeyType::TABLE_DATA) {
+    auto symbols = std::set<std::string>();
+    for (int i = start; i < end; ++i) {
+        auto symbol = fmt::format("{}_{}", symbol_prefix, i);
+        write_in_store(store, symbol, key_type);
+        symbols.emplace(symbol);
+    }
+    return symbols;
 }
 
 }

--- a/cpp/arcticdb/storage/test/test_azure_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_azure_storage.cpp
@@ -74,3 +74,13 @@ TEST_F(AzureMockStorageFixture, test_list) {
 
     ASSERT_EQ(list_in_store(store), symbols);
 }
+
+TEST_F(AzureMockStorageFixture, test_matching_key_type_prefix_list) {
+    auto log_symbols = populate_store(store, "symbol_log", 0, 5, entity::KeyType::LOG);
+    ASSERT_EQ(list_in_store(store, entity::KeyType::LOG), log_symbols);
+
+    auto log_compacted_symbols = populate_store(store, "symbol_logc", 0, 5, entity::KeyType::LOG_COMPACTED);
+    ASSERT_EQ(list_in_store(store, entity::KeyType::LOG_COMPACTED), log_compacted_symbols);
+
+    ASSERT_EQ(list_in_store(store, entity::KeyType::LOG), log_symbols);
+}

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -289,3 +289,13 @@ TEST_F(S3StorageFixture, test_list) {
 
     ASSERT_THROW(list_in_store(store), UnexpectedS3ErrorException);
 }
+
+TEST_F(S3StorageFixture, test_matching_key_type_prefix_list) {
+    auto log_symbols = populate_store(store, "symbol_log", 0, 5, entity::KeyType::LOG);
+    ASSERT_EQ(list_in_store(store, entity::KeyType::LOG), log_symbols);
+
+    auto log_compacted_symbols = populate_store(store, "symbol_logc", 0, 5, entity::KeyType::LOG_COMPACTED);
+    ASSERT_EQ(list_in_store(store, entity::KeyType::LOG_COMPACTED), log_compacted_symbols);
+
+    ASSERT_EQ(list_in_store(store, entity::KeyType::LOG), log_symbols);
+}


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1336 
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
