### PR TITLE
Remove non-lmdb stores from unit tests

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import pytest
 import numpy as np
 import pandas as pd
@@ -217,7 +218,7 @@ def test_hypothesis_count_agg_strings(lmdb_version_store, df):
     count_aggregation(lmdb_version_store, df)
 
 
-def test_count_aggregation(local_object_version_store):
+def test_count_aggregation(lmdb_version_store):
     df = DataFrame(
         {
             "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2", "group_3"],
@@ -228,9 +229,9 @@ def test_count_aggregation(local_object_version_store):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"to_count": "count"})
     symbol = "test_count_aggregation"
-    local_object_version_store.write(symbol, df)
+    lmdb_version_store.write(symbol, df)
 
-    res = local_object_version_store.read(symbol, query_builder=q)
+    res = lmdb_version_store.read(symbol, query_builder=q)
     res.data.sort_index(inplace=True)
 
     df = pd.DataFrame({"to_count": [3, 2, 0]}, index=["group_1", "group_2", "group_3"], dtype=np.uint64)
@@ -272,7 +273,7 @@ def test_hypothesis_first_agg_numeric(lmdb_version_store, df):
 
 
 @pytest.mark.skip(reason="Feature flagged off until working with string columns and dynamic schema")
-def test_first_aggregation(local_object_version_store):
+def test_first_aggregation(lmdb_version_store):
     df = DataFrame(
         {
             "grouping_column": ["group_1", "group_2", "group_4", "group_2", "group_1", "group_3", "group_1"],
@@ -283,9 +284,9 @@ def test_first_aggregation(local_object_version_store):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"get_first": "first"})
     symbol = "test_first_aggregation"
-    local_object_version_store.write(symbol, df)
+    lmdb_version_store.write(symbol, df)
 
-    res = local_object_version_store.read(symbol, query_builder=q)
+    res = lmdb_version_store.read(symbol, query_builder=q)
     res.data.sort_index(inplace=True)
 
     df = pd.DataFrame({"get_first": [100.0, 2.7, 5.8, np.nan]}, index=["group_1", "group_2", "group_3", "group_4"])
@@ -296,8 +297,8 @@ def test_first_aggregation(local_object_version_store):
 
 
 @pytest.mark.skip(reason="Feature flagged off until working with string columns and dynamic schema")
-def test_first_agg_with_append(local_object_version_store):
-    lib = local_object_version_store
+def test_first_agg_with_append(lmdb_version_store):
+    lib = lmdb_version_store
 
     symbol = "first_agg"
     lib.write(symbol, pd.DataFrame({"grouping_column": [0], "get_first": [10.0]}))
@@ -346,10 +347,20 @@ def test_hypothesis_last_agg_numeric(lmdb_version_store, df):
 
 
 @pytest.mark.skip(reason="Feature flagged off until working with string columns and dynamic schema")
-def test_last_aggregation(local_object_version_store):
+def test_last_aggregation(lmdb_version_store):
     df = DataFrame(
         {
-            "grouping_column": ["group_1", "group_2", "group_4", "group_5", "group_2", "group_1", "group_3", "group_1", "group_5"],
+            "grouping_column": [
+                "group_1",
+                "group_2",
+                "group_4",
+                "group_5",
+                "group_2",
+                "group_1",
+                "group_3",
+                "group_1",
+                "group_5",
+            ],
             "get_last": [100.0, 2.7, np.nan, np.nan, np.nan, 1.4, 5.8, 3.45, 6.9],
         },
         index=np.arange(9),
@@ -357,12 +368,14 @@ def test_last_aggregation(local_object_version_store):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"get_last": "last"})
     symbol = "test_last_aggregation"
-    local_object_version_store.write(symbol, df)
+    lmdb_version_store.write(symbol, df)
 
-    res = local_object_version_store.read(symbol, query_builder=q)
+    res = lmdb_version_store.read(symbol, query_builder=q)
     res.data.sort_index(inplace=True)
 
-    df = pd.DataFrame({"get_last": [3.45, 2.7, 5.8, np.nan, 6.9]}, index=["group_1", "group_2", "group_3", "group_4", "group_5"])
+    df = pd.DataFrame(
+        {"get_last": [3.45, 2.7, 5.8, np.nan, 6.9]}, index=["group_1", "group_2", "group_3", "group_4", "group_5"]
+    )
     df.index.rename("grouping_column", inplace=True)
     res.data.sort_index(inplace=True)
 
@@ -370,8 +383,8 @@ def test_last_aggregation(local_object_version_store):
 
 
 @pytest.mark.skip(reason="Feature flagged off until working with string columns and dynamic schema")
