### PR TITLE
Fix #1148: Show clearer error message for mismatched types in QueryBuilder

### DIFF
--- a/cpp/arcticdb/entity/type_utils.hpp
+++ b/cpp/arcticdb/entity/type_utils.hpp
@@ -7,7 +7,9 @@
 
 #pragma once
 #include<optional>
+#include <fmt/format.h>
 #include<arcticdb/entity/descriptors.hpp>
+#include <arcticdb/entity/types.hpp>
 
 namespace arcticdb {
 
@@ -38,4 +40,9 @@ namespace entity {
     const proto::descriptors::TypeDescriptor& left,
     const proto::descriptors::TypeDescriptor& right
 );
+
+inline std::string get_user_friendly_type_string(const entity::TypeDescriptor& type) {
+    return is_sequence_type(type.data_type()) ? "TD<type=STRING, dim=0>" : fmt::format("{}", type);
+}
+
 }

--- a/cpp/arcticdb/entity/type_utils.hpp
+++ b/cpp/arcticdb/entity/type_utils.hpp
@@ -42,7 +42,7 @@ namespace entity {
 );
 
 inline std::string get_user_friendly_type_string(const entity::TypeDescriptor& type) {
-    return is_sequence_type(type.data_type()) ? "TD<type=STRING, dim=0>" : fmt::format("{}", type);
+    return is_sequence_type(type.data_type()) ? fmt::format("TD<type=STRING, dim={}>", type.dimension_) : fmt::format("{}", type);
 }
 
 }

--- a/cpp/arcticdb/pipeline/value.hpp
+++ b/cpp/arcticdb/pipeline/value.hpp
@@ -132,6 +132,16 @@ struct Value {
         *str_data() = data;
     }
 
+    template<typename RawType>
+    std::string to_string() const {
+        if (has_sequence_type()) {
+            return "\"" + std::string(*str_data(), len()) + "\"";
+        }
+        else {
+            return fmt::format("{}", get<RawType>());
+        }
+    }
+
     ~Value() {
         if(has_sequence_type())
             delete[] *str_data();
@@ -209,26 +219,3 @@ inline std::optional<std::string> ascii_to_padded_utf32(std::string_view str, si
 }
 
 } //namespace arcticdb
-
-namespace fmt {
-template<>
-struct formatter<arcticdb::Value> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    auto format(const arcticdb::Value& value, FormatContext& ctx) const {
-        if (is_sequence_type(value.type().data_type())) {
-            fmt::format_to(ctx.out(), "\"{}\"", std::string(*value.str_data(), value.len()));
-        }
-        else {
-            arcticdb::entity::details::visit_type(value.data_type_, [&](auto val_tag) {
-                using type_info = arcticdb::entity::ScalarTypeInfo<decltype(val_tag)>;
-                fmt::format_to(ctx.out(), "{}", value.get<typename type_info::RawType>());
-            });
-        }
-
-        return ctx.out();
-    }
-};
-}

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -14,6 +14,7 @@
 #include <arcticdb/processing/operation_types.hpp>
 #include <arcticdb/pipeline/value.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
