### PR TITLE
Make all modification methods respect prune_previous_versions

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -490,7 +490,7 @@ std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
 }
 
 
-VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool dynamic_schema) {
+VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool dynamic_schema, bool prune_previous_versions) {
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, VersionQuery{});
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto version_id = get_next_version_from_key(*maybe_prev);
@@ -522,7 +522,7 @@ VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool d
         bucketize_dynamic);
 
     auto versioned_item = pipelines::index::index_and_version(index, store(), time_series, std::move(slice_and_keys), stream_id, version_id).get();
-    version_map()->write_version(store(), versioned_item.key_, maybe_prev);
+    write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, maybe_prev);
     ARCTICDB_DEBUG(log::version(), "sorted index of stream_id: {} , version_id: {}", stream_id, version_id);
     return versioned_item;
 }
@@ -530,15 +530,15 @@ VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool d
 VersionedItem LocalVersionedEngine::delete_range_internal(
     const StreamId& stream_id,
     const UpdateQuery & query,
-    bool dynamic_schema) {
+    const DeleteRangeOptions& option) {
     auto maybe_prev = get_latest_undeleted_version(store(), version_map(), stream_id, VersionQuery{});
     util::check(maybe_prev.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
     auto versioned_item = delete_range_impl(store(),
                                             *maybe_prev,
                                             query,
                                             get_write_options(),
-                                            dynamic_schema);
-    version_map()->write_version(store(), versioned_item.key_, maybe_prev);
+                                            option.dynamic_schema_);
+    write_version_and_prune_previous(option.prune_previous_versions_, versioned_item.key_, maybe_prev);
     return versioned_item;
 }
 
@@ -1011,7 +1011,7 @@ bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::
     return is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction);
 }
 
-VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& stream_id, std::optional<size_t> segment_size) {
+VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& stream_id, std::optional<size_t> segment_size, bool prune_previous_versions) {
     log::version().info("Defragmenting data for symbol {}", stream_id);
 
     // Currently defragmentation only for latest version - is there a use-case to allow compaction for older data?
@@ -1023,7 +1023,7 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(const StreamId& strea
             store(), stream_id, update_info, options,
             segment_size.has_value() ? *segment_size : options.segment_row_size);
 
-    version_map_->write_version(store_, versioned_item.key_, update_info.previous_index_key_);
+    write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
 
     if(cfg_.symbol_list())
         symbol_list().add_symbol(store_, stream_id, versioned_item.key_.version_id());
@@ -1667,14 +1667,10 @@ std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> Local
 VersionedItem LocalVersionedEngine::sort_merge_internal(
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
-    bool append,
-    bool convert_int_to_float,
-    bool via_iteration,
-    bool sparsify
-    ) {
+    const SortMergeOptions& option) {
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id, VersionQuery{});
-    auto versioned_item = sort_merge_impl(store_, stream_id, user_meta, update_info, append, convert_int_to_float, via_iteration, sparsify);
-    version_map()->write_version(store(), versioned_item.key_, update_info.previous_index_key_);
+    auto versioned_item = sort_merge_impl(store_, stream_id, user_meta, update_info, option.append_, option.convert_int_to_float_, option.via_iteration_, option.sparsify_);
+    write_version_and_prune_previous(option.prune_previous_versions_, versioned_item.key_, update_info.previous_index_key_);
     return versioned_item;
 }
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -49,6 +49,14 @@ struct KeySizesInfo {
     size_t uncompressed_size; // bytes
 };
 
+struct SortMergeOptions {
+    bool append_;
+    bool convert_int_to_float_;
+    bool via_iteration_;
+    bool sparsify_;
+    bool prune_previous_versions_;
+};
+
 class LocalVersionedEngine : public VersionedEngine {
 
 public:
@@ -81,7 +89,7 @@ public:
     VersionedItem delete_range_internal(
         const StreamId& stream_id,
         const UpdateQuery& query,
-        bool dynamic_schema) override;
+        const DeleteRangeOptions& option) override;
 
     void append_incomplete_segment(
         const StreamId& stream_id,
@@ -258,11 +266,7 @@ public:
     VersionedItem sort_merge_internal(
         const StreamId& stream_id,
         const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
-        bool append,
-        bool convert_int_to_float,
-        bool via_iteration,
-        bool sparsify
-        );
+        const SortMergeOptions& option);
 
     std::vector<folly::Future<AtomKey>> batch_write_internal(
         const std::vector<VersionId>& version_ids,
@@ -329,7 +333,7 @@ public:
 
     bool is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) override;
 
