### PR TITLE
NO_SUCH_BUCKET and RESOURCE_UNAVAILABLE are not expected error types

### DIFF
--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -91,7 +91,7 @@ namespace s3 {
         }
 
         inline bool is_expected_error_type(Aws::S3::S3Errors err) {
-            return err == Aws::S3::S3Errors::NO_SUCH_KEY || err == Aws::S3::S3Errors::RESOURCE_NOT_FOUND || err == Aws::S3::S3Errors::NO_SUCH_BUCKET;
+            return err == Aws::S3::S3Errors::NO_SUCH_KEY;
         }
 
         inline void raise_if_unexpected_error(const Aws::S3::S3Error& err) {


### PR DESCRIPTION
We should not treat resource unavailable or no such bucket as expected S3 errors, as we might incorrectly decide that an object doesn't exist and can be newly created when in fact we've just not managed to talk to the storage to ascertain whether it's there or not.