### PR TITLE
Enhancement 1750: lazy dataframe implementation

### DIFF
--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -10,8 +10,16 @@ import arcticdb.version_store.library as library
 from arcticdb.tools import set_config_from_env_vars
 from arcticdb_ext.version_store import DataError, VersionRequestType
 from arcticdb_ext.exceptions import ErrorCode, ErrorCategory
-from arcticdb.version_store.library import WritePayload, ReadInfoRequest, ReadRequest
-from arcticdb.version_store.library import StagedDataFinalizeMethod, WriteMetadataPayload
+from arcticdb.version_store.library import (
+    WritePayload,
+    ReadInfoRequest,
+    ReadRequest,
+    col,
+    LazyDataFrame,
+    LazyDataFrameCollection,
+    StagedDataFinalizeMethod,
+    WriteMetadataPayload
+)
 
 set_config_from_env_vars(_os.environ)
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -312,7 +312,7 @@ class ReadInfoRequest(NamedTuple):
 class LazyDataFrame(QueryBuilder):
     """
     Lazy dataframe implementation, allowing chains of queries to be added before the read is actually executed.
-    Returned by `Library.read` calls when `lazy=True`.
+    Returned by `Library.read`, `Library.head`, and `Library.tail` calls when `lazy=True`.
 
     See Also
     --------
@@ -346,7 +346,7 @@ class LazyDataFrame(QueryBuilder):
 
     def to_read_request(self) -> ReadRequest:
         """
-        Convert this object back into a ReadRequest, including any queries applied to this object since the read call.
+        Convert this object into a ReadRequest, including any queries applied to this object since the read call.
 
         Returns
         -------
@@ -387,7 +387,7 @@ class LazyDataFrame(QueryBuilder):
 class LazyDataFrameCollection(QueryBuilder):
     """
     Lazy dataframe implementation for batch operations. Allows the application of chains of queries to be added before
-    the actual reads are performed. Queries applied to this object will be applied to all of the symbols being read.
+    the actual reads are performed. Queries applied to this object will be applied to all  the symbols being read.
     If per-symbol queries are required, split can be used to break this class into a list of LazyDataFrame objects.
     Returned by `Library.read_batch` calls when `lazy=True`.
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-
+import copy
 import datetime
 
 import pytz
@@ -15,10 +15,11 @@ from numpy import datetime64
 
 from arcticdb.options import \
     LibraryOptions, EnterpriseLibraryOptions, ModifiableLibraryOption, ModifiableEnterpriseLibraryOption
+from arcticdb.preconditions import check
 from arcticdb.supported_types import Timestamp
 from arcticdb.util._versions import IS_PANDAS_TWO
 
-from arcticdb.version_store.processing import QueryBuilder
+from arcticdb.version_store.processing import ExpressionNode, QueryBuilder
 from arcticdb.version_store._store import NativeVersionStore, VersionedItem, VersionQueryInput
 from arcticdb_ext.exceptions import ArcticException
 from arcticdb_ext.version_store import DataError
@@ -194,7 +195,10 @@ class WritePayload:
         self.metadata = metadata
 
     def __repr__(self):
-        return f"WritePayload(symbol={self.symbol}, data_id={id(self.data)}, metadata={self.metadata})"
+        res = f"WritePayload(symbol={self.symbol}, data_id={id(self.data)}"
+        res += f", metadata={self.metadata}" if self.metadata is not None else ""
+        res += ")"
+        return res
 
     def __iter__(self):
         yield self.symbol
@@ -267,6 +271,16 @@ class ReadRequest(NamedTuple):
     columns: Optional[List[str]] = None
     query_builder: Optional[QueryBuilder] = None
 
+    def __repr__(self):
+        res = f"ReadRequest(symbol={self.symbol}"
+        res += f", as_of={self.as_of}" if self.as_of is not None else ""
+        res += f", date_range={self.date_range}" if self.date_range is not None else ""
+        res += f", row_range={self.row_range}" if self.row_range is not None else ""
+        res += f", columns={self.columns}" if self.columns is not None else ""
+        res += f", query_builder={self.query_builder}" if self.query_builder is not None else ""
+        res += ")"
+        return res
+
 
 class ReadInfoRequest(NamedTuple):
     """ReadInfoRequest is useful for batch methods like read_metadata_batch and get_description_batch, where we
@@ -287,6 +301,195 @@ class ReadInfoRequest(NamedTuple):
 
     symbol: str
     as_of: Optional[AsOf] = None
