### PR TITLE
Billion row challenge speedup

### DIFF
--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -396,7 +396,7 @@ public:
         return SegmentInMemory(impl_->truncate(start_row, end_row, reconstruct_string_pool));
     }
 
-    std::vector<SegmentInMemory> partition(const std::vector<std::optional<uint8_t>>& row_to_segment,
+    std::vector<SegmentInMemory> partition(const std::vector<uint8_t>& row_to_segment,
                            const std::vector<uint64_t>& segment_counts) const{
         std::vector<SegmentInMemory> res;
         auto impls = impl_->partition(row_to_segment, segment_counts);

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -388,7 +388,7 @@ std::vector<std::shared_ptr<SegmentInMemoryImpl>> SegmentInMemoryImpl::partition
             auto input_data = (*column)->data();
             auto cend = input_data.cend<typename type_info::TDT>();
             for (auto input_it = input_data.cbegin<typename type_info::TDT>(); input_it != cend; ++input_it, ++row_to_segment_it) {
-                if (ARCTICDB_LIKELY(*row_to_segment_it != 255)) {
+                if (ARCTICDB_LIKELY(*row_to_segment_it != std::numeric_limits<uint8_t>::max())) {
                     *(output_ptrs[*row_to_segment_it]++) = *input_it;
                 }
             }

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -795,7 +795,7 @@ public:
     // by the row_to_segment vector (std::nullopt means the row is not included in any output segment).
     // segment_counts is the length of the number of output segments, and should be greater than or equal to the max value
     // in row_to_segment
-    std::vector<std::shared_ptr<SegmentInMemoryImpl>> partition(const std::vector<std::optional<uint8_t>>& row_to_segment,
+    std::vector<std::shared_ptr<SegmentInMemoryImpl>> partition(const std::vector<uint8_t>& row_to_segment,
                                                        const std::vector<uint64_t>& segment_counts) const;
 
     std::vector<std::shared_ptr<SegmentInMemoryImpl>> split(size_t rows) const;

--- a/cpp/arcticdb/pipeline/filter_segment.hpp
+++ b/cpp/arcticdb/pipeline/filter_segment.hpp
@@ -20,7 +20,7 @@ inline SegmentInMemory filter_segment(const SegmentInMemory& input,
 }
 
 inline std::vector<SegmentInMemory> partition_segment(const SegmentInMemory& input,
-                                      const std::vector<std::optional<uint8_t>>& row_to_segment,
+                                      const std::vector<uint8_t>& row_to_segment,
                                       const std::vector<uint64_t>& segment_counts) {
     return input.partition(row_to_segment, segment_counts);
 }

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -77,35 +77,15 @@ Composite<ProcessingUnit> gather_entities(std::shared_ptr<ComponentManager> comp
     return entity_ids.transform([&component_manager, include_atom_keys, include_bucket, include_initial_expected_get_calls]
     (const EntityIds& entity_ids) -> ProcessingUnit {
         ProcessingUnit res;
-        std::vector<std::shared_ptr<SegmentInMemory>> segments;
-        std::vector<std::shared_ptr<RowRange>> row_ranges;
-        std::vector<std::shared_ptr<ColRange>> col_ranges;
-        segments.reserve(entity_ids.size());
-        row_ranges.reserve(entity_ids.size());
-        col_ranges.reserve(entity_ids.size());
-        for (auto entity_id: entity_ids) {
-            segments.emplace_back(component_manager->get<std::shared_ptr<SegmentInMemory>>(entity_id));
-            row_ranges.emplace_back(component_manager->get<std::shared_ptr<RowRange>>(entity_id));
-            col_ranges.emplace_back(component_manager->get<std::shared_ptr<ColRange>>(entity_id));
-        }
-        res.set_segments(std::move(segments));
-        res.set_row_ranges(std::move(row_ranges));
-        res.set_col_ranges(std::move(col_ranges));
+        res.set_segments(component_manager->get<std::shared_ptr<SegmentInMemory>>(entity_ids));
+        res.set_row_ranges(component_manager->get<std::shared_ptr<RowRange>>(entity_ids));
+        res.set_col_ranges(component_manager->get<std::shared_ptr<ColRange>>(entity_ids));
 
         if (include_atom_keys) {
-            std::vector<std::shared_ptr<AtomKey>> keys;
-            keys.reserve(entity_ids.size());
-            for (auto entity_id: entity_ids) {
-                keys.emplace_back(component_manager->get<std::shared_ptr<AtomKey>>(entity_id));
-            }
-            res.set_atom_keys(std::move(keys));
+            res.set_atom_keys(component_manager->get<std::shared_ptr<AtomKey>>(entity_ids));
         }
         if (include_bucket) {
-            std::vector<size_t> buckets;
-            buckets.reserve(entity_ids.size());
-            for (auto entity_id: entity_ids) {
-                buckets.emplace_back(component_manager->get<size_t>(entity_id));
-            }
+            std::vector<bucket_id> buckets{component_manager->get<bucket_id>(entity_ids)};
             // Each entity_id has a bucket, but they must all be the same within one processing unit
             if (buckets.size() > 0) {
                 internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -137,52 +117,20 @@ Composite<ProcessingUnit> gather_entities(std::shared_ptr<ComponentManager> comp
 EntityIds push_entities(std::shared_ptr<ComponentManager> component_manager, ProcessingUnit&& proc) {
     std::optional<EntityIds> res;
     if (proc.segments_.has_value()) {
-        res = std::make_optional<EntityIds>();
-        for (const auto& segment: *proc.segments_) {
-            res->emplace_back(component_manager->add(segment, std::nullopt, 1));
-        }
+        res = std::make_optional<EntityIds>(component_manager->add(std::move(*proc.segments_)));
     }
     if (proc.row_ranges_.has_value()) {
-        if (res.has_value()) {
-            for (const auto& [idx, row_range]: folly::enumerate(*proc.row_ranges_)) {
-                component_manager->add(row_range, res->at(idx));
-            }
-        } else {
-            res = std::make_optional<EntityIds>();
-            for (const auto& row_range: *proc.row_ranges_) {
-                res->emplace_back(component_manager->add(row_range));
-            }
-        }
+        res = component_manager->add(std::move(*proc.row_ranges_), res);
     }
     if (proc.col_ranges_.has_value()) {
-        if (res.has_value()) {
-            for (const auto& [idx, col_range]: folly::enumerate(*proc.col_ranges_)) {
-                component_manager->add(col_range, res->at(idx));
-            }
-        } else {
-            res = std::make_optional<EntityIds>();
-            for (const auto& col_range: *proc.col_ranges_) {
-                res->emplace_back(component_manager->add(col_range));
-            }
-        }
+        res = component_manager->add(std::move(*proc.col_ranges_), res);
     }
     if (proc.atom_keys_.has_value()) {
-        if (res.has_value()) {
-            for (const auto& [idx, atom_key]: folly::enumerate(*proc.atom_keys_)) {
-                component_manager->add(atom_key, res->at(idx));
-            }
-        } else {
-            res = std::make_optional<EntityIds>();
-            for (const auto& atom_key: *proc.atom_keys_) {
-                res->emplace_back(component_manager->add(atom_key));
-            }
-        }
+        res = component_manager->add(std::move(*proc.atom_keys_), res);
     }
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(res.has_value(), "Unexpected empty result in push_entities");
     if (proc.bucket_.has_value()) {
-        for (auto entity_id: *res) {
-            component_manager->add(*proc.bucket_, entity_id);
-        }
+        component_manager->add(std::vector<bucket_id>(res->size(), *proc.bucket_), res);
     }
     return *res;
 }
@@ -367,12 +315,12 @@ AggregationClause::AggregationClause(const std::string& grouping_column,
 }
 
 Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_ids) const {
-    auto procs_as_range = gather_entities(component_manager_, std::move(entity_ids)).as_range();
+    auto procs = gather_entities(component_manager_, std::move(entity_ids)).as_range();
 
-    // Sort procs following row range ascending order
-    std::sort(std::begin(procs_as_range), std::end(procs_as_range),
+    // Sort procs following row range descending order, as we are going to iterate through them backwards
+    std::sort(std::begin(procs), std::end(procs),
               [](const auto& left, const auto& right) {
-                  return left.row_ranges_->at(0)->start() < right.row_ranges_->at(0)->start();
+                  return left.row_ranges_->at(0)->start() >= right.row_ranges_->at(0)->start();
     });
 
     std::vector<GroupingAggregatorData> aggregators_data;
@@ -384,7 +332,7 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
     }
 
     // Work out the common type between the processing units for the columns being aggregated
-    for (auto& proc: procs_as_range) {
+    for (auto& proc: procs) {
         for (auto agg_data: folly::enumerate(aggregators_data)) {
             // Check that segments row ranges are the same
             internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -404,105 +352,118 @@ Composite<EntityIds> AggregationClause::process(Composite<EntityIds>&& entity_id
     auto string_pool = std::make_shared<StringPool>();
     DataType grouping_data_type;
     GroupingMap grouping_map;
-    Composite<ProcessingUnit> procs(std::move(procs_as_range));
-    procs.broadcast(
-        [&num_unique, &grouping_data_type, &grouping_map, &next_group_id, &aggregators_data, &string_pool, this](auto &proc) {
-            auto partitioning_column = proc.get(ColumnName(grouping_column_));
-            if (std::holds_alternative<ColumnWithStrings>(partitioning_column)) {
-                ColumnWithStrings col = std::get<ColumnWithStrings>(partitioning_column);
-                details::visit_type(col.column_->type().data_type(),
-                                    [&proc_=proc, &grouping_map, &next_group_id, &aggregators_data, &string_pool, &col,
-                                     &num_unique, &grouping_data_type, this](auto data_type_tag) {
-                                        using col_type_info = ScalarTypeInfo<decltype(data_type_tag)>;
-                                        grouping_data_type = col_type_info::data_type;
-                                        std::vector<size_t> row_to_group;
-                                        row_to_group.reserve(col.column_->row_count());
-                                        auto hash_to_group = grouping_map.get<typename col_type_info::RawType>();
-                                        // For string grouping columns, keep a local map within this ProcessingUnit
-                                        // from offsets to groups, to avoid needless calls to col.string_at_offset and
-                                        // string_pool->get
-                                        // This could be slower in cases where there aren't many repeats in string
-                                        // grouping columns. Maybe track hit ratio of finds and stop using it if it is
-                                        // too low?
-                                        // Tested with 100,000,000 row dataframe with 100,000 unique values in the grouping column. Timings:
-                                        // 11.14 seconds without caching
-                                        // 11.01 seconds with caching
-                                        // Not worth worrying about right now
-                                        ankerl::unordered_dense::map<typename col_type_info::RawType, size_t> offset_to_group;
+    // Iterating backwards as we are going to erase from this vector as we go along
+    // This is to spread out deallocation of the input segments
+    for (auto it = procs.rbegin(); it != procs.rend(); ++it) {
+        auto& proc = *it;
+        auto partitioning_column = proc.get(ColumnName(grouping_column_));
+        if (std::holds_alternative<ColumnWithStrings>(partitioning_column)) {
+            ColumnWithStrings col = std::get<ColumnWithStrings>(partitioning_column);
+            details::visit_type(
+                col.column_->type().data_type(),
+                [&proc_ = proc, &grouping_map, &next_group_id, &aggregators_data, &string_pool, &col,
+                        &num_unique, &grouping_data_type, this](auto data_type_tag) {
+                    using col_type_info = ScalarTypeInfo<decltype(data_type_tag)>;
+                    grouping_data_type = col_type_info::data_type;
+                    // Faster to initialise to zero (missing value group) and use raw ptr than repeated calls to emplace_back
+                    std::vector<size_t> row_to_group(col.column_->last_row() + 1, 0);
+                    size_t* row_to_group_ptr = row_to_group.data();
+                    auto hash_to_group = grouping_map.get<typename col_type_info::RawType>();
+                    // For string grouping columns, keep a local map within this ProcessingUnit
+                    // from offsets to groups, to avoid needless calls to col.string_at_offset and
+                    // string_pool->get
+                    // This could be slower in cases where there aren't many repeats in string
+                    // grouping columns. Maybe track hit ratio of finds and stop using it if it is
+                    // too low?
+                    // Tested with 100,000,000 row dataframe with 100,000 unique values in the grouping column. Timings:
+                    // 11.14 seconds without caching
+                    // 11.01 seconds with caching
+                    // Not worth worrying about right now
+                    ankerl::unordered_dense::map<typename col_type_info::RawType, size_t> offset_to_group;
 
-                                        const bool is_sparse = col.column_->is_sparse();
-                                        if (is_sparse && next_group_id == 0) {
-                                            // We use 0 for the missing value group id
-                                            ++next_group_id;
+                    const bool is_sparse = col.column_->is_sparse();
+                    if (is_sparse && next_group_id == 0) {
+                        // We use 0 for the missing value group id
+                        ++next_group_id;
+                    }
+                    ssize_t previous_value_index = 0;
+                    constexpr size_t missing_value_group_id = 0;
+
+                    Column::for_each_enumerated<typename col_type_info::TDT>(
+                            *col.column_,
+                            [&](auto enumerating_it) {
+                                typename col_type_info::RawType val;
+                                if constexpr (is_sequence_type(col_type_info::data_type)) {
+                                    auto offset = enumerating_it.value();
+                                    if (auto it = offset_to_group.find(offset); it !=
+                                                                                offset_to_group.end()) {
+                                        val = it->second;
+                                    } else {
+                                        std::optional<std::string_view> str = col.string_at_offset(
+                                                offset);
+                                        if (str.has_value()) {
+                                            val = string_pool->get(*str, true).offset();
+                                        } else {
+                                            val = offset;
                                         }
-                                        ssize_t previous_value_index = 0;
-                                        constexpr size_t missing_value_group_id = 0;
+                                        typename col_type_info::RawType val_copy(val);
+                                        offset_to_group.insert(
+                                                std::make_pair<typename col_type_info::RawType, size_t>(
+                                                        std::forward<typename col_type_info::RawType>(
+                                                                offset),
+                                                        std::forward<typename col_type_info::RawType>(
+                                                                val_copy)));
+                                    }
+                                } else {
+                                    val = enumerating_it.value();
+                                }
 
-                                        Column::for_each_enumerated<typename col_type_info::TDT>(
-                                                *col.column_,
-                                                [&](auto enumerating_it) {
-                                                    typename col_type_info::RawType val;
-                                                    if constexpr(is_sequence_type(col_type_info::data_type)) {
-                                                        auto offset = enumerating_it.value();
-                                                        if (auto it = offset_to_group.find(offset); it != offset_to_group.end()) {
-                                                            val = it->second;
-                                                        } else {
-                                                            std::optional<std::string_view> str = col.string_at_offset(offset);
-                                                            if (str.has_value()) {
-                                                                val = string_pool->get(*str, true).offset();
-                                                            } else {
-                                                                val = offset;
-                                                            }
-                                                            typename col_type_info::RawType val_copy(val);
-                                                            offset_to_group.insert(std::make_pair<typename col_type_info::RawType, size_t>(std::forward<typename col_type_info::RawType>(offset), std::forward<typename col_type_info::RawType>(val_copy)));
-                                                        }
-                                                    } else {
-                                                        val = enumerating_it.value();
-                                                    }
+                                if (is_sparse) {
+                                    for (auto j = previous_value_index;
+                                         j != enumerating_it.idx(); ++j) {
+                                        *row_to_group_ptr++ = missing_value_group_id;
+                                    }
+                                    previous_value_index = enumerating_it.idx() + 1;
+                                }
 
-                                                    if (is_sparse) {
-                                                        for (auto j = previous_value_index; j != enumerating_it.idx(); ++j) {
-                                                            row_to_group.emplace_back(missing_value_group_id);
-                                                        }
-                                                        previous_value_index = enumerating_it.idx() + 1;
-                                                    }
+                                if (auto it = hash_to_group->find(val); it ==
+                                                                        hash_to_group->end()) {
+                                    *row_to_group_ptr++ = next_group_id;
+                                    auto group_id = next_group_id++;
+                                    hash_to_group->insert(
+                                            std::make_pair<typename col_type_info::RawType, size_t>(
+                                                    std::forward<typename col_type_info::RawType>(
+                                                            val),
+                                                    std::forward<typename col_type_info::RawType>(
+                                                            group_id)));
+                                } else {
+                                    *row_to_group_ptr++ = it->second;
+                                }
+                            }
+                    );
 
-                                                    if (auto it = hash_to_group->find(val); it == hash_to_group->end()) {
-                                                        row_to_group.emplace_back(next_group_id);
-                                                        auto group_id = next_group_id++;
-                                                        hash_to_group->insert(std::make_pair<typename col_type_info::RawType, size_t>(std::forward<typename col_type_info::RawType>(val), std::forward<typename col_type_info::RawType>(group_id)));
-                                                    } else {
-                                                        row_to_group.emplace_back(it->second);
-                                                    }
-                                                }
-                                                );
-
-                                        // Marking all the last non-represented values as missing.
-                                        for (size_t i = row_to_group.size(); i <= size_t(col.column_->last_row()); ++i) {
-                                            row_to_group.emplace_back(missing_value_group_id);
-                                        }
-
-                                        num_unique = next_group_id;
-                                        util::check(num_unique != 0, "Got zero unique values");
-                                        for (auto agg_data: folly::enumerate(aggregators_data)) {
-                                            auto input_column_name = aggregators_.at(agg_data.index).get_input_column_name();
-                                            auto input_column = proc_.get(input_column_name);
-                                            std::optional<ColumnWithStrings> opt_input_column;
-                                            if (std::holds_alternative<ColumnWithStrings>(input_column)) {
-                                                auto column_with_strings = std::get<ColumnWithStrings>(input_column);
-                                                // Empty columns don't contribute to aggregations
-                                                if (!is_empty_type(column_with_strings.column_->type().data_type())) {
-                                                    opt_input_column.emplace(std::move(column_with_strings));
-                                                }
-                                            }
-                                            agg_data->aggregate(opt_input_column, row_to_group, num_unique);
-                                        }
-                                    });
-            } else {
-                util::raise_rte("Expected single column from expression");
-            }
-        });
-
+                    num_unique = next_group_id;
+                    util::check(num_unique != 0, "Got zero unique values");
+                    for (auto agg_data: folly::enumerate(aggregators_data)) {
+                        auto input_column_name = aggregators_.at(
+                                agg_data.index).get_input_column_name();
+                        auto input_column = proc_.get(input_column_name);
+                        std::optional<ColumnWithStrings> opt_input_column;
+                        if (std::holds_alternative<ColumnWithStrings>(input_column)) {
+                            auto column_with_strings = std::get<ColumnWithStrings>(input_column);
+                            // Empty columns don't contribute to aggregations
+                            if (!is_empty_type(column_with_strings.column_->type().data_type())) {
+                                opt_input_column.emplace(std::move(column_with_strings));
+                            }
+                        }
+                        agg_data->aggregate(opt_input_column, row_to_group, num_unique);
+                    }
+                });
+        } else {
+            util::raise_rte("Expected single column from expression");
+        }
+        procs.erase(std::next(it).base());
+    }
     SegmentInMemory seg;
     auto index_col = std::make_shared<Column>(make_scalar_type(grouping_data_type), grouping_map.size(), true, false);
     seg.add_column(scalar_field(grouping_data_type, grouping_column_), index_col);

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -63,8 +63,6 @@ struct ProcessingConfig {
     uint64_t total_rows_ = 0;
 };
 
-using EntityIds = std::vector<EntityId>;
-
 struct IClause {
     template<class Base>
     struct Interface : Base {

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -17,7 +17,8 @@ namespace arcticdb {
 
 using namespace pipelines;
 using EntityId = uint64_t;
-using bucket_id = size_t;
+using EntityIds = std::vector<EntityId>;
+using bucket_id = uint8_t;
 
 class ComponentManager {
 public:
@@ -25,6 +26,36 @@ public:
     ARCTICDB_NO_MOVE_OR_COPY(ComponentManager)
 
     void set_next_entity_id(EntityId id);
+
+    template<typename T>
+    EntityIds add(std::vector<T>&& components, const std::optional<EntityIds>& ids=std::nullopt) {
+        EntityIds insertion_ids;
+        if (ids.has_value()) {
+            insertion_ids = *ids;
+        } else {
+            insertion_ids.reserve(components.size());
+            for (size_t idx = 0; idx < components.size(); ++idx) {
+                insertion_ids.emplace_back(next_entity_id_.fetch_add(1));
+            }
+        }
+
+        if constexpr(std::is_same_v<T, std::shared_ptr<SegmentInMemory>>) {
+            segment_map_.add(insertion_ids, std::move(components));
+        } else if constexpr(std::is_same_v<T, std::shared_ptr<RowRange>>) {
+            row_range_map_.add(insertion_ids, std::move(components));
+        } else if constexpr(std::is_same_v<T, std::shared_ptr<ColRange>>) {
+            col_range_map_.add(insertion_ids, std::move(components));
+        } else if constexpr(std::is_same_v<T, std::shared_ptr<AtomKey>>) {
+            atom_key_map_.add(insertion_ids, std::move(components));
+        } else if constexpr(std::is_same_v<T, bucket_id>) {
+            bucket_map_.add(insertion_ids, std::move(components));
+        } else {
+            // Hacky workaround for static_assert(false) not being allowed
+            // See https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html
+            static_assert(sizeof(T) == 0, "Unsupported component type passed to ComponentManager::add");
+        }
+        return insertion_ids;
+    }
 
     template<typename T>
     EntityId add(T component, std::optional<EntityId> id=std::nullopt, std::optional<uint64_t> expected_get_calls=std::nullopt) {
@@ -48,17 +79,17 @@ public:
     }
 
     template<typename T>
-    T get(EntityId id) {
+    std::vector<T> get(const EntityIds& ids) {
         if constexpr(std::is_same_v<T, std::shared_ptr<SegmentInMemory>>) {
-            return segment_map_.get(id);
+            return segment_map_.get(ids);
         } else if constexpr(std::is_same_v<T, std::shared_ptr<RowRange>>) {
-            return row_range_map_.get(id);
+            return row_range_map_.get(ids);
         } else if constexpr(std::is_same_v<T, std::shared_ptr<ColRange>>) {
-            return col_range_map_.get(id);
+            return col_range_map_.get(ids);
         } else if constexpr(std::is_same_v<T, std::shared_ptr<AtomKey>>) {
-            return atom_key_map_.get(id);
+            return atom_key_map_.get(ids);
         } else if constexpr(std::is_same_v<T, bucket_id>) {
-            return bucket_map_.get(id);
+            return bucket_map_.get(ids);
         } else {
             // Hacky workaround for static_assert(false) not being allowed
             // See https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html
@@ -89,6 +120,22 @@ private:
         };
         ARCTICDB_NO_MOVE_OR_COPY(ComponentMap)
 
+        void add(const EntityIds& ids,
+                 std::vector<T>&& entities) {
+            std::lock_guard <std::mutex> lock(mtx_);
+            for (auto [idx, id]: folly::enumerate(ids)) {
+                ARCTICDB_DEBUG(log::storage(), "Adding {} with id {}", entity_type_, id);
+                internal::check<ErrorCode::E_ASSERTION_FAILURE>(map_.try_emplace(id, std::move(entities[idx])).second,
+                                                                "Failed to insert {} with ID {}, already exists",
+                                                                entity_type_, id);
+                if (opt_expected_get_calls_map_.has_value()) {
+                    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                            opt_expected_get_calls_map_->try_emplace(id, 1).second,
+                            "Failed to insert {} with ID {}, already exists",
+                            entity_type_, id);
+                }
+            }
+        }
         void add(EntityId id, T&& entity, std::optional<uint64_t> expected_get_calls=std::nullopt) {
             std::lock_guard <std::mutex> lock(mtx_);
             ARCTICDB_DEBUG(log::storage(), "Adding {} with id {}", entity_type_, id);
@@ -107,25 +154,30 @@ private:
                                                                 entity_type_, id);
             }
         }
-        T get(EntityId id) {
+        std::vector<T> get(const EntityIds& ids) {
+            std::vector<T> res;
+            res.reserve(ids.size());
             std::lock_guard <std::mutex> lock(mtx_);
-            ARCTICDB_DEBUG(log::storage(), "Getting {} with id {}", entity_type_, id);
-            auto entity_it = map_.find(id);
-            internal::check<ErrorCode::E_ASSERTION_FAILURE>(entity_it != map_.end(),
-                                                            "Requested non-existent {} with ID {}",
-                                                            entity_type_, id);
-            auto res = entity_it->second;
-            if (opt_expected_get_calls_map_.has_value()) {
-                auto expected_get_calls_it = opt_expected_get_calls_map_->find(id);
-                internal::check<ErrorCode::E_ASSERTION_FAILURE>(expected_get_calls_it != opt_expected_get_calls_map_->end(),
+            for (auto id: ids) {
+                ARCTICDB_DEBUG(log::storage(), "Getting {} with id {}", entity_type_, id);
+                auto entity_it = map_.find(id);
+                internal::check<ErrorCode::E_ASSERTION_FAILURE>(entity_it != map_.end(),
                                                                 "Requested non-existent {} with ID {}",
                                                                 entity_type_, id);
-                if (--expected_get_calls_it->second == 0) {
-                    ARCTICDB_DEBUG(log::storage(),
-                                   "{} with id {} has been fetched the expected number of times, erasing from component manager",
-                                   entity_type_, id);
-                    map_.erase(entity_it);
-                    opt_expected_get_calls_map_->erase(expected_get_calls_it);
+                res.emplace_back(entity_it->second);
+                if (opt_expected_get_calls_map_.has_value()) {
+                    auto expected_get_calls_it = opt_expected_get_calls_map_->find(id);
+                    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                            expected_get_calls_it != opt_expected_get_calls_map_->end(),
+                            "Requested non-existent {} with ID {}",
+                            entity_type_, id);
+                    if (--expected_get_calls_it->second == 0) {
+                        ARCTICDB_DEBUG(log::storage(),
+                                       "{} with id {} has been fetched the expected number of times, erasing from component manager",
+                                       entity_type_, id);
+                        map_.erase(entity_it);
+                        opt_expected_get_calls_map_->erase(expected_get_calls_it);
+                    }
                 }
             }
             return res;

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -133,6 +133,10 @@ private:
                             opt_expected_get_calls_map_->try_emplace(id, 1).second,
                             "Failed to insert {} with ID {}, already exists",
                             entity_type_, id);
+                    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                            opt_expected_get_calls_initial_map_->try_emplace(id, 1).second,
+                            "Failed to insert {} with ID {}, already exists",
+                            entity_type_, id);
                 }
             }
         }

--- a/cpp/arcticdb/processing/grouper.hpp
+++ b/cpp/arcticdb/processing/grouper.hpp
@@ -7,20 +7,6 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <vector>
-
-#include <fmt/core.h>
-
-#include <arcticdb/column_store/memory_segment.hpp>
-#include <arcticdb/processing/expression_context.hpp>
-#include <arcticdb/processing/expression_node.hpp>
-#include <arcticdb/pipeline/frame_slice.hpp>
-#include <arcticdb/pipeline/filter_segment.hpp>
-#include <arcticdb/util/composite.hpp>
-#include <arcticdb/util/string_utils.hpp>
-#include <arcticdb/util/variant.hpp>
-#include <folly/Poly.h>
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/util/hash.hpp>
 
@@ -36,55 +22,29 @@ public:
         using RawType = typename DataTypeTag::raw_type;
 
         // The multiple return statements in here are ugly, but avoids creating temporaries as far as possible
-        std::optional<size_t> group(RawType key, const std::shared_ptr<StringPool>& sp) {
+        std::optional<uint8_t> group(RawType key, const std::shared_ptr<StringPool>& sp) const {
             constexpr DataType dt = DataTypeTag::data_type;
             if constexpr (dt == DataType::ASCII_FIXED64 || dt == DataType::ASCII_DYNAMIC64 ||
                           dt == DataType::UTF_FIXED64 || dt == DataType::UTF_DYNAMIC64) {
-                if (auto it = cache_.find(key); it != cache_.end()) {
-                    return it->second;
+                if (ARCTICDB_LIKELY(is_a_string(key))) {
+                    return static_cast<uint8_t>(hash(sp->get_view(key)) & 0xFF);
                 } else {
-                    if (is_a_string(key)) {
-                        auto hashed_value = hash(sp->get_view(key));
-                        cache_.insert(std::make_pair(std::move(key), std::optional<size_t>(hashed_value)));
-                        return hashed_value;
-                    } else {
-                        cache_.insert(std::make_pair(std::move(key), std::optional<size_t>()));
-                        return std::nullopt;
-                    }
+                    return std::nullopt;
                 }
             } else if constexpr(dt == DataType::FLOAT32 || dt == DataType::FLOAT64) {
-                if (std::isnan(key)) {
+                if (ARCTICDB_UNLIKELY(std::isnan(key))) {
                     return std::nullopt;
                 } else {
-                    return hash<RawType>(key);
+                    return static_cast<uint8_t>(hash<RawType>(key) & 0xFF);
                 }
             } else {
-                return hash<RawType>(key);
+                return static_cast<uint8_t>(hash<RawType>(key) & 0xFF);
             }
         }
-    private:
-        // Only use a cache for grouping on string columns to avoid getting and hashing the same string view repeatedly
-        // No point for numeric types, as we would have to hash it to look it up in this map anyway
-        // This will be slower in cases where there aren't many repeats in string grouping columns
-        // Maybe track cache hit ratio and stop using it if it is too low?
-        // Tested with 100,000,000 row dataframe with 100,000 unique values in the grouping column. Timings:
-        // 10.39 seconds without caching
-        // 11.01 seconds with caching
-        // Not worth worrying about right now
-        ankerl::unordered_dense::map<RawType, std::optional<size_t>> cache_;
     };
 };
 
-class Bucketizer {
-    public:
-    virtual uint8_t bucket(size_t group) const = 0;
-
-    virtual uint8_t num_buckets() const = 0;
-
-    virtual ~Bucketizer() {};
-};
-
-class ModuloBucketizer : Bucketizer {
+class ModuloBucketizer {
     uint8_t mod_;
 public:
     ModuloBucketizer(uint8_t mod) :
@@ -93,25 +53,13 @@ public:
 
     ARCTICDB_MOVE_COPY_DEFAULT(ModuloBucketizer)
 
-    uint8_t bucket(size_t group) const {
+    uint8_t bucket(uint8_t group) const {
         return group % mod_;
     }
 
-    virtual uint8_t num_buckets() const {
+    uint8_t num_buckets() const {
         return mod_;
     }
-
-    virtual ~ModuloBucketizer() = default;
 };
 
-class IdentityBucketizer : Bucketizer {
-public:
-    uint8_t bucket(size_t group) const {
-        return group;
-    }
-
-    virtual uint8_t num_buckets() const {
-        return 0;
-    }
-};
 }

--- a/cpp/arcticdb/processing/processing_unit.hpp
+++ b/cpp/arcticdb/processing/processing_unit.hpp
@@ -129,16 +129,17 @@ namespace arcticdb {
 
 
     template<typename Grouper, typename Bucketizer>
-    std::pair<std::vector<std::optional<uint8_t>>, std::vector<uint64_t>> get_buckets(
+    std::pair<std::vector<bucket_id>, std::vector<uint64_t>> get_buckets(
             const ColumnWithStrings& col,
-            Grouper& grouper,
-            Bucketizer& bucketizer) {
+            const Grouper& grouper,
+            const Bucketizer& bucketizer) {
         schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(!col.column_->is_sparse(),
                                                             "GroupBy not supported with sparse columns");
         // Mapping from row to bucket
-        // std::nullopt only for Nones and NaNs in string/float columns
-        std::vector<std::optional<uint8_t>> row_to_bucket;
-        row_to_bucket.reserve(col.column_->row_count());
+        // 255 reserved for Nones and NaNs in string/float columns
+        // Faster to initialise to 255 and use a raw ptr for the output than to call emplace_back repeatedly
+        std::vector<bucket_id> row_to_bucket(col.column_->row_count(), std::numeric_limits<bucket_id>::max());
+        auto out_ptr = row_to_bucket.data();
         // Tracks how many rows are in each bucket
         // Use to skip empty buckets, and presize columns in the output ProcessingUnit
         std::vector<uint64_t> bucket_counts(bucketizer.num_buckets(), 0);
@@ -146,12 +147,12 @@ namespace arcticdb {
         using TDT = typename Grouper::GrouperDescriptor;
         Column::for_each<TDT>(*col.column_, [&] (auto val) {
             auto opt_group = grouper.group(val, col.string_pool_);
-            if (opt_group.has_value()) {
+            if (ARCTICDB_LIKELY(opt_group.has_value())) {
                 auto bucket = bucketizer.bucket(*opt_group);
-                row_to_bucket.emplace_back(bucket);
+                *out_ptr++ = bucket;
                 ++bucket_counts[bucket];
             } else {
-                row_to_bucket.emplace_back(std::nullopt);
+                ++out_ptr;
             }
         });
         return {std::move(row_to_bucket), std::move(bucket_counts)};
@@ -178,11 +179,11 @@ namespace arcticdb {
                     ResolvedGrouperType grouper;
                     auto num_buckets = ConfigsMap::instance()->get_int("Partition.NumBuckets",
                                                                        async::TaskScheduler::instance()->cpu_thread_count());
-                    if (num_buckets > std::numeric_limits<uint8_t>::max()) {
+                    if (num_buckets > std::numeric_limits<bucket_id>::max()) {
                         log::version().warn("GroupBy partitioning buckets capped at {} (received {})",
-                                            std::numeric_limits<uint8_t>::max(),
+                                            std::numeric_limits<bucket_id>::max(),
                                             num_buckets);
-                        num_buckets = std::numeric_limits<uint8_t>::max();
+                        num_buckets = std::numeric_limits<bucket_id>::max();
                     }
                     std::vector<ProcessingUnit> procs{static_cast<bucket_id>(num_buckets)};
                     BucketizerType bucketizer(num_buckets);

--- a/cpp/arcticdb/processing/test/test_component_manager.cpp
+++ b/cpp/arcticdb/processing/test/test_component_manager.cpp
@@ -39,18 +39,18 @@ TEST(ComponentManager, Simple) {
     ASSERT_EQ(id_0, 0);
     ASSERT_EQ(id_1, 1);
 
-    ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>(id_0), segment_0);
-    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>(id_0), expected_get_calls_0);
-    ASSERT_EQ(component_manager.get<std::shared_ptr<RowRange>>(id_0), row_range_0);
-    ASSERT_EQ(component_manager.get<std::shared_ptr<ColRange>>(id_0), col_range_0);
-    ASSERT_EQ(component_manager.get<std::shared_ptr<AtomKey>>(id_0), key_0);
-    EXPECT_THROW(component_manager.get<std::shared_ptr<SegmentInMemory>>(id_0), InternalException);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_0})[0], segment_0);
+    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>({id_0})[0], expected_get_calls_0);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<RowRange>>({id_0})[0], row_range_0);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<ColRange>>({id_0})[0], col_range_0);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<AtomKey>>({id_0})[0], key_0);
+    EXPECT_THROW(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_0}), InternalException);
 
-    ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>(id_1), segment_1);
-    ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>(id_1), segment_1);
-    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>(id_1), expected_get_calls_1);
-    ASSERT_EQ(component_manager.get<std::shared_ptr<RowRange>>(id_1), row_range_1);
-    ASSERT_EQ(component_manager.get<std::shared_ptr<ColRange>>(id_1), col_range_1);
-    ASSERT_EQ(component_manager.get<std::shared_ptr<AtomKey>>(id_1), key_1);
-    EXPECT_THROW(component_manager.get<std::shared_ptr<SegmentInMemory>>(id_1), InternalException);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_1})[0], segment_1);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_1})[0], segment_1);
+    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>({id_1})[0], expected_get_calls_1);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<RowRange>>({id_1})[0], row_range_1);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<ColRange>>({id_1})[0], col_range_1);
+    ASSERT_EQ(component_manager.get<std::shared_ptr<AtomKey>>({id_1})[0], key_1);
+    EXPECT_THROW(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_1}), InternalException);
 }

--- a/cpp/arcticdb/processing/test/test_component_manager.cpp
+++ b/cpp/arcticdb/processing/test/test_component_manager.cpp
@@ -40,7 +40,7 @@ TEST(ComponentManager, Simple) {
     ASSERT_EQ(id_1, 1);
 
     ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_0})[0], segment_0);
