### PR TITLE
Sort merge starts from zero

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -103,6 +103,7 @@ jobs:
       VCPKG_MAN_NUGET_USER: ${{secrets.VCPKG_MAN_NUGET_USER}} # For forks to download pre-compiled dependencies from the Man repo
       VCPKG_MAN_NUGET_TOKEN: ${{secrets.VCPKG_MAN_NUGET_TOKEN}}
       ARCTIC_CMAKE_PRESET: linux-debug
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3.3.0
         with:

--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -27,6 +27,7 @@ jobs:
       VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:
       run: {shell: bash}
     steps:  

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -94,12 +94,13 @@ jobs:
           disk-root: "D:"  # This is also the checkout directory. Total size 12GB.
         continue-on-error: true
 
+      - name: Install VS2022 BuildTools 17.9.7
+        if: matrix.os == 'windows'
+        run: choco install -y visualstudio2022buildtools --version=117.9.7.0 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/180911598_-255012421/channel"
+
       - name: Enable Windows compiler commands
         if: matrix.os == 'windows'
         uses: ilammy/msvc-dev-cmd@v1.12.1
-        with:
-          # The version of the toolset is specified due to faulty version discovery.
-          toolset: 14.39
 
       - name: Extra envs
         # This has to come after msvc-dev-cmd to overwrite the bad VCPKG_ROOT it sets

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -65,6 +65,7 @@ jobs:
       ARCTICDB_DEBUG_FIND_PYTHON: ${{vars.ARCTICDB_DEBUG_FIND_PYTHON}}
       python_impl_name: ${{inputs.python3 > 0 && format('cp3{0}', inputs.python3) || 'default'}}
       CIBW_BUILD: ${{format('cp3{0}-{1}', inputs.python3, matrix.cibw_build_suffix)}}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:
       run: {shell: bash}
     steps:
@@ -251,6 +252,7 @@ jobs:
     env:
       python_impl_name: ${{needs.compile.outputs.python_impl_name}}
       distinguishing_name: ${{matrix.os}}-${{needs.compile.outputs.python_impl_name}}-${{matrix.type}}${{matrix.python_deps_id}}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -73,6 +73,13 @@ jobs:
         with:
           submodules: recursive # Just in case a dep has its own third-party deps
 
+      # See: https://github.com/actions/runner-images/issues/9680#issuecomment-2051917949
+      - name: HOTFIX Setup CMake 3.29.2
+        if: matrix.os == 'windows'
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.29.2'
+
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.3
         with:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
 :earth_americas: <a href="http://arcticdb.io">ArcticDB Website</a> | :ledger: <a href="https://medium.com/arcticdb">ArcticDB Blog</a> | :mega: <a href="https://www.man.com/man-group-brings-powerful-dataframe-database-product-arcticdb-to-market-with-bloomberg">Press Release</a> | :mega: <a href="https://www.bloomberg.com/company/press/man-group-brings-powerful-dataframe-database-product-arcticdb-to-market-with-bloomberg/">Press Release</a> | :busts_in_silhouette: <a href="#community">Community</a>
 <br /><br />
