### PR TITLE
Completely disable Pandas consolidation

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -326,7 +326,6 @@ class Library:
         """
         self.arctic_instance_desc = arctic_instance_description
         self._nvs = nvs
-        self._nvs._normalizer.df._skip_df_consolidation = True
         self._dev_tools = DevTools(nvs)
 
     def __repr__(self):

--- a/python/tests/unit/arcticdb/test_flattener.py
+++ b/python/tests/unit/arcticdb/test_flattener.py
@@ -16,7 +16,7 @@ from arcticdb.version_store._custom_normalizers import (
 
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_frame_equal, assert_series_equal
+from arcticdb.util.test import assert_frame_equal, assert_series_equal
 
 fl = Flattener()
 separator = fl.SEPARATOR

--- a/python/tests/unit/arcticdb/test_flattener.py
+++ b/python/tests/unit/arcticdb/test_flattener.py
@@ -16,6 +16,7 @@ from arcticdb.version_store._custom_normalizers import (
 
 import numpy as np
 import pandas as pd
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 fl = Flattener()
 separator = fl.SEPARATOR
@@ -98,7 +99,7 @@ def test_pandas_series(lmdb_version_store):
 
     lib = lmdb_version_store
     lib.write("sym", test_data, recursive_normalizers=True)
-    assert lib.read("sym").data[0].equals(test_data[0])
+    assert_series_equal(lib.read("sym").data[0], test_data[0])
 
 
 def test_multiindex_recursive_normalizer(lmdb_version_store):
@@ -106,4 +107,4 @@ def test_multiindex_recursive_normalizer(lmdb_version_store):
     vals = ["a", "b", "c"]
     df = pd.DataFrame(data=np.arange(6), index=pd.MultiIndex.from_product([dtidx, vals], names=["a", "b"]))
     lmdb_version_store.write("df", {"data": df}, recursive_normalizers=True)
-    assert lmdb_version_store.read("df").data["data"].equals(df)
+    assert_frame_equal(lmdb_version_store.read("df").data["data"], df)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Closes: #1226
#### What does this implement or fix?
* Remove the environment variable which was used to enable the consolidation phase
* Make our custom block manager to cast blocks for empty columns to float64. To be removed after empty types become enabled.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
