### PR TITLE
Pin Windows CI to VS 17.9.7 toolset as runner image update has build failures

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -94,9 +94,6 @@ jobs:
       - name: Enable Windows compiler commands
         if: matrix.os == 'windows'
         uses: ilammy/msvc-dev-cmd@v1.12.1
-        with:
-          # The version of the toolset is specified due to faulty version discovery.
-          toolset: 14.40
 
       - name: Extra envs
         # This has to come after msvc-dev-cmd to overwrite the bad VCPKG_ROOT it sets

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -87,6 +87,10 @@ jobs:
           disk-root: "D:"  # This is also the checkout directory. Total size 12GB.
         continue-on-error: true
 
+      - name: Install VS2022 BuildTools 17.9.7
+        if: matrix.os == 'windows'
+        run: choco install -y visualstudio2022buildtools --version=117.9.7.0 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/180911598_-255012421/channel"
+
       - name: Enable Windows compiler commands
         if: matrix.os == 'windows'
         uses: ilammy/msvc-dev-cmd@v1.12.1

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -92,7 +92,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1.12.1
         with:
           # The version of the toolset is specified due to faulty version discovery.
-          toolset: 14.39
+          toolset: 14.40
 
       - name: Extra envs
         # This has to come after msvc-dev-cmd to overwrite the bad VCPKG_ROOT it sets


### PR DESCRIPTION
The new GH runner release [20240603.1](https://github.com/actions/runner-images/releases/tag/win22%2F20240603.1) requires minimum 14.40 for MSVC toolset.

Set [VS2022 BuildTools to 17.9.7](https://github.com/actions/runner-images/issues/10004#issuecomment-2155695838) as version 17.10 is busted with several dependencies.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