-    VersionedItem defragment_symbol_data(const StreamId& stream_id, std::optional<size_t> segment_size) override;
+    VersionedItem defragment_symbol_data(const StreamId& stream_id, std::optional<size_t> segment_size, bool prune_previous_versions) override;
     
     StorageLockWrapper get_storage_lock(const StreamId& stream_id) override;
 
@@ -344,7 +348,7 @@ public:
 
     timestamp latest_timestamp(const std::string& symbol) override;
 
-    VersionedItem sort_index(const StreamId& stream_id, bool dynamic_schema) override;
+    VersionedItem sort_index(const StreamId& stream_id, bool dynamic_schema, bool prune_previous_versions) override;
 
     void move_storage(
         KeyType key_type,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -479,10 +479,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::arg("convert_int_to_float") = false,
              py::arg("via_iteration") = true,
              py::arg("sparsify") = false,
+             py::arg("prune_previous_versions") = false,
              py::call_guard<SingleThreadMutexHolder>(), "sort_merge will sort and merge incomplete segments. The segments do not have to be ordered - incomplete segments can contain interleaved time periods but the final result will be fully ordered")
-         .def("sort_merge",
-              &PythonVersionStore::sort_merge,
-              py::call_guard<SingleThreadMutexHolder>(), "Sort and merge incomplete segments")
         .def("compact_library",
              &PythonVersionStore::compact_library,
              py::call_guard<SingleThreadMutexHolder>(), "Compact the whole library wherever necessary")

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -194,7 +194,7 @@ TEST_F(VersionStoreTest, SortMerge) {
         test_store_->append_incomplete_frame(symbol, std::move(frame.input_frame_));
     }
 
