### PR TITLE
Refactor/1643/reduce prune previous memory footprint

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -197,6 +197,7 @@ set(arcticdb_srcs
         column_store/column_data_random_accessor.hpp
         column_store/column.hpp
         column_store/column_utils.hpp
+        column_store/key_segment.hpp
         column_store/memory_segment.hpp
         column_store/memory_segment_impl.hpp
         column_store/row_ref.hpp
@@ -396,6 +397,7 @@ set(arcticdb_srcs
         column_store/chunked_buffer.cpp
         column_store/column.cpp
         column_store/column_data.cpp
+        column_store/key_segment.cpp
         column_store/memory_segment_impl.cpp
         column_store/memory_segment_impl.cpp
         column_store/string_pool.cpp

--- a/cpp/arcticdb/column_store/key_segment.cpp
+++ b/cpp/arcticdb/column_store/key_segment.cpp
@@ -1,0 +1,153 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/column_store/key_segment.hpp>
+#include <arcticdb/pipeline/index_fields.hpp>
+
+namespace arcticdb {
+
+StreamId stream_id_from_column_entry(uint64_t column_entry, bool is_sequence_type, const StringPool& string_pool) {
+    if (is_sequence_type) {
+        // String columns are stored as uint64s (offsets into the string pool), but StringPool::get_const_view expects an int64
+        // Hence the static cast
+        return StringId(string_pool.get_const_view(static_cast<int64_t>(column_entry)));
+    } else {
+        return NumericId(column_entry);
+    }
+}
+
+IndexValue index_value_from_column_entry(int64_t column_entry, bool is_sequence_type, const StringPool& string_pool) {
+    if (is_sequence_type) {
+        // String columns are stored as uint64s, whereas timestamp index start/end values are stored as int64s (nanoseconds since epoch)
+        // We could add another if statement based on index_is_sequence_type, but as these types are the same width,
+        // we can just do some fancy casting to reinterpret the value in the iterator as a uint64.
+        // We then need to static cast back to int64 for the same reason as above RE StringPool::get_const_view
+        return StringId(string_pool.get_const_view(static_cast<int64_t>(*reinterpret_cast<const uint64_t*>(&(column_entry)))));
+    } else {
+        return NumericIndex(column_entry);
+    }
+}
+
+KeySegment::KeySegment(SegmentInMemory&& segment, SymbolStructure symbol_structure):
+        num_keys_(segment.row_count()),
+        string_pool_(segment.string_pool_ptr()),
+        symbol_structure_(symbol_structure)
+{
+    // Needed as the column map is not initialised at read time if the segment has no rows
+    segment.init_column_map();
+    stream_ids_ = segment.column_ptr(static_cast<uint32_t>(pipelines::index::Fields::stream_id));
+    version_ids_ = segment.column_ptr(static_cast<uint32_t>(pipelines::index::Fields::version_id));
+    creation_timestamps_ = segment.column_ptr(static_cast<uint32_t>(pipelines::index::Fields::creation_ts));
+    content_hashes_ = segment.column_ptr(static_cast<uint32_t>(pipelines::index::Fields::content_hash));
+    start_indexes_ = segment.column_ptr(static_cast<uint32_t>(pipelines::index::Fields::start_index));
+    end_indexes_ = segment.column_ptr(static_cast<uint32_t>(pipelines::index::Fields::end_index));
+    key_types_ = segment.column_ptr(static_cast<uint32_t>(pipelines::index::Fields::key_type));
+
+    switch (symbol_structure_) {
+        case SymbolStructure::SAME:
+            debug::check<ErrorCode::E_ASSERTION_FAILURE>(check_symbols_all_same(),
+                                                         "Expected all symbols to be identical in KeySegment");
+            if (stream_ids_->row_count() != 0) {
+                if (is_sequence_type(stream_ids_->type().data_type())) {
+                    symbol_ = std::string(string_pool_->get_const_view(stream_ids_->template reference_at<uint64_t>(0)));
+                } else {
+                    symbol_ = safe_convert_to_numeric_id(stream_ids_->template reference_at<uint64_t>(0));
+                }
+            }
+            break;
+        case SymbolStructure::UNIQUE:
+            debug::check<ErrorCode::E_ASSERTION_FAILURE>(check_symbols_all_unique(),
+                                                         "Expected all symbols to be unique in KeySegment");
+        case SymbolStructure::UNKNOWN:
+        default:
+            break;
+    }
+}
+
+std::variant<std::vector<AtomKeyPacked>, std::vector<AtomKey>> KeySegment::materialise() const {
+    auto version_data = version_ids_->data();
+    auto creation_ts_data = creation_timestamps_->data();
+    auto content_hash_data = content_hashes_->data();
+    auto index_start_data = start_indexes_->data();
+    auto index_end_data = end_indexes_->data();
+    auto key_types_data = key_types_->data();
+
+    auto version_it = version_data.template cbegin<uint64_TDT>();
+    auto creation_ts_it = creation_ts_data.template cbegin<int64_TDT>();
+    auto content_hash_it = content_hash_data.template cbegin<uint64_TDT>();
+    auto key_types_it = key_types_data.template cbegin<uint8_TDT>();
+
+    if (symbol_structure_ == SymbolStructure::SAME && !is_sequence_type(start_indexes_->type().data_type())) {
+        // Can return AtomKeyPacked vector, much more time and memory efficient, and most common case
+        std::vector<AtomKeyPacked> res;
+        res.reserve(num_keys_);
+        auto index_start_it = index_start_data.template cbegin<int64_TDT>();
+        auto index_end_it = index_end_data.template cbegin<int64_TDT>();
+        for (size_t row_idx = 0;
+             row_idx < num_keys_;
+             ++row_idx, ++version_it, ++creation_ts_it, ++content_hash_it, ++index_start_it, ++index_end_it, ++key_types_it) {
+            res.emplace_back(*version_it, *creation_ts_it, *content_hash_it, KeyType(*key_types_it), *index_start_it, *index_end_it);
+        }
+        return res;
+    } else {
+        // Fall back to returning fully materialised AtomKeys
+        std::vector<AtomKey> res;
+        res.reserve(num_keys_);
+        auto stream_id_data = stream_ids_->data();
+        auto stream_id_it = stream_id_data.template cbegin<uint64_TDT>();
+        const bool stream_id_is_sequence_type = is_sequence_type(stream_ids_->type().data_type());
+        const bool index_is_sequence_type = is_sequence_type(start_indexes_->type().data_type());
+        auto index_start_it = index_start_data.template cbegin<int64_TDT>();
+        auto index_end_it = index_start_data.template cbegin<int64_TDT>();
+        for (size_t row_idx = 0;
+             row_idx < num_keys_;
+             ++row_idx, ++stream_id_it, ++version_it, ++creation_ts_it, ++content_hash_it, ++index_start_it, ++index_end_it, ++key_types_it) {
+            res.emplace_back(
+                    symbol_.value_or(stream_id_from_column_entry(*stream_id_it, stream_id_is_sequence_type, *string_pool_)),
+                    *version_it,
+                    *creation_ts_it,
+                    *content_hash_it,
+                    index_value_from_column_entry(*index_start_it, index_is_sequence_type, *string_pool_),
+                    index_value_from_column_entry(*index_end_it, index_is_sequence_type, *string_pool_),
+                    KeyType(*key_types_it)
+            );
+        }
+        return res;
+    }
+}
+
+bool KeySegment::check_symbols_all_same() const {
+    if (stream_ids_->row_count() != 0) {
+        auto data = stream_ids_->data();
+        auto end_it = data.template cend<uint64_TDT>();
+        auto it = data.template cbegin<uint64_TDT>();
+        uint64_t value{*it};
+        for (;it != end_it; ++it) {
+            if (*it != value) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool KeySegment::check_symbols_all_unique() const {
+    if (stream_ids_->row_count() != 0) {
+        auto data = stream_ids_->data();
+        auto end_it = data.template cend<uint64_TDT>();
+        ankerl::unordered_dense::set<uint64_t> values;
+        values.reserve(stream_ids_->row_count());
+        for (auto it = data.template cbegin<uint64_TDT>();it != end_it; ++it) {
+            if (!values.insert(*it).second) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+} // arcticdb

--- a/cpp/arcticdb/column_store/key_segment.hpp
+++ b/cpp/arcticdb/column_store/key_segment.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/entity/atom_key.hpp>
+
+namespace arcticdb {
+
+enum class SymbolStructure: uint8_t {
+    UNKNOWN,
+    SAME, // e.g. in index keys
+    UNIQUE // e.g. in snapshot ref keys
+};
+
+/*
+ * Class to wrap segments in memory that only contain keys. Examples include:
+ *  - VERSION_REF
+ *  - VERSION
+ *  - TABLE_INDEX
+ *  - SNAPSHOT_REF
+ *  - MULTI_KEY
+ *  - LOG_COMPACTED
+ *  - SNAPSHOT (deprecated)
+ *  This is to avoid materialising the AtomKey class for each row, particularly when operations involve many such keys.
+ *  Many of these key types have special properties, such as all the contained keys having the same stream id, or all
+ *  of the contained keys being of the same type, in which case further optimisations can be made.
+ *  For now, this class does the bare minimum required for it's one use. Useful extensions could include:
+ *  - IndexKeySegment: inheriting from this class. Would also contain start/end row/column columns, and use sortedness information
+ *  - ShapshotRefKeySegment: inheriting from this class. Sorted on StreamId, so would allow rapid checks for contained symbol/version pairs
+ *  - Filtering: maintain a bitset to represent keys (rows) that have not been filtered out. Optionally memcpy when
+ *               true bits falls below some threshold
+*   - Iterators: Iterate through all the keys in the segment (or all with true bits if filtered)
+ *  - HashSet operations: maintain hashes of each row for quick set membership operations
+ */
+class KeySegment {
+public:
+    KeySegment(SegmentInMemory&& segment, SymbolStructure symbol_structure);
+
+    ARCTICDB_NO_MOVE_OR_COPY(KeySegment)
+
+    // Returns AtomKeyPacked vector for SymbolStructure::SAME keys with numeric indexes, and AtomKey vector otherwise
+    [[nodiscard]] std::variant<std::vector<AtomKeyPacked>, std::vector<AtomKey>> materialise() const;
+
+private:
+    [[nodiscard]] bool check_symbols_all_same() const;
+    [[nodiscard]] bool check_symbols_all_unique() const;
+
+    size_t num_keys_;
+    std::shared_ptr<StringPool> string_pool_;
+
+    std::shared_ptr<Column> stream_ids_;
+    std::shared_ptr<Column> version_ids_;
+    std::shared_ptr<Column> creation_timestamps_;
+    std::shared_ptr<Column> content_hashes_;
+    std::shared_ptr<Column> start_indexes_;
+    std::shared_ptr<Column> end_indexes_;
+    std::shared_ptr<Column> key_types_;
+
+    using uint8_TDT = ScalarTagType<DataTypeTag<DataType::UINT8>>;
+    using uint64_TDT = ScalarTagType<DataTypeTag<DataType::UINT64>>;
+    using int64_TDT = ScalarTagType<DataTypeTag<DataType::INT64>>;
+
+    SymbolStructure symbol_structure_{SymbolStructure::UNKNOWN};
+    // If all the keys in this segment have the same symbol, stored here. std::nullopt otherwise
+    std::optional<StreamId> symbol_;
+};
+
+} // arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -52,7 +52,7 @@ template LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<storag
 template LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<storage::Library>& library, const util::ManualClock&);
 
 folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_indexes(
-        const std::vector<AtomKey> &pruned_indexes,
+        std::vector<AtomKey>&& pruned_indexes,
         const AtomKey& key_to_keep
 ) {
     try {
@@ -62,7 +62,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_inde
             auto [not_in_snaps, in_snaps] = get_index_keys_partitioned_by_inclusion_in_snapshots(
                     store(),
                     pruned_indexes.begin()->id(),
-                    pruned_indexes);
+                    std::move(pruned_indexes));
             in_snaps.insert(key_to_keep);
             PreDeleteChecks checks{false, false, false, false, std::move(in_snaps)};
             return delete_trees_responsibly(not_in_snaps, {}, {}, checks)
@@ -894,11 +894,11 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
 
     storage::ReadKeyOpts read_opts;
     read_opts.ignores_missing_key_ = true;
-    auto data_keys_to_be_deleted = get_data_keys_set(store(), *keys_to_delete, read_opts);
+    auto data_keys_to_be_deleted = recurse_index_keys(store(), *keys_to_delete, read_opts);
     log::version().debug("Candidate: {} total of data keys", data_keys_to_be_deleted.size());
 
     read_opts.dont_warn_about_missing_key = true;
-    auto data_keys_not_to_be_deleted = get_data_keys_set(store(), *not_to_delete, read_opts);
+    auto data_keys_not_to_be_deleted = recurse_index_keys(store(), *not_to_delete, read_opts);
     not_to_delete.clear();
     log::version().debug("Forbidden: {} total of data keys", data_keys_not_to_be_deleted.size());
     storage::RemoveOpts remove_opts;
@@ -1223,7 +1223,7 @@ void LocalVersionedEngine::write_version_and_prune_previous(
         const std::optional<IndexTypeKey>& previous_key) {
     if (prune_previous_versions) {
         auto pruned_indexes = version_map()->write_and_prune_previous(store(), new_version, previous_key);
-        delete_unreferenced_pruned_indexes(pruned_indexes, new_version).get();
+        delete_unreferenced_pruned_indexes(std::move(pruned_indexes), new_version).get();
     }
     else {
         version_map()->write_version(store(), new_version, previous_key);

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -426,7 +426,7 @@ protected:
      * @param pruned_indexes Must all share the same id() and should be tombstoned.
      */
     folly::Future<folly::Unit> delete_unreferenced_pruned_indexes(
-            const std::vector<AtomKey> &pruned_indexes,
+            std::vector<AtomKey>&& pruned_indexes,
             const AtomKey& key_to_keep
     );
 

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -183,19 +183,14 @@ std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(
 std::pair<std::vector<AtomKey>, std::unordered_set<AtomKey>> get_index_keys_partitioned_by_inclusion_in_snapshots(
         const std::shared_ptr<Store>& store,
         const StreamId& stream_id,
-        const std::vector<entity::AtomKey> &all_index_keys
+        std::vector<entity::AtomKey>&& all_index_keys
 ) {
     ARCTICDB_SAMPLE(GetIndexKeysPartitionedByInclusionInSnapshots, 0)
     auto index_keys_in_snapshot = get_index_keys_in_snapshots(store, stream_id);
-
-    std::vector<entity::AtomKey> index_keys_not_in_snapshot;
-    for (const auto &index_key: all_index_keys) {
-        if (!index_keys_in_snapshot.count(index_key)) {
-            index_keys_not_in_snapshot.emplace_back(index_key);
-        }
-    }
-
-    return std::make_pair(index_keys_not_in_snapshot, index_keys_in_snapshot);
+    std::erase_if(all_index_keys, [&index_keys_in_snapshot](const auto& index_key) {
+        return index_keys_in_snapshot.count(index_key) == 1;
+    });
+    return {std::move(all_index_keys), std::move(index_keys_in_snapshot)};
 }
 
 VariantKey get_ref_key(const SnapshotId& snap_name) {

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -59,7 +59,7 @@ std::unordered_set<entity::AtomKey> get_index_keys_in_snapshots(
 std::pair<std::vector<AtomKey>, std::unordered_set<AtomKey>> get_index_keys_partitioned_by_inclusion_in_snapshots(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    const std::vector<entity::AtomKey> &all_index_keys
+    std::vector<entity::AtomKey>&& all_index_keys
 );
 
 std::vector<AtomKey> get_versions_from_segment(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -960,7 +960,7 @@ void PythonVersionStore::prune_previous_versions(const StreamId& stream_id) {
 
     auto previous = ::arcticdb::get_specific_version(store(), version_map(), stream_id, *prev_id, VersionQuery{});
     auto [_, pruned_indexes] = version_map()->tombstone_from_key_or_all(store(), stream_id, previous);
-    delete_unreferenced_pruned_indexes(pruned_indexes, *latest).get();
+    delete_unreferenced_pruned_indexes(std::move(pruned_indexes), *latest).get();
 }
 
 void PythonVersionStore::delete_all_versions(const StreamId& stream_id) {


### PR DESCRIPTION
Closes #1643 

Vastly reduces the runtime and memory footprint of pruning lots of old versions of a symbol. Needed because of #1637

Performance differences tested with:
```
def test_prune_previous_memory_usage(lmdb_version_store_very_big_map):
    lib = lmdb_version_store_very_big_map
    sym = "test_prune_previous_memory_usage"
    num_versions = 8000
    for idx in range(num_versions):
        lib.append(sym, pd.DataFrame({"col": np.arange(idx, idx+1)}), write_if_missing=True)
    assert len(lib.list_versions(sym)) == num_versions
    gc.collect()
    start = time.time()
    lib.prune_previous_versions(sym)
    print(f"Prune took {time.time() - start}s")
    assert len(lib.list_versions(sym)) == 1
``` 
Results:
```
                Max RSS      Time
Before change     8.7GB     25.9s
 After change     1.3GB      4.1s
```