### PR TITLE
Fix overflow bug on append and update

### DIFF
--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -43,6 +43,7 @@ using VersionId = uint64_t;
 using SignedVersionId = int64_t;
 using GenerationId = VersionId;
 using timestamp = int64_t;
+// TODO: shape_t probably should be unsigned. Negative shapes don't make sense. This will involve a lot of changes in native_tensor.hpp
 using shape_t = int64_t;
 using stride_t = int64_t;
 using position_t = int64_t;

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -12,6 +12,7 @@
 namespace arcticdb {
 
 TimeseriesDescriptor make_timeseries_descriptor(
+        // TODO: It would be more explicit to use uint64_t instead of size_t. Not doing now as it involves a lot of type changes and needs to be done carefully.
         size_t total_rows,
         StreamDescriptor&& desc,
         arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta,

--- a/cpp/arcticdb/pipeline/index_utils.cpp
+++ b/cpp/arcticdb/pipeline/index_utils.cpp
@@ -80,7 +80,7 @@ std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vec
 }
 
 TimeseriesDescriptor get_merged_tsd(
-        int row_count,
+        size_t row_count,
         bool dynamic_schema,
         const TimeseriesDescriptor& existing_tsd,
         const std::shared_ptr<pipelines::InputTensorFrame>& new_frame) {

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -139,7 +139,7 @@ std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vec
 // Combines the stream descriptors of an existing index key and a new frame.
 // Can be used to get the metadata for [write_index] when updating or appending.
 TimeseriesDescriptor get_merged_tsd(
-    int row_count,
+    size_t row_count,
     bool dynamic_schema,
     const TimeseriesDescriptor& existing_tsd,
     const std::shared_ptr<pipelines::InputTensorFrame>& new_frame);

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -30,8 +30,8 @@ struct InputTensorFrame {
     std::optional<entity::NativeTensor> index_tensor;
     std::vector<entity::NativeTensor> field_tensors;
     IndexRange index_range;
-    ssize_t num_rows = 0;
-    mutable ssize_t offset = 0;
+    size_t num_rows = 0;
+    mutable size_t offset = 0;
     mutable bool bucketize_dynamic = 0;
 
     void set_offset(ssize_t off) const {

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -227,7 +227,7 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
         util::check(index_tensor.ndim() == 1, "Multi-dimensional indexes not handled");
         util::check(index_tensor.shape() != nullptr, "Index tensor expected to contain shapes");
         std::string index_column_name = !idx_names.empty() ? idx_names[0] : "index";
-        res->num_rows = index_tensor.shape(0);
+        res->num_rows = static_cast<size_t>(index_tensor.shape(0));
         // TODO handle string indexes
         if (index_tensor.data_type() == DataType::NANOSECONDS_UTC64) {
             res->desc.set_index_field_count(1);
@@ -253,7 +253,7 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
 
     for (auto i = 0u; i < col_vals.size(); ++i) {
         auto tensor = obj_to_tensor(col_vals[i].ptr(), empty_types);
-        res->num_rows = std::max(res->num_rows, static_cast<ssize_t>(tensor.shape(0)));
+        res->num_rows = std::max(res->num_rows, static_cast<size_t>(tensor.shape(0)));
         if(tensor.expanded_dim() == 1) {
             res->desc.add_field(scalar_field(tensor.data_type(), col_names[i]));
         } else if(tensor.expanded_dim() == 2) {
@@ -305,7 +305,7 @@ std::shared_ptr<InputTensorFrame> py_none_to_frame() {
     const shape_t shapes = 1;
     constexpr int ndim = 1;
     auto tensor = NativeTensor{8, ndim, &strides, &shapes, DataType::UINT64, 8, none_char, ndim};
-    res->num_rows = std::max(res->num_rows, static_cast<ssize_t>(tensor.shape(0)));
+    res->num_rows = std::max(res->num_rows, static_cast<size_t>(tensor.shape(0)));
     res->desc.add_field(scalar_field(tensor.data_type(), col_name));
     res->field_tensors.push_back(std::move(tensor));
 

--- a/cpp/arcticdb/stream/test/test_append_map.cpp
+++ b/cpp/arcticdb/stream/test/test_append_map.cpp
@@ -36,7 +36,7 @@ TEST(Append, Simple) {
     generate_filtered_field_descriptors(pipeline_context, {});
 
     SegmentInMemory allocated_frame = allocate_frame(pipeline_context);
-    ASSERT_EQ(allocated_frame.row_count(), size_t(frame->num_rows));
+    ASSERT_EQ(allocated_frame.row_count(), frame->num_rows);
 }
 
 TEST(Append, MergeDescriptorsPromote) {

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -513,6 +513,10 @@ def lmdb_version_store_big_map(version_store_factory):
 
 
 @pytest.fixture
+def lmdb_version_store_very_big_map(version_store_factory):
+    return version_store_factory(lmdb_config={"map_size": 2**35})
+
+@pytest.fixture
 def lmdb_version_store_column_buckets(version_store_factory):
     return version_store_factory(dynamic_schema=True, column_group_size=3, segment_row_size=2, bucketize_dynamic=True)
 

--- a/python/tests/stress/arcticdb/version_store/test_large_df.py
+++ b/python/tests/stress/arcticdb/version_store/test_large_df.py
@@ -1,0 +1,57 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import datetime
+import random
+
+import numpy as np
+import pandas as pd
+
+from arcticdb.util.test import (
+    assert_frame_equal,
+    dataframe_for_date,
+    random_strings_of_length,
+    random_floats,
+    random_strings_of_length_with_nan,
+)
+
+def create_large_df(num_rows, start_time):
+    index = pd.date_range(start=start_time, periods=num_rows, freq='ns')
+    df = pd.DataFrame(data={"col": np.arange(num_rows, dtype=np.int8)}, index=index)
+    return df
+
+# We use map_size of at least 2**35 to allow storing 2**32 rows
+def test_write_large_df_in_chunks(lmdb_version_store_very_big_map):
+    symbol = "symbol"
+    lib = lmdb_version_store_very_big_map
+    chunk_size = 2**22
+    num_chunks = 2**10
+    start_time = pd.Timestamp(0)
+
+    lib.delete(symbol)
+    chunk = create_large_df(chunk_size, start_time)
+    lib.write(symbol, chunk)
+    del chunk
+
+    for i in range(num_chunks-1):
+        start_time = start_time + pd.Timedelta(chunk_size)
+        chunk = create_large_df(chunk_size, start_time)
+        lib.append(symbol, chunk)
+        del chunk
+
+    # Verify that number of rows is correct
+    assert(lib.get_num_rows(symbol) == chunk_size*num_chunks)
+
+    # Test that head works correctly
+    expected_head = create_large_df(5, datetime.datetime.utcfromtimestamp(0))
+    assert_frame_equal(lib.head(symbol).data, expected_head)
+
+    # Test that update works correctly
+    expected_head["col"] = np.array([7, 8, 9, 10, 11], dtype=np.int8)
+    lib.update(symbol, expected_head)
+    assert_frame_equal(lib.head(symbol).data, expected_head)
+


### PR DESCRIPTION
Fixes int overflow bug when appending to a symbol with more than `MAX_INT` rows.

Involves two commits:
- First commit: Adds a stress test which writes `2**32` rows and demonstrates the bug.
- Second commit: Fixes the overflow by using the correct type. Test now passes.