+#include <utility>
 
 
 namespace arcticdb {
@@ -42,19 +43,23 @@ class StringPool;
 struct ColumnWithStrings {
     std::shared_ptr<Column> column_;
     const std::shared_ptr<StringPool> string_pool_;
+    ColumnName column_name_;
 
-    explicit ColumnWithStrings(std::unique_ptr<Column>&& col) :
-        column_(std::move(col)) {
+    ColumnWithStrings(std::unique_ptr<Column>&& col, ColumnName col_name) :
+        column_(std::move(col)),
+        column_name_(std::move(col_name)) {
     }
 
-    ColumnWithStrings(Column&& col, std::shared_ptr<StringPool> string_pool) :
+    ColumnWithStrings(Column&& col, std::shared_ptr<StringPool> string_pool, ColumnName col_name) :
         column_(std::make_shared<Column>(std::move(col))),
-        string_pool_(std::move(string_pool)) {
+        string_pool_(std::move(string_pool)),
+        column_name_(std::move(col_name)) {
     }
 
-    ColumnWithStrings(std::shared_ptr<Column> column, const std::shared_ptr<StringPool>& string_pool) :
+    ColumnWithStrings(std::shared_ptr<Column> column, const std::shared_ptr<StringPool>& string_pool, ColumnName col_name) :
         column_(std::move(column)),
-        string_pool_(string_pool) {
+        string_pool_(string_pool),
+        column_name_(std::move(col_name)) {
     }
 
     [[nodiscard]] std::optional<std::string_view> string_at_offset(entity::position_t offset, bool strip_fixed_width_trailing_nulls=false) const;

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -43,23 +43,23 @@ class StringPool;
 struct ColumnWithStrings {
     std::shared_ptr<Column> column_;
     const std::shared_ptr<StringPool> string_pool_;
-    ColumnName column_name_;
+    std::string column_name_;
 
-    ColumnWithStrings(std::unique_ptr<Column>&& col, ColumnName col_name) :
+    ColumnWithStrings(std::unique_ptr<Column>&& col, std::string_view col_name) :
         column_(std::move(col)),
-        column_name_(std::move(col_name)) {
+        column_name_(col_name) {
     }
 
-    ColumnWithStrings(Column&& col, std::shared_ptr<StringPool> string_pool, ColumnName col_name) :
+    ColumnWithStrings(Column&& col, std::shared_ptr<StringPool> string_pool, std::string_view col_name) :
         column_(std::make_shared<Column>(std::move(col))),
         string_pool_(std::move(string_pool)),
-        column_name_(std::move(col_name)) {
+        column_name_(col_name) {
     }
 
-    ColumnWithStrings(std::shared_ptr<Column> column, const std::shared_ptr<StringPool>& string_pool, ColumnName col_name) :
+    ColumnWithStrings(std::shared_ptr<Column> column, const std::shared_ptr<StringPool>& string_pool, std::string_view col_name) :
         column_(std::move(column)),
         string_pool_(string_pool),
-        column_name_(std::move(col_name)) {
+        column_name_(col_name) {
     }
 
     [[nodiscard]] std::optional<std::string_view> string_at_offset(entity::position_t offset, bool strip_fixed_width_trailing_nulls=false) const;

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -130,6 +130,7 @@ VariantData visit_binary_membership(const VariantData &left, const VariantData &
             },
             [](const auto &, const auto&) -> VariantData {
             user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Binary membership operations must be Column/ValueSet");
+            return EmptyResult{};
         }
         }, left, right);
 }
@@ -245,11 +246,19 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                 });
 
             } else {
-                user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Invalid comparison {} {} '{}' {}",
-                                column_with_strings.column_name_,
-                                get_user_friendly_type_string(column_with_strings.column_->type()),
-                                func,
-                                get_user_friendly_type_string(val.type()));
+                if constexpr (arguments_reversed) {
+                    user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Invalid comparison {} '{}' {} {}",
+                                    get_user_friendly_type_string(val.type()),
+                                    func,
+                                    column_with_strings.column_name_,
+                                    get_user_friendly_type_string(column_with_strings.column_->type()));
+                } else {
+                    user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Invalid comparison {} {} '{}' {}",
+                                    column_with_strings.column_name_,
+                                    get_user_friendly_type_string(column_with_strings.column_->type()),
+                                    func,
+                                    get_user_friendly_type_string(val.type()));
+                }
             }
         });
     });
@@ -278,9 +287,11 @@ VariantData visit_binary_comparator(const VariantData& left, const VariantData& 
         },
         [&] ([[maybe_unused]] const std::shared_ptr<Value>& l, [[maybe_unused]] const std::shared_ptr<Value>& r) ->VariantData  {
         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Two value inputs not accepted to binary comparators");
+        return EmptyResult{};
         },
         [](const auto &, const auto&) -> VariantData {
         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Bitset/ValueSet inputs not accepted to binary comparators");
+        return EmptyResult{};
     }
     }, left, right);
 }
@@ -419,7 +430,8 @@ VariantData visit_binary_operator(const VariantData& left, const VariantData& ri
             },
             [](const auto &, const auto&) -> VariantData {
             user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Bitset/ValueSet inputs not accepted to binary operators");
-        }
+            return EmptyResult{};
+            }
         }, left, right);
 }
 

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -103,6 +103,7 @@ VariantData visit_unary_operator(const VariantData& left, Func&& func) {
         },
         [](const auto&) -> VariantData {
             user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Bitset/ValueSet inputs not accepted to unary operators");
+            return EmptyResult{};
         }
     }, left);
 }
@@ -155,6 +156,7 @@ VariantData visit_unary_comparator(const VariantData& left, Func&& func) {
             },
             [](const auto&) -> VariantData {
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Bitset/ValueSet inputs not accepted to unary comparators");
+                return EmptyResult{};
             }
     }, left);
 }

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -617,7 +617,7 @@ struct formatter<arcticdb::EqualsOperator> {
 
     template<typename FormatContext>
     constexpr auto format(const arcticdb::EqualsOperator&, FormatContext &ctx) const {
-        return fmt::format_to(ctx.out(), "=");
+        return fmt::format_to(ctx.out(), "==");
     }
 };
 
