### PR TITLE
Bugfix 1552: Set row_count/rows to None in get_description/get_info and batch versions thereof if symbol is pickled

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2542,7 +2542,7 @@ class NativeVersionStore:
     def name(self):
         return self._lib_cfg.lib_desc.name
 
-    def get_num_rows(self, symbol: str, as_of: Optional[VersionQueryInput] = None, **kwargs) -> int:
+    def get_num_rows(self, symbol: str, as_of: Optional[VersionQueryInput] = None, **kwargs) -> Optional[int]:
         """
         Query the number of rows in the specified revision of the symbol.
 
@@ -2555,12 +2555,12 @@ class NativeVersionStore:
 
         Returns
         -------
-        `int`
-            The number of rows in the specified revision of the symbol.
+        `Optional[int]`
+            The number of rows in the specified revision of the symbol, or `None` if the symbol is pickled.
         """
         version_query = self._get_version_query(as_of)
         dit = self.version_store.read_descriptor(symbol, version_query)
-        return dit.timeseries_descriptor.total_rows
+        return None if self.is_pickled_descriptor(dit.timeseries_descriptor) else dit.timeseries_descriptor.total_rows
 
     def lib_cfg(self):
         return self._lib_cfg
@@ -2621,7 +2621,7 @@ class NativeVersionStore:
         return {
             "col_names": {"columns": columns, "index": index, "index_dtype": index_dtype},
             "dtype": dtypes,
-            "rows": timeseries_descriptor.total_rows,
+            "rows": None if self.is_pickled_descriptor(timeseries_descriptor) else timeseries_descriptor.total_rows,
             "last_update": last_update,
             "input_type": input_type,
             "index_type": index_type,
@@ -2649,7 +2649,7 @@ class NativeVersionStore:
 
             - col_names, `Dict`
             - dtype, `List`
-            - rows, `int`
+            - rows, `Optional[int]`
             - last_update, `datetime`
             - input_type, `str`
             - index_type, `index_type`
@@ -2684,7 +2684,7 @@ class NativeVersionStore:
 
             - col_names, `Dict`
             - dtype, `List`
-            - rows, `int`
+            - rows, `Optional[int]`
             - last_update, `datetime`
             - input_type, `str`
             - index_type, `index_type`

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -120,8 +120,8 @@ class SymbolDescription(NamedTuple):
         Index of the symbol.
     index_type : str {"NA", "index", "multi_index"}
         Whether the index is a simple index or a multi_index. ``NA`` indicates that the stored data does not have an index.
-    row_count : int
-        Number of rows.
+    row_count : Optional[int]
+        Number of rows, or None if the symbol is pickled.
     last_update_time : datetime.datetime
         The time of the last update to the symbol, in UTC.
     date_range : Tuple[Union[datetime.datetime, numpy.datetime64], Union[datetime.datetime, numpy.datetime64]]

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -810,6 +810,30 @@ def test_get_info_unsorted_timestamp_index_date_range(basic_store):
     assert np.isnat(info["date_range"][1])
 
 
+def test_get_info_pickled(basic_store):
+    lib = basic_store
+    sym = "test_get_info_pickled"
+    lib.write(sym, 1)
+    info = lib.get_info(sym)
+    assert info["col_names"]["columns"] == ["bytes"]
+    assert info["input_type"] == "msg_pack_frame"
+    assert np.isnat(info["date_range"][0]) and np.isnat(info["date_range"][1])
+    assert info["sorted"] == "UNKNOWN"
+    assert info["rows"] is None
+
+
+def test_batch_get_info_pickled(basic_store):
+    lib = basic_store
+    sym = "test_get_info_pickled"
+    lib.write(sym, 1)
+    info = lib.batch_get_info([sym])[0]
+    assert info["col_names"]["columns"] == ["bytes"]
+    assert info["input_type"] == "msg_pack_frame"
+    assert np.isnat(info["date_range"][0]) and np.isnat(info["date_range"][1])
+    assert info["sorted"] == "UNKNOWN"
+    assert info["rows"] is None
+
+
 def test_update_times(basic_store):
     # given
     df = pd.DataFrame(data={"col1": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -83,3 +83,9 @@ def test_get_num_rows(lmdb_version_store, two_col_df):
     rows = lmdb_version_store.get_num_rows(symbol)
 
     assert rows == df.shape[0]
+
+
+def test_get_num_rows_pickled(lmdb_version_store):
+    symbol = "test_get_num_rows_pickled"
+    lmdb_version_store.write(symbol, 1)
+    assert lmdb_version_store.get_num_rows(symbol) is None


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1552 

The `row_count` field of the `get_description` return value (and equivalent on V1 API, and the return value of `get_num_rows`) was misleadingly set if the symbol was pickled. Now it will be `None` in this case.

Causes (tiny) API change for V2, so wait to merge until 5.0.0