### PR TITLE
Correctly hash descriptor in segment header

### DIFF
--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -89,8 +89,8 @@ struct EncodeAtomTask : BaseTask {
         ARCTICDB_DEBUG(log::codec(), "Encoding object with partial key {}", partial_key_);
         auto enc_seg = ::arcticdb::encode_dispatch(std::move(segment_), *codec_meta_, encoding_version_);
         auto content_hash = hash_segment_data(enc_seg.header(), enc_seg.fields_ptr());
-
         AtomKey k = partial_key_.build_key(creation_ts_, content_hash);
+        log::version().info("Got hash {} for key {}", content_hash, k);
         return {std::move(k), std::move(enc_seg)};
     }
 

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -90,7 +90,7 @@ struct EncodeAtomTask : BaseTask {
         auto enc_seg = ::arcticdb::encode_dispatch(std::move(segment_), *codec_meta_, encoding_version_);
         auto content_hash = hash_segment_data(enc_seg.header(), enc_seg.fields_ptr());
         AtomKey k = partial_key_.build_key(creation_ts_, content_hash);
-        log::version().info("Got hash {} for key {}", content_hash, k);
+        ARCTICDB_DEBUG(log::codec(), "Got hash {} for key {}", content_hash, k);
         return {std::move(k), std::move(enc_seg)};
     }
 

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -88,7 +88,7 @@ struct EncodeAtomTask : BaseTask {
     storage::KeySegmentPair encode() {
         ARCTICDB_DEBUG(log::codec(), "Encoding object with partial key {}", partial_key_);
         auto enc_seg = ::arcticdb::encode_dispatch(std::move(segment_), *codec_meta_, encoding_version_);
-        auto content_hash = hash_segment_header(enc_seg.header());
+        auto content_hash = hash_segment_data(enc_seg.header(), enc_seg.fields_ptr());
 
         AtomKey k = partial_key_.build_key(creation_ts_, content_hash);
         return {std::move(k), std::move(enc_seg)};

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -535,7 +535,7 @@ static void hash_field(const arcticdb::proto::encoding::EncodedField &field, Has
     }
 }
 
-HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hdr, const std::shared_ptr<FieldCollection>& fields) {
+HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hdr, const std::shared_ptr<FieldCollection>& /*fields*/) {
     HashAccum accum;
     if (hdr.has_metadata_field()) {
         hash_field(hdr.metadata_field(), accum);

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -546,9 +546,9 @@ HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hd
     if(hdr.has_string_pool_field()) {
         hash_field(hdr.string_pool_field(), accum);
     }
-    if(fields && !fields->empty()) {
-        hash_buffer(fields->buffer(), accum);
-    }
+   // if(fields && !fields->empty()) {
+   //     hash_buffer(fields->buffer(), accum);
+   // }
     return accum.digest();
 }
 

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -535,7 +535,7 @@ static void hash_field(const arcticdb::proto::encoding::EncodedField &field, Has
     }
 }
 
-HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hdr, const std::shared_ptr<FieldCollection>& /*fields*/) {
+HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hdr, const std::shared_ptr<FieldCollection>& fields) {
     HashAccum accum;
     if (hdr.has_metadata_field()) {
         hash_field(hdr.metadata_field(), accum);
@@ -546,9 +546,9 @@ HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hd
     if(hdr.has_string_pool_field()) {
         hash_field(hdr.string_pool_field(), accum);
     }
-   // if(fields && !fields->empty()) {
-   //     hash_buffer(fields->buffer(), accum);
-   // }
+    if(fields && !fields->empty()) {
+        hash_buffer(fields->buffer(), accum);
+    }
     return accum.digest();
 }
 

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -535,11 +535,8 @@ static void hash_field(const arcticdb::proto::encoding::EncodedField &field, Has
     }
 }
 
-HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader &hdr) {
+HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hdr, const std::shared_ptr<FieldCollection>& fields) {
     HashAccum accum;
-    if(hdr.has_descriptor_field()) {
-        hash_field(hdr.descriptor_field(), accum);
-    }
     if (hdr.has_metadata_field()) {
         hash_field(hdr.metadata_field(), accum);
     }
@@ -548,6 +545,9 @@ HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader &
     }
     if(hdr.has_string_pool_field()) {
         hash_field(hdr.string_pool_field(), accum);
+    }
+    if(fields && !fields->empty()) {
+        hash_buffer(fields->buffer(), accum);
     }
     return accum.digest();
 }

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -537,6 +537,9 @@ static void hash_field(const arcticdb::proto::encoding::EncodedField &field, Has
 
 HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader &hdr) {
     HashAccum accum;
+    if(hdr.has_descriptor_field()) {
+        hash_field(hdr.descriptor_field(), accum);
+    }
     if (hdr.has_metadata_field()) {
         hash_field(hdr.metadata_field(), accum);
     }

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -63,7 +63,7 @@ std::optional<std::tuple<google::protobuf::Any, arcticdb::proto::descriptors::Ti
 decode_timeseries_descriptor_for_incompletes(
         Segment& segment);
 
-HashedValue hash_segment_header(const arcticdb::proto::encoding::SegmentHeader &hdr);
+HashedValue hash_segment_data(const arcticdb::proto::encoding::SegmentHeader &hdr, const std::shared_ptr<FieldCollection>& fields);
 } // namespace arcticdb
 
 #define ARCTICDB_SEGMENT_ENCODER_H_

--- a/cpp/arcticdb/codec/encode_v1.cpp
+++ b/cpp/arcticdb/codec/encode_v1.cpp
@@ -158,6 +158,7 @@ namespace arcticdb {
         ARCTICDB_DEBUG(log::codec(), "Block count {} header size {} ratio {}",
             in_mem_seg.num_blocks(), segment_header->ByteSizeLong(),
             in_mem_seg.num_blocks() ? segment_header->ByteSizeLong() / in_mem_seg.num_blocks() : 0);
+        util::check(segment_header->has_stream_descriptor(), "Expected stream descriptor field");
         return {std::move(arena), segment_header, std::move(out_buffer), in_mem_seg.descriptor().fields_ptr()};
     }
 }

--- a/cpp/arcticdb/codec/test/test_codec.cpp
+++ b/cpp/arcticdb/codec/test/test_codec.cpp
@@ -525,7 +525,7 @@ TEST(Segment, ColumnNamesProduceDifferentHashes) {
         scalar_field(DataType::UINT8, "ints10")
     });
 
-    SegmentInMemory in_mem_seg_2{stream_desc_1.clone()};
+    SegmentInMemory in_mem_seg_2{stream_desc_2.clone()};
 
     in_mem_seg_2.set_scalar(0, uint8_t(0));
     in_mem_seg_2.set_scalar(1, uint8_t(0));
@@ -537,8 +537,8 @@ TEST(Segment, ColumnNamesProduceDifferentHashes) {
     auto seg_1 = encode_dispatch(std::move(in_mem_seg_1), codec::default_lz4_codec(), EncodingVersion::V1);
     auto seg_2 = encode_dispatch(std::move(in_mem_seg_2), codec::default_lz4_codec(), EncodingVersion::V1);
 
-    auto hash_1 = hash_segment_header(seg_1.header());
-    auto hash_2 = hash_segment_header(seg_2.header());
+    auto hash_1 = hash_segment_data(seg_1.header(), seg_1.fields_ptr());
+    auto hash_2 = hash_segment_data(seg_2.header(), seg_2.fields_ptr());
 
     ASSERT_NE(hash_1, hash_2);
 }
@@ -562,13 +562,13 @@ TEST(Segment, ColumnNamesProduceDifferentHashesEmpty) {
         scalar_field(DataType::UINT8, "ints10")
     });
 
-    SegmentInMemory in_mem_seg_2{stream_desc_1.clone()};
+    SegmentInMemory in_mem_seg_2{stream_desc_2.clone()};
 
     auto seg_1 = encode_dispatch(std::move(in_mem_seg_1), codec::default_lz4_codec(), EncodingVersion::V1);
     auto seg_2 = encode_dispatch(std::move(in_mem_seg_2), codec::default_lz4_codec(), EncodingVersion::V1);
 
