### PR TITLE
Refactor - safer KeySegmentPair API

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -144,9 +144,9 @@ jobs:
           ls arcticdb
           make -j ${{ steps.cpu-cores.outputs.count }} arcticdb_rapidcheck_tests
           make -j ${{ steps.cpu-cores.outputs.count }} test_unit_arcticdb
-          ctest
+          ctest --rerun-failed --output-on-failure
 
-      # We are chainging the python here because we want to use the default python to build (it is devel version)
+      # We are changing the python here because we want to use the default python to build (it is devel version)
       # and this python for the rest of the testing
       - name: Select Python (Linux)
         run: echo /opt/python/cp36-cp36m/bin >> $GITHUB_PATH

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -180,6 +180,7 @@ set(arcticdb_srcs
         # header files
         async/async_store.hpp
         async/batch_read_args.hpp
+        async/bit_rate_stats.hpp
         async/task_scheduler.hpp
         async/tasks.hpp
         codec/codec.hpp
@@ -389,6 +390,7 @@ set(arcticdb_srcs
         version/version_utils.hpp
         # CPP files
         async/async_store.cpp
+        async/bit_rate_stats.cpp
         async/task_scheduler.cpp
         async/tasks.cpp
         codec/codec.cpp

--- a/cpp/arcticdb/async/async_store.cpp
+++ b/cpp/arcticdb/async/async_store.cpp
@@ -12,7 +12,7 @@
 #include <arcticdb/version/de_dup_map.hpp>
 
 namespace arcticdb::async {
-std::pair<entity::VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
+std::pair<entity::VariantKey, std::optional<std::shared_ptr<Segment>>> lookup_match_in_dedup_map(
     const std::shared_ptr<DeDupMap> &de_dup_map,
     storage::KeySegmentPair&& key_seg) {
     std::optional<AtomKey> de_dup_key;
@@ -20,8 +20,7 @@ std::pair<entity::VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
         ARCTICDB_DEBUG(log::version(),
                        "No existing key with same contents: writing new object {}",
                        key_seg.atom_key());
-        return std::make_pair(std::move(key_seg.atom_key()), std::make_optional(std::move(key_seg.segment())));
-
+        return std::make_pair(key_seg.atom_key(), std::make_optional(key_seg.segment_ptr()));
     } else {
         ARCTICDB_DEBUG(log::version(),
                        "Found existing key with same contents: using existing object {}",

--- a/cpp/arcticdb/async/bit_rate_stats.cpp
+++ b/cpp/arcticdb/async/bit_rate_stats.cpp
@@ -1,0 +1,50 @@
+#include "bit_rate_stats.hpp"
+
+#include <folly/Likely.h>
+
+#include "log/log.hpp"
+#include "util/format_bytes.hpp"
+#include "entity/performance_tracing.hpp"
+
+constexpr uint64_t max_bytes{0xFFFFFFFFFF};
+constexpr uint64_t max_time_ms{0xFFFFFF};
+constexpr arcticdb::entity::timestamp log_frequency_ns{60LL * 1000L * 1000L * 1000L};
+
+namespace arcticdb::async {
+
+    BitRateStats::BitRateStats():
+            last_log_time_ns_(util::SysClock::coarse_nanos_since_epoch())
+    {}
+
+    void BitRateStats::add_stat(std::size_t bytes, double time_ms) {
+        auto now = util::SysClock::coarse_nanos_since_epoch();
+        uint64_t stat = data_to_stat(bytes, time_ms);
+        auto previous_stats = stats_.fetch_add(stat);
+        auto current_stats = previous_stats + stat;
+        if (now - last_log_time_ns_ > log_frequency_ns && stats_.compare_exchange_strong(current_stats, 0)) {
+            last_log_time_ns_ = now;
+            log_stats(current_stats);
+        }
+    }
+
+    uint64_t BitRateStats::data_to_stat(std::size_t bytes, double time_ms) const {
+        if (UNLIKELY(bytes > max_bytes || time_ms > max_time_ms)) {
+            log::storage().warn("Bit rate stats provided too large to represent, ignoring: {} in {}ms",
+                                format_bytes(bytes),
+                                time_ms);
+            return 0;
+        }
+        uint64_t stat{(bytes << 24) + static_cast<uint64_t>(time_ms)};
+        return stat;
+    }
+
+    void BitRateStats::log_stats(uint64_t stats) const {
+        double time_s = static_cast<double>(stats & max_time_ms) / 1000;
+        double bytes = static_cast<double>(stats >> 24);
+        double bandwidth = bytes / time_s;
+        log::storage().info("Byte rate {}/s", format_bytes(bandwidth));
+        std::string log_msg = "Current BW is " + format_bytes(bandwidth)+"/s";
+        ARCTICDB_SAMPLE_LOG(log_msg.c_str());
+    }
+
+} // arcticdb::async

--- a/cpp/arcticdb/async/bit_rate_stats.hpp
+++ b/cpp/arcticdb/async/bit_rate_stats.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+#include "arcticdb/util/clock.hpp"
+#include "arcticdb/util/constructors.hpp"
+
+namespace arcticdb::async {
+
+    class BitRateStats {
+    public:
+        BitRateStats();
+        void add_stat(std::size_t bytes, double time_ms);
+
+        ARCTICDB_NO_MOVE_OR_COPY(BitRateStats)
+    private:
+        uint64_t data_to_stat(std::size_t bytes, double time_ms) const;
+        void log_stats(uint64_t stats) const;
+
+        // Use an 8 byte atomic for lock free implementation
+        // Upper 5 bytes represent the number of bytes of data transferred (giving max representable value of 1TB)
+        // Lower 3 bytes represent the total time in milliseconds (giving max representable value of 4.5 hours)
+        std::atomic_uint64_t stats_{0};
+
+        entity::timestamp last_log_time_ns_;
+    };
+
+} // arcticdb::async
+

--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -36,11 +36,10 @@ namespace arcticdb::async {
     }
 
     pipelines::SegmentAndSlice DecodeSliceTask::decode_into_slice(storage::KeySegmentPair&& key_segment_pair) {
-        auto key = std::move(key_segment_pair.atom_key());
-        auto seg = std::move(key_segment_pair.release_segment());
-        ARCTICDB_DEBUG(log::storage(), "ReadAndDecodeAtomTask decoding segment of size {} with key {}",
+        const Segment& seg = key_segment_pair.segment();
+        ARCTICDB_DEBUG(log::storage(), "decode_into_slice with key_segment_pair decoding segment of size {} with key {}",
                        seg.size(),
-                       key);
+                       key_segment_pair.atom_key());
         auto &hdr = seg.header();
         const auto& desc = seg.descriptor();
         auto descriptor = async::get_filtered_descriptor(desc, columns_to_decode_);
@@ -53,7 +52,7 @@ namespace arcticdb::async {
 
     pipelines::SliceAndKey DecodeSlicesTask::decode_into_slice(std::pair<Segment, pipelines::SliceAndKey>&& sk_pair) const {
         auto [seg, sk] = std::move(sk_pair);
-        ARCTICDB_DEBUG(log::storage(), "ReadAndDecodeAtomTask decoding segment with key {}",
+        ARCTICDB_DEBUG(log::storage(), "decode_into_slice with sk_pair decoding segment with key {}",
                       variant_key_view(sk.key()));
 
         auto &hdr = seg.header();

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -323,7 +323,7 @@ std::optional<TimeseriesDescriptor> decode_timeseries_descriptor(
 }
 
 std::optional<TimeseriesDescriptor> decode_timeseries_descriptor(
-    Segment& segment) {
+    const Segment& segment) {
     const auto &hdr = segment.header();
     const uint8_t* data = segment.buffer().data();
 
@@ -354,7 +354,7 @@ std::optional<TimeseriesDescriptor> decode_timeseries_descriptor_for_incompletes
 }
 
 std::optional<TimeseriesDescriptor> decode_timeseries_descriptor_for_incompletes(
-        Segment& segment) {
+        const Segment& segment) {
     auto &hdr = segment.header();
     const uint8_t* data = segment.buffer().data();
 
@@ -366,7 +366,7 @@ std::optional<TimeseriesDescriptor> decode_timeseries_descriptor_for_incompletes
 }
 
 std::pair<std::optional<google::protobuf::Any>, StreamDescriptor> decode_metadata_and_descriptor_fields(
-    Segment& segment) {
+    const Segment& segment) {
     auto &hdr = segment.header();
     const uint8_t* data = segment.buffer().data();
 
@@ -547,7 +547,7 @@ void decode_v1(const Segment& segment,
 
 void decode_into_memory_segment(
     const Segment& segment,
-    SegmentHeader& hdr,
+    const SegmentHeader& hdr,
     SegmentInMemory& res,
     const StreamDescriptor& desc)
 {
@@ -557,8 +557,7 @@ void decode_into_memory_segment(
         decode_v1(segment, hdr, res, desc);
 }
 
-SegmentInMemory decode_segment(Segment&& s) {
-    auto segment = std::move(s);
+SegmentInMemory decode_segment(const Segment& segment) {
     auto &hdr = segment.header();
     ARCTICDB_TRACE(log::codec(), "Decoding descriptor: {}", segment.descriptor());
     auto descriptor = segment.descriptor();

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -57,11 +57,11 @@ EncodedFieldCollection decode_encoded_fields(
     const uint8_t* data,
     const uint8_t* begin ARCTICDB_UNUSED);
 
-SegmentInMemory decode_segment(Segment&& segment);
+SegmentInMemory decode_segment(const Segment& segment);
 
 void decode_into_memory_segment(
     const Segment& segment,
-    SegmentHeader& hdr,
+    const SegmentHeader& hdr,
     SegmentInMemory& res,
     const entity::StreamDescriptor& desc);
 
@@ -78,12 +78,12 @@ std::optional<google::protobuf::Any> decode_metadata_from_segment(
     const Segment& segment);
 
 std::pair<std::optional<google::protobuf::Any>, StreamDescriptor> decode_metadata_and_descriptor_fields(
-    Segment& segment);
+    const Segment& segment);
 
 std::optional<TimeseriesDescriptor> decode_timeseries_descriptor(
-    Segment& segment);
+    const Segment& segment);
 
-std::optional<TimeseriesDescriptor> decode_timeseries_descriptor_for_incompletes(Segment& segment);
+std::optional<TimeseriesDescriptor> decode_timeseries_descriptor_for_incompletes(const Segment& segment);
 
 HashedValue get_segment_hash(Segment& seg);
 

--- a/cpp/arcticdb/codec/python_bindings.cpp
+++ b/cpp/arcticdb/codec/python_bindings.cpp
@@ -102,8 +102,8 @@ Segment encode_segment(SegmentInMemory segment_in_memory, const py::object &opts
     return encode_dispatch(std::move(segment_in_memory), opts_cpp, encoding_version);
 }
 
-SegmentInMemory decode_python_segment(Segment& segment) {
-    return decode_segment(std::move(segment));
+SegmentInMemory decode_python_segment(const Segment& segment) {
+    return decode_segment(segment);
 }
 
 class BufferPairDataSink {

--- a/cpp/arcticdb/codec/segment.cpp
+++ b/cpp/arcticdb/codec/segment.cpp
@@ -238,7 +238,7 @@ Segment Segment::from_buffer(const std::shared_ptr<Buffer>& buffer) {
     return{std::move(seg_hdr), buffer, std::move(desc_data), std::move(fields), stream_id, readable_size};
 }
 
-size_t Segment::write_proto_header(uint8_t* dst) {
+size_t Segment::write_proto_header(uint8_t* dst) const {
     const auto& header = generate_header_proto();
     const auto hdr_size = proto_size();
     FixedHeader hdr = {MAGIC_NUMBER, HEADER_VERSION_V1, std::uint32_t(hdr_size)};
@@ -256,7 +256,7 @@ size_t Segment::write_binary_header(uint8_t* dst) const {
     return bytes_written;
 }
 
-std::pair<uint8_t*, size_t> Segment::serialize_header_v2(size_t expected_bytes) {
+std::pair<uint8_t*, size_t> Segment::serialize_header_v2(size_t expected_bytes) const {
     ARCTICDB_TRACE(log::codec(), "Calculating bytes for header {}", header_);
     const auto header_bytes = header_.bytes() + sizeof(FixedHeader);
     FixedHeader hdr = {MAGIC_NUMBER, HEADER_VERSION_V2, std::uint32_t(expected_bytes)};
@@ -265,31 +265,31 @@ std::pair<uint8_t*, size_t> Segment::serialize_header_v2(size_t expected_bytes) 
     auto* dst = buffer->preamble();
     write_fixed_header(dst, hdr);
     header_.serialize_to_bytes(dst + FIXED_HEADER_SIZE, expected_bytes);
-    return std::make_pair(buffer->preamble(), calculate_size());
+    return std::make_pair(buffer->preamble(), size());
 }
 
-std::pair<uint8_t*, size_t> Segment::serialize_v1_header_in_place(size_t total_hdr_size) {
+std::pair<uint8_t*, size_t> Segment::serialize_v1_header_in_place(size_t total_hdr_size) const {
     const auto &buffer = buffer_.get_owning_buffer();
     auto base_ptr = buffer->preamble() + (buffer->preamble_bytes() - total_hdr_size);
     util::check(base_ptr + total_hdr_size == buffer->data(), "Expected base ptr to align with data ptr, {} != {}",fmt::ptr(base_ptr + total_hdr_size),fmt::ptr(buffer->data()));
     write_proto_header(base_ptr);
     ARCTICDB_TRACE(log::storage(), "Header fits in internal buffer {:x} with {} bytes space: {}", intptr_t (base_ptr), buffer->preamble_bytes() - total_hdr_size,dump_bytes(buffer->data(), buffer->bytes(), 100u));
-    return std::make_pair(base_ptr, calculate_size());
+    return std::make_pair(base_ptr, size());
 }
 
-std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_v1_header_to_buffer(size_t hdr_size) {
+std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_v1_header_to_buffer(size_t hdr_size) const {
     auto tmp = std::make_unique<Buffer>();
     ARCTICDB_TRACE(log::storage(), "Header doesn't fit in internal buffer, needed {} bytes but had {}, writing to temp buffer at {:x}", hdr_size, buffer_.preamble_bytes(),uintptr_t(tmp->data()));
-    tmp->ensure(calculate_size());
+    tmp->ensure(size());
     auto* dst = tmp->preamble();
     write_proto_header(dst);
     std::memcpy(dst + FIXED_HEADER_SIZE + hdr_size,
                 buffer().data(),
                 buffer().bytes());
-    return std::make_tuple(tmp->preamble(), calculate_size(), std::move(tmp));
+    return std::make_tuple(tmp->preamble(), size(), std::move(tmp));
 }
 
-std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_header_v1() {
+std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_header_v1() const {
     auto proto_header = generate_v1_header(header_, desc_);
     const auto hdr_size = proto_header.ByteSizeLong();
     auto total_hdr_size = hdr_size + FIXED_HEADER_SIZE;
@@ -302,7 +302,7 @@ std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_header_
     }
 }
 
-std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_header() {
+std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_header() const {
     if (header_.encoding_version() == EncodingVersion::V1) {
         return serialize_header_v1();
     } else {
@@ -323,22 +323,23 @@ std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> Segment::serialize_header(
     return desc_.fields(pos);
 }
 
-const arcticdb::proto::encoding::SegmentHeader& Segment::generate_header_proto() {
+const arcticdb::proto::encoding::SegmentHeader& Segment::generate_header_proto() const {
     if(!proto_)
         proto_ = std::make_unique<arcticdb::proto::encoding::SegmentHeader>(generate_v1_header(header_, desc_));
 
     return *proto_;
 }
 
-void Segment::write_to(std::uint8_t* dst) {
+void Segment::write_to(std::uint8_t* dst) const {
     ARCTICDB_SAMPLE(SegmentWriteToStorage, RMTSF_Aggregate)
     ARCTICDB_SUBSAMPLE(SegmentWriteHeader, RMTSF_Aggregate)
 
     size_t header_size;
-    if(header_.encoding_version() == EncodingVersion::V1)
+    if(header_.encoding_version() == EncodingVersion::V1) {
         header_size = write_proto_header(dst);
-    else
+    } else {
         header_size = write_binary_header(dst);
+    }
 
     ARCTICDB_SUBSAMPLE(SegmentWriteBody, RMTSF_Aggregate)
     ARCTICDB_DEBUG(log::codec(), "Writing {} bytes to body at offset {}", buffer().bytes(), FIXED_HEADER_SIZE + header_size);

--- a/cpp/arcticdb/codec/segment.hpp
+++ b/cpp/arcticdb/codec/segment.hpp
@@ -139,39 +139,33 @@ class Segment {
 
     static Segment from_bytes(const std::uint8_t *src, std::size_t readable_size, bool copy_data = false);
 
-    void write_to(std::uint8_t *dst);
+    void write_to(std::uint8_t *dst) const;
 
-    std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> serialize_header();
+    std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> serialize_header() const;
 
-    size_t write_proto_header(uint8_t* dst);
+    size_t write_proto_header(uint8_t* dst) const;
 
     [[nodiscard]] std::size_t size() const {
-        util::check(size_.has_value(), "Segment size has not been set");
-        return *size_;
-    }
-
-    [[nodiscard]] std::size_t calculate_size() {
         if(!size_.has_value())
             size_ = FIXED_HEADER_SIZE + segment_header_bytes_size() + buffer_bytes();
-
         return *size_;
     }
 
-    const arcticdb::proto::encoding::SegmentHeader& generate_header_proto();
+    const arcticdb::proto::encoding::SegmentHeader& generate_header_proto() const;
 
-    [[nodiscard]] size_t proto_size() {
+    [[nodiscard]] size_t proto_size() const {
         util::check(static_cast<bool>(proto_), "Proto has not been generated");
 
         return proto_->ByteSizeLong();
     }
 
-    [[nodiscard]] std::size_t segment_header_bytes_size() {
+    [[nodiscard]] std::size_t segment_header_bytes_size() const {
         if(header_.encoding_version() == EncodingVersion::V1) {
             generate_header_proto();
             return proto_size();
-        }
-        else
+        } else {
             return header_.bytes();
+        }
     }
 
     [[nodiscard]] std::size_t buffer_bytes() const {
@@ -253,18 +247,18 @@ class Segment {
         size_(size) {
     }
 
-    std::tuple<uint8_t*, size_t,  std::unique_ptr<Buffer>> serialize_v1_header_to_buffer(size_t total_hdr_size);
-    std::pair<uint8_t*, size_t> serialize_v1_header_in_place(size_t total_header_size);
-    std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> serialize_header_v1();
-    std::pair<uint8_t*, size_t> serialize_header_v2(size_t expected_bytes);
+    std::tuple<uint8_t*, size_t,  std::unique_ptr<Buffer>> serialize_v1_header_to_buffer(size_t total_hdr_size) const;
+    std::pair<uint8_t*, size_t> serialize_v1_header_in_place(size_t total_header_size) const;
+    std::tuple<uint8_t*, size_t, std::unique_ptr<Buffer>> serialize_header_v1() const;
+    std::pair<uint8_t*, size_t> serialize_header_v2(size_t expected_bytes) const;
     size_t write_binary_header(uint8_t* dst) const;
 
     SegmentHeader header_;
     VariantBuffer buffer_;
     StreamDescriptor desc_;
     std::any keepalive_;
-    std::unique_ptr<arcticdb::proto::encoding::SegmentHeader> proto_;
-    std::optional<size_t> size_;
+    mutable std::unique_ptr<arcticdb::proto::encoding::SegmentHeader> proto_;  // computed on first read and cached
+    mutable std::optional<size_t> size_;  // computed on first read and cached
 };
 
 } //namespace arcticdb

--- a/cpp/arcticdb/codec/test/test_codec.cpp
+++ b/cpp/arcticdb/codec/test/test_codec.cpp
@@ -317,9 +317,9 @@ TYPED_TEST(SegmentStringEncodingTest, EncodeSingleString) {
     lz4ptr->set_acceleration(1);
     auto copy = s.clone();
     constexpr EncodingVersion encoding_version = TypeParam::value;
-    Segment seg = encode_dispatch(s.clone(), opt, encoding_version);
+    auto seg = encode_dispatch(s.clone(), opt, encoding_version);
 
-    SegmentInMemory res = decode_segment(std::move(seg));
+    SegmentInMemory res = decode_segment(seg);
     ASSERT_EQ(copy.string_at(0, 1), res.string_at(0, 1));
     ASSERT_EQ(std::string("happy"), res.string_at(0, 1));
 }
@@ -346,7 +346,7 @@ TYPED_TEST(SegmentStringEncodingTest, EncodeStringsBasic) {
     constexpr EncodingVersion encoding_version = TypeParam::value;
     Segment seg = encode_dispatch(SegmentInMemory{s}, opt, encoding_version);
 
-    SegmentInMemory res = decode_segment(std::move(seg));
+    SegmentInMemory res = decode_segment(seg);
     ASSERT_EQ(copy.string_at(0, 1), res.string_at(0, 1));
     ASSERT_EQ(std::string("happy"), res.string_at(0, 1));
     ASSERT_EQ(copy.string_at(1, 3), res.string_at(1, 3));
@@ -444,7 +444,7 @@ TEST(Segment, RoundtripTimeseriesDescriptorWriteToBufferV1) {
     auto copy = in_mem_seg.clone();
     auto seg = encode_v1(std::move(in_mem_seg), codec::default_lz4_codec());
     std::vector<uint8_t> vec;
-    const auto bytes = seg.calculate_size();
+    const auto bytes = seg.size();
     vec.resize(bytes);
     seg.write_to(vec.data());
     auto unserialized = Segment::from_bytes(vec.data(), bytes);
@@ -462,7 +462,7 @@ TEST(Segment, RoundtripStringsWriteToBufferV1) {
     auto copy = in_mem_seg.clone();
     auto seg = encode_v1(std::move(in_mem_seg), codec::default_lz4_codec());
     std::vector<uint8_t> vec;
-    const auto bytes = seg.calculate_size();
+    const auto bytes = seg.size();
     vec.resize(bytes);
     seg.write_to(vec.data());
     auto unserialized = Segment::from_bytes(vec.data(), bytes);
@@ -501,7 +501,7 @@ TEST(Segment, RoundtripTimeseriesDescriptorWriteToBufferV2) {
     auto copy = in_mem_seg.clone();
     auto seg = encode_v2(std::move(in_mem_seg), codec::default_lz4_codec());
     std::vector<uint8_t> vec;
-    const auto bytes = seg.calculate_size();
+    const auto bytes = seg.size();
     ARCTICDB_DEBUG(log::codec(), "## Resizing buffer to {} bytes", bytes);
     vec.resize(bytes);
     seg.write_to(vec.data());

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -81,7 +81,7 @@ folly::Future<std::vector<VariantKey>> fetch_data(
 void decode_into_frame_static(
     SegmentInMemory &frame,
     PipelineContextRow &context,
-    Segment &&seg,
+    const Segment& seg,
     const std::shared_ptr<BufferHolder>& buffers
     );
 

--- a/cpp/arcticdb/storage/azure/azure_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_wrapper.hpp
@@ -50,11 +50,11 @@ public:
     using Config = arcticdb::proto::azure_storage::Config;
     virtual void write_blob(
             const std::string& blob_name,
-            Segment&& segment,
+            const Segment& segment,
             const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
             unsigned int request_timeout) = 0;
 
-    virtual Segment read_blob(
+    virtual std::shared_ptr<Segment> read_blob(
             const std::string& blob_name,
             const Azure::Storage::Blobs::DownloadBlobToOptions& download_option,
             unsigned int request_timeout) = 0;

--- a/cpp/arcticdb/storage/azure/azure_mock_client.cpp
+++ b/cpp/arcticdb/storage/azure/azure_mock_client.cpp
@@ -55,7 +55,7 @@ std::optional<Azure::Core::RequestFailedException> has_failure_trigger(const std
 
 void MockAzureClient::write_blob(
         const std::string& blob_name,
-        arcticdb::Segment&& segment,
+        const arcticdb::Segment& segment,
         const Azure::Storage::Blobs::UploadBlockBlobFromOptions&,
         unsigned int) {
 
@@ -64,10 +64,10 @@ void MockAzureClient::write_blob(
         throw maybe_exception.value();
     }
 
-    azure_contents.insert_or_assign(blob_name, std::move(segment));
+    azure_contents.insert_or_assign(blob_name, segment.clone());
 }
 
-Segment MockAzureClient::read_blob(
+std::shared_ptr<Segment> MockAzureClient::read_blob(
         const std::string& blob_name,
         const Azure::Storage::Blobs::DownloadBlobToOptions&,
         unsigned int) {
@@ -84,7 +84,7 @@ Segment MockAzureClient::read_blob(
         throw get_exception(message, error_code, Azure::Core::Http::HttpStatusCode::NotFound);
     }
 
-    return std::move(pos->second);
+    return std::make_shared<Segment>(std::move(pos->second));
 }
 
 void MockAzureClient::delete_blobs(

--- a/cpp/arcticdb/storage/azure/azure_mock_client.hpp
+++ b/cpp/arcticdb/storage/azure/azure_mock_client.hpp
@@ -24,11 +24,11 @@ public:
 
     void write_blob(
             const std::string& blob_name,
-            Segment&& segment,
+            const Segment& segment,
             const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
             unsigned int request_timeout) override;
 
-    Segment read_blob(
+    std::shared_ptr<Segment> read_blob(
             const std::string& blob_name,
             const Azure::Storage::Blobs::DownloadBlobToOptions& download_option,
             unsigned int request_timeout) override;

--- a/cpp/arcticdb/storage/azure/azure_real_client.cpp
+++ b/cpp/arcticdb/storage/azure/azure_real_client.cpp
@@ -47,7 +47,7 @@ Azure::Storage::Blobs::BlobClientOptions RealAzureClient::get_client_options(con
 
 void RealAzureClient::write_blob(
         const std::string& blob_name,
-        Segment&& segment,
+        const Segment& segment,
         const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
         unsigned int request_timeout) {
 
@@ -60,7 +60,7 @@ void RealAzureClient::write_blob(
     blob_client.UploadFrom(dst, write_size, upload_option, get_context(request_timeout));
 }
 
-Segment RealAzureClient::read_blob(
+std::shared_ptr<Segment> RealAzureClient::read_blob(
         const std::string& blob_name,
         const Azure::Storage::Blobs::DownloadBlobToOptions& download_option,
         unsigned int request_timeout) {
@@ -72,7 +72,7 @@ Segment RealAzureClient::read_blob(
     blob_client.DownloadTo(buffer->preamble(), buffer->available(), download_option, get_context(request_timeout));
     ARCTICDB_SUBSAMPLE(AzureStorageVisitSegment, 0)
 
-    return Segment::from_buffer(std::move(buffer));
+    return std::make_shared<Segment>(Segment::from_buffer(std::move(buffer)));
 }
 
 void RealAzureClient::delete_blobs(

--- a/cpp/arcticdb/storage/azure/azure_real_client.hpp
+++ b/cpp/arcticdb/storage/azure/azure_real_client.hpp
@@ -26,11 +26,11 @@ public:
 
     void write_blob(
             const std::string& blob_name,
-            Segment&& segment,
+            const Segment& segment,
             const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
             unsigned int request_timeout) override;
 
-    Segment read_blob(
+    std::shared_ptr<Segment> read_blob(
             const std::string& blob_name,
             const Azure::Storage::Blobs::DownloadBlobToOptions& download_option,
             unsigned int request_timeout) override;

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -124,10 +124,10 @@ void do_write_impl(
                 for (auto& kv : group.values()) {
                     auto& k = kv.variant_key();
                     auto blob_name = object_path(b.bucketize(key_type_dir, k), k);
-                    auto& seg = kv.segment();
+                    const Segment& seg = kv.segment();
 
                     try {
-                        azure_client.write_blob(blob_name, std::move(seg), upload_option, request_timeout);
+                        azure_client.write_blob(blob_name, seg, upload_option, request_timeout);
                     }
                     catch (const Azure::Core::RequestFailedException& e) {
                         raise_azure_exception(e, blob_name);

--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -27,6 +27,12 @@ using StorageName = util::StringWrappingValue<StorageNameTag>;
 struct InstanceUriTag{};
 using InstanceUri = util::StringWrappingValue<InstanceUriTag>;
 
+template<class T>
+requires std::is_same_v<T, EnvironmentName> || std::is_same_v<T, StorageName>
+bool operator==(const T &l, const T &r) {
+    return l.value == r.value;
+}
+
 /*
  * Placeholder class for now
  */

--- a/cpp/arcticdb/storage/file/mapped_file_storage.cpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.cpp
@@ -56,7 +56,7 @@ void MappedFileStorage::init() {
 
 SegmentInMemory MappedFileStorage::read_segment(size_t offset, size_t bytes) const  {
     auto index_segment = Segment::from_bytes(file_.data() + offset, bytes);
-    return decode_segment(std::move(index_segment));
+    return decode_segment(index_segment);
 }
 
 void MappedFileStorage::do_load_header(size_t header_offset, size_t header_size) {
@@ -75,8 +75,7 @@ uint64_t MappedFileStorage::get_data_offset(const Segment& seg) {
     return previous_offset;
 }
 
-uint64_t MappedFileStorage::write_segment(Segment&& seg) {
-    auto segment = std::move(seg);
+uint64_t MappedFileStorage::write_segment(const Segment& segment) {
     auto offset = get_data_offset(segment);
     auto* data = file_.data() + offset;
     ARCTICDB_SUBSAMPLE(FileStorageMemCpy, 0)
@@ -89,7 +88,7 @@ void MappedFileStorage::do_write(Composite<KeySegmentPair>&& kvs) {
     ARCTICDB_SAMPLE(MappedFileStorageWriteValues, 0)
     auto key_values = std::move(kvs);
     key_values.broadcast([this] (auto key_seg) {
-        const auto offset = write_segment(std::move(key_seg.segment()));
+        const auto offset = write_segment(key_seg.segment());
         const auto size = key_seg.segment().size();
         multi_segment_header_.add_key_and_offset(key_seg.atom_key(), offset, size);
     });
@@ -107,7 +106,7 @@ void MappedFileStorage::do_read(Composite<VariantKey>&& ks, const ReadVisitor& v
         util::check(maybe_offset.has_value(), "Failed to find key {} in file", key);
         auto [offset, bytes] = std::move(maybe_offset.value());
         auto segment = Segment::from_bytes(file_.data() + offset, bytes);
-        visitor(key, std::move(segment));
+        visitor(key, std::make_shared<Segment>(std::move(segment)));
     });
 }
 

--- a/cpp/arcticdb/storage/file/mapped_file_storage.hpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.hpp
@@ -62,7 +62,7 @@ class MappedFileStorage final : public SingleFileStorage {
 
     void do_load_header(size_t header_offset, size_t header_size) override;
 
-    uint64_t write_segment(Segment&& seg);
+    uint64_t write_segment(const Segment& seg);
 
     uint8_t* do_read_raw(size_t offset, size_t bytes) override;
 

--- a/cpp/arcticdb/storage/key_segment_pair.hpp
+++ b/cpp/arcticdb/storage/key_segment_pair.hpp
@@ -9,6 +9,7 @@
 
 #include <arcticdb/entity/key.hpp>
 #include <arcticdb/codec/segment.hpp>
+#include <utility>
 
 namespace arcticdb::storage {
     using namespace entity;
@@ -18,63 +19,51 @@ namespace arcticdb::storage {
      * not contain any positioning information for the contained data.
      */
     class KeySegmentPair {
-        struct KeySegmentData {
-            VariantKey key_;
-            Segment segment_;
-
-            KeySegmentData() = default;
-            explicit KeySegmentData(VariantKey &&key) : key_(std::move(key)), segment_() {}
-            KeySegmentData(VariantKey &&key, Segment &&segment) : key_(std::move(key)), segment_(std::move(segment)) {}
-
-            ARCTICDB_NO_MOVE_OR_COPY(KeySegmentData)
-        };
-
     public:
-        KeySegmentPair() : data_(std::make_shared<KeySegmentData>()) {}
-        explicit KeySegmentPair(VariantKey &&key) : data_(std::make_shared<KeySegmentData>(std::move(key))) {}
-        KeySegmentPair(VariantKey &&key, Segment&& segment) :
-            data_(std::make_shared<KeySegmentData>(std::move(key), std::move(segment))) {}
+        KeySegmentPair() = default;
+
+        explicit KeySegmentPair(VariantKey &&key)
+            : key_(std::make_shared<VariantKey>(std::move(key))) {}
+
+        KeySegmentPair(VariantKey &&key, Segment &&segment)
+            : key_(std::make_shared<VariantKey>(std::move(key))),
+              segment_(std::make_shared<Segment>(std::move(segment))) {}
+
+        KeySegmentPair(const VariantKey &key, Segment &&segment)
+            : key_(std::make_shared<VariantKey>(key)), segment_(std::make_shared<Segment>(std::move(segment))) {}
+
+        template<typename K>
+        KeySegmentPair(K &&key, std::shared_ptr<Segment> segment)
+            : key_(std::make_shared<VariantKey>(std::forward<K>(key))),
+              segment_(std::move(segment)) {}
 
         ARCTICDB_MOVE_COPY_DEFAULT(KeySegmentPair)
 
-        Segment &segment() {
-            return data_->segment_;
-        }
-
-        Segment&& release_segment() {
-            return std::move(data_->segment_);
-        }
-
-        AtomKey &atom_key() {
-            util::check(std::holds_alternative<AtomKey>(variant_key()), "Expected atom key access");
-            return std::get<AtomKey >(variant_key());
+        [[nodiscard]] std::shared_ptr<Segment> segment_ptr() const {
+          return segment_;
         }
 
         [[nodiscard]] const AtomKey &atom_key() const {
             util::check(std::holds_alternative<AtomKey>(variant_key()), "Expected atom key access");
-            return std::get<AtomKey >(variant_key());
+            return std::get<AtomKey>(variant_key());
         }
 
-        RefKey &ref_key() {
+        [[nodiscard]] const RefKey& ref_key() const {
             util::check(std::holds_alternative<RefKey>(variant_key()), "Expected ref key access");
-            return std::get<RefKey >(variant_key());
+            return std::get<RefKey>(variant_key());
         }
 
-        [[nodiscard]] const RefKey &ref_key() const {
-            util::check(std::holds_alternative<RefKey>(variant_key()), "Expected ref key access");
-            return std::get<RefKey >(variant_key());
-        }
-
-        VariantKey& variant_key() {
-            return data_->key_;
+        template<typename T>
+        void set_key(T&& key) {
+          key_ = std::make_shared<VariantKey>(key);
         }
 
         [[nodiscard]] const VariantKey& variant_key() const {
-            return data_->key_;
+            return *key_;
         }
 
-        [[nodiscard]] const Segment &segment() const {
-            return data_->segment_;
+        [[nodiscard]] const Segment& segment() const {
+            return *segment_;
         }
 
         [[nodiscard]] bool has_segment() const {
@@ -90,14 +79,8 @@ namespace arcticdb::storage {
         }
 
     private:
-        std::shared_ptr<KeySegmentData> data_;
+        std::shared_ptr<VariantKey> key_ = std::make_shared<VariantKey>();
+        std::shared_ptr<Segment> segment_ = std::make_shared<Segment>();
     };
-
-    template<class T, std::enable_if_t<std::is_same_v<T, EnvironmentName> || std::is_same_v<T, StorageName>, int> = 0>
-    bool operator==(const T &l, const T &r) {
-        return l.value == r.value;
-    }
-
-
 
 } //namespace arcticdb

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -24,6 +24,7 @@
 #include <folly/concurrency/ConcurrentHashMap.h>
 #include <boost/core/noncopyable.hpp>
 #include <filesystem>
+#include <utility>
 
 
 
@@ -122,10 +123,10 @@ class Library {
     }
 
     KeySegmentPair read(VariantKey key, ReadKeyOpts opts = ReadKeyOpts{}) {
-        KeySegmentPair res{VariantKey{key}};
+        KeySegmentPair res;
         util::check(!std::holds_alternative<StringId>(variant_key_id(key)) || !std::get<StringId>(variant_key_id(key)).empty(), "Unexpected empty id");
-        const ReadVisitor& visitor = [&res](const VariantKey&, Segment&& value) {
-            res.segment() = std::move(value);
+        const ReadVisitor& visitor = [&res](const VariantKey& k, std::shared_ptr<Segment> value) {
+            res = KeySegmentPair{k, std::move(value)};
         };
 
         read(Composite<VariantKey>(std::move(key)), visitor, opts);

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_wrapper.hpp
@@ -37,7 +37,7 @@ public:
     virtual void write(
             const std::string& db_name,
             std::string& path,
-            Segment&& segment,
+            const Segment& segment,
             ::lmdb::txn& txn,
             ::lmdb::dbi& dbi,
             int64_t overwrite_flag) = 0;

--- a/cpp/arcticdb/storage/lmdb/lmdb_mock_client.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_mock_client.cpp
@@ -90,7 +90,7 @@ std::optional<Segment> MockLmdbClient::read(const std::string& db_name, std::str
     return std::make_optional<Segment>(lmdb_contents_.at(key).clone());
 }
 
-void MockLmdbClient::write(const std::string& db_name, std::string& path, arcticdb::Segment&& segment,
+void MockLmdbClient::write(const std::string& db_name, std::string& path, const arcticdb::Segment& segment,
                            ::lmdb::txn&, ::lmdb::dbi&, int64_t) {
     LmdbKey key = {db_name, path};
             raise_if_has_failure_trigger(key, StorageOperation::WRITE);
@@ -98,7 +98,7 @@ void MockLmdbClient::write(const std::string& db_name, std::string& path, arctic
     if(has_key(key)) {
         raise_key_exists_error(lmdb_operation_string(StorageOperation::WRITE));
     } else {
-        lmdb_contents_.try_emplace(key, std::move(segment));
+        lmdb_contents_.try_emplace(key, segment.clone());
     }
 }
 

--- a/cpp/arcticdb/storage/lmdb/lmdb_mock_client.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_mock_client.hpp
@@ -55,7 +55,7 @@ public:
     void write(
             const std::string& db_name,
             std::string& path,
-            Segment&& segment,
+            const Segment& segment,
             ::lmdb::txn& txn,
             ::lmdb::dbi& dbi,
             int64_t overwrite_flag) override;

--- a/cpp/arcticdb/storage/lmdb/lmdb_real_client.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_real_client.cpp
@@ -35,16 +35,15 @@ std::optional<Segment> RealLmdbClient::read(const std::string&, std::string& pat
         return std::nullopt;
     }
 
-    auto segment = Segment::from_bytes(reinterpret_cast<std::uint8_t *>(mdb_val.mv_data), mdb_val.mv_size);
-    return segment;
+    return Segment::from_bytes(reinterpret_cast<std::uint8_t *>(mdb_val.mv_data), mdb_val.mv_size);
 }
 
-void RealLmdbClient::write(const std::string&, std::string& path, arcticdb::Segment&& seg,
+void RealLmdbClient::write(const std::string&, std::string& path, const arcticdb::Segment& seg,
                            ::lmdb::txn& txn, ::lmdb::dbi& dbi, int64_t overwrite_flag) {
     MDB_val mdb_key{path.size(), path.data()};
 
     MDB_val mdb_val;
-    mdb_val.mv_size = seg.calculate_size();
+    mdb_val.mv_size = seg.size();
 
     ARCTICDB_SUBSAMPLE(LmdbPut, 0)
     int rc = ::mdb_put(txn.handle(), dbi.handle(), &mdb_key, &mdb_val, MDB_RESERVE | overwrite_flag);

--- a/cpp/arcticdb/storage/lmdb/lmdb_real_client.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_real_client.hpp
@@ -34,7 +34,7 @@ public:
     void write(
             const std::string& db_name,
             std::string& path,
-            Segment&& segment,
+            const Segment& segment,
             ::lmdb::txn& txn,
             ::lmdb::dbi& dbi,
             int64_t overwrite_flag) override;

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -47,7 +47,7 @@ namespace arcticdb::storage::memory {
 
         std::string do_key_path(const VariantKey&) const final { return {}; };
 
-        using KeyMap = folly::ConcurrentHashMap<VariantKey, Segment>;
+        using KeyMap = folly::ConcurrentHashMap<VariantKey, std::shared_ptr<Segment>>;
         // This is pre-populated so that concurrent access is fine.
         // An outer folly::ConcurrentHashMap would only return const inner hash maps which is no good.
         using TypeMap = std::unordered_map<KeyType, KeyMap>;

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -135,7 +135,7 @@ auto build_document(storage::KeySegmentPair &kv) {
 
     const auto &key = kv.variant_key();
     auto &segment = kv.segment();
-    const auto total_size = segment.calculate_size();
+    const auto total_size = segment.size();
     /*thread_local*/ std::vector<uint8_t> buffer{};
     buffer.resize(total_size);
     bsoncxx::types::b_binary data = {};

--- a/cpp/arcticdb/storage/mongo/mongo_mock_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_mock_client.cpp
@@ -107,7 +107,7 @@ bool MockMongoClient::write_segment(
         return false;
     }
 
-    mongo_contents.insert_or_assign(std::move(key), std::move(kv.segment()));
+    mongo_contents.insert_or_assign(std::move(key), kv.segment().clone());
     return true;
 }
 
@@ -129,7 +129,7 @@ UpdateResult MockMongoClient::update_segment(
         return {0}; // upsert is false, don't update and return 0 as modified_count
     }
 
-    mongo_contents.insert_or_assign(std::move(key), std::move(kv.segment()));
+    mongo_contents.insert_or_assign(std::move(key), kv.segment().clone());
     return {key_found ? 1 : 0};
 }
 

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -134,7 +134,7 @@ void MongoStorage::do_read(Composite<VariantKey>&& ks, const ReadVisitor& visito
                     keys_not_found.push_back(k);
                 }
                 else {
-                    visitor(k, std::move(kv.value().segment()));
+                    visitor(k, kv.value().segment_ptr());
                 }
 
             } catch (const mongocxx::operation_exception& ex) {

--- a/cpp/arcticdb/storage/rocksdb/rocksdb_storage.cpp
+++ b/cpp/arcticdb/storage/rocksdb/rocksdb_storage.cpp
@@ -140,7 +140,7 @@ void RocksDBStorage::do_read(Composite<VariantKey>&& ks, const ReadVisitor& visi
                         s.ToString());
                 failed_reads.push_back(k);
             } else {
-                visitor(k, Segment::from_bytes(reinterpret_cast<uint8_t*>(value.data()), value.size()));
+                visitor(k, std::make_shared<Segment>(Segment::from_bytes(reinterpret_cast<uint8_t*>(value.data()), value.size())));
             }
         }
     });
@@ -237,7 +237,7 @@ void RocksDBStorage::do_write_internal(Composite<KeySegmentPair>&& kvs) {
             auto k_str = to_serialized_key(kv.variant_key());
 
             auto& seg = kv.segment();
-            auto total_sz = seg.calculate_size();
+            auto total_sz = seg.size();
             std::string seg_data;
             seg_data.resize(total_sz);
             seg.write_to(reinterpret_cast<std::uint8_t *>(seg_data.data()));

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -118,7 +118,7 @@ namespace s3 {
                             auto s3_object_name = object_path(b.bucketize(key_type_dir, k), k);
                             auto &seg = kv.segment();
 
-                            auto put_object_result = s3_client.put_object(s3_object_name, std::move(seg), bucket_name);
+                            auto put_object_result = s3_client.put_object(s3_object_name, seg, bucket_name);
 
                             if (!put_object_result.is_success()) {
                                 auto& error = put_object_result.get_error();
@@ -167,7 +167,7 @@ namespace s3 {
                             if (get_object_result.is_success()) {
                                 ARCTICDB_SUBSAMPLE(S3StorageVisitSegment, 0)
 
-                                visitor(k, std::move(get_object_result.get_output()));
+                                visitor(k, std::make_shared<Segment>(std::move(get_object_result.get_output())));
 
                                 ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(k),
                                                variant_key_view(k));

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/util/simple_string_hash.hpp>
 #include <arcticdb/storage/s3/s3_storage.hpp>
 #include <arcticdb/storage/s3/s3_real_client.hpp>
+#include <arcticdb/storage/s3/s3_mock_client.hpp>
 #include <arcticdb/storage/s3/s3_client_wrapper.hpp>
 #include <utility>
 
@@ -184,11 +185,16 @@ bool NfsBackedStorage::do_key_exists(const VariantKey& key) {
 
 NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
     Storage(library_path, mode),
-    s3_api_(s3::S3ApiInstance::instance()),
     root_folder_(object_store_utils::get_root_folder(library_path)),
     bucket_name_(conf.bucket_name()),
     region_(conf.region()) {
-    s3_client_ = std::make_unique<s3::RealS3Client>(s3::get_aws_credentials(conf), s3::get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+
+    if (conf.use_mock_storage_for_testing()) {
+        log::storage().warn("Using Mock S3 storage for NfsBackedStorage");
+        s3_client_ = std::make_unique<s3::MockS3Client>();
+    } else {
+        s3_client_ = std::make_unique<s3::RealS3Client>(s3::get_aws_credentials(conf), s3::get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+    }
     if (!conf.prefix().empty()) {
         ARCTICDB_DEBUG(log::version(), "prefix found, using: {}", conf.prefix());
         auto prefix_path = LibraryPath::from_delim_path(conf.prefix(), '.');
@@ -202,7 +208,6 @@ NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mod
     std::locale locale{ std::locale::classic(), new std::num_put<char>()};
     (void)std::locale::global(locale);
     ARCTICDB_DEBUG(log::storage(), "Opened NFS backed storage at {}", root_folder_);
-    s3_api_.reset();
 }
 
 } //namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -60,7 +60,6 @@ private:
     const std::string& root_folder() const { return root_folder_; }
     const std::string& region() const { return region_; }
 
-    std::shared_ptr<storage::s3::S3ApiInstance> s3_api_;
     std::unique_ptr<storage::s3::S3ClientWrapper> s3_client_;
     std::string root_folder_;
     std::string bucket_name_;

--- a/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
@@ -56,7 +56,7 @@ public:
 
     virtual S3Result<std::monostate> put_object(
             const std::string& s3_object_name,
-            Segment&& segment,
+            const Segment& segment,
             const std::string& bucket_name) = 0;
 
     virtual S3Result<DeleteOutput> delete_objects(

--- a/cpp/arcticdb/storage/s3/s3_mock_client.cpp
+++ b/cpp/arcticdb/storage/s3/s3_mock_client.cpp
@@ -82,14 +82,14 @@ S3Result<Segment> MockS3Client::get_object(
 
 S3Result<std::monostate> MockS3Client::put_object(
         const std::string &s3_object_name,
-        Segment &&segment,
+        const Segment& segment,
         const std::string &bucket_name) {
     auto maybe_error = has_failure_trigger(s3_object_name, StorageOperation::WRITE);
     if (maybe_error.has_value()) {
         return {maybe_error.value()};
     }
 
-    s3_contents.insert_or_assign({bucket_name, s3_object_name}, std::move(segment));
+    s3_contents.insert_or_assign({bucket_name, s3_object_name}, segment.clone());
 
     return {std::monostate()};
 }

--- a/cpp/arcticdb/storage/s3/s3_mock_client.hpp
+++ b/cpp/arcticdb/storage/s3/s3_mock_client.hpp
@@ -60,7 +60,7 @@ public:
 
     S3Result<std::monostate> put_object(
             const std::string& s3_object_name,
-            Segment&& segment,
+            const Segment& segment,
             const std::string& bucket_name) override;
 
     S3Result<DeleteOutput> delete_objects(

--- a/cpp/arcticdb/storage/s3/s3_real_client.cpp
+++ b/cpp/arcticdb/storage/s3/s3_real_client.cpp
@@ -132,7 +132,7 @@ S3Result<Segment> RealS3Client::get_object(
 
 S3Result<std::monostate> RealS3Client::put_object(
         const std::string &s3_object_name,
-        Segment &&segment,
+        const Segment& segment,
         const std::string &bucket_name) {
 
     ARCTICDB_SUBSAMPLE(S3StorageWritePreamble, 0)

--- a/cpp/arcticdb/storage/s3/s3_real_client.hpp
+++ b/cpp/arcticdb/storage/s3/s3_real_client.hpp
@@ -37,7 +37,7 @@ public:
 
     S3Result<std::monostate> put_object(
             const std::string& s3_object_name,
-            Segment&& segment,
+            const Segment& segment,
             const std::string& bucket_name) override;
 
     S3Result<DeleteOutput> delete_objects(

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -13,7 +13,7 @@
 
 namespace arcticdb::storage {
 
-using ReadVisitor = std::function<void(const VariantKey&, Segment &&)>;
+using ReadVisitor = std::function<void(const VariantKey&, std::shared_ptr<Segment>)>;
 
 class DuplicateKeyException : public ArcticSpecificException<ErrorCode::E_DUPLICATE_KEY> {
 public:
@@ -127,9 +127,8 @@ public:
     template<class KeyType>
     KeySegmentPair read(KeyType&& key, ReadKeyOpts opts) {
         KeySegmentPair key_seg;
-        const ReadVisitor& visitor = [&key_seg](const VariantKey & vk, Segment&& value) {
-            key_seg.variant_key() = vk;
-            key_seg.segment() = std::move(value);
+        const ReadVisitor& visitor = [&key_seg](const VariantKey & vk, std::shared_ptr<Segment> value) {
+            key_seg = KeySegmentPair{vk, value};
         };
 
         read(std::forward<KeyType>(key), visitor, opts);

--- a/cpp/arcticdb/storage/test/test_embedded.cpp
+++ b/cpp/arcticdb/storage/test/test_embedded.cpp
@@ -108,9 +108,8 @@ TEST_P(SimpleTestSuite, Example) {
 
     as::KeySegmentPair res;
     storage->read(k, [&](auto &&k, auto &&seg) {
-        res.atom_key() = std::get<AtomKey>(k);
-        res.segment() = std::move(seg);
-        res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        res = as::KeySegmentPair{k, std::move(seg)};
+        res.segment_ptr()->force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
     }, storage::ReadKeyOpts{});
 
     res = storage->read(k, as::ReadKeyOpts{});
@@ -132,9 +131,8 @@ TEST_P(SimpleTestSuite, Example) {
 
     as::KeySegmentPair update_res;
     storage->read(k, [&](auto &&k, auto &&seg) {
-        update_res.atom_key() = std::get<AtomKey>(k);
-        update_res.segment() = std::move(seg);
-        update_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        update_res = as::KeySegmentPair{k, std::move(seg)};
+        update_res.segment_ptr()->force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
     }, as::ReadKeyOpts{});
 
     update_res = storage->read(k, as::ReadKeyOpts{});
@@ -187,13 +185,12 @@ TEST_P(SimpleTestSuite, Strings) {
     storage->write(std::move(kv));
 
     as::KeySegmentPair res;
-    storage->read(save_k, [&](auto &&k, auto &&seg) {
-        res.atom_key() = std::get<AtomKey>(k);
-        res.segment() = std::move(seg);
-        res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+    storage->read(save_k, [&res](auto &&k, auto &&seg) {
+        res = as::KeySegmentPair{k, std::move(seg)};
+        res.segment_ptr()->force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
     }, as::ReadKeyOpts{});
 
-    SegmentInMemory res_mem = decode_segment(std::move(res.segment()));
+    SegmentInMemory res_mem = decode_segment(res.segment());
     ASSERT_EQ(s.string_at(0, 1), res_mem.string_at(0, 1));
     ASSERT_EQ(std::string("happy"), res_mem.string_at(0, 1));
     ASSERT_EQ(s.string_at(1, 3), res_mem.string_at(1, 3));

--- a/cpp/arcticdb/storage/test/test_mongo_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_mongo_storage.cpp
@@ -42,9 +42,8 @@ TEST(MongoStorage, ClientSession) {
     as::KeySegmentPair res;
 
     storage.read(k, [&](auto &&k, auto &&seg) {
-        res.atom_key() = std::get<as::AtomKey>(k);
-        res.segment() = std::move(seg);
-        res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        res = as::KeySegmentPair{k, std::move(seg)};
+
     }, as::ReadKeyOpts{});
 
     res = storage.read(k, as::ReadKeyOpts{});
@@ -70,9 +69,8 @@ TEST(MongoStorage, ClientSession) {
     as::KeySegmentPair update_res;
 
     storage.read(k, [&](auto &&k, auto &&seg) {
-        update_res.atom_key() = std::get<as::AtomKey>(k);
-        update_res.segment() = std::move(seg);
-        update_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        update_res = as::KeySegmentPair{k, std::move(seg)};
+        update_res.segment_ptr()->force_own_buffer();
     }, as::ReadKeyOpts{});
 
     update_res = storage.read(k, as::ReadKeyOpts{});
@@ -93,9 +91,8 @@ TEST(MongoStorage, ClientSession) {
     as::KeySegmentPair numeric_res;
 
     storage.read(numeric_k, [&](auto &&k, auto &&seg) {
-        numeric_res.atom_key() = std::get<as::AtomKey>(k);
-        numeric_res.segment() = std::move(seg);
-        numeric_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+        numeric_res = as::KeySegmentPair{k, std::move(seg)};
+        numeric_res.segment_ptr()->force_own_buffer();
     }, as::ReadKeyOpts{});
 
     numeric_res = storage.read(numeric_k, as::ReadKeyOpts{});

--- a/cpp/arcticdb/stream/stream_utils.hpp
+++ b/cpp/arcticdb/stream/stream_utils.hpp
@@ -404,9 +404,9 @@ storage::KeySegmentPair make_target_key(KeyType key_type,
                            const StreamId &stream_id,
                            VersionId version_id,
                            const VariantKey &source_key,
-                           Segment&& segment) {
+                           std::shared_ptr<Segment> segment) {
     if (is_ref_key_class(key_type)) {
-        return {RefKey{stream_id, key_type}, std::move(segment)};
+        return {RefKey{stream_id, key_type}, segment};
     } else {
         util::check(!is_ref_key_class(variant_key_type(source_key)),
             "Cannot convert ref key {} to {}", source_key, key_type);
@@ -416,7 +416,7 @@ storage::KeySegmentPair make_target_key(KeyType key_type,
             .content_hash(atom_source_key.content_hash())
             .build(stream_id, key_type);
 
-        return {new_key, std::move(segment)};
+        return {new_key, segment};
     }
 }
 

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -29,8 +29,8 @@ LibraryTool::LibraryTool(std::shared_ptr<storage::Library> lib) {
 }
 
 ReadResult LibraryTool::read(const VariantKey& key) {
-    auto segment = read_to_segment(key);
-    auto segment_in_memory = decode_segment(std::move(segment));
+    const Segment& segment = read_to_segment(key);
+    auto segment_in_memory = decode_segment(segment);
     auto frame_and_descriptor = frame_and_descriptor_from_segment(std::move(segment_in_memory));
     return pipelines::make_read_result_from_frame(frame_and_descriptor, to_atom(key));
 }
@@ -38,8 +38,8 @@ ReadResult LibraryTool::read(const VariantKey& key) {
 Segment LibraryTool::read_to_segment(const VariantKey& key) {
     auto kv = store_->read_compressed_sync(key, storage::ReadKeyOpts{});
     util::check(kv.has_segment(), "Failed to read key: {}", key);
-    kv.segment().force_own_buffer();
-    return std::move(kv.segment());
+    kv.segment_ptr()->force_own_buffer();
+    return std::move(*kv.segment_ptr());
 }
 
 std::optional<google::protobuf::Any> LibraryTool::read_metadata(const VariantKey& key){

--- a/cpp/arcticdb/util/test/config_common.hpp
+++ b/cpp/arcticdb/util/test/config_common.hpp
@@ -14,20 +14,32 @@
 
 namespace arcticdb {
 
+inline auto get_test_lmdb_config(
+    ) {
+    arcticdb::proto::lmdb_storage::Config cfg;
+    cfg.set_path("./"); //TODO local path is a bit annoying. TMPDIR?
+    cfg.set_recreate_if_exists(true);
+    return cfg;
+}
+
+template<typename T = arcticdb::proto::lmdb_storage::Config>
 inline auto get_test_environment_config(
     const arcticdb::storage::LibraryPath& path,
     const arcticdb::storage::StorageName& storage_name,
-    const arcticdb::storage::EnvironmentName& environment_name) {
+    const arcticdb::storage::EnvironmentName& environment_name,
+    const std::optional<T> storage_config=std::nullopt) {
 
     using namespace arcticdb::storage;
     using MemoryConfig = storage::details::InMemoryConfigResolver::MemoryConfig;
     MemoryConfig mem_config = {};
 
     arcticdb::proto::storage::VariantStorage storage_conf;
-    arcticdb::proto::lmdb_storage::Config cfg;
-    cfg.set_path("./"); //TODO local path is a bit annoying. TMPDIR?
-    cfg.set_recreate_if_exists(true);
-    util::pack_to_any(cfg, *storage_conf.mutable_config());
+    if (storage_config) {
+        util::pack_to_any(*storage_config, *storage_conf.mutable_config());
+    } else {
+        auto default_lmdb_config = get_test_lmdb_config();
+        util::pack_to_any(default_lmdb_config, *storage_conf.mutable_config());
+    }
     mem_config.storages_.try_emplace(storage_name, storage_conf);
 
     arcticdb::proto::storage::LibraryDescriptor library_descriptor;

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -78,7 +78,7 @@ void tombstone_snapshot(
     }
     // Append a timestamp to the ID so that other snapshot(s) can reuse the same snapshot name before the cleanup job:
     std::string new_key = fmt::format("{}@{:x}", key_segment_pair.ref_key(), util::SysClock::coarse_nanos_since_epoch() / 1'000'000);
-    key_segment_pair.ref_key() = RefKey(new_key, KeyType::SNAPSHOT_TOMBSTONE);
+    key_segment_pair.set_key(RefKey(new_key, KeyType::SNAPSHOT_TOMBSTONE));
     store->write_compressed(std::move(key_segment_pair)).get();
 }
 

--- a/cpp/proto/arcticc/pb2/nfs_backed_storage.proto
+++ b/cpp/proto/arcticc/pb2/nfs_backed_storage.proto
@@ -24,4 +24,5 @@ message Config {
     bool use_virtual_addressing = 12;
     string ca_cert_path = 13;
     string ca_cert_dir = 14;
+    bool use_mock_storage_for_testing = 15;
 }

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -407,7 +407,7 @@ def s3_version_store(s3_version_store_v1, s3_version_store_v2, encoding_version)
     elif encoding_version == EncodingVersion.V2:
         return s3_version_store_v2
     else:
-        raise ValueError(f"Unexoected encoding version: {encoding_version}")
+        raise ValueError(f"Unexpected encoding version: {encoding_version}")
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/unit/arcticdb/version_store/test_deletion.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion.py
@@ -127,7 +127,7 @@ def test_delete_library_tool(version_store_factory, sym):
 
 
 def test_delete_snapshot(version_store_factory):
-    lmdb_version_store = version_store_factory(col_per_group=5, row_per_segment=10)
+    lmdb_version_store = version_store_factory(col_per_group=7, row_per_segment=500)
     lt = lmdb_version_store.library_tool()
 
     symbol = "test_delete_snapshot"


### PR DESCRIPTION
The motivation for the change is to allow `arcticdb-enterprise` to copy blocks to NFS storages without a use-after-move. I explained this in https://github.com/man-group/arcticdb-enterprise/pull/139 but to have an open record:

CopyCompressedInterStoreTask has:

```
                        // Don't bother copying the key segment pair when writing to the final target
                        if (it == std::prev(target_stores_.end())) {
                            (*it)->write_compressed_sync(std::move(key_segment_pair));
                        } else {
                            auto key_segment_pair_copy = key_segment_pair;
                            (*it)->write_compressed_sync(std::move(key_segment_pair_copy));
                        }
```

KeySegmentPair has a shared_ptr to a KeySegmentPair, which we can think of here as just a `Segment`.

Therefore the old `key_segment_pair_copy` is shallow, the underlying Segment is the same. But the segment eventually gets passed as an rvalue reference further down the stack.

In `do_write_impl` we call `put_object` which calls `serialize_header`.

This modifies the segment in place and passes that buffer to the AWS SDK.

In the `NfsBackedStorage` we have:

```
void NfsBackedStorage::do_write(Composite<KeySegmentPair>&& kvs) {
    auto enc = kvs.transform([] (auto&& key_seg) {
      return KeySegmentPair{encode_object_id(key_seg.variant_key()), std::move(key_seg.segment())};
    });
    s3::detail::do_write_impl(std::move(enc), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
}
```

where the segment gets moved from.

Subsequent attempts to use the segment (eg copying on to the next store) then fail.

https://github.com/man-group/arcticdb-enterprise/pull/139 fixed this issue by cloning the segment, but this approach avoids the (expensive) clone.

## HEAD~1 Commit

Refactor the KeySegmentPair API so that it is possible to re-use a `Segment` without cloning it.

Do not expose lvalue references to the segment.
Make the Segment const (ish) and pass it with a shared_ptr rather than moving when possible.

The main design decisions to review are in `key_segment_pair.hpp` and `segment.hpp`, which we now pass by const-ref whenever possible. Most of the other changes are just coping with those API changes.

## HEAD Commit

Move the CopyCompressedInterStoreTask down to ArcticDB from arcticdb-enterprise. Add a test for it on NFS storage. I've verified that the tests in this commit fail without the refactor in the HEAD~1 commit. The only changes to `CopyCompressedInterstoreTask` from enterprise are:

- Get rid of the optimisation where we skipped the `key_segment_pair_copy` for the last target. The `KeySegmentPair` is cheap to copy (especially considering we are about to copy an object across storages, likely with a network hop).
- We have adopted the new `set_key` API of `KeySegmentPair`:
```
if (key_to_write_.has_value()) {
                key_segment_pair.set_key(*key_to_write_);
            }
```


