### PR TITLE
Reduce memory usage during conda build

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -434,9 +434,15 @@ set(arcticdb_srcs
         processing/operation_dispatch_unary.cpp
         processing/operation_dispatch_binary.cpp
         processing/operation_dispatch_binary_eq.cpp
+        processing/operation_dispatch_binary_neq.cpp
         processing/operation_dispatch_binary_gt.cpp
+        processing/operation_dispatch_binary_gte.cpp
         processing/operation_dispatch_binary_lt.cpp
-        processing/operation_dispatch_binary_operator.cpp
+        processing/operation_dispatch_binary_lte.cpp
+        processing/operation_dispatch_binary_operator_plus.cpp
+        processing/operation_dispatch_binary_operator_minus.cpp
+        processing/operation_dispatch_binary_operator_times.cpp
+        processing/operation_dispatch_binary_operator_divide.cpp
         processing/sorted_aggregation.cpp
         processing/unsorted_aggregation.cpp
         python/python_to_tensor_frame.cpp

--- a/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
@@ -11,6 +11,5 @@
 namespace arcticdb {
 
 template VariantData visit_binary_comparator<GreaterThanOperator>(const VariantData&, const VariantData&, GreaterThanOperator&&);
-template VariantData visit_binary_comparator<GreaterThanEqualsOperator>(const VariantData&, const VariantData&, GreaterThanEqualsOperator&&);
 
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_gte.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_gte.cpp
@@ -10,6 +10,6 @@
 
 namespace arcticdb {
 
-template VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
+template VariantData visit_binary_comparator<GreaterThanEqualsOperator>(const VariantData&, const VariantData&, GreaterThanEqualsOperator&&);
 
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
@@ -11,6 +11,5 @@
 namespace arcticdb {
 
 template VariantData visit_binary_comparator<LessThanOperator>(const VariantData&, const VariantData&, LessThanOperator&&);
-template VariantData visit_binary_comparator<LessThanEqualsOperator>(const VariantData&, const VariantData&, LessThanEqualsOperator&&);
 
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_lte.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_lte.cpp
@@ -10,6 +10,6 @@
 
 namespace arcticdb {
 
-template VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
+template VariantData visit_binary_comparator<LessThanEqualsOperator>(const VariantData&, const VariantData&, LessThanEqualsOperator&&);
 
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_neq.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_neq.cpp
@@ -10,6 +10,6 @@
 
 namespace arcticdb {
 
-template VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
+template VariantData visit_binary_comparator<NotEqualsOperator>(const VariantData&, const VariantData&, NotEqualsOperator&&);
 
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_divide.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_divide.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2024 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *
@@ -9,7 +9,5 @@
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {
-
-template VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
-
+template VariantData visit_binary_operator<DivideOperator>(const VariantData&, const VariantData&, DivideOperator&&);
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_minus.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_minus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2024 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *
@@ -9,7 +9,5 @@
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {
-
-template VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
-
+template VariantData visit_binary_operator<MinusOperator>(const VariantData&, const VariantData&, MinusOperator&&);
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_plus.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_plus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2024 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *
@@ -11,8 +11,4 @@
 namespace arcticdb {
 
 template VariantData visit_binary_operator<PlusOperator>(const VariantData&, const VariantData&, PlusOperator&&);
-template VariantData visit_binary_operator<MinusOperator>(const VariantData&, const VariantData&, MinusOperator&&);
-template VariantData visit_binary_operator<TimesOperator>(const VariantData&, const VariantData&, TimesOperator&&);
-template VariantData visit_binary_operator<DivideOperator>(const VariantData&, const VariantData&, DivideOperator&&);
-
 }

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_times.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_times.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2024 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *
@@ -9,7 +9,5 @@
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {
-
-template VariantData visit_binary_comparator<EqualsOperator>(const VariantData&, const VariantData&, EqualsOperator&&);
-
+template VariantData visit_binary_operator<TimesOperator>(const VariantData&, const VariantData&, TimesOperator&&);
 }


### PR DESCRIPTION
Add more translation units for binary operators to reduce memory usage.

The build on conda was failing in arcticdb-feedstock as it was using a lot of memory. The feedstock runner only have `6.7GB` of RAM. Splitting the binary operators in multiple translation units reduces memory usage and fixes the issue.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
