### PR TITLE
Always use strict weak ordering in std::sort comparators

### DIFF
--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -325,7 +325,7 @@ std::vector<EntityId> AggregationClause::process(std::vector<EntityId>&& entity_
     // Sort procs following row range descending order, as we are going to iterate through them backwards
     std::sort(std::begin(row_slices), std::end(row_slices),
               [](const auto& left, const auto& right) {
-                  return left.row_ranges_->at(0)->start() >= right.row_ranges_->at(0)->start();
+                  return left.row_ranges_->at(0)->start() > right.row_ranges_->at(0)->start();
     });
 
     std::vector<GroupingAggregatorData> aggregators_data;


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes part of #1724.

#### What does this implement or fix?

When testing on macOS ARM using hardened `libcxx` and latest `master` branch commit (89817db81) I see 4 failures in Clause testing:
```
125 - Clause.AggregationEmptyColumn (Subprocess aborted)
126 - Clause.AggregationColumn (Subprocess aborted)
127 - Clause.AggregationSparseColumn (Subprocess aborted)
128 - Clause.AggregationSparseGroupby (Subprocess aborted)
```
All 4 are fixed by the single character change to `clause.cpp` in this PR. Comparator functions passed to `std::sort` should be [strict weak order](https://en.cppreference.com/w/cpp/concepts/strict_weak_order) such that `sort(a, a)` is `false`. All other sort functions are already strict weak ordering.

There is no functional change here and there is no explicit test for it. It probably shouldn't be labelled "bug", it is more "code quality" but even so is really theoretical as I see no way to get the code to do something wrong based on different sorting order of two identical elements.