### PR TITLE
Bugfix 1683: Add validate_index arg to staged data finalization in both V1 and V2 APIs

### DIFF
--- a/cpp/arcticdb/stream/append_map.cpp
+++ b/cpp/arcticdb/stream/append_map.cpp
@@ -204,12 +204,13 @@ folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
     const std::shared_ptr<InputTensorFrame>& frame,
+    bool validate_index,
     std::optional<AtomKey>&& next_key)  {
     using namespace arcticdb::pipelines;
 
-    if (!index_is_not_timeseries_or_is_sorted_ascending(*frame)) {
-        sorting::raise<ErrorCode::E_UNSORTED_DATA>("When writing/appending staged data in parallel, input data must be sorted.");
-    }
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+            !validate_index || index_is_not_timeseries_or_is_sorted_ascending(*frame),
+            "When writing/appending staged data in parallel, input data must be sorted.");
 
     auto index_range = frame->index_range;
     auto segment = incomplete_segment_from_frame(frame, 0, std::move(next_key), false);
@@ -225,9 +226,10 @@ folly::Future<arcticdb::entity::VariantKey> write_incomplete_frame(
 void write_parallel(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    const std::shared_ptr<InputTensorFrame>& frame) {
+    const std::shared_ptr<InputTensorFrame>& frame,
+    bool validate_index) {
     // TODO: dynamic bucketize doesn't work with incompletes
-    (void)write_incomplete_frame(store, stream_id, frame, std::nullopt).get();
+    (void)write_incomplete_frame(store, stream_id, frame, validate_index, std::nullopt).get();
 }
 
 std::vector<SliceAndKey> get_incomplete(
@@ -367,7 +369,8 @@ AppendMapEntry entry_from_key(const std::shared_ptr<StreamSource>& store, const 
 void append_incomplete(
         const std::shared_ptr<Store>& store,
         const StreamId& stream_id,
-        const std::shared_ptr<InputTensorFrame>& frame) {
+        const std::shared_ptr<InputTensorFrame>& frame,
+        bool validate_index) {
     using namespace arcticdb::proto::descriptors;
     using namespace arcticdb::stream;
     ARCTICDB_SAMPLE_DEFAULT(AppendIncomplete)
@@ -377,7 +380,7 @@ void append_incomplete(
     const auto num_rows = frame->num_rows;
     total_rows += num_rows;
     auto desc = frame->desc.clone();
-    auto new_key = write_incomplete_frame(store, stream_id, frame, std::move(next_key)).get();
+    auto new_key = write_incomplete_frame(store, stream_id, frame, validate_index, std::move(next_key)).get();
 
 
     ARCTICDB_DEBUG(log::version(), "Wrote incomplete frame for stream {}, {} rows, total rows {}", stream_id, num_rows, total_rows);

--- a/cpp/arcticdb/stream/append_map.hpp
+++ b/cpp/arcticdb/stream/append_map.hpp
@@ -53,7 +53,8 @@ void remove_incomplete_segments(
 void write_parallel(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    const std::shared_ptr<pipelines::InputTensorFrame>& frame);
+    const std::shared_ptr<pipelines::InputTensorFrame>& frame,
+    bool validate_index);
 
 void write_head(
     const std::shared_ptr<Store>& store,
@@ -68,7 +69,8 @@ void append_incomplete_segment(
 void append_incomplete(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,
-    const std::shared_ptr<pipelines::InputTensorFrame>& frame);
+    const std::shared_ptr<pipelines::InputTensorFrame>& frame,
+    bool validate_index);
 
 std::optional<int64_t> latest_incomplete_timestamp(
     const std::shared_ptr<Store>& store,

--- a/cpp/arcticdb/stream/test/test_append_map.cpp
+++ b/cpp/arcticdb/stream/test/test_append_map.cpp
@@ -23,7 +23,7 @@ TEST(Append, Simple) {
     auto wrapper = get_test_simple_frame(stream_id, 10, 0);
     auto& frame = wrapper.frame_;
     auto desc = frame->desc.clone();
-    append_incomplete(store, stream_id, frame);
+    append_incomplete(store, stream_id, frame, true);
     pipelines::FilterRange range;
     auto pipeline_context = std::make_shared<PipelineContext>(desc);
     pipeline_context->selected_columns_ = util::BitSet(2);

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -49,14 +49,6 @@ struct KeySizesInfo {
     size_t uncompressed_size; // bytes
 };
 
-struct SortMergeOptions {
-    bool append_;
-    bool convert_int_to_float_;
-    bool via_iteration_;
-    bool sparsify_;
-    bool prune_previous_versions_;
-};
-
 folly::Future<folly::Unit> delete_trees_responsibly(
     std::shared_ptr<Store> store,
     std::shared_ptr<VersionMap> &version_map,
@@ -112,7 +104,8 @@ public:
 
     void append_incomplete_frame(
         const StreamId& stream_id,
-        const std::shared_ptr<InputTensorFrame>& frame) const override;
+        const std::shared_ptr<InputTensorFrame>& frame,
+        bool validate_index) const override;
 
     void remove_incomplete(
         const StreamId& stream_id
@@ -163,7 +156,8 @@ public:
 
     void write_parallel_frame(
         const StreamId& stream_id,
-        const std::shared_ptr<InputTensorFrame>& frame) const override;
+        const std::shared_ptr<InputTensorFrame>& frame,
+        bool validate_index) const override;
 
     void delete_tree(
         const std::vector<IndexTypeKey>& idx_to_be_deleted,
@@ -262,7 +256,7 @@ public:
     VersionedItem sort_merge_internal(
         const StreamId& stream_id,
         const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
-        const SortMergeOptions& option);
+        const CompactIncompleteOptions& options);
 
     std::vector<folly::Future<AtomKey>> batch_write_internal(
         const std::vector<VersionId>& version_ids,
@@ -419,11 +413,7 @@ protected:
     VersionedItem compact_incomplete_dynamic(
             const StreamId& stream_id,
             const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
-            bool append,
-            bool convert_int_to_float,
-            bool via_iteration,
-            bool sparsify,
-            bool prune_previous_versions);
+            const CompactIncompleteOptions& options);
 
     /**
      * Take tombstoned indexes that have been pruned in the version map and perform the actual deletion

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -496,6 +496,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::arg("sparsify") = false,
              py::arg("user_meta") = std::nullopt,
              py::arg("prune_previous_versions") = false,
+             py::arg("validate_index") = false,
              py::call_guard<SingleThreadMutexHolder>(), "Compact incomplete segments")
          .def("sort_merge",
              &PythonVersionStore::sort_merge,

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -858,14 +858,18 @@ void check_incompletes_index_ranges_dont_overlap(const std::shared_ptr<PipelineC
                     "Cannot append staged segments to existing data as incomplete segment contains index value < existing data: {} <= {}",
                     it->slice_and_key().key().start_time(),
                     *last_existing_index_value);
-            unique_timestamp_ranges.insert({it->slice_and_key().key().start_time(), it->slice_and_key().key().end_time()});
-        }
+            auto [_, inserted] = unique_timestamp_ranges.insert({it->slice_and_key().key().start_time(), it->slice_and_key().key().end_time()});
+            // This is correct because incomplete segments aren't column sliced
+            sorting::check<ErrorCode::E_UNSORTED_DATA>(
+                    inserted,
+                    "Cannot finalize staged data as incomplete segments overlap one another");
+        };
         for (auto it = unique_timestamp_ranges.begin(); it != unique_timestamp_ranges.end(); it++) {
             auto next_it = std::next(it);
             if (next_it != unique_timestamp_ranges.end()) {
                 sorting::check<ErrorCode::E_UNSORTED_DATA>(
                         next_it->first >= it->second,
-                        "Cannot append staged segments to existing data as incomplete segment index values overlap one another: ({}, {}) intersects ({}, {})",
+                        "Cannot finalize staged data as incomplete segment index values overlap one another: ({}, {}) intersects ({}, {})",
                         it->first, it->second - 1, next_it->first, next_it->second - 1);
             }
         }
@@ -1245,25 +1249,27 @@ VersionedItem sort_merge_impl(
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& norm_meta,
     const UpdateInfo& update_info,
-    bool append,
-    bool convert_int_to_float,
-    bool via_iteration,
-    bool sparsify
-    ) {
+    const CompactIncompleteOptions& options) {
     auto pipeline_context = std::make_shared<PipelineContext>();
     pipeline_context->stream_id_ = stream_id;
     pipeline_context->version_id_ = update_info.next_version_id_;
     ReadQuery read_query;
 
     std::optional<SortedValue> previous_sorted_value;
-    if(append && update_info.previous_index_key_.has_value()) {
+    if(options.append_ && update_info.previous_index_key_.has_value()) {
         read_indexed_keys_to_pipeline(store, pipeline_context, *(update_info.previous_index_key_), read_query, ReadOptions{});
         previous_sorted_value.emplace(pipeline_context->desc_->sorted());
     }
 
     auto num_versioned_rows = pipeline_context->total_rows_;
 
-    read_incompletes_to_pipeline(store, pipeline_context, read_query, ReadOptions{}, convert_int_to_float, via_iteration, sparsify);
+    read_incompletes_to_pipeline(store,
+                                 pipeline_context,
+                                 read_query,
+                                 ReadOptions{},
+                                 options.convert_int_to_float_,
+                                 options.via_iteration_,
+                                 options.sparsify_);
 
     std::vector<entity::VariantKey> delete_keys;
     for(auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
@@ -1306,7 +1312,7 @@ VersionedItem sort_merge_impl(
                 aggregator.add_segment(
                     std::move(sk->segment(store)),
                     sk->slice(),
-                    convert_int_to_float);
+                    options.convert_int_to_float_);
 
                 sk->unset_segment();
             }
@@ -1336,10 +1342,7 @@ VersionedItem compact_incomplete_impl(
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     const UpdateInfo& update_info,
-    bool append,
-    bool convert_int_to_float,
-    bool via_iteration,
-    bool sparsify,
+    const CompactIncompleteOptions& options,
     const WriteOptions& write_options) {
 
     auto pipeline_context = std::make_shared<PipelineContext>();
@@ -1351,17 +1354,25 @@ VersionedItem compact_incomplete_impl(
 
     std::optional<SegmentInMemory> last_indexed;
     std::optional<SortedValue> previous_sorted_value;
-    if(append && update_info.previous_index_key_.has_value()) {
+    if(options.append_ && update_info.previous_index_key_.has_value()) {
         read_indexed_keys_to_pipeline(store, pipeline_context, *(update_info.previous_index_key_), read_query, read_options);
         previous_sorted_value.emplace(pipeline_context->desc_->sorted());
     }
 
     auto prev_size = pipeline_context->slice_and_keys_.size();
-    read_incompletes_to_pipeline(store, pipeline_context, ReadQuery{}, ReadOptions{}, convert_int_to_float, via_iteration, sparsify);
+    read_incompletes_to_pipeline(store,
+                                 pipeline_context,
+                                 ReadQuery{},
+                                 ReadOptions{},
+                                 options.convert_int_to_float_,
+                                 options.via_iteration_,
+                                 options.sparsify_);
     if (pipeline_context->slice_and_keys_.size() == prev_size) {
         util::raise_rte("No incomplete segments found for {}", stream_id);
     }
-    check_incompletes_index_ranges_dont_overlap(pipeline_context, previous_sorted_value);
+    if (options.validate_index_) {
+        check_incompletes_index_ranges_dont_overlap(pipeline_context, previous_sorted_value);
+    }
     const auto& first_seg = pipeline_context->slice_and_keys_.begin()->segment(store);
 
     std::vector<entity::VariantKey> delete_keys;
@@ -1377,11 +1388,11 @@ VersionedItem compact_incomplete_impl(
     auto policies = std::make_tuple(
         index,
         dynamic_schema ? VariantSchema{DynamicSchema::default_schema(index, stream_id)} : VariantSchema{FixedSchema::default_schema(index, stream_id)},
-        sparsify ? VariantColumnPolicy{SparseColumnPolicy{}} : VariantColumnPolicy{DenseColumnPolicy{}}
+        options.sparsify_ ? VariantColumnPolicy{SparseColumnPolicy{}} : VariantColumnPolicy{DenseColumnPolicy{}}
         );
 
     util::variant_match(std::move(policies), [
-        &fut_vec, &slices, pipeline_context=pipeline_context, &store, convert_int_to_float, &previous_sorted_value, &write_options] (auto &&idx, auto &&schema, auto &&column_policy) {
+        &fut_vec, &slices, pipeline_context=pipeline_context, &store, &options, &previous_sorted_value, &write_options] (auto &&idx, auto &&schema, auto &&column_policy) {
         using IndexType = std::remove_reference_t<decltype(idx)>;
         using SchemaType = std::remove_reference_t<decltype(schema)>;
         using ColumnPolicyType = std::remove_reference_t<decltype(column_policy)>;
@@ -1392,7 +1403,7 @@ VersionedItem compact_incomplete_impl(
                 fut_vec,
                 slices,
                 store,
-                convert_int_to_float,
+                options.convert_int_to_float_,
                 write_options.segment_row_size);
         if constexpr(std::is_same_v<IndexType, TimeseriesIndex>) {
             pipeline_context->desc_->set_sorted(deduce_sorted(previous_sorted_value.value_or(SortedValue::ASCENDING), SortedValue::ASCENDING));

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -29,6 +29,15 @@ namespace arcticdb::version_store {
 using namespace arcticdb::entity;
 using namespace arcticdb::pipelines;
 
+struct CompactIncompleteOptions {
+    bool prune_previous_versions_;
+    bool append_;
+    bool convert_int_to_float_;
+    bool via_iteration_;
+    bool sparsify_;
+    bool validate_index_{true}; // Default value as unused in sort_merge
+};
+
 VersionedItem write_dataframe_impl(
     const std::shared_ptr<Store>& store,
     VersionId version_id,
@@ -126,10 +135,7 @@ VersionedItem compact_incomplete_impl(
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     const UpdateInfo& update_info,
-    bool append,
-    bool convert_int_to_float,
-    bool via_iteration,
-    bool sparsify,
+    const CompactIncompleteOptions& options,
     const WriteOptions& write_options);
 
 struct PredefragmentationInfo{
@@ -172,11 +178,7 @@ VersionedItem sort_merge_impl(
     const StreamId& stream_id,
     const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
     const UpdateInfo& update_info,
-    bool append,
-    bool convert_int_to_float,
-    bool via_iteration,
-    bool sparsify
-    );
+    const CompactIncompleteOptions& options);
 
 void modify_descriptor(
     const std::shared_ptr<pipelines::PipelineContext>& pipeline_context,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -119,7 +119,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         const StreamId& stream_id,
         const py::tuple &item,
         const py::object &norm,
-        const py::object & user_meta) const;
+        const py::object & user_meta,
+        bool validate_index) const;
 
     VersionedItem compact_incomplete(
             const StreamId& stream_id,
@@ -128,13 +129,15 @@ class PythonVersionStore : public LocalVersionedEngine {
             bool via_iteration = true,
             bool sparsify = false,
             const std::optional<py::object>& user_meta = std::nullopt,
-            bool prune_previous_versions = false);
+            bool prune_previous_versions = false,
+            bool validate_index = false);
 
     void write_parallel(
         const StreamId& stream_id,
         const py::tuple &item,
         const py::object &norm,
-        const py::object & user_meta) const;
+        const py::object & user_meta,
+        bool validate_index) const;
 
     VersionedItem write_metadata(
         const StreamId& stream_id,

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -77,7 +77,8 @@ public:
 
     virtual void append_incomplete_frame(
         const StreamId& stream_id,
-        const std::shared_ptr<InputTensorFrame>& frame) const = 0;
+        const std::shared_ptr<InputTensorFrame>& frame,
+        bool validate_index) const = 0;
 
     virtual void append_incomplete_segment(
         const StreamId& stream_id,
@@ -89,7 +90,8 @@ public:
 
     virtual void write_parallel_frame(
         const StreamId& stream_id,
-        const std::shared_ptr<InputTensorFrame>& frame) const = 0;
+        const std::shared_ptr<InputTensorFrame>& frame,
+        bool validate_index) const = 0;
 
     /**
      * Delete the given index keys, and their associated data excluding those shared with keys not in the argument.

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -583,10 +583,10 @@ class NativeVersionStore:
         # TODO: allow_sparse for write_parallel / recursive normalizers as well.
         if isinstance(item, NPDDataFrame):
             if parallel:
-                self.version_store.write_parallel(symbol, item, norm_meta, udm)
+                self.version_store.write_parallel(symbol, item, norm_meta, udm, validate_index)
                 return None
             elif incomplete:
-                self.version_store.append_incomplete(symbol, item, norm_meta, udm)
+                self.version_store.append_incomplete(symbol, item, norm_meta, udm, validate_index)
                 return None
             else:
                 vit = self.version_store.write_versioned_dataframe(
@@ -713,7 +713,7 @@ class NativeVersionStore:
         if isinstance(item, NPDDataFrame):
             with _diff_long_stream_descriptor_mismatch(self):
                 if incomplete:
-                    self.version_store.append_incomplete(symbol, item, norm_meta, udm)
+                    self.version_store.append_incomplete(symbol, item, norm_meta, udm, validate_index)
                 else:
                     vit = self.version_store.append(
                         symbol, item, norm_meta, udm, write_if_missing, prune_previous_version, validate_index
@@ -1903,6 +1903,7 @@ class NativeVersionStore:
         sparsify: Optional[bool] = False,
         metadata: Optional[Any] = None,
         prune_previous_version: Optional[bool] = None,
+        validate_index: bool = False,
     ):
         """
         Compact previously written un-indexed chunks of data, produced by a tick collector or parallel
@@ -1927,6 +1928,10 @@ class NativeVersionStore:
             Add user-defined metadata in the same way as write etc
         prune_previous_version
             Removes previous (non-snapshotted) versions from the database.
+        validate_index: bool, default=False
+            If True, will verify that the index of the symbol after this operation supports date range searches and
+            update operations. This requires that the indexes of the incomplete segments are non-overlapping with each
+            other, and, in the case of append=True, fall after the last index value in the previous version.
         Returns
         -------
         VersionedItem
@@ -1937,7 +1942,7 @@ class NativeVersionStore:
         )
         udm = normalize_metadata(metadata) if metadata is not None else None
         return self.version_store.compact_incomplete(
-            symbol, append, convert_int_to_float, via_iteration, sparsify, udm, prune_previous_version
+            symbol, append, convert_int_to_float, via_iteration, sparsify, udm, prune_previous_version, validate_index
         )
 
     @staticmethod

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -389,8 +389,8 @@ class Library:
         Note that `write` is not designed for multiple concurrent writers over a single symbol *unless the staged
         keyword argument is set to True*. If ``staged`` is True, written segments will be staged and left in an
         "incomplete" stage, unable to be read until they are finalized. This enables multiple
-        writers to a single symbol - all writing staged data at the same time - with one process able to later finalise
-        all staged data rendering the data readable by clients. To finalise staged data, see `finalize_staged_data`.
+        writers to a single symbol - all writing staged data at the same time - with one process able to later finalize
+        all staged data rendering the data readable by clients. To finalize staged data, see `finalize_staged_data`.
 
         Note: ArcticDB will use the 0-th level index of the Pandas DataFrame for its on-disk index.
 
@@ -410,8 +410,7 @@ class Library:
             Removes previous (non-snapshotted) versions from the database.
         staged : bool, default=False
             Whether to write to a staging area rather than immediately to the library.
-            Each unit of staged data must a) be datetime indexed and b) not overlap with any other unit of
-            staged data. Note that this will create symbols with Dynamic Schema enabled.
+            See documentation on `finalize_staged_data` for more information.
         validate_index: bool, default=True
             If True, verify that the index of `data` supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
@@ -902,9 +901,10 @@ class Library:
         mode: Optional[StagedDataFinalizeMethod] = StagedDataFinalizeMethod.WRITE,
         prune_previous_versions: bool = False,
         metadata: Any = None,
+        validate_index=True,
     ):
         """
-        Finalises staged data, making it available for reads.
+        Finalizes staged data, making it available for reads.
 
         Parameters
         ----------
@@ -912,12 +912,17 @@ class Library:
             Symbol to finalize data for.
 
         mode : `StagedDataFinalizeMethod`, default=StagedDataFinalizeMethod.WRITE
-            Finalise mode. Valid options are WRITE or APPEND. Write collects the staged data and writes them to a
-            new timeseries. Append collects the staged data and appends them to the latest version.
+            Finalize mode. Valid options are WRITE or APPEND. Write collects the staged data and writes them to a
+            new version. Append collects the staged data and appends them to the latest version.
         prune_previous_versions: bool, default=False
             Removes previous (non-snapshotted) versions from the database.
         metadata : Any, default=None
             Optional metadata to persist along with the symbol.
+        validate_index: bool, default=True
+            If True, and staged segments are timeseries, will verify that the index of the symbol after this operation
+            supports date range searches and update operations. This requires that the indexes of the staged segments
+            are non-overlapping with each other, and, in the case of `StagedDataFinalizeMethod.APPEND`, fall after the
+            last index value in the previous version.
 
         See Also
         --------
@@ -930,6 +935,7 @@ class Library:
             convert_int_to_float=False,
             metadata=metadata,
             prune_previous_version=prune_previous_versions,
+            validate_index=validate_index,
         )
 
     def sort_and_finalize_staged_data(
@@ -949,7 +955,7 @@ class Library:
             Symbol to finalize data for.
 
         mode : `StagedDataFinalizeMethod`, default=StagedDataFinalizeMethod.WRITE
-            Finalise mode. Valid options are WRITE or APPEND. Write collects the staged data and writes them to a
+            Finalize mode. Valid options are WRITE or APPEND. Write collects the staged data and writes them to a
             new timeseries. Append collects the staged data and appends them to the latest version.
 
         prune_previous_versions : bool, default=False

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -300,18 +300,32 @@ def test_compact_incomplete_sets_sortedness(lmdb_version_store):
 
 
 @pytest.mark.parametrize("append", (True, False))
-def test_parallel_sortedness_checks(lmdb_version_store, append):
+@pytest.mark.parametrize("validate_index", (True, False, None))
+def test_parallel_sortedness_checks(lmdb_version_store, append, validate_index):
     lib = lmdb_version_store
     sym = "test_parallel_sortedness_checks"
     if append:
         df_0 = pd.DataFrame({"col": [1, 2]}, index=[pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")])
         lib.write(sym, df_0)
     df_1 = pd.DataFrame({"col": [3, 4]}, index=[pd.Timestamp("2024-01-04"), pd.Timestamp("2024-01-03")])
-    with pytest.raises(SortingException):
-        if append:
-            lib.append(sym, df_1, incomplete=True)
+    if validate_index:
+        with pytest.raises(SortingException):
+            if append:
+                lib.append(sym, df_1, incomplete=True, validate_index=True)
+            else:
+                lib.write(sym, df_1, parallel=True, validate_index=True)
+    else:
+        if validate_index is None:
+            # Test default behaviour when arg isn't provided
+            if append:
+                lib.append(sym, df_1, incomplete=True)
+            else:
+                lib.write(sym, df_1, parallel=True)
         else:
-            lib.write(sym, df_1, parallel=True)
+            if append:
+                lib.append(sym, df_1, incomplete=True, validate_index=False)
+            else:
+                lib.write(sym, df_1, parallel=True, validate_index=False)
 
 
 @pytest.mark.parametrize("append", (True, False))
@@ -369,7 +383,8 @@ def test_parallel_all_same_index_values(lmdb_version_store, append):
 
 
 @pytest.mark.parametrize("append", (True, False))
-def test_parallel_overlapping_incomplete_segments(lmdb_version_store, append):
+@pytest.mark.parametrize("validate_index", (True, False, None))
+def test_parallel_overlapping_incomplete_segments(lmdb_version_store, append, validate_index):
     lib = lmdb_version_store
     sym = "test_parallel_overlapping_incomplete_segments"
     if append:
@@ -383,8 +398,18 @@ def test_parallel_overlapping_incomplete_segments(lmdb_version_store, append):
     else:
         lib.write(sym, df_2, parallel=True)
         lib.write(sym, df_1, parallel=True)
-    with pytest.raises(SortingException):
-        lib.compact_incomplete(sym, append, False)
+    if validate_index:
+        with pytest.raises(SortingException):
+            lib.compact_incomplete(sym, append, False, validate_index=True)
+    else:
+        if validate_index is None:
+            # Test default behaviour when arg isn't provided
+            lib.compact_incomplete(sym, append, False)
+        else:
+            lib.compact_incomplete(sym, append, False, validate_index=False)
+        received = lib.read(sym).data
+        expected = pd.concat([df_0, df_1, df_2]) if append else pd.concat([df_1, df_2])
+        assert_frame_equal(received, expected)
 
 
 def test_parallel_append_exactly_matches_existing(lmdb_version_store):
@@ -401,19 +426,64 @@ def test_parallel_append_exactly_matches_existing(lmdb_version_store):
     assert lib.get_info(sym)["sorted"] == "ASCENDING"
 
 
-def test_parallel_append_overlapping_with_existing(lmdb_version_store):
+@pytest.mark.parametrize("append", (True, False))
+@pytest.mark.parametrize("validate_index", (True, False, None))
+def test_parallel_all_incomplete_segments_same_index(lmdb_version_store_v1, append, validate_index):
+    lib = lmdb_version_store_v1
+    sym = "test_parallel_all_incomplete_segments_same_index"
+    if append:
+        df_0 = pd.DataFrame({"col": [1, 2]}, index=[pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")])
+        lib.write(sym, df_0)
+    df_1 = pd.DataFrame({"col": [3, 4]}, index=[pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-04")])
+    df_2 = pd.DataFrame({"col": [5, 6]}, index=[pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-04")])
+    if append:
+        lib.append(sym, df_2, incomplete=True)
+        lib.append(sym, df_1, incomplete=True)
+    else:
+        lib.write(sym, df_2, parallel=True)
+        lib.write(sym, df_1, parallel=True)
+    if validate_index:
+        with pytest.raises(SortingException):
+            lib.compact_incomplete(sym, append, False, validate_index=True)
+    else:
+        if validate_index is None:
+            # Test default behaviour when arg isn't provided
+            lib.compact_incomplete(sym, append, False)
+        else:
+            lib.compact_incomplete(sym, append, False, validate_index=False)
+        received = lib.read(sym).data
+        # Order is arbitrary if all index values are the same
+        if received["col"].iloc[-1] == 6:
+            expected = pd.concat([df_0, df_1, df_2]) if append else pd.concat([df_1, df_2])
+        else:
+            expected = pd.concat([df_0, df_2, df_1]) if append else pd.concat([df_2, df_1])
+        assert_frame_equal(received, expected)
+
+
+@pytest.mark.parametrize("validate_index", (True, False, None))
+def test_parallel_append_overlapping_with_existing(lmdb_version_store, validate_index):
     lib = lmdb_version_store
     sym = "test_parallel_append_overlapping_with_existing"
     df_0 = pd.DataFrame({"col": [1, 2]}, index=[pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")])
     lib.write(sym, df_0)
     df_1 = pd.DataFrame({"col": [3, 4]}, index=[pd.Timestamp("2024-01-01T12"), pd.Timestamp("2024-01-03")])
     lib.append(sym, df_1, incomplete=True)
-    with pytest.raises(SortingException):
-        lib.compact_incomplete(sym, True, False)
+    if validate_index:
+        with pytest.raises(SortingException):
+            lib.compact_incomplete(sym, True, False, validate_index=validate_index)
+    else:
+        if validate_index is None:
+            # Test default behaviour when arg isn't provided
+            lib.compact_incomplete(sym, True, False)
+        else:
+            lib.compact_incomplete(sym, True, False, validate_index=False)
+        received = lib.read(sym).data
+        assert_frame_equal(received, pd.concat([df_0, df_1]))
 
 
 @pytest.mark.parametrize("sortedness", ("DESCENDING", "UNSORTED"))
-def test_parallel_append_existing_data_unsorted(lmdb_version_store, sortedness):
+@pytest.mark.parametrize("validate_index", (True, False, None))
+def test_parallel_append_existing_data_unsorted(lmdb_version_store, sortedness, validate_index):
     lib = lmdb_version_store
     sym = "test_parallel_append_existing_data_unsorted"
     last_index_date = "2024-01-01" if sortedness == "DESCENDING" else "2024-01-03"
@@ -425,8 +495,18 @@ def test_parallel_append_existing_data_unsorted(lmdb_version_store, sortedness):
     assert lib.get_info(sym)["sorted"] == sortedness
     df_1 = pd.DataFrame({"col": [3, 4]}, index=[pd.Timestamp("2024-01-05"), pd.Timestamp("2024-01-06")])
     lib.append(sym, df_1, incomplete=True)
-    with pytest.raises(SortingException):
-        lib.compact_incomplete(sym, True, False)
+    if validate_index:
+        with pytest.raises(SortingException):
+            lib.compact_incomplete(sym, True, False, validate_index=True)
+    else:
+        if validate_index is None:
+            # Test the default case with no arg provided
+            lib.compact_incomplete(sym, True, False)
+        else:
+            lib.compact_incomplete(sym, True, False, validate_index=False)
+        expected = pd.concat([df_0, df_1])
+        received = lib.read(sym).data
+        assert_frame_equal(expected, received)
 
 
 def test_parallel_no_column_slicing(lmdb_version_store_tiny_segment):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1683 

#### What does this implement or fix?
V2 API `finalize_staged_data` continues to validate that index values are sorted and non-overlapping by default, but now checking can be disabled by passing `validate_index=False` in line with other writing methods.
V1 API `compact_incomplete` now allows unsorted timeseries index data by default, and checking can be enabled by passing `validate_index=True` in line with other writing methods.

Also means that when writing incomplete segments, the `validate_index` argument is used to check sortedness or not, previously it was assumed that incompletes had to be `ASCENDING`.