-def test_last_agg_with_append(local_object_version_store):
-    lib = local_object_version_store
+def test_last_agg_with_append(lmdb_version_store):
+    lib = lmdb_version_store
 
     symbol = "last_agg"
     lib.write(symbol, pd.DataFrame({"grouping_column": [0], "get_last": [10.0]}))
@@ -388,7 +401,7 @@ def test_last_agg_with_append(local_object_version_store):
     assert_frame_equal(vit.data, df)
 
 
-def test_sum_aggregation(local_object_version_store):
+def test_sum_aggregation(lmdb_version_store):
     df = DataFrame(
         {"grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"], "to_sum": [1, 1, 2, 2, 2]},
         index=np.arange(5),
@@ -396,9 +409,9 @@ def test_sum_aggregation(local_object_version_store):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"to_sum": "sum"})
     symbol = "test_sum_aggregation"
-    local_object_version_store.write(symbol, df)
+    lmdb_version_store.write(symbol, df)
 
-    res = local_object_version_store.read(symbol, query_builder=q)
+    res = lmdb_version_store.read(symbol, query_builder=q)
     res.data.sort_index(inplace=True)
 
     df = pd.DataFrame({"to_sum": [4, 4]}, index=["group_1", "group_2"])
@@ -408,7 +421,7 @@ def test_sum_aggregation(local_object_version_store):
     assert_frame_equal(res.data, df)
 
 
-def test_mean_aggregation(local_object_version_store):
+def test_mean_aggregation(lmdb_version_store):
     df = DataFrame(
         {"grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"], "to_mean": [1, 1, 2, 2, 2]},
         index=np.arange(5),
@@ -416,9 +429,9 @@ def test_mean_aggregation(local_object_version_store):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"to_mean": "mean"})
     symbol = "test_aggregation"
-    local_object_version_store.write(symbol, df)
+    lmdb_version_store.write(symbol, df)
 
-    res = local_object_version_store.read(symbol, query_builder=q)
+    res = lmdb_version_store.read(symbol, query_builder=q)
     res.data.sort_index(inplace=True)
 
     df = pd.DataFrame({"to_mean": [4 / 3, 2]}, index=["group_1", "group_2"])
@@ -428,7 +441,7 @@ def test_mean_aggregation(local_object_version_store):
     assert_frame_equal(res.data, df)
 
 
