### PR TITLE
Enhancement 1666: Do not fallback to iterating snapshots if if version as_of int or timestamp not found in version chain in V2 API

### DIFF
--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -84,10 +84,12 @@ struct SnapshotVersionQuery {
 
 struct TimestampVersionQuery {
     timestamp timestamp_;
+    bool iterate_snapshots_if_tombstoned;
 };
 
 struct SpecificVersionQuery {
     SignedVersionId version_id_;
+    bool iterate_snapshots_if_tombstoned;
 };
 
 using VersionQueryType = std::variant<
@@ -104,12 +106,12 @@ struct VersionQuery {
         content_ = SnapshotVersionQuery{snap_name};
     }
 
-    void set_timestamp(timestamp ts) {
-        content_ = TimestampVersionQuery{ts};
+    void set_timestamp(timestamp ts, bool iterate_snapshots_if_tombstoned) {
+        content_ = TimestampVersionQuery{ts, iterate_snapshots_if_tombstoned};
     }
 
-    void set_version(SignedVersionId version) {
-        content_ = SpecificVersionQuery{version};
+    void set_version(SignedVersionId version, bool iterate_snapshots_if_tombstoned) {
+        content_ = SpecificVersionQuery{version, iterate_snapshots_if_tombstoned};
     }
 };
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -116,11 +116,13 @@ public:
 
     std::optional<VersionedItem> get_specific_version(
         const StreamId &stream_id,
-        SignedVersionId signed_version_id);
+        SignedVersionId signed_version_id,
+        const VersionQuery& version_query);
 
     std::optional<VersionedItem> get_version_at_time(
         const StreamId& stream_id,
-        timestamp as_of);
+        timestamp as_of,
+        const VersionQuery& version_query);
 
     std::optional<VersionedItem> get_version_from_snapshot(
         const StreamId& stream_id,

--- a/cpp/arcticdb/version/test/test_stream_version_data.cpp
+++ b/cpp/arcticdb/version/test/test_stream_version_data.cpp
@@ -7,9 +7,9 @@ TEST(StreamVersionData, SpecificVersion) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}};
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12), false}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{SpecificVersionQuery{VersionId(4)}};
+    VersionQuery query_2{SpecificVersionQuery{VersionId(4), false}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::DOWNTO);
@@ -21,8 +21,8 @@ TEST(StreamVersionData, SpecificVersionReversed) {
     using namespace arcticdb;
     using namespace arcticdb::pipelines;
 
-    StreamVersionData stream_version_data(VersionQuery{SpecificVersionQuery{VersionId(4)}});
-    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}};
+    StreamVersionData stream_version_data(VersionQuery{SpecificVersionQuery{VersionId(4), false}});
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12), false}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::DOWNTO);
@@ -35,9 +35,9 @@ TEST(StreamVersionData, Timestamp) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(12)}};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(12), false}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(4)}};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(4), false}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::FROM_TIME);
@@ -50,11 +50,11 @@ TEST(StreamVersionData, TimestampUnordered) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3), false}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(7)}};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(7), false}};
     stream_version_data.react(query_2);
-    VersionQuery query_3{TimestampVersionQuery{timestamp(4)}};
+    VersionQuery query_3{TimestampVersionQuery{timestamp(4), false}};
     stream_version_data.react(query_3);
     ASSERT_EQ(stream_version_data.count_, 3);
     ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::FROM_TIME);
@@ -80,9 +80,9 @@ TEST(StreamVersionData, SpecificToTimestamp) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{SpecificVersionQuery{VersionId(12)}};
+    VersionQuery query_1{SpecificVersionQuery{VersionId(12), false}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{TimestampVersionQuery{timestamp(3)}};
+    VersionQuery query_2{TimestampVersionQuery{timestamp(3), false}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::ALL);
@@ -96,9 +96,9 @@ TEST(StreamVersionData, TimestampToSpecific) {
     using namespace arcticdb::pipelines;
 
     StreamVersionData stream_version_data;
-    VersionQuery query_1{TimestampVersionQuery{timestamp(3)}};
+    VersionQuery query_1{TimestampVersionQuery{timestamp(3), false}};
     stream_version_data.react(query_1);
-    VersionQuery query_2{SpecificVersionQuery{VersionId(12)}};
+    VersionQuery query_2{SpecificVersionQuery{VersionId(12), false}};
     stream_version_data.react(query_2);
     ASSERT_EQ(stream_version_data.count_, 2);
     ASSERT_EQ(stream_version_data.load_strategy_.load_type_, LoadType::ALL);

--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -57,7 +57,7 @@ TEST_F(VersionMapBatchStore, SimpleVersionIdQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j), false}});
         }
     }
 