@@ -683,7 +683,7 @@ struct formatter<arcticdb::IsInOperator> {
 
     template<typename FormatContext>
     constexpr auto format(const arcticdb::IsInOperator&, FormatContext &ctx) const {
-        return fmt::format_to(ctx.out(), "IN");
+        return fmt::format_to(ctx.out(), "IS IN");
     }
 };
 

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -520,3 +520,182 @@ bool operator()(T t, const ankerl::unordered_dense::set<U>& u) const {
 };
 
 } //namespace arcticdb
+
+namespace fmt {
+template<>
+struct formatter<arcticdb::AbsOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::AbsOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "ABS");
+    }
+};
+
+template<>
+struct formatter<arcticdb::NegOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::NegOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "-");
+    }
+};
+
+template<>
+struct formatter<arcticdb::IsNullOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::IsNullOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "ISNULL");
+    }
+};
+
+template<>
+struct formatter<arcticdb::NotNullOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::NotNullOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "NOTNULL");
+    }
+};
+
+template<>
+struct formatter<arcticdb::PlusOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::PlusOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "+");
+    }
+};
+
+template<>
+struct formatter<arcticdb::MinusOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::MinusOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "-");
+    }
+};
+
+template<>
+struct formatter<arcticdb::TimesOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::TimesOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "*");
+    }
+};
+
+template<>
+struct formatter<arcticdb::DivideOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::DivideOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "/");
+    }
+};
+
+template<>
+struct formatter<arcticdb::EqualsOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::EqualsOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "=");
+    }
+};
+
+template<>
+struct formatter<arcticdb::NotEqualsOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::NotEqualsOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "!=");
+    }
+};
+
+template<>
+struct formatter<arcticdb::LessThanOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::LessThanOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "<");
+    }
+};
+
+template<>
+struct formatter<arcticdb::LessThanEqualsOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::LessThanEqualsOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "<=");
+    }
+};
+
+template<>
+struct formatter<arcticdb::GreaterThanOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::GreaterThanOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), ">");
+    }
+};
+
+template<>
+struct formatter<arcticdb::GreaterThanEqualsOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::GreaterThanEqualsOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), ">=");
+    }
+};
+
+template<>
+struct formatter<arcticdb::IsInOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::IsInOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "IN");
+    }
+};
+
+template<>
+struct formatter<arcticdb::IsNotInOperator> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    constexpr auto format(const arcticdb::IsNotInOperator&, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "NOT IN");
+    }
+};
+
+} // namespace fmt

--- a/cpp/arcticdb/processing/processing_unit.cpp
+++ b/cpp/arcticdb/processing/processing_unit.cpp
@@ -53,7 +53,8 @@ VariantData ProcessingUnit::get(const VariantNode &name) {
                 return VariantData(ColumnWithStrings(
                         segment->column_ptr(
                         position_t(position_t(opt_idx.value()))),
-                        segment->string_pool_ptr()));
+                        segment->string_pool_ptr(),
+                        column_name));
             }
         }
         // Try multi-index column names
@@ -64,7 +65,8 @@ VariantData ProcessingUnit::get(const VariantNode &name) {
                 return VariantData(ColumnWithStrings(
                         segment->column_ptr(
                         position_t(*opt_idx)),
-                        segment->string_pool_ptr()));
+                        segment->string_pool_ptr(),
+                        column_name));
             }
         }
 

--- a/cpp/arcticdb/processing/processing_unit.cpp
+++ b/cpp/arcticdb/processing/processing_unit.cpp
@@ -54,7 +54,7 @@ VariantData ProcessingUnit::get(const VariantNode &name) {
                         segment->column_ptr(
                         position_t(position_t(opt_idx.value()))),
                         segment->string_pool_ptr(),
-                        column_name));
+                        column_name.value));
             }
         }
         // Try multi-index column names
@@ -66,7 +66,7 @@ VariantData ProcessingUnit::get(const VariantNode &name) {
                         segment->column_ptr(
                         position_t(*opt_idx)),
                         segment->string_pool_ptr(),
-                        column_name));
+                        column_name.value));
             }
         }
 

