### PR TITLE
44x read streaming 20240628

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -238,6 +238,12 @@ folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descr
     return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
 }
 
+folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor_for_incompletes(
+        const entity::VariantKey &key,
+        storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) override {
+    return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorForIncompletesTask{});
+}
+
 folly::Future<bool> key_exists(const entity::VariantKey &key) override {
     return async::submit_io_task(KeyExistsTask{&key, library_});
 }

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -235,6 +235,9 @@ decode_timeseries_descriptor_for_incompletes(
         return std::nullopt;
 
     auto tsd = timeseries_descriptor_from_any(*maybe_any);
+
+    // Unlike `decode_timeseries_descriptor`, prefer the stream descriptor on the segment header.
+    // See PR #1647.
     tsd.mutable_stream_descriptor()->CopyFrom(hdr.stream_descriptor());
 
     if(has_magic_numbers)

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -219,6 +219,56 @@ std::optional<FieldCollection> decode_descriptor_fields(
     }
 }
 
+std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>>
+decode_timeseries_descriptor_for_incompletes(
+        const arcticdb::proto::encoding::SegmentHeader& hdr,
+        const uint8_t* data,
+        const uint8_t* begin,
+        const uint8_t* end) {
+    util::check(data != nullptr, "Got null data ptr from segment");
+    const auto has_magic_numbers = EncodingVersion(hdr.encoding_version()) == EncodingVersion::V2;
+    if(has_magic_numbers)
+        util::check_magic<MetadataMagic>(data);
+
+    auto maybe_any = decode_metadata(hdr, data, begin);
+    if(!maybe_any)
+        return std::nullopt;
+
+    auto tsd = timeseries_descriptor_from_any(*maybe_any);
+    tsd.mutable_stream_descriptor()->CopyFrom(hdr.stream_descriptor());
+
+    if(has_magic_numbers)
+        util::check_magic<DescriptorMagic>(data);
+
+    if(hdr.has_descriptor_field() && hdr.descriptor_field().has_ndarray())
+        data += encoding_sizes::ndarray_field_compressed_size(hdr.descriptor_field().ndarray());
+
+    if(has_magic_numbers)
+        util::check_magic<IndexMagic>(data);
+
+    auto maybe_fields = decode_index_fields(hdr, data, begin, end);
+    if(!maybe_fields) {
+        auto old_fields = fields_from_proto(tsd.stream_descriptor());
+        return std::make_optional(std::make_tuple(std::move(*maybe_any), std::move(tsd), std::move(old_fields)));
+    }
+
+    maybe_fields->regenerate_offsets();
+    return std::make_tuple(std::move(*maybe_any), std::move(tsd), std::move(*maybe_fields));
+}
+
+std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>>
+decode_timeseries_descriptor_for_incompletes(
+        Segment& segment) {
+    auto &hdr = segment.header();
+    const uint8_t* data = segment.buffer().data();
+
+    util::check(data != nullptr, "Got null data ptr from segment");
+    const uint8_t* begin = data;
+    const uint8_t* end = data + segment.buffer().bytes();
+
+    return decode_timeseries_descriptor_for_incompletes(hdr, data, begin, end);
+}
+
 std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>> decode_timeseries_descriptor(
     const arcticdb::proto::encoding::SegmentHeader& hdr,
     const uint8_t* data,

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -59,6 +59,10 @@ std::pair<std::optional<google::protobuf::Any>, StreamDescriptor> decode_metadat
 std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>> decode_timeseries_descriptor(
     Segment& segment);
 
+std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>>
+decode_timeseries_descriptor_for_incompletes(
+        Segment& segment);
+
 HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader &hdr);
 } // namespace arcticdb
 

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -384,7 +384,6 @@ namespace arcticdb {
             return folly::makeFuture(std::move(components));
         }
 
-
         folly::Future<std::pair<std::variant<arcticdb::entity::AtomKeyImpl, arcticdb::entity::RefKey>, arcticdb::TimeseriesDescriptor>>
         read_timeseries_descriptor(const entity::VariantKey& key,
                                    storage::ReadKeyOpts /*opts*/) override {
@@ -404,6 +403,23 @@ namespace arcticdb {
             });
         }
 
