### PR TITLE
Additional warning for diverted prometheus config

### DIFF
--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -33,7 +33,25 @@ namespace arcticdb {
 
     void PrometheusInstance::configure(const MetricsConfig& config, const bool reconfigure) {
         if (configured_ && !reconfigure) {
-            arcticdb::log::version().warn("Prometheus already configured");
+            arcticdb::log::version().warn("Prometheus already configured; Existing setting will be used");
+            if (config.host != cfg_.host) {
+                arcticdb::log::version().warn("New Prometheus host is different from the existing: {} vs {}", config.host, cfg_.host);
+            }
+            if (config.port != cfg_.port) {
+                arcticdb::log::version().warn("New Prometheus port is different from the existing: {} vs {}", config.port, cfg_.port);
+            }
+            if (config.job_name != cfg_.job_name) {
+                arcticdb::log::version().warn("New Prometheus job_name is different from the existing: {} vs {}", config.job_name, cfg_.job_name);
+            }
+            if (config.instance != cfg_.instance) {
+                arcticdb::log::version().warn("New Prometheus instance is different from the existing: {} vs {}", config.instance, cfg_.instance);
+            }
+            if (config.prometheus_env != cfg_.prometheus_env) {
+                arcticdb::log::version().warn("New Prometheus env is different from the existing: {} vs {}", config.prometheus_env, cfg_.prometheus_env);
+            }
+            if (config.model_ != cfg_.model_) {
+                arcticdb::log::version().warn("New Prometheus model is different from the existing: {} vs {}", static_cast<int>(config.model_), static_cast<int>(cfg_.model_));
+            }
             return;
         }
         


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
`PrometheusInstance` is static which has a lifetime as the python interpreter. Once setup, its configuration can't be overwritten and shared by all arcticdb instances. This may give a nasty suprise to user when they want to setup new replicator with different prometheus config. Thus additional warning will be useful.
#### Any other comments?
Copilot turns out to be very useful for such task :)
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
