### PR TITLE
Bugfix/944: Include field index in error message

### DIFF
--- a/cpp/arcticdb/entity/field_collection.hpp
+++ b/cpp/arcticdb/entity/field_collection.hpp
@@ -213,7 +213,7 @@ namespace fmt {
         constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
         template<typename FormatContext>
         auto format(const arcticdb::FieldCollection &fc, FormatContext &ctx) const {
-            for (auto i = 0; i < fc.size(); ++i) {
+            for (size_t i = 0; i < fc.size(); ++i) {
                 if (i == fc.size() - 1) {
                     fmt::format_to(ctx.out(), "FD<name={}, type={}, idx={}>", fc[i].name(), fc[i].type(), i);
                 }

--- a/cpp/arcticdb/entity/field_collection.hpp
+++ b/cpp/arcticdb/entity/field_collection.hpp
@@ -204,3 +204,25 @@ FieldCollection fields_from_range(const RangeType& fields) {
 
 
 } //namespace arcticdb
+
+
+namespace fmt {
+    template<>
+    struct formatter<arcticdb::FieldCollection> {
+        template<typename ParseContext>
+        constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+        template<typename FormatContext>
+        auto format(const arcticdb::FieldCollection &fc, FormatContext &ctx) const {
+            for (auto i = 0; i < fc.size(); ++i) {
+                if (i == fc.size() - 1) {
+                    fmt::format_to(ctx.out(), "FD<name={}, type={}, idx={}>", fc[i].name(), fc[i].type(), i);
+                }
+                else {
+                    fmt::format_to(ctx.out(), "FD<name={}, type={}, idx={}>, ", fc[i].name(), fc[i].type(), i);
+                }
+            }
+
+            return ctx.out();
+        }
+    };
+}

--- a/cpp/arcticdb/stream/test/test_types.cpp
+++ b/cpp/arcticdb/stream/test/test_types.cpp
@@ -48,7 +48,7 @@ TEST(TickStreamDesc, FromFields) {
             scalar_field(DataType::INT8, "int8")
         })};
     ASSERT_EQ(fmt::format("{}", tsd),
-              "TSD<tsid=123, idx=IDX<size=1, kind=T>, fields=[FD<name=time, type=TD<type=NANOSECONDS_UTC64, dim=0>>, FD<name=uint8, type=TD<type=UINT8, dim=0>>, FD<name=int8, type=TD<type=INT8, dim=0>>]>");
+              "TSD<tsid=123, idx=IDX<size=1, kind=T>, fields=FD<name=time, type=TD<type=NANOSECONDS_UTC64, dim=0>, idx=0>, FD<name=uint8, type=TD<type=UINT8, dim=0>, idx=1>, FD<name=int8, type=TD<type=INT8, dim=0>, idx=2>>");
 }
 
 TEST(DataTypeVisit, VisitTag) {

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -26,7 +26,7 @@ inline std::string_view normalization_operation_str(NormalizationOperation opera
 struct StreamDescriptorMismatch : ArcticSpecificException<ErrorCode::E_DESCRIPTOR_MISMATCH>  {
     StreamDescriptorMismatch(const char* preamble, const StreamDescriptor& existing, const StreamDescriptor& new_val, NormalizationOperation operation) :
     ArcticSpecificException(fmt::format("{}: {} \nexisting={}\n new_val={}", preamble, normalization_operation_str(operation),
-                                        fmt::join(existing.fields(), ", "), fmt::join(new_val.fields(), ", "))) {}
+                                        existing.fields(), new_val.fields())) {}
 };
 
 inline void check_normalization_index_match(NormalizationOperation operation,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -149,7 +149,7 @@ def _handle_categorical_columns(symbol, data, throw=True):
 
 
 _BATCH_BAD_ARGS: Dict[Any, Sequence[str]] = {}
-_STREAM_DESCRIPTOR_SPLIT = re.compile(r"(?<=>), ")
+_STREAM_DESCRIPTOR_SPLIT = re.compile(r", (?=FD<)")
 
 
 def _check_batch_kwargs(batch_fun, non_batch_fun, kwargs: Dict):

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2418,7 +2418,7 @@ def test_wrong_df_col_order(basic_store):
     lib.write(sym, df1)
 
     df2 = pd.DataFrame({"col2": [4, 5, 6], "col1": [14, 15, 16]})
-    with pytest.raises(StreamDescriptorMismatch, match=", idx="):
+    with pytest.raises(StreamDescriptorMismatch, match="type=TD<type=INT64, dim=0>, idx="):
         lib.append(sym, df2)
 
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2410,6 +2410,17 @@ def test_diff_long_stream_descriptor_mismatch(basic_store, method, num):
             if i % 20 == 4:
                 assert f"FD<name=col{i}, type=TD<type=UTF" in msg
 
+def test_wrong_df_col_order(basic_store):
+    lib = basic_store
+
+    df1 = pd.DataFrame({"col1": [11, 12, 13], "col2": [1, 2, 3]})
+    sym = "symbol"
+    lib.write(sym, df1)
+
+    df2 = pd.DataFrame({"col2": [4, 5, 6], "col1": [14, 15, 16]})
+    with pytest.raises(StreamDescriptorMismatch, match=", idx="):
+        lib.append(sym, df2)
+
 
 def test_get_non_existing_columns_in_series(basic_store, sym):
     lib = basic_store


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #944
The error message now includes the field index which shows a better error when two columns are simply swapped.
To do this, a formatter is defined for `FieldCollection` because the index is not saved in `Field` (previously the formatter of Field was called for composing the error message), it is only known at `FieldCollection` level.

Furthermore, the pattern matching regular expression is also updated as the output now becomes `FD<name=col1, type=TD<type=typ1, dim=0>, idx=0>, FD<name=col2, type=TD<type=type2, dim=0>, idx=1>`. After `idx` was added, the previous regular expression was separating this into
```python
["FD<name=col1, type=TD<type=typ1, dim=0>", "idx=0>", "FD<name=col2, type=TD<type=type2, dim=0>", "idx=1>"]
```
but we want
```python
["FD<name=col1, type=TD<type=typ1, dim=0>, idx=0>", "FD<name=col2, type=TD<type=type2, dim=0>, idx=1>"]
```

Now the fix shows the following output which explains the error better:
```
The columns (names and types) in the argument are not identical to that of the existing version: APPEND 
(Showing only the mismatch. Full col list saved in the `last_mismatch_msg` attribute of the lib instance.
'-' marks columns missing from the argument, '+' for unexpected.)
-FD<name=col1, type=TD<type=INT64, dim=0>, idx=0>
-FD<name=col2, type=TD<type=INT64, dim=0>, idx=1>
+FD<name=col2, type=TD<type=INT64, dim=0>, idx=0>
+FD<name=col1, type=TD<type=INT64, dim=0>, idx=1>
```

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
