### PR TITLE
Revert destructor speed regression from #1152

### DIFF
--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -290,7 +290,7 @@ namespace arcticdb {
 
     template<class TracingPolicy, class ClockType>
     void AllocatorImpl<TracingPolicy, ClockType>::maybe_trim() {
-        const uint32_t trim_count = ConfigsMap::instance()->get_int("Allocator.TrimCount", 250);
+        static const uint32_t trim_count = ConfigsMap::instance()->get_int("Allocator.TrimCount", 250);
         if (free_count_of<TracingPolicy, ClockType>().readFast() > trim_count && free_count_of<TracingPolicy, ClockType>().readFastAndReset() > trim_count)
             trim();
     }


### PR DESCRIPTION
We noticed a speed regression in the version_chain benchmarks arising from #1152.

Profiling showed that the majority of the slowdown was because the `~SegmentInMemory` destructor became a lot slower. And all of the slowdown was because of the recurring `ConfigsMap::get_int` inside `maybe_trim`.

We fix this by again using a `static` variable for getting the config value.

I've verified that there aren't other similar regressions from that PR.
