### PR TITLE
Fix setup.py to cope with newer pip versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def _log_and_run(*cmd, **kwargs):
 
 class CompileProto(Command):
     # When adding new protobuf versions, also update: setup.cfg, python/arcticdb/__init__.py
-    _PROTOBUF_TO_GRPC_VERSION = {"3": "<=1.30.*", "4": ">=1.49", "5": ">=1.64"}
+    _PROTOBUF_TO_GRPC_VERSION = {"3": "<1.31", "4": ">=1.49", "5": ">=1.64"}
 
     description = '"protoc" generate code _pb2.py from .proto files'
     user_options = [


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?
The requirement with .* is no longer supported on newer versions of pip and results in the following error:
`ERROR: Invalid requirement: 'grpcio-tools<=1.30.*': .* suffix can only be used with `==` or `!=` operators grpcio-tools<=1.30.*`

This PR changes how we handle this requirement to support this new format.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