--- a/cpp/arcticdb/processing/test/benchmark_clause.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_clause.cpp
@@ -116,7 +116,7 @@ void BM_hash_grouping_int(benchmark::State& state) {
     constexpr auto data_type = data_type_from_raw_type<integer>();
     Column column(make_scalar_type(data_type), num_rows, true, false);
     memcpy(column.ptr(), data.data(), num_rows * sizeof(integer));
-    ColumnWithStrings col_with_strings(std::move(column), {});
+    ColumnWithStrings col_with_strings(std::move(column), {}, ColumnName("random_ints"));
 
     grouping::HashingGroupers::Grouper<ScalarTagType<DataTypeTag<data_type>>> grouper;
     grouping::ModuloBucketizer bucketizer(num_buckets);
@@ -157,7 +157,7 @@ void BM_hash_grouping_string(benchmark::State& state) {
         column.set_scalar(idx, ofstr.offset());
     }
 
-    ColumnWithStrings col_with_strings(std::move(column), string_pool);
+    ColumnWithStrings col_with_strings(std::move(column), string_pool, ColumnName("random_strings"));
 
     grouping::HashingGroupers::Grouper<ScalarTagType<DataTypeTag<DataType::UTF_DYNAMIC64>>> grouper;
     grouping::ModuloBucketizer bucketizer(num_buckets);

--- a/cpp/arcticdb/processing/test/benchmark_clause.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_clause.cpp
@@ -116,7 +116,7 @@ void BM_hash_grouping_int(benchmark::State& state) {
     constexpr auto data_type = data_type_from_raw_type<integer>();
     Column column(make_scalar_type(data_type), num_rows, true, false);
     memcpy(column.ptr(), data.data(), num_rows * sizeof(integer));
-    ColumnWithStrings col_with_strings(std::move(column), {}, ColumnName("random_ints"));
+    ColumnWithStrings col_with_strings(std::move(column), {}, "random_ints");
 
     grouping::HashingGroupers::Grouper<ScalarTagType<DataTypeTag<data_type>>> grouper;
     grouping::ModuloBucketizer bucketizer(num_buckets);
@@ -157,7 +157,7 @@ void BM_hash_grouping_string(benchmark::State& state) {
         column.set_scalar(idx, ofstr.offset());
     }
 
-    ColumnWithStrings col_with_strings(std::move(column), string_pool, ColumnName("random_strings"));
+    ColumnWithStrings col_with_strings(std::move(column), string_pool, "random_strings");
 
     grouping::HashingGroupers::Grouper<ScalarTagType<DataTypeTag<DataType::UTF_DYNAMIC64>>> grouper;
     grouping::ModuloBucketizer bucketizer(num_buckets);

--- a/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
@@ -17,8 +17,8 @@
 TEST(OperationDispatch, unary_operator) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), "empty_col");
 
     // int col
     auto variant_data = visit_unary_operator(int_column, NegOperator{});
@@ -34,8 +34,8 @@ TEST(OperationDispatch, unary_operator) {
 TEST(OperationDispatch, binary_operator) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), "empty_col");
     auto value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
 
     // int col + int col
@@ -77,8 +77,8 @@ TEST(OperationDispatch, binary_operator) {
 TEST(OperationDispatch, binary_comparator) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), "empty_col");
     auto value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
 
     // int col < int col
@@ -113,8 +113,8 @@ TEST(OperationDispatch, binary_comparator) {
 TEST(OperationDispatch, binary_membership) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), "empty_col");
     std::unordered_set<int64_t> raw_set{0, 23, 82, static_cast<int64_t>(num_rows) - 1, 1000000};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<int64_t>>(raw_set));
 

--- a/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
@@ -17,8 +17,8 @@
 TEST(OperationDispatch, unary_operator) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
 
     // int col
     auto variant_data = visit_unary_operator(int_column, NegOperator{});
@@ -34,8 +34,8 @@ TEST(OperationDispatch, unary_operator) {
 TEST(OperationDispatch, binary_operator) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
     auto value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
 
     // int col + int col
@@ -77,8 +77,8 @@ TEST(OperationDispatch, binary_operator) {
 TEST(OperationDispatch, binary_comparator) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
     auto value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
 
     // int col < int col
@@ -113,8 +113,8 @@ TEST(OperationDispatch, binary_comparator) {
 TEST(OperationDispatch, binary_membership) {
     using namespace arcticdb;
     size_t num_rows = 100;
-    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)));
-    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()));
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), ColumnName("int_col"));
+    auto empty_column = ColumnWithStrings(std::make_unique<Column>(generate_empty_column()), ColumnName("empty_col"));
     std::unordered_set<int64_t> raw_set{0, 23, 82, static_cast<int64_t>(num_rows) - 1, 1000000};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<int64_t>>(raw_set));
 

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -211,7 +211,7 @@ def test_filter_categorical(request, lib_type):
     q = q[q.a == "hi"]
     symbol = "test_filter_categorical"
     lib.write(symbol, df)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lib.read(symbol, query_builder=q)
 
 
