### PR TITLE
Cleanup arctic client after usage in local_quary_builder in ASV

### DIFF
--- a/python/benchmarks/local_query_builder.py
+++ b/python/benchmarks/local_query_builder.py
@@ -31,7 +31,8 @@ class LocalQueryBuilderFunctions:
             lib.write(f"{rows}_rows", generate_benchmark_df(rows))
 
     def teardown(self, num_rows):
-        pass
+        del self.lib
+        del self.ac
 
     def setup(self, num_rows):
         self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)


### PR DESCRIPTION
- This should eliminate warnings about multiple connections to LMDB
