### PR TITLE
Fix batch version map copy

### DIFF
--- a/cpp/arcticdb/version/test/test_version_map_batch.cpp
+++ b/cpp/arcticdb/version/test/test_version_map_batch.cpp
@@ -270,3 +270,21 @@ TEST_F(VersionMapBatchStore, CombinedQueries) {
         }
     }
 }
+
+TEST_F(VersionMapBatchStore, SpecificVersionsShouldCopyInput) {
+    SKIP_WIN("Exceeds LMDB map size");
+    ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
+    auto store = test_store_->_test_get_store();
+    auto version_map = std::make_shared<VersionMap>();
+    std::string symbol = "symbol";
+    std::string symbol_2 = "symbol_2";
+
+    add_versions_for_stream(version_map, store, symbol, 5);
+
+    for (uint64_t i=0; i<1000; ++i) {
+        auto sym_versions = std::map<StreamId, VersionVectorType>{{symbol, {4}}};
+        batch_get_specific_versions(store, version_map, sym_versions);
+        // We add to the sym_versions a missing symbol after the batch_get to mimic the issue: https://github.com/man-group/ArcticDB/issues/1716
+        sym_versions.insert({symbol_2, {50}});
+    }
+}


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1716 

#### What does this implement or fix?
It fixes an issue where we were passing a `const std::map&` to `folly::window`. This was a problem because `folly::window` requires ownership of the input as it can fill all of the futures but still need access to the input to finish correctly. What was happening is that we were destructing the std::map before folly::window could finish.

This pr also addresses a performance regression. The `std::advance` used in `MapRandomAccessWrapper` is actually linear causing the batch operation to be `O(N**2)`. This is easily resolved by using `std::vector`.

#### Any other comments?
This pr consists of two commits:
1. Adds a c++ test to mimic the segfault.
2. Fixes the bug and does the performance improvement.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