@@ -282,32 +282,32 @@ def test_filter_bool_nonbool_comparison(lmdb_version_store):
     # bool column to string column
     q = QueryBuilder()
     q = q[q["bool"] == q["string"]]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         lib.read(symbol, query_builder=q)
     # bool column to numeric column
     q = QueryBuilder()
     q = q[q["bool"] == q["numeric"]]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         lib.read(symbol, query_builder=q)
     # bool column to string value
     q = QueryBuilder()
     q = q[q["bool"] == "test"]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         lib.read(symbol, query_builder=q)
     # bool column to numeric value
     q = QueryBuilder()
     q = q[q["bool"] == 0]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         lib.read(symbol, query_builder=q)
     # string column to bool value
     q = QueryBuilder()
     q = q[q["string"] == True]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         lib.read(symbol, query_builder=q)
     # numeric column to bool value
     q = QueryBuilder()
     q = q[q["numeric"] == True]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         lib.read(symbol, query_builder=q)
 
 
@@ -790,11 +790,11 @@ def test_filter_compare_string_number_col_val(lmdb_version_store, df, val):
     q = q[q["a"] < val]
     symbol = "test_filter_compare_string_number_col_val"
     lmdb_version_store.write(symbol, df)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
-    q = q[val < q["a"]]
-    with pytest.raises(InternalException) as e_info:
+    q = q[(val < q["a"])]
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -807,11 +807,11 @@ def test_filter_compare_string_number_val_col(lmdb_version_store, df, val):
     q = q[val < q["a"]]
     symbol = "test_filter_compare_string_number_val_col"
     lmdb_version_store.write(symbol, df)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[q["a"] < val]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -828,11 +828,11 @@ def test_filter_compare_string_number_col_col(lmdb_version_store, df):
     q = q[q["a"] < q["b"]]
     symbol = "test_filter_compare_string_number_col_col"
     lmdb_version_store.write(symbol, df)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[q["b"] < q["a"]]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -849,7 +849,7 @@ def test_filter_isin_string_number_signed(lmdb_version_store, df, vals):
     q = q[q["a"].isin(vals)]
     symbol = "test_filter_isin_string_number"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -866,7 +866,7 @@ def test_filter_isin_string_number_unsigned(lmdb_version_store, df, vals):
     q = q[q["a"].isin(vals)]
     symbol = "test_filter_isin_string_number"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -882,7 +882,7 @@ def test_filter_isin_number_string(lmdb_version_store, df, vals):
     q = q[q["a"].isin(vals)]
     symbol = "test_filter_isin_number_string"
     lmdb_version_store.write(symbol, df)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1395,11 +1395,11 @@ def test_filter_arithmetic_string_number_col_val(lmdb_version_store, df, val):
     q = q[(q["a"] + val) < 10]
     symbol = "test_filter_arithmetic_string_number_col_val"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[(val + q["a"]) < 10]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1412,11 +1412,11 @@ def test_filter_arithmetic_string_number_val_col(lmdb_version_store, df, val):
     q = q[(q["a"] + val) < 10]
     symbol = "test_filter_arithmetic_string_number_val_col"
     lmdb_version_store.write(symbol, df)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[(val + q["a"]) < 10]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1433,11 +1433,11 @@ def test_filter_arithmetic_string_number_col_col(lmdb_version_store, df):
     q = q[(q["a"] + q["b"]) < 10]
     symbol = "test_filter_arithmetic_string_number_val_col"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[(q["b"] + q["a"]) < 10]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1450,11 +1450,11 @@ def test_filter_arithmetic_string_string_col_val(lmdb_version_store, df, val):
     q = q[(q["a"] + val) < 10]
     symbol = "test_filter_arithmetic_string_string_col_val"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[(val + q["a"]) < 10]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1467,11 +1467,11 @@ def test_filter_arithmetic_string_string_val_col(lmdb_version_store, df, val):
     q = q[(q["a"] + val) < 10]
     symbol = "test_filter_arithmetic_string_string_val_col"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[(val + q["a"]) < 10]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1488,11 +1488,11 @@ def test_filter_arithmetic_string_string_col_col(lmdb_version_store, df):
     q = q[(q["a"] + q["b"]) < 10]
     symbol = "test_filter_arithmetic_string_string_col_col"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
     q = QueryBuilder()
     q = q[(q["b"] + q["a"]) < 10]
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1519,7 +1519,7 @@ def test_filter_abs_string(lmdb_version_store, df, val):
     q = q[abs(q["a"]) < val]
     symbol = "test_filter_abs_string"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 
