### PR TITLE
Remove the option to enable Pandas consolidation

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -283,7 +283,7 @@ def _from_tz_timestamp(ts, tz):
 _range_index_props_are_public = hasattr(RangeIndex, "start")
 
 
-def _normalize_single_index(index, index_names, index_norm, dynamic_strings=None, string_max_len=None, empty_types=False):
+def _normalize_single_index(index, index_names, index_norm, dynamic_strings=None, string_max_len=None, empty_types=True):
     # index: pd.Index or np.ndarray -> np.ndarray
     index_tz = None
     is_empty = len(index) == 0
@@ -581,7 +581,7 @@ class SeriesNormalizer(_PandasNormalizer):
     def __init__(self):
         self._df_norm = DataFrameNormalizer()
 
-    def normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=False, **kwargs):
+    def normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=True, **kwargs):
         df, norm = self._df_norm.normalize(
             item.to_frame(),
             dynamic_strings=dynamic_strings,
@@ -805,7 +805,7 @@ class DataFrameNormalizer(_PandasNormalizer):
 
         return df
 
-    def normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=False, **kwargs):
+    def normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=True, **kwargs):
         # type: (DataFrame, Optional[int])->NormalizedInput
         norm_meta = NormalizationMetadata()
         norm_meta.df.common.mark = True
@@ -977,7 +977,7 @@ class Pickler(object):
 
 
 class TimeFrameNormalizer(Normalizer):
-    def normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=False, **kwargs):
+    def normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=True, **kwargs):
         norm_meta = NormalizationMetadata()
         norm_meta.ts.mark = True
         index_norm = norm_meta.ts.common.index
@@ -1055,7 +1055,7 @@ class CompositeNormalizer(Normalizer):
         self.msg_pack_denorm = MsgPackNormalizer()  # must exist for deserialization
         self.fallback_normalizer = fallback_normalizer
 
-    def _normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=False, **kwargs):
+    def _normalize(self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=True, **kwargs):
         normalizer = self.get_normalizer_for_type(item)
 
         if not normalizer:
@@ -1105,7 +1105,7 @@ class CompositeNormalizer(Normalizer):
         return None
 
     def normalize(
-        self, item, string_max_len=None, pickle_on_failure=False, dynamic_strings=False, coerce_columns=None, empty_types=False, **kwargs
+        self, item, string_max_len=None, pickle_on_failure=False, dynamic_strings=False, coerce_columns=None, empty_types=True, **kwargs
     ):
         """
         :param item: Item to be normalized to something Arctic Native understands.

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -660,7 +660,6 @@ class DataFrameNormalizer(_PandasNormalizer):
 
     def __init__(self, *args, **kwargs):
         super(DataFrameNormalizer, self).__init__(*args, **kwargs)
-        self._skip_df_consolidation = os.getenv("SKIP_DF_CONSOLIDATION") is not None
 
     def df_without_consolidation(self, columns, index, item, n_indexes, data):
         """
@@ -708,42 +707,10 @@ class DataFrameNormalizer(_PandasNormalizer):
 
         columns, denormed_columns, data = _denormalize_columns(item, norm_meta, idx_type, n_indexes)
 
-        if not self._skip_df_consolidation:
-            df = DataFrame(data, index=index, columns=columns)
-
-            # Setting the columns' dtype manually, since pandas might just convert the dtype of some
-            # (empty) columns to another one and since the `dtype` keyword for `pd.DataFrame` constructor
-            # does not accept a mapping such as `columns_dtype`.
-            # For instance the following code has been tried but returns a pandas.DataFrame full of NaNs:
-            #
-            #       columns_mapping = {} if data is None else {
-            #           name: pd.Series(np_array, index=index, dtype=np_array.dtype)
-            #           for name, np_array in data.items()
-            #       }
-            #       df = DataFrame(index=index, columns=columns_mapping, copy=False)
-            #
-            if not IS_PANDAS_TWO:
-                # TODO(jjerphan): Remove once pandas < 2 is not supported anymore.
-                # Before Pandas 2.0, empty series' dtype was float, but as of Pandas 2.0. empty series' dtype became object.
-                # See: https://github.com/pandas-dev/pandas/issues/17261
-                # EMPTY type column are returned as pandas.Series with "object" dtype to match Pandas 2.0 default.
-                # We cast it back to "float" so that it matches Pandas 1.0 default for empty series.
-                # Moreover, we explicitly provide the index otherwise Pandas 0.X overrides it for a RangeIndex
-                empty_columns_names = (
-                    [] if data is None else
-                    [
-                        name for name, np_array in data.items()
-                        if np_array.dtype in OBJECT_TOKENS and len(df[name]) == 0
-                    ]
-                )
-                for column_name in empty_columns_names:
-                    df[column_name] = pd.Series([], index=index, dtype='float64')
-
+        if index is not None:
+            df = self.df_without_consolidation(columns, index, item, n_indexes, data)
         else:
