### PR TITLE
Use EncodedFieldImpl.blocks() rather than casting member variable _blocks

### DIFF
--- a/cpp/arcticdb/codec/encoded_field.hpp
+++ b/cpp/arcticdb/codec/encoded_field.hpp
@@ -307,9 +307,9 @@ struct EncodedFieldImpl : public EncodedField {
     [[nodiscard]] const EncodedBlock& shapes(size_t n) const {
         util::check(shapes_count_ != 0, "No shape allocated");
         if(!is_old_style_shapes())
-            return *reinterpret_cast<const EncodedBlock*>(&blocks_[0]);
+            return blocks()[n];
         else
-            return *reinterpret_cast<const EncodedBlock*>(&blocks_[n * 2]);
+            return blocks()[n * 2];
     }
 
     [[nodiscard]] const EncodedBlock &values(size_t n) const {

--- a/cpp/arcticdb/codec/encoded_field.hpp
+++ b/cpp/arcticdb/codec/encoded_field.hpp
@@ -306,9 +306,10 @@ struct EncodedFieldImpl : public EncodedField {
 
     [[nodiscard]] const EncodedBlock& shapes(size_t n) const {
         util::check(shapes_count_ != 0, "No shape allocated");
-        if(!is_old_style_shapes())
-            return blocks()[n];
-        else
+        if(!is_old_style_shapes()) {
+            util::check(n == 0, "Block index must be 0 not {} if not using old style shapes", n);
+            return blocks()[0];
+        } else
             return blocks()[n * 2];
     }
 

--- a/cpp/arcticdb/codec/encoded_field.hpp
+++ b/cpp/arcticdb/codec/encoded_field.hpp
@@ -309,8 +309,9 @@ struct EncodedFieldImpl : public EncodedField {
         if(!is_old_style_shapes()) {
             util::check(n == 0, "Block index must be 0 not {} if not using old style shapes", n);
             return blocks()[0];
-        } else
+        } else {
             return blocks()[n * 2];
+        }
     }
 
     [[nodiscard]] const EncodedBlock &values(size_t n) const {


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes part of #1724.

#### What does this implement or fix?

This fixes one of the undefined behaviours that came to light in issue #1724 when building and testing ArcticDB on macOS ARM using a hardened build of `libcxx`. The C++ test it fixes is `SegmentHeader.SerializeUnserializeV1`.

#### Any other comments?

Previously `EncodedFieldImpl::shapes` was applying an offset into the `_blocks` member variable `std::array` before casting to an `EncodedBlock`. Other use of `_blocks` in this class uses the member function `blocks()` to do it the other way round, i.e. casting then offsetting. In practice this has been fine but in principle it is not as some hardware platform could have some interesting memory alignment to mess this up, which is what the hardened `libcxx` identifies.

The fix is to use the same approach in `shapes()` to that in `values()`, the function below it.

I have tested this locally against a hardened build on macOS ARM, and also against an unhardened build on Ubuntu. Hardened builds are currently not tested in CI and I suspect that we don't want to add one as it would be considered a poor use of CI resources.