### PR TITLE
Sort index should always start from zero

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -832,7 +832,7 @@ if(${TEST})
             version/test/test_sorting_info_state_machine.cpp
             version/test/version_map_model.hpp
             storage/test/common.hpp
-    )
+            version/test/test_sort_index.cpp)
 
     set(EXECUTABLE_PERMS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE) # 755
 

--- a/cpp/arcticdb/column_store/test/test_index_filtering.cpp
+++ b/cpp/arcticdb/column_store/test/test_index_filtering.cpp
@@ -86,6 +86,7 @@ TEST(IndexFilter, Static) {
     for (auto &slice_and_key : slice_and_keys) {
         writer.add(slice_and_key.key(), slice_and_key.slice());
     }
+
     auto key_fut = writer.commit();
     auto key = std::move(key_fut).get();
     auto seg = mock_store->read(key, storage::ReadKeyOpts{}).get();

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -98,12 +98,12 @@ void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& p
     pipeline_context->total_rows_ = adjust_slice_rowcounts(pipeline_context->slice_and_keys_);
 }
 
-size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys) {
+size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row) {
     using namespace arcticdb::pipelines;
     if(slice_and_keys.empty())
 		return 0u;
-	
-	auto offset = slice_and_keys[0].slice_.row_range.first;
+
+    auto offset = first_row.value_or(slice_and_keys[0].slice_.row_range.first);
 	auto diff = slice_and_keys[0].slice_.row_range.diff();
     auto col_begin = slice_and_keys[0].slice_.col_range.first;
 	

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -300,7 +300,7 @@ struct PipelineContext;
 }
 
 size_t adjust_slice_rowcounts(
-    std::vector<pipelines::SliceAndKey> & slice_and_keys);
+    std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row = std::nullopt);
 
 void adjust_slice_rowcounts(
     const std::shared_ptr<pipelines::PipelineContext>& pipeline_context);

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -54,12 +54,10 @@ class LocalVersionedEngine : public VersionedEngine {
 public:
     LocalVersionedEngine() = default;
 
-    template<class ClockType = util::SysClock>
+    template<class ClockType=util::SysClock>
     explicit LocalVersionedEngine(
         const std::shared_ptr<storage::Library>& library,
         const ClockType& = ClockType{});
-
-
 
     virtual ~LocalVersionedEngine() = default;
 
@@ -394,6 +392,15 @@ public:
     void _test_set_store(std::shared_ptr<Store> store);
     std::shared_ptr<VersionMap> _test_get_version_map();
 
+
+    template<typename ClockType>
+    static LocalVersionedEngine _test_init_from_store(
+        const std::shared_ptr<Store>& store,
+        const ClockType& clock
+    ) {
+        return LocalVersionedEngine(store, clock);
+    }
+
     /** Get the time used by the Store (e.g. that would be used in the AtomKey).
         For testing purposes only. */
     entity::timestamp get_store_current_timestamp_for_tests() {
@@ -443,8 +450,14 @@ protected:
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries);
 
+
 private:
     void initialize(const std::shared_ptr<storage::Library>& library);
+
+    template<class ClockType=util::SysClock>
+    explicit LocalVersionedEngine(
+        const std::shared_ptr<Store>& store,
+        const ClockType& = ClockType{});
 
     std::shared_ptr<Store> store_;
     arcticdb::proto::storage::VersionStoreConfig cfg_;

--- a/cpp/arcticdb/version/test/test_sort_index.cpp
+++ b/cpp/arcticdb/version/test/test_sort_index.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+#include <arcticdb/entity/atom_key.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/pipeline_common.hpp>
+#include <arcticdb/pipeline/index_writer.hpp>
+#include "storage/test/in_memory_store.hpp"
+
+TEST(SortIndex, Basic) {
+    using namespace arcticdb;
+    using namespace arcticdb::entity;
+    using namespace arcticdb::pipelines;
+
+    std::vector<SliceAndKey> keys_and_slices;
+    StreamId stream_id{"sort_index"};
+
+    for(auto i = 0; i < 20; ++i) {
+        auto key = atom_key_builder().start_index(i).end_index(i+1).creation_ts(i).build<KeyType::TABLE_DATA>(stream_id);
+        FrameSlice slice{ColRange{0, 5}, RowRange{i, i+1}};
+        keys_and_slices.emplace_back(SliceAndKey{slice, key});
+    }
+
+    auto copy = keys_and_slices;
+    std::random_shuffle(std::begin(keys_and_slices), std::end(keys_and_slices));
+    const auto version_id = VersionId{0};
+
+    const IndexPartialKey& partial_key{stream_id, version_id};
+    auto mock_store = std::make_shared<InMemoryStore>();
+    auto desc = stream_descriptor(stream_id, stream::RowCountIndex(), {scalar_field(DataType::UTF_DYNAMIC64, "col_1")});
+    TimeseriesDescriptor timeseries_desc;
+    timeseries_desc.set_stream_descriptor(desc);
+    index::IndexWriter<stream::RowCountIndex> index_writer(mock_store, partial_key, std::move(timeseries_desc));
+    for(const auto& [maybe_seg, slice, key] : keys_and_slices)
+        index_writer.add_unchecked(*key, slice);
+
+    auto key_fut = index_writer.commit();
+    auto index_key = std::move(key_fut).get();
+    VersionMap version_map;
+    version_map.write_version(mock_store, index_key, std::nullopt);
+
+    auto engine = version_store::LocalVersionedEngine::_test_init_from_store(mock_store, util::SysClock{});
+    auto versioned_item = engine.sort_index(stream_id, false);
+
+    auto seg = mock_store->read(versioned_item.key_, storage::ReadKeyOpts{}).get();
+    pipelines::index::IndexSegmentReader isr{std::move(seg.second)};
+    auto vec = unfiltered_index(isr);
+
+    ASSERT_EQ(vec, copy);
+}
+
+TEST(SortIndex, Nonzero) {
+    using namespace arcticdb;
+    using namespace arcticdb::entity;
+    using namespace arcticdb::pipelines;
+
+    std::vector<SliceAndKey> keys_and_slices;
+    StreamId stream_id{"sort_index_non_zero"};
+
+    for(auto i = 0; i < 20; ++i) {
+        auto key = atom_key_builder().start_index(i).end_index(i+1).creation_ts(i).build<KeyType::TABLE_DATA>(stream_id);
+        FrameSlice slice{ColRange{0, 5}, RowRange{i+5, i+6}};
+        keys_and_slices.emplace_back(SliceAndKey{slice, key});
+    }
+
+    std::random_shuffle(std::begin(keys_and_slices), std::end(keys_and_slices));
+    const auto version_id = VersionId{0};
+
+    const IndexPartialKey& partial_key{stream_id, version_id};
+    auto mock_store = std::make_shared<InMemoryStore>();
+    auto desc = stream_descriptor(stream_id, stream::RowCountIndex(), {scalar_field(DataType::UTF_DYNAMIC64, "col_1")});
+    TimeseriesDescriptor timeseries_desc;
+    timeseries_desc.set_stream_descriptor(desc);
+    index::IndexWriter<stream::RowCountIndex> index_writer(mock_store, partial_key, std::move(timeseries_desc));
+    for(const auto& [maybe_seg, slice, key] : keys_and_slices)
+        index_writer.add_unchecked(*key, slice);
+
+    auto key_fut = index_writer.commit();
+    auto index_key = std::move(key_fut).get();
+    VersionMap version_map;
+    version_map.write_version(mock_store, index_key, std::nullopt);
+
+    auto engine = version_store::LocalVersionedEngine::_test_init_from_store(mock_store, util::SysClock{});
+    auto versioned_item = engine.sort_index(stream_id, false);
+
+    auto seg = mock_store->read(versioned_item.key_, storage::ReadKeyOpts{}).get();
+    pipelines::index::IndexSegmentReader isr{std::move(seg.second)};
+    auto vec = unfiltered_index(isr);
+
+    std::vector<SliceAndKey> expected;
+
+    for(auto i = 0; i < 20; ++i) {
+        auto key = atom_key_builder().start_index(i).end_index(i+1).creation_ts(i).build<KeyType::TABLE_DATA>(stream_id);
+        FrameSlice slice{ColRange{0, 5}, RowRange{i, i+1}};
+        expected.emplace_back(SliceAndKey{slice, key});
+    }
+
+    ASSERT_EQ(vec, expected);
+}

--- a/cpp/arcticdb/version/test/test_sort_index.cpp
+++ b/cpp/arcticdb/version/test/test_sort_index.cpp
@@ -21,7 +21,9 @@ TEST(SortIndex, Basic) {
     }
 
     auto copy = keys_and_slices;
-    std::random_shuffle(std::begin(keys_and_slices), std::end(keys_and_slices));
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(std::begin(keys_and_slices), std::end(keys_and_slices), g);
     const auto version_id = VersionId{0};
 
     const IndexPartialKey& partial_key{stream_id, version_id};
@@ -62,7 +64,9 @@ TEST(SortIndex, Nonzero) {
         keys_and_slices.emplace_back(SliceAndKey{slice, key});
     }
 
-    std::random_shuffle(std::begin(keys_and_slices), std::end(keys_and_slices));
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(std::begin(keys_and_slices), std::end(keys_and_slices), g);
     const auto version_id = VersionId{0};
 
     const IndexPartialKey& partial_key{stream_id, version_id};


### PR DESCRIPTION
adjust_slice_rowcounts can handle preceding rows, but when it's used in sort_index it should always start from zero as it's always running over the whole timeseries