### PR TITLE
Fix version map cache update on compaction

### DIFF
--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -364,7 +364,7 @@ public:
         if (validate_)
             new_entry->validate();
 
-        std::swap(entry, new_entry);
+        std::swap(*entry, *new_entry);
     }
 
     VariantKey journal_single_key(
@@ -456,7 +456,7 @@ public:
         if (validate_)
             new_entry->validate();
 
-        std::swap(entry, new_entry);
+        std::swap(*entry, *new_entry);
     }
 
     void overwrite_symbol_tree(


### PR DESCRIPTION
Fixes the version map compaction cache update.

Consists of two commits:
- first one introduces the new c++ test for compaction
- second one actually fixes the trivial issue

#### Reference Issues/PRs

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
