### PR TITLE
Sort index should always start from row zero

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -824,7 +824,7 @@ if(${TEST})
             version/test/test_sorting_info_state_machine.cpp
             version/test/version_map_model.hpp
             storage/test/common.hpp
-         )
+            version/test/test_sort_index.cpp)
 
     set(EXECUTABLE_PERMS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE) # 755
 

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -79,12 +79,12 @@ void adjust_slice_rowcounts(const std::shared_ptr<pipelines::PipelineContext>& p
     pipeline_context->total_rows_ = adjust_slice_rowcounts(pipeline_context->slice_and_keys_);
 }
 
-size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys) {
+size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row) {
     using namespace arcticdb::pipelines;
     if(slice_and_keys.empty())
 		return 0u;
-	
-	auto offset = slice_and_keys[0].slice_.row_range.first;
+
+    auto offset = first_row.value_or(slice_and_keys[0].slice_.row_range.first);
 	auto diff = slice_and_keys[0].slice_.row_range.diff();
     auto col_begin = slice_and_keys[0].slice_.col_range.first;
 	

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -300,7 +300,7 @@ struct PipelineContext;
 }
 
 size_t adjust_slice_rowcounts(
-    std::vector<pipelines::SliceAndKey> & slice_and_keys);
+    std::vector<pipelines::SliceAndKey> & slice_and_keys, const std::optional<size_t>& first_row = std::nullopt);
 
 void adjust_slice_rowcounts(
     const std::shared_ptr<pipelines::PipelineContext>& pipeline_context);

--- a/cpp/arcticdb/pipeline/index_writer.hpp
+++ b/cpp/arcticdb/pipeline/index_writer.hpp
@@ -42,23 +42,7 @@ public:
         agg_.segment().set_timeseries_descriptor(tsd);
     }
 
-    void add(const arcticdb::entity::AtomKey &key, const FrameSlice &slice) {
-        // ensure sorted by col group then row group, this is normally the case but in append scenario,
-        // one will need to ensure that this holds, otherwise the assumptions in the read pipeline will be
-        // broken.
-        ARCTICDB_DEBUG(log::version(), "Writing key {} to the index", key);
-        util::check_arg(!current_col_.has_value() || *current_col_ <= slice.col_range.first,
-                        "expected increasing column group, last col range left value {}, arg {}",
-                        current_col_.value_or(-1), slice.col_range
-        );
-
-        bool new_col_group = !current_col_.has_value() || *current_col_ < slice.col_range.first;
-        util::check_arg(!current_row_.has_value() || new_col_group
-                        ||
-                        (*current_col_ == slice.col_range.first && *current_row_ < slice.row_range.first),
-                        "expected increasing row group, last col range left value {}, arg {}",
-                        current_col_.value_or(-1), slice.col_range
-        );
+    void add_unchecked(const arcticdb::entity::AtomKey& key, const FrameSlice& slice) {
         auto add_to_row ARCTICDB_UNUSED = [&](auto &rb) {
             rb.set_scalar(int(Fields::version_id), key.version_id());
             rb.set_scalar(int(Fields::creation_ts), key.creation_ts());
@@ -89,6 +73,27 @@ public:
             std::visit([&rb](auto &&val) { rb.set_scalar(int(Fields::start_index), val); }, key.start_index());
             add_to_row(rb);
         });
+    }
+
+    void add(const arcticdb::entity::AtomKey &key, const FrameSlice &slice) {
+        // ensure sorted by col group then row group, this is normally the case but in append scenario,
+        // one will need to ensure that this holds, otherwise the assumptions in the read pipeline will be
+        // broken.
+        ARCTICDB_DEBUG(log::version(), "Writing key {} to the index", key);
+        util::check_arg(!current_col_.has_value() || *current_col_ <= slice.col_range.first,
+                        "expected increasing column group, last col range left value {}, arg {}",
+                        current_col_.value_or(-1), slice.col_range
+        );
+
+        bool new_col_group = !current_col_.has_value() || *current_col_ < slice.col_range.first;
+        util::check_arg(!current_row_.has_value() || new_col_group
+                            ||
+                                (*current_col_ == slice.col_range.first && *current_row_ < slice.row_range.first),
+                        "expected increasing row group, last col range left value {}, arg {}",
+                        current_col_.value_or(-1), slice.col_range
+        );
+
+        add_unchecked(key, slice);
 
         if (new_col_group) {
             current_col_ = slice.col_range.first;

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -33,6 +33,14 @@ LocalVersionedEngine::LocalVersionedEngine(
     initialize(library);
 }
 
+template<class ClockType>
+LocalVersionedEngine::LocalVersionedEngine(
+    const std::shared_ptr<Store>& store,
+    const ClockType&) :
+    store_(store),
+    symbol_list_(std::make_shared<SymbolList>(version_map_)){
+}
+
 void LocalVersionedEngine::initialize(const std::shared_ptr<storage::Library>& library) {
     configure(library->config());
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Created versioned engine at {} for library path {}  with config {}", uintptr_t(this),
@@ -50,6 +58,7 @@ void LocalVersionedEngine::initialize(const std::shared_ptr<storage::Library>& l
 }
 
 template LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<storage::Library>& library, const util::SysClock&);
+template LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<Store>& library, const util::SysClock&);
 template LocalVersionedEngine::LocalVersionedEngine(const std::shared_ptr<storage::Library>& library, const util::ManualClock&);
 
 folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_indexes(
@@ -513,7 +522,7 @@ VersionedItem LocalVersionedEngine::sort_index(const StreamId& stream_id, bool d
         });
     }
 