+        folly::Future<std::pair<std::variant<arcticdb::entity::AtomKeyImpl, arcticdb::entity::RefKey>, arcticdb::TimeseriesDescriptor>>
+        read_timeseries_descriptor_for_incompletes(const entity::VariantKey& key,
+                                   storage::ReadKeyOpts /*opts*/) override {
+            return util::variant_match(key, [&](const AtomKey &ak) {
+                                           auto it = seg_by_atom_key_.find(ak);
+                                           if (it == seg_by_atom_key_.end())
+                                               throw storage::KeyNotFoundException(Composite<VariantKey>(ak));
+                                           ARCTICDB_DEBUG(log::storage(), "Mock store read for atom key {}", ak);
+                                           auto tsd = it->second->index_descriptor();
+                                           tsd.proto_->mutable_stream_descriptor()->CopyFrom(it->second->descriptor().proto());
+                                           return std::make_pair(key, it->second->index_descriptor());
+                                       },
+                                       [&](const RefKey&) {
+                                           util::raise_rte("Not implemented");
+                                           return std::make_pair(key, TimeseriesDescriptor{});
+                                       });
+        }
 
         void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &) override {}
 

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -340,7 +340,7 @@ std::pair<TimeseriesDescriptor, std::optional<SegmentInMemory>> get_descriptor_a
         auto [key, seg] = store->read_sync(k, opts);
         return std::make_pair(TimeseriesDescriptor{seg.timeseries_proto(), seg.index_fields()}, std::make_optional<SegmentInMemory>(seg));
     } else {
-        auto [key, tsd] = store->read_timeseries_descriptor(k, opts).get();
+        auto [key, tsd] = store->read_timeseries_descriptor_for_incompletes(k, opts).get();
         return std::make_pair(std::move(tsd), std::nullopt);
     }
 }

--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -407,7 +407,9 @@ void append_incomplete_segment(
     auto end_index = TimeseriesIndex::end_value_for_segment(seg);
     auto seg_row_count = seg.row_count();
 
-    auto tsd = pack_timeseries_descriptor(seg.descriptor().clone(), seg_row_count, std::move(next_key), {});
+    auto desc = stream_descriptor(stream_id, RowCountIndex{}, {});
+    auto tsd = pack_timeseries_descriptor(std::move(desc), seg_row_count, std::move(next_key), {});
+
     seg.set_timeseries_descriptor(std::move(tsd));
     util::check(static_cast<bool>(seg.metadata()), "Expected metadata");
     auto new_key = store->write(

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -80,6 +80,9 @@ struct StreamSource {
         read_timeseries_descriptor(const entity::VariantKey& key,
                                    storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
+    virtual folly::Future<std::pair<VariantKey, TimeseriesDescriptor>>
+    read_timeseries_descriptor_for_incompletes(const entity::VariantKey& key,
+                               storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
 };
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2528,15 +2528,3 @@ def test_missing_first_version_key_batch(basic_store):
     vits = lib.batch_read(symbols, as_ofs=write_times)
     for x in range(num_items):
         assert_frame_equal(vits[symbols[x]].data, expected[x])
-
-
-def test_load_streaming_data():
-    from ahl.mongo.mongoose import NativeMongoose
-    m = NativeMongoose("mktdatad")
-    lib = m.get_library("aseaton.test_streaming")
-    #lib.list_symbols()
-    #lib.version_store.get_active_incomplete_refs()
-    res = lib.read("IMBALANCE:FR US", date_range=(None, None))
-    data = res.data
-    print(data)
-    assert res.data.size == 5

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -2528,3 +2528,15 @@ def test_missing_first_version_key_batch(basic_store):
     vits = lib.batch_read(symbols, as_ofs=write_times)
     for x in range(num_items):
         assert_frame_equal(vits[symbols[x]].data, expected[x])
+
+
+def test_load_streaming_data():
+    from ahl.mongo.mongoose import NativeMongoose
+    m = NativeMongoose("mktdatad")
+    lib = m.get_library("aseaton.test_streaming")
+    #lib.list_symbols()
+    #lib.version_store.get_active_incomplete_refs()
+    res = lib.read("IMBALANCE:FR US", date_range=(None, None))
+    data = res.data
+    print(data)
+    assert res.data.size == 5


### PR DESCRIPTION
Please see the description on the `master` version of this change, https://github.com/man-group/ArcticDB/pull/1647

The implementation is significantly different to the master version, because master is written on top of the new binary encoding work.