-    auto hash_1 = hash_segment_header(seg_1.header());
-    auto hash_2 = hash_segment_header(seg_2.header());
+    auto hash_1 = hash_segment_data(seg_1.header(), seg_1.fields_ptr());
+    auto hash_2 = hash_segment_data(seg_2.header(), seg_2.fields_ptr());
 
     ASSERT_NE(hash_1, hash_2);
 }

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -429,10 +429,9 @@ std::vector<ChunkedBufferImpl<BlockSize>> split(const ChunkedBufferImpl<BlockSiz
 template <size_t BlockSize>
 ChunkedBufferImpl<BlockSize> truncate(const ChunkedBufferImpl<BlockSize>& input, size_t start_byte, size_t end_byte);
 
-inline HashedValue hash_buffer(const ChunkedBuffer& buffer, HashAccum& accum) {
+inline void hash_buffer(const ChunkedBuffer& buffer, HashAccum& accum) {
     for(const auto& block : buffer.blocks()) {
         accum(block->data(), block->bytes());
     }
-    return accum.digest();
 }
 }

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -13,7 +13,7 @@
 #include <arcticdb/util/allocator.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/column_store/block.hpp>
-
+#include <arcticdb/util/hash.hpp>
 #include <boost/container/small_vector.hpp>
 
 #include <cstdint>
@@ -428,4 +428,11 @@ std::vector<ChunkedBufferImpl<BlockSize>> split(const ChunkedBufferImpl<BlockSiz
 
 template <size_t BlockSize>
 ChunkedBufferImpl<BlockSize> truncate(const ChunkedBufferImpl<BlockSize>& input, size_t start_byte, size_t end_byte);
+
+inline HashedValue hash_buffer(const ChunkedBuffer& buffer, HashAccum& accum) {
+    for(const auto& block : buffer.blocks()) {
+        accum(block->data(), block->bytes());
+    }
+    return accum.digest();
+}
 }

--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -334,6 +334,7 @@ public:
     }
 
     ChunkedBuffer &buffer()  {
+        util::check(data_ != nullptr, "Got null buffer in column data");
         return *const_cast<ChunkedBuffer*>(data_);
     }
 

--- a/cpp/arcticdb/entity/field_collection.hpp
+++ b/cpp/arcticdb/entity/field_collection.hpp
@@ -179,6 +179,10 @@ public:
         return {&buffer_.buffer(), &shapes_.buffer(), type_, nullptr};
     }
 
+    const ChunkedBuffer& buffer() const {
+        return buffer_.buffer();
+    }
+
     const Field& operator[](size_t pos) const {
         return at(pos);
     }

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -22,7 +22,6 @@ struct StreamDescriptor {
 
     std::shared_ptr<Proto> data_ = std::make_shared<Proto>();
     std::shared_ptr<FieldCollection> fields_ = std::make_shared<FieldCollection>();
-    ;
 
     StreamDescriptor() = default;
     ~StreamDescriptor() = default;

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -530,6 +530,8 @@ struct FieldRef {
     }
 };
 
+#pragma pack(push)
+#pragma pack(1)
 struct Field {
     uint32_t size_ = 0;
     TypeDescriptor type_;
@@ -578,6 +580,7 @@ public:
     void set(TypeDescriptor type, std::string_view name) {
         type_ = type;
         size_ = name.size();
+        name_[1] = 0;
         memcpy(name_, name.data(), size_);
     }
 
@@ -593,6 +596,7 @@ public:
         return lt < rt;
     }
 };
+#pragma pack(pop)
 
 struct FieldWrapper {
     std::vector<uint8_t> data_;

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -530,7 +530,6 @@ struct FieldRef {
     }
 };
 
-
 struct Field {
     uint32_t size_ = 0;
     TypeDescriptor type_;
@@ -538,8 +537,6 @@ struct Field {
     char name_[NameSize] = {};
 
     ARCTICDB_NO_MOVE_OR_COPY(Field)
-
-
 
 private:
     explicit Field(const FieldRef& ref) {

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -1128,6 +1128,7 @@ struct ReduceColumnTask : async::BaseTask {
             }
             if (is_sequence_type(field_type)) {
                 auto string_reducer = get_string_reducer(column, context_, frame_, frame_field, *slice_map_, unique_string_map_, py_nan_, lock_, do_lock_);
+                util::check(column_data != std::end(slice_map_->columns_), "Failed to find mapping for field {}", frame_field.name());
                 for (const auto &row : column_data->second) {
                     PipelineContextRow context_row{context_, row.second.context_index_};
                     if(context_row.slice_and_key().slice().row_range.diff() > 0)


### PR DESCRIPTION
For some reason we are still not hashing the column descriptors, which leads to incorrect deduplication. Fix this once and for all