-    auto total_rows = adjust_slice_rowcounts(slice_and_keys);
+    auto total_rows = adjust_slice_rowcounts(slice_and_keys, std::make_optional<size_t>(0U));
 
     auto index = index_type_from_descriptor(index_segment_reader.tsd().as_stream_descriptor());
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -407,9 +407,21 @@ public:
         return store()->current_timestamp();
     }
 
+    template<typename ClockType>
+    static LocalVersionedEngine _test_init_from_store(
+        const std::shared_ptr<Store>& store,
+        const ClockType& clock
+    ) {
+        return LocalVersionedEngine(store, clock);
+    }
+
     const arcticdb::proto::storage::VersionStoreConfig& cfg() const override { return cfg_; }
 
 protected:
+    template<class ClockType=util::SysClock>
+    explicit LocalVersionedEngine(
+        const std::shared_ptr<Store>& store,
+        const ClockType& = ClockType{});
     VersionedItem compact_incomplete_dynamic(
             const StreamId& stream_id,
             const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,

--- a/cpp/arcticdb/version/test/test_sort_index.cpp
+++ b/cpp/arcticdb/version/test/test_sort_index.cpp
@@ -1,0 +1,105 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/entity/atom_key.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/pipeline_common.hpp>
+#include <arcticdb/pipeline/index_writer.hpp>
+#include "storage/test/in_memory_store.hpp"
+
+TEST(SortIndex, Basic) {
+    using namespace arcticdb;
+    using namespace arcticdb::entity;
+    using namespace arcticdb::pipelines;
+
+    std::vector<SliceAndKey> keys_and_slices;
+    StreamId stream_id{"sort_index"};
+
+    for(auto i = 0; i < 20; ++i) {
+        auto key = atom_key_builder().start_index(i).end_index(i+1).creation_ts(i).build<KeyType::TABLE_DATA>(stream_id);
+        FrameSlice slice{ColRange{0, 5}, RowRange{i, i+1}};
+        keys_and_slices.emplace_back(SliceAndKey{slice, key});
+    }
+
+    auto copy = keys_and_slices;
+    std::random_shuffle(std::begin(keys_and_slices), std::end(keys_and_slices));
+    const auto version_id = VersionId{0};
+
+    const IndexPartialKey& partial_key{stream_id, version_id};
+    auto mock_store = std::make_shared<InMemoryStore>();
+    auto desc = stream_descriptor(stream_id, stream::RowCountIndex(), {scalar_field(DataType::UTF_DYNAMIC64, "col_1")});
+    TimeseriesDescriptor timeseries_desc;
+    timeseries_desc.set_stream_descriptor(desc);
+    index::IndexWriter<stream::RowCountIndex> index_writer(mock_store, partial_key, std::move(timeseries_desc));
+    for(const auto& [maybe_seg, slice, key] : keys_and_slices)
+        index_writer.add_unchecked(*key, slice);
+
+    auto key_fut = index_writer.commit();
+    auto index_key = std::move(key_fut).get();
+    VersionMap version_map;
+    version_map.write_version(mock_store, index_key, std::nullopt);
+
+    auto engine = version_store::LocalVersionedEngine::_test_init_from_store(mock_store, util::SysClock{});
+    auto versioned_item = engine.sort_index(stream_id, false, false);
+
+    auto seg = mock_store->read(versioned_item.key_, storage::ReadKeyOpts{}).get();
+    pipelines::index::IndexSegmentReader isr{std::move(seg.second)};
+    auto vec = unfiltered_index(isr);
+
+    ASSERT_EQ(vec, copy);
+}
+
+TEST(SortIndex, Nonzero) {
+    using namespace arcticdb;
+    using namespace arcticdb::entity;
+    using namespace arcticdb::pipelines;
+
+    std::vector<SliceAndKey> keys_and_slices;
+    StreamId stream_id{"sort_index_non_zero"};
+
+    for(auto i = 0; i < 20; ++i) {
+        auto key = atom_key_builder().start_index(i).end_index(i+1).creation_ts(i).build<KeyType::TABLE_DATA>(stream_id);
+        FrameSlice slice{ColRange{0, 5}, RowRange{i+5, i+6}};
+        keys_and_slices.emplace_back(SliceAndKey{slice, key});
+    }
+
+    std::random_shuffle(std::begin(keys_and_slices), std::end(keys_and_slices));
+    const auto version_id = VersionId{0};
+
+    const IndexPartialKey& partial_key{stream_id, version_id};
+    auto mock_store = std::make_shared<InMemoryStore>();
+    auto desc = stream_descriptor(stream_id, stream::RowCountIndex(), {scalar_field(DataType::UTF_DYNAMIC64, "col_1")});
+    TimeseriesDescriptor timeseries_desc;
+    timeseries_desc.set_stream_descriptor(desc);
+    index::IndexWriter<stream::RowCountIndex> index_writer(mock_store, partial_key, std::move(timeseries_desc));
+    for(const auto& [maybe_seg, slice, key] : keys_and_slices)
+        index_writer.add_unchecked(*key, slice);
+
+    auto key_fut = index_writer.commit();
+    auto index_key = std::move(key_fut).get();
+    VersionMap version_map;
+    version_map.write_version(mock_store, index_key, std::nullopt);
+
+    auto engine = version_store::LocalVersionedEngine::_test_init_from_store(mock_store, util::SysClock{});
+    auto versioned_item = engine.sort_index(stream_id, false, false);
+
+    auto seg = mock_store->read(versioned_item.key_, storage::ReadKeyOpts{}).get();
+    pipelines::index::IndexSegmentReader isr{std::move(seg.second)};
+    auto vec = unfiltered_index(isr);
+
+    std::vector<SliceAndKey> expected;
+
+    for(auto i = 0; i < 20; ++i) {
+        auto key = atom_key_builder().start_index(i).end_index(i+1).creation_ts(i).build<KeyType::TABLE_DATA>(stream_id);
+        FrameSlice slice{ColRange{0, 5}, RowRange{i, i+1}};
+        expected.emplace_back(SliceAndKey{slice, key});
+    }
+
+    ASSERT_EQ(vec, expected);
+}


### PR DESCRIPTION
Sort_index sorts the whole timeseries, so no matter what the sort order is, the first row slice needs to start from zero