@@ -99,7 +99,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j), false}});
         }
     }
 
@@ -111,7 +111,7 @@ TEST_F(VersionMapBatchStore, SimpleTimestampQueries) {
     for(uint64_t i = 0; i < num_streams; i++){
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
-            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}});
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts()), false}});
         }
     }
 
@@ -149,7 +149,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolVersionIdQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.emplace_back("stream_0");
-        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i), false}});
     }
 
     // Do query
@@ -182,7 +182,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     // Add queries
     for(uint64_t i = 0; i < num_versions; i++){
         stream_ids.emplace_back("stream_0");
-        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i)}});
+        version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(i), false}});
     }
 
     // Do query
@@ -191,7 +191,7 @@ TEST_F(VersionMapBatchStore, MultipleVersionsSameSymbolTimestampQueries) {
     //Secondly, once we have the timestamps in hand, we are going to query them
     version_queries.clear();
     for(uint64_t i = 0; i < num_versions; i++){
-        version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts())}});
+        version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[i]->creation_ts()), false}});
     }
 
     // Now we can perform the actual batch query per timestamps
@@ -229,7 +229,7 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         auto stream = fmt::format("stream_{}", i);
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j), false}});
         }
     }
 
@@ -244,9 +244,9 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         for(uint64_t j = 0; j < num_versions_per_stream; j++){
             uint64_t idx = i * num_versions_per_stream + j;
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j)}});
+            version_queries.emplace_back(VersionQuery{SpecificVersionQuery{static_cast<SignedVersionId>(j), false}});
             stream_ids.emplace_back(stream);
-            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts())}});
+            version_queries.emplace_back(VersionQuery{TimestampVersionQuery{timestamp(versions[idx]->creation_ts()), false}});
             stream_ids.emplace_back(stream);
             version_queries.emplace_back(VersionQuery{std::monostate{}});
         }

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1095,7 +1095,8 @@ class Library:
             row_range=row_range,
             columns=columns,
             query_builder=query_builder,
-            implement_read_index=True
+            implement_read_index=True,
+            iterate_snapshots_if_tombstoned=False,
         )
 
     def read_batch(
@@ -1195,7 +1196,15 @@ class Library:
                 )
         throw_on_error = False
         return self._nvs._batch_read_to_versioned_items(
-            symbol_strings, as_ofs, date_ranges, row_ranges, columns, query_builder or query_builders, throw_on_error, implement_read_index=True
+            symbol_strings,
+            as_ofs,
+            date_ranges,
+            row_ranges,
+            columns,
+            query_builder or query_builders,
+            throw_on_error,
+            implement_read_index=True,
+            iterate_snapshots_if_tombstoned=False,
         )
 
     def read_metadata(self, symbol: str, as_of: Optional[AsOf] = None) -> VersionedItem:
@@ -1217,7 +1226,7 @@ class Library:
             Structure containing metadata and version number of the affected symbol in the store. The data attribute
             will be None.
         """
-        return self._nvs.read_metadata(symbol, as_of)
+        return self._nvs.read_metadata(symbol, as_of, iterate_snapshots_if_tombstoned=False)
 
     def read_metadata_batch(self, symbols: List[Union[str, ReadInfoRequest]]) -> List[Union[VersionedItem, DataError]]:
         """
