### PR TITLE
Get version information from the symbol list when available

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -505,7 +505,7 @@ set(arcticdb_srcs
         version/version_map_batch_methods.cpp
         storage/s3/ec2_utils.cpp
         storage/lmdb/lmdb.hpp
-        )
+        version/version_result.hpp)
 
 if(${ARCTICDB_INCLUDE_ROCKSDB})
     list (APPEND arcticdb_srcs

--- a/cpp/arcticdb/version/version_result.hpp
+++ b/cpp/arcticdb/version/version_result.hpp
@@ -1,0 +1,26 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/entity/types.hpp>
+
+namespace arcticdb {
+
+struct VersionResult {
+    StreamId stream_id_;
+    entity::VersionId version_id_;
+    entity::timestamp timestamp_;
+    std::vector<entity::SnapshotId> snapshots_;
+    bool is_deleted_;
+
+    friend bool operator<(const VersionResult& left, const VersionResult& right) {
+        return std::tie(left.stream_id_, left.timestamp_) >
+            std::tie(right.stream_id_, right.timestamp_);
+    };
+};
+} // namespace arcticdb

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -32,6 +32,7 @@
 #include <arcticdb/version/local_versioned_engine.hpp>
 #include <arcticdb/entity/read_result.hpp>
 #include <arcticdb/version/version_log.hpp>
+#include <arcticdb/version/version_result.hpp>
 
 #include <type_traits>
 #include <iostream>
@@ -260,7 +261,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::vector<VersionId>& version_ids
         );
 
-    std::vector<std::tuple<StreamId, VersionId, timestamp, std::vector<SnapshotId>, bool>> list_versions(
+    std::vector<VersionResult> list_versions(
         const std::optional<StreamId> &stream_id,
         const std::optional<SnapshotId>& snap_name,
         const std::optional<bool> &latest_only,


### PR DESCRIPTION
WIP In the case where we don't need snapshot information or deleted versions, we can get the latest version information more quickly from the new-style symbol list