### PR TITLE
Fix sort_and_finalize_staged_data

### DIFF
--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -43,7 +43,7 @@ TEST(Async, SinkBasic) {
 
     auto seg = ac::SegmentInMemory();
     aa::EncodeAtomTask enc{
-        ac::entity::KeyType::GENERATION, ac::entity::VersionId{6}, ac::entity::NumericId{123}, ac::entity::NumericId{456}, ac::timestamp{457}, {ac::entity::NumericIndex{999}}, std::move(seg), codec_opt, ac::EncodingVersion::V2
+        ac::entity::KeyType::GENERATION, ac::entity::VersionId{6}, ac::entity::NumericId{123}, ac::entity::NumericId{456}, ac::timestamp{457}, ac::entity::NumericIndex{999}, std::move(seg), codec_opt, ac::EncodingVersion::V2
     };
 
     auto v = sched.submit_cpu_task(std::move(enc)).via(&aa::io_executor()).thenValue(aa::WriteSegmentTask{lib}).get();

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -461,7 +461,7 @@ void Column::inflate_string_array(
         const TensorType<position_t> &string_refs,
         CursoredBuffer<ChunkedBuffer> &data,
         CursoredBuffer<Buffer> &shapes,
-        std::vector<position_t> &offsets,
+        boost::container::small_vector<position_t, 1> &offsets,
         const StringPool &string_pool) {
     ssize_t max_size = 0;
     for (int i = 0; i < string_refs.size(); ++i)
@@ -490,7 +490,7 @@ void Column::inflate_string_arrays(const StringPool &string_pool) {
 
     CursoredBuffer<ChunkedBuffer> data;
     CursoredBuffer<Buffer> shapes;
-    std::vector<position_t> offsets;
+    boost::container::small_vector<position_t, 1> offsets;
     for (position_t row = 0; row < row_count(); ++row) {
         auto string_refs = tensor_at<position_t>(row).value();
         inflate_string_array(string_refs, data, shapes, offsets, string_pool);

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -440,7 +440,7 @@ public:
     void inflate_string_array(const TensorType<position_t> &string_refs,
                               CursoredBuffer<ChunkedBuffer> &data,
                               CursoredBuffer<Buffer> &shapes,
-                              std::vector<position_t> &offsets,
+                              boost::container::small_vector<position_t, 1> &offsets,
                               const StringPool &string_pool);
 
     void inflate_string_arrays(const StringPool &string_pool);
@@ -920,7 +920,7 @@ private:
     CursoredBuffer<ChunkedBuffer> data_;
     CursoredBuffer<Buffer> shapes_;
 
-    mutable std::vector<position_t> offsets_;
+    mutable boost::container::small_vector<position_t, 1> offsets_;
     TypeDescriptor type_;
     std::optional<TypeDescriptor> orig_type_;
     ssize_t last_logical_row_ = -1;

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -490,9 +490,9 @@ void decode_into_frame_dynamic(
             // decode_or_expand will invoke the empty type handler which will do backfilling with the default value depending on the
             // destination type.
             if (!trivially_compatible_types(m.source_type_desc_, m.dest_type_desc_) && !source_is_empty) {
-                m.dest_type_desc_.visit_tag([&buffer, &m, &data, encoded_field, buffers, encdoing_version] (auto dest_desc_tag) {
+                m.dest_type_desc_.visit_tag([&buffer, &m, buffers] (auto dest_desc_tag) {
                     using DestinationType =  typename decltype(dest_desc_tag)::DataTypeTag::raw_type;
-                    m.source_type_desc_.visit_tag([&buffer, &m, &data, &encoded_field, &buffers, encdoing_version] (auto src_desc_tag ) {
+                    m.source_type_desc_.visit_tag([&buffer, &m] (auto src_desc_tag ) {
                         using SourceType =  typename decltype(src_desc_tag)::DataTypeTag::raw_type;
                         if constexpr(std::is_arithmetic_v<SourceType> && std::is_arithmetic_v<DestinationType>) {
                             // If the source and destination types are different, then sizeof(destination type) >= sizeof(source type)

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -109,9 +109,11 @@ struct IClause {
 
 using Clause = folly::Poly<IClause>;
 
-std::vector<std::vector<size_t>> structure_by_row_slice(std::vector<RangesAndKey>& ranges_and_keys,
-                                                        size_t start_from);
+std::vector<std::vector<size_t>> structure_by_row_slice(std::vector<RangesAndKey>& ranges_and_keys, size_t start_from);
+
 std::vector<std::vector<size_t>> structure_by_column_slice(std::vector<RangesAndKey>& ranges_and_keys);
+
+std::vector<std::vector<size_t>> structure_all_together(std::vector<RangesAndKey>& ranges_and_keys);
 
 Composite<ProcessingUnit> gather_entities(std::shared_ptr<ComponentManager> component_manager,
                                           Composite<EntityIds>&& entity_ids,
@@ -614,8 +616,8 @@ struct MergeClause {
 
     [[nodiscard]] std::vector<std::vector<size_t>> structure_for_processing(
             std::vector<RangesAndKey>& ranges_and_keys,
-            size_t start_from) {
-        return structure_by_row_slice(ranges_and_keys, start_from);
+            size_t) {
+        return structure_all_together(ranges_and_keys);
     }
 
     [[nodiscard]] Composite<EntityIds> process(Composite<EntityIds>&& entity_ids) const;

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -402,7 +402,7 @@ VariantData binary_operator(const ColumnWithStrings& col, const Value& val, Func
                 Column::transform<typename col_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
                         *(col.column_),
                         *output_column,
-                        [&func, &col, &column_name, raw_value](auto input_value) -> ReversedTargetType {
+                        [&func, raw_value](auto input_value) -> ReversedTargetType {
                             return func.apply(raw_value, input_value);
                 });
             } else {
@@ -412,7 +412,7 @@ VariantData binary_operator(const ColumnWithStrings& col, const Value& val, Func
                 Column::transform<typename col_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
                         *(col.column_),
                         *output_column,
-                        [&func, &col, &column_name, raw_value](auto input_value) -> TargetType {
+                        [&func, raw_value](auto input_value) -> TargetType {
                             return func.apply(input_value, raw_value);
                 });
             }

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -127,7 +127,7 @@ VariantData unary_comparator(const ColumnWithStrings& col, Func&& func) {
     constexpr auto sparse_missing_value_output = std::is_same_v<std::remove_reference_t<Func>, IsNullOperator>;
     details::visit_type(col.column_->type().data_type(), [&](auto col_tag) {
         using type_info = ScalarTypeInfo<decltype(col_tag)>;
-        Column::transform<typename type_info::TDT>(*(col.column_), output_bitset, sparse_missing_value_output, [&col, &func](auto input_value) -> bool {
+        Column::transform<typename type_info::TDT>(*(col.column_), output_bitset, sparse_missing_value_output, [&](auto input_value) -> bool {
             if constexpr (is_floating_point_type(type_info::data_type)) {
                 return func.apply(input_value);
             } else if constexpr (is_sequence_type(type_info::data_type)) {

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -56,16 +56,7 @@ SegmentInMemory MinMaxAggregatorData::finalize(const std::vector<ColumnName>& ou
     return seg;
 }
 
-namespace
-{
-    inline util::BitMagic::enumerator::value_type deref(util::BitMagic::enumerator iter) {
-        return *iter;
-    }
-
-    inline std::size_t deref(std::size_t index) {
-        return index;
-    }
-
+namespace {
     template<typename T, typename T2=void>
     struct OutputType;
 

--- a/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
+++ b/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
@@ -22,7 +22,7 @@ uint64_t get_symbol_prefix(const entity::StreamId& stream_id) {
     constexpr size_t begin = sizeof(InternalType) - sizeof(StorageType);
     StorageType data{};
     util::variant_match(stream_id,
-        [&data, begin, end] (const entity::StringId& string_id) {
+        [&] (const entity::StringId& string_id) {
             auto* target = reinterpret_cast<char*>(&data);
             for(size_t p = begin, i = 0; p < end && i < string_id.size(); ++p, ++i) {
                 const auto c = string_id[i];

--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -29,9 +29,6 @@ class DefaultStringViewable : public std::shared_ptr<std::string> {
         std::make_shared<std::string>(args...)),
                                             hash_(arcticdb::hash(std::string_view{*this})) {}
 
-    DefaultStringViewable(const DefaultStringViewable &that) :
-        std::shared_ptr<std::string>::shared_ptr(that), hash_(that.hash_) {}
-
     operator std::string_view() const {
         return *this->get();
     }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -657,7 +657,7 @@ std::vector<SliceAndKey> read_and_process(
     // i.e. if the first processing unit needs ranges_and_keys[0] and ranges_and_keys[1], and the second needs ranges_and_keys[2] and ranges_and_keys[3]
     // then the structure will be {{0, 1}, {2, 3}}
     std::vector<std::vector<size_t>> processing_unit_indexes = read_query.clauses_[0]->structure_for_processing(ranges_and_keys, start_from);
-        component_manager->set_next_entity_id(ranges_and_keys.size());
+    component_manager->set_next_entity_id(ranges_and_keys.size());
 
     // Start reading as early as possible
     auto segment_and_slice_futures = store->batch_read_uncompressed(std::move(ranges_and_keys), columns_to_decode(pipeline_context));
@@ -1285,9 +1285,10 @@ VersionedItem sort_merge_impl(
         [&](const stream::TimeseriesIndex &timeseries_index) {
             read_query.clauses_.emplace_back(std::make_shared<Clause>(SortClause{timeseries_index.name()}));
             read_query.clauses_.emplace_back(std::make_shared<Clause>(RemoveColumnPartitioningClause{}));
-            const auto split_size = ConfigsMap::instance()->get_int("Split.RowCount", 10000);
-            read_query.clauses_.emplace_back(std::make_shared<Clause>(SplitClause{static_cast<size_t>(split_size)}));
-            read_query.clauses_.emplace_back(std::make_shared<Clause>(MergeClause{timeseries_index, DenseColumnPolicy{}, stream_id, pipeline_context->descriptor()}));
+            //const auto split_size = ConfigsMap::instance()->get_int("Split.RowCount", 10000);
+            //read_query.clauses_.emplace_back(std::make_shared<Clause>(SplitClause{static_cast<size_t>(split_size)}));
+
+            read_query.clauses_.emplace_back(std::make_shared<Clause>(MergeClause{timeseries_index, SparseColumnPolicy{}, stream_id, pipeline_context->descriptor()}));
             auto segments = read_and_process(store, pipeline_context, read_query, ReadOptions{}, pipeline_context->incompletes_after());
             pipeline_context->total_rows_ = num_versioned_rows + get_slice_rowcounts(segments);
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2455,9 +2455,9 @@ class NativeVersionStore:
 
     def _get_time_range_from_ts(self, desc, min_ts, max_ts):
         if desc.stream_descriptor.index.kind != IndexDescriptor.Type.TIMESTAMP or \
-            desc.stream_descriptor.sorted == SortedValue.UNSORTED or \
-            min_ts is None or \
-            max_ts is None:
+                desc.stream_descriptor.sorted == SortedValue.UNSORTED or \
+                min_ts is None or \
+                max_ts is None:
             return datetime64("nat"), datetime64("nat")
         input_type = desc.normalization.WhichOneof("input_type")
         tz = None

--- a/python/tests/unit/arcticdb/version_store/test_sort_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort_merge.py
@@ -1,0 +1,128 @@
+import pandas as pd
+import numpy as np
+from pandas.testing import assert_frame_equal
+
+
+def test_merge_single_column(arctic_library):
+    lib = arctic_library
+
+    dates1 = [np.datetime64('2023-01-01'), np.datetime64('2023-01-03'), np.datetime64('2023-01-05')]
+    dates2 = [np.datetime64('2023-01-02'), np.datetime64('2023-01-04'), np.datetime64('2023-01-06')]
+
+    data1 = {"x": [1, 3, 5]}
+    data2 = {"x": [2, 4, 6]}
+
+    df1 = pd.DataFrame(data1, index=dates1)
+    df2 = pd.DataFrame(data2, index=dates2)
+
+    sym1 = "symbol_1"
+    lib.write(sym1, df1, staged=True)
+    lib.write(sym1, df2, staged=True)
+    lib.sort_and_finalize_staged_data(sym1)
+
+    expected_dates = [np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03'),
+                      np.datetime64('2023-01-04'), np.datetime64('2023-01-05'), np.datetime64('2023-01-06')]
+
+    expected_values = {"x": [1, 2, 3, 4, 5, 6]}
+    expected_df = pd.DataFrame(expected_values, index=expected_dates)
+    assert_frame_equal(lib.read(sym1).data, expected_df)
+
+
+def test_merge_two_column(arctic_library):
+    lib = arctic_library
+
+    dates1 = [np.datetime64('2023-01-01'), np.datetime64('2023-01-03'), np.datetime64('2023-01-05')]
+    dates2 = [np.datetime64('2023-01-02'), np.datetime64('2023-01-04'), np.datetime64('2023-01-06')]
+
+    data1 = {"x": [1, 3, 5], "y": [10, 12, 14]}
+    data2 = {"x": [2, 4, 6], "y": [11, 13, 15]}
+
+    df1 = pd.DataFrame(data1, index=dates1)
+    df2 = pd.DataFrame(data2, index=dates2)
+
+    sym1 = "symbol_1"
+    lib.write(sym1, df1, staged=True)
+    lib.write(sym1, df2, staged=True)
+    lib.sort_and_finalize_staged_data(sym1)
+
+    expected_dates = [np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03'),
+                      np.datetime64('2023-01-04'), np.datetime64('2023-01-05'), np.datetime64('2023-01-06')]
+
+    expected_values = {"x": [1, 2, 3, 4, 5, 6], "y": [10, 11, 12, 13, 14, 15]}
+    expected_df = pd.DataFrame(expected_values, index=expected_dates)
+    assert_frame_equal(lib.read(sym1).data, expected_df)
+
+
+def test_merge_dynamic(arctic_library):
+    lib = arctic_library
+
+    dates1 = [np.datetime64('2023-01-01'), np.datetime64('2023-01-03'), np.datetime64('2023-01-05')]
+    dates2 = [np.datetime64('2023-01-02'), np.datetime64('2023-01-04'), np.datetime64('2023-01-06')]
+
+    data1 = {"x": [1, 3, 5]}
+    data2 = {"y": [2, 4, 6]}
+
+    df1 = pd.DataFrame(data1, index=dates1)
+    df2 = pd.DataFrame(data2, index=dates2)
+
+    sym1 = "symbol_1"
+    lib.write(sym1, df1, staged=True)
+    lib.write(sym1, df2, staged=True)
+    lib.sort_and_finalize_staged_data(sym1)
+
+    expected_dates = [np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03'),
+                      np.datetime64('2023-01-04'), np.datetime64('2023-01-05'), np.datetime64('2023-01-06')]
+
+    expected_values = {"x": [1, 0, 3, 0, 5, 0], "y": [0, 2, 0, 4, 0, 6]}
+    expected_df = pd.DataFrame(expected_values, index=expected_dates)
+    assert_frame_equal(lib.read(sym1).data, expected_df)
+
+
+def test_merge_strings(arctic_library):
+    lib = arctic_library
+
+    dates1 = [np.datetime64('2023-01-01'), np.datetime64('2023-01-03'), np.datetime64('2023-01-05')]
+    dates2 = [np.datetime64('2023-01-02'), np.datetime64('2023-01-04'), np.datetime64('2023-01-06')]
+
+    data1 = {"x": [1, 3, 5], "y": ["one","three", "five"]}
+    data2 = {"x": [2, 4, 6], "y": ["two", "four", "six"]}
+
+    df1 = pd.DataFrame(data1, index=dates1)
+    df2 = pd.DataFrame(data2, index=dates2)
+
+    sym1 = "symbol_1"
+    lib.write(sym1, df1, staged=True)
+    lib.write(sym1, df2, staged=True)
+    lib.sort_and_finalize_staged_data(sym1)
+
+    expected_dates = [np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03'),
+                      np.datetime64('2023-01-04'), np.datetime64('2023-01-05'), np.datetime64('2023-01-06')]
+
+    expected_values = {"x": [1, 2, 3, 4, 5, 6], "y": ["one", "two", "three", "four", "five", "six"]}
+    expected_df = pd.DataFrame(expected_values, index=expected_dates)
+    assert_frame_equal(lib.read(sym1).data, expected_df)
+
+
+def test_merge_strings_dynamic(arctic_library):
+    lib = arctic_library
+
+    dates1 = [np.datetime64('2023-01-01'), np.datetime64('2023-01-03'), np.datetime64('2023-01-05')]
+    dates2 = [np.datetime64('2023-01-02'), np.datetime64('2023-01-04'), np.datetime64('2023-01-06')]
+
+    data1 = {"x": ["one","three", "five"]}
+    data2 = {"y": ["two", "four", "six"]}
+
+    df1 = pd.DataFrame(data1, index=dates1)
+    df2 = pd.DataFrame(data2, index=dates2)
+
+    sym1 = "symbol_1"
+    lib.write(sym1, df1, staged=True)
+    lib.write(sym1, df2, staged=True)
+    lib.sort_and_finalize_staged_data(sym1)
+
+    expected_dates = [np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03'),
+                      np.datetime64('2023-01-04'), np.datetime64('2023-01-05'), np.datetime64('2023-01-06')]
+
+    expected_values = {"x": ["one", None, "three", None, "five", None], "y": [None, "two", None, "four", None, "six"]}
+    expected_df = pd.DataFrame(expected_values, index=expected_dates)
+    assert_frame_equal(lib.read(sym1).data, expected_df)


### PR DESCRIPTION
sort_and_finalize_staged_data lost some tests in the transition to open-source, and so when it was broken by a processing pipeline factor this was not recognised. This PR fixes it and adds some elementary tests to check that it's doing what it's supposed to