### PR TITLE
Release GIL when using recursive normalizers

### DIFF
--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -562,6 +562,7 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     bool prune_previous_versions
     ) {
     ARCTICDB_SAMPLE(WriteVersionedMultiKey, 0)
+    py::gil_scoped_release release_gil;
 
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_composite_data");
     auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id, VersionQuery{});

--- a/python/tests/integration/arcticdb/blns.txt
+++ b/python/tests/integration/arcticdb/blns.txt
@@ -1,0 +1,742 @@
+#	Reserved Strings
+#
+#	Strings which may be used elsewhere in code
+
+undefined
+undef
+null
+NULL
+(null)
+nil
+NIL
+true
+false
+True
+False
+TRUE
+FALSE
+None
+hasOwnProperty
+then
+constructor
+\
+\\
+
+#	Numeric Strings
+#
+#	Strings which can be interpreted as numeric
+
+0
+1
+1.00
+$1.00
+1/2
+1E2
+1E02
+1E+02
+-1
+-1.00
+-$1.00
+-1/2
+-1E2
+-1E02
+-1E+02
+1/0
+0/0
+-2147483648/-1
+-9223372036854775808/-1
+-0
+-0.0
++0
++0.0
+0.00
+0..0
+.
+0.0.0
+0,00
+0,,0
+,
+0,0,0
+0.0/0
+1.0/0.0
+0.0/0.0
+1,0/0,0
+0,0/0,0
+--1
+-
+-.
+-,
+999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+NaN
+Infinity
+-Infinity
+INF
+1#INF
+-1#IND
+1#QNAN
+1#SNAN
+1#IND
+0x0
+0xffffffff
+0xffffffffffffffff
+0xabad1dea
+123456789012345678901234567890123456789
+1,000.00
+1 000.00
+1'000.00
+1,000,000.00
+1 000 000.00
+1'000'000.00
+1.000,00
+1 000,00
+1'000,00
+1.000.000,00
+1 000 000,00
+1'000'000,00
+01000
+08
+09
+2.2250738585072011e-308
+
+#	Special Characters
+#
+# ASCII punctuation.  All of these characters may need to be escaped in some
+# contexts.  Divided into three groups based on (US-layout) keyboard position.
+
+,./;'[]\-=
+<>?:"{}|_+
+!@#$%^&*()`~
+
+# Non-whitespace C0 controls: U+0001 through U+0008, U+000E through U+001F,
+# and U+007F (DEL)
+# Often forbidden to appear in various text-based file formats (e.g. XML),
+# or reused for internal delimiters on the theory that they should never
+# appear in input.
+# The next line may appear to be blank or mojibake in some viewers.
+
+
+# Non-whitespace C1 controls: U+0080 through U+0084 and U+0086 through U+009F.
+# Commonly misinterpreted as additional graphic characters.
+# The next line may appear to be blank, mojibake, or dingbats in some viewers.
+
+
+# Whitespace: all of the characters with category Zs, Zl, or Zp (in Unicode
+# version 8.0.0), plus U+0009 (HT), U+000B (VT), U+000C (FF), U+0085 (NEL),
+# and U+200B (ZERO WIDTH SPACE), which are in the C categories but are often
+# treated as whitespace in some contexts.
+# This file unfortunately cannot express strings containing
+# U+0000, U+000A, or U+000D (NUL, LF, CR).
+# The next line may appear to be blank or mojibake in some viewers.
+# The next line may be flagged for "trailing whitespace" in some viewers.
+	              ​    　
+
+# Unicode additional control characters: all of the characters with
+# general category Cf (in Unicode 8.0.0).
+# The next line may appear to be blank or mojibake in some viewers.
+­؀؁؂؃؄؅؜۝܏᠎​‌‍‎‏‪‫‬‭‮⁠⁡⁢⁣⁤⁦⁧⁨⁩⁪⁫⁬⁭⁮⁯﻿￹￺￻𑂽𛲠𛲡𛲢𛲣𝅳𝅴𝅵𝅶𝅷𝅸𝅹𝅺󠀁󠀠󠀡󠀢󠀣󠀤󠀥󠀦󠀧󠀨󠀩󠀪󠀫󠀬󠀭󠀮󠀯󠀰󠀱󠀲󠀳󠀴󠀵󠀶󠀷󠀸󠀹󠀺󠀻󠀼󠀽󠀾󠀿󠁀󠁁󠁂󠁃󠁄󠁅󠁆󠁇󠁈󠁉󠁊󠁋󠁌󠁍󠁎󠁏󠁐󠁑󠁒󠁓󠁔󠁕󠁖󠁗󠁘󠁙󠁚󠁛󠁜󠁝󠁞󠁟󠁠󠁡󠁢󠁣󠁤󠁥󠁦󠁧󠁨󠁩󠁪󠁫󠁬󠁭󠁮󠁯󠁰󠁱󠁲󠁳󠁴󠁵󠁶󠁷󠁸󠁹󠁺󠁻󠁼󠁽󠁾󠁿
+
+# "Byte order marks", U+FEFF and U+FFFE, each on its own line.
+# The next two lines may appear to be blank or mojibake in some viewers.
+﻿
+￾
+
+#	Unicode Symbols
+#
+#	Strings which contain common unicode symbols (e.g. smart quotes)
+
+Ω≈ç√∫˜µ≤≥÷
+åß∂ƒ©˙∆˚¬…æ
+œ∑´®†¥¨ˆøπ“‘
+¡™£¢∞§¶•ªº–≠
+¸˛Ç◊ı˜Â¯˘¿
+ÅÍÎÏ˝ÓÔÒÚÆ☃
+Œ„´‰ˇÁ¨ˆØ∏”’
+`⁄€‹›ﬁﬂ‡°·‚—±
+⅛⅜⅝⅞
+ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя
+٠١٢٣٤٥٦٧٨٩
+
+#	Unicode Subscript/Superscript/Accents
+#
+#	Strings which contain unicode subscripts/superscripts; can cause rendering issues
+
+⁰⁴⁵
+₀₁₂
+⁰⁴⁵₀₁₂
+ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็
+
+#	Quotation Marks
+#
+#	Strings which contain misplaced quotation marks; can cause encoding errors
+
+'
+"
+''
+""
+'"'
+"''''"'"
+"'"'"''''"
+<foo val=“bar” />
+<foo val=“bar” />
+<foo val=”bar“ />
+<foo val=`bar' />
+
+#	Two-Byte Characters
+#
+#	Strings which contain two-byte characters: can cause rendering issues or character-length issues
+
+田中さんにあげて下さい
+パーティーへ行かないか
+和製漢語
+部落格
+사회과학원 어학연구소
+찦차를 타고 온 펲시맨과 쑛다리 똠방각하
+社會科學院語學研究所
+울란바토르
+𠜎𠜱𠝹𠱓𠱸𠲖𠳏
+
+#	Strings which contain two-byte letters: can cause issues with naïve UTF-16 capitalizers which think that 16 bits == 1 character
+
+𐐜 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐙𐐊𐐡𐐝𐐓/𐐝𐐇𐐗𐐊𐐤𐐔 𐐒𐐋𐐗 𐐒𐐌 𐐜 𐐡𐐀𐐖𐐇𐐤𐐓𐐝 𐐱𐑂 𐑄 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐏𐐆𐐅𐐤𐐆𐐚𐐊𐐡𐐝𐐆𐐓𐐆
+
+#	Special Unicode Characters Union
+#
+#	A super string recommended by VMware Inc. Globalization Team: can effectively cause rendering issues or character-length issues to validate product globalization readiness.
+#
+#	表          CJK_UNIFIED_IDEOGRAPHS (U+8868)
+#	ポ          KATAKANA LETTER PO (U+30DD)
+#	あ          HIRAGANA LETTER A (U+3042)
+#	A           LATIN CAPITAL LETTER A (U+0041)
+#	鷗          CJK_UNIFIED_IDEOGRAPHS (U+9DD7)
+#	Œ           LATIN SMALL LIGATURE OE (U+0153) 
+#	é           LATIN SMALL LETTER E WITH ACUTE (U+00E9)
+#	Ｂ           FULLWIDTH LATIN CAPITAL LETTER B (U+FF22)
+#	逍          CJK_UNIFIED_IDEOGRAPHS (U+900D)
+#	Ü           LATIN SMALL LETTER U WITH DIAERESIS (U+00FC)
+#	ß           LATIN SMALL LETTER SHARP S (U+00DF)
+#	ª           FEMININE ORDINAL INDICATOR (U+00AA)
+#	ą           LATIN SMALL LETTER A WITH OGONEK (U+0105)
+#	ñ           LATIN SMALL LETTER N WITH TILDE (U+00F1)
+#	丂          CJK_UNIFIED_IDEOGRAPHS (U+4E02)
+#	㐀          CJK Ideograph Extension A, First (U+3400)
+#	𠀀          CJK Ideograph Extension B, First (U+20000)
+
+表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀
+
+#	Changing length when lowercased
+#
+#	Characters which increase in length (2 to 3 bytes) when lowercased
+#	Credit: https://twitter.com/jifa/status/625776454479970304
+
+Ⱥ
+Ⱦ
+
+#	Japanese Emoticons
+#
+#	Strings which consists of Japanese-style emoticons which are popular on the web
+
+ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ
+(｡◕ ∀ ◕｡)
+｀ｨ(´∀｀∩
+__ﾛ(,_,*)
+・(￣∀￣)・:*:
+ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ
+,。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’
+(╯°□°）╯︵ ┻━┻)
+(ﾉಥ益ಥ）ﾉ﻿ ┻━┻
+┬─┬ノ( º _ ºノ)
+( ͡° ͜ʖ ͡°)
+¯\_(ツ)_/¯
+
+#	Emoji
+#
+#	Strings which contain Emoji; should be the same behavior as two-byte characters, but not always
+
+😍
+👩🏽
+👨‍🦰 👨🏿‍🦰 👨‍🦱 👨🏿‍🦱 🦹🏿‍♂️
+👾 🙇 💁 🙅 🙆 🙋 🙎 🙍
+🐵 🙈 🙉 🙊
+❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙
+✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿
+👨‍👩‍👦 👨‍👩‍👧‍👦 👨‍👨‍👦 👩‍👩‍👧 👨‍👦 👨‍👧‍👦 👩‍👦 👩‍👧‍👦
+🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧
+0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟
+
+#       Regional Indicator Symbols
+#
+#       Regional Indicator Symbols can be displayed differently across
+#       fonts, and have a number of special behaviors
+
+🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸
+🇺🇸🇷🇺🇸🇦🇫🇦🇲
+🇺🇸🇷🇺🇸🇦
+
+#	Unicode Numbers
+#
+#	Strings which contain unicode numbers; if the code is localized, it should see the input as numeric
+
+１２３
+١٢٣
+
+#	Right-To-Left Strings
+#
+#	Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)
+
+ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو.
+בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ
+הָיְתָהtestالصفحات التّحول
+﷽
+ﷺ
+مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،
+الكل في المجمو عة (5)
+
+#	Ogham Text
+#
+#	The only unicode alphabet to use a space which isn't empty but should still act like a space.
+
+᚛ᚄᚓᚐᚋᚒᚄ ᚑᚄᚂᚑᚏᚅ᚜
+᚛                 ᚜
+
+#	Trick Unicode
+#
+#	Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)
+
+‪‪test‪
+‫test‫
+ test 
+test⁠test‫
+⁦test⁧
+
+#	Zalgo Text
+#
+#	Strings which contain "corrupted" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)
+
+Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣
+̡͓̞ͅI̗̘̦͝n͇͇͙v̮̫ok̲̫̙͈i̖͙̭̹̠̞n̡̻̮̣̺g̲͈͙̭͙̬͎ ̰t͔̦h̞̲e̢̤ ͍̬̲͖f̴̘͕̣è͖ẹ̥̩l͖͔͚i͓͚̦͠n͖͍̗͓̳̮g͍ ̨o͚̪͡f̘̣̬ ̖̘͖̟͙̮c҉͔̫͖͓͇͖ͅh̵̤̣͚͔á̗̼͕ͅo̼̣̥s̱͈̺̖̦̻͢.̛̖̞̠̫̰
+̗̺͖̹̯͓Ṯ̤͍̥͇͈h̲́e͏͓̼̗̙̼̣͔ ͇̜̱̠͓͍ͅN͕͠e̗̱z̘̝̜̺͙p̤̺̹͍̯͚e̠̻̠͜r̨̤͍̺̖͔̖̖d̠̟̭̬̝͟i̦͖̩͓͔̤a̠̗̬͉̙n͚͜ ̻̞̰͚ͅh̵͉i̳̞v̢͇ḙ͎͟-҉̭̩̼͔m̤̭̫i͕͇̝̦n̗͙ḍ̟ ̯̲͕͞ǫ̟̯̰̲͙̻̝f ̪̰̰̗̖̭̘͘c̦͍̲̞͍̩̙ḥ͚a̮͎̟̙͜ơ̩̹͎s̤.̝̝ ҉Z̡̖̜͖̰̣͉̜a͖̰͙̬͡l̲̫̳͍̩g̡̟̼̱͚̞̬ͅo̗͜.̟
+̦H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕
+Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮
+
+#	Unicode Upsidedown
+#
+#	Strings which contain unicode with an "upsidedown" effect (via http://www.upsidedowntext.com)
+
+˙ɐnbᴉlɐ ɐuƃɐɯ ǝɹolop ʇǝ ǝɹoqɐl ʇn ʇunpᴉpᴉɔuᴉ ɹodɯǝʇ poɯsnᴉǝ op pǝs 'ʇᴉlǝ ƃuᴉɔsᴉdᴉpɐ ɹnʇǝʇɔǝsuoɔ 'ʇǝɯɐ ʇᴉs ɹolop ɯnsdᴉ ɯǝɹo˥
+00˙Ɩ$-
+
+#	Unicode font
+#
+#	Strings which contain bold/italic/etc. versions of normal characters
+
+Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ
+𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠
+𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌
+𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈
+𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰
+𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘
+𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐
+⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢
+
+#	Script Injection
+#
+#	Strings which attempt to invoke a benign script injection; shows vulnerability to XSS
+
+<script>alert(0)</script>
+&lt;script&gt;alert(&#39;1&#39;);&lt;/script&gt;
+<img src=x onerror=alert(2) />
+<svg><script>123<1>alert(3)</script>
+"><script>alert(4)</script>
+'><script>alert(5)</script>
+><script>alert(6)</script>
+</script><script>alert(7)</script>
+< / script >< script >alert(8)< / script >
+ onfocus=JaVaSCript:alert(9) autofocus
+" onfocus=JaVaSCript:alert(10) autofocus
+' onfocus=JaVaSCript:alert(11) autofocus
+＜script＞alert(12)＜/script＞
+<sc<script>ript>alert(13)</sc</script>ript>
+--><script>alert(14)</script>
+";alert(15);t="
+';alert(16);t='
+JavaSCript:alert(17)
+;alert(18);
+src=JaVaSCript:prompt(19)
+"><script>alert(20);</script x="
+'><script>alert(21);</script x='
+><script>alert(22);</script x=
+" autofocus onkeyup="javascript:alert(23)
+' autofocus onkeyup='javascript:alert(24)
+<script\x20type="text/javascript">javascript:alert(25);</script>
+<script\x3Etype="text/javascript">javascript:alert(26);</script>
+<script\x0Dtype="text/javascript">javascript:alert(27);</script>
+<script\x09type="text/javascript">javascript:alert(28);</script>
+<script\x0Ctype="text/javascript">javascript:alert(29);</script>
+<script\x2Ftype="text/javascript">javascript:alert(30);</script>
+<script\x0Atype="text/javascript">javascript:alert(31);</script>
+'`"><\x3Cscript>javascript:alert(32)</script>
+'`"><\x00script>javascript:alert(33)</script>
+ABC<div style="x\x3Aexpression(javascript:alert(34)">DEF
+ABC<div style="x:expression\x5C(javascript:alert(35)">DEF
+ABC<div style="x:expression\x00(javascript:alert(36)">DEF
+ABC<div style="x:exp\x00ression(javascript:alert(37)">DEF
+ABC<div style="x:exp\x5Cression(javascript:alert(38)">DEF
+ABC<div style="x:\x0Aexpression(javascript:alert(39)">DEF
+ABC<div style="x:\x09expression(javascript:alert(40)">DEF
+ABC<div style="x:\xE3\x80\x80expression(javascript:alert(41)">DEF
+ABC<div style="x:\xE2\x80\x84expression(javascript:alert(42)">DEF
+ABC<div style="x:\xC2\xA0expression(javascript:alert(43)">DEF
+ABC<div style="x:\xE2\x80\x80expression(javascript:alert(44)">DEF
+ABC<div style="x:\xE2\x80\x8Aexpression(javascript:alert(45)">DEF
+ABC<div style="x:\x0Dexpression(javascript:alert(46)">DEF
+ABC<div style="x:\x0Cexpression(javascript:alert(47)">DEF
+ABC<div style="x:\xE2\x80\x87expression(javascript:alert(48)">DEF
+ABC<div style="x:\xEF\xBB\xBFexpression(javascript:alert(49)">DEF
+ABC<div style="x:\x20expression(javascript:alert(50)">DEF
+ABC<div style="x:\xE2\x80\x88expression(javascript:alert(51)">DEF
+ABC<div style="x:\x00expression(javascript:alert(52)">DEF
+ABC<div style="x:\xE2\x80\x8Bexpression(javascript:alert(53)">DEF
+ABC<div style="x:\xE2\x80\x86expression(javascript:alert(54)">DEF
+ABC<div style="x:\xE2\x80\x85expression(javascript:alert(55)">DEF
+ABC<div style="x:\xE2\x80\x82expression(javascript:alert(56)">DEF
+ABC<div style="x:\x0Bexpression(javascript:alert(57)">DEF
+ABC<div style="x:\xE2\x80\x81expression(javascript:alert(58)">DEF
+ABC<div style="x:\xE2\x80\x83expression(javascript:alert(59)">DEF
+ABC<div style="x:\xE2\x80\x89expression(javascript:alert(60)">DEF
+<a href="\x0Bjavascript:javascript:alert(61)" id="fuzzelement1">test</a>
+<a href="\x0Fjavascript:javascript:alert(62)" id="fuzzelement1">test</a>
+<a href="\xC2\xA0javascript:javascript:alert(63)" id="fuzzelement1">test</a>
+<a href="\x05javascript:javascript:alert(64)" id="fuzzelement1">test</a>
+<a href="\xE1\xA0\x8Ejavascript:javascript:alert(65)" id="fuzzelement1">test</a>
+<a href="\x18javascript:javascript:alert(66)" id="fuzzelement1">test</a>
+<a href="\x11javascript:javascript:alert(67)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x88javascript:javascript:alert(68)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x89javascript:javascript:alert(69)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x80javascript:javascript:alert(70)" id="fuzzelement1">test</a>
+<a href="\x17javascript:javascript:alert(71)" id="fuzzelement1">test</a>
+<a href="\x03javascript:javascript:alert(72)" id="fuzzelement1">test</a>
+<a href="\x0Ejavascript:javascript:alert(73)" id="fuzzelement1">test</a>
+<a href="\x1Ajavascript:javascript:alert(74)" id="fuzzelement1">test</a>
+<a href="\x00javascript:javascript:alert(75)" id="fuzzelement1">test</a>
+<a href="\x10javascript:javascript:alert(76)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x82javascript:javascript:alert(77)" id="fuzzelement1">test</a>
+<a href="\x20javascript:javascript:alert(78)" id="fuzzelement1">test</a>
+<a href="\x13javascript:javascript:alert(79)" id="fuzzelement1">test</a>
+<a href="\x09javascript:javascript:alert(80)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x8Ajavascript:javascript:alert(81)" id="fuzzelement1">test</a>
+<a href="\x14javascript:javascript:alert(82)" id="fuzzelement1">test</a>
+<a href="\x19javascript:javascript:alert(83)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\xAFjavascript:javascript:alert(84)" id="fuzzelement1">test</a>
+<a href="\x1Fjavascript:javascript:alert(85)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x81javascript:javascript:alert(86)" id="fuzzelement1">test</a>
+<a href="\x1Djavascript:javascript:alert(87)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x87javascript:javascript:alert(88)" id="fuzzelement1">test</a>
+<a href="\x07javascript:javascript:alert(89)" id="fuzzelement1">test</a>
+<a href="\xE1\x9A\x80javascript:javascript:alert(90)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x83javascript:javascript:alert(91)" id="fuzzelement1">test</a>
+<a href="\x04javascript:javascript:alert(92)" id="fuzzelement1">test</a>
+<a href="\x01javascript:javascript:alert(93)" id="fuzzelement1">test</a>
+<a href="\x08javascript:javascript:alert(94)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x84javascript:javascript:alert(95)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x86javascript:javascript:alert(96)" id="fuzzelement1">test</a>
+<a href="\xE3\x80\x80javascript:javascript:alert(97)" id="fuzzelement1">test</a>
+<a href="\x12javascript:javascript:alert(98)" id="fuzzelement1">test</a>
+<a href="\x0Djavascript:javascript:alert(99)" id="fuzzelement1">test</a>
+<a href="\x0Ajavascript:javascript:alert(100)" id="fuzzelement1">test</a>
+<a href="\x0Cjavascript:javascript:alert(101)" id="fuzzelement1">test</a>
+<a href="\x15javascript:javascript:alert(102)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\xA8javascript:javascript:alert(103)" id="fuzzelement1">test</a>
+<a href="\x16javascript:javascript:alert(104)" id="fuzzelement1">test</a>
+<a href="\x02javascript:javascript:alert(105)" id="fuzzelement1">test</a>
+<a href="\x1Bjavascript:javascript:alert(106)" id="fuzzelement1">test</a>
+<a href="\x06javascript:javascript:alert(107)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\xA9javascript:javascript:alert(108)" id="fuzzelement1">test</a>
+<a href="\xE2\x80\x85javascript:javascript:alert(109)" id="fuzzelement1">test</a>
+<a href="\x1Ejavascript:javascript:alert(110)" id="fuzzelement1">test</a>
+<a href="\xE2\x81\x9Fjavascript:javascript:alert(111)" id="fuzzelement1">test</a>
+<a href="\x1Cjavascript:javascript:alert(112)" id="fuzzelement1">test</a>
+<a href="javascript\x00:javascript:alert(113)" id="fuzzelement1">test</a>
+<a href="javascript\x3A:javascript:alert(114)" id="fuzzelement1">test</a>
+<a href="javascript\x09:javascript:alert(115)" id="fuzzelement1">test</a>
+<a href="javascript\x0D:javascript:alert(116)" id="fuzzelement1">test</a>
+<a href="javascript\x0A:javascript:alert(117)" id="fuzzelement1">test</a>
+`"'><img src=xxx:x \x0Aonerror=javascript:alert(118)>
+`"'><img src=xxx:x \x22onerror=javascript:alert(119)>
+`"'><img src=xxx:x \x0Bonerror=javascript:alert(120)>
+`"'><img src=xxx:x \x0Donerror=javascript:alert(121)>
+`"'><img src=xxx:x \x2Fonerror=javascript:alert(122)>
+`"'><img src=xxx:x \x09onerror=javascript:alert(123)>
+`"'><img src=xxx:x \x0Conerror=javascript:alert(124)>
+`"'><img src=xxx:x \x00onerror=javascript:alert(125)>
+`"'><img src=xxx:x \x27onerror=javascript:alert(126)>
+`"'><img src=xxx:x \x20onerror=javascript:alert(127)>
+"`'><script>\x3Bjavascript:alert(128)</script>
+"`'><script>\x0Djavascript:alert(129)</script>
+"`'><script>\xEF\xBB\xBFjavascript:alert(130)</script>
+"`'><script>\xE2\x80\x81javascript:alert(131)</script>
+"`'><script>\xE2\x80\x84javascript:alert(132)</script>
+"`'><script>\xE3\x80\x80javascript:alert(133)</script>
+"`'><script>\x09javascript:alert(134)</script>
+"`'><script>\xE2\x80\x89javascript:alert(135)</script>
+"`'><script>\xE2\x80\x85javascript:alert(136)</script>
+"`'><script>\xE2\x80\x88javascript:alert(137)</script>
+"`'><script>\x00javascript:alert(138)</script>
+"`'><script>\xE2\x80\xA8javascript:alert(139)</script>
+"`'><script>\xE2\x80\x8Ajavascript:alert(140)</script>
+"`'><script>\xE1\x9A\x80javascript:alert(141)</script>
+"`'><script>\x0Cjavascript:alert(142)</script>
+"`'><script>\x2Bjavascript:alert(143)</script>
+"`'><script>\xF0\x90\x96\x9Ajavascript:alert(144)</script>
+"`'><script>-javascript:alert(145)</script>
+"`'><script>\x0Ajavascript:alert(146)</script>
+"`'><script>\xE2\x80\xAFjavascript:alert(147)</script>
+"`'><script>\x7Ejavascript:alert(148)</script>
+"`'><script>\xE2\x80\x87javascript:alert(149)</script>
+"`'><script>\xE2\x81\x9Fjavascript:alert(150)</script>
+"`'><script>\xE2\x80\xA9javascript:alert(151)</script>
+"`'><script>\xC2\x85javascript:alert(152)</script>
+"`'><script>\xEF\xBF\xAEjavascript:alert(153)</script>
+"`'><script>\xE2\x80\x83javascript:alert(154)</script>
+"`'><script>\xE2\x80\x8Bjavascript:alert(155)</script>
+"`'><script>\xEF\xBF\xBEjavascript:alert(156)</script>
+"`'><script>\xE2\x80\x80javascript:alert(157)</script>
+"`'><script>\x21javascript:alert(158)</script>
+"`'><script>\xE2\x80\x82javascript:alert(159)</script>
+"`'><script>\xE2\x80\x86javascript:alert(160)</script>
+"`'><script>\xE1\xA0\x8Ejavascript:alert(161)</script>
+"`'><script>\x0Bjavascript:alert(162)</script>
+"`'><script>\x20javascript:alert(163)</script>
+"`'><script>\xC2\xA0javascript:alert(164)</script>
+<img \x00src=x onerror="alert(165)">
+<img \x47src=x onerror="javascript:alert(166)">
+<img \x11src=x onerror="javascript:alert(167)">
+<img \x12src=x onerror="javascript:alert(168)">
+<img\x47src=x onerror="javascript:alert(169)">
+<img\x10src=x onerror="javascript:alert(170)">
+<img\x13src=x onerror="javascript:alert(171)">
+<img\x32src=x onerror="javascript:alert(172)">
+<img\x47src=x onerror="javascript:alert(173)">
+<img\x11src=x onerror="javascript:alert(174)">
+<img \x47src=x onerror="javascript:alert(175)">
+<img \x34src=x onerror="javascript:alert(176)">
+<img \x39src=x onerror="javascript:alert(177)">
+<img \x00src=x onerror="javascript:alert(178)">
+<img src\x09=x onerror="javascript:alert(179)">
+<img src\x10=x onerror="javascript:alert(180)">
+<img src\x13=x onerror="javascript:alert(181)">
+<img src\x32=x onerror="javascript:alert(182)">
+<img src\x12=x onerror="javascript:alert(183)">
+<img src\x11=x onerror="javascript:alert(184)">
+<img src\x00=x onerror="javascript:alert(185)">
+<img src\x47=x onerror="javascript:alert(186)">
+<img src=x\x09onerror="javascript:alert(187)">
+<img src=x\x10onerror="javascript:alert(188)">
+<img src=x\x11onerror="javascript:alert(189)">
+<img src=x\x12onerror="javascript:alert(190)">
+<img src=x\x13onerror="javascript:alert(191)">
+<img[a][b][c]src[d]=x[e]onerror=[f]"alert(192)">
+<img src=x onerror=\x09"javascript:alert(193)">
+<img src=x onerror=\x10"javascript:alert(194)">
+<img src=x onerror=\x11"javascript:alert(195)">
+<img src=x onerror=\x12"javascript:alert(196)">
+<img src=x onerror=\x32"javascript:alert(197)">
+<img src=x onerror=\x00"javascript:alert(198)">
+<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(199)>XXX</a>
+<img src="x` `<script>javascript:alert(200)</script>"` `>
+<img src onerror /" '"= alt=javascript:alert(201)//">
+<title onpropertychange=javascript:alert(202)></title><title title=>
+<a href=http://foo.bar/#x=`y></a><img alt="`><img src=x:x onerror=javascript:alert(203)></a>">
+<!--[if]><script>javascript:alert(204)</script -->
+<!--[if<img src=x onerror=javascript:alert(205)//]> -->
+<script src="/\%(jscript)s"></script>
+<script src="\\%(jscript)s"></script>
+<IMG """><SCRIPT>alert("206")</SCRIPT>">
+<IMG SRC=javascript:alert(String.fromCharCode(50,48,55))>
+<IMG SRC=# onmouseover="alert('208')">
+<IMG SRC= onmouseover="alert('209')">
+<IMG onmouseover="alert('210')">
+<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#50;&#49;&#49;&#39;&#41;>
+<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000050&#0000049&#0000050&#0000039&#0000041>
+<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x32&#x31&#x33&#x27&#x29>
+<IMG SRC="jav   ascript:alert('214');">
+<IMG SRC="jav&#x09;ascript:alert('215');">
+<IMG SRC="jav&#x0A;ascript:alert('216');">
+<IMG SRC="jav&#x0D;ascript:alert('217');">
+perl -e 'print "<IMG SRC=java\0script:alert(\"218\")>";' > out
+<IMG SRC=" &#14;  javascript:alert('219');">
+<SCRIPT/XSS SRC="http://ha.ckers.org/xss.js"></SCRIPT>
+<BODY onload!#$%&()*~+-_.,:;?@[/|\]^`=alert("220")>
+<SCRIPT/SRC="http://ha.ckers.org/xss.js"></SCRIPT>
+<<SCRIPT>alert("221");//<</SCRIPT>
+<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >
+<SCRIPT SRC=//ha.ckers.org/.j>
+<IMG SRC="javascript:alert('222')"
+<iframe src=http://ha.ckers.org/scriptlet.html <
+\";alert('223');//
+<u oncopy=alert()> Copy me</u>
+<i onwheel=alert(224)> Scroll over me </i>
+<plaintext>
+http://a/%%30%30
+</textarea><script>alert(225)</script>
+
+#	SQL Injection
+#
+#	Strings which can cause a SQL injection if inputs are not sanitized
+
+1;DROP TABLE users
+1'; DROP TABLE users-- 1
+' OR 1=1 -- 1
+' OR '1'='1
+'; EXEC sp_MSForEachTable 'DROP TABLE ?'; --
+ 
+%
+_
+
+#	Server Code Injection
+#
+#	Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)
+
+-
+--
+--version
+--help
+$USER
+/dev/null; touch /tmp/blns.fail ; echo
+`touch /tmp/blns.fail`
+$(touch /tmp/blns.fail)
+@{[system "touch /tmp/blns.fail"]}
+
+#	Command Injection (Ruby)
+#
+#	Strings which can call system commands within Ruby/Rails applications
+
+eval("puts 'hello world'")
+System("ls -al /")
+`ls -al /`
+Kernel.exec("ls -al /")
+Kernel.exit(1)
+%x('ls -al /')
+
+#      XXE Injection (XML)
+#
+#	String which can reveal system files when parsed by a badly configured XML parser
+
+<?xml version="1.0" encoding="ISO-8859-1"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM "file:///etc/passwd" >]><foo>&xxe;</foo>
+
+#	Unwanted Interpolation
+#
+#	Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.
+
+$HOME
+$ENV{'HOME'}
+%d
+%s%s%s%s%s
+{0}
+%*.*s
+%@
+%n
+File:///
+
+#	File Inclusion
+#
+#	Strings which can cause user to pull in files that should not be a part of a web server
+
+../../../../../../../../../../../etc/passwd%00
+../../../../../../../../../../../etc/hosts
+
+#	Known CVEs and Vulnerabilities
+#
+#	Strings that test for known vulnerabilities
+
+() { 0; }; touch /tmp/blns.shellshock1.fail;
+() { _; } >_[$($())] { touch /tmp/blns.shellshock2.fail; }
+<<< %s(un='%s') = %u
++++ATH0
+
+#	MSDOS/Windows Special Filenames
+#
+#	Strings which are reserved characters in MSDOS/Windows
+
+CON
+PRN
+AUX
+CLOCK$
+NUL
+A:
+ZZ:
+COM1
+LPT1
+LPT2
+LPT3
+COM2
+COM3
+COM4
+
+#   IRC specific strings
+#
+#   Strings that may occur on IRC clients that make security products freak out
+
+DCC SEND STARTKEYLOGGER 0 0 0
+
+#	Scunthorpe Problem
+#
+#	Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)
+
+Scunthorpe General Hospital
+Penistone Community Church
+Lightwater Country Park
+Jimmy Clitheroe
+Horniman Museum
+shitake mushrooms
+RomansInSussex.co.uk
+http://www.cum.qc.ca/
+Craig Cockburn, Software Specialist
+Linda Callahan
+Dr. Herman I. Libshitz
+magna cum laude
+Super Bowl XXX
+medieval erection of parapets
+evaluate
+mocha
+expression
+Arsenal canal
+classic
+Tyson Gay
+Dick Van Dyke
+basement
+
+#	Human injection
+#
+#	Strings which may cause human to reinterpret worldview
+
+If you're reading this, you've been in a coma for almost 20 years now. We're trying a new technique. We don't know where this message will end up in your dream, but we hope it works. Please wake up, we miss you.
+
+#	Terminal escape codes
+#
+#	Strings which punish the fools who use cat/type on this file
+
+Roses are [0;31mred[0m, violets are [0;34mblue. Hope you enjoy terminal hue
+But now...[20Cfor my greatest trick...[8m
+The quick brown fox... [Beeeep]
+
+#	iOS Vulnerabilities
+#
+#	Strings which crashed iMessage in various versions of iOS
+
+Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗
+🏳0🌈️
+జ్ఞ‌ా
+
+# Persian special characters
+#
+# This is a four characters string which includes Persian special characters (گچپژ)
+
+گچپژ
+
+# jinja2 injection
+#
+# first one is supposed to raise "MemoryError" exception
+# second, obviously, prints contents of /etc/passwd
+
+{% print 'x' * 64 * 1024**3 %}
+{{ "".__class__.__mro__[2].__subclasses__()[40]("/etc/passwd").read() }}

--- a/python/tests/integration/arcticdb/test_unicode_strings.py
+++ b/python/tests/integration/arcticdb/test_unicode_strings.py
@@ -1,0 +1,89 @@
+import os
+from pandas.testing import assert_frame_equal
+import pandas as pd
+import numpy as np
+
+
+def read_strings():
+    script_directory = os.path.dirname(os.path.abspath(__file__))
+    file_path = "{}/blns.txt".format(script_directory)
+
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+
+    filtered_lines = [line.strip() for line in lines if line.strip() and not line.strip().startswith('#')]
+    return filtered_lines
+
+
+def create_dataframe(strings):
+    start_date = '2023-01-01'
+    data = {
+        'strings': strings,
+        'ints': np.random.randint(1, 100, size=len(strings))
+    }
+    date_range = pd.date_range(start=start_date, periods=len(strings), freq='D')
+    date_range.freq = None
+    df = pd.DataFrame(data, index=date_range)
+    return df
+
+
+def test_write_blns(lmdb_version_store):
+    strings = read_strings()
+    symbol = "blns_write"
+    df = create_dataframe(strings)
+    lmdb_version_store.write(symbol, df)
+    vit = lmdb_version_store.read(symbol)
+    assert_frame_equal(df, vit.data)
+
+
+def test_append_blns(lmdb_version_store):
+    strings = read_strings()
+    symbol = "blns_append"
+    df = create_dataframe(strings)
+    half_index = len(df) // 2
+    df_first_half = df.iloc[:half_index]
+    df_second_half = df.iloc[half_index:]
+    lmdb_version_store.write(symbol, df_first_half)
+    lmdb_version_store.append(symbol, df_second_half)
+    vit = lmdb_version_store.read(symbol)
+    assert_frame_equal(df, vit.data)
+
+
+def test_update_blns(lmdb_version_store):
+    strings = read_strings()
+    symbol = "blns_update"
+    df = create_dataframe(strings)
+    total_length = len(df)
+    half_length = total_length // 2
+    start_index = (total_length - half_length) // 2
+    end_index = start_index + half_length
+    df_removed_middle = df.drop(df.index[start_index:end_index])
+    df_middle_half = df.iloc[start_index:end_index]
+
+    lmdb_version_store.write(symbol, df_removed_middle)
+    lmdb_version_store.update(symbol, df_middle_half)
+    vit = lmdb_version_store.read(symbol)
+    assert_frame_equal(df, vit.data)
+
+
+def assert_dicts_of_dfs_equal(dict1, dict2):
+    assert dict1.keys() == dict2.keys(), "Dictionary keys do not match"
+
+    for key in dict1:
+        pd.testing.assert_frame_equal(dict1[key], dict2[key], obj=f"DataFrame at key '{key}'")
+
+def test_recursive_normalizers_blns(lmdb_version_store):
+    lib = lmdb_version_store
+    strings = read_strings()
+    symbol = "blnd_recursive"
+    df = create_dataframe(strings)
+    keys = [
+        "a",
+        "b",
+        "c",
+        "d"
+    ]
+    dict = {s: df for s in keys}
+    lib.write(symbol, dict, recursive_normalizers=True)
+    vit = lib.read(symbol)
+    assert_dicts_of_dfs_equal(dict, vit.data)

--- a/python/tests/integration/arcticdb/test_unicode_strings.py
+++ b/python/tests/integration/arcticdb/test_unicode_strings.py
@@ -8,7 +8,7 @@ def read_strings():
     script_directory = os.path.dirname(os.path.abspath(__file__))
     file_path = "{}/blns.txt".format(script_directory)
 
-    with open(file_path, 'r') as file:
+    with open(file_path, 'r', errors="ignore") as file:
         lines = file.readlines()
 
     filtered_lines = [line.strip() for line in lines if line.strip() and not line.strip().startswith('#')]


### PR DESCRIPTION
We aren't releasing the GIL when writing with recursive normalizers so if we get a non-standard unicode character than needs to allocate it deadlocks

Tested manually, will merge automated tests to master