-    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>({id_0})[0], expected_get_calls_0);
+    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>(id_0), expected_get_calls_0);
     ASSERT_EQ(component_manager.get<std::shared_ptr<RowRange>>({id_0})[0], row_range_0);
     ASSERT_EQ(component_manager.get<std::shared_ptr<ColRange>>({id_0})[0], col_range_0);
     ASSERT_EQ(component_manager.get<std::shared_ptr<AtomKey>>({id_0})[0], key_0);
@@ -48,7 +48,7 @@ TEST(ComponentManager, Simple) {
 
     ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_1})[0], segment_1);
     ASSERT_EQ(component_manager.get<std::shared_ptr<SegmentInMemory>>({id_1})[0], segment_1);
-    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>({id_1})[0], expected_get_calls_1);
+    ASSERT_EQ(component_manager.get_initial_expected_get_calls<std::shared_ptr<SegmentInMemory>>(id_1), expected_get_calls_1);
     ASSERT_EQ(component_manager.get<std::shared_ptr<RowRange>>({id_1})[0], row_range_1);
     ASSERT_EQ(component_manager.get<std::shared_ptr<ColRange>>({id_1})[0], col_range_1);
     ASSERT_EQ(component_manager.get<std::shared_ptr<AtomKey>>({id_1})[0], key_1);

