### PR TITLE
Make modification of snapshot atomic and corresponding tombstone handling changes

### DIFF
--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -514,24 +514,17 @@ struct DecodeMetadataAndDescriptorTask : BaseTask {
             );
     }
 };
-
-template<typename ConstVarKeyGetter,
-        typename=std::enable_if_t<!std::is_reference_v<ConstVarKeyGetter> // Make obvious if iterator& is captured
-                        && std::is_same_v<decltype(*std::declval<ConstVarKeyGetter>()), const entity::VariantKey&>>>
 struct KeyExistsTask : BaseTask {
-    ConstVarKeyGetter key_;
+    const VariantKey key_;
     std::shared_ptr<storage::Library> lib_;
 
-    /**
-     * @param key Could be a vector iterator or a pointer to a const VariantKey.
-     */
-    KeyExistsTask(ConstVarKeyGetter key, std::shared_ptr<storage::Library> lib): key_(key), lib_(std::move(lib)) {
-        ARCTICDB_DEBUG(log::storage(), "Creating key exists task for key {}", variant_key_view(*key_));
+    KeyExistsTask(auto &&key, std::shared_ptr<storage::Library> lib): key_(std::forward<decltype(key)>(key)), lib_(std::move(lib)) {
+        ARCTICDB_DEBUG(log::storage(), "Creating key exists task for key {}",key_);
     }
 
     bool operator()() {
         ARCTICDB_SAMPLE(KeyExistsTask, 0)
-        return lib_->key_exists(*key_);
+        return lib_->key_exists(key_);
     }
 };
 

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -125,6 +125,7 @@ using SinkConf = arcticdb::proto::logger::SinkConfig;
 Loggers::Loggers()
         : impl_(std::make_unique<Impl>()) {
     impl_->unconfigured_->set_level(get_default_log_level());
+    impl_->unconfigured_->set_pattern(DefaultLogPattern);
 }
 
 Loggers::~Loggers() = default;

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -111,7 +111,7 @@ std::set<StreamId> get_active_incomplete_refs(const std::shared_ptr<Store>& stor
     for (const auto& vk: ref_keys) {
         const auto& stream_id = variant_key_id(vk);
         auto [next_key, _] = read_head(store, stream_id);
-        if (next_key && store->key_exists(next_key.value()).get()) {
+        if (next_key && store->key_exists(std::move(next_key.value())).get()) {
             output.insert(stream_id);
         }
     }

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -37,6 +37,16 @@ enum class BatchGetVersionOption {
     COUNT
 };
 
+inline std::optional<std::string> collect_futures_exceptions(auto&& futures) {
+    std::optional<std::string> all_exceptions;
+    for (auto&& collected_fut: futures) {
+        if (!collected_fut.hasValue()) {
+            all_exceptions = all_exceptions.value_or("").append(collected_fut.exception().what().toStdString()).append("\n");
+        }
+    }
+    return all_exceptions;
+}
+
 template <typename Inputs, typename TaskSubmitter, typename ResultHandler>
 inline void submit_tasks_for_range(const Inputs& inputs, TaskSubmitter submitter, ResultHandler result_handler) {
     const auto window_size = async::TaskScheduler::instance()->io_thread_count() * 2;
@@ -50,12 +60,7 @@ inline void submit_tasks_for_range(const Inputs& inputs, TaskSubmitter submitter
     }, window_size);
 
     auto collected_futs = folly::collectAll(futures).get();
-    std::optional<std::string> all_exceptions;
-    for (auto&& collected_fut: collected_futs) {
-        if (!collected_fut.hasValue()) {
-            all_exceptions = all_exceptions.value_or("").append(collected_fut.exception().what().toStdString()).append("\n");
-        }
-    }
+    std::optional<std::string> all_exceptions = collect_futures_exceptions(std::move(collected_futs));
     internal::check<ErrorCode::E_RUNTIME_ERROR>(!all_exceptions.has_value(), all_exceptions.value_or(""));
 }
 

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -358,12 +358,15 @@ void PythonVersionStore::add_to_snapshot(
         util::check(inserted, "Multiple elements in add_to_snapshot with key {}", id_version.first);
     }
 
+    bool is_delete_keys_immediately = variant_key_type(snap_key) != KeyType::SNAPSHOT_REF || !cfg().write_options().delayed_deletes();
     for(auto&& key : snapshot_contents) {
         auto new_version = affected_keys.find(key.id());
         if(new_version == std::end(affected_keys)) {
             retained_keys.emplace_back(std::move(key));
         } else {
-            deleted_keys.emplace_back(std::move(key));
+            if (is_delete_keys_immediately) {
+                deleted_keys.emplace_back(std::move(key));
+            }
         }
     }
 
@@ -371,10 +374,8 @@ void PythonVersionStore::add_to_snapshot(
         retained_keys.emplace_back(std::move(key));
 
     std::sort(std::begin(retained_keys), std::end(retained_keys));
-    if(variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
-        tombstone_snapshot(store(), to_ref(snap_key), std::move(snap_segment), version_map()->log_changes());
-    } else {
-        delete_trees_responsibly(deleted_keys, get_master_snapshots_map(store()), snap_name).get();
+    if(is_delete_keys_immediately) {
+        delete_trees_responsibly(store(), version_map(), deleted_keys, get_master_snapshots_map(store()), snap_name).get();
         if (version_map()->log_changes()) {
             log_delete_snapshot(store(), snap_name);
         }
@@ -402,20 +403,21 @@ void PythonVersionStore::remove_from_snapshot(
         symbol_versions.emplace(stream_ids[i], version_ids[i]);
     }
 
+    bool is_delete_keys_immediately = variant_key_type(snap_key) != KeyType::SNAPSHOT_REF || !cfg().write_options().delayed_deletes();
     std::vector<AtomKey> deleted_keys;
     std::vector<AtomKey> retained_keys;
     for(auto&& key : snapshot_contents) {
         if(symbol_versions.find(SymbolVersion{key.id(), key.version_id()}) == symbol_versions.end()) {
             retained_keys.emplace_back(std::move(key));
         } else {
-            deleted_keys.emplace_back(std::move(key));
+            if (is_delete_keys_immediately) {
+                deleted_keys.emplace_back(std::move(key));
+            }
         }
     }
 
-    if(variant_key_type(snap_key) == KeyType::SNAPSHOT_REF && cfg().write_options().delayed_deletes()) {
-        tombstone_snapshot(store(), to_ref(snap_key), std::move(snap_segment), version_map()->log_changes());
-    } else {
-        delete_trees_responsibly(deleted_keys, get_master_snapshots_map(store()), snap_name).get();
+    if(is_delete_keys_immediately) {
+        delete_trees_responsibly(store(), version_map(), deleted_keys, get_master_snapshots_map(store()), snap_name).get();
         if (version_map()->log_changes()) {
             log_delete_snapshot(store(), snap_name);
         }
@@ -862,6 +864,8 @@ void PythonVersionStore::delete_snapshot_sync(const SnapshotId& snap_name, const
 
     try {
         delete_trees_responsibly(
+            store(),
+            version_map(),
             index_keys_in_current_snapshot,
             snap_map,
             snap_name).get();

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -216,9 +216,10 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
     _bucket_id = 0
     _live_buckets: List[S3Bucket] = []
 
-    def __init__(self, use_ssl: bool, ssl_test_support: bool):
+    def __init__(self, use_ssl: bool, ssl_test_support: bool, bucket_versioning: bool):
         self.http_protocol = "https" if use_ssl else "http"
         self.ssl_test_support = ssl_test_support
+        self.bucket_versioning = bucket_versioning
 
     @staticmethod
     def run_server(port, key_file, cert_file):
@@ -369,6 +370,13 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         bucket = f"test_bucket_{self._bucket_id}"
         self._s3_admin.create_bucket(Bucket=bucket)
         self._bucket_id += 1
+        if self.bucket_versioning:
+            self._s3_admin.put_bucket_versioning(
+                Bucket=bucket,
+                VersioningConfiguration={
+                    'Status': 'Enabled'
+                }
+            )
 
         out = S3Bucket(self, bucket)
         self._live_buckets.append(out)

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -25,6 +25,7 @@ from arcticdb.version_store.library import (
 )
 
 from tests.util.mark import AZURE_TESTS_MARK, MONGO_TESTS_MARK, REAL_S3_TESTS_MARK
+from tests.util.storage_test import get_s3_storage_config
 
 from arcticdb.options import ModifiableEnterpriseLibraryOption, ModifiableLibraryOption
 
@@ -283,19 +284,12 @@ def test_do_not_persist_s3_details(s3_storage):
     """We apply an in-memory overlay for these instead. In particular we should absolutely not persist credentials
     in the storage."""
 
-    def _get_s3_storage_config(cfg):
-        primary_storage_name = cfg.lib_desc.storage_ids[0]
-        primary_any = cfg.storage_by_id[primary_storage_name]
-        s3_config = S3Config()
-        primary_any.config.Unpack(s3_config)
-        return s3_config
-
     ac = Arctic(s3_storage.arctic_uri)
     lib = ac.create_library("test")
     lib.write("sym", pd.DataFrame())
 
     config = ac._library_manager.get_library_config("test")
-    s3_storage = _get_s3_storage_config(config)
+    s3_storage = get_s3_storage_config(config)
     assert s3_storage.bucket_name == ""
     assert s3_storage.credential_name == ""
     assert s3_storage.credential_key == ""

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -8,6 +8,7 @@ import re
 from datetime import datetime
 
 from arcticdb import Arctic
+from arcticc.pb2.s3_storage_pb2 import Config as S3Config
 
 
 # TODO: Remove this when the latest version that we support
@@ -81,6 +82,14 @@ def get_real_s3_uri(shared_path: bool = True):
         f"s3s://{endpoint}:{bucket}?access={access_key}&secret={secret_key}&region={region}&path_prefix={path_prefix}"
     )
     return aws_uri
+
+
+def get_s3_storage_config(cfg):
+    primary_storage_name = cfg.lib_desc.storage_ids[0]
+    primary_any = cfg.storage_by_id[primary_storage_name]
+    s3_config = S3Config()
+    primary_any.config.Unpack(s3_config)
+    return s3_config
 
 
 def normalize_lib_name(lib_name):


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Originally only for forward porting https://mangit.maninvestments.com/projects/DATA/repos/arcticc/pull-requests/1095/overview
But corresponding test requires https://github.com/man-group/arcticdb-enterprise/issues/32 so part of changes is included too.

#### What does this implement or fix?
1. Modification of snapshot will not longer delete the original `SNAPSHOT_REF` key. It will be simply overwritten so atomicity can be achieved
2. As the changes will affect op logs as well and the test cannot be made without https://github.com/man-group/arcticdb-enterprise/issues/32 so some corresponding changes for that ticket as well. More details can be found there.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