-    test_store_->sort_merge_internal(symbol, std::nullopt, true, false, false, false);
+    test_store_->sort_merge_internal(symbol, std::nullopt, arcticdb::version_store::SortMergeOptions{true, false, false, false, false});
 }
 
 TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -636,8 +636,9 @@ VersionedItem PythonVersionStore::update(
 VersionedItem PythonVersionStore::delete_range(
     const StreamId& stream_id,
     const UpdateQuery& query,
-    bool dynamic_schema) {
-    return delete_range_internal(stream_id, query, dynamic_schema);
+    bool dynamic_schema,
+    bool prune_previous_versions) {
+    return delete_range_internal(stream_id, query, DeleteRangeOptions{dynamic_schema, prune_previous_versions});
 }
 
 void PythonVersionStore::append_incomplete(
@@ -718,14 +719,15 @@ VersionedItem PythonVersionStore::sort_merge(
         bool append,
         bool convert_int_to_float,
         bool via_iteration,
-        bool sparsify
+        bool sparsify,
+        bool prune_previous_versions
 ) {
     std::optional<arcticdb::proto::descriptors::UserDefinedMetadata> meta;
     if (!user_meta.is_none()) {
         meta = std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>();
         python_util::pb_from_python(user_meta, *meta);
     }
-    return sort_merge_internal(stream_id, meta, append, convert_int_to_float, via_iteration, sparsify);
+    return sort_merge_internal(stream_id, meta, SortMergeOptions{append, convert_int_to_float, via_iteration, sparsify, prune_previous_versions});
 }
 
 void PythonVersionStore::write_parallel(

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -112,7 +112,8 @@ class PythonVersionStore : public LocalVersionedEngine {
     VersionedItem delete_range(
         const StreamId& stream_id,
         const UpdateQuery& query,
-        bool dynamic_schema);
+        bool dynamic_schema,
+        bool prune_previous_versions);
 
     void append_incomplete(
         const StreamId& stream_id,
@@ -170,8 +171,8 @@ class PythonVersionStore : public LocalVersionedEngine {
             bool append,
             bool convert_int_to_float,
             bool via_iteration,
-            bool sparsify
-            );
+            bool sparsify,
+            bool prune_previous_versions);
 
     ReadResult read_dataframe_merged(
         const StreamId& target_id,

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -36,6 +36,11 @@ struct ReadVersionOutput {
     FrameAndDescriptor frame_and_descriptor_;
 };
 
+struct DeleteRangeOptions {
+    bool dynamic_schema_;
+    bool prune_previous_versions_;
+};
+
 /**
  * The VersionedEngine interface contains methods that are portable between languages.
  *
@@ -63,10 +68,12 @@ public:
     virtual VersionedItem delete_range_internal(
         const StreamId& stream_id,
         const UpdateQuery& query,
-        bool dynamic_schema)= 0;
+        const DeleteRangeOptions& option)= 0;
 
     virtual VersionedItem sort_index(
-        const StreamId& stream_id, bool dynamic_schema) = 0;
+        const StreamId& stream_id,
+        bool dynamic_schema,
+        bool prune_previous_versions = false) = 0;
 
     virtual void append_incomplete_frame(
         const StreamId& stream_id,
@@ -145,7 +152,10 @@ public:
 
     virtual bool is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) = 0;
 
-    virtual VersionedItem defragment_symbol_data(const StreamId& stream_id, std::optional<size_t> segment_size) = 0;
+    virtual VersionedItem defragment_symbol_data(
+        const StreamId& stream_id,
+        std::optional<size_t> segment_size,
+        bool prune_previous_versions) = 0;
 
     virtual void move_storage(
         KeyType key_type,

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -927,7 +927,7 @@ class Library:
         )
 
     def sort_and_finalize_staged_data(
-        self, symbol: str, mode: Optional[StagedDataFinalizeMethod] = StagedDataFinalizeMethod.WRITE
+        self, symbol: str, mode: Optional[StagedDataFinalizeMethod] = StagedDataFinalizeMethod.WRITE, prune_previous_versions: Optional[bool] = False
     ):
         """
         sort_merge will sort and finalize staged data. This differs from `finalize_staged_data` in that it
@@ -943,13 +943,16 @@ class Library:
             Finalise mode. Valid options are WRITE or APPEND. Write collects the staged data and writes them to a
             new timeseries. Append collects the staged data and appends them to the latest version.
 
+        prune_previous_versions : `Optional[bool]`, default=False
+            Remove previous versions from version list. Uses library default if left as None.
+
         See Also
         --------
         write
             Documentation on the ``staged`` parameter explains the concept of staged data in more detail.
         """
 
-        self._nvs.version_store.sort_merge(symbol, None, mode == StagedDataFinalizeMethod.APPEND, False)
+        self._nvs.version_store.sort_merge(symbol, None, mode == StagedDataFinalizeMethod.APPEND, prune_previous_versions=prune_previous_versions)
 
     def get_staged_symbols(self) -> List[str]:
         """
@@ -1723,7 +1726,7 @@ class Library:
         """
         return self._nvs.is_symbol_fragmented(symbol, segment_size)
 
-    def defragment_symbol_data(self, symbol: str, segment_size: Optional[int] = None) -> VersionedItem:
+    def defragment_symbol_data(self, symbol: str, segment_size: Optional[int] = None, prune_previous_versions:bool = False) -> VersionedItem:
         """
         Compacts fragmented segments by merging row-sliced segments (https://docs.arcticdb.io/technical/on_disk_storage/#data-layer).
         This method calls `is_symbol_fragmented` to determine whether to proceed with the defragmentation operation.
@@ -1781,7 +1784,7 @@ class Library:
         Config map setting - SymbolDataCompact.SegmentCount will be replaced by a library setting
         in the future. This API will allow overriding the setting as well.
         """
-        return self._nvs.defragment_symbol_data(symbol, segment_size)
+        return self._nvs.defragment_symbol_data(symbol, segment_size, prune_previous_versions)
 
     @property
     def name(self):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -238,6 +238,26 @@ def arctic_library(arctic_client, lib_name):
     return arctic_client.create_library(lib_name)
 
 
+@pytest.fixture(
+    scope="function",
+    params=[
+        "lmdb",
+        "mem",
+        pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
+    ],
+)
+def basic_arctic_client(request, encoding_version):
+    storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage")
+    ac = storage_fixture.create_arctic(encoding_version=encoding_version)
+    assert not ac.list_libraries()
+    return ac
+
+
+@pytest.fixture
+def basic_arctic_library(basic_arctic_client, lib_name):
+    return basic_arctic_client.create_library(lib_name)
+
+
 # endregion
 # region ============================ `NativeVersionStore` Fixture Factories ============================
 @pytest.fixture


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://github.com/man-group/ArcticDB/issues/711
#### What does this implement or fix?
Add prune_previous option to APIs which still don't support it
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
