### PR TITLE
Bugfix 1615: Fix segfault in benchmark_clause.cpp

### DIFF
--- a/cpp/arcticdb/processing/test/benchmark_clause.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_clause.cpp
@@ -116,6 +116,7 @@ void BM_hash_grouping_int(benchmark::State& state) {
     constexpr auto data_type = data_type_from_raw_type<integer>();
     Column column(make_scalar_type(data_type), num_rows, true, false);
     memcpy(column.ptr(), data.data(), num_rows * sizeof(integer));
+    column.set_row_data(num_rows - 1);
     ColumnWithStrings col_with_strings(std::move(column), {}, "random_ints");
 
     grouping::HashingGroupers::Grouper<ScalarTagType<DataTypeTag<data_type>>> grouper;
@@ -170,8 +171,8 @@ void BM_hash_grouping_string(benchmark::State& state) {
 BENCHMARK(BM_merge_interleaved)->Args({10'000, 100});
 BENCHMARK(BM_merge_ordered)->Args({10'000, 100});
 
-BENCHMARK(BM_hash_grouping_int<int8_t>)->Args({100'000, 10, 2})->Args({100'000, 100'000, 2});
-BENCHMARK(BM_hash_grouping_int<int16_t>)->Args({100'000, 10, 2})->Args({100'000, 100'000, 2});
+BENCHMARK(BM_hash_grouping_int<int8_t>)->Args({100'000, 10, 2});
+BENCHMARK(BM_hash_grouping_int<int16_t>)->Args({100'000, 10, 2})->Args({100'000, 10'000, 2});
 BENCHMARK(BM_hash_grouping_int<int32_t>)->Args({100'000, 10, 2})->Args({100'000, 100'000, 2});
 BENCHMARK(BM_hash_grouping_int<int64_t>)->Args({100'000, 10, 2})->Args({100'000, 100'000, 2});
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #1615 

After the refactor to speed up hash-based grouping, the C++ grouping benchmark needs updating to correctly set the last logical row on the input column, as this is now used to presize the vector mapping rows to buckets.

Also noticed that some benchmarks did not make sense (e.g. `int8_t` column with 100,000 unique grouping values), so corrected this as well.