### PR TITLE
Bugfix/1509/disallow appending different rangeindexes in dynamic schema

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -461,6 +461,7 @@ set(arcticdb_srcs
         storage/storage_factory.cpp
         stream/aggregator.cpp
         stream/append_map.cpp
+        stream/index.cpp
         stream/piloted_clock.cpp
         toolbox/library_tool.cpp
         util/allocator.cpp

--- a/cpp/arcticdb/entity/merge_descriptors.cpp
+++ b/cpp/arcticdb/entity/merge_descriptors.cpp
@@ -46,8 +46,13 @@ StreamDescriptor merge_descriptors(
     // Merge all the fields for all slices, apart from the index which we already have from the first descriptor.
     // Note that we preserve the ordering as we see columns, especially the index which needs to be column 0.
     for (const auto &fields : entries) {
-        if(has_index)
-            util::variant_match(index, [&fields] (const auto& idx) { idx.check(*fields); });
+        if (has_index) {
+            util::variant_match(index,
+                [](const EmptyIndex&) {},
+                [](const RowCountIndex&) {},
+                [&fields] (const auto& idx) { idx.check(*fields); }
+            );
+        }
 
         for (size_t idx = has_index ? 1u : 0u; idx < static_cast<size_t>(fields->size()); ++idx) {
             const auto& field = fields->at(idx);

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -22,7 +22,6 @@ struct StreamDescriptor {
 
     std::shared_ptr<Proto> data_ = std::make_shared<Proto>();
     std::shared_ptr<FieldCollection> fields_ = std::make_shared<FieldCollection>();
-    ;
 
     StreamDescriptor() = default;
     ~StreamDescriptor() = default;
@@ -65,7 +64,7 @@ struct StreamDescriptor {
         data_->set_sorted(sorted_value_to_proto(sorted));
     }
 
-    SortedValue get_sorted() {
+    SortedValue get_sorted() const {
         return sorted_value_from_proto(data_->sorted());
     }
 

--- a/cpp/arcticdb/entity/types_proto.cpp
+++ b/cpp/arcticdb/entity/types_proto.cpp
@@ -123,4 +123,69 @@ namespace arcticdb::entity {
             }, id);
     }
 
+    IndexDescriptor::IndexDescriptor(size_t field_count, Type type) {
+        data_.set_kind(type);
+        data_.set_field_count(static_cast<uint32_t>(field_count));
+    }
+
+    IndexDescriptor::IndexDescriptor(arcticdb::proto::descriptors::IndexDescriptor data)
+        : data_(std::move(data)) {
+    }
+
+    bool IndexDescriptor::uninitialized() const {
+        return data_.field_count() == 0 && data_.kind() == Type::IndexDescriptor_Type_UNKNOWN;
+    }
+
+    const IndexDescriptor::Proto& IndexDescriptor::proto() const {
+        return data_;
+    }
+
+    size_t IndexDescriptor::field_count() const {
+        return static_cast<size_t>(data_.field_count());
+    }
+
+    IndexDescriptor::Type IndexDescriptor::type() const {
+        return data_.kind();
+    }
+
+    void IndexDescriptor::set_type(Type type) {
+        data_.set_kind(type);
+    }
+
+    bool operator==(const IndexDescriptor& left, const IndexDescriptor& right) {
+        return left.type() == right.type();
+    }
+
+    IndexDescriptor::TypeChar to_type_char(IndexDescriptor::Type type) {
+        switch (type) {
+        case IndexDescriptor::EMPTY: return 'E';
+        case IndexDescriptor::TIMESTAMP: return 'T';
+        case IndexDescriptor::ROWCOUNT: return 'R';
+        case IndexDescriptor::STRING: return 'S';
+        case IndexDescriptor::UNKNOWN: return 'U';
+        default: util::raise_rte("Unknown index type: {}", int(type));
+        }
+    }
+
+    IndexDescriptor::Type from_type_char(IndexDescriptor::TypeChar type) {
+        switch (type) {
+        case 'E': return IndexDescriptor::EMPTY;
+        case 'T': return IndexDescriptor::TIMESTAMP;
+        case 'R': return IndexDescriptor::ROWCOUNT;
+        case 'S': return IndexDescriptor::STRING;
+        case 'U': return IndexDescriptor::UNKNOWN;
+        default: util::raise_rte("Unknown index type: {}", int(type));
+        }
+    }
+
+    const char* index_type_to_str(IndexDescriptor::Type type) {
+        switch (type) {
+        case IndexDescriptor::EMPTY: return "Empty";
+        case IndexDescriptor::TIMESTAMP: return "Timestamp";
+        case IndexDescriptor::ROWCOUNT: return "Row count";
+        case IndexDescriptor::STRING: return "String";
+        case IndexDescriptor::UNKNOWN: return "Unknown";
+        default: util::raise_rte("Unknown index type: {}", int(type));
+        }
+    }
 } // namespace arcticdb

--- a/cpp/arcticdb/entity/types_proto.hpp
+++ b/cpp/arcticdb/entity/types_proto.hpp
@@ -49,69 +49,29 @@ namespace arcticdb::entity {
         Proto data_;
         using Type = arcticdb::proto::descriptors::IndexDescriptor::Type;
 
-        static const Type UNKNOWN = arcticdb::proto::descriptors::IndexDescriptor_Type_UNKNOWN;
-        static const Type ROWCOUNT = arcticdb::proto::descriptors::IndexDescriptor_Type_ROWCOUNT;
-        static const Type STRING = arcticdb::proto::descriptors::IndexDescriptor_Type_STRING;
-        static const Type TIMESTAMP = arcticdb::proto::descriptors::IndexDescriptor_Type_TIMESTAMP;
+        static constexpr Type UNKNOWN = arcticdb::proto::descriptors::IndexDescriptor_Type_UNKNOWN;
+        static constexpr Type EMPTY = arcticdb::proto::descriptors::IndexDescriptor_Type_EMPTY;
+        static constexpr Type ROWCOUNT = arcticdb::proto::descriptors::IndexDescriptor_Type_ROWCOUNT;
+        static constexpr Type STRING = arcticdb::proto::descriptors::IndexDescriptor_Type_STRING;
+        static constexpr Type TIMESTAMP = arcticdb::proto::descriptors::IndexDescriptor_Type_TIMESTAMP;
 
         using TypeChar = char;
 
         IndexDescriptor() = default;
-        IndexDescriptor(size_t field_count, Type type) {
-            data_.set_kind(type);
-            data_.set_field_count(static_cast<uint32_t>(field_count));
-        }
-
-        explicit IndexDescriptor(arcticdb::proto::descriptors::IndexDescriptor data)
-            : data_(std::move(data)) {
-        }
-
-        bool uninitialized() const {
-            return data_.field_count() == 0 && data_.kind() == Type::IndexDescriptor_Type_UNKNOWN;
-        }
-
-        const Proto& proto() const {
-            return data_;
-        }
-
-        size_t field_count() const {
-            return static_cast<size_t>(data_.field_count());
-        }
-
-        Type type() const {
-            return data_.kind();
-        }
-
-        void set_type(Type type) {
-            data_.set_kind(type);
-        }
-
         ARCTICDB_MOVE_COPY_DEFAULT(IndexDescriptor)
-
-        friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right) {
-            return left.type() == right.type();
-        }
+        IndexDescriptor(size_t field_count, Type type);
+        explicit IndexDescriptor(arcticdb::proto::descriptors::IndexDescriptor data);
+        bool uninitialized() const;
+        const Proto& proto() const;
+        size_t field_count() const;
+        Type type() const;
+        void set_type(Type type);
+        friend bool operator==(const IndexDescriptor& left, const IndexDescriptor& right);
     };
 
-    constexpr IndexDescriptor::TypeChar to_type_char(IndexDescriptor::Type type) {
-        switch (type) {
-        case IndexDescriptor::TIMESTAMP:return 'T';
-        case IndexDescriptor::ROWCOUNT:return 'R';
-        case IndexDescriptor::STRING:return 'S';
-        case IndexDescriptor::UNKNOWN:return 'U';
-        default:util::raise_rte("Unknown index type: {}", int(type));
-        }
-    }
-
-    constexpr IndexDescriptor::Type from_type_char(IndexDescriptor::TypeChar type) {
-        switch (type) {
-        case 'T': return IndexDescriptor::TIMESTAMP;
-        case 'R': return IndexDescriptor::ROWCOUNT;
-        case 'S': return IndexDescriptor::STRING;
-        case 'U': return IndexDescriptor::UNKNOWN;
-        default:util::raise_rte("Unknown index type: {}", int(type));
-        }
-    }
+    IndexDescriptor::TypeChar to_type_char(IndexDescriptor::Type type);
+    IndexDescriptor::Type from_type_char(IndexDescriptor::TypeChar type);
+    const char* index_type_to_str(IndexDescriptor::Type type);
 
     void set_id(arcticdb::proto::descriptors::StreamDescriptor& pb_desc, StreamId id);
 

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -148,8 +148,8 @@ std::pair<size_t, size_t> offset_and_row_count(const std::shared_ptr<pipelines::
     return std::make_pair(offset, row_count);
 }
 
-bool index_is_not_timeseries_or_is_sorted_ascending(const std::shared_ptr<pipelines::InputTensorFrame>& frame) {
-    return !std::holds_alternative<stream::TimeseriesIndex>(frame->index) || frame->desc.get_sorted() == SortedValue::ASCENDING;
+bool index_is_not_timeseries_or_is_sorted_ascending(const pipelines::InputTensorFrame& frame) {
+    return !std::holds_alternative<stream::TimeseriesIndex>(frame.index) || frame.desc.get_sorted() == SortedValue::ASCENDING;
 }
 
 }

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -311,6 +311,6 @@ size_t get_slice_rowcounts(
 std::pair<size_t, size_t> offset_and_row_count(
     const std::shared_ptr<pipelines::PipelineContext>& context);
 
-bool index_is_not_timeseries_or_is_sorted_ascending(const std::shared_ptr<pipelines::InputTensorFrame>& frame);
+bool index_is_not_timeseries_or_is_sorted_ascending(const pipelines::InputTensorFrame& frame);
 
 } //namespace arcticdb

--- a/cpp/arcticdb/pipeline/index_writer.hpp
+++ b/cpp/arcticdb/pipeline/index_writer.hpp
@@ -17,7 +17,7 @@
 
 namespace arcticdb::pipelines::index {
 // TODO: change the name - something like KeysSegmentWriter or KeyAggragator or  better
-template<class Index, std::enable_if_t<InputTensorFrame::is_valid_index_v<Index>, bool> = 0>
+template<ValidIndex Index>
 class IndexWriter {
     // All index segments are row-count indexed in the sense that the keys are
     // already ordered - they don't need an additional index

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -18,14 +18,20 @@ namespace arcticdb::pipelines {
 
 using namespace arcticdb::entity;
 
+/// @TODO Move to a separate "util" header
+template <typename T, typename... U>
+concept is_any_of = (std::same_as<T, U> || ...);
+
+template <typename IndexT>
+concept ValidIndex = is_any_of<
+    std::remove_cvref_t<std::remove_pointer_t<std::decay_t<IndexT>>>,
+    stream::TimeseriesIndex,
+    stream::RowCountIndex,
+    stream::TableIndex,
+    stream::EmptyIndex>;
+
+
 struct InputTensorFrame {
-
-    template<class T>
-    static constexpr bool is_valid_index_v =
-        std::is_same_v<T, stream::TimeseriesIndex> ||
-        std::is_same_v<T, stream::RowCountIndex> ||
-        std::is_same_v<T, stream::TableIndex>;
-
     InputTensorFrame() :
         index(stream::empty_index()) {}
 

--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -122,17 +122,15 @@ void update_rowcount_normalization_data(
             );
 
             size_t new_start = new_index->start();
-            if (new_start != 0) {
-                auto stop = old_index->start() + old_length * old_index->step();
-                normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
-                    new_start == stop,
-                    "The appending data has a RangeIndex.start={} that is not contiguous with the {}"
-                    "stop ({}) of",
-                    error_suffix,
-                    new_start,
-                    stop
-                );
-            }
+            auto stop = old_index->start() + old_length * old_index->step();
+            normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
+                new_start == stop,
+                "The appending data has a RangeIndex.start={} that is not contiguous with the {}"
+                "stop ({}) of",
+                error_suffix,
+                new_start,
+                stop
+            );
 
             new_pandas->get().mutable_index()->set_start(old_index->start());
         }

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -264,17 +264,16 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
 
     // idx_names are passed by the python layer. They are empty in case row count index is used see:
     // https://github.com/man-group/ArcticDB/blob/4184a467d9eee90600ddcbf34d896c763e76f78f/python/arcticdb/version_store/_normalization.py#L291
-    // Currently the python layers assign RowRange index to both empty dataframes and dataframes wich do not specify
+    // Currently the python layers assign RowRange index to both empty dataframes and dataframes which do not specify
     // index explicitly. Thus we handle this case after all columns are read so that we know how many rows are there.
     if (idx_names.empty()) {
-        if (!empty_types || res->num_rows > 0) {
-            res->index = stream::RowCountIndex();
-            res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
-        } else {
-            res->index = stream::EmptyIndex();
-            res->desc.set_index_type(IndexDescriptor::EMPTY);
-        }
+        res->index = stream::RowCountIndex();
+        res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
+    }
 
+    if (empty_types && res->num_rows == 0) {
+        res->index = stream::EmptyIndex();
+        res->desc.set_index_type(IndexDescriptor::EMPTY);
     }
 
     ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res->desc);

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -16,15 +16,15 @@
 #include <pybind11/numpy.h>
 
 namespace arcticdb::convert {
-const char none_char[8] = {'\300', '\000', '\000', '\000', '\000', '\000', '\000', '\000'};
+constexpr const char none_char[8] = {'\300', '\000', '\000', '\000', '\000', '\000', '\000', '\000'};
 
 using namespace arcticdb::pipelines;
 
-bool is_unicode(PyObject *obj) {
+[[nodiscard]] static inline bool is_unicode(PyObject *obj) {
     return PyUnicode_Check(obj);
 }
 
-bool is_py_boolean(PyObject* obj) {
+[[nodiscard]] static inline bool is_py_boolean(PyObject* obj) {
     return PyBool_Check(obj);
 }
 
@@ -47,7 +47,7 @@ std::variant<StringEncodingError, PyStringWrapper> pystring_to_buffer(PyObject *
     return api.PyArray_Check_(obj);
 }
 
-std::tuple<ValueType, uint8_t, ssize_t> determine_python_object_type(PyObject* obj) {
+[[nodiscard]] static std::tuple<ValueType, uint8_t, ssize_t> determine_python_object_type(PyObject* obj) {
     if (is_py_boolean(obj)) {
         normalization::raise<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>("Nullable booleans are not supported at the moment");
         return {ValueType::BOOL_OBJECT, 1, 1};
@@ -62,7 +62,7 @@ std::tuple<ValueType, uint8_t, ssize_t> determine_python_object_type(PyObject* o
 /// @todo We will iterate over all arrays in a column in aggregator_set_data anyways, so this is redundant, however
 ///     the type is determined at the point when obj_to_tensor is called. We need to make it possible to change the
 ///     the column type in aggregator_set_data in order not to iterate all arrays twice.
-std::tuple<ValueType, uint8_t, ssize_t> determine_python_array_type(PyObject** begin, PyObject** end) {
+[[nodiscard]] static std::tuple<ValueType, uint8_t, ssize_t> determine_python_array_type(PyObject** begin, PyObject** end) {
         auto none = py::none{};
         while(begin != end) {
         if(none.ptr() == *begin) {
@@ -221,10 +221,7 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
                 "Number idx names {} and values {} do not match",
                 idx_names.size(), idx_vals.size());
 
-    if (idx_names.empty()) {
-        res->index = stream::RowCountIndex();
-        res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
-    } else {
+    if (!idx_names.empty()) {
         util::check(idx_names.size() == 1, "Multi-indexed dataframes not handled");
         auto index_tensor = obj_to_tensor(idx_vals[0].ptr(), empty_types);
         util::check(index_tensor.ndim() == 1, "Multi-dimensional indexes not handled");
@@ -232,10 +229,7 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
         std::string index_column_name = !idx_names.empty() ? idx_names[0] : "index";
         res->num_rows = index_tensor.shape(0);
         // TODO handle string indexes
-        // Empty type check is added to preserve the current behavior which is that 0-rowed dataframes
-        // are assigned datetime index. This will be changed in further PR creating empty typed index.
-        if (index_tensor.data_type() == DataType::NANOSECONDS_UTC64 || is_empty_type(index_tensor.data_type())) {
-
+        if (index_tensor.data_type() == DataType::NANOSECONDS_UTC64) {
             res->desc.set_index_field_count(1);
             res->desc.set_index_type(IndexDescriptor::TIMESTAMP);
 
@@ -266,6 +260,21 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
             res->desc.add_field(FieldRef{TypeDescriptor{tensor.data_type(), Dimension::Dim1}, col_names[i]});
         }
         res->field_tensors.push_back(std::move(tensor));
+    }
+
+    // idx_names are passed by the python layer. They are empty in case row count index is used see:
+    // https://github.com/man-group/ArcticDB/blob/4184a467d9eee90600ddcbf34d896c763e76f78f/python/arcticdb/version_store/_normalization.py#L291
+    // Currently the python layers assign RowRange index to both empty dataframes and dataframes wich do not specify
+    // index explicitly. Thus we handle this case after all columns are read so that we know how many rows are there.
+    if (idx_names.empty()) {
+        if (res->num_rows > 0) {
+            res->index = stream::RowCountIndex();
+            res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
+        } else {
+            res->index = stream::EmptyIndex();
+            res->desc.set_index_type(IndexDescriptor::EMPTY);
+        }
+
     }
 
     ARCTICDB_DEBUG(log::version(), "Received frame with descriptor {}", res->desc);

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -116,7 +116,7 @@ NativeTensor obj_to_tensor(PyObject *ptr, bool empty_types) {
     const auto arr = pybind11::detail::array_proxy(ptr);
     const auto descr = pybind11::detail::array_descriptor_proxy(arr->descr);
     auto ndim = arr->nd;
-    ssize_t size = ndim == 1 ? arr->dimensions[0] : arr->dimensions[0] * arr->dimensions[1];
+    const ssize_t size = ndim == 1 ? arr->dimensions[0] : arr->dimensions[0] * arr->dimensions[1];
     // In Pandas < 2, empty series dtype is `"float"`, but as of Pandas 2.0, empty series dtype is `"object"`
     // The Normalizer in Python cast empty `"float"` series to `"object"` so `EMPTY` is used here.
     // See: https://github.com/man-group/ArcticDB/pull/1049

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -267,7 +267,7 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
     // Currently the python layers assign RowRange index to both empty dataframes and dataframes wich do not specify
     // index explicitly. Thus we handle this case after all columns are read so that we know how many rows are there.
     if (idx_names.empty()) {
-        if (res->num_rows > 0) {
+        if (!empty_types || res->num_rows > 0) {
             res->index = stream::RowCountIndex();
             res->desc.set_index_type(IndexDescriptor::ROWCOUNT);
         } else {

--- a/cpp/arcticdb/storage/single_file_storage.hpp
+++ b/cpp/arcticdb/storage/single_file_storage.hpp
@@ -63,7 +63,7 @@ struct formatter<arcticdb::storage::KeyData> {
 
     template<typename FormatContext>
     auto format(const arcticdb::storage::KeyData &k, FormatContext &ctx) const {
-        return format_to(ctx.out(), "{}:{}", k.key_offset_, k.key_size_);
+        return fmt::format_to(ctx.out(), "{}:{}", k.key_offset_, k.key_size_);
     }
 };
 

--- a/cpp/arcticdb/stream/aggregator.hpp
+++ b/cpp/arcticdb/stream/aggregator.hpp
@@ -170,7 +170,9 @@ class Aggregator {
         // size then you get default buffer sizes.
         segment_(desc.value_or(schema_policy_.default_descriptor()), row_count.value_or(segmenting_policy_.expected_row_size()), false, SparsePolicy::allow_sparse) {
             segment_.init_column_map();
-            index().check(segment_.descriptor().fields());
+            if constexpr (!(std::is_same_v<Index, EmptyIndex> || std::is_same_v<Index, RowCountIndex>)) {
+                index().check(segment_.descriptor().fields());
+            }
     };
 
     virtual ~Aggregator() = default;

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -214,7 +214,7 @@ folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(
     std::optional<AtomKey>&& next_key)  {
     using namespace arcticdb::pipelines;
 
-    if (!index_is_not_timeseries_or_is_sorted_ascending(frame)) {
+    if (!index_is_not_timeseries_or_is_sorted_ascending(*frame)) {
         sorting::raise<ErrorCode::E_UNSORTED_DATA>("When writing/appending staged data in parallel, input data must be sorted.");
     }
 

--- a/cpp/arcticdb/stream/index.cpp
+++ b/cpp/arcticdb/stream/index.cpp
@@ -1,0 +1,252 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/stream/index.hpp>
+#include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/pipeline/index_fields.hpp>
+#include <arcticdb/entity/type_utils.hpp>
+
+
+namespace arcticdb::stream {
+
+IndexDescriptor::Type get_index_value_type(const AtomKey& key) {
+        return std::holds_alternative<timestamp>(key.start_index()) ? IndexDescriptor::TIMESTAMP
+                                                                    : IndexDescriptor::STRING;
+    }
+
+template <typename Derived>
+    StreamDescriptor BaseIndex<Derived>::create_stream_descriptor(
+    StreamId stream_id,
+    std::initializer_list<FieldRef> fields
+) const {
+    std::vector<FieldRef> fds{fields};
+    return create_stream_descriptor(stream_id, folly::range(fds));
+}
+
+template <typename Derived> const Derived* BaseIndex<Derived>::derived() const {
+    return static_cast<const Derived*>(this);
+}
+
+template <typename Derived> BaseIndex<Derived>::operator IndexDescriptor() const {
+    return {Derived::field_count(), Derived::type()};
+}
+
+template <typename Derived> FieldRef BaseIndex<Derived>::field(size_t) const {
+    return {static_cast<TypeDescriptor>(typename Derived::TypeDescTag{}), std::string_view(derived()->name())};
+}
+
+TimeseriesIndex::TimeseriesIndex(const std::string& name) : name_(name) {}
+
+TimeseriesIndex TimeseriesIndex::default_index() {
+    return TimeseriesIndex(DefaultName);
+}
+
+void TimeseriesIndex::check(const FieldCollection& fields) const {
+    const size_t fields_size = fields.size();
+    constexpr int current_fields_size = int(field_count());
+
+    const TypeDescriptor& first_field_type = fields[0].type();
+    const TypeDescriptor& current_first_field_type = this->field(0).type();
+
+    const bool valid_type_promotion = has_valid_type_promotion(first_field_type, current_first_field_type).has_value();
+    const bool trivial_type_compatibility = trivially_compatible_types(first_field_type, current_first_field_type);
+
+    const bool compatible_types = valid_type_promotion || trivial_type_compatibility;
+
+    util::check_arg(
+        fields_size >= current_fields_size,
+        "expected at least {} fields, actual {}",
+        current_fields_size,
+        fields_size
+    );
+    util::check_arg(compatible_types, "expected field[0]={}, actual {}", this->field(0), fields[0]);
+}
+
+IndexValue TimeseriesIndex::start_value_for_segment(const SegmentInMemory& segment) {
+    if (segment.row_count() == 0)
+        return {NumericIndex{0}};
+    auto first_ts = segment.template scalar_at<timestamp>(0, 0).value();
+    return {first_ts};
+}
+
+IndexValue TimeseriesIndex::end_value_for_segment(const SegmentInMemory& segment) {
+    auto row_count = segment.row_count();
+    if (row_count == 0)
+        return {NumericIndex{0}};
+    auto last_ts = segment.template scalar_at<timestamp>(row_count - 1, 0).value();
+    return {last_ts};
+}
+
+IndexValue TimeseriesIndex::start_value_for_keys_segment(const SegmentInMemory& segment) {
+    if (segment.row_count() == 0)
+        return {NumericIndex{0}};
+    auto start_index_id = int(pipelines::index::Fields::start_index);
+    auto first_ts = segment.template scalar_at<timestamp>(0, start_index_id).value();
+    return {first_ts};
+}
+
+IndexValue TimeseriesIndex::end_value_for_keys_segment(const SegmentInMemory& segment) {
+    auto row_count = segment.row_count();
+    if (row_count == 0)
+        return {NumericIndex{0}};
+    auto end_index_id = int(pipelines::index::Fields::end_index);
+    auto last_ts = segment.template scalar_at<timestamp>(row_count - 1, end_index_id).value();
+    return {last_ts};
+}
+
+const char* TimeseriesIndex::name() const {
+    return name_.c_str();
+}
+
+TimeseriesIndex TimeseriesIndex::make_from_descriptor(const StreamDescriptor& desc) {
+    if (desc.field_count() > 0)
+        return TimeseriesIndex(std::string(desc.fields(0).name()));
+
+    return TimeseriesIndex(DefaultName);
+}
+
+
+TableIndex::TableIndex(const std::string& name) : name_(name) {
+}
+
+TableIndex TableIndex::default_index() {
+    return TableIndex(DefaultName);
+}
+
+void TableIndex::check(const FieldCollection& fields) const {
+    util::check_arg(
+        fields.size() >= int(field_count()),
+        "expected at least {} fields, actual {}",
+        field_count(),
+        fields.size()
+    );
+
+    util::check(fields.ref_at(0) == field(0), "Field descriptor mismatch {} != {}", fields.ref_at(0), field(0));
+}
+
+IndexValue TableIndex::start_value_for_segment(const SegmentInMemory& segment) {
+    auto string_index = segment.string_at(0, 0).value();
+    return {std::string{string_index}};
+}
+
+IndexValue TableIndex::end_value_for_segment(const SegmentInMemory& segment) {
+    auto last_rowid = segment.row_count() - 1;
+    auto string_index = segment.string_at(last_rowid, 0).value();
+    return {std::string{string_index}};
+}
+
+IndexValue TableIndex::start_value_for_keys_segment(const SegmentInMemory& segment) {
+    if (segment.row_count() == 0)
+        return {NumericIndex{0}};
+    auto start_index_id = int(pipelines::index::Fields::start_index);
+    auto string_index = segment.string_at(0, start_index_id).value();
+    return {std::string{string_index}};
+}
+
+IndexValue TableIndex::end_value_for_keys_segment(const SegmentInMemory& segment) {
+    auto row_count = segment.row_count();
+    if (row_count == 0)
+        return {NumericIndex{0}};
+    auto end_index_id = int(pipelines::index::Fields::end_index);
+    auto string_index = segment.string_at(row_count - 1, end_index_id).value();
+    return {std::string{string_index}};
+}
+
+TableIndex TableIndex::make_from_descriptor(const StreamDescriptor& desc) {
+    if (desc.field_count() > 0)
+        return TableIndex(std::string(desc.field(0).name()));
+
+    return TableIndex(DefaultName);
+}
+
+const char* TableIndex::name() const {
+    return name_.c_str();
+}
+
+RowCountIndex RowCountIndex::default_index() {
+    return RowCountIndex{};
+}
+
+
+IndexValue RowCountIndex::start_value_for_segment(const SegmentInMemory& segment) {
+    return static_cast<timestamp>(segment.offset());
+}
+
+IndexValue RowCountIndex::end_value_for_segment(const SegmentInMemory& segment) {
+    return static_cast<timestamp>(segment.offset() + (segment.row_count() - 1));
+}
+
+IndexValue RowCountIndex::start_value_for_keys_segment(const SegmentInMemory& segment) {
+    return static_cast<timestamp>(segment.offset());
+}
+
+IndexValue RowCountIndex::end_value_for_keys_segment(const SegmentInMemory& segment) {
+    return static_cast<timestamp>(segment.offset() + (segment.row_count() - 1));
+}
+
+RowCountIndex RowCountIndex::make_from_descriptor(const StreamDescriptor&) const {
+    return RowCountIndex::default_index();
+}
+
+IndexValue EmptyIndex::start_value_for_segment(const SegmentInMemory& segment) {
+    return static_cast<NumericIndex>(segment.offset());
+}
+
+IndexValue EmptyIndex::end_value_for_segment(const SegmentInMemory& segment) {
+    return static_cast<NumericIndex>(segment.offset());
+}
+
+IndexValue EmptyIndex::start_value_for_keys_segment(const SegmentInMemory& segment) {
+    return static_cast<NumericIndex>(segment.offset());
+}
+
+IndexValue EmptyIndex::end_value_for_keys_segment(const SegmentInMemory& segment) {
+    return static_cast<NumericIndex>(segment.offset());
+}
+
+Index index_type_from_descriptor(const StreamDescriptor& desc) {
+    switch (desc.index().proto().kind()) {
+    case IndexDescriptor::EMPTY: return EmptyIndex{};
+    case IndexDescriptor::TIMESTAMP: return TimeseriesIndex::make_from_descriptor(desc);
+    case IndexDescriptor::STRING: return TableIndex::make_from_descriptor(desc);
+    case IndexDescriptor::ROWCOUNT: return RowCountIndex{};
+    default:
+        util::raise_rte(
+            "Data obtained from storage refers to an index type that this build of ArcticDB doesn't understand ({}).",
+            int(desc.index().proto().kind())
+        );
+    }
+}
+
+Index default_index_type_from_descriptor(const IndexDescriptor::Proto& desc) {
+    switch (desc.kind()) {
+    case IndexDescriptor::EMPTY: return EmptyIndex{};
+    case IndexDescriptor::TIMESTAMP: return TimeseriesIndex::default_index();
+    case IndexDescriptor::STRING: return TableIndex::default_index();
+    case IndexDescriptor::ROWCOUNT: return RowCountIndex::default_index();
+    default: util::raise_rte("Unknown index type {} trying to generate index type", int(desc.kind()));
+    }
+}
+
+Index default_index_type_from_descriptor(const IndexDescriptor& desc) {
+    return default_index_type_from_descriptor(desc.proto());
+}
+
+IndexDescriptor get_descriptor_from_index(const Index& index) {
+    return util::variant_match(index, [](const auto& idx) { return static_cast<IndexDescriptor>(idx); });
+}
+
+Index empty_index() {
+    return RowCountIndex::default_index();
+}
+
+template class BaseIndex<TimeseriesIndex>;
+template class BaseIndex<TableIndex>;
+template class BaseIndex<RowCountIndex>;
+template class BaseIndex<EmptyIndex>;
+}

--- a/cpp/arcticdb/stream/index.hpp
+++ b/cpp/arcticdb/stream/index.hpp
@@ -9,65 +9,38 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/clock.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/index_range.hpp>
-#include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/entity/stream_descriptor.hpp>
-#include <arcticdb/entity/type_utils.hpp>
-#include <arcticdb/column_store/memory_segment.hpp>
 
-#include <folly/Range.h>
+
+namespace arcticdb {
+    class SegmentInMemory;
+}
 
 namespace arcticdb::stream {
 
 using namespace arcticdb::entity;
 
-inline IndexDescriptor::Type get_index_value_type(const AtomKey &key) {
-    return std::holds_alternative<timestamp>(key.start_index()) ? IndexDescriptor::TIMESTAMP : IndexDescriptor::STRING;
-}
+IndexDescriptor::Type get_index_value_type(const AtomKey& key);
 
-template<typename Derived>
+template <typename Derived>
 class BaseIndex {
-  public:
-    template<class RangeType>
-    StreamDescriptor create_stream_descriptor(StreamId stream_id, RangeType&& fields) const {
+public:
+    template <class RangeType> StreamDescriptor create_stream_descriptor(StreamId stream_id, RangeType&& fields) const {
         return stream_descriptor(stream_id, *derived(), std::move(fields));
     }
 
-    [[nodiscard]] StreamDescriptor create_stream_descriptor(
-                                              StreamId stream_id,
-                                              std::initializer_list<FieldRef> fields) const {
-        std::vector<FieldRef> fds{fields};
-        return create_stream_descriptor(stream_id, folly::range(fds));
-
-    }
-
-    [[nodiscard]] const Derived* derived() const {
-        return static_cast<const Derived*>(this);
-    }
-
-    explicit operator IndexDescriptor() const {
-        return {Derived::field_count(), Derived::type()};
-    }
-
-    [[nodiscard]] FieldRef field(size_t) const {
-        return {static_cast<TypeDescriptor>(typename Derived::TypeDescTag{}), std::string_view(derived()->name())};
-    }
+    [[nodiscard]] StreamDescriptor create_stream_descriptor(StreamId stream_id, std::initializer_list<FieldRef> fields) const;
+    [[nodiscard]] const Derived* derived() const;
+    explicit operator IndexDescriptor() const;
+    [[nodiscard]] FieldRef field(size_t) const;
 };
 
 //TODO make this into just a numeric index, of which timestamp is a special case
 class TimeseriesIndex : public BaseIndex<TimeseriesIndex> {
 public:
     static constexpr const char* DefaultName = "time" ;
-
-    explicit TimeseriesIndex(const std::string& name) :
-        name_(name) {
-    }
-
-    static TimeseriesIndex default_index() {
-        return TimeseriesIndex(DefaultName);
-    }
 
     using TypeDescTag = TypeDescriptorTag<
         DataTypeTag<DataType::NANOSECONDS_UTC64>,
@@ -80,63 +53,19 @@ public:
     static constexpr IndexDescriptor::Type type() {
         return IndexDescriptor::TIMESTAMP;
     }
+    TimeseriesIndex(const std::string& name);
+    static TimeseriesIndex default_index();
+    void check(const FieldCollection& fields) const;
+    static IndexValue start_value_for_segment(const SegmentInMemory& segment);
+    static IndexValue end_value_for_segment(const SegmentInMemory& segment);
+    static IndexValue start_value_for_keys_segment(const SegmentInMemory& segment);
+    static IndexValue end_value_for_keys_segment(const SegmentInMemory& segment);
 
-    void check(const FieldCollection &fields) const {
-        const size_t fields_size = fields.size();
-        constexpr int current_fields_size = int(field_count());
+    [[nodiscard]] const char* name() const;
+    static TimeseriesIndex make_from_descriptor(const StreamDescriptor& desc);
 
-        const TypeDescriptor &first_field_type = fields[0].type();
-        const TypeDescriptor &current_first_field_type = this->field(0).type();
-
-        const bool valid_type_promotion = has_valid_type_promotion(first_field_type, current_first_field_type).has_value();
-        const bool trivial_type_compatibility = trivially_compatible_types(first_field_type, current_first_field_type);
-
-        const bool compatible_types = valid_type_promotion || trivial_type_compatibility;
-
-        util::check_arg(fields_size >= current_fields_size, "expected at least {} fields, actual {}",
-                        current_fields_size, fields_size);
-        util::check_arg(compatible_types, "expected field[0]={}, actual {}",
-                        this->field(0), fields[0]);
-    }
-
-    template<typename SegmentType>
-    static IndexValue start_value_for_segment(const SegmentType &segment) {
-        if (segment.row_count() == 0)
-            return { NumericIndex{0} };
-        auto first_ts = segment.template scalar_at<timestamp>(0, 0).value();
-        return {first_ts};
-    }
-
-    template<typename SegmentType>
-    static IndexValue end_value_for_segment(const SegmentType &segment) {
-        auto row_count = segment.row_count();
-        if (row_count == 0)
-            return { NumericIndex{0} };
-        auto last_ts = segment.template scalar_at<timestamp>(row_count - 1, 0).value();
-        return {last_ts};
-    }
-
-    template<typename SegmentType>
-    static IndexValue start_value_for_keys_segment(const SegmentType &segment) {
-        if (segment.row_count() == 0)
-            return { NumericIndex{0} };
-        auto start_index_id = int(pipelines::index::Fields::start_index);
-        auto first_ts = segment.template scalar_at<timestamp>(0, start_index_id).value();
-        return {first_ts};
-    }
-
-    template<typename SegmentType>
-    static IndexValue end_value_for_keys_segment(const SegmentType &segment) {
-        auto row_count = segment.row_count();
-        if (row_count == 0)
-            return { NumericIndex{0} };
-        auto end_index_id = int(pipelines::index::Fields::end_index);
-        auto last_ts = segment.template scalar_at<timestamp>(row_count - 1, end_index_id).value();
-        return {last_ts};
-    }
-
-    template<class RowCellSetter>
-    void set(RowCellSetter setter, const IndexValue &index_value) {
+    template <class RowCellSetter>
+    void set(RowCellSetter setter, const IndexValue& index_value) {
         if (std::holds_alternative<timestamp>(index_value)) {
             auto ts = std::get<timestamp>(index_value);
             util::check_arg(ts >= ts_, "timestamp decreasing, current val={}, candidate={}", ts_, ts);
@@ -144,15 +73,6 @@ public:
             setter(0, ts);
         } else
             util::raise_rte("Cannot set this type, expecting timestamp");
-    }
-
-    [[nodiscard]] const char *name() const { return name_.c_str(); }
-
-    static TimeseriesIndex make_from_descriptor(const StreamDescriptor& desc) {
-        if(desc.field_count() > 0)
-            return TimeseriesIndex(std::string(desc.fields(0).name()));
-
-        return TimeseriesIndex(DefaultName);
     }
 
   private:
@@ -164,13 +84,9 @@ class TableIndex : public BaseIndex<TableIndex> {
 public:
     static constexpr const char* DefaultName = "Key";
 
-    explicit TableIndex(const std::string& name) :
-        name_(name) {
-    }
+    explicit TableIndex(const std::string& name);
 
-    static TableIndex default_index() {
-        return TableIndex(DefaultName);
-    }
+    static TableIndex default_index();
 
     using TypeDescTag = TypeDescriptorTag<
         DataTypeTag<DataType::ASCII_DYNAMIC64>,
@@ -184,45 +100,15 @@ public:
         return IndexDescriptor::STRING;
     }
 
-    void check(const FieldCollection &fields) const {
-        util::check_arg(fields.size() >= int(field_count()), "expected at least {} fields, actual {}",
-                        field_count(), fields.size());
+    void check(const FieldCollection& fields) const;
 
-        util::check(fields.ref_at(0) == field(0),
-            "Field descriptor mismatch {} != {}", fields.ref_at(0), field(0));
-    }
+    static IndexValue start_value_for_segment(const SegmentInMemory& segment);
 
-    template<typename SegmentType>
-    static IndexValue start_value_for_segment(const SegmentType &segment) {
-        auto string_index = segment.string_at(0, 0).value();
-        return {std::string{string_index}};
-    }
+    static IndexValue end_value_for_segment(const SegmentInMemory& segment);
 
-    template<typename SegmentType>
-    static IndexValue end_value_for_segment(const SegmentType &segment) {
-        auto last_rowid = segment.row_count() - 1;
-        auto string_index = segment.string_at(last_rowid, 0).value();
-        return {std::string{string_index}};
-    }
+    static IndexValue start_value_for_keys_segment(const SegmentInMemory& segment);
 
-    template<typename SegmentType>
-    static IndexValue start_value_for_keys_segment(const SegmentType &segment) {
-        if (segment.row_count() == 0)
-            return { NumericIndex{0} };
-        auto start_index_id = int(pipelines::index::Fields::start_index);
-        auto string_index = segment.string_at(0, start_index_id).value();
-        return {std::string{string_index}};
-    }
-
-    template<typename SegmentType>
-    static IndexValue end_value_for_keys_segment(const SegmentType &segment) {
-        auto row_count = segment.row_count();
-        if (row_count == 0)
-            return { NumericIndex{0} };
-        auto end_index_id = int(pipelines::index::Fields::end_index);
-        auto string_index = segment.string_at(row_count - 1, end_index_id).value();
-        return {std::string{string_index}};
-    }
+    static IndexValue end_value_for_keys_segment(const SegmentInMemory& segment);
 
     template<class RowCellSetter>
     void set(RowCellSetter setter, const IndexValue &index_value) const {
@@ -232,14 +118,9 @@ public:
             util::raise_rte("Cannot set this type. Expecting std::string");
     }
 
-    static TableIndex make_from_descriptor(const StreamDescriptor& desc) {
-        if(desc.field_count() > 0)
-            return TableIndex(std::string(desc.field(0).name()));
+    static TableIndex make_from_descriptor(const StreamDescriptor& desc);
 
-        return TableIndex(DefaultName);
-    }
-
-    const char *name() const { return name_.c_str(); }
+    const char* name() const;
 
 private:
     std::string name_;
@@ -253,42 +134,26 @@ class RowCountIndex : public BaseIndex<RowCountIndex> {
 
     RowCountIndex() = default;
 
-    static RowCountIndex default_index() {
-        return RowCountIndex{};
-    }
+    static RowCountIndex default_index();
 
     static constexpr size_t field_count() { return 0; }
 
     static constexpr IndexDescriptor::Type type() { return IndexDescriptor::ROWCOUNT; }
 
-    template<typename SegmentType>
-    static IndexValue start_value_for_segment(const SegmentType &segment) {
-        return static_cast<timestamp>(segment.offset());
-    }
+    static IndexValue start_value_for_segment(const SegmentInMemory& segment);
 
-    template<typename SegmentType>
-    static IndexValue end_value_for_segment(const SegmentType &segment) {
-        return static_cast<timestamp>(segment.offset() + (segment.row_count() - 1));
-    }
+    static IndexValue end_value_for_segment(const SegmentInMemory& segment);
 
-    template<typename SegmentType>
-    static IndexValue start_value_for_keys_segment(const SegmentType &segment) {
-        return static_cast<timestamp>(segment.offset());
-    }
+    static IndexValue start_value_for_keys_segment(const SegmentInMemory& segment);
 
-    template<typename SegmentType>
-    static IndexValue end_value_for_keys_segment(const SegmentType &segment) {
-        return static_cast<timestamp>(segment.offset() + (segment.row_count() - 1));
-    }
+    static IndexValue end_value_for_keys_segment(const SegmentInMemory& segment);
 
     template<class RowCellSetter>
     void set(RowCellSetter, const IndexValue & = {timestamp(0)}) {
         // No index value
     }
 
-    RowCountIndex make_from_descriptor(const StreamDescriptor&) const {
-        return RowCountIndex::default_index();
-    }
+    RowCountIndex make_from_descriptor(const StreamDescriptor&) const;
 
     static constexpr const char *name() { return "row_count"; }
 };
@@ -312,80 +177,22 @@ public:
         return {};
     }
 
-    [[nodiscard]] static IndexValue start_value_for_segment(const SegmentInMemory& segment) {
-        return static_cast<NumericIndex>(segment.offset());
-    }
-
-    [[nodiscard]] static IndexValue end_value_for_segment(const SegmentInMemory& segment) {
-        return static_cast<NumericIndex>(segment.offset());
-    }
-
-    [[nodiscard]] static IndexValue start_value_for_keys_segment(const SegmentInMemory& segment) {
-        return static_cast<NumericIndex>(segment.offset());
-    }
-
-    [[nodiscard]] static IndexValue end_value_for_keys_segment(const SegmentInMemory& segment) {
-        return static_cast<NumericIndex>(segment.offset());
-    }
+    [[nodiscard]] static IndexValue start_value_for_segment(const SegmentInMemory& segment);
+    [[nodiscard]] static IndexValue end_value_for_segment(const SegmentInMemory& segment);
+    [[nodiscard]] static IndexValue start_value_for_keys_segment(const SegmentInMemory& segment);
+    [[nodiscard]] static IndexValue end_value_for_keys_segment(const SegmentInMemory& segment);
 };
 
 using Index = std::variant<stream::TimeseriesIndex, stream::RowCountIndex, stream::TableIndex, stream::EmptyIndex>;
 
-inline Index index_type_from_descriptor(const StreamDescriptor &desc) {
-    switch (desc.index().proto().kind()) {
-    case IndexDescriptor::EMPTY: return EmptyIndex{};
-    case IndexDescriptor::TIMESTAMP:
-        return TimeseriesIndex::make_from_descriptor(desc);
-    case IndexDescriptor::STRING:
-        return TableIndex::make_from_descriptor(desc);
-    case IndexDescriptor::ROWCOUNT:
-        return RowCountIndex{};
-    default:util::raise_rte("Data obtained from storage refers to an index type that this build of ArcticDB doesn't understand ({}).", int(desc.index().proto().kind()));
-    }
-}
-
-inline Index default_index_type_from_descriptor(const IndexDescriptor::Proto &desc) {
-    switch (desc.kind()) {
-    case IndexDescriptor::EMPTY: return EmptyIndex{};
-    case IndexDescriptor::TIMESTAMP:
-        return TimeseriesIndex::default_index();
-    case IndexDescriptor::STRING:
-        return TableIndex::default_index();
-    case IndexDescriptor::ROWCOUNT:
-        return RowCountIndex::default_index();
-    default:
-        util::raise_rte("Unknown index type {} trying to generate index type", int(desc.kind()));
-    }
-}
+Index index_type_from_descriptor(const StreamDescriptor& desc);
+Index default_index_type_from_descriptor(const IndexDescriptor::Proto& desc);
 
 // Only to be used for visitation to get field count etc as the name is not set
-inline Index variant_index_from_type(IndexDescriptor::Type type) {
-    switch (type) {
-    case IndexDescriptor::EMPTY: return EmptyIndex{};
-    case IndexDescriptor::TIMESTAMP:
-        return TimeseriesIndex{TimeseriesIndex::DefaultName};
-    case IndexDescriptor::STRING:
-        return TableIndex{TableIndex::DefaultName};
-    case IndexDescriptor::ROWCOUNT:
-        return RowCountIndex{};
-    default:
-        util::raise_rte("Unknown index type {} trying to generate index type", int(type));
-    }
-}
-
-inline Index default_index_type_from_descriptor(const IndexDescriptor &desc) {
-    return default_index_type_from_descriptor(desc.proto());
-}
-
-inline IndexDescriptor get_descriptor_from_index(const Index& index) {
-    return util::variant_match(index, [] (const auto& idx) {
-        return static_cast<IndexDescriptor>(idx);
-    });
-}
-
-inline Index empty_index() {
-    return RowCountIndex::default_index();
-}
+Index variant_index_from_type(IndexDescriptor::Type type);
+Index default_index_type_from_descriptor(const IndexDescriptor& desc);
+IndexDescriptor get_descriptor_from_index(const Index& index);
+Index empty_index();
 
 }
 

--- a/cpp/arcticdb/stream/index.hpp
+++ b/cpp/arcticdb/stream/index.hpp
@@ -15,6 +15,7 @@
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/entity/stream_descriptor.hpp>
 #include <arcticdb/entity/type_utils.hpp>
+#include <arcticdb/column_store/memory_segment.hpp>
 
 #include <folly/Range.h>
 
@@ -260,10 +261,6 @@ class RowCountIndex : public BaseIndex<RowCountIndex> {
 
     static constexpr IndexDescriptor::Type type() { return IndexDescriptor::ROWCOUNT; }
 
-    void check(const FieldCollection& ) const {
-        // No index defined
-    }
-
     template<typename SegmentType>
     static IndexValue start_value_for_segment(const SegmentType &segment) {
         return static_cast<timestamp>(segment.offset());
@@ -296,10 +293,47 @@ class RowCountIndex : public BaseIndex<RowCountIndex> {
     static constexpr const char *name() { return "row_count"; }
 };
 
-using Index = std::variant<stream::TimeseriesIndex, stream::RowCountIndex, stream::TableIndex>;
+class EmptyIndex : public BaseIndex<EmptyIndex> {
+public:
+    using TypeDescTag = TypeDescriptorTag<DataTypeTag<DataType::EMPTYVAL>, DimensionTag<Dimension::Dim0>>;
+    static constexpr size_t field_count() {
+        return 0;
+    }
+
+    static constexpr IndexDescriptor::Type type() {
+        return IndexDescriptor::EMPTY;
+    }
+
+    static constexpr const char* name() {
+        return "empty";
+    }
+
+    static constexpr EmptyIndex default_index() {
+        return {};
+    }
+
+    [[nodiscard]] static IndexValue start_value_for_segment(const SegmentInMemory& segment) {
+        return static_cast<NumericIndex>(segment.offset());
+    }
+
+    [[nodiscard]] static IndexValue end_value_for_segment(const SegmentInMemory& segment) {
+        return static_cast<NumericIndex>(segment.offset());
+    }
+
+    [[nodiscard]] static IndexValue start_value_for_keys_segment(const SegmentInMemory& segment) {
+        return static_cast<NumericIndex>(segment.offset());
+    }
+
+    [[nodiscard]] static IndexValue end_value_for_keys_segment(const SegmentInMemory& segment) {
+        return static_cast<NumericIndex>(segment.offset());
+    }
+};
+
+using Index = std::variant<stream::TimeseriesIndex, stream::RowCountIndex, stream::TableIndex, stream::EmptyIndex>;
 
 inline Index index_type_from_descriptor(const StreamDescriptor &desc) {
     switch (desc.index().proto().kind()) {
+    case IndexDescriptor::EMPTY: return EmptyIndex{};
     case IndexDescriptor::TIMESTAMP:
         return TimeseriesIndex::make_from_descriptor(desc);
     case IndexDescriptor::STRING:
@@ -312,6 +346,7 @@ inline Index index_type_from_descriptor(const StreamDescriptor &desc) {
 
 inline Index default_index_type_from_descriptor(const IndexDescriptor::Proto &desc) {
     switch (desc.kind()) {
+    case IndexDescriptor::EMPTY: return EmptyIndex{};
     case IndexDescriptor::TIMESTAMP:
         return TimeseriesIndex::default_index();
     case IndexDescriptor::STRING:
@@ -326,6 +361,7 @@ inline Index default_index_type_from_descriptor(const IndexDescriptor::Proto &de
 // Only to be used for visitation to get field count etc as the name is not set
 inline Index variant_index_from_type(IndexDescriptor::Type type) {
     switch (type) {
+    case IndexDescriptor::EMPTY: return EmptyIndex{};
     case IndexDescriptor::TIMESTAMP:
         return TimeseriesIndex{TimeseriesIndex::DefaultName};
     case IndexDescriptor::STRING:

--- a/cpp/arcticdb/stream/protobuf_mappings.hpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.hpp
@@ -36,7 +36,7 @@ inline arcticdb::proto::descriptors::NormalizationMetadata make_rowcount_norm_me
     auto id = std::get<entity::StringId>(stream_id);
     pandas.mutable_common()->set_name(std::move(id));
     NormalizationMetadata_PandasIndex pandas_index;
-    pandas_index.set_is_not_range_index(true);
+    pandas_index.set_is_physically_stored(true);
     pandas.mutable_common()->mutable_index()->CopyFrom(pandas_index);
     norm_meta.mutable_df()->CopyFrom(pandas);
     return norm_meta;

--- a/cpp/arcticdb/stream/row_builder.hpp
+++ b/cpp/arcticdb/stream/row_builder.hpp
@@ -53,7 +53,7 @@ class RowBuilder {
     template<class...Args>
     void start_row(const Args...args) {
         reset();
-        if constexpr(sizeof...(Args)> 0) {
+        if constexpr(sizeof...(Args)> 0 && !std::is_same_v<Index, EmptyIndex>) {
             index().set([&](std::size_t pos, auto arg) {
                 if constexpr (std::is_integral_v<decltype(arg)> || std::is_floating_point_v<decltype(arg)>)
                     set_scalar_impl(pos, arg);

--- a/cpp/arcticdb/stream/stream_utils.hpp
+++ b/cpp/arcticdb/stream/stream_utils.hpp
@@ -376,7 +376,7 @@ inline std::vector<std::string> get_index_columns_from_descriptor(const Timeseri
     ssize_t index_till;
     const auto& common = norm_info.df().common();
     if(auto idx_type = common.index_type_case(); idx_type == arcticdb::proto::descriptors::NormalizationMetadata_Pandas::kIndex)
-        index_till = common.index().is_not_range_index() ? 1 : stream_descriptor.index().field_count();
+        index_till = common.index().is_physically_stored() ? 1 : stream_descriptor.index().field_count();
     else
         index_till = 1 + common.multi_index().field_count();  //# The value of field_count is len(index) - 1
 
@@ -388,7 +388,10 @@ inline std::vector<std::string> get_index_columns_from_descriptor(const Timeseri
 }
 
 inline IndexRange get_range_from_segment(const Index& index, const SegmentInMemory& segment) {
-    return util::variant_match(index, [&segment] (auto index_type) {
+    return util::variant_match(
+        index,
+        [](const EmptyIndex&) { return IndexRange{}; },
+        [&segment] (auto index_type) {
         using IndexType = decltype(index_type);
         auto start = IndexType::start_value_for_segment(segment);
         auto end = IndexType::end_value_for_segment(segment);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -587,7 +587,8 @@ VersionedItem LocalVersionedEngine::update_internal(
                                           query,
                                           frame,
                                           get_write_options(),
-                                          dynamic_schema);
+                                          dynamic_schema,
+                                          cfg().write_options().empty_types());
         write_version_and_prune_previous(
             prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
         return versioned_item;
@@ -1398,7 +1399,8 @@ VersionedItem LocalVersionedEngine::append_internal(
                                           update_info,
                                           frame,
                                           get_write_options(),
-                                          validate_index);
+                                          validate_index,
+                                          cfg().write_options().empty_types());
         write_version_and_prune_previous(
             prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
         return versioned_item;
@@ -1446,7 +1448,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                 auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                 auto write_options = get_write_options();
                 if (update_info.previous_index_key_.has_value()) {
-                    index_key_fut = async_append_impl(store(), update_info, frame, write_options, validate_index);
+                    index_key_fut = async_append_impl(store(), update_info, frame, write_options, validate_index, cfg().write_options().empty_types());
                 } else {
                     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
                     upsert,

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -67,7 +67,7 @@ inline void check_normalization_index_match(
             );
         } else {
             // (old_idx_kind == IndexDescriptor::TIMESTAMP && new_idx_kind == IndexDescriptor::ROWCOUNT) is left to preserve
-            // pre-empty index behavior with pandas 2, see test_empty_writes.cpp::test_append_empty_series. Empty pd.Series
+            // pre-empty index behavior with pandas 2, see test_empty_writes.py::test_append_empty_series. Empty pd.Series
             // have Rowrange index, but due to: https://github.com/man-group/ArcticDB/blob/bd1776291fe402d8b18af9fea865324ebd7705f1/python/arcticdb/version_store/_normalization.py#L545
             // it gets converted to DatetimeIndex (all empty indexes except categorical and multiindex are converted to datetime index
             // in pandas 2 if empty index type is disabled), however we still want to be able to append pd.Series to empty pd.Series.
@@ -87,25 +87,23 @@ inline void check_normalization_index_match(
 
 inline bool columns_match(
     const StreamDescriptor& df_in_store_descriptor,
-    const StreamDescriptor& new_df_descriptor,
-    bool empty_types
+    const StreamDescriptor& new_df_descriptor
 ) {
-    const int right_fields_offset = (empty_types && df_in_store_descriptor.index().type() == IndexDescriptor::EMPTY)
-        ? new_df_descriptor.index().field_count()
-        : 0;
+    const int index_field_size =
+        df_in_store_descriptor.index().type() == IndexDescriptor::EMPTY ? new_df_descriptor.index().field_count() : 0;
     // The empty index is compatible with all other index types. Differences in the index fields in this case is
     // allowed. The index fields are always the first in the list.
-    if (df_in_store_descriptor.fields().size() + right_fields_offset != new_df_descriptor.fields().size()) {
+    if (df_in_store_descriptor.fields().size() + index_field_size != new_df_descriptor.fields().size()) {
         return false;
     }
     // In case the left index is empty index we want to skip name/type checking of the index fields which are always
     // the first fields.
     for (auto i = 0; i < int(df_in_store_descriptor.fields().size()); ++i) {
-        if (df_in_store_descriptor.fields(i).name() != new_df_descriptor.fields(i + right_fields_offset).name())
+        if (df_in_store_descriptor.fields(i).name() != new_df_descriptor.fields(i + index_field_size).name())
             return false;
 
         const TypeDescriptor& left_type = df_in_store_descriptor.fields(i).type();
-        const TypeDescriptor& right_type = new_df_descriptor.fields(i + right_fields_offset).type();
+        const TypeDescriptor& right_type = new_df_descriptor.fields(i + index_field_size).type();
 
         if (!trivially_compatible_types(left_type, right_type) &&
             !(is_empty_type(left_type.data_type()) || is_empty_type(right_type.data_type())))
@@ -128,7 +126,7 @@ inline void fix_descriptor_mismatch_or_throw(
 
     fix_normalization_or_throw(operation == APPEND, existing_isr, new_frame);
 
-    if (!columns_match(old_sd, new_frame.desc, empty_types)) {
+    if (!columns_match(old_sd, new_frame.desc)) {
         throw StreamDescriptorMismatch(
             "The columns (names and types) in the argument are not identical to that of the existing version",
             StreamDescriptor{old_sd},

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -121,12 +121,9 @@ inline void fix_descriptor_mismatch_or_throw(
     const auto &old_sd = existing_isr.tsd().as_stream_descriptor();
     check_normalization_index_match(operation, old_sd, new_frame, empty_types);
 
-    if (dynamic_schema)
-        return; // TODO: dynamic schema may need some of the checks as below
-
     fix_normalization_or_throw(operation == APPEND, existing_isr, new_frame);
 
-    if (!columns_match(old_sd, new_frame.desc)) {
+    if (!dynamic_schema && !columns_match(old_sd, new_frame.desc)) {
         throw StreamDescriptorMismatch(
             "The columns (names and types) in the argument are not identical to that of the existing version",
             StreamDescriptor{old_sd},

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -42,29 +42,49 @@ inline IndexDescriptor::Type get_common_index_type(const IndexDescriptor::Type& 
     return IndexDescriptor::UNKNOWN;
 }
 
-inline void check_normalization_index_match(NormalizationOperation operation,
-                                     const StreamDescriptor &old_descriptor,
-                                     const pipelines::InputTensorFrame &frame) {
+inline void check_normalization_index_match(
+    NormalizationOperation operation,
+    const StreamDescriptor& old_descriptor,
+    const pipelines::InputTensorFrame& frame,
+    bool empty_types
+) {
     const IndexDescriptor::Type old_idx_kind = old_descriptor.index().type();
     const IndexDescriptor::Type new_idx_kind = frame.desc.index().type();
     if (operation == UPDATE) {
         const bool new_is_timeseries = std::holds_alternative<TimeseriesIndex>(frame.index);
         util::check_rte(
             (old_idx_kind == IndexDescriptor::TIMESTAMP || old_idx_kind == IndexDescriptor::EMPTY) && new_is_timeseries,
-                        "Update will not work as expected with a non-timeseries index");
+            "Update will not work as expected with a non-timeseries index"
+        );
     } else {
         const IndexDescriptor::Type common_index_type = get_common_index_type(old_idx_kind, new_idx_kind);
-        normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
-            common_index_type != IndexDescriptor::UNKNOWN,
-            "Cannot append {} index to {} index",
-            index_type_to_str(new_idx_kind),
-            index_type_to_str(old_idx_kind)
-        );
+        if (empty_types) {
+            normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
+                common_index_type != IndexDescriptor::UNKNOWN,
+                "Cannot append {} index to {} index",
+                index_type_to_str(new_idx_kind),
+                index_type_to_str(old_idx_kind)
+            );
+        } else {
+            normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
+                common_index_type != IndexDescriptor::UNKNOWN ||
+                    (old_idx_kind == IndexDescriptor::TIMESTAMP && new_idx_kind == IndexDescriptor::ROWCOUNT),
+                "Cannot append {} index to {} index",
+                index_type_to_str(new_idx_kind),
+                index_type_to_str(old_idx_kind)
+            );
+        }
     }
 }
 
-inline bool columns_match(const StreamDescriptor& df_in_store_descriptor, const StreamDescriptor& new_df_descriptor) {
-    const int right_fields_offset = df_in_store_descriptor.index().type() == IndexDescriptor::EMPTY ? new_df_descriptor.index().field_count() : 0;
+inline bool columns_match(
+    const StreamDescriptor& df_in_store_descriptor,
+    const StreamDescriptor& new_df_descriptor,
+    bool empty_types
+) {
+    const int right_fields_offset = (empty_types && df_in_store_descriptor.index().type() == IndexDescriptor::EMPTY)
+        ? new_df_descriptor.index().field_count()
+        : 0;
     // The empty index is compatible with all other index types. Differences in the index fields in this case is
     // allowed. The index fields are always the first in the list.
     if (df_in_store_descriptor.fields().size() + right_fields_offset != new_df_descriptor.fields().size()) {
@@ -90,16 +110,17 @@ inline void fix_descriptor_mismatch_or_throw(
     NormalizationOperation operation,
     bool dynamic_schema,
     const pipelines::index::IndexSegmentReader &existing_isr,
-    const pipelines::InputTensorFrame &new_frame) {
+    const pipelines::InputTensorFrame &new_frame,
+    bool empty_types) {
     const auto &old_sd = existing_isr.tsd().as_stream_descriptor();
-    check_normalization_index_match(operation, old_sd, new_frame);
+    check_normalization_index_match(operation, old_sd, new_frame, empty_types);
 
     if (dynamic_schema)
         return; // TODO: dynamic schema may need some of the checks as below
 
     fix_normalization_or_throw(operation == APPEND, existing_isr, new_frame);
 
-    if (!columns_match(old_sd, new_frame.desc)) {
+    if (!columns_match(old_sd, new_frame.desc, empty_types)) {
         throw StreamDescriptorMismatch(
             "The columns (names and types) in the argument are not identical to that of the existing version",
             StreamDescriptor{old_sd},

--- a/cpp/arcticdb/version/version_core-inl.hpp
+++ b/cpp/arcticdb/version/version_core-inl.hpp
@@ -64,10 +64,11 @@ void merge_frames_for_keys_impl(
     if (std::holds_alternative<IndexRange>(query.row_filter))
         index_range = std::get<IndexRange>(query.row_filter);
 
-    auto compare =
-        [=](const std::unique_ptr <StreamMergeWrapper> &left, const std::unique_ptr <StreamMergeWrapper> &right) {
-            return pipelines::index::index_value_from_row(left->row(), IndexDescriptor::TIMESTAMP, 0) > pipelines::index::index_value_from_row(right->row(), IndexDescriptor::TIMESTAMP, 0);
-        };
+    auto compare = [](const std::unique_ptr<StreamMergeWrapper>& left,
+                      const std::unique_ptr<StreamMergeWrapper>& right) {
+        return pipelines::index::index_value_from_row(left->row(), IndexDescriptor::TIMESTAMP, 0) >
+            pipelines::index::index_value_from_row(right->row(), IndexDescriptor::TIMESTAMP, 0);
+    };
 
     movable_priority_queue<std::unique_ptr<StreamMergeWrapper>, std::vector<std::unique_ptr<StreamMergeWrapper>>, decltype(compare)> input_streams{compare};
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -102,7 +102,7 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
     frame->set_bucketize_dynamic(options.bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, *frame);
     auto partial_key = IndexPartialKey{frame->desc.id(), version_id};
-    if (validate_index && !index_is_not_timeseries_or_is_sorted_ascending(frame)) {
+    if (validate_index && !index_is_not_timeseries_or_is_sorted_ascending(*frame)) {
         sorting::raise<ErrorCode::E_UNSORTED_DATA>("When calling write with validate_index enabled, input data must be sorted");
     }
     return write_frame(std::move(partial_key), frame, slicing_arg, store, de_dup_map, sparsify_floats);
@@ -111,7 +111,8 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
 namespace {
 IndexDescriptor::Proto check_index_match(const arcticdb::stream::Index& index, const IndexDescriptor::Proto& desc) {
     if (std::holds_alternative<stream::TimeseriesIndex>(index))
-        util::check(desc.kind() == IndexDescriptor::TIMESTAMP,
+        util::check(
+            desc.kind() == IndexDescriptor::TIMESTAMP || desc.kind() == IndexDescriptor::EMPTY,
                     "Index mismatch, cannot update a non-timeseries-indexed frame with a timeseries");
     else
         util::check(desc.kind() == IndexDescriptor::ROWCOUNT,
@@ -121,12 +122,12 @@ IndexDescriptor::Proto check_index_match(const arcticdb::stream::Index& index, c
 }
 }
 
-void sorted_data_check_append(const std::shared_ptr<InputTensorFrame>& frame, index::IndexSegmentReader& index_segment_reader){
+void sorted_data_check_append(const InputTensorFrame& frame, index::IndexSegmentReader& index_segment_reader){
     if (!index_is_not_timeseries_or_is_sorted_ascending(frame)) {
         sorting::raise<ErrorCode::E_UNSORTED_DATA>("When calling append with validate_index enabled, input data must be sorted");
     }
     sorting::check<ErrorCode::E_UNSORTED_DATA>(
-        !std::holds_alternative<stream::TimeseriesIndex>(frame->index) ||
+        !std::holds_alternative<stream::TimeseriesIndex>(frame.index) ||
         index_segment_reader.mutable_tsd().mutable_proto().stream_descriptor().sorted() == arcticdb::proto::descriptors::SortedValue::ASCENDING,
         "When calling append with validate_index enabled, the existing data must be sorted");
 }
@@ -145,11 +146,11 @@ folly::Future<AtomKey> async_append_impl(
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     auto row_offset = index_segment_reader.tsd().proto().total_rows();
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
-    if (validate_index) {
-        sorted_data_check_append(frame, index_segment_reader);
-    }
     frame->set_offset(static_cast<ssize_t>(row_offset));
     fix_descriptor_mismatch_or_throw(APPEND, options.dynamic_schema, index_segment_reader, *frame);
+    if (validate_index) {
+        sorted_data_check_append(*frame, index_segment_reader);
+    }
 
     frame->set_bucketize_dynamic(bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, *frame);
@@ -329,7 +330,10 @@ VersionedItem update_impl(
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot update pickled data");
     auto index_desc = check_index_match(frame->index, index_segment_reader.tsd().proto().stream_descriptor().index());
-    util::check(index_desc.kind() == IndexDescriptor::TIMESTAMP, "Update not supported for non-timeseries indexes");
+    util::check(
+        index_desc.kind() == IndexDescriptor::TIMESTAMP || index_desc.kind() == IndexDescriptor::EMPTY,
+        "Update not supported for non-timeseries indexes"
+    );
     sorted_data_check_update(*frame, index_segment_reader);
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     (void)check_and_mark_slices(index_segment_reader, dynamic_schema, false, std::nullopt, bucketize_dynamic);
@@ -538,7 +542,7 @@ void set_output_descriptors(
             auto mutable_index = pipeline_context->norm_meta_->mutable_df()->mutable_common()->mutable_index();
             mutable_index->set_name(*new_index);
             mutable_index->clear_fake_name();
-            mutable_index->set_is_not_range_index(true);
+            mutable_index->set_is_physically_stored(true);
             break;
         }
     }

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -54,14 +54,16 @@ folly::Future<AtomKey> async_append_impl(
     const UpdateInfo& update_info,
     const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
-    bool validate_index);
+    bool validate_index,
+    bool empty_types);
 
 VersionedItem append_impl(
     const std::shared_ptr<Store>& store,
     const UpdateInfo& update_info,
     const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions& options,
-    bool validate_index);
+    bool validate_index,
+    bool empty_types);
 
 VersionedItem update_impl(
     const std::shared_ptr<Store>& store,
@@ -69,7 +71,8 @@ VersionedItem update_impl(
     const UpdateQuery & query,
     const std::shared_ptr<InputTensorFrame>& frame,
     const WriteOptions&& options,
-    bool dynamic_schema);
+    bool dynamic_schema,
+    bool empty_types);
 
 VersionedItem delete_range_impl(
     const std::shared_ptr<Store>& store,

--- a/cpp/proto/arcticc/pb2/descriptors.proto
+++ b/cpp/proto/arcticc/pb2/descriptors.proto
@@ -57,6 +57,8 @@ message TypeDescriptor {
 message IndexDescriptor {
     enum Type {
         UNKNOWN = 0;
+        // Used then the dataframe has 0 rows. Convertible to any other type
+        EMPTY = 69; // 'E'
         ROWCOUNT = 82; // 'R'
         STRING = 83; // 'S'
         TIMESTAMP = 84; //  'T'
@@ -122,7 +124,7 @@ message NormalizationMetadata {
         string name = 1; // RangeIndex are not represented as a field, hence no name is associated
         string tz = 2;
         bool fake_name = 3;
-        bool is_not_range_index = 4;
+        bool is_physically_stored = 4;
         int64 start = 5; // Used for RangeIndex
         int64 step = 6; // Used for RangeIndex
         bool is_int = 7;

--- a/python/arcticdb/util/hypothesis.py
+++ b/python/arcticdb/util/hypothesis.py
@@ -197,7 +197,7 @@ class InputFactories(_InputFactoryValues, Enum):
         ),
         _ROWCOUNT,
         "df",
-        "is_not_range_index",
+        "is_physically_stored",
     )
 
     DF_DTI = (

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -292,7 +292,7 @@ _range_index_props_are_public = hasattr(RangeIndex, "start")
 def _normalize_single_index(index, index_names, index_norm, dynamic_strings=None, string_max_len=None):
     # index: pd.Index or np.ndarray -> np.ndarray
     index_tz = None
-    if isinstance(index_norm, NormalizationMetadata.PandasIndex) and not index_norm.is_physically_stored:
+    if isinstance(index, RangeIndex):
         if index.name:
             if not isinstance(index.name, int) and not isinstance(index.name, str):
                 raise NormalizationException(
@@ -529,7 +529,7 @@ class _PandasNormalizer(Normalizer):
         if empty_df and empty_types:
             index_norm = pd_norm.index
             index_norm.is_physically_stored = False
-            index = Index([])
+            index = DatetimeIndex([])
         elif isinstance(index, MultiIndex):
             # This is suboptimal and only a first implementation since it reduplicates the data
             index_norm = pd_norm.multi_index
@@ -553,8 +553,7 @@ class _PandasNormalizer(Normalizer):
         else:
             index_norm = pd_norm.index
             index_norm.is_physically_stored = not isinstance(index, RangeIndex) and not empty_df
-            if empty_df:
-                index = DatetimeIndex([])
+            index = DatetimeIndex([]) if empty_df else index
 
         return _normalize_single_index(index, list(index.names), index_norm, dynamic_strings, string_max_len)
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -332,9 +332,7 @@ class NativeVersionStore:
         dynamic_schema = self.resolve_defaults(
             "dynamic_schema", self._lib_cfg.lib_desc.version.write_options, False, **kwargs
         )
-        empty_types = self.resolve_defaults(
-            "empty_types", self._lib_cfg.lib_desc.version.write_options, False, **kwargs
-        )
+        empty_types = self.resolve_defaults("empty_types", self._lib_cfg.lib_desc.version.write_options, False)
         try:
             udm = normalize_metadata(metadata) if metadata is not None else None
             opt_custom = self._custom_normalizer.normalize(dataframe)

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1934,7 +1934,7 @@ class NativeVersionStore:
         # is 0.
         idx_type = norm_info.df.common.WhichOneof("index_type")
         if idx_type == "index":
-            last_index_column_idx = 1 if norm_info.df.common.index.is_not_range_index else 0
+            last_index_column_idx = 1 if norm_info.df.common.index.is_physically_stored else 0
         else:
             # The value of field_count is len(index) - 1
             last_index_column_idx = 1 + norm_info.df.common.multi_index.field_count
@@ -2547,7 +2547,7 @@ class NativeVersionStore:
             else:
                 index_metadata = timeseries_descriptor.normalization.df.common.multi_index
 
-            if index_type == "multi_index" or (index_type == "index" and index_metadata.is_not_range_index):
+            if index_type == "multi_index" or (index_type == "index" and index_metadata.is_physically_stored):
                 index_name_from_store = columns.pop(0)
                 has_fake_name = (
                     0 in index_metadata.fake_field_pos if index_type == "multi_index" else index_metadata.fake_name

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -332,6 +332,9 @@ class NativeVersionStore:
         dynamic_schema = self.resolve_defaults(
             "dynamic_schema", self._lib_cfg.lib_desc.version.write_options, False, **kwargs
         )
+        empty_types = self.resolve_defaults(
+            "empty_types", self._lib_cfg.lib_desc.version.write_options, False, **kwargs
+        )
         try:
             udm = normalize_metadata(metadata) if metadata is not None else None
             opt_custom = self._custom_normalizer.normalize(dataframe)
@@ -347,6 +350,7 @@ class NativeVersionStore:
                     dynamic_strings=dynamic_strings,
                     coerce_columns=coerce_columns,
                     dynamic_schema=dynamic_schema,
+                    empty_types=empty_types,
                     **kwargs,
                 )
         except ArcticDbNotYetImplemented as ex:

--- a/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
@@ -584,6 +584,7 @@ class TestCanAppendToEmptyColumn:
     @pytest.fixture(autouse=True)
     def create_empty_column(self, lmdb_version_store_static_and_dynamic, dtype, empty_index):
         lmdb_version_store_static_and_dynamic.write("sym", pd.DataFrame({"col": []}, dtype=dtype, index=empty_index))
+        assert lmdb_version_store_static_and_dynamic.read("sym").data.index.equals(pd.DatetimeIndex([]))
         yield
 
     def test_integer(self, lmdb_version_store_static_and_dynamic, int_dtype, dtype, append_index):
@@ -744,6 +745,7 @@ class TestCanUpdateEmptyColumn:
     @pytest.fixture(autouse=True)
     def create_empty_column(self, lmdb_version_store_static_and_dynamic, dtype, empty_index):
         lmdb_version_store_static_and_dynamic.write("sym", pd.DataFrame({"col": []}, dtype=dtype, index=empty_index))
+        assert lmdb_version_store_static_and_dynamic.read("sym").data.index.equals(pd.DatetimeIndex([]))
         yield
 
     def update_index(self):


### PR DESCRIPTION
Fixes #1509 

While fixing, noticed that the added test `test_append_range_index_from_zero` would also not have passed, so fixed this too.