+
+    def __repr__(self):
+        res = f"ReadInfoRequest(symbol={self.symbol}"
+        res += f", as_of={self.as_of}" if self.as_of is not None else ""
+        res += ")"
+        return res
+
+
+class LazyDataFrame(QueryBuilder):
+    """
+    Lazy dataframe implementation, allowing chains of queries to be added before the read is actually executed.
+    Returned by `Library.read` calls when `lazy=True`.
+
+    See Also
+    --------
+    QueryBuilder for supported querying operations.
+
+    Examples
+    --------
+
+    # Specify that we want version 0 of "test" symbol, and to only return the "new_column" column in the output
+    >>> lazy_df = lib.read("test", as_of=0, columns=["new_column"], lazy=True)
+    # Perform a filtering operation
+    >>> lazy_df = lazy_df[lazy_df["col1"].isin(0, 3, 6, 9)]
+    # Create a new column through a projection operation
+    >>> lazy_df["new_col"] = lazy_df["col1"] + lazy_df["col2"]
+    # Actual read and processing happens here
+    >>> df = lazy_df.collect().data
+    """
+    def __init__(
+            self,
+            lib: "Library",
+            read_request: ReadRequest,
+    ):
+        if read_request.query_builder is None:
+            super().__init__()
+        else:
+            self.clauses = read_request.query_builder.clauses
+            self._python_clauses = read_request.query_builder._python_clauses
+            self._optimisation = read_request.query_builder._optimisation
+        self.lib = lib
+        self.read_request = read_request._replace(query_builder=None)
+
+    def to_read_request(self) -> ReadRequest:
+        """
+        Convert this object back into a ReadRequest, including any queries applied to this object since the read call.
+
+        Returns
+        -------
+        ReadRequest
+            Object with all the parameters necessary to completely specify the data to be read.
+        """
+        q = QueryBuilder().prepend(self)
+        q._optimisation = self._optimisation
+        return ReadRequest(
+            symbol=self.read_request.symbol,
+            as_of=self.read_request.as_of,
+            date_range=self.read_request.date_range,
+            row_range=self.read_request.row_range,
+            columns=self.read_request.columns,
+            query_builder=q,
+        )
+
+    def collect(self) -> VersionedItem:
+        """
+        Read the data and execute any queries applied to this object since the read call.
+
+        Returns
+        -------
+        VersionedItem
+            Object that contains a .data and .metadata element.
+        """
+        return self.lib.read(**self.to_read_request()._asdict())
+
+    def __str__(self) -> str:
+        query_builder_repr = super().__str__()
+        return "LazyDataFrame(" + self.read_request.__repr__() + (" | " if len(query_builder_repr) else "") + query_builder_repr + ")"
+
+    # Needs to be explicitly defined for lists of these objects in LazyDataFrameCollection to render correctly
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class LazyDataFrameCollection(QueryBuilder):
+    """
+    Lazy dataframe implementation for batch operations. Allows the application of chains of queries to be added before
+    the actual reads are performed. Queries applied to this object will be applied to all of the symbols being read.
+    If per-symbol queries are required, split can be used to break this class into a list of LazyDataFrame objects.
+    Returned by `Library.read_batch` calls when `lazy=True`.
+
+    See Also
+    --------
+    QueryBuilder for supported querying operations.
+
+    Examples
+    --------
+
+    # Specify that we want the latest version of "test_0" symbol, and version 0 of "test_1" symbol
+    >>> lazy_dfs = lib.read_batch(["test_0", ReadRequest("test_1", as_of=0)], lazy=True)
+    # Perform a filtering operation on both the "test_0" and "test_1" symbols
+    >>> lazy_dfs = lazy_dfs[lazy_dfs["col1"].isin(0, 3, 6, 9)]
+    # Perform a different projection operation on each symbol
+    >>> lazy_dfs = lazy_dfs.split()
+    >>> lazy_dfs[0].apply("new_col", lazy_dfs[0]["col1"] + 1)
+    >>> lazy_dfs[1].apply("new_col", lazy_dfs[1]["col1"] + 2)
+    # Bring together again and perform the same filter on both symbols
+    >>> lazy_dfs = LazyDataFrameCollection(lazy_dfs)
+    >>> lazy_dfs = lazy_dfs[lazy_dfs["new_col"] > 0]
+    # Actual read and processing happens here
+    >>> res = lazy_dfs.collect()
+    """
+    def __init__(
+            self,
+            lazy_dataframes: List[LazyDataFrame],
+    ):
+        lib_set = set([lazy_dataframe.lib for lazy_dataframe in lazy_dataframes])
+        check(
+            len(lib_set) in [0, 1],
+            f"LazyDataFrameCollection init requires all provided lazy dataframes to be referring to the same library, but received:\n{[lib for lib in lib_set]}"
+        )
+        super().__init__()
+        self._lazy_dataframes = lazy_dataframes
+        if len(self._lazy_dataframes):
+            self._lib = self._lazy_dataframes[0].lib
+
+    def split(self) -> List[LazyDataFrame]:
+        """
+        Separate the collection into a list of LazyDataFrames, including any queries already applied to this object.
+
+        Returns
+        -------
+        List[LazyDataFrame]
+        """
+        return [LazyDataFrame(self._lib, read_request) for read_request in self._read_requests()]
+
+    def collect(self) -> List[Union[VersionedItem, DataError]]:
+        """
+        Read the data and execute any queries applied to this object since the read_batch call.
+
+        Returns
+        -------
+        List[Union[VersionedItem, DataError]]
+            See documentation on `Library.read_batch`.
+        """
+        if self._lib is None:
+            return []
+        return self._lib.read_batch(self._read_requests())
+
+    def _read_requests(self) -> List[ReadRequest]:
+        # Combines queries for individual LazyDataFrames with the global query associated with this
+        # LazyDataFrameCollection and returns a list of corresponding read requests
+        read_requests = [lazy_dataframe.to_read_request() for lazy_dataframe in self._lazy_dataframes]
+        if len(self.clauses):
+            for read_request in read_requests:
+                if read_request.query_builder is None:
+                    read_request.query_builder = QueryBuilder()
+                read_request.query_builder.then(self)
+        return read_requests
+
+    def __str__(self) -> str:
+        query_builder_repr = super().__str__()
+        return "LazyDataFrameCollection(" + str(self._lazy_dataframes) + (" | " if len(query_builder_repr) else "") + query_builder_repr + ")"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+def col(name: str) -> ExpressionNode:
+    """
+    Placeholder for referencing columns by name in lazy dataframe operations before the underlying object has been
+    initialised.
+
+    Parameters
+    ----------
+    name : str
+        Column name.
+
+    Returns
+    -------
+    ExpressionNode
+        Reference to named column for use in querying operations.
+
+    Examples
+    --------
+
+    >>> lazy_df = lib.read("test", lazy=True).apply("new_col", col("col1") + col("col2"))
+    >>> df = lazy_df.collect().data
+    """
+    return ExpressionNode.column_ref(name)
 
 
 class StagedDataFinalizeMethod(Enum):
