### PR TITLE
Add support for testing NFS based layout with S3 backend

### DIFF
--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -230,9 +230,13 @@ def get_s3_proto(
     ca_cert_path=None,
     ca_cert_dir=None,
     ssl=False,
+    is_nfs_layout=False,
 ):
     env = cfg.env_by_id[env_name]
-    s3 = S3Config()
+    if is_nfs_layout:
+        s3 = NfsConfig()
+    else:
+        s3 = S3Config()
     if bucket_name is not None:
         s3.bucket_name = bucket_name
     if credential_name is not None:
@@ -287,6 +291,7 @@ def add_s3_library_to_env(
     ca_cert_path=None,
     ca_cert_dir=None,
     ssl=False,
+    is_nfs_layout=False
 ):
     env = cfg.env_by_id[env_name]
     if with_prefix and isinstance(with_prefix, str) and (with_prefix.endswith("/") or "//" in with_prefix):
@@ -311,6 +316,7 @@ def add_s3_library_to_env(
         ca_cert_path=ca_cert_path,
         ca_cert_dir=ca_cert_dir,
         ssl=ssl,
+        is_nfs_layout=is_nfs_layout
     )
 
     _add_lib_desc_to_env(env, lib_name, sid, description)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -10,7 +10,6 @@ import enum
 import hypothesis
 import os
 import pytest
-import numpy as np
 import pandas as pd
 import platform
 import random
@@ -25,6 +24,7 @@ from arcticdb.storage_fixtures.azure import AzuriteStorageFixtureFactory
 from arcticdb.storage_fixtures.lmdb import LmdbStorageFixture
 from arcticdb.storage_fixtures.s3 import (
     MotoS3StorageFixtureFactory,
+    MotoNfsBackedS3StorageFixtureFactory,
     real_s3_from_environment_variables,
     mock_s3_with_error_simulation,
 )
@@ -129,9 +129,21 @@ def s3_bucket_versioning_storage_factory():
         yield f
 
 
+@pytest.fixture(scope="session")
+def nfs_backed_s3_storage_factory():
+    with MotoNfsBackedS3StorageFixtureFactory(use_ssl=False, ssl_test_support=False, bucket_versioning=False) as f:
+        yield f
+
+
 @pytest.fixture
 def s3_storage(s3_storage_factory):
     with s3_storage_factory.create_fixture() as f:
+        yield f
+
+
+@pytest.fixture
+def nfs_backed_s3_storage(nfs_backed_s3_storage_factory):
+    with nfs_backed_s3_storage_factory.create_fixture() as f:
         yield f
 
 


### PR DESCRIPTION
I need to test against the NFS style backend in the `arcticdb-enterprise` repo so I need these test fixture improvements.

I thought it would be worthwhile adding an NFS backend test while I'm here, as a way to make sure that the fixtures are maintained properly.

Motivation: https://github.com/man-group/arcticdb-enterprise/pull/139