--- a/python/benchmarks/non_asv/profile_billion_row_challenge.py
+++ b/python/benchmarks/non_asv/profile_billion_row_challenge.py
@@ -1,0 +1,62 @@
+"""
+Copyright 2024 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import time
+
+import numpy as np
+import pandas as pd
+
+from arcticdb import QueryBuilder, Arctic
+
+rows_per_segment = 100_000
+rng = np.random.default_rng()
+
+ac = Arctic("lmdb:///tmp/arcticdb")
+lib = ac.get_library("billion_row_challenge_profiling", create_if_missing=True)
+lib = lib._nvs
+sym = f"billion_row_challenge"
+
+
+def test_write_data():
+    lib.delete(sym)
+    num_rows = 1_000_000_000
+    num_cities = 10_000
+    cities = [f"City {idx :04}" for idx in range(num_cities)]
+
+    num_segments = num_rows // rows_per_segment
+    for idx in range(num_segments):
+        print(f"{idx + 1}/{num_segments}")
+        temperature_column = 100_000 * rng.random(rows_per_segment)
+        cities_column = np.random.choice(cities, rows_per_segment)
+        df = pd.DataFrame({"City": cities_column, "Temperature": temperature_column})
+        lib.append(sym, df, write_if_missing=True)
+
+
+def test_read_data():
+    start = time.time()
+    df = lib.read(sym).data
+    end = time.time()
+    print(f"Reading {len(df)} rows took {end - start}s")
+
+
+def test_groupby():
+    q = QueryBuilder()
+    q = q.groupby("City").agg({"Min": ("Temperature", "min"), "Max": ("Temperature", "max"), "Mean": ("Temperature", "mean")})
+    start = time.time()
+    df = lib.read(sym, query_builder=q).data
+    end = time.time()
+    print(f"Grouping to {len(df)} rows took {end - start}s")
+
+
+def test_project_then_filter():
+    q = QueryBuilder()
+    q = q.apply("new col", q["Temperature"] * 1.5)
+    q = q[q["City"] == "City 9999"]
+    start = time.time()
+    df = lib.read(sym, query_builder=q).data
+    end = time.time()
+    print(f"Projecting then filtering to {len(df)} rows took {end - start}s")


### PR DESCRIPTION
After establishing that deallocating segments was a bottleneck when scaling the billion row challenge out to many cores, we've decided to move to using [mimalloc everywhere](https://github.com/man-group/ArcticDB/issues/1577).
Using `LD_PRELOAD` with mimalloc, these optimisations further speed up running the billion row challenge (run on a 64 core machine with hyperthreading):
```
Cores master brc-speedup
1     76.47  61.39
2     40.10  33.79
4     18.70  16.58
8     10.11   8.68
16     6.83   6.44
32     4.78   5.17
64     5.41   5.15
```
This shows that scaling is good out to 8 cores, and drops off after that. Logging timings shows an obvious bottleneck in `gather_entities` within `AggregationClause::process`, which will be addressed in a [future ticket](https://github.com/man-group/ArcticDB/issues/1586) to avoid conflicts with https://github.com/man-group/ArcticDB/pull/1495.