@@ -1019,7 +1222,8 @@ class Library:
         row_range: Optional[Tuple[int, int]] = None,
         columns: Optional[List[str]] = None,
         query_builder: Optional[QueryBuilder] = None,
-    ) -> VersionedItem:
+        lazy: bool = False,
+    ) -> Union[VersionedItem, LazyDataFrame]:
         """
         Read data for the named symbol.  Returns a VersionedItem object with a data and metadata element (as passed into
         write).
@@ -1065,9 +1269,15 @@ class Library:
             A QueryBuilder object to apply to the dataframe before it is returned. For more information see the
             documentation for the QueryBuilder class (``from arcticdb import QueryBuilder; help(QueryBuilder)``).
 
+        lazy: bool, default=False:
+            Defer query execution until `collect` is called on the returned `LazyDataFrame` object. See documentation
+            on `LazyDataFrame` for more details.
+
         Returns
         -------
-        VersionedItem object that contains a .data and .metadata element
+        Union[VersionedItem, LazyDataFrame]
+            If lazy is False, VersionedItem object that contains a .data and .metadata element.
+            If lazy is True, a LazyDataFrame object on which further querying can be performed prior to collect.
 
         Examples
         --------
@@ -1088,20 +1298,36 @@ class Library:
         1       6
         2       7
         """
-        return self._nvs.read(
-            symbol=symbol,
-            as_of=as_of,
-            date_range=date_range,
-            row_range=row_range,
-            columns=columns,
-            query_builder=query_builder,
-            implement_read_index=True,
-            iterate_snapshots_if_tombstoned=False,
-        )
+        if lazy:
+            return LazyDataFrame(
+                self,
+                ReadRequest(
+                    symbol=symbol,
+                    as_of=as_of,
+                    date_range=date_range,
+                    row_range=row_range,
+                    columns=columns,
+                    query_builder=query_builder,
+                ),
+            )
+        else:
+            return self._nvs.read(
+                symbol=symbol,
+                as_of=as_of,
+                date_range=date_range,
+                row_range=row_range,
+                columns=columns,
+                query_builder=query_builder,
+                implement_read_index=True,
+                iterate_snapshots_if_tombstoned=False,
+            )
 
     def read_batch(
-        self, symbols: List[Union[str, ReadRequest]], query_builder: Optional[QueryBuilder] = None
-    ) -> List[Union[VersionedItem, DataError]]:
+        self,
+        symbols: List[Union[str, ReadRequest]],
+        query_builder: Optional[QueryBuilder] = None,
+        lazy: bool = False,
+    ) -> Union[List[Union[VersionedItem, DataError]], LazyDataFrameCollection]:
         """
         Reads multiple symbols.
 
@@ -1114,13 +1340,20 @@ class Library:
             A single QueryBuilder to apply to all the dataframes before they are returned. If this argument is passed
             then none of the ``symbols`` may have their own query_builder specified in their request.
 
+        lazy: bool, default=False:
+            Defer query execution until `collect` is called on the returned `LazyDataFrameCollection` object. See
+            documentation on `LazyDataFrameCollection` for more details.
+
         Returns
         -------
-        List[Union[VersionedItem, DataError]]
+        Union[List[Union[VersionedItem, DataError]], LazyDataFrameCollection]
+            If lazy is False:
             A list of the read results, whose i-th element corresponds to the i-th element of the ``symbols`` parameter.
             If the specified version does not exist, a DataError object is returned, with symbol, version_request_type,
             version_request_data properties, error_code, error_category, and exception_string properties. If a key error or
             any other internal exception occurs, the same DataError object is also returned.
+            If lazy is True:
+            A LazyDataFrameCollection object on which further querying can be performed prior to collection.
 
         Raises
         ------
@@ -1195,17 +1428,38 @@ class Library:
                     " [ReadRequest] are supported."
                 )
         throw_on_error = False
-        return self._nvs._batch_read_to_versioned_items(
-            symbol_strings,
-            as_ofs,
-            date_ranges,
-            row_ranges,
-            columns,
-            query_builder or query_builders,
-            throw_on_error,
-            implement_read_index=True,
-            iterate_snapshots_if_tombstoned=False,
-        )
+        if lazy:
+            lazy_dataframes = []
+            for idx in range(len(symbol_strings)):
+                q = copy.deepcopy(query_builder)
+                if q is None and len(query_builders):
+                    q = copy.deepcopy(query_builders[idx])
+                lazy_dataframes.append(
+                    LazyDataFrame(
+                        self,
+                        ReadRequest(
+                            symbol=symbol_strings[idx],
+                            as_of=as_ofs[idx],
+                            date_range=date_ranges[idx],
+                            row_range=row_ranges[idx],
+                            columns=columns[idx],
+                            query_builder=q,
+                        )
+                    )
+                )
+            return LazyDataFrameCollection(lazy_dataframes)
+        else:
+            return self._nvs._batch_read_to_versioned_items(
+                symbol_strings,
+                as_ofs,
+                date_ranges,
+                row_ranges,
+                columns,
+                query_builder or query_builders,
+                throw_on_error,
+                implement_read_index=True,
+                iterate_snapshots_if_tombstoned=False,
+            )
 
     def read_metadata(self, symbol: str, as_of: Optional[AsOf] = None) -> VersionedItem:
         """