-            if index is not None:
-                df = self.df_without_consolidation(columns, index, item, n_indexes, data)
-            else:
-                df = self.df_without_consolidation(columns, item.data[0], item, n_indexes, data)
+            df = self.df_without_consolidation(columns, item.data[0], item, n_indexes, data)
 
         if denormed_columns is not None:
             df.columns = denormed_columns

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -332,7 +332,7 @@ class NativeVersionStore:
         dynamic_schema = self.resolve_defaults(
             "dynamic_schema", self._lib_cfg.lib_desc.version.write_options, False, **kwargs
         )
-        empty_types = self.resolve_defaults("empty_types", self._lib_cfg.lib_desc.version.write_options, False)
+        empty_types = self.resolve_defaults("empty_types", self._lib_cfg.lib_desc.version.write_options, True)
         try:
             udm = normalize_metadata(metadata) if metadata is not None else None
             opt_custom = self._custom_normalizer.normalize(dataframe)

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -326,7 +326,6 @@ class Library:
         """
         self.arctic_instance_desc = arctic_instance_description
         self._nvs = nvs
-        self._nvs._normalizer.df._skip_df_consolidation = True
         self._dev_tools = DevTools(nvs)
 
     def __repr__(self):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -523,38 +523,6 @@ def lmdb_version_store_dynamic_schema(
 
 
 @pytest.fixture
-def lmdb_version_store_empty_types_v1(version_store_factory, lib_name):
-    library_name = lib_name + "_v1"
-    return version_store_factory(dynamic_strings=True, empty_types=True, name=library_name)
-
-
-@pytest.fixture
-def lmdb_version_store_empty_types_v2(version_store_factory, lib_name):
-    library_name = lib_name + "_v2"
-    return version_store_factory(
-        dynamic_strings=True, empty_types=True, encoding_version=int(EncodingVersion.V2), name=library_name
-    )
-
-
-@pytest.fixture
-def lmdb_version_store_empty_types_dynamic_schema_v1(version_store_factory, lib_name):
-    library_name = lib_name + "_v1"
-    return version_store_factory(dynamic_strings=True, empty_types=True, dynamic_schema=True, name=library_name)
-
-
-@pytest.fixture
-def lmdb_version_store_empty_types_dynamic_schema_v2(version_store_factory, lib_name):
-    library_name = lib_name + "_v2"
-    return version_store_factory(
-        dynamic_strings=True,
-        empty_types=True,
-        dynamic_schema=True,
-        encoding_version=int(EncodingVersion.V2),
-        name=library_name,
-    )
-
-
-@pytest.fixture
 def lmdb_version_store_delayed_deletes_v1(version_store_factory):
     return version_store_factory(
         delayed_deletes=True, dynamic_strings=True, empty_types=True, prune_previous_version=True
@@ -767,10 +735,10 @@ def get_wide_df():
 @pytest.fixture(
     scope="function",
     params=(
-        "lmdb_version_store_empty_types_v1",
-        "lmdb_version_store_empty_types_v2",
-        "lmdb_version_store_empty_types_dynamic_schema_v1",
-        "lmdb_version_store_empty_types_dynamic_schema_v2",
+        "lmdb_version_store_v1",
+        "lmdb_version_store_v2",
+        "lmdb_version_store_dynamic_schema_v1",
+        "lmdb_version_store_dynamic_schema_v2",
     ),
 )
 def lmdb_version_store_static_and_dynamic(request):

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -204,9 +204,9 @@ def test_batch_write_unicode_strings(lmdb_version_store):
     (pd.Series, assert_series_equal),
     (pd.DataFrame, assert_frame_equal),
 ])
-def test_update_with_empty_series_or_dataframe(lmdb_version_store_empty_types_v1, PandasType, assert_pandas_container_equal):
+def test_update_with_empty_series_or_dataframe(lmdb_version_store_v1, PandasType, assert_pandas_container_equal):
     # Non-regression test for https://github.com/man-group/ArcticDB/issues/892
-    lib = lmdb_version_store_empty_types_v1
+    lib = lmdb_version_store_v1
 
     kwargs = { "name": "a" } if PandasType == pd.Series else { "columns": ["a"] }
     data = np.array([1.0]) if PandasType == pd.Series else np.array([[1.0]])


### PR DESCRIPTION
* Pandas consolidation is disabled by default
* Remove the environment variable allowing to change the default
* Remove the postprocessing step happening when consolidation is enabled

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
