### PR TITLE
conda-build: Unpin libcxx <18

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   # Build tools
-  - libcxx==17.0.6
   - cxx-compiler
   - c-compiler
   - cmake


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?

#1724 has been fixed.

#### Any other comments?

#### Checklist