### PR TITLE
Fix ArcticDB reading streaming data

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -242,6 +242,12 @@ folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descr
     return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
 }
 
+folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor_for_incompletes(
+        const entity::VariantKey &key,
+        storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) override {
+    return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorForIncompletesTask{});
+}
+
 folly::Future<bool> key_exists(const entity::VariantKey &key) override {
     return async::submit_io_task(KeyExistsTask{&key, library_});
 }

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -454,7 +454,6 @@ struct DecodeMetadataTask : BaseTask {
     }
 };
 
-
 struct DecodeTimeseriesDescriptorTask : BaseTask {
     ARCTICDB_MOVE_ONLY_DEFAULT(DecodeTimeseriesDescriptorTask)
 
@@ -474,6 +473,29 @@ struct DecodeTimeseriesDescriptorTask : BaseTask {
 
     }
 };
+
+struct DecodeTimeseriesDescriptorForIncompletesTask : BaseTask {
+    ARCTICDB_MOVE_ONLY_DEFAULT(DecodeTimeseriesDescriptorForIncompletesTask)
+
+    DecodeTimeseriesDescriptorForIncompletesTask() = default;
+
+    std::pair<VariantKey, TimeseriesDescriptor> operator()(storage::KeySegmentPair &&ks) const {
+        ARCTICDB_SAMPLE(DecodeTimeseriesDescriptorForIncompletesTask, 0)
+        auto key_seg = std::move(ks);
+        ARCTICDB_DEBUG(
+                log::storage(),
+                "DecodeTimeseriesDescriptorForIncompletesTask decoding segment with key {}",
+                variant_key_view(key_seg.variant_key()));
+
+        auto maybe_desc = decode_timeseries_descriptor_for_incompletes(key_seg.segment());
+
+        util::check(static_cast<bool>(maybe_desc), "Failed to decode timeseries descriptor");
+        return std::make_pair(
+                std::move(key_seg.variant_key()),
+                std::move(*maybe_desc));
+    }
+};
+
 struct DecodeMetadataAndDescriptorTask : BaseTask {
     ARCTICDB_MOVE_ONLY_DEFAULT(DecodeMetadataAndDescriptorTask)
 

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -245,6 +245,8 @@ TimeseriesDescriptor unpack_timeseries_descriptor_from_proto(
 
     auto tsd = timeseries_descriptor_from_any(any);
     if (is_decoding_incompletes) {
+        // Prefer the stream descriptor on the segment header for incompletes.
+        // See PR #1647.
         arcticc::pb2::descriptors_pb2::StreamDescriptor desc_proto;
         copy_stream_descriptor_to_proto(stream_desc, desc_proto);
         tsd.mutable_stream_descriptor()->CopyFrom(desc_proto);

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -39,7 +39,8 @@ Segment encode_v1(
 void decode_v1(const Segment& segment,
                const SegmentHeader& hdr,
                SegmentInMemory& res,
-               const StreamDescriptor& desc);
+               const StreamDescriptor& desc,
+               bool is_decoding_incompletes = false);
 
 void decode_v2(const Segment& segment,
                const SegmentHeader& hdr,
@@ -82,11 +83,11 @@ std::pair<std::optional<google::protobuf::Any>, StreamDescriptor> decode_metadat
 std::optional<TimeseriesDescriptor> decode_timeseries_descriptor(
     Segment& segment);
 
+std::optional<TimeseriesDescriptor> decode_timeseries_descriptor_for_incompletes(Segment& segment);
+
 HashedValue get_segment_hash(Segment& seg);
 
 SegmentDescriptorImpl read_segment_descriptor(const uint8_t*& data);
-
-TimeseriesDescriptor unpack_timeseries_descriptor_from_proto(const google::protobuf::Any& any);
 
 } // namespace arcticdb
 

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -408,7 +408,6 @@ namespace arcticdb {
             return folly::makeFuture(std::move(components));
         }
 
-
         folly::Future<std::pair<std::variant<arcticdb::entity::AtomKeyImpl, arcticdb::entity::RefKey>, arcticdb::TimeseriesDescriptor>>
         read_timeseries_descriptor(const entity::VariantKey& key,
                                    storage::ReadKeyOpts /*opts*/) override {
@@ -428,6 +427,23 @@ namespace arcticdb {
             });
         }
 
+        folly::Future<std::pair<std::variant<arcticdb::entity::AtomKeyImpl, arcticdb::entity::RefKey>, arcticdb::TimeseriesDescriptor>>
+        read_timeseries_descriptor_for_incompletes(const entity::VariantKey& key,
+                                   storage::ReadKeyOpts /*opts*/) override {
+            return util::variant_match(key, [&](const AtomKey &ak) {
+                                           auto it = seg_by_atom_key_.find(ak);
+                                           if (it == seg_by_atom_key_.end())
+                                               throw storage::KeyNotFoundException(Composite<VariantKey>(ak));
+                                           ARCTICDB_DEBUG(log::storage(), "Mock store read for atom key {}", ak);
+                                           auto tsd = it->second->index_descriptor();
+                                           tsd.set_stream_descriptor(it->second->descriptor());
+                                           return std::make_pair(key, it->second->index_descriptor());
+                                       },
+                                       [&](const RefKey&) {
+                                           util::raise_rte("Not implemented");
+                                           return std::make_pair(key, TimeseriesDescriptor{});
+                                       });
+        }
 
         void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &) override {}
 

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -399,8 +399,11 @@ void append_incomplete_segment(
     auto end_index = TimeseriesIndex::end_value_for_segment(seg);
     auto seg_row_count = seg.row_count();
 
-    auto tsd = pack_timeseries_descriptor(seg.descriptor().clone(), seg_row_count, std::move(next_key), {});
-    seg.set_timeseries_descriptor(tsd);
+    auto desc = stream_descriptor(stream_id, RowCountIndex{}, {});
+    auto tsd = pack_timeseries_descriptor(std::move(desc), seg_row_count, std::move(next_key), {});
+
+    seg.set_timeseries_descriptor(std::move(tsd));
+    util::check(static_cast<bool>(seg.metadata()), "Expected metadata");
     auto new_key = store->write(
             arcticdb::stream::KeyType::APPEND_DATA,
             0,

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -400,10 +400,9 @@ void append_incomplete_segment(
     auto seg_row_count = seg.row_count();
 
     auto desc = stream_descriptor(stream_id, RowCountIndex{}, {});
-    auto tsd = pack_timeseries_descriptor(std::move(desc), seg_row_count, std::move(next_key), {});
+    auto tsd = pack_timeseries_descriptor(desc, seg_row_count, std::move(next_key), {});
+    seg.set_timeseries_descriptor(tsd);
 
-    seg.set_timeseries_descriptor(std::move(tsd));
-    util::check(static_cast<bool>(seg.metadata()), "Expected metadata");
     auto new_key = store->write(
             arcticdb::stream::KeyType::APPEND_DATA,
             0,

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -332,7 +332,7 @@ std::pair<TimeseriesDescriptor, std::optional<SegmentInMemory>> get_descriptor_a
         auto [key, seg] = store->read_sync(k, opts);
         return std::make_pair(seg.index_descriptor(), std::make_optional<SegmentInMemory>(seg));
     } else {
-        auto [key, tsd] = store->read_timeseries_descriptor(k, opts).get();
+        auto [key, tsd] = store->read_timeseries_descriptor_for_incompletes(k, opts).get();
         return std::make_pair(std::move(tsd), std::nullopt);
     }
 }

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -80,6 +80,9 @@ struct StreamSource {
         read_timeseries_descriptor(const entity::VariantKey& key,
                                    storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
+    virtual folly::Future<std::pair<VariantKey, TimeseriesDescriptor>>
+    read_timeseries_descriptor_for_incompletes(const entity::VariantKey& key,
+                               storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
 };
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2589,3 +2589,15 @@ def test_missing_first_version_key_batch(basic_store):
     vits = lib.batch_read(symbols, as_ofs=write_times)
     for x in range(num_items):
         assert_frame_equal(vits[symbols[x]].data, expected[x])
+
+
+def test_load_streaming_data():
+    from ahl.mongo.mongoose import NativeMongoose
+    m = NativeMongoose("mktdatad")
+    lib = m.get_library("aseaton.test_streaming")
+    #lib.list_symbols()
+    #lib.version_store.get_active_incomplete_refs()
+    res = lib.read("IMBALANCE:FR US", date_range=(None, None))
+    data = res.data
+    print(data)
+    assert res.data.size == 5

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2589,15 +2589,3 @@ def test_missing_first_version_key_batch(basic_store):
     vits = lib.batch_read(symbols, as_ofs=write_times)
     for x in range(num_items):
         assert_frame_equal(vits[symbols[x]].data, expected[x])
-
-
-def test_load_streaming_data():
-    from ahl.mongo.mongoose import NativeMongoose
-    m = NativeMongoose("mktdatad")
-    lib = m.get_library("aseaton.test_streaming")
-    #lib.list_symbols()
-    #lib.version_store.get_active_incomplete_refs()
-    res = lib.read("IMBALANCE:FR US", date_range=(None, None))
-    data = res.data
-    print(data)
-    assert res.data.size == 5


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/man-group/arcticdb-man/issues/80

#### What does this implement or fix?

Allows ArcticDB to read incomplete segments written by arcticc tick collectors.

#### Any other comments?

arcticc has a different append incompletes logic to ArcticDB. It writes a dummy `StreamDescriptor` on the `TimeseriesDescriptor`, and relies entirely on the `StreamDescriptor` in the segment header. That approach is better than the existing ArcticDB approach, which writes the same `StreamDescriptor` twice (directly in the header, and in the `TimeseriesDescriptor`).

ArcticDB was reading this dummy stream descriptor and crashing.

Firstly, this PR changes readers to first check the StreamDescriptor on the _header_ of incompletes, rather than using the one stamped on the `TimeseriesDescriptor`. It also adds a backwards compat test for the format.

Secondly, and this is not required for the PR to be logically correct, we change writers so that, like arcticc, they do not duplicate the `StreamDescriptor`. This is done in 99d0870307.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
