### PR TITLE
Bugfix 1609: Allow parallel appends when incomplete index values match last existing index value in the symbol

### DIFF
--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -859,8 +859,8 @@ void check_incompletes_index_ranges_dont_overlap(const std::shared_ptr<PipelineC
         std::set<TimestampRange> unique_timestamp_ranges;
         for (auto it = pipeline_context->incompletes_begin(); it!= pipeline_context->end(); it++) {
             sorting::check<ErrorCode::E_UNSORTED_DATA>(
-                    !last_existing_index_value.has_value() || it->slice_and_key().key().start_time() > *last_existing_index_value,
-                    "Cannot append staged segments to existing data as incomplete segment contains index value <= existing data: {} <= {}",
+                    !last_existing_index_value.has_value() || it->slice_and_key().key().start_time() >= *last_existing_index_value,
+                    "Cannot append staged segments to existing data as incomplete segment contains index value < existing data: {} <= {}",
                     it->slice_and_key().key().start_time(),
                     *last_existing_index_value);
             unique_timestamp_ranges.insert({it->slice_and_key().key().start_time(), it->slice_and_key().key().end_time()});

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -304,6 +304,21 @@ def test_append_not_sorted_exception(lmdb_version_store):
         lmdb_version_store.append(symbol, df2, validate_index=True)
 
 
+@pytest.mark.parametrize("validate_index", (True, False))
+def test_append_same_index_value(lmdb_version_store_v1, validate_index):
+    lib = lmdb_version_store_v1
+    sym = "test_append_same_index_value"
+    df_0 = pd.DataFrame({"col": [1, 2]}, index=pd.date_range("2024-01-01", periods=2))
+    lib.write(sym, df_0)
+
+    df_1 = pd.DataFrame({"col": [3, 4]}, index=pd.date_range(df_0.index[-1], periods=2))
+    lib.append(sym, df_1, validate_index=validate_index)
+    expected = pd.concat([df_0, df_1])
+    received = lib.read(sym).data
+    assert_frame_equal(expected, received)
+    assert lib.get_info(sym)["sorted"] == "ASCENDING"
+
+
 def test_append_existing_not_sorted_exception(lmdb_version_store):
     symbol = "bad_append"
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #1609