@@ -1606,7 +1860,14 @@ class Library:
             for v in versions
         }
 
-    def head(self, symbol: str, n: int = 5, as_of: Optional[AsOf] = None, columns: List[str] = None) -> VersionedItem:
+    def head(
+            self,
+            symbol: str,
+            n: int = 5,
+            as_of: Optional[AsOf] = None,
+            columns: List[str] = None,
+            lazy: bool = False,
+    ) -> Union[VersionedItem, LazyDataFrame]:
         """
         Read the first n rows of data for the named symbol. If n is negative, return all rows except the last n rows.
 
@@ -1620,23 +1881,44 @@ class Library:
             See documentation on `read`.
         columns
             See documentation on `read`.
+        lazy : bool, default=False
+            See documentation on `read`.
 
         Returns
         -------
-        VersionedItem object that contains a .data and .metadata element.
+        Union[VersionedItem, LazyDataFrame]
+            If lazy is False, VersionedItem object that contains a .data and .metadata element.
+            If lazy is True, a LazyDataFrame object on which further querying can be performed prior to collect.
         """
-        return self._nvs.head(
-            symbol=symbol,
-            n=n,
-            as_of=as_of,
-            columns=columns,
-            implement_read_index=True,
-            iterate_snapshots_if_tombstoned=False,
-        )
+        if lazy:
+            q = QueryBuilder()._head(n)
+            return LazyDataFrame(
+                self,
+                ReadRequest(
+                    symbol=symbol,
+                    as_of=as_of,
+                    columns=columns,
+                    query_builder=q,
+                ),
+            )
+        else:
+            return self._nvs.head(
+                symbol=symbol,
+                n=n,
+                as_of=as_of,
+                columns=columns,
+                implement_read_index=True,
+                iterate_snapshots_if_tombstoned=False,
+            )
 
     def tail(
-        self, symbol: str, n: int = 5, as_of: Optional[Union[int, str]] = None, columns: List[str] = None
-    ) -> VersionedItem:
+        self,
+            symbol: str,
+            n: int = 5,
+            as_of: Optional[Union[int, str]] = None,
+            columns: List[str] = None,
+            lazy: bool = False,
+    ) -> Union[VersionedItem, LazyDataFrame]:
         """
         Read the last n rows of data for the named symbol. If n is negative, return all rows except the first n rows.
 
@@ -1650,19 +1932,35 @@ class Library:
             See documentation on `read`.
         columns
             See documentation on `read`.
+        lazy : bool, default=False
+            See documentation on `read`.
 
         Returns
         -------
-        VersionedItem object that contains a .data and .metadata element.
+        Union[VersionedItem, LazyDataFrame]
+            If lazy is False, VersionedItem object that contains a .data and .metadata element.
+            If lazy is True, a LazyDataFrame object on which further querying can be performed prior to collect.
         """
