### PR TITLE
Refactor log_event function and add retry logic

### DIFF
--- a/cpp/arcticdb/version/version_log.hpp
+++ b/cpp/arcticdb/version/version_log.hpp
@@ -25,8 +25,24 @@ namespace arcticdb {
     };
 
     inline void log_event(const std::shared_ptr<StreamSink>& store, const StreamId& id, std::string action, VersionId version_id=0) {
-        SegmentInMemory seg{log_stream_descriptor(action)};
-        store->write_sync(KeyType::LOG, version_id, StreamId{action}, IndexValue{id}, IndexValue{id}, std::move(seg));
+        static const auto max_trial_config = ConfigsMap::instance()->get_int("Storage.MaxOpLogWriteRetries", 2);
+        auto max_trials = max_trial_config;
+        while (true) {
+            try {
+                SegmentInMemory seg{log_stream_descriptor(action)};
+                store->write_sync(KeyType::LOG, version_id, StreamId{action}, IndexValue{id}, IndexValue{id}, std::move(seg));
+                break;
+            } catch (const std::exception &err) {
+                if (--max_trials <= 0) {
+                    throw;
+                }
+                log::storage().warn(
+                        "Failed to write op log for operation: {} for stream {} because of:{} . Retrying",
+                        action, id, err.what());
+                continue;
+            }
+        }
+        
     }
 
     inline void log_write(const std::shared_ptr<StreamSink>& store, const StreamId& symbol,  VersionId version_id) {


### PR DESCRIPTION
We will attempt to retry the writing of the op log up to `Storage.MaxOpLogWriteRetries` times.
This approach is similar to the one already used when [loading the ref key](https://github.com/man-group/ArcticDB/blob/66a5d19c4a2c3b2423b52a68f984ca8d9b52afce/cpp/arcticdb/version/version_map.hpp#L190)

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
