### PR TITLE
Fix sort index

### DIFF
--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -98,7 +98,7 @@ void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& p
     pipeline_context->total_rows_ = adjust_slice_rowcounts(pipeline_context->slice_and_keys_);
 }
 
-size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t> first_row) {
+size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row) {
     using namespace arcticdb::pipelines;
     if(slice_and_keys.empty())
 		return 0u;

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -98,12 +98,12 @@ void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& p
     pipeline_context->total_rows_ = adjust_slice_rowcounts(pipeline_context->slice_and_keys_);
 }
 
-size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys) {
+size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t> first_row) {
     using namespace arcticdb::pipelines;
     if(slice_and_keys.empty())
 		return 0u;
 	
-	auto offset = slice_and_keys[0].slice_.row_range.first;
+	auto offset = first_row.value_or(slice_and_keys[0].slice_.row_range.first);
 	auto diff = slice_and_keys[0].slice_.row_range.diff();
     auto col_begin = slice_and_keys[0].slice_.col_range.first;
 	

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -300,7 +300,7 @@ struct PipelineContext;
 }
 
 size_t adjust_slice_rowcounts(
-    std::vector<pipelines::SliceAndKey> & slice_and_keys);
+    std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row = std::nullopt);
 
 void adjust_slice_rowcounts(
     const std::shared_ptr<pipelines::PipelineContext>& pipeline_context);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -507,7 +507,7 @@ VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool d
         });
     }
 
-    auto total_rows = adjust_slice_rowcounts(slice_and_keys);
+    auto total_rows = adjust_slice_rowcounts(slice_and_keys, std::make_optional<size_t>(0U));
 
     auto index = index_type_from_descriptor(index_segment_reader.tsd().as_stream_descriptor());
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();

--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -15,4 +15,4 @@ from arcticdb.version_store.library import StagedDataFinalizeMethod, WriteMetada
 
 set_config_from_env_vars(_os.environ)
 
-__version__ = "4.4.0"
+__version__ = "4.4.4rc2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = arcticdb
-version = 4.4.0
+version = 4.4.4rc2
 description = ArcticDB DataFrame Database
 author = Man Alpha Technology
 author_email = arcticdb@man.com


### PR DESCRIPTION
In the case where there's no sensible way to sort on start_index, sort_index should nevertheless start from zero, otherwise the data will be become unreadable