### PR TITLE
LibraryTool add read_index

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2817,4 +2817,4 @@ class NativeVersionStore:
         return self._library
 
     def library_tool(self) -> LibraryTool:
-        return LibraryTool(self.library())
+        return LibraryTool(self.library(), self)

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -290,6 +290,12 @@ class StagedDataFinalizeMethod(Enum):
     WRITE = auto()
     APPEND = auto()
 
+class DevTools:
+    def __init__(self, nvs):
+        self._nvs = nvs
+
+    def library_tool(self):
+        return self._nvs.library_tool()
 
 class Library:
     """
@@ -321,6 +327,7 @@ class Library:
         self.arctic_instance_desc = arctic_instance_description
         self._nvs = nvs
         self._nvs._normalizer.df._skip_df_consolidation = True
+        self._dev_tools = DevTools(nvs)
 
     def __repr__(self):
         return "Library(%s, path=%s, storage=%s)" % (
@@ -1747,13 +1754,14 @@ class Library:
         >>> lib.write("symbol", pd.DataFrame({"A": [0]}, index=[pd.Timestamp(0)]))
         >>> lib.append("symbol", pd.DataFrame({"A": [1, 2]}, index=[pd.Timestamp(1), pd.Timestamp(2)]))
         >>> lib.append("symbol", pd.DataFrame({"A": [3]}, index=[pd.Timestamp(3)]))
-        >>> lib.read_index(sym)
+        >>> lib_tool = lib._dev_tools.library_tool()
+        >>> lib_tool.read_index(sym)
                             start_index                     end_index  version_id stream_id          creation_ts          content_hash  index_type  key_type  start_col  end_col  start_row  end_row
         1970-01-01 00:00:00.000000000 1970-01-01 00:00:00.000000001          20    b'sym'  1678974096622685727   6872717287607530038          84         2          1        2          0        1
         1970-01-01 00:00:00.000000001 1970-01-01 00:00:00.000000003          21    b'sym'  1678974096931527858  12345256156783683504          84         2          1        2          1        3
         1970-01-01 00:00:00.000000003 1970-01-01 00:00:00.000000004          22    b'sym'  1678974096970045987   7952936283266921920          84         2          1        2          3        4
         >>> lib.version_store.defragment_symbol_data("symbol", 2)
-        >>> lib.read_index(sym)  # Returns two segments rather than three as a result of the defragmentation operation
+        >>> lib_tool.read_index(sym)  # Returns two segments rather than three as a result of the defragmentation operation
                             start_index                     end_index  version_id stream_id          creation_ts         content_hash  index_type  key_type  start_col  end_col  start_row  end_row
         1970-01-01 00:00:00.000000000 1970-01-01 00:00:00.000000003          23    b'sym'  1678974097067271451  5576804837479525884          84         2          1        2          0        3
         1970-01-01 00:00:00.000000003 1970-01-01 00:00:00.000000004          23    b'sym'  1678974097067427062  7952936283266921920          84         2          1        2          3        4

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -105,6 +105,10 @@ def lmdb_storage(tmp_path):
     with LmdbStorageFixture(tmp_path) as f:
         yield f
 
+@pytest.fixture
+def lmdb_library(lmdb_storage, lib_name):
+    return lmdb_storage.create_arctic().create_library(lib_name)
+
 
 @pytest.fixture(scope="session")
 def s3_storage_factory():

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -903,6 +903,16 @@ def test_azure_sas_token(azurite_storage_factory: StorageFixtureFactory):
             ac = f.create_arctic()
             ac.create_library("x")
 
+def test_lib_has_lib_tools_read_index(lmdb_library):
+    lib = lmdb_library
+    sym = "my_symbol"
+
+    df = pd.DataFrame({"col": [1, 2, 3]})
+    lib.write(sym, df)
+    lib_tool = lib._dev_tools.library_tool()
+
+    assert lib_tool.read_index(sym).equals(lib._nvs.read_index(sym))
+
 
 def test_s3_force_uri_lib_config_handling(s3_storage):
     # force_uri_lib_config is a obsolete configuration. However, user still includes this option in their setup.


### PR DESCRIPTION
#### Reference Issues/PRs
Implements #1391 and fixes #1532.
- Added read_index in LibraryTool (as required in #1391)
- Allowed Library to get LibraryTool and call read_index (to fix #1532). Also updated the docs accordingly.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
