### PR TITLE
Bugfix 1507+1509: dynamic schema different index append fixes

### DIFF
--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -124,12 +124,12 @@ void update_rowcount_normalization_data(
             size_t new_start = new_index->start();
             auto stop = old_index->start() + old_length * old_index->step();
             normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
-                new_start == stop,
-                "The appending data has a RangeIndex.start={} that is not contiguous with the {}"
-                "stop ({}) of",
-                error_suffix,
+                new_start == stop || (new_start == 0 && new_index->step() == 1),
+                "The appending data has a RangeIndex.start={} that is not contiguous with the "
+                "stop ({}) of {}",
                 new_start,
-                stop
+                stop,
+                error_suffix
             );
 
             new_pandas->get().mutable_index()->set_start(old_index->start());

--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -122,17 +122,15 @@ void update_rowcount_normalization_data(
             );
 
             size_t new_start = new_index->start();
-            if (new_start != 0) {
-                auto stop = old_index->start() + old_length * old_index->step();
-                normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
-                    new_start == stop,
-                    "The appending data has a RangeIndex.start={} that is not contiguous with the {}"
-                    "stop ({}) of",
-                    error_suffix,
-                    new_start,
-                    stop
-                );
-            }
+            auto stop = old_index->start() + old_length * old_index->step();
+            normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
+                new_start == stop,
+                "The appending data has a RangeIndex.start={} that is not contiguous with the {}"
+                "stop ({}) of",
+                error_suffix,
+                new_start,
+                stop
+            );
 
             new_pandas->get().mutable_index()->set_start(old_index->start());
         }

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -121,12 +121,9 @@ inline void fix_descriptor_mismatch_or_throw(
     const auto &old_sd = existing_isr.tsd().as_stream_descriptor();
     check_normalization_index_match(operation, old_sd, new_frame, empty_types);
 
-    if (dynamic_schema)
-        return; // TODO: dynamic schema may need some of the checks as below
-
     fix_normalization_or_throw(operation == APPEND, existing_isr, new_frame);
 
-    if (!columns_match(old_sd, new_frame.desc)) {
+    if (!dynamic_schema && !columns_match(old_sd, new_frame.desc)) {
         throw StreamDescriptorMismatch(
             "The columns (names and types) in the argument are not identical to that of the existing version",
             StreamDescriptor{old_sd},

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -74,9 +74,10 @@ inline void check_normalization_index_match(
             // Having this will not allow appending RowCont indexed pd.DataFrames to DateTime indexed pd.DataFrames because they would
             // have different field size (the rowcount index is not stored as a field). This logic is bug prone and will become better
             // after we enable the empty index.
+            const bool input_frame_is_series = frame.norm_meta.has_series();
             normalization::check<ErrorCode::E_INCOMPATIBLE_INDEX>(
                 common_index_type != IndexDescriptor::UNKNOWN ||
-                    (old_idx_kind == IndexDescriptor::TIMESTAMP && new_idx_kind == IndexDescriptor::ROWCOUNT),
+                    (input_frame_is_series && old_idx_kind == IndexDescriptor::TIMESTAMP && new_idx_kind == IndexDescriptor::ROWCOUNT),
                 "Cannot append {} index to {} index",
                 index_type_to_str(new_idx_kind),
                 index_type_to_str(old_idx_kind)

--- a/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
@@ -864,7 +864,7 @@ class TestIndexTypeWithEmptyTypeDisabledPands2AndLater(DisabledEmptyIndexBase):
         result = self.roundtrip(pd.DataFrame({"a": []}), lmdb_version_store_static_and_dynamic)
         assert result.index.equals(pd.DatetimeIndex([]))
         with pytest.raises(NormalizationException):
-            lmdb_version_store_static_and_dynamic.append(self.sym(), pd.DataFrame({"a": [1.0]}, index=pd.RangeIndex(0, 1, 1)))
+            lmdb_version_store_static_and_dynamic.append(self.sym(), pd.DataFrame({"a": [1.0]}))
         to_append_successfuly = pd.DataFrame({"a": [1.0]}, index=pd.DatetimeIndex(["01/01/2024"])) 
         lmdb_version_store_static_and_dynamic.append(self.sym(), to_append_successfuly)
         assert_frame_equal(

--- a/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_dynamic.py
@@ -37,6 +37,7 @@ from arcticdb_ext.exceptions import InternalException
 
 
 def generic_dynamic_filter_test(version_store, symbol, df, arctic_query, pandas_query, dynamic_strings=True):
+    version_store.delete(symbol)
     expected, slices = make_dynamic(df)
     for df_slice in slices:
         version_store.append(symbol, df_slice, write_if_missing=True)


### PR DESCRIPTION
Closes #1507 
Closes #1509

While fixing, noticed that the added test `test_append_range_index_from_zero` would also not have passed, so fixed this too.