-        return self._nvs.tail(
-            symbol=symbol,
-            n=n,
-            as_of=as_of,
-            columns=columns,
-            implement_read_index=True,
-            iterate_snapshots_if_tombstoned=False,
-        )
+        if lazy:
+            q = QueryBuilder()._tail(n)
+            return LazyDataFrame(
+                self,
+                ReadRequest(
+                    symbol=symbol,
+                    as_of=as_of,
+                    columns=columns,
+                    query_builder=q,
+                ),
+            )
+        else:
+            return self._nvs.tail(
+                symbol=symbol,
+                n=n,
+                as_of=as_of,
+                columns=columns,
+                implement_read_index=True,
+                iterate_snapshots_if_tombstoned=False,
+            )
 
     @staticmethod
     def _info_to_desc(info: Dict[str, Any]) -> SymbolDescription:

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -6,6 +6,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 from collections import namedtuple
+import copy
 from dataclasses import dataclass
 import datetime
 from math import inf
@@ -873,9 +874,10 @@ class QueryBuilder:
             if isinstance(item, ExpressionNode) and item.operator == COLUMN:
                 item = ExpressionNode.compose(item, _OperationType.IDENTITY, None)
             input_columns, expression_context = visit_expression(item)
-            self.clauses.append(_FilterClause(input_columns, expression_context, self._optimisation))
-            self._python_clauses.append(PythonFilterClause(item))
-            return self
+            self_copy = copy.deepcopy(self)
+            self_copy.clauses.append(_FilterClause(input_columns, expression_context, self_copy._optimisation))
+            self_copy._python_clauses.append(PythonFilterClause(item))
+            return self_copy
 
     def __setitem__(self, key, item):
         return self.apply(key, item)

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -877,6 +877,9 @@ class QueryBuilder:
             self._python_clauses.append(PythonFilterClause(item))
             return self
 
+    def __setitem__(self, key, item):
+        return self.apply(key, item)
+
     def __getattr__(self, key):
         return self[key]
 

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -8,7 +8,6 @@ As of the Change Date specified in that file, in accordance with the Business So
 import numpy as np
 import pandas as pd
 import pickle
-import pytest
 
 from arcticdb import col, LazyDataFrame, LazyDataFrameCollection, QueryBuilder, ReadRequest
 from arcticdb.util.test import assert_frame_equal
@@ -56,6 +55,7 @@ def test_lazy_filter(lmdb_library):
     lib.write(sym, df)
 
     lazy_df = lib.read(sym, lazy=True)
