### PR TITLE
Release GIL on update and append

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -550,6 +550,7 @@ VersionedItem LocalVersionedEngine::update_internal(
     bool dynamic_schema,
     bool prune_previous_versions) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: update");
+    py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
                                                                         version_map(),
                                                                         stream_id,
@@ -1362,7 +1363,7 @@ VersionedItem LocalVersionedEngine::append_internal(
     bool upsert,
     bool prune_previous_versions,
     bool validate_index) {
-
+    py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
                                                                         version_map(),
                                                                         stream_id,


### PR DESCRIPTION
We need to take the GIL when Python needs to allocate special characters, otherwise we will deadlock. At the moment write() releases the GIL but update() and append() don't


