### PR TITLE
Only write ref key once when writing with prune_previous_versions (#1…

### DIFF
--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -9,16 +9,16 @@ echo Saving results to ${TEST_OUTPUT_DIR:="$(realpath "$tooling_dir/../cpp/out")
 
 catch=`{ which catchsegv 2>/dev/null || echo ; } | tail -n 1`
 
-    set -o xtrace -o pipefail
+set -o xtrace -o pipefail
 
-    # Build a directory that's just the test assets, so can't access other Python source not in the wheel
-    mkdir -p $PARALLEL_TEST_ROOT
-    MSYS=winsymlinks:nativestrict ln -s "$(realpath "$tooling_dir/../python/tests")" $PARALLEL_TEST_ROOT/
-    cd $PARALLEL_TEST_ROOT
+# Build a directory that's just the test assets, so can't access other Python source not in the wheel
+mkdir -p $PARALLEL_TEST_ROOT
+MSYS=winsymlinks:nativestrict ln -s "$(realpath "$tooling_dir/../python/tests")" $PARALLEL_TEST_ROOT/
+cd $PARALLEL_TEST_ROOT
 
-    export ARCTICDB_RAND_SEED=$RANDOM
+export ARCTICDB_RAND_SEED=$RANDOM
 
-    $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
-        --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
-        --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
-        "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#\2#"
+$catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
+    --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
+    --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
+    "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#\2#"

--- a/python/tests/stress/arcticdb/version_store/test_concurrent_read_and_write.py
+++ b/python/tests/stress/arcticdb/version_store/test_concurrent_read_and_write.py
@@ -1,0 +1,49 @@
+import time
+import pytest
+from multiprocessing import Process, Queue
+
+
+@pytest.fixture
+def writer_store(lmdb_version_store_delayed_deletes_v2):
+    return lmdb_version_store_delayed_deletes_v2
+
+
+@pytest.fixture
+def reader_store(lmdb_version_store_delayed_deletes_v2):
+    return lmdb_version_store_delayed_deletes_v2
+
+
+def read_repeatedly(version_store, queue: Queue):
+    while True:
+        try:
+            version_store.read("sym")
+        except Exception as e:
+            queue.put(e)
+            raise  # don't get stuck in the while loop when we already know there's an issue
+        time.sleep(0.1)
+
+
+def write_repeatedly(version_store):
+    while True:
+        version_store.write("sym", [1, 2, 3], prune_previous_version=True)
+        time.sleep(0.1)
+
+
+def test_concurrent_read_write(writer_store, reader_store):
+    """When using delayed deletes, a reader should always be able to read a symbol even if it is being modified
+    and pruned by another process."""
+    writer_store.write("sym", [1, 2, 3], prune_previous_version=True)
+    exceptions_in_reader = Queue()
+    reader = Process(target=read_repeatedly, args=(reader_store, exceptions_in_reader))
+    writer = Process(target=write_repeatedly, args=(writer_store,))
+
+    try:
+        reader.start()
+        writer.start()
+        reader.join(5)
+        writer.join(0.001)
+    finally:
+        writer.terminate()
+        reader.terminate()
+
+    assert exceptions_in_reader.empty()


### PR DESCRIPTION
…560)

#### What does this implement or fix?

We should only write the version ref key once when we write with `prune_previous_versions=True`. Currently we are writing it twice - once after we write the tombstone all and once when we write the new version. This means that there is a period of time where the symbol is unreadable.

This was fixed a while ago with PR #1104 but regressed with PR #1355.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
