### PR TITLE
Change the default `dynamic_strings` to True

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -597,16 +597,14 @@ class NativeVersionStore:
 
     def _resolve_dynamic_strings(self, kwargs):
         proto_cfg = self._lib_cfg.lib_desc.version.write_options
+        dynamic_strings = self.resolve_defaults("dynamic_strings", proto_cfg, global_default=True, **kwargs)
         if IS_WINDOWS:
             # Fixed size strings not implemented yet for Windows as Py_UNICODE_SIZE is 2 whereas on Linux it is 4
-            normal_value = self.resolve_defaults("dynamic_strings", proto_cfg, global_default=True, **kwargs)
-            if not normal_value:
+            if not dynamic_strings:
                 log.debug(
                     "Windows only supports dynamic_strings=True, using dynamic strings despite configuration or kwarg"
                 )
             dynamic_strings = True
-        else:
-            dynamic_strings = self.resolve_defaults("dynamic_strings", proto_cfg, global_default=False, **kwargs)
         return dynamic_strings
 
     last_mismatch_msg: Optional[str] = None


### PR DESCRIPTION
This is in line with library creation.