### PR TITLE
Correct last_update_time type hint

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -122,7 +122,7 @@ class SymbolDescription(NamedTuple):
         Whether the index is a simple index or a multi_index. ``NA`` indicates that the stored data does not have an index.
     row_count : int
         Number of rows.
-    last_update_time : datetime64
+    last_update_time : datetime.datetime
         The time of the last update to the symbol, in UTC.
     date_range : Tuple[Union[datetime.datetime, numpy.datetime64], Union[datetime.datetime, numpy.datetime64]]
         The values of the index column in the first and last rows of this symbol in UTC. Both values will be NaT if:
@@ -145,7 +145,7 @@ class SymbolDescription(NamedTuple):
     index: NameWithDType
     index_type: str
     row_count: int
-    last_update_time: datetime64
+    last_update_time: datetime.datetime
     date_range: Tuple[Union[datetime.datetime, datetime64], Union[datetime.datetime, datetime64]]
     sorted: str
 


### PR DESCRIPTION
#### What does this implement or fix?

`SymbolDescription.last_update_time` is a `pandas._libs.tslibs.timestamps.Timestamp` which is a `datetime.datetime` subtype, not a `numpy.datetime64`.

#### Any other comments?

Should this be `Union[datetime.datetime, numpy.datetime64]`?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
