### PR TITLE
Set numpy<2 for older arcticdb

### DIFF
--- a/.github/workflows/persistent_storage.yml
+++ b/.github/workflows/persistent_storage.yml
@@ -61,7 +61,7 @@ jobs:
       # Change this value, if we need to support a newer one in the future
       - name: Install oldest supported release
         run: |
-          pip install pytest arcticdb=="3.0.0" "protobuf<5"
+          pip install pytest arcticdb=="3.0.0" "protobuf<5" "numpy<2"
 
       - name: Set persistent storage variables
         uses: ./.github/actions/set_persistent_storage_env_vars


### PR DESCRIPTION
Pin numpy<2 for persistent storage tests on older versions of arcticdb
#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