-<a href="https://github.com/man-group/ArcticDB/actions"><img src="https://github.com/man-group/ArcticDB/actions/workflows/build.yml/badge.svg"/></a>
+<a href="https://github.com/man-group/ArcticDB/actions"></a>
 </p>
 
 ---

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -9,16 +9,16 @@ echo Saving results to ${TEST_OUTPUT_DIR:="$(realpath "$tooling_dir/../cpp/out")
 
 catch=`{ which catchsegv 2>/dev/null || echo ; } | tail -n 1`
 
-    set -o xtrace -o pipefail
+set -o xtrace -o pipefail
 
-    # Build a directory that's just the test assets, so can't access other Python source not in the wheel
-    mkdir -p $PARALLEL_TEST_ROOT
-    MSYS=winsymlinks:nativestrict ln -s "$(realpath "$tooling_dir/../python/tests")" $PARALLEL_TEST_ROOT/
-    cd $PARALLEL_TEST_ROOT
+# Build a directory that's just the test assets, so can't access other Python source not in the wheel
+mkdir -p $PARALLEL_TEST_ROOT
+MSYS=winsymlinks:nativestrict ln -s "$(realpath "$tooling_dir/../python/tests")" $PARALLEL_TEST_ROOT/
+cd $PARALLEL_TEST_ROOT
 
-    export ARCTICDB_RAND_SEED=$RANDOM
+export ARCTICDB_RAND_SEED=$RANDOM
 
-    $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
-        --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
-        --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
-        "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#\2#"
+$catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
+    --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
+    --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
+    "$@" 2>&1 | sed -ur "s#^(tests/.*/([^/]+\.py))?#\2#"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.21) # TARGET_RUNTIME_DLLS
 # Make the `project` command handle the version of the project.
 cmake_policy(SET CMP0048 NEW)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # We do not need any compilers' extensions, so we disable them.
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -485,7 +485,7 @@ set(arcticdb_srcs
         version/symbol_list.cpp
         version/version_map_batch_methods.cpp
         storage/s3/ec2_utils.cpp
-        storage/lmdb/lmdb.hpp)
+        storage/lmdb/lmdb.hpp util/cxx17_concepts.hpp)
 
 if(${ARCTICDB_INCLUDE_ROCKSDB})
     list (APPEND arcticdb_srcs

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -347,7 +347,6 @@ set(arcticdb_srcs
         util/memory_mapped_file.hpp
         util/name_validation.hpp
         util/offset_string.hpp
-        util/offset_string.hpp
         util/optional_defaults.hpp
         util/pb_util.hpp
         util/preconditions.hpp
@@ -472,7 +471,6 @@ set(arcticdb_srcs
         util/memory_mapped_file.hpp
         util/name_validation.cpp
         util/offset_string.cpp
-        util/offset_string.cpp
         util/sparse_utils.cpp
         util/string_utils.cpp
         util/trace.cpp
@@ -487,7 +485,7 @@ set(arcticdb_srcs
         version/symbol_list.cpp
         version/version_map_batch_methods.cpp
         storage/s3/ec2_utils.cpp
-)
+        storage/lmdb/lmdb.hpp)
 
 if(${ARCTICDB_INCLUDE_ROCKSDB})
     list (APPEND arcticdb_srcs
@@ -679,6 +677,7 @@ target_include_directories(arcticdb_python PRIVATE
         ${LIBMONGOCXX_STATIC_INCLUDE_DIRS}
         ${LIBBSONCXX_STATIC_INCLUDE_DIRS}
         ${BITMAGIC_INCLUDE_DIRS}
+        ${LMDB_LIBRARIES}
         )
 
 

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -238,6 +238,12 @@ folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descr
     return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
 }
 
+folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor_for_incompletes(
+        const entity::VariantKey &key,
+        storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) override {
+    return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorForIncompletesTask{});
+}
+
 folly::Future<bool> key_exists(const entity::VariantKey &key) override {
     return async::submit_io_task(KeyExistsTask{&key, library_});
 }

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -19,7 +19,6 @@
 
 #include <arcticdb/codec/encode_common.hpp>
 
-
 namespace arcticdb {
 
 Segment encode_v2(
@@ -320,6 +319,19 @@ void decode_string_pool( const arcticdb::proto::encoding::SegmentHeader& hdr,
     }
 }
 
+ssize_t calculate_last_row(const Column& col) {
+    ssize_t last_row{0};
+    if (col.opt_sparse_map().has_value()) {
+        bm::bvector_size_type last_set_bit;
+        if (col.sparse_map().find_reverse(last_set_bit)) {
+            last_row = static_cast<ssize_t>(last_set_bit);
+        }
+    } else {
+        last_row = static_cast<ssize_t>(col.row_count());
+    }
+    return last_row;
+}
+
 void decode_v2(
     const Segment& segment,
     arcticdb::proto::encoding::SegmentHeader& hdr,
@@ -348,7 +360,7 @@ void decode_v2(
         const auto fields_size = desc.fields().size();
         const auto start_row = res.row_count();
         EncodedFieldCollection encoded_fields(std::move(encoded_fields_buffer));
-        const auto seg_row_count = fields_size ? ssize_t(encoded_fields.at(0).ndarray().items_count()) : 0L;
+        ssize_t seg_row_count = 0;
         res.init_column_map();
 
         for (std::size_t i = 0; i < fields_size; ++i) {
@@ -358,6 +370,7 @@ void decode_v2(
             if(auto col_index = res.column_index(field_name)) {
                 auto& col = res.column(static_cast<position_t>(*col_index));
                 data += decode_field(res.field(*col_index).type(), encoded_field, data, col, col.opt_sparse_map(), to_encoding_version(hdr.encoding_version()));
+                seg_row_count = std::max(seg_row_count, calculate_last_row(col));
             } else {
                 data += encoding_sizes::field_compressed_size(encoded_field) + sizeof(ColumnMagic);
             }
@@ -391,7 +404,7 @@ void decode_v1(
         util::check(fields_size == hdr.fields_size(), "Mismatch between descriptor and header field size: {} != {}", fields_size, hdr.fields_size());
         const auto start_row = res.row_count();
 
-        const auto seg_row_count = fields_size ? ssize_t(hdr.fields(0).ndarray().items_count()) : 0LL;
+        ssize_t seg_row_count = 0;
         res.init_column_map();
 
         for (int i = 0; i < fields_size; ++i) {
@@ -412,6 +425,7 @@ void decode_v1(
                     col.opt_sparse_map(),
                     to_encoding_version(hdr.encoding_version())
                 );
+                seg_row_count = std::max(seg_row_count, calculate_last_row(col));
             } else {
                 util::check(data != end, "Reached end of input block with {} fields to decode", fields_size - i);
                 data += encoding_sizes::field_compressed_size(field);

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -59,6 +59,10 @@ std::pair<std::optional<google::protobuf::Any>, StreamDescriptor> decode_metadat
 std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>> decode_timeseries_descriptor(
     Segment& segment);
 
+std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::TimeSeriesDescriptor, FieldCollection>>
+decode_timeseries_descriptor_for_incompletes(
+        Segment& segment);
+
 HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader &hdr);
 } // namespace arcticdb
 

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -393,8 +393,7 @@ void Column::set_row_data(size_t row_id) {
     const auto last_stored_row = row_count() - 1;
     if(sparse_map_) {
         last_physical_row_ = sparse_map_->count() - 1;
-    }
-    else if (last_logical_row_ != last_stored_row) {
+    } else if (last_logical_row_ != last_stored_row) {
         last_physical_row_ = last_stored_row;
         backfill_sparse_map(last_stored_row);
     } else {

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -700,13 +700,13 @@ public:
     }
 
     template <
-        typename input_tdt,
-        typename output_tdt,
-        typename functor,
-        typename = std::enable_if<
-                std::is_invocable_r_v<
-                        typename output_tdt::DataTypeTag::raw_type, functor,
-                        typename input_tdt::DataTypeTag::raw_type>>>
+            typename input_tdt,
+            typename output_tdt,
+            typename functor,
+            typename = std::enable_if<
+                    std::is_invocable_r_v<
+                            typename output_tdt::DataTypeTag::raw_type, functor,
+                            typename input_tdt::DataTypeTag::raw_type>>>
     static void transform(const Column& input_column, Column& output_column, functor&& f) {
         auto input_data = input_column.data();
         initialise_output_column(input_column, output_column);
@@ -725,10 +725,10 @@ public:
             typename output_tdt,
             typename functor,
             typename = std::enable_if<std::is_invocable_r_v<
-                typename output_tdt::DataTypeTag::raw_type,
-                functor,
-                typename left_input_tdt::DataTypeTag::raw_type,
-                typename right_input_tdt::DataTypeTag::raw_type>>>
+                    typename output_tdt::DataTypeTag::raw_type,
+                    functor,
+                    typename left_input_tdt::DataTypeTag::raw_type,
+                    typename right_input_tdt::DataTypeTag::raw_type>>>
     static void transform(const Column& left_input_column,
                           const Column& right_input_column,
                           Column& output_column,
@@ -787,10 +787,8 @@ public:
 
     template <
             typename input_tdt,
-            typename functor,
-            typename = std::enable_if<is_unary_predicate_v<input_tdt, functor>>>
-    // std::predicate<typename input_tdt::DataTypeTag::raw_type> functor>
-    static void transform(const Column& input_column,
+            typename functor>
+    static void transform_to_bitset(const Column& input_column,
                           util::BitSet& output_bitset,
                           bool sparse_missing_value_output,
                           functor&& f) {
@@ -812,9 +810,7 @@ public:
     template <
             typename left_input_tdt,
             typename right_input_tdt,
-            // std::relation<typename left_input_tdt::DataTypeTag::raw_type, typename right_input_tdt::DataTypeTag::raw_type> functor>
             typename functor>
-            //std::enable_if<is_binary_predicate_v<left_input_tdt, right_input_tdt, functor>>>
     static void transform(const Column& left_input_column,
                           const Column& right_input_column,
                           util::BitSet& output_bitset,

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -28,7 +28,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
-#include <concepts>
 #include <numeric>
 #include <optional>
 
@@ -677,7 +676,7 @@ public:
     template <
             typename input_tdt,
             typename functor>
-    requires std::is_invocable_r_v<void, functor, typename input_tdt::DataTypeTag::raw_type>
+    // requires std::is_invocable_r_v<void, functor, typename input_tdt::DataTypeTag::raw_type> //TODO reinstate with C++20
     static void for_each(const Column& input_column, functor&& f) {
         auto input_data = input_column.data();
         std::for_each(input_data.cbegin<input_tdt>(), input_data.cend<input_tdt>(), std::forward<functor>(f));
@@ -686,7 +685,7 @@ public:
     template <
             typename input_tdt,
             typename functor>
-    requires std::is_invocable_r_v<void, functor, typename ColumnData::Enumeration<typename input_tdt::DataTypeTag::raw_type>>
+    //requires std::is_invocable_r_v<void, functor, typename ColumnData::Enumeration<typename input_tdt::DataTypeTag::raw_type>>
     static void for_each_enumerated(const Column& input_column, functor&& f) {
         auto input_data = input_column.data();
         if (input_column.is_sparse()) {
@@ -702,7 +701,7 @@ public:
         typename input_tdt,
         typename output_tdt,
         typename functor>
-    requires std::is_invocable_r_v<typename output_tdt::DataTypeTag::raw_type, functor, typename input_tdt::DataTypeTag::raw_type>
+    //  requires std::is_invocable_r_v<typename output_tdt::DataTypeTag::raw_type, functor, typename input_tdt::DataTypeTag::raw_type>
     static void transform(const Column& input_column, Column& output_column, functor&& f) {
         auto input_data = input_column.data();
         initialise_output_column(input_column, output_column);
@@ -720,11 +719,11 @@ public:
             typename right_input_tdt,
             typename output_tdt,
             typename functor>
-    requires std::is_invocable_r_v<
+    /*requires std::is_invocable_r_v<
             typename output_tdt::DataTypeTag::raw_type,
             functor,
             typename left_input_tdt::DataTypeTag::raw_type,
-            typename right_input_tdt::DataTypeTag::raw_type>
+            typename right_input_tdt::DataTypeTag::raw_type>*/
     static void transform(const Column& left_input_column,
                           const Column& right_input_column,
                           Column& output_column,
@@ -783,7 +782,8 @@ public:
 
     template <
             typename input_tdt,
-            std::predicate<typename input_tdt::DataTypeTag::raw_type> functor>
+            typename functor>
+    // std::predicate<typename input_tdt::DataTypeTag::raw_type> functor>
     static void transform(const Column& input_column,
                           util::BitSet& output_bitset,
                           bool sparse_missing_value_output,
@@ -806,7 +806,8 @@ public:
     template <
             typename left_input_tdt,
             typename right_input_tdt,
-            std::relation<typename left_input_tdt::DataTypeTag::raw_type, typename right_input_tdt::DataTypeTag::raw_type> functor>
+            // std::relation<typename left_input_tdt::DataTypeTag::raw_type, typename right_input_tdt::DataTypeTag::raw_type> functor>
+            typename functor>
     static void transform(const Column& left_input_column,
                           const Column& right_input_column,
                           util::BitSet& output_bitset,

--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -258,7 +258,7 @@ public:
             return data_.ptr_ == other.data_.ptr_;
         }
 
-        base_type::reference dereference() const {
+        typename base_type::reference dereference() const {
             if constexpr (iterator_type == IteratorType::ENUMERATED) {
                 return data_;
             } else {
@@ -270,7 +270,7 @@ public:
         ColumnData* parent_{nullptr};
         std::optional<TypedBlockData<TDT>> opt_block_{std::nullopt};
         std::size_t remaining_values_in_block_{0};
-        base_type::value_type data_;
+        typename base_type::value_type data_;
     };
 
     ColumnData(

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -564,6 +564,7 @@ std::optional<std::string_view> SegmentInMemoryImpl::string_at(position_t row, p
     const auto& col_ref = column(col);
 
     if(is_fixed_string_type(td.data_type()) && col_ref.is_inflated()) {
+
         auto string_size = col_ref.bytes() / row_count();
         auto ptr = col_ref.data().buffer().ptr_cast<char>(row * string_size, string_size);
         return std::string_view(ptr, string_size);

--- a/cpp/arcticdb/entity/descriptor_item.hpp
+++ b/cpp/arcticdb/entity/descriptor_item.hpp
@@ -16,27 +16,27 @@ namespace arcticdb {
 struct DescriptorItem {
     DescriptorItem(
         entity::AtomKey &&key, 
-        std::optional<IndexValue> start_index, 
-        std::optional<IndexValue> end_index,
-        std::optional<google::protobuf::Any> timeseries_descriptor) :
+        std::optional<timestamp> start_index,
+        std::optional<timestamp> end_index,
+        std::optional<arcticdb::proto::descriptors::TimeSeriesDescriptor>&& timeseries_descriptor) :
         key_(std::move(key)),
         start_index_(start_index),
         end_index_(end_index),
-        timeseries_descriptor_(timeseries_descriptor) {
+        timeseries_descriptor_(std::move(timeseries_descriptor)) {
     }
 
     DescriptorItem() = delete;
 
     entity::AtomKey key_;
-    std::optional<IndexValue> start_index_;
-    std::optional<IndexValue> end_index_;
-    std::optional<google::protobuf::Any> timeseries_descriptor_;
+    std::optional<timestamp> start_index_;
+    std::optional<timestamp> end_index_;
+    std::optional<arcticdb::proto::descriptors::TimeSeriesDescriptor> timeseries_descriptor_;
     
     std::string symbol() const { return fmt::format("{}", key_.id()); }
     uint64_t version() const { return key_.version_id(); }
     timestamp creation_ts() const { return key_.creation_ts(); }
-    std::optional<IndexValue> start_index() const { return start_index_; }
-    std::optional<IndexValue> end_index() const { return end_index_; }
-    std::optional<google::protobuf::Any> timeseries_descriptor() const { return timeseries_descriptor_; }
+    std::optional<timestamp> start_index() const { return start_index_; }
+    std::optional<timestamp> end_index() const { return end_index_; }
+    std::optional<arcticdb::proto::descriptors::TimeSeriesDescriptor> timeseries_descriptor() const { return timeseries_descriptor_; }
 };
 }

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -273,8 +273,7 @@ StreamDescriptor index_descriptor(const StreamId& stream_id, IndexType, const Ra
 }
 
 template <typename IndexType>
-StreamDescriptor index_descriptor(StreamId stream_id, IndexType index_type,
-                                  std::initializer_list<FieldRef> fields) {
+StreamDescriptor index_descriptor(StreamId stream_id, IndexType index_type, std::initializer_list<FieldRef> fields) {
     std::vector<FieldRef> fields_vec;
     fields_vec.reserve(fields.size());
     for(const auto& field : fields)

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -275,7 +275,12 @@ StreamDescriptor index_descriptor(const StreamId& stream_id, IndexType, const Ra
 template <typename IndexType>
 StreamDescriptor index_descriptor(StreamId stream_id, IndexType index_type,
                                   std::initializer_list<FieldRef> fields) {
-    return index_descriptor(stream_id, index_type, folly::gen::from(fields) | folly::gen::as<std::vector>());
+    std::vector<FieldRef> fields_vec;
+    fields_vec.reserve(fields.size());
+    for(const auto& field : fields)
+        fields_vec.push_back(field);
+
+    return index_descriptor(stream_id, index_type, fields_vec);
 }
 
 template <typename IndexType, typename RangeType>

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -43,6 +43,7 @@ using VersionId = uint64_t;
 using SignedVersionId = int64_t;
 using GenerationId = VersionId;
 using timestamp = int64_t;
+// TODO: shape_t probably should be unsigned. Negative shapes don't make sense. This will involve a lot of changes in native_tensor.hpp
 using shape_t = int64_t;
 using stride_t = int64_t;
 using position_t = int64_t;

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -33,16 +33,12 @@ namespace arcticdb::log {
 
 static const char* DefaultLogPattern = "%Y%m%d %H:%M:%S.%f %t %L %n | %v";
 
-
 namespace {
-    std::shared_ptr<Loggers> loggers_instance_;
-    std::once_flag loggers_init_flag_;
-}
+std::shared_ptr<Loggers> loggers_instance_;
+std::once_flag loggers_init_flag_;
+} // namespace
 
-
-struct Loggers::Impl
-{
-
+struct Loggers::Impl {
     std::mutex config_mutex_;
     std::unordered_map<std::string, spdlog::sink_ptr> sink_by_id_;
     std::unique_ptr<spdlog::logger> unconfigured_ = std::make_unique<spdlog::logger>("arcticdb",
@@ -69,7 +65,6 @@ struct Loggers::Impl
 
     spdlog::logger& logger_ref(std::unique_ptr<spdlog::logger>& src);
 };
-
 
 constexpr auto get_default_log_level() {
     return spdlog::level::info;
@@ -128,15 +123,13 @@ namespace fs = std::filesystem;
 using SinkConf = arcticdb::proto::logger::SinkConfig;
 
 Loggers::Loggers()
-    : impl_(std::make_unique<Impl>())
-{
+        : impl_(std::make_unique<Impl>()) {
     impl_->unconfigured_->set_level(get_default_log_level());
 }
 
 Loggers::~Loggers() = default;
 
-Loggers& Loggers::instance()
-{
+Loggers& Loggers::instance() {
     std::call_once(loggers_init_flag_, &Loggers::init);
     return *loggers_instance_;
 }
@@ -204,7 +197,6 @@ void Loggers::flush_all() {
     snapshot().flush();
 }
 
-
 void Loggers::destroy_instance() {
     loggers_instance_.reset();
 }
@@ -212,7 +204,6 @@ void Loggers::destroy_instance() {
 void Loggers::init() {
     loggers_instance_ = std::make_shared<Loggers>();
 }
-
 
 namespace {
 std::string make_parent_dir(const std::string &p_str, std::string_view def_p_str) {
@@ -235,7 +226,6 @@ spdlog::logger& Loggers::Impl::logger_ref(std::unique_ptr<spdlog::logger>& src) 
 
     return *unconfigured_;
 }
-
 
 bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool force) {
     auto lock = std::scoped_lock(impl_->config_mutex_);
@@ -320,7 +310,6 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool
     check_and_configure("symbol", "root", impl_->symbol_);
     check_and_configure("snapshot", "root", impl_->snapshot_);
 
-
     if (auto flush_sec = util::as_opt(conf.flush_interval_seconds()).value_or(1); flush_sec != 0) {
         impl_->periodic_worker_.emplace(
             [loggers = std::weak_ptr(loggers_instance_)]() {
@@ -331,7 +320,6 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig &conf, bool
     }
     return true;
 }
-
 
 void Loggers::Impl::configure_logger(
         const arcticdb::proto::logger::LoggerConfig &conf,
@@ -354,18 +342,15 @@ void Loggers::Impl::configure_logger(
         logger = std::make_unique<spdlog::logger>(fq_name, sink_ptrs.begin(), sink_ptrs.end());
     }
 
-    if (!conf.pattern().empty()) {
+    if (!conf.pattern().empty())
         logger->set_pattern(conf.pattern());
-    }
-    else {
+    else
         logger->set_pattern(DefaultLogPattern);
-    }
 
-    if (conf.level() != 0) {
+    if (conf.level() != 0)
         logger->set_level(static_cast<spdlog::level::level_enum>(conf.level() - 1));
-    } else {
+    else
         logger->set_level(get_default_log_level());
-    }
 }
 
 }

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -98,12 +98,12 @@ void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& p
     pipeline_context->total_rows_ = adjust_slice_rowcounts(pipeline_context->slice_and_keys_);
 }
 
-size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys) {
+size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row) {
     using namespace arcticdb::pipelines;
     if(slice_and_keys.empty())
 		return 0u;
-	
-	auto offset = slice_and_keys[0].slice_.row_range.first;
+
+    auto offset = first_row.value_or(slice_and_keys[0].slice_.row_range.first);
 	auto diff = slice_and_keys[0].slice_.row_range.diff();
     auto col_begin = slice_and_keys[0].slice_.col_range.first;
 	

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -12,6 +12,7 @@
 namespace arcticdb {
 
 TimeseriesDescriptor make_timeseries_descriptor(
+        // TODO: It would be more explicit to use uint64_t instead of size_t. Not doing now as it involves a lot of type changes and needs to be done carefully.
         size_t total_rows,
         StreamDescriptor&& desc,
         arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta,

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -300,7 +300,7 @@ struct PipelineContext;
 }
 
 size_t adjust_slice_rowcounts(
-    std::vector<pipelines::SliceAndKey> & slice_and_keys);
+    std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row = std::nullopt);
 
 void adjust_slice_rowcounts(
     const std::shared_ptr<pipelines::PipelineContext>& pipeline_context);

--- a/cpp/arcticdb/pipeline/index_utils.cpp
+++ b/cpp/arcticdb/pipeline/index_utils.cpp
@@ -80,7 +80,7 @@ std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vec
 }
 
 TimeseriesDescriptor get_merged_tsd(
-        int row_count,
+        size_t row_count,
         bool dynamic_schema,
         const TimeseriesDescriptor& existing_tsd,
         const std::shared_ptr<pipelines::InputTensorFrame>& new_frame) {

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -139,7 +139,7 @@ std::pair<index::IndexSegmentReader, std::vector<SliceAndKey>> read_index_to_vec
 // Combines the stream descriptors of an existing index key and a new frame.
 // Can be used to get the metadata for [write_index] when updating or appending.
 TimeseriesDescriptor get_merged_tsd(
-    int row_count,
+    size_t row_count,
     bool dynamic_schema,
     const TimeseriesDescriptor& existing_tsd,
     const std::shared_ptr<pipelines::InputTensorFrame>& new_frame);

--- a/cpp/arcticdb/pipeline/index_writer.hpp
+++ b/cpp/arcticdb/pipeline/index_writer.hpp
@@ -16,8 +16,8 @@
 #include <arcticdb/pipeline/pipeline_common.hpp>
 
 namespace arcticdb::pipelines::index {
-// TODO: change the name - something like KeysSegmentWriter or KeyAggragator or  better
-template<class Index, std::enable_if_t<InputTensorFrame::is_valid_index_v<Index>, bool> = 0>
+
+template<typename Index>
 class IndexWriter {
     // All index segments are row-count indexed in the sense that the keys are
     // already ordered - they don't need an additional index

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -36,8 +36,8 @@ struct InputTensorFrame {
     std::optional<entity::NativeTensor> index_tensor;
     std::vector<entity::NativeTensor> field_tensors;
     IndexRange index_range;
-    ssize_t num_rows = 0;
-    mutable ssize_t offset = 0;
+    size_t num_rows = 0;
+    mutable size_t offset = 0;
     mutable bool bucketize_dynamic = 0;
 
     void set_offset(ssize_t off) const {

--- a/cpp/arcticdb/processing/operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch.cpp
@@ -50,7 +50,7 @@ VariantData transform_to_bitset(const VariantData& data) {
                 details::visit_type(column_with_strings.column_->type().data_type(), [&column_with_strings, &output_bitset](auto col_tag) {
                     using type_info = ScalarTypeInfo<decltype(col_tag)>;
                     if constexpr (is_bool_type(type_info::data_type)) {
-                        Column::transform<typename type_info::TDT>(*column_with_strings.column_, output_bitset, false, [](auto input_value) -> bool {
+                        Column::transform_to_bitset<typename type_info::TDT>(*column_with_strings.column_, output_bitset, false, [](auto input_value) -> bool {
                             return input_value;
                         });
                     } else {

--- a/cpp/arcticdb/processing/test/benchmark_clause.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_clause.cpp
@@ -89,7 +89,6 @@ static void BM_merge_ordered(benchmark::State& state){
 }
 
 template <typename integer>
-requires std::integral<integer>
 void BM_hash_grouping_int(benchmark::State& state) {
     auto num_rows = state.range(0);
     auto num_unique_values = state.range(1);

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -230,7 +230,7 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
         util::check(index_tensor.ndim() == 1, "Multi-dimensional indexes not handled");
         util::check(index_tensor.shape() != nullptr, "Index tensor expected to contain shapes");
         std::string index_column_name = !idx_names.empty() ? idx_names[0] : "index";
-        res->num_rows = index_tensor.shape(0);
+        res->num_rows = static_cast<size_t>(index_tensor.shape(0));
         // TODO handle string indexes
         // Empty type check is added to preserve the current behavior which is that 0-rowed dataframes
         // are assigned datetime index. This will be changed in further PR creating empty typed index.
@@ -259,7 +259,7 @@ std::shared_ptr<InputTensorFrame> py_ndf_to_frame(
 
     for (auto i = 0u; i < col_vals.size(); ++i) {
         auto tensor = obj_to_tensor(col_vals[i].ptr(), empty_types);
-        res->num_rows = std::max(res->num_rows, static_cast<ssize_t>(tensor.shape(0)));
+        res->num_rows = std::max(res->num_rows, static_cast<size_t>(tensor.shape(0)));
         if(tensor.expanded_dim() == 1) {
             res->desc.add_field(scalar_field(tensor.data_type(), col_names[i]));
         } else if(tensor.expanded_dim() == 2) {
@@ -297,7 +297,7 @@ std::shared_ptr<InputTensorFrame> py_none_to_frame() {
     const shape_t shapes = 1;
     constexpr int ndim = 1;
     auto tensor = NativeTensor{8, ndim, &strides, &shapes, DataType::UINT64, 8, none_char, ndim};
-    res->num_rows = std::max(res->num_rows, static_cast<ssize_t>(tensor.shape(0)));
+    res->num_rows = std::max(res->num_rows, static_cast<size_t>(tensor.shape(0)));
     res->desc.add_field(scalar_field(tensor.data_type(), col_name));
     res->field_tensors.push_back(std::move(tensor));
 

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -202,30 +202,29 @@ void do_remove_impl(Composite<VariantKey>&& ks,
         static const size_t delete_object_limit =
             std::min(BATCH_SUBREQUEST_LIMIT, static_cast<size_t>(ConfigsMap::instance()->get_int("AzureStorage.DeleteBatchSize", BATCH_SUBREQUEST_LIMIT)));
 
-        unsigned int batch_counter = 0u;
-        auto submit_batch = [&azure_client, &request_timeout, &batch_counter](auto &to_delete) {
+        auto submit_batch = [&azure_client, &request_timeout](auto &to_delete) {
             try {
                 azure_client.delete_blobs(to_delete, request_timeout);
             }
             catch (const Azure::Core::RequestFailedException& e) {
                 raise_azure_exception(e);
             }
-            batch_counter = 0u;
+            to_delete.clear();
         };
 
         (fg::from(ks.as_range()) | fg::move | fg::groupBy(fmt_db)).foreach(
-            [&root_folder, b=std::move(bucketizer), delete_object_limit=delete_object_limit, &batch_counter, &to_delete, &submit_batch] (auto&& group) {//bypass incorrect 'set but no used" error for delete_object_limit
+            [&root_folder, b=std::move(bucketizer), delete_object_limit=delete_object_limit, &to_delete, &submit_batch] (auto&& group) {//bypass incorrect 'set but no used" error for delete_object_limit
                 auto key_type_dir = key_type_folder(root_folder, group.key());
                 for (auto k : folly::enumerate(group.values())) {
                     auto blob_name = object_path(b.bucketize(key_type_dir, *k), *k);
                     to_delete.emplace_back(std::move(blob_name));
-                    if (++batch_counter == delete_object_limit) {
+                    if (to_delete.size() == delete_object_limit) {
                         submit_batch(to_delete);
                     }
                 }
             }
         );
-        if (batch_counter) {
+        if (!to_delete.empty()) {
             submit_batch(to_delete);
         }
 }

--- a/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
+++ b/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
@@ -22,7 +22,7 @@ uint64_t get_symbol_prefix(const entity::StreamId& stream_id) {
     constexpr size_t begin = sizeof(InternalType) - sizeof(StorageType);
     StorageType data{};
     util::variant_match(stream_id,
-        [&data] (const entity::StringId& string_id) {
+        [&data, begin, end] (const entity::StringId& string_id) {
             auto* target = reinterpret_cast<char*>(&data);
             for(size_t p = begin, i = 0; p < end && i < string_id.size(); ++p, ++i) {
                 const auto c = string_id[i];

--- a/cpp/arcticdb/storage/lmdb/lmdb.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+// LMDB++ is using `std::is_pod` in `lmdb++.h`, which is deprecated as of C++20.
+// See: https://github.com/drycpp/lmdbxx/blob/0b43ca87d8cfabba392dfe884eb1edb83874de02/lmdb%2B%2B.h#L1068
+// See: https://en.cppreference.com/w/cpp/types/is_pod
+// This suppresses the warning.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#ifdef ARCTICDB_USING_CONDA
+#include <lmdb++.h>
+#else
+#include <third_party/lmdbcxx/lmdb++.h>
+#endif
+#pragma GCC diagnostic pop

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_wrapper.hpp
@@ -12,18 +12,10 @@
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/storage_utils.hpp>
 
-// LMDB++ is using `std::is_pod` in `lmdb++.h`, which is deprecated as of C++20.
-// See: https://github.com/drycpp/lmdbxx/blob/0b43ca87d8cfabba392dfe884eb1edb83874de02/lmdb%2B%2B.h#L1068
-// See: https://en.cppreference.com/w/cpp/types/is_pod
-// This suppresses the warning.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#ifdef ARCTICDB_USING_CONDA
-#include <lmdb++.h>
-#else
-#include <third_party/lmdbxx/lmdb++.h>
-#endif
-#pragma GCC diagnostic pop
+namespace lmdb {
+class txn;
+class dbi;
+}
 
 
 namespace arcticdb::storage::lmdb {

--- a/cpp/arcticdb/storage/lmdb/lmdb_mock_client.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_mock_client.cpp
@@ -11,6 +11,7 @@
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/serialized_key.hpp>
 #include <arcticdb/util/string_utils.hpp>
+#include <arcticdb/storage/lmdb/lmdb.hpp>
 
 
 namespace arcticdb::storage::lmdb {

--- a/cpp/arcticdb/storage/lmdb/lmdb_real_client.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_real_client.cpp
@@ -11,7 +11,7 @@
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/lmdb/lmdb_real_client.hpp>
 #include <arcticdb/storage/storage_utils.hpp>
-
+#include <arcticdb/storage/lmdb/lmdb.hpp>
 
 namespace arcticdb::storage::lmdb {
 

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -20,6 +20,11 @@
 
 namespace fs = std::filesystem;
 
+namespace lmdb {
+class env;
+class dbi;
+}
+
 namespace arcticdb::storage::lmdb {
 
 class LmdbStorage final : public Storage {
@@ -52,13 +57,7 @@ class LmdbStorage final : public Storage {
 
     bool do_key_exists(const VariantKey & key) final;
 
-    ::lmdb::env& env() {
-        if (!env_) {
-            raise<ErrorCode::E_UNEXPECTED_LMDB_ERROR>("Unexpected LMDB Error: Invalid operation: LMDB environment has been removed. "
-                                                      "Possibly because the library has been deleted");
-        }
-        return *env_;
-    }
+    ::lmdb::env& env();
 
     std::string do_key_path(const VariantKey&) const final { return {}; };
 
@@ -70,7 +69,7 @@ class LmdbStorage final : public Storage {
     std::unique_ptr<std::mutex> write_mutex_;
     std::unique_ptr<::lmdb::env> env_;
 
-    std::unordered_map<std::string, ::lmdb::dbi> dbi_by_key_type_;
+    std::unordered_map<std::string, std::unique_ptr<::lmdb::dbi>> dbi_by_key_type_;
 
     std::filesystem::path lib_dir_;
 

--- a/cpp/arcticdb/storage/mongo/mongo_mock_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_mock_client.cpp
@@ -5,7 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/mongo/mongo_client_wrapper.hpp>
 #include <arcticdb/storage/mongo/mongo_mock_client.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
@@ -13,7 +12,6 @@
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/query_exception.hpp>
-
 
 namespace arcticdb::storage::mongo {
 
@@ -45,7 +43,7 @@ MongoFailure get_failure(const std::string& message, StorageOperation operation,
         case StorageOperation::EXISTS:
             return create_failure<mongocxx::query_exception>(message, error_code);
         case StorageOperation::DELETE:
-            return create_failure<mongocxx::bulk_write_exception>(message, error_code);
+            [[fallthrough]];
         case StorageOperation::DELETE_LOCAL:
             return create_failure<mongocxx::bulk_write_exception>(message, error_code);
         case StorageOperation::LIST:
@@ -58,7 +56,7 @@ MongoFailure get_failure(const std::string& message, StorageOperation operation,
 std::optional<MongoFailure> has_failure_trigger(
         const MongoKey& key,
         StorageOperation operation) {
-    auto key_id = key.doc_key.id_string();
+    auto key_id = key.doc_key_.id_string();
     auto failure_string_for_operation = "#Failure_" + operation_to_string(operation) + "_";
     auto position = key_id.rfind(failure_string_for_operation);
     if (position == std::string::npos) {
@@ -83,8 +81,8 @@ bool matches_prefix(
         const std::string& collection_name,
         const std::string& prefix) {
 
-    return key.database_name == database_name && key.collection_name == collection_name &&
-           key.doc_key.id_string().find(prefix) == 0;
+    return key.database_name_ == database_name && key.collection_name_ == collection_name &&
+           key.doc_key_.id_string().find(prefix) == 0;
 }
 
 void throw_if_exception(MongoFailure& failure) {
@@ -109,7 +107,7 @@ bool MockMongoClient::write_segment(
         return false;
     }
 
-    mongo_contents.insert_or_assign(key, std::move(kv.segment()));
+    mongo_contents.insert_or_assign(std::move(key), std::move(kv.segment()));
     return true;
 }
 
@@ -131,7 +129,7 @@ UpdateResult MockMongoClient::update_segment(
         return {0}; // upsert is false, don't update and return 0 as modified_count
     }
 
-    mongo_contents.insert_or_assign(key, std::move(kv.segment()));
+    mongo_contents.insert_or_assign(std::move(key), std::move(kv.segment()));
     return {key_found ? 1 : 0};
 }
 
@@ -151,7 +149,7 @@ std::optional<KeySegmentPair> MockMongoClient::read_segment(
         return std::nullopt;
     }
 
-    return KeySegmentPair(std::move(mongo_key.doc_key.key), std::move(it->second));
+    return KeySegmentPair(std::move(mongo_key.doc_key_.key_), std::move(it->second));
 }
 
 DeleteResult MockMongoClient::remove_keyvalue(
@@ -203,7 +201,7 @@ std::vector<VariantKey> MockMongoClient::list_keys(
                 throw_if_exception(failure.value());
                 return {};
             }
-            output.push_back(key.first.doc_key.key);
+            output.push_back(key.first.doc_key_.key_);
         }
     }
 
@@ -216,7 +214,7 @@ void MockMongoClient::ensure_collection(std::string_view, std::string_view ) {
 
 void MockMongoClient::drop_collection(std::string database_name, std::string collection_name) {
     for (auto it = mongo_contents.begin(); it != mongo_contents.end(); ) {
-        if (it->first.database_name == database_name && it->first.collection_name == collection_name) {
+        if (it->first.database_name_ == database_name && it->first.collection_name_ == collection_name) {
             it = mongo_contents.erase(it);
         } else {
             ++it;

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -15,7 +15,6 @@
 
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/library_manager.hpp>
-#include <arcticdb/storage/protobuf_mappings.hpp>
 #include <arcticdb/storage/library_index.hpp>
 #include <arcticdb/storage/config_resolvers.hpp>
 #include <arcticdb/storage/constants.hpp>

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -384,7 +384,6 @@ namespace arcticdb {
             return folly::makeFuture(std::move(components));
         }
 
-
         folly::Future<std::pair<std::variant<arcticdb::entity::AtomKeyImpl, arcticdb::entity::RefKey>, arcticdb::TimeseriesDescriptor>>
         read_timeseries_descriptor(const entity::VariantKey& key,
                                    storage::ReadKeyOpts /*opts*/) override {
@@ -404,6 +403,23 @@ namespace arcticdb {
             });
         }
 
+        folly::Future<std::pair<std::variant<arcticdb::entity::AtomKeyImpl, arcticdb::entity::RefKey>, arcticdb::TimeseriesDescriptor>>
+        read_timeseries_descriptor_for_incompletes(const entity::VariantKey& key,
+                                   storage::ReadKeyOpts /*opts*/) override {
+            return util::variant_match(key, [&](const AtomKey &ak) {
+                                           auto it = seg_by_atom_key_.find(ak);
+                                           if (it == seg_by_atom_key_.end())
+                                               throw storage::KeyNotFoundException(Composite<VariantKey>(ak));
+                                           ARCTICDB_DEBUG(log::storage(), "Mock store read for atom key {}", ak);
+                                           auto tsd = it->second->index_descriptor();
+                                           tsd.proto_->mutable_stream_descriptor()->CopyFrom(it->second->descriptor().proto());
+                                           return std::make_pair(key, it->second->index_descriptor());
+                                       },
+                                       [&](const RefKey&) {
+                                           util::raise_rte("Not implemented");
+                                           return std::make_pair(key, TimeseriesDescriptor{});
+                                       });
+        }
 
         void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator &) override {}
 

--- a/cpp/arcticdb/storage/test/test_storage_exceptions.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_exceptions.cpp
@@ -26,6 +26,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <arcticdb/storage/lmdb/lmdb.hpp>
 
 using namespace arcticdb;
 using namespace storage;

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -80,6 +80,9 @@ struct StreamSource {
         read_timeseries_descriptor(const entity::VariantKey& key,
                                    storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
+    virtual folly::Future<std::pair<VariantKey, TimeseriesDescriptor>>
+    read_timeseries_descriptor_for_incompletes(const entity::VariantKey& key,
+                               storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
 
 };
 

--- a/cpp/arcticdb/stream/test/test_append_map.cpp
+++ b/cpp/arcticdb/stream/test/test_append_map.cpp
@@ -36,7 +36,7 @@ TEST(Append, Simple) {
     generate_filtered_field_descriptors(pipeline_context, {});
 
     SegmentInMemory allocated_frame = allocate_frame(pipeline_context);
-    ASSERT_EQ(allocated_frame.row_count(), size_t(frame->num_rows));
+    ASSERT_EQ(allocated_frame.row_count(), frame->num_rows);
 }
 
 TEST(Append, MergeDescriptorsPromote) {

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -290,7 +290,7 @@ namespace arcticdb {
 
     template<class TracingPolicy, class ClockType>
     void AllocatorImpl<TracingPolicy, ClockType>::maybe_trim() {
-        const uint32_t trim_count = ConfigsMap::instance()->get_int("Allocator.TrimCount", 250);
+        static const uint32_t trim_count = ConfigsMap::instance()->get_int("Allocator.TrimCount", 250);
         if (free_count_of<TracingPolicy, ClockType>().readFast() > trim_count && free_count_of<TracingPolicy, ClockType>().readFastAndReset() > trim_count)
             trim();
     }

--- a/cpp/arcticdb/util/cxx17_concepts.hpp
+++ b/cpp/arcticdb/util/cxx17_concepts.hpp
@@ -1,0 +1,18 @@
+#include <type_traits>
+#include <functional>
+
+namespace arcticdb {
+
+template<typename F, typename Arg>
+using is_unary_predicate = std::is_invocable_r<bool, F, Arg>;
+
+template<typename F, typename Arg>
+constexpr bool is_unary_predicate_v = is_unary_predicate<F, Arg>::value;
+
+template<typename F, typename G, typename Arg>
+using is_binary_predicate = std::is_invocable_r<bool, F, G, Arg>;
+
+template<typename F, typename G, typename Arg>
+constexpr bool is_binary_predicate_v = is_binary_predicate<F, G, Arg>::value;
+
+}

--- a/cpp/arcticdb/util/cxx17_concepts.hpp
+++ b/cpp/arcticdb/util/cxx17_concepts.hpp
@@ -2,7 +2,7 @@
 #include <functional>
 
 namespace arcticdb {
-
+    
 template<typename F, typename Arg>
 using is_unary_predicate = std::is_invocable_r<bool, F, Arg>;
 

--- a/cpp/arcticdb/util/format_date.hpp
+++ b/cpp/arcticdb/util/format_date.hpp
@@ -19,7 +19,7 @@ using TimePoint = std::chrono::time_point<Clock>;
 
 inline std::string format_timestamp(entity::timestamp ts) {
     std::stringstream ss;
-#if  defined(_WIN32) or defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__)
     auto time_point = Clock::time_point(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::nanoseconds(ts)));
 #else
     auto time_point = Clock::time_point(std::chrono::nanoseconds(ts));

--- a/cpp/arcticdb/util/offset_string.cpp
+++ b/cpp/arcticdb/util/offset_string.cpp
@@ -24,9 +24,5 @@ OffsetString::offset_t OffsetString::offset() const {
 }
 
 // Given a set of string pool offsets, removes any that represent None or NaN
-void remove_nones_and_nans(ankerl::unordered_dense::set<OffsetString::offset_t>& offsets) {
-    offsets.erase(not_a_string());
-    offsets.erase(nan_placeholder());
-}
 
 } //namespace arcticdb

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -52,8 +52,10 @@ constexpr bool is_a_string(OffsetString::offset_t offset) {
 }
 
 // Given a set of string pool offsets, removes any that represent None or NaN
-void remove_nones_and_nans(ankerl::unordered_dense::set<OffsetString::offset_t>& offsets);
-
+inline void remove_nones_and_nans(ankerl::unordered_dense::set<OffsetString::offset_t>& offsets) {
+    offsets.erase(not_a_string());
+    offsets.erase(nan_placeholder());
+}
 
 template <typename LockPtrType>
 inline PyObject* create_py_nan(LockPtrType& lock) {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -866,7 +866,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_trees_responsibly(
                 return true;
             }
             get_matching_prev_and_next_versions(entry, key.version_id(), // Check 2)
-                    [](ARCTICDB_UNUSED auto& matching) {},
+                    [](const AtomKey&) {},
                     [&check, &not_to_delete](auto& prev) { if (check.prev_version) not_to_delete.insert(prev);},
                     [&check, &not_to_delete](auto& next) { if (check.next_version) not_to_delete.insert(next);},
                     [v=key.version_id()](const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry) {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -507,7 +507,7 @@ VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool d
         });
     }
 
-    auto total_rows = adjust_slice_rowcounts(slice_and_keys);
+    auto total_rows = adjust_slice_rowcounts(slice_and_keys, std::make_optional<size_t>(0U));
 
     auto index = index_type_from_descriptor(index_segment_reader.tsd().as_stream_descriptor());
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -550,6 +550,7 @@ VersionedItem LocalVersionedEngine::update_internal(
     bool dynamic_schema,
     bool prune_previous_versions) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: update");
+    py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
                                                                         version_map(),
                                                                         stream_id,
@@ -1361,7 +1362,7 @@ VersionedItem LocalVersionedEngine::append_internal(
     bool upsert,
     bool prune_previous_versions,
     bool validate_index) {
-
+    py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(),
                                                                         version_map(),
                                                                         stream_id,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -200,16 +200,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def_property_readonly("end_index", &DescriptorItem::end_index)
         .def_property_readonly("creation_ts", &DescriptorItem::creation_ts)
         .def_property_readonly("timeseries_descriptor", [](const DescriptorItem& self) {
-          py::object pyobj;
-          auto timeseries_descriptor = self.timeseries_descriptor();
-          if (timeseries_descriptor.has_value()) {
-               arcticdb::proto::descriptors::TimeSeriesDescriptor tsd;
-               timeseries_descriptor->UnpackTo(&tsd);
-               pyobj = python_util::pb_to_python(tsd);
-          } else {
-               pyobj = pybind11::none();
-          }
-          return pyobj;
+            // FUTURE: Use std::optional monadic operations in C++23
+            auto opt_tsd = self.timeseries_descriptor();
+            return opt_tsd.has_value() ? python_util::pb_to_python(*opt_tsd) : pybind11::none();
         });
 
     py::class_<pipelines::FrameSlice, std::shared_ptr<pipelines::FrameSlice>>(version, "FrameSlice")

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -128,17 +128,35 @@ MaybeCompaction last_compaction(const std::vector<AtomKey>& keys) {
     }
 }
 
+// The below string_at and scalar_at functions should be used for symbol list cache segments instead of the ones
+// provided in SegmentInMemory, because the symbol list structure is the only place where columns can have more entries
+// than the segment has rows. Hence, we need to bypass the checks inside SegmentInMemory's function and directly call the
+// Column's string_at and scalar_at.
+std::string string_at(const SegmentInMemory& seg, position_t row, position_t col){
+    auto offset = seg.column(col).scalar_at<position_t>(row);
+    util::check(offset.has_value(), "Symbol list trying to call string_at for missing row {}, column {}", row, col);
+    return std::string(seg.string_pool_ptr()->get_view(offset.value()));
+}
+
+template<typename T>
+T scalar_at(const SegmentInMemory& seg, position_t row, position_t col){
+    auto scalar = seg.column(col).scalar_at<T>(row);
+    util::check(scalar.has_value(), "Symbol list trying to call scalar_at for missing row {}, column {}", row, col);
+    return scalar.value();
+}
+
+
 StreamId stream_id_from_segment(
         DataType data_type,
         const SegmentInMemory& seg,
         position_t row_id,
         position_t column) {
     if (data_type == DataType::UINT64) {
-            auto num_id = seg.scalar_at<uint64_t>(row_id, column).value();
+            auto num_id = scalar_at<uint64_t>(seg, row_id, column);
             ARCTICDB_DEBUG(log::symbol(), "Reading numeric symbol {}", num_id);
             return safe_convert_to_numeric_id(num_id);
     } else {
-        auto sym = std::string(seg.string_at(row_id, column).value());
+        auto sym = string_at(seg, row_id, column);
         ARCTICDB_DEBUG(log::symbol(), "Reading string symbol '{}'", sym);
         return {std::move(sym)};
     }
@@ -183,8 +201,8 @@ std::vector<SymbolListEntry> read_new_style_list_from_storage(const SegmentInMem
 
     for(auto i = 0L; i < seg.column(0).row_count(); ++i) {
         auto stream_id = stream_id_from_segment(data_type, seg, i, 0);
-        auto reference_id = VersionId{seg.scalar_at<uint64_t>(i, 1).value()};
-        auto reference_time = timestamp{seg.scalar_at<int64_t>(i, 2).value()};
+        auto reference_id = VersionId{scalar_at<uint64_t>(seg, i, 1)};
+        auto reference_time = timestamp{scalar_at<int64_t>(seg, i, 2)};
         ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Reading added symbol {}: {}@{}", stream_id, reference_id, reference_time);
         output.emplace_back(stream_id, reference_id, reference_time, ActionType::ADD);
     }
@@ -195,8 +213,8 @@ std::vector<SymbolListEntry> read_new_style_list_from_storage(const SegmentInMem
 
         for (auto i = 0L; i < seg.column(3).row_count(); ++i) {
             auto stream_id = stream_id_from_segment(data_type, seg, i, 3);
-            auto reference_id = VersionId{seg.scalar_at<uint64_t>(i, 4).value()};
-            auto reference_time = timestamp{seg.scalar_at<int64_t>(i, 5).value()};
+            auto reference_id = VersionId{scalar_at<uint64_t>(seg, i, 4)};
+            auto reference_time = timestamp{scalar_at<int64_t>(seg, i, 5)};
             ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Reading deleted symbol {}: {}@{}", stream_id, reference_id, reference_time);
             output.emplace_back(stream_id, reference_id, reference_time, ActionType::DELETE);
         }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -888,8 +888,11 @@ void copy_frame_data_to_buffer(const SegmentInMemory& destination, size_t target
 
     auto type_promotion_error_msg = fmt::format("Can't promote type {} to type {} in field {}",
                                                 src_column.type(), dst_column.type(), destination.field(target_index).name());
-
-    if (trivially_compatible_types(src_column.type(), dst_column.type())) {
+    if (is_empty_type(src_column.type().data_type())) {
+        dst_column.type().visit_tag([&](auto dst_desc_tag) {
+            util::default_initialize<decltype(dst_desc_tag)>(dst_ptr, num_rows * dst_rawtype_size);
+        });
+    } else if (trivially_compatible_types(src_column.type(), dst_column.type())) {
         memcpy(dst_ptr, src_ptr, total_size);
     } else if (has_valid_type_promotion(src_column.type(), dst_column.type())) {
         dst_column.type().visit_tag([&src_ptr, &dst_ptr, &src_column, &type_promotion_error_msg, num_rows] (auto dest_desc_tag) {

--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -15,4 +15,4 @@ from arcticdb.version_store.library import StagedDataFinalizeMethod, WriteMetada
 
 set_config_from_env_vars(_os.environ)
 
-__version__ = "dev"
+__version__ = "4.4.0rc1"

--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -15,4 +15,4 @@ from arcticdb.version_store.library import StagedDataFinalizeMethod, WriteMetada
 
 set_config_from_env_vars(_os.environ)
 
-__version__ = "4.4.0rc2"
+__version__ = "4.4.0"

--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -15,4 +15,4 @@ from arcticdb.version_store.library import StagedDataFinalizeMethod, WriteMetada
 
 set_config_from_env_vars(_os.environ)
 
-__version__ = "4.4.0rc1"
+__version__ = "4.4.0rc2"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -467,6 +467,10 @@ def lmdb_version_store_big_map(version_store_factory):
 
 
 @pytest.fixture
+def lmdb_version_store_very_big_map(version_store_factory):
+    return version_store_factory(lmdb_config={"map_size": 2**35})
+
+@pytest.fixture
 def lmdb_version_store_column_buckets(version_store_factory):
     return version_store_factory(dynamic_schema=True, column_group_size=3, segment_row_size=2, bucketize_dynamic=True)
 

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -440,6 +440,15 @@ def test_write_batch_missing_keys_dedup(library_factory):
     assert_frame_equal(read_dataframe.data, df2)
 
 
+def test_delete_batch(library_factory, sym):
+    lib = library_factory(LibraryOptions(rows_per_segment=2))
+    df = pd.DataFrame({"y": np.arange(1000)})
+    lib.write(sym, df)
+    lib.delete(sym)
+    lib_tool = lib._nvs.library_tool()
+    assert not lib_tool.find_keys_for_id(KeyType.TABLE_DATA, sym)
+
+
 def test_append_batch(library_factory):
     lib = library_factory(LibraryOptions(rows_per_segment=10))
     assert lib._nvs._lib_cfg.lib_desc.version.write_options.segment_row_size == 10

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -1316,8 +1316,8 @@ def test_read_description_batch_empty_nat(arctic_library):
     requests = [ReadInfoRequest("sym_" + str(sym)) for sym in range(num_symbols)]
     results_list = lib.get_description_batch(requests)
     for sym in range(num_symbols):
-        assert np.isnat(results_list[sym].date_range[0]) == True
-        assert np.isnat(results_list[sym].date_range[1]) == True
+        assert np.isnat(results_list[sym].date_range[0])
+        assert np.isnat(results_list[sym].date_range[1])
 
 
 def test_read_batch_mixed_with_snapshots(arctic_library):

--- a/python/tests/integration/test_import.py
+++ b/python/tests/integration/test_import.py
@@ -1,0 +1,5 @@
+#import ray
+#import arcticdb
+
+def test_thing(lmdb_version_store):
+    lmdb_version_store.write("Hello", 23)

--- a/python/tests/stress/arcticdb/version_store/test_concurrent_read_and_write.py
+++ b/python/tests/stress/arcticdb/version_store/test_concurrent_read_and_write.py
@@ -1,0 +1,49 @@
+import time
+import pytest
+from multiprocessing import Process, Queue
+
+
+@pytest.fixture
+def writer_store(lmdb_version_store_delayed_deletes_v2):
+    return lmdb_version_store_delayed_deletes_v2
+
+
+@pytest.fixture
+def reader_store(lmdb_version_store_delayed_deletes_v2):
+    return lmdb_version_store_delayed_deletes_v2
+
+
+def read_repeatedly(version_store, queue: Queue):
+    while True:
+        try:
+            version_store.read("sym")
+        except Exception as e:
+            queue.put(e)
+            raise  # don't get stuck in the while loop when we already know there's an issue
+        time.sleep(0.1)
+
+
+def write_repeatedly(version_store):
+    while True:
+        version_store.write("sym", [1, 2, 3], prune_previous_version=True)
+        time.sleep(0.1)
+
+
+def test_concurrent_read_write(writer_store, reader_store):
+    """When using delayed deletes, a reader should always be able to read a symbol even if it is being modified
+    and pruned by another process."""
+    writer_store.write("sym", [1, 2, 3], prune_previous_version=True)
+    exceptions_in_reader = Queue()
+    reader = Process(target=read_repeatedly, args=(reader_store, exceptions_in_reader))
+    writer = Process(target=write_repeatedly, args=(writer_store,))
+
+    try:
+        reader.start()
+        writer.start()
+        reader.join(5)
+        writer.join(0.001)
+    finally:
+        writer.terminate()
+        reader.terminate()
+
+    assert exceptions_in_reader.empty()

--- a/python/tests/stress/arcticdb/version_store/test_large_df.py
+++ b/python/tests/stress/arcticdb/version_store/test_large_df.py
@@ -1,0 +1,57 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import datetime
+import random
+
+import numpy as np
+import pandas as pd
+
+from arcticdb.util.test import (
+    assert_frame_equal,
+    dataframe_for_date,
+    random_strings_of_length,
+    random_floats,
+    random_strings_of_length_with_nan,
+)
+
+def create_large_df(num_rows, start_time):
+    index = pd.date_range(start=start_time, periods=num_rows, freq='ns')
+    df = pd.DataFrame(data={"col": np.arange(num_rows, dtype=np.int8)}, index=index)
+    return df
+
+# We use map_size of at least 2**35 to allow storing 2**32 rows
+def test_write_large_df_in_chunks(lmdb_version_store_very_big_map):
+    symbol = "symbol"
+    lib = lmdb_version_store_very_big_map
+    chunk_size = 2**22
+    num_chunks = 2**10
+    start_time = pd.Timestamp(0)
+
+    lib.delete(symbol)
+    chunk = create_large_df(chunk_size, start_time)
+    lib.write(symbol, chunk)
+    del chunk
+
+    for i in range(num_chunks-1):
+        start_time = start_time + pd.Timedelta(chunk_size)
+        chunk = create_large_df(chunk_size, start_time)
+        lib.append(symbol, chunk)
+        del chunk
+
+    # Verify that number of rows is correct
+    assert(lib.get_num_rows(symbol) == chunk_size*num_chunks)
+
+    # Test that head works correctly
+    expected_head = create_large_df(5, datetime.datetime.utcfromtimestamp(0))
+    assert_frame_equal(lib.head(symbol).data, expected_head)
+
+    # Test that update works correctly
+    expected_head["col"] = np.array([7, 8, 9, 10, 11], dtype=np.int8)
+    lib.update(symbol, expected_head)
+    assert_frame_equal(lib.head(symbol).data, expected_head)
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     # conda-forge's package and feedstock browser.
     #
     # See: https://conda-forge.org/feedstock-outputs/
-    numpy
+    numpy <2 # To guard against numpy v2 when it gets released https://pythonspeed.com/articles/numpy-2/
     pandas
     attrs
     dataclasses ; python_version < '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = arcticdb
-version = 4.1.0.dev0
+version = 4.4.0rc1
 description = ArcticDB DataFrame Database
 author = Man Alpha Technology
 author_email = arcticdb@man.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = arcticdb
-version = 4.4.0rc1
+version = 4.4.0rc2
 description = ArcticDB DataFrame Database
 author = Man Alpha Technology
 author_email = arcticdb@man.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = arcticdb
-version = 4.4.0rc2
+version = 4.4.0
 description = ArcticDB DataFrame Database
 author = Man Alpha Technology
 author_email = arcticdb@man.com


### PR DESCRIPTION
adjust_slice_rowcounts is sometimes used when there are pre-existing rows, but sort_index is always over a whole timeseries so the first row should be zero