### PR TITLE
Improve logging for stress tests

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -923,15 +923,10 @@ folly::Future<folly::Unit> delete_trees_responsibly(
 
     folly::Future<folly::Unit> remove_keys_fut;
     if (!dry_run) {
-        for (const auto& key : vks_column_stats) {
-            log::version().debug("Column Stats key to be deleted: {}", key);
-        }
-        for (const auto& key : vks_to_delete) {
-            log::version().debug("Index key to be deleted: {}", key);
-        }
-        for (const auto& key : vks_data_to_delete) {
-            log::version().debug("Data key to be deleted: {}", key);
-        }
+        ARCTICDB_TRACE(log::version(), fmt::format("Column Stats keys to be deleted: {}", fmt::join(vks_column_stats, ", ")));
+        ARCTICDB_TRACE(log::version(), fmt::format("Index keys to be deleted: {}", fmt::join(vks_to_delete, ", ")));
+        ARCTICDB_TRACE(log::version(), fmt::format("Data keys to be deleted: {}", fmt::join(vks_data_to_delete, ", ")));
+
         // Delete any associated column stats keys first
         remove_keys_fut = store->remove_keys(std::move(vks_column_stats), remove_opts)
         .thenValue([store=store, vks_to_delete = std::move(vks_to_delete), remove_opts](auto&& ) mutable {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -923,6 +923,15 @@ folly::Future<folly::Unit> delete_trees_responsibly(
 
     folly::Future<folly::Unit> remove_keys_fut;
     if (!dry_run) {
+        for (const auto& key : vks_column_stats) {
+            log::version().debug("Column Stats key to be deleted: {}", key);
+        }
+        for (const auto& key : vks_to_delete) {
+            log::version().debug("Index key to be deleted: {}", key);
+        }
+        for (const auto& key : vks_data_to_delete) {
+            log::version().debug("Data key to be deleted: {}", key);
+        }
         // Delete any associated column stats keys first
         remove_keys_fut = store->remove_keys(std::move(vks_column_stats), remove_opts)
         .thenValue([store=store, vks_to_delete = std::move(vks_to_delete), remove_opts](auto&& ) mutable {

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -310,12 +310,10 @@ def apply_lib_cfg(lib_cfg: LibraryDescriptor, cfg_dict: Mapping[str, Any]):
 
 
 def compare_version_data(source_lib, target_libs, versions):
-    log.version.debug("Source {} versions: {}".format(source_lib, versions))
     for symbol, symbol_versions in versions.items():
         for version, version_info in symbol_versions.items():
             source_vit = source_lib.read(symbol, as_of=version)
             for target_lib in target_libs:
-                log.version.debug("Target {} versions: {}".format(target_lib, target_lib.list_versions(symbol)))
                 target_vit = target_lib.read(symbol, as_of=version)
                 try:
                     compare_data(


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
- added debug logging for what keys will be deleted by `delete_trees_responsibly`
- fixes some bugs around stress tests scenarios e.g. function taking a symbol name but not using it
- added logs for what the different scenarios actually did
- using the arcticdb log to log the stress tests scenarios so the messages can be interweaved with the rest of the logs
- added interface to specify whether or not to get all symbols for `get_symbols`/`get_versions`

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