+    lazy_df_2 = lazy_df
     lazy_df = lazy_df[lazy_df["col1"].isin(0, 3, 6, 9)]
     received = lazy_df.collect().data
     expected = df.query("col1 in [0, 3, 6, 9]")

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -1,0 +1,456 @@
+"""
+Copyright 2024 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import numpy as np
+import pandas as pd
+import pickle
+import pytest
+
+from arcticdb import col, LazyDataFrame, LazyDataFrameCollection, QueryBuilder, ReadRequest
+from arcticdb.util.test import assert_frame_equal
+
+
+def test_lazy_read(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_read"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+    lib.write_pickle(sym, 1)
+
+    lazy_df = lib.read(sym, as_of=0, date_range=(pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-07")), columns=["col2"], lazy=True)
+    assert isinstance(lazy_df, LazyDataFrame)
+    received = lazy_df.collect().data
+    expected = lib.read(sym, as_of=0, date_range=(pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-07")), columns=["col2"]).data
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_date_range(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_date_range"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df.date_range((pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-09")))
+    received = lazy_df.collect().data
+    expected = df.iloc[1:9]
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_filter(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_filter"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df[lazy_df["col1"].isin(0, 3, 6, 9)]
+    received = lazy_df.collect().data
+    expected = df.query("col1 in [0, 3, 6, 9]")
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_head(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_head"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.head(sym, 4, lazy=True)
+    lazy_df = lazy_df[lazy_df["col1"] >= 2]
+    received = lazy_df.collect().data
+    expected = df.iloc[2:4]
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_tail(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_tail"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.tail(sym, 4, lazy=True)
+    lazy_df = lazy_df[lazy_df["col1"] <= 7]
+    received = lazy_df.collect().data
+    expected = df.iloc[6:8]
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_apply(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_apply"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df.apply("new_col", lazy_df["col1"] + lazy_df["col2"])
+    received = lazy_df.collect().data
+    expected = df
+    expected["new_col"] = expected["col1"] + expected["col2"]
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_apply_inline_col(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_apply_inline_col"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True).apply("new_col", col("col1") + col("col2"))
+    received = lazy_df.collect().data
+    expected = df
+    expected["new_col"] = expected["col1"] + expected["col2"]
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_project(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_project"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df["new_col"] = lazy_df["col1"] + lazy_df["col2"]
+    received = lazy_df.collect().data
+    expected = df
+    expected["new_col"] = expected["col1"] + expected["col2"]
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_groupby(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_groupby"
+    df = pd.DataFrame({"col1": [0, 1, 0, 1, 2, 2], "col2": np.arange(6, dtype=np.int64)})
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df.groupby("col1").agg({"col2": "sum"})
+    received = lazy_df.collect().data
+    received.sort_index(inplace=True)
+    expected = df.groupby("col1").agg({"col2": "sum"})
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_resample(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_resample"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df.resample("D").agg({"col1": "sum", "col2": "first"})
+    received = lazy_df.collect().data
+    expected = df.resample("D").agg({"col1": "sum", "col2": "first"})
+
+    assert_frame_equal(expected, received)
+
+
+def test_lazy_with_initial_query_builder(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_chaining"
+    idx = [0, 1, 2, 3, 1000, 1001]
+    idx = np.array(idx, dtype="datetime64[ns]")
+    df = pd.DataFrame({"col": np.arange(6, dtype=np.int64)}, index=idx)
+    lib.write(sym, df)
+
+    q = QueryBuilder().resample("us").agg({"col": "sum"})
+
+    lazy_df = lib.read(sym, query_builder=q, lazy=True)
+    lazy_df["new_col"] = lazy_df["col"] * 3
+    received = lazy_df.collect().data
+
+    expected = df.resample("us").agg({"col": "sum"})
+    expected["new_col"] = expected["col"] * 3
+    assert_frame_equal(expected, received, check_dtype=False)
+
+
+def test_lazy_chaining(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_chaining"
+    idx = [0, 1, 2, 3, 1000, 1001]
+    idx = np.array(idx, dtype="datetime64[ns]")
+    df = pd.DataFrame({"col": np.arange(6, dtype=np.int64)}, index=idx)
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True).resample("us").agg({"col": "sum"})
+    lazy_df["new_col"] = lazy_df["col"] * 3
+    received = lazy_df.collect().data
+
+    expected = df.resample("us").agg({"col": "sum"})
+    expected["new_col"] = expected["col"] * 3
+    assert_frame_equal(expected, received, check_dtype=False)
+
+
+def test_lazy_batch_read(lmdb_library):
+    lib = lmdb_library
+    sym_0 = "test_lazy_batch_read_0"
+    sym_1 = "test_lazy_batch_read_1"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym_0, df)
+    lib.write_pickle(sym_0, 1)
+    lib.write(sym_1, df)
+
+    read_request_0 = ReadRequest(
+        symbol=sym_0,
+        as_of=0,
+        date_range=(pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-07")),
+        columns=["col2"],
+    )
+
+    lazy_dfs = lib.read_batch([read_request_0, sym_1], lazy=True)
+    assert isinstance(lazy_dfs, LazyDataFrameCollection)
+    received = lazy_dfs.collect()
+    expected_0 = lib.read(sym_0, as_of=0, date_range=(pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-07")), columns=["col2"]).data
+    expected_1 = lib.read(sym_1).data
+    assert_frame_equal(expected_0, received[0].data)
+    assert_frame_equal(expected_1, received[1].data)
+
+
+def test_lazy_batch_one_query(lmdb_library):
+    lib = lmdb_library
+    syms = [f"test_lazy_batch_one_query_{idx}" for idx in range(3)]
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    for sym in syms:
+        lib.write(sym, df)
+    lazy_dfs = lib.read_batch(syms, lazy=True)
+    lazy_dfs = lazy_dfs[lazy_dfs["col1"].isin(0, 3, 6, 9)]
+    received = lazy_dfs.collect()
+    expected = df.query("col1 in [0, 3, 6, 9]")
+    for vit in received:
+        assert_frame_equal(expected, vit.data)
+
+
+def test_lazy_batch_collect_separately(lmdb_library):
+    lib = lmdb_library
+    syms = [f"test_lazy_batch_collect_separately_{idx}" for idx in range(3)]
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    for sym in syms:
+        lib.write(sym, df)
+    lazy_dfs = lib.read_batch(syms, lazy=True)
+    lazy_df_0, lazy_df_1, lazy_df_2 = lazy_dfs.split()
+    lazy_df_0 = lazy_df_0[lazy_df_0["col1"].isin(0, 3, 6, 9)]
+    lazy_df_2 = lazy_df_2[lazy_df_2["col1"].isin(2, 4, 8)]
+    expected_0 = df.query("col1 in [0, 3, 6, 9]")
+    expected_1 = df
+    expected_2 = df.query("col1 in [2, 4, 8]")
+    received_0 = lazy_df_0.collect().data
+    received_1 = lazy_df_1.collect().data
+    received_2 = lazy_df_2.collect().data
+    assert_frame_equal(expected_0, received_0)
+    assert_frame_equal(expected_1, received_1)
+    assert_frame_equal(expected_2, received_2)
+
+
+def test_lazy_batch_separate_queries_collect_together(lmdb_library):
+    lib = lmdb_library
+    syms = [f"test_lazy_batch_separate_queries_collect_together_{idx}" for idx in range(3)]
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    for sym in syms:
+        lib.write(sym, df)
+    lazy_dfs = lib.read_batch(syms, lazy=True).split()
+    lazy_df_0 = lazy_dfs[0]
+    lazy_df_2 = lazy_dfs[2]
+    lazy_df_0 = lazy_df_0[lazy_df_0["col1"].isin(0, 3, 6, 9)]
+    lazy_df_2 = lazy_df_2[lazy_df_2["col1"].isin(2, 4, 8)]
+    expected_0 = df.query("col1 in [0, 3, 6, 9]")
+    expected_1 = df
+    expected_2 = df.query("col1 in [2, 4, 8]")
+
+    received = LazyDataFrameCollection(lazy_dfs).collect()
+    assert_frame_equal(expected_0, received[0].data)
+    assert_frame_equal(expected_1, received[1].data)
+    assert_frame_equal(expected_2, received[2].data)
+
+
+def test_lazy_batch_complex(lmdb_library):
+    lib = lmdb_library
+    syms = [f"test_lazy_batch_complex_{idx}" for idx in range(3)]
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    for sym in syms:
+        lib.write(sym, df)
+    # Start with one query for all syms
+    q = QueryBuilder()
+    q = q[q["col1"] > 0]
+    lazy_dfs = lib.read_batch(syms, query_builder=q, lazy=True)
+    # Apply the same projection to all syms
+    lazy_dfs["shared_new_col_1"] = lazy_dfs["col2"] * 2
+    lazy_dfs = lazy_dfs.split()
+    # Apply a different projection to each sym
+    for idx, lazy_df in enumerate(lazy_dfs):
+        lazy_df.apply(f"new_col", col("col1") * idx)
+    # Collapse back together and apply another projection to all syms
+    lazy_dfs = LazyDataFrameCollection(lazy_dfs)
+    lazy_dfs["shared_new_col_2"] = lazy_dfs["new_col"] + 10
+    received = lazy_dfs.collect()
+    expected_0 = df.iloc[1:]
+    expected_0["shared_new_col_1"] = expected_0["col2"] * 2
+    expected_0["new_col"] = expected_0["col1"] * 0
+    expected_0["shared_new_col_2"] = expected_0["new_col"] + 10
+    expected_1 = df.iloc[1:]
+    expected_1["shared_new_col_1"] = expected_1["col2"] * 2
+    expected_1["new_col"] = expected_1["col1"] * 1
+    expected_1["shared_new_col_2"] = expected_1["new_col"] + 10
+    expected_2 = df.iloc[1:]
+    expected_2["shared_new_col_1"] = expected_2["col2"] * 2
+    expected_2["new_col"] = expected_2["col1"] * 2
+    expected_2["shared_new_col_2"] = expected_2["new_col"] + 10
+    assert_frame_equal(expected_0, received[0].data)
+    assert_frame_equal(expected_1, received[1].data)
+    assert_frame_equal(expected_2, received[2].data)
+
+
+def test_lazy_collect_multiple_times(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_collect_multiple_times"
+    idx = [0, 1, 2, 3, 1000, 1001]
+    idx = np.array(idx, dtype="datetime64[ns]")
+    df = pd.DataFrame({"col": np.arange(6, dtype=np.int64)}, index=idx)
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True).resample("us").agg({"col": "sum"})
+    expected = df.resample("us").agg({"col": "sum"})
+    received_0 = lazy_df.collect().data
+    assert_frame_equal(expected, received_0, check_dtype=False)
+    received_1 = lazy_df.collect().data
+    assert_frame_equal(expected, received_1, check_dtype=False)
+
+    lazy_df["new_col"] = lazy_df["col"] * 3
+    received_2 = lazy_df.collect().data
+
+    expected["new_col"] = expected["col"] * 3
+    assert_frame_equal(expected, received_2, check_dtype=False)
+
+
+def test_lazy_batch_collect_multiple_times(lmdb_library):
+    lib = lmdb_library
+    syms = [f"test_lazy_batch_collect_multiple_times_{idx}" for idx in range(3)]
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    for sym in syms:
+        lib.write(sym, df)
+    lazy_dfs = lib.read_batch(syms, lazy=True)
+    lazy_dfs = lazy_dfs[lazy_dfs["col1"].isin(0, 3, 6, 9)]
+    received_0 = lazy_dfs.collect()
+    expected = df.query("col1 in [0, 3, 6, 9]")
+    for vit in received_0:
+        assert_frame_equal(expected, vit.data)
+
+    received_1 = lazy_dfs.collect()
+    for vit in received_1:
+        assert_frame_equal(expected, vit.data)
+
+    lazy_dfs = lazy_dfs[lazy_dfs["col1"].isin(0, 6)]
+    received_2 = lazy_dfs.collect()
+    expected = df.query("col1 in [0, 6]")
+    for vit in received_2:
+        assert_frame_equal(expected, vit.data)
+
+
+def test_lazy_collect_twice_with_date_range(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_collect_twice_with_date_range"
+    df = pd.DataFrame(
+        {
+            "col1": np.arange(10, dtype=np.int64),
+            "col2": np.arange(100, 110, dtype=np.int64),
+        },
+        index=pd.date_range("2000-01-01", periods=10),
+    )
+    lib.write(sym, df)
+    lazy_df = lib.read(sym, date_range=(pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-07")), lazy=True)
+    expected = lib.read(sym, date_range=(pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-07"))).data
+    received_0 = lazy_df.collect().data
+    assert_frame_equal(expected, received_0, check_dtype=False)
+    received_1 = lazy_df.collect().data
+    assert_frame_equal(expected, received_1, check_dtype=False)
+
+
+def test_lazy_pickling(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_pickling"
+    idx = [0, 1, 2, 3, 1000, 1001]
+    idx = np.array(idx, dtype="datetime64[ns]")
+    df = pd.DataFrame({"col": np.arange(6, dtype=np.int64)}, index=idx)
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True).resample("us").agg({"col": "sum"})
+    lazy_df["new_col"] = lazy_df["col"] * 3
+
+    expected = df.resample("us").agg({"col": "sum"})
+    expected["new_col"] = expected["col"] * 3
+
+    roundtripped = pickle.loads(pickle.dumps(lazy_df))
+    assert roundtripped == lazy_df
+    received_initial = lazy_df.collect().data
+    assert_frame_equal(expected, received_initial, check_dtype=False)
+
+    received_roundtripped = roundtripped.collect().data
+    assert_frame_equal(expected, received_roundtripped, check_dtype=False)
+
+
+def test_lazy_batch_pickling(lmdb_library):
+    lib = lmdb_library
+    syms = [f"test_lazy_batch_pickling_{idx}" for idx in range(3)]
+    idx = [0, 1, 2, 3, 1000, 1001]
+    idx = np.array(idx, dtype="datetime64[ns]")
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    for sym in syms:
+        lib.write(sym, df)
+    lazy_dfs = lib.read_batch(syms, lazy=True)
+    lazy_dfs = lazy_dfs[lazy_dfs["col1"].isin(0, 3, 6, 9)]
+
+    expected = df.query("col1 in [0, 3, 6, 9]")
+
+    roundtripped = pickle.loads(pickle.dumps(lazy_dfs))
+    assert roundtripped == lazy_dfs
+    received_initial = lazy_dfs.collect()
+    for vit in received_initial:
+        assert_frame_equal(expected, vit.data)
+
+    received_roundtripped = roundtripped.collect()
+    for vit in received_roundtripped:
+        assert_frame_equal(expected, vit.data)

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -286,10 +286,8 @@ def test_lazy_batch_separate_queries_collect_together(lmdb_library):
     for sym in syms:
         lib.write(sym, df)
     lazy_dfs = lib.read_batch(syms, lazy=True).split()
-    lazy_df_0 = lazy_dfs[0]
-    lazy_df_2 = lazy_dfs[2]
-    lazy_df_0 = lazy_df_0[lazy_df_0["col1"].isin(0, 3, 6, 9)]
-    lazy_df_2 = lazy_df_2[lazy_df_2["col1"].isin(2, 4, 8)]
+    lazy_dfs[0] = lazy_dfs[0][lazy_dfs[0]["col1"].isin(0, 3, 6, 9)]
+    lazy_dfs[2] = lazy_dfs[2][lazy_dfs[2]["col1"].isin(2, 4, 8)]
     expected_0 = df.query("col1 in [0, 3, 6, 9]")
     expected_1 = df
     expected_2 = df.query("col1 in [2, 4, 8]")

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -55,7 +55,6 @@ def test_lazy_filter(lmdb_library):
     lib.write(sym, df)
 
     lazy_df = lib.read(sym, lazy=True)
-    lazy_df_2 = lazy_df
     lazy_df = lazy_df[lazy_df["col1"].isin(0, 3, 6, 9)]
     received = lazy_df.collect().data
     expected = df.query("col1 in [0, 3, 6, 9]")

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -133,6 +133,10 @@ def test_reuse_querybuilder_date_range(lmdb_version_store_tiny_segment):
     received_2 = lib.read(symbol, query_builder=q).data
     assert_frame_equal(expected_2, received_2)
 
+    expected_3 = df.query("col1 in [7]")
+    received_3 = lib.read(symbol, date_range=(pd.Timestamp("2000-01-06"), pd.Timestamp("2000-01-08")), query_builder=q).data
+    assert_frame_equal(expected_3, received_3)
+
 
 def test_reuse_querybuilder_date_range_batch(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -17,6 +17,21 @@ from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.util.test import assert_frame_equal
 
 
+def test_querybuilder_getitem_idempotency(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_querybuilder_getitem_idempotency"
+    df = pd.DataFrame({"a": [0, 1]}, index=np.arange(2))
+    lib.write(sym, df)
+    q = QueryBuilder()
+    q_copy = q
+    q = q[q["a"] == 1]
+    q_copy = q_copy[q_copy["a"] == 0]
+    expected = df[df["a"] == 1]
+    expected_copy = df[df["a"] == 0]
+    assert_frame_equal(expected, lib.read(sym, query_builder=q).data)
+    assert_frame_equal(expected_copy, lib.read(sym, query_builder=q_copy).data)
+
+
 def test_querybuilder_shallow_copy(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_querybuilder_shallow_copy"


### PR DESCRIPTION
Closes #1750 

Adds a lazy dataframe implementation that allows a more natural syntax for querying operations, with actual read+processing deferred until `collect` is called.

Also fixes #1788 