### PR TITLE
Add object information to the exception messages

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -61,27 +61,41 @@ std::string get_error_code(const Azure::Core::RequestFailedException& e) {
     return error_code;
 }
 
-void raise_azure_exception(const Azure::Core::RequestFailedException& e) {
+void raise_azure_exception(const Azure::Core::RequestFailedException& e, const std::string& object_name) {
     auto error_code = get_error_code(e);
     auto status_code = e.StatusCode;
     std::string error_message;
 
     if(status_code == Azure::Core::Http::HttpStatusCode::NotFound && error_code == AzureErrorCode_to_string(AzureErrorCode::BlobNotFound)) {
-        throw KeyNotFoundException(fmt::format("Key Not Found Error: AzureError#{} {}: {}",
-                                               static_cast<int>(status_code), error_code, e.ReasonPhrase));
+        throw KeyNotFoundException(fmt::format("Key Not Found Error: AzureError#{} {}: {} for object {}",
+                                               static_cast<int>(status_code),
+                                               error_code, 
+                                               e.ReasonPhrase,
+                                               object_name));
     }
 
     if(status_code == Azure::Core::Http::HttpStatusCode::Unauthorized || status_code == Azure::Core::Http::HttpStatusCode::Forbidden) {
-        raise<ErrorCode::E_PERMISSION>(fmt::format("Permission error: AzureError#{} {}: {}",
-                                                   static_cast<int>(status_code), error_code, e.ReasonPhrase));
+        raise<ErrorCode::E_PERMISSION>(fmt::format("Permission error: AzureError#{} {}: {} for object {}",
+                                                   static_cast<int>(status_code),
+                                                   error_code,
+                                                   e.ReasonPhrase,
+                                                   object_name));
     }
 
     if(static_cast<int>(status_code) >= 500) {
-        error_message = fmt::format("Unexpected Server Error: AzureError#{} {}: {} {}",
-                                    static_cast<int>(status_code), error_code, e.ReasonPhrase, e.what());
+        error_message = fmt::format("Unexpected Server Error: AzureError#{} {}: {} {} for object {}",
+                                    static_cast<int>(status_code),
+                                    error_code,
+                                    e.ReasonPhrase,
+                                    e.what(),
+                                    object_name);
     } else {
-        error_message = fmt::format("Unexpected Error: AzureError#{} {}: {} {}",
-                                    static_cast<int>(status_code), error_code, e.ReasonPhrase, e.what());
+        error_message = fmt::format("Unexpected Error: AzureError#{} {}: {} {} for object {}",
+                                    static_cast<int>(status_code),
+                                    error_code,
+                                    e.ReasonPhrase,
+                                    e.what(),
+                                    object_name);
     }
 
     raise<ErrorCode::E_UNEXPECTED_AZURE_ERROR>(error_message);
@@ -92,12 +106,12 @@ bool is_expected_error_type(const std::string& error_code, Azure::Core::Http::Ht
                                                                           error_code == AzureErrorCode_to_string(AzureErrorCode::ContainerNotFound));
 }
 
-void raise_if_unexpected_error(const Azure::Core::RequestFailedException& e) {
+void raise_if_unexpected_error(const Azure::Core::RequestFailedException& e, const std::string& object_name) {
     auto error_code = get_error_code(e);
     auto status_code = e.StatusCode;
 
     if(!is_expected_error_type(error_code, status_code)) {
-        raise_azure_exception(e);
+        raise_azure_exception(e, object_name);
     }
 }
 
@@ -127,7 +141,7 @@ void do_write_impl(
                         azure_client.write_blob(blob_name, std::move(seg), upload_option, request_timeout);
                     }
                     catch (const Azure::Core::RequestFailedException& e) {
-                        raise_azure_exception(e);
+                        raise_azure_exception(e, blob_name);
                     }
 
                 }
@@ -174,7 +188,7 @@ void do_read_impl(Composite<VariantKey> && ks,
                     ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(k), variant_key_view(k));
                 }
                 catch (const Azure::Core::RequestFailedException& e) {
-                    raise_if_unexpected_error(e);
+                    raise_if_unexpected_error(e, blob_name);
                     if (!opts.dont_warn_about_missing_key) {
                         log::storage().warn("Failed to read azure segment with key '{}' {} {}: {}",
                                                 k,
@@ -205,9 +219,9 @@ void do_remove_impl(Composite<VariantKey>&& ks,
         auto submit_batch = [&azure_client, &request_timeout](auto &to_delete) {
             try {
                 azure_client.delete_blobs(to_delete, request_timeout);
-            }
-            catch (const Azure::Core::RequestFailedException& e) {
-                raise_azure_exception(e);
+            } catch (const Azure::Core::RequestFailedException& e) {
+                std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
+                raise_azure_exception(e, failed_objects);
             }
             to_delete.clear();
         };
@@ -269,7 +283,7 @@ void do_iterate_type_impl(KeyType key_type,
             }
         }
         catch (const Azure::Core::RequestFailedException& e) {
-            raise_if_unexpected_error(e);
+            raise_if_unexpected_error(e, key_prefix);
             log::storage().warn("Failed to iterate azure blobs '{}' {}: {}",
                                 key_type,
                                 static_cast<int>(e.StatusCode),
@@ -289,7 +303,7 @@ bool do_key_exists_impl(
             return azure_client.blob_exists(blob_name);
         }
         catch (const Azure::Core::RequestFailedException& e) {
-            raise_if_unexpected_error(e);
+            raise_if_unexpected_error(e, blob_name);
             log::storage().debug("Failed to check azure key '{}' {} {}: {}",
                                 key,
                                 blob_name,

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -207,8 +207,8 @@ std::vector<VariantKey> LmdbStorage::do_remove_internal(Composite<VariantKey>&& 
                     }
                 } catch (const ::lmdb::not_found_error&) {
                     if (!opts.ignores_missing_key_) {
-                        log::storage().warn("Failed to delete segment for key {}", variant_key_view(k) );
-                                            failed_deletes.push_back(k);
+                        log::storage().warn("Failed to delete segment for key {}", variant_key_view(k));
+                        failed_deletes.push_back(k);
                     }
                 } catch (const ::lmdb::error& ex) {
                     raise_lmdb_exception(ex, stored_key);

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -30,22 +30,34 @@ namespace arcticdb::storage::lmdb {
 
 namespace fg = folly::gen;
 
-void raise_lmdb_exception(const ::lmdb::error& e) {
+void raise_lmdb_exception(const ::lmdb::error& e, const std::string& object_name) {
     auto error_code = e.code();
 
     if (error_code == MDB_NOTFOUND) {
-        throw KeyNotFoundException(fmt::format("Key Not Found Error: LMDBError#{}: {}", error_code, e.what()));
+        throw KeyNotFoundException(fmt::format("Key Not Found Error: LMDBError#{}: {} for object {}",
+                                                error_code,
+                                                e.what(),
+                                                object_name));
     }
 
     if (error_code == MDB_KEYEXIST) {
-        throw DuplicateKeyException(fmt::format("Duplicate Key Error: LMDBError#{}: {}", error_code, e.what()));
+        throw DuplicateKeyException(fmt::format("Duplicate Key Error: LMDBError#{}: {} for object {}",
+                                                 error_code, 
+                                                 e.what(),
+                                                 object_name));
     }
 
     if (error_code == MDB_MAP_FULL) {
-        throw LMDBMapFullException(fmt::format("Map Full Error: LMDBError#{}: {}", error_code, e.what()));
+        throw LMDBMapFullException(fmt::format("Map Full Error: LMDBError#{}: {} for object {}",
+                                                error_code,
+                                                e.what(),
+                                                object_name));
     }
 
-    raise<ErrorCode::E_UNEXPECTED_LMDB_ERROR>(fmt::format("Unexpected LMDB Error: LMDBError#{}: {}", error_code, e.what()));
+    raise<ErrorCode::E_UNEXPECTED_LMDB_ERROR>(fmt::format("Unexpected LMDB Error: LMDBError#{}: {} for object {}",
+                                                           error_code,
+                                                           e.what(),
+                                                           object_name));
 }
 
 ::lmdb::env& LmdbStorage::env() {
@@ -71,14 +83,13 @@ void LmdbStorage::do_write_internal(Composite<KeySegmentPair>&& kvs, ::lmdb::txn
             ARCTICDB_DEBUG(log::storage(), "Lmdb storage writing segment with key {}", kv.key_view());
             auto k = to_serialized_key(kv.variant_key());
             auto &seg = kv.segment();
-
             int64_t overwrite_flag = std::holds_alternative<RefKey>(kv.variant_key()) ? 0 : MDB_NOOVERWRITE;
             try {
                 lmdb_client_->write(db_name, k, std::move(seg), txn, dbi, overwrite_flag);
             } catch (const ::lmdb::key_exist_error& e) {
                 throw DuplicateKeyException(fmt::format("Key already exists: {}: {}", kv.variant_key(), e.what()));
             } catch (const ::lmdb::error& ex) {
-                raise_lmdb_exception(ex);
+                raise_lmdb_exception(ex, k);
             }
         }
     });
@@ -150,7 +161,7 @@ void LmdbStorage::do_read(Composite<VariantKey>&& ks, const ReadVisitor& visitor
                 ARCTICDB_DEBUG(log::storage(), "Failed to find segment for key {}", variant_key_view(k));
                 failed_reads.push_back(k);
             } catch (const ::lmdb::error& ex) {
-                raise_lmdb_exception(ex);
+                raise_lmdb_exception(ex, stored_key);
             }
         }
     });
@@ -165,15 +176,14 @@ bool LmdbStorage::do_key_exists(const VariantKey&key) {
 
     auto db_name = fmt::format("{}", variant_key_type(key));
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
-
+    auto stored_key = to_serialized_key(key);
     try {
         ::lmdb::dbi& dbi = *dbi_by_key_type_.at(db_name);
-        auto stored_key = to_serialized_key(key);
         return lmdb_client_->exists(db_name, stored_key, txn, dbi);
     } catch ([[maybe_unused]] const ::lmdb::not_found_error &ex) {
         ARCTICDB_DEBUG(log::storage(), "Caught lmdb not found error: {}", ex.what());
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex);
+        raise_lmdb_exception(ex, stored_key);
     }
     return false;
 }
@@ -189,27 +199,30 @@ std::vector<VariantKey> LmdbStorage::do_remove_internal(Composite<VariantKey>&& 
         try {
             // If no key of this type has been written before, this can fail
             ::lmdb::dbi& dbi = *dbi_by_key_type_.at(db_name);
+        
             for (auto &k : group.values()) {
                 auto stored_key = to_serialized_key(k);
 
-                if (lmdb_client_->remove(db_name, stored_key, txn, dbi)) {
-                    ARCTICDB_DEBUG(log::storage(), "Deleted segment for key {}", variant_key_view(k));
-                } else {
-                    if (!opts.ignores_missing_key_) {
-                        log::storage().warn("Failed to delete segment for key {}", variant_key_view(k));
-                        failed_deletes.push_back(k);
+                try {
+                    if (lmdb_client_->remove(db_name, stored_key, txn, dbi)) {
+                        ARCTICDB_DEBUG(log::storage(), "Deleted segment for key {}", variant_key_view(k));
+                    } else {
+                        if (!opts.ignores_missing_key_) {
+                            log::storage().warn("Failed to delete segment for key {}", variant_key_view(k));
+                            failed_deletes.push_back(k);
+                        }
                     }
-                }
-            }
-        } catch (const ::lmdb::not_found_error&) {
-            if (!opts.ignores_missing_key_) {
-                for (auto &k : group.values()) {
-                    log::storage().warn("Failed to delete segment for key {}", variant_key_view(k) );
-                                        failed_deletes.push_back(k);
+                } catch (const ::lmdb::not_found_error&) {
+                    if (!opts.ignores_missing_key_) {
+                        log::storage().warn("Failed to delete segment for key {}", variant_key_view(k) );
+                                            failed_deletes.push_back(k);
+                    }
+                } catch (const ::lmdb::error& ex) {
+                    raise_lmdb_exception(ex, stored_key);
                 }
             }
         } catch (const ::lmdb::error& ex) {
-            raise_lmdb_exception(ex);
+            raise_lmdb_exception(ex, db_name);
         }
     });
     return failed_deletes;
@@ -246,7 +259,7 @@ bool LmdbStorage::do_fast_delete() {
         try {
             ::lmdb::dbi_drop(dtxn, dbi);
         } catch (const ::lmdb::error& ex) {
-            raise_lmdb_exception(ex);
+            raise_lmdb_exception(ex, db_name);
         }
     });
 
@@ -267,7 +280,7 @@ void LmdbStorage::do_iterate_type(KeyType key_type, const IterateTypeVisitor& vi
             visitor(std::move(k));
         }
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex);
+        raise_lmdb_exception(ex, type_db);
     }
 }
 
@@ -396,7 +409,7 @@ LmdbStorage::LmdbStorage(const LibraryPath &library_path, OpenMode mode, const C
             dbi_by_key_type_.insert(std::make_pair(std::move(db_name), std::make_unique<::lmdb::dbi>(std::move(dbi))));
         });
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex);
+        raise_lmdb_exception(ex, "dbi creation");
     }
 
     txn.commit();

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -33,31 +33,24 @@ namespace fg = folly::gen;
 void raise_lmdb_exception(const ::lmdb::error& e, const std::string& object_name) {
     auto error_code = e.code();
 
+    auto error_message_suffix = fmt::format("LMDBError#{}: {} for object {}",
+                                             error_code,
+                                             e.what(),
+                                             object_name);
+
     if (error_code == MDB_NOTFOUND) {
-        throw KeyNotFoundException(fmt::format("Key Not Found Error: LMDBError#{}: {} for object {}",
-                                                error_code,
-                                                e.what(),
-                                                object_name));
+        throw KeyNotFoundException(fmt::format("Key Not Found Error: {}", error_message_suffix));
     }
 
     if (error_code == MDB_KEYEXIST) {
-        throw DuplicateKeyException(fmt::format("Duplicate Key Error: LMDBError#{}: {} for object {}",
-                                                 error_code, 
-                                                 e.what(),
-                                                 object_name));
+        throw DuplicateKeyException(fmt::format("Duplicate Key Error: {}", error_message_suffix));
     }
 
     if (error_code == MDB_MAP_FULL) {
-        throw LMDBMapFullException(fmt::format("Map Full Error: LMDBError#{}: {} for object {}",
-                                                error_code,
-                                                e.what(),
-                                                object_name));
+        throw LMDBMapFullException(fmt::format("Map Full Error: {}", error_message_suffix));
     }
 
-    raise<ErrorCode::E_UNEXPECTED_LMDB_ERROR>(fmt::format("Unexpected LMDB Error: LMDBError#{}: {} for object {}",
-                                                           error_code,
-                                                           e.what(),
-                                                           object_name));
+    raise<ErrorCode::E_UNEXPECTED_LMDB_ERROR>(fmt::format("Unexpected LMDB Error: {}", error_message_suffix));
 }
 
 ::lmdb::env& LmdbStorage::env() {

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -38,27 +38,20 @@ std::string MongoStorage::collection_name(KeyType k) {
  */
 void raise_mongo_exception(const mongocxx::operation_exception& e, const std::string& object_name) {
     auto error_code = e.code().value();
+    auto mongo_error_suffix = fmt::format("MongoError#{}: {} for object {}", error_code, e.what(), object_name);
 
     if (error_code == static_cast<int>(MongoError::NoSuchKey) || error_code == static_cast<int>(MongoError::KeyNotFound)) {
-        throw KeyNotFoundException(fmt::format("Key Not Found Error: MongoError#{}: {} for object {}",
-                                                error_code,
-                                                e.what(),
-                                                object_name));
+        throw KeyNotFoundException(fmt::format("Key Not Found Error: {}", mongo_error_suffix));
     }
 
     if (error_code == static_cast<int>(MongoError::UnAuthorized) || error_code == static_cast<int>(MongoError::AuthenticationFailed)) {
-        raise<ErrorCode::E_PERMISSION>(fmt::format("Permission error: MongoError#{}: {} for object {}",
-                                                    error_code,
-                                                    e.what(),
-                                                    object_name));
+        raise<ErrorCode::E_PERMISSION>(fmt::format("Permission error: {}", mongo_error_suffix));
     }
 
-    raise<ErrorCode::E_UNEXPECTED_MONGO_ERROR>(fmt::format("Unexpected Mongo Error: MongoError#{}: {} {} {} for object {}",
-                                                           error_code,
-                                                           e.what(),
+    raise<ErrorCode::E_UNEXPECTED_MONGO_ERROR>(fmt::format("Unexpected Mongo Error: {} {} {}",
+                                                           mongo_error_suffix,
                                                            e.code().category().name(),
-                                                           e.code().message(),
-                                                           object_name));
+                                                           e.code().message()));
 }
 
 bool is_expected_error_type(int error_code) {


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1699 

#### What does this implement or fix?
Add information about that object for which the given operation failed when the exception was raised in the various storages.