-def test_mean_aggregation_float(local_object_version_store):
+def test_mean_aggregation_float(lmdb_version_store):
     df = DataFrame(
         {
             "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
@@ -439,9 +452,9 @@ def test_mean_aggregation_float(local_object_version_store):
     q = QueryBuilder()
     q = q.groupby("grouping_column").agg({"to_mean": "mean"})
     symbol = "test_aggregation"
-    local_object_version_store.write(symbol, df)
+    lmdb_version_store.write(symbol, df)
 
-    res = local_object_version_store.read(symbol, query_builder=q)
+    res = lmdb_version_store.read(symbol, query_builder=q)
     res.data.sort_index(inplace=True)
 
     df = pd.DataFrame({"to_mean": [(1.1 + 1.4 + 2.5) / 3, 2.2]}, index=["group_1", "group_2"])
@@ -455,12 +468,7 @@ def test_named_agg(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     sym = "test_named_agg"
     gen = np.random.default_rng()
-    df = DataFrame(
-        {
-            "grouping_column": [1, 1, 1, 2, 3, 4],
-            "agg_column": gen.random(6)
-        }
-    )
+    df = DataFrame({"grouping_column": [1, 1, 1, 2, 3, 4], "agg_column": gen.random(6)})
     lib.write(sym, df)
     expected = df.groupby("grouping_column").agg(
         agg_column_sum=pd.NamedAgg("agg_column", "sum"),

--- a/python/tests/unit/arcticdb/version_store/test_aggregation_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation_dynamic.py
@@ -37,7 +37,10 @@ def assert_equal_value(data, expected):
     assert_frame_equal(received.astype("float"), expected)
 
 
-@pytest.mark.xfail(MACOS_CONDA_BUILD, reason="Conda Pandas returns nan instead of inf like other platforms")
+@pytest.mark.xfail(
+    MACOS_CONDA_BUILD,
+    reason="Conda Pandas returns nan instead of inf like other platforms",
+)
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
 @given(
@@ -93,8 +96,8 @@ def test_hypothesis_mean_agg_dynamic(lmdb_version_store_dynamic_schema_v1, df):
         index=range_indexes(),
     )
 )
-def test_hypothesis_sum_agg_dynamic(s3_version_store_dynamic_schema_v2, df):
-    lib = s3_version_store_dynamic_schema_v2
+def test_hypothesis_sum_agg_dynamic(lmdb_version_store_dynamic_schema_v1, df):
+    lib = lmdb_version_store_dynamic_schema_v1
     assume(not df.empty)
 
     symbol = f"sum_agg-{uuid.uuid4().hex}"
@@ -213,11 +216,18 @@ def test_hypothesis_count_agg_dynamic_strings(lmdb_version_store_dynamic_schema_
     count_agg_dynamic(lmdb_version_store_dynamic_schema_v1, df)
 
 
-def test_count_aggregation_dynamic(s3_version_store_dynamic_schema_v2):
-    lib = s3_version_store_dynamic_schema_v2
+def test_count_aggregation_dynamic(lmdb_version_store_dynamic_schema_v2):
+    lib = lmdb_version_store_dynamic_schema_v2
     df = DataFrame(
         {
-            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2", "group_3"],
+            "grouping_column": [
+                "group_1",
+                "group_1",
+                "group_1",
+                "group_2",
+                "group_2",
+                "group_3",
+            ],
             "to_count": [100, 1, 3, 2, 2, np.nan],
         },
         index=np.arange(6),
@@ -276,11 +286,19 @@ def test_hypothesis_first_agg_dynamic_numeric(lmdb_version_store_dynamic_schema_
 
 
 @pytest.mark.xfail(reason="Not supported yet")
-def test_first_aggregation_dynamic(s3_version_store_dynamic_schema_v2):
-    lib = s3_version_store_dynamic_schema_v2
+def test_first_aggregation_dynamic(lmdb_version_store_dynamic_schema_v2):
+    lib = lmdb_version_store_dynamic_schema_v2
     df = DataFrame(
         {
-            "grouping_column": ["group_1", "group_2", "group_4", "group_2", "group_1", "group_3", "group_1"],
+            "grouping_column": [
+                "group_1",
+                "group_2",
+                "group_4",
+                "group_2",
+                "group_1",
+                "group_3",
+                "group_1",
+            ],
             "get_first": [100.0, np.nan, np.nan, 2.7, 1.4, 5.8, 3.45],
         },
         index=np.arange(7),
@@ -338,11 +356,21 @@ def test_hypothesis_last_agg_dynamic_numeric(lmdb_version_store_dynamic_schema_v
 
 
 @pytest.mark.xfail(reason="Not supported yet")
-def test_last_aggregation_dynamic(s3_version_store_dynamic_schema_v2):
-    lib = s3_version_store_dynamic_schema_v2
+def test_last_aggregation_dynamic(lmdb_version_store_dynamic_schema_v2):
+    lib = lmdb_version_store_dynamic_schema_v2
     df = DataFrame(
         {
-            "grouping_column": ["group_1", "group_2", "group_4", "group_5", "group_2", "group_1", "group_3", "group_1", "group_5"],
+            "grouping_column": [
+                "group_1",
+                "group_2",
+                "group_4",
+                "group_5",
+                "group_2",
+                "group_1",
+                "group_3",
+                "group_1",
+                "group_5",
+            ],
             "get_last": [100.0, 2.7, np.nan, np.nan, np.nan, 1.4, 5.8, 3.45, 6.9],
         },
         index=np.arange(9),
@@ -363,10 +391,13 @@ def test_last_aggregation_dynamic(s3_version_store_dynamic_schema_v2):
     assert_frame_equal(received, expected)
 
 
-def test_sum_aggregation_dynamic(s3_version_store_dynamic_schema_v2):
-    lib = s3_version_store_dynamic_schema_v2
+def test_sum_aggregation_dynamic(lmdb_version_store_dynamic_schema_v2):
+    lib = lmdb_version_store_dynamic_schema_v2
     df = DataFrame(
-        {"grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"], "to_sum": [1, 1, 2, 2, 2]},
+        {
+            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
+            "to_sum": [1, 1, 2, 2, 2],
+        },
         index=np.arange(5),
     )
     symbol = "test_sum_aggregation_dynamic"
@@ -385,7 +416,10 @@ def test_sum_aggregation_dynamic(s3_version_store_dynamic_schema_v2):
 def test_sum_aggregation_with_range_index_dynamic(lmdb_version_store_dynamic_schema_v1):
     lib = lmdb_version_store_dynamic_schema_v1
     df = DataFrame(
-        {"grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"], "to_sum": [1, 1, 2, 2, 2]}
+        {
+            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"],
+            "to_sum": [1, 1, 2, 2, 2],
+        }
     )
     symbol = "test_sum_aggregation_dynamic"
     expected, slices = make_dynamic(df)
@@ -457,12 +491,23 @@ def test_group_column_splitting_dynamic(lmdb_version_store_tiny_segment_dynamic)
     assert_equal_value(vit.data, expected)
 
 
-def test_group_column_splitting_strings_dynamic(lmdb_version_store_tiny_segment_dynamic):
+def test_group_column_splitting_strings_dynamic(
+    lmdb_version_store_tiny_segment_dynamic,
+):
     lib = lmdb_version_store_tiny_segment_dynamic
     symbol = "test_group_column_splitting"
     df = DataFrame(
         {
-            "grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2", "group_1", "group_2", "group_1"],
+            "grouping_column": [
+                "group_1",
+                "group_1",
+                "group_1",
+                "group_2",
+                "group_2",
+                "group_1",
+                "group_2",
+                "group_1",
+            ],
             "sum1": [1, 2, 3, 4, 1, 2, 3, 4],
             "max1": [1, 2, 3, 4, 1, 2, 3, 4],
             "sum2": [2, 3, 4, 5, 2, 3, 4, 5],
@@ -536,7 +581,9 @@ def test_minimal_repro_type_change_max(lmdb_version_store_dynamic_schema):
     assert_equal_value(received, expected)
 
 
-def test_minimal_repro_type_sum_similar_string_group_values(lmdb_version_store_dynamic_schema):
+def test_minimal_repro_type_sum_similar_string_group_values(
+    lmdb_version_store_dynamic_schema,
+):
     lib = lmdb_version_store_dynamic_schema
     sym = "test_minimal_repro_type_change_max"
 
@@ -550,7 +597,9 @@ def test_minimal_repro_type_sum_similar_string_group_values(lmdb_version_store_d
     assert_equal_value(received, expected)
 
 
-def test_aggregation_grouping_column_missing_from_row_group(lmdb_version_store_dynamic_schema):
+def test_aggregation_grouping_column_missing_from_row_group(
+    lmdb_version_store_dynamic_schema,
+):
     lib = lmdb_version_store_dynamic_schema
     df0 = DataFrame(
         {"to_sum": [1, 2], "grouping_column": ["group_1", "group_2"]},

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import time
 from multiprocessing import Pool
 from pickle import loads, dumps
@@ -70,11 +71,11 @@ def _read_and_assert_symbol(args):
             time.sleep(0.5)  # Make sure the writes have finished, especially azurite.
 
 
-def test_parallel_reads(local_object_version_store):
+def test_parallel_reads(lmdb_version_store):
     symbols = ["XXX"] * 20
     p = Pool(10)
-    local_object_version_store.write(symbols[0], df("test1"))
+    lmdb_version_store.write(symbols[0], df("test1"))
     time.sleep(0.1)  # Make sure the writes have finished, especially azurite.
-    p.map(_read_and_assert_symbol, [(local_object_version_store, s, idx) for idx, s in enumerate(symbols)])
+    p.map(_read_and_assert_symbol, [(lmdb_version_store, s, idx) for idx, s in enumerate(symbols)])
     p.close()
     p.join()

--- a/python/tests/unit/arcticdb/version_store/test_projection.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 from hypothesis import assume, given, settings
 from hypothesis.extra.pandas import column, data_frames, range_indexes
 import numpy as np
@@ -19,8 +20,8 @@ from arcticdb.util.hypothesis import (
 )
 
 
-def test_project(local_object_version_store):
-    lib = local_object_version_store
+def test_project(lmdb_version_store):
+    lib = lmdb_version_store
     df = pd.DataFrame(
         {
             "VWAP": np.arange(0, 10, dtype=np.float64),

--- a/python/tests/unit/arcticdb/version_store/test_projection_dynamic.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection_dynamic.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 from hypothesis import assume, given, settings
 from hypothesis.extra.pandas import column, data_frames, range_indexes
 import numpy as np
@@ -162,8 +163,8 @@ def test_project_multiply_col_val(lmdb_version_store_dynamic_schema_v1, df):
         index=range_indexes(),
     )
 )
-def test_project_divide_val_col(s3_version_store_dynamic_schema_v2, df):
-    lib = s3_version_store_dynamic_schema_v2
+def test_project_divide_val_col(lmdb_version_store_dynamic_schema_v2, df):
+    lib = lmdb_version_store_dynamic_schema_v2
     assume(not df.empty)
     symbol = "test_project_divide_val_col"
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1564 

#### What does this implement or fix?
It remove all simulators from the unit tests (e.g. S3 moto, azurite, mongo)

TODO - make sure that we don't need these tests, if we don - add them to the integration tests