@@ -1616,7 +1625,14 @@ class Library:
         -------
         VersionedItem object that contains a .data and .metadata element.
         """
-        return self._nvs.head(symbol=symbol, n=n, as_of=as_of, columns=columns, implement_read_index=True)
+        return self._nvs.head(
+            symbol=symbol,
+            n=n,
+            as_of=as_of,
+            columns=columns,
+            implement_read_index=True,
+            iterate_snapshots_if_tombstoned=False,
+        )
 
     def tail(
         self, symbol: str, n: int = 5, as_of: Optional[Union[int, str]] = None, columns: List[str] = None
@@ -1639,7 +1655,14 @@ class Library:
         -------
         VersionedItem object that contains a .data and .metadata element.
         """
-        return self._nvs.tail(symbol=symbol, n=n, as_of=as_of, columns=columns, implement_read_index=True)
+        return self._nvs.tail(
+            symbol=symbol,
+            n=n,
+            as_of=as_of,
+            columns=columns,
+            implement_read_index=True,
+            iterate_snapshots_if_tombstoned=False,
+        )
 
     @staticmethod
     def _info_to_desc(info: Dict[str, Any]) -> SymbolDescription:
@@ -1682,7 +1705,12 @@ class Library:
         SymbolDescription
             For documentation on each field.
         """
-        info = self._nvs.get_info(symbol, as_of, date_range_ns_precision=True)
+        info = self._nvs.get_info(
+            symbol,
+            as_of,
+            date_range_ns_precision=True,
+            iterate_snapshots_if_tombstoned=False,
+        )
         return self._info_to_desc(info)
 
     @staticmethod

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -470,17 +470,16 @@ def test_non_existent_list_versions_latest_only(arctic_library):
 
 def test_delete_version_with_snapshot(arctic_library):
     lib = arctic_library
-    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
-    lib.write("symbol", df, metadata={"very": "interesting"})
-    lib.write("symbol", df, metadata={"muy": "interesante"}, prune_previous_versions=False)
-    lib.snapshot("my_snap")
-    lib.delete("symbol", versions=1)
-    assert lib["symbol"].version == 0
-    assert lib["symbol"].metadata == {"very": "interesting"}
-    assert lib.read("symbol", as_of=1).version == 1
-    assert lib.read("symbol", as_of=1).metadata == {"muy": "interesante"}
-    assert lib.read("symbol", as_of="my_snap").version == 1
-    assert lib.read("symbol", as_of="my_snap").metadata == {"muy": "interesante"}
+    sym = "test_delete_version_with_snapshot"
+    df = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(sym, df)
+    lib.snapshot("snap")
+    lib.delete(sym)
+
+    for method in ["read", "head", "tail", "read_metadata", "get_description"]:
+        for as_of in [0, pd.Timestamp("2200-01-01")]:
+            with pytest.raises(NoDataFoundException):
+                getattr(lib, method)(sym, as_of=as_of)
 
 
 def test_list_versions_with_snapshot(arctic_library):

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -1136,6 +1136,26 @@ def test_read_batch_query_builder_version_doesnt_exist(arctic_library):
     assert batch[2].error_category == ErrorCategory.MISSING_DATA
 
 
+def test_delete_version_with_snapshot_batch(arctic_library):
+    lib = arctic_library
+    sym = "test_delete_version_with_snapshot_batch"
+    df = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(sym, df)
+    lib.snapshot("snap")
+    lib.delete(sym)
+
+    q = QueryBuilder()
+    q = q.apply("new_col", q["col"] + 1)
+
+    for as_of in [0, pd.Timestamp("2200-01-01")]:
+        read_request = ReadRequest(sym, as_of=as_of)
+        read_info_request = ReadInfoRequest(sym, as_of=as_of)
+        assert isinstance(lib.read_batch([read_request])[0], DataError)
+        assert isinstance(lib.read_batch([read_request], query_builder=q)[0], DataError)
+        assert isinstance(lib.read_metadata_batch([read_info_request])[0], DataError)
+        assert isinstance(lib.get_description_batch([read_info_request])[0], DataError)
+
+
 def test_get_description_batch(arctic_library):
     lib = arctic_library
 


### PR DESCRIPTION
#### Reference Issues/PRs
CLoses #1666 
Closes #682 

Only affects V2 API, V1 API will behave as it always has

⚠️  API change, do not merge until 5.0.0 ⚠️ 