@@ -1546,7 +1546,7 @@ def test_filter_neg_string(lmdb_version_store, df, val):
     q = q[-q["a"] < val]
     symbol = "test_filter_neg_string"
     lmdb_version_store.write(symbol, df, dynamic_strings=True)
-    with pytest.raises(InternalException) as e_info:
+    with pytest.raises(UserInputException) as e_info:
         _ = lmdb_version_store.read(symbol, query_builder=q)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -13,7 +13,7 @@ import dateutil
 
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.util.test import assert_frame_equal
-from arcticdb_ext.exceptions import SchemaException
+from arcticdb_ext.exceptions import SchemaException, InternalException
 
 
 def test_reuse_querybuilder(lmdb_version_store_tiny_segment):
@@ -266,6 +266,40 @@ def test_querybuilder_filter_then_filter(lmdb_version_store_tiny_segment):
 
     expected = df.query("col1 in [2, 3]")
     assert_frame_equal(expected, received)
+
+
+def test_df_query_wrong_type(lmdb_version_store_small_segment):
+    lib = lmdb_version_store_small_segment
+
+    df1 = pd.DataFrame({"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [4, 5, 6], "col_str": ["1", "2", "3"]})
+    sym = "symbol"
+    lib.write(sym, df1)
+
+    q = QueryBuilder()
+    q = q[q["col1"] + q["col_str"] == 3]
+    with pytest.raises(InternalException, match="Non-numeric column provided.*col_str.*type=STRING"):
+        lib.read(sym, query_builder=q)
+
+    q = QueryBuilder()
+    q = q[q["col1"] + "1" == 3]
+    with pytest.raises(InternalException, match="Non-numeric type provided.*type=STRING"):
+        lib.read(sym, query_builder=q)
+
+    q = QueryBuilder()
+    q = q[-q["col_str"] == 3]
+    with pytest.raises(InternalException, match="Cannot perform arithmetic on col_str.*type=STRING"):
+        lib.read(sym, query_builder=q)
+
+    q = QueryBuilder()
+    q = q[q["col1"] - 1 >= "1"]
+    with pytest.raises(InternalException, match="Cannot compare.*col1 - 1.*type=INT64.* to .*type=STRING"):
+        lib.read(sym, query_builder=q)
+
+    q = QueryBuilder()
+    q = q[1 + q["col1"] * q["col2"] - q["col3"] == q["col_str"]]
+    # check that ((1 + (col1 * col2)) + col3) is generated as a column name and shown in the error message
+    with pytest.raises(InternalException, match="Cannot compare.*\(1 \+ \(col1 \* col2\)\) - col3.*type=INT64.* to col_str .*type=STRING"):
+        lib.read(sym, query_builder=q)
 
 
 def test_querybuilder_filter_then_project(lmdb_version_store_tiny_segment):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1148.
previously if a type was mismatched in the QueryBuilder as follows
```python
df1 = pd.DataFrame({"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [4, 5, 6], "col_str": ["1", "2", "3"]})
sym = "symbol"
lib.write(sym, df1)
q = QueryBuilder()
q = q[q["col1" + 1]  == "3"]
lib.read(sym, query_builder=q)
```
it would show an unclear message with `UTF_DYNAMIC64` type shown for strings 
```
arcticdb_ext.exceptions.InternalException: E_ASSERTION_FAILURE Cannot compare TD<type=UTF_DYNAMIC64, dim=0> to TD<type=UINT32, dim=0> (possible categorical?)
```
Now the error is much clearer where column names are generated according to the query and STRING type is shown for strings
```
arcticdb_ext.exceptions.UserInputException: E_INVALID_USER_ARGUMENT Invalid comparison (col1 + 1) (TD<type=INT64, dim=0>) == "3" (TD<type=STRING, dim=0>)
```
For a more complex query like `q = q[1 + q["col1"] * q["col2"] - q["col3"] == q["col_str"]]` it will show column name `((1 + (col1 * col2)) - col3)` in the error message which allows the user to better understand the error.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
