### PR TITLE
Extend memory tracing for programatic use and to report on max RSS

### DIFF
--- a/cpp/arcticdb/util/memory_tracing.hpp
+++ b/cpp/arcticdb/util/memory_tracing.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2024 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *
@@ -11,10 +11,9 @@
 #include <fstream>
 #include <arcticdb/util/preprocess.hpp>
 #include <log/log.hpp>
-#ifdef WIN32
-#include <process.h>
-#else
+#ifndef WIN32
 #include <unistd.h>
+#include <sys/resource.h>
 #endif
 
 namespace arcticdb::util {
@@ -35,7 +34,16 @@ inline MemBytes pages(uint64_t num_pages) {
     return {num_pages * page_size};
 }
 
-} //namespace arcticdb::util
+struct MemorySummary {
+    MemBytes size;
+    MemBytes resident;
+    MemBytes max_resident;
+    MemBytes shared;
+    MemBytes text;
+    MemBytes data_stack;
+};
+
+}; //namespace arcticdb::util
 
 namespace fmt {
 template<>
@@ -48,7 +56,7 @@ struct formatter<arcticdb::util::MemBytes> {
         using namespace arcticdb::util;
 
         uint8_t s = 0;
-        double count = static_cast<double>(bytes.value_);
+        auto count = static_cast<double>(bytes.value_);
         while (count >= 1024 && s < MemBytes::num_suffixes_) {
             s++;
             count /= 1024;
@@ -62,11 +70,36 @@ struct formatter<arcticdb::util::MemBytes> {
     }
 };
 
+template<>
+struct formatter<arcticdb::util::MemorySummary> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    auto format(arcticdb::util::MemorySummary summary, FormatContext &ctx) const {
+        return fmt::format_to(
+            ctx.out(),
+            "size[{}] resident[{}] max_resident[{}] shared[{}] text[{}] data/stack[{}]",
+            summary.size,
+            summary.resident,
+            summary.max_resident,
+            summary.shared,
+            summary.text,
+            summary.data_stack
+            );
+    }
+};
+
 } //namespace fmt
 
 namespace arcticdb::util {
 
-inline void print_total_mem_usage(const char *file ARCTICDB_UNUSED, int line ARCTICDB_UNUSED, const char *function ARCTICDB_UNUSED) {
+inline MemorySummary get_memory_use_summary() {
+#if defined(_WIN32) || defined(__APPLE__)
+    ARCTICDB_RUNTIME_DEBUG(log::memory(), "print_total_mem_usage not implemented on Windows or Apple");
+    return MemorySummary{};
+#else
+    // Read statm file, fields are in units of number of pages
     auto pid = getpid();
     auto file_name = fmt::format("/proc/{:d}/statm", pid);
     std::array<int, 7> mem_stat{};
@@ -76,7 +109,7 @@ inline void print_total_mem_usage(const char *file ARCTICDB_UNUSED, int line ARC
     statm_file = fopen(file_name.c_str(), "r");
     if(statm_file == nullptr) {
         ARCTICDB_RUNTIME_DEBUG(log::memory(), "Unable to read {}", file_name);
-        return;
+        return MemorySummary{};
     }
 
     for(auto i = 0u; i < 7u; ++i){
@@ -85,14 +118,34 @@ inline void print_total_mem_usage(const char *file ARCTICDB_UNUSED, int line ARC
         if(fscanf(statm_file, "%d", &mem_stat[i])){}
     }
     fclose(statm_file);
-    ARCTICDB_RUNTIME_DEBUG(log::memory(), "{} ({}:{}) size {} resident {} share {} text {} data/stack {}",
+
+    // Read rusage, fields are in kibibytes
+    struct rusage rusage{};
+    getrusage(RUSAGE_SELF, &rusage);
+
+    return MemorySummary{
+        .size=pages(mem_stat[0]),
+        .resident=pages(mem_stat[1]),
+        .max_resident=MemBytes{1024 * static_cast<uint64_t>(rusage.ru_maxrss)},
+        .shared=pages(mem_stat[2]),
+        .text=pages(mem_stat[3]),
+        .data_stack=pages(mem_stat[5]),
+    };
+#endif
+}
+
+inline void print_total_mem_usage(const char *file ARCTICDB_UNUSED, int line ARCTICDB_UNUSED, const char *function ARCTICDB_UNUSED) {
+#if defined(_WIN32) || defined(__APPLE__)
+    ARCTICDB_RUNTIME_DEBUG(log::memory(), "print_total_mem_usage not implemented on Windows or Apple");
+#else
+    auto summary = get_memory_use_summary();
+
+    ARCTICDB_RUNTIME_DEBUG(log::memory(), "{} ({}:{}) {}",
                        file,
                        function,
                        line,
-                       pages(mem_stat[0]),
-                       pages(mem_stat[1]),
-                       pages(mem_stat[2]),
-                       pages(mem_stat[3]),
-                       pages(mem_stat[5]));
+                       summary);
+#endif
 }
+
 }  //namespace arcticdb::util

--- a/cpp/arcticdb/util/test/test_tracing_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_tracing_allocator.cpp
@@ -45,10 +45,19 @@ TEST(Allocator, PrintMemUsage) {
     arcticdb::util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
 
     auto summary = arcticdb::util::get_memory_use_summary();
+#if defined(_WIN32) || defined(__APPLE__)
+    ASSERT_EQ(summary.size.value_, 0);
+    ASSERT_EQ(summary.resident.value_, 0);
+    ASSERT_EQ(summary.max_resident.value_, 0);
+    ASSERT_EQ(summary.shared.value_, 0);
+    ASSERT_EQ(summary.text.value_, 0);
+    ASSERT_EQ(summary.data_stack.value_, 0);
+#else
     ASSERT_GT(summary.size.value_, 0);
     ASSERT_GT(summary.resident.value_, 0);
     ASSERT_GT(summary.max_resident.value_, 0);
     ASSERT_GT(summary.shared.value_, 0);
     ASSERT_GT(summary.text.value_, 0);
     ASSERT_GT(summary.data_stack.value_, 0);
+#endif
 }

--- a/cpp/arcticdb/util/test/test_tracing_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_tracing_allocator.cpp
@@ -41,6 +41,14 @@ TEST(Allocator, Tracing) {
 }
 
 TEST(Allocator, PrintMemUsage) {
-    arcticdb::log::memory().set_level(spdlog::level::trace);
+    arcticdb::log::memory().set_level(spdlog::level::debug);
     arcticdb::util::print_total_mem_usage(__FILE__, __LINE__, __FUNCTION__);
+
+    auto summary = arcticdb::util::get_memory_use_summary();
+    ASSERT_GT(summary.size.value_, 0);
+    ASSERT_GT(summary.resident.value_, 0);
+    ASSERT_GT(summary.max_resident.value_, 0);
+    ASSERT_GT(summary.shared.value_, 0);
+    ASSERT_GT(summary.text.value_, 0);
+    ASSERT_GT(summary.data_stack.value_, 0);
 }


### PR DESCRIPTION
The idea for this is so that we can measure growth in peak RSS in benchmarks. I'll add one to enterprise soon like,

```
    for (auto _ : state) {
        auto before_sync = util::get_memory_use_summary();
        sync.go();
        auto after_sync = util::get_memory_use_summary();
        uint64_t max_rss_before_mib = before_sync.max_resident.value_ >> 20;
        state.counters["max_rss_before_sync_mib"] = max_rss_before_mib;
        uint64_t max_rss_after_mib = after_sync.max_resident.value_ >> 20;
        state.counters["max_rss_after_sync_mib"] = max_rss_after_mib;
        state.counters["max_rss_growth_during_sync_mib"] = max_rss_after_mib - max_rss_before_mib;
    }
```

Test output:

```
(310) ➜  cpp git:(sync_snapshots_mem) ✗ /home/alex/source/arcticdb-enterprise/out/linux-release-build/ArcticDB/cpp/arcticdb/test_unit_arcticdb --gtest_filter=*PrintMemUsage* --gtest_color=no Note: Google Test filter = *PrintMemUsage*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Allocator
[ RUN      ] Allocator.PrintMemUsage
[2024-06-04 16:21:17.596] [arcticdb] [debug] /home/alex/source/arcticdb-enterprise/ArcticDB/cpp/arcticdb/util/test/test_tracing_allocator.cpp (TestBody:45) size[95.7Mb] resident[33.6Mb] max_resident[33.6Mb] shared[28.1Mb] text[43.9Mb] data/stack[6.2Mb]
[       OK ] Allocator.PrintMemUsage (0 ms)
[----------] 1 test from Allocator (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total) [  PASSED  ] 1 test.
```