### PR TITLE
Bugfix 1637: append does not respect prune previous

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -617,7 +617,7 @@ class NativeVersionStore:
         dataframe: TimeSeriesType,
         metadata: Optional[Any] = None,
         incomplete: bool = False,
-        prune_previous_version: bool = False,
+        prune_previous_version: Optional[bool] = None,
         validate_index: bool = False,
         **kwargs,
     ) -> Optional[VersionedItem]:
@@ -691,6 +691,11 @@ class NativeVersionStore:
         dynamic_strings = self._resolve_dynamic_strings(kwargs)
         coerce_columns = kwargs.get("coerce_columns", None)
 
+        proto_cfg = self._lib_cfg.lib_desc.version.write_options
+        prune_previous_version = self.resolve_defaults(
+            "prune_previous_version", proto_cfg, global_default=False, existing_value=prune_previous_version, **kwargs
+        )
+
         _handle_categorical_columns(symbol, dataframe)
 
         udm, item, norm_meta = self._try_normalize(
@@ -722,7 +727,7 @@ class NativeVersionStore:
         metadata: Any = None,
         date_range: Optional[DateRangeInput] = None,
         upsert: bool = False,
-        prune_previous_version: bool = False,
+        prune_previous_version: Optional[bool] = None,
         **kwargs,
     ) -> VersionedItem:
         """
@@ -785,10 +790,15 @@ class NativeVersionStore:
         """
         update_query = _PythonVersionStoreUpdateQuery()
         dynamic_strings = self._resolve_dynamic_strings(kwargs)
+        proto_cfg = self._lib_cfg.lib_desc.version.write_options
         dynamic_schema = self.resolve_defaults(
-            "dynamic_schema", self._lib_cfg.lib_desc.version.write_options, False, **kwargs
+            "dynamic_schema", proto_cfg, False, **kwargs
         )
         coerce_columns = kwargs.get("coerce_columns", None)
+
+        prune_previous_version = self.resolve_defaults(
+            "prune_previous_version", proto_cfg, global_default=False, existing_value=prune_previous_version, **kwargs
+        )
 
         if date_range is not None:
             start, end = normalize_dt_range_to_ts(date_range)
@@ -2225,13 +2235,22 @@ class NativeVersionStore:
             Remove previous versions from version list. Uses library default if left as None.
         """
         if date_range is not None:
+            proto_cfg = self._lib_cfg.lib_desc.version.write_options
             dynamic_schema = self.resolve_defaults(
-                "dynamic_schema", self._lib_cfg.lib_desc.version.write_options, False, **kwargs
+                "dynamic_schema", proto_cfg, False, **kwargs
             )
+            # All other methods use prune_previous_version, but also support prune_previous_versions here in case
+            # anyone is relying on it
             prune_previous_versions = _assume_false("prune_previous_versions", kwargs)
+            if prune_previous_versions:
+                prune_previous_version = True
+            else:
+                prune_previous_version = self.resolve_defaults(
+                    "prune_previous_version", proto_cfg, global_default=False, **kwargs
+                )
             update_query = _PythonVersionStoreUpdateQuery()
             update_query.row_filter = _normalize_dt_range(date_range)
-            self.version_store.delete_range(symbol, update_query, dynamic_schema, prune_previous_versions)
+            self.version_store.delete_range(symbol, update_query, dynamic_schema, prune_previous_version)
 
         else:
             self.version_store.delete(symbol)
@@ -2780,7 +2799,13 @@ class NativeVersionStore:
         """
         return self.version_store.is_symbol_fragmented(symbol, segment_size)
 
-    def defragment_symbol_data(self, symbol: str, segment_size: Optional[int] = None, prune_previous_versions: Optional[bool] = False) -> VersionedItem:
+    def defragment_symbol_data(
+            self,
+            symbol: str,
+            segment_size: Optional[int] = None,
+            prune_previous_versions: Optional[bool] = None,
+            **kwargs,
+    ) -> VersionedItem:
         """
         Compacts fragmented segments by merging row-sliced segments (https://docs.arcticdb.io/technical/on_disk_storage/#data-layer).
         This method calls `is_symbol_fragmented` to determine whether to proceed with the defragmentation operation.
@@ -2840,10 +2865,17 @@ class NativeVersionStore:
         in the future. This API will allow overriding the setting as well.
         """
 
-        if self._lib_cfg.lib_desc.version.write_options.bucketize_dynamic:
+        proto_cfg = self._lib_cfg.lib_desc.version.write_options
+        if proto_cfg.bucketize_dynamic:
             raise ArcticDbNotYetImplemented(f"Support for library with 'bucketize_dynamic' ON is not implemented yet")
 
-        result = self.version_store.defragment_symbol_data(symbol, segment_size, prune_previous_versions)
+        # All other methods use prune_previous_version, but also support prune_previous_versions here in case
+        # anyone is relying on it
+        prune_previous_version = self.resolve_defaults(
+            "prune_previous_version", proto_cfg, global_default=False, existing_value=prune_previous_versions, **kwargs
+        )
+
+        result = self.version_store.defragment_symbol_data(symbol, segment_size, prune_previous_version)
         return VersionedItem(
             symbol=result.symbol,
             library=self._library.library_path,

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -12,7 +12,8 @@ import pytest
 import sys
 
 from arcticdb.util.test import assert_frame_equal, assert_series_equal
-from arcticdb.util._versions import IS_PANDAS_TWO
+from arcticdb_ext import set_config_int
+from arcticdb_ext.storage import KeyType
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.util.date import DateRange
 
@@ -295,3 +296,108 @@ def test_date_range_multi_index(lmdb_version_store):
         sym, date_range=DateRange(pd.Timestamp("2099-01-01"), pd.Timestamp("2099-01-02"))
     ).data
     assert_frame_equal(result_df, expected_df)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ("write", "append", "update", "write_metadata", "batch_write", "batch_append", "batch_write_metadata")
+)
+@pytest.mark.parametrize("lib_config", (True, False))
+@pytest.mark.parametrize("env_var", (True, False))
+@pytest.mark.parametrize("arg", (True, False, None))
+def test_prune_previous_general(version_store_factory, monkeypatch, method, lib_config, env_var, arg):
+    lib = version_store_factory(prune_previous_version=lib_config, use_tombstones=True)
+    should_be_pruned = lib_config
+    if env_var:
+        monkeypatch.setenv("PRUNE_PREVIOUS_VERSION", "true")
+        should_be_pruned = True
+    if arg is not None:
+        should_be_pruned = arg
+
+    lt = lib.library_tool()
+    sym = f"test_prune_previous_general"
+    df_0 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(sym, df_0)
+
+    df_1 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-11", periods=10))
+    arg_0 = [sym] if method.startswith("batch") else sym
+    arg_1 = [df_1] if method.startswith("batch") else df_1
+
+    getattr(lib, method)(arg_0, arg_1, prune_previous_version=arg)
+
+    assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 1 if should_be_pruned else 2
+
+
+@pytest.mark.parametrize("append", (True, False))
+@pytest.mark.parametrize("lib_config", (True, False))
+@pytest.mark.parametrize("env_var", (True, False))
+@pytest.mark.parametrize("arg", (True, False, None))
+def test_prune_previous_compact_incomplete(version_store_factory, monkeypatch, append, lib_config, env_var, arg):
+    lib = version_store_factory(prune_previous_version=lib_config, use_tombstones=True)
+    should_be_pruned = lib_config
+    if env_var:
+        monkeypatch.setenv("PRUNE_PREVIOUS_VERSION", "true")
+        should_be_pruned = True
+    if arg is not None:
+        should_be_pruned = arg
+
+    lt = lib.library_tool()
+    sym = f"test_prune_previous_compact_incomplete"
+    df_0 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(sym, df_0)
+
+    df_1 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-11", periods=10))
+    lib.write(sym, df_1, parallel=True)
+
+    lib.compact_incomplete(sym, append, False, prune_previous_version=arg)
+
+    assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 1 if should_be_pruned else 2
+
+
+@pytest.mark.parametrize("lib_config", (True, False))
+@pytest.mark.parametrize("env_var", (True, False))
+@pytest.mark.parametrize("arg", (True, False, None))
+def test_prune_previous_delete_date_range(version_store_factory, monkeypatch, lib_config, env_var, arg):
+    lib = version_store_factory(prune_previous_version=lib_config, use_tombstones=True)
+    should_be_pruned = lib_config
+    if env_var:
+        monkeypatch.setenv("PRUNE_PREVIOUS_VERSION", "true")
+        should_be_pruned = True
+    if arg is not None:
+        should_be_pruned = arg
+
+    lt = lib.library_tool()
+    sym = f"test_prune_previous_delete_date_range"
+    df_0 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(sym, df_0)
+
+    lib.delete(sym, (pd.Timestamp("2024-01-05"), pd.Timestamp("2024-01-07")), prune_previous_version=arg)
+
+    assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 1 if should_be_pruned else 2
+
+
+@pytest.mark.parametrize("lib_config", (True, False))
+@pytest.mark.parametrize("env_var", (True, False))
+@pytest.mark.parametrize("arg", (True, False, None))
+def test_prune_previous_defragment_symbol_data(version_store_factory, monkeypatch, lib_config, env_var, arg):
+    lib = version_store_factory(prune_previous_version=lib_config, use_tombstones=True)
+    should_be_pruned = lib_config
+    if env_var:
+        monkeypatch.setenv("PRUNE_PREVIOUS_VERSION", "true")
+        should_be_pruned = True
+    if arg is not None:
+        should_be_pruned = arg
+
+    lt = lib.library_tool()
+    sym = f"test_prune_previous_defragment_symbol_data"
+    df_0 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-11", periods=10))
+    lib.append(sym, df_1, prune_previous_version=arg)
+
+    assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 1 if should_be_pruned else 2
+
+    set_config_int("SymbolDataCompact.SegmentCount", 1)
+    lib.defragment_symbol_data(sym, prune_previous_version=arg)
+
+    assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 1 if should_be_pruned else 3


### PR DESCRIPTION
Fixes #1637 

Also fixes some other bugs and inconsistencies in our handling of prune previous:

- `update`, `delete` with a `date_range`, and `defragment_symbol_data` also did not respect the prune previous lib config setting/env var.
- `delete` with a `date_range` argument and `defragment_symbol_data` used `prune_previous_versions` (i.e. with a trailing `s`). All other methods use `prune_previous_version` (i.e. without the trailing `s`). For backwards compatibility, these two methods now support both variants.
- `write_metadata` and `delete_data_in_range` on the V2 API did not have a `prune_previous_versions` argument.
- `write_metadata_batch` on the V2 API defaulted the argument to `None` (implying respecting the lib config setting, but this is not a library option on the V2 API), where everything else defaults to `False`.
- Homogenised docstrings for `prune_previous_versions` on V2 API.