### PR TITLE
Enhancement/1610/method to force compact symbol list

### DIFF
--- a/cpp/arcticdb/util/timer.hpp
+++ b/cpp/arcticdb/util/timer.hpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <ctime>
 #include <sstream>
+#include <iomanip>
 
 namespace arcticdb {
 
@@ -292,6 +293,13 @@ arcticdb::ScopedTimerTotal timer1{#name, [&data](auto totals) { \
 arcticdb::ScopedTimerTotal timer2{#name, [&data](auto totals) { \
     std::copy(std::begin(totals), std::end(totals), std::back_inserter(data)); \
 }};
+
+inline std::string date_and_time(int64_t ts) {
+    std::time_t seconds_since_epoch = ts / BILLION;
+    std::stringstream ss;
+    ss << std::put_time(std::gmtime(&seconds_since_epoch), "%F %T");
+    return ss.str();
+}
 
 
 } //namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -203,6 +203,11 @@ std::set<StreamId> LocalVersionedEngine::list_streams_internal(
     return res;
 }
 
+size_t LocalVersionedEngine::compact_symbol_list_internal() {
+    ARCTICDB_SAMPLE(CompactSymbolListInternal, 0)
+    return symbol_list().compact(store());
+}
+
 std::string LocalVersionedEngine::dump_versions(const StreamId& stream_id) {
     return version_map()->dump_entry(store(), stream_id);
 }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -187,6 +187,8 @@ public:
         const std::optional<bool>& opt_all_symbols
     ) override;
 
+    size_t compact_symbol_list_internal() override;
+
     VersionedItem  write_versioned_dataframe_internal(
         const StreamId& stream_id,
         const std::shared_ptr<InputTensorFrame>& frame,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -611,6 +611,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("list_streams",
              &PythonVersionStore::list_streams,
              py::call_guard<SingleThreadMutexHolder>(), "List all the stream ids that have been written")
+        .def("compact_symbol_list",
+             &PythonVersionStore::compact_symbol_list,
+             py::call_guard<SingleThreadMutexHolder>(), "Compacts the symbol list cache into a single key in the storage")
         .def("read_metadata",
              &PythonVersionStore::read_metadata,
              py::call_guard<SingleThreadMutexHolder>(), "Get back the metadata and version info for a symbol.")

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -165,6 +165,8 @@ class SymbolList {
         return load(data_.version_map_, store, false);
     }
 
+    size_t compact(const std::shared_ptr<Store>& store);
+
     static void add_symbol(const std::shared_ptr<Store>& store, const entity::StreamId& symbol, entity::VersionId reference_id);
 
     static void remove_symbol(const std::shared_ptr<Store>& store, const entity::StreamId& symbol, entity::VersionId reference_id);
@@ -172,6 +174,8 @@ class SymbolList {
     static void clear(const std::shared_ptr<Store>& store);
 
 private:
+    void compact_internal(const std::shared_ptr<Store>& store, LoadResult& load_result) const;
+
     [[nodiscard]] bool needs_compaction(const LoadResult& load_result) const;
 };
 

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -504,6 +504,10 @@ std::set<StreamId> PythonVersionStore::list_streams(
     return list_streams_internal(snap_name, regex, prefix, opt_use_symbol_list, opt_all_symbols);
 }
 
+size_t PythonVersionStore::compact_symbol_list() {
+    return compact_symbol_list_internal();
+}
+
 VersionedItem PythonVersionStore::write_partitioned_dataframe(
     const StreamId& stream_id,
     const py::tuple &item,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -312,6 +312,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::optional<bool>& use_symbol_list = std::nullopt,
         const std::optional<bool>& all_symbols = std::nullopt);
 
+    size_t compact_symbol_list();
+
     void clear(const bool continue_on_error = true);
     bool empty();
     void force_delete_symbol(const StreamId& stream_id);

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -140,6 +140,8 @@ public:
         const std::optional<bool>& opt_all_symbols
     ) = 0;
 
+    virtual size_t compact_symbol_list_internal() = 0;
+
     virtual IndexRange get_index_range(
         const StreamId &stream_id,
         const VersionQuery& version_query) = 0;

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2071,6 +2071,24 @@ class NativeVersionStore:
             use_symbol_list = False
         return list(self.version_store.list_streams(snapshot, regex, prefix, use_symbol_list, all_symbols))
 
+    def compact_symbol_list(self) -> int:
+        """
+        Compact the symbol list cache into a single key in the storage
+
+        Returns
+        -------
+        The number of symbol list keys prior to compaction
+
+
+        Raises
+        ------
+        PermissionException
+            Library has been opened in read-only mode
+        InternalException
+            Storage lock required to compact the symbol list could not be acquired
+        """
+        return self.version_store.compact_symbol_list()
+
     def list_snapshots(self, load_metadata: Optional[bool] = True) -> Dict[str, Any]:
         """
         List the snapshots in the library.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1706,6 +1706,24 @@ class Library:
         """
         self._nvs.version_store.reload_symbol_list()
 
+    def compact_symbol_list(self) -> None:
+        """
+        Compact the symbol list cache into a single key in the storage
+
+        Returns
+        -------
+        The number of symbol list keys prior to compaction
+
+
+        Raises
+        ------
+        PermissionException
+            Library has been opened in read-only mode
+        InternalException
+            Storage lock required to compact the symbol list could not be acquired
+        """
+        return self._nvs.compact_symbol_list()
+
     def is_symbol_fragmented(self, symbol: str, segment_size: Optional[int] = None) -> bool:
         """
         Check whether the number of segments that would be reduced by compaction is more than or equal to the


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #1610 

Considered augmenting `list_symbols` API to make this an option, but there are already a lot of arguments (particularly in the `NativeVersionStore` version) that this would not be compatible with, so added another method instead.