### PR TITLE
Throw exception if appending using sort_and_finalize will create unordered index

### DIFF
--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1299,7 +1299,7 @@ VersionedItem sort_merge_impl(
             read_query.clauses_.emplace_back(std::make_shared<Clause>(MergeClause{timeseries_index, SparseColumnPolicy{}, stream_id, pipeline_context->descriptor()}));
             auto segments = read_and_process(store, pipeline_context, read_query, ReadOptions{}, pipeline_context->incompletes_after());
             if (options.append_ && update_info.previous_index_key_.has_value() &&
-                update_info.previous_index_key_->start_time() > std::get<timestamp>(TimeseriesIndex::start_value_for_segment(segments[0].segment_.value()))) {
+                update_info.previous_index_key_->end_time() - 1 > std::get<timestamp>(TimeseriesIndex::start_value_for_segment(segments[0].segment_.value()))) {
                 store->remove_keys(delete_keys).get();
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                     "Cannot append index starting at {} to data frame with index ending at {}",

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1304,7 +1304,7 @@ VersionedItem sort_merge_impl(
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                     "Cannot append index starting at {} to data frame with index ending at {}",
                     std::get<timestamp>(TimeseriesIndex::start_value_for_segment(segments[0].segment_.value())),
-                    update_info.previous_index_key_->start_time()
+                    update_info.previous_index_key_->end_time() - 1
                 );
             }
             pipeline_context->total_rows_ = num_versioned_rows + get_slice_rowcounts(segments);

--- a/python/tests/unit/arcticdb/version_store/test_sort_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort_merge.py
@@ -189,12 +189,19 @@ class TestMergeSortAppend:
 
     def test_appended_df_start_same_as_df_end(self, lmdb_library):
         lib = lmdb_library
-        df = pd.DataFrame({"col": [1]}, index=pd.DatetimeIndex([np.datetime64('2023-01-01')]))
+        df = pd.DataFrame(
+            {"col": [1, 2, 3]},
+            index=pd.DatetimeIndex([np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03')], dtype="datetime64[ns]")
+        )
         lib.write("sym", df)
-        lib.write("sym", df, staged=True)
+        df_to_append = pd.DataFrame(
+            {"col": [4, 5, 6]},
+            index=pd.DatetimeIndex([np.datetime64('2023-01-03'), np.datetime64('2023-01-04'), np.datetime64('2023-01-05')], dtype="datetime64[ns]")
+        )
+        lib.write("sym", df_to_append, staged=True)
         lib.sort_and_finalize_staged_data("sym", mode=StagedDataFinalizeMethod.APPEND)
         res = lib.read("sym").data
-        expected_df = pd.DataFrame({"col": [1, 1]}, index=pd.DatetimeIndex([np.datetime64('2023-01-01'), np.datetime64('2023-01-01')]))
+        expected_df = pd.concat([df, df_to_append])
         assert_frame_equal(lib.read("sym").data, expected_df)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_sort_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort_merge.py
@@ -176,7 +176,6 @@ class TestMergeSortAppend:
         expected_df = pd.DataFrame({"col": range(1, 9)}, index=expected_index)
         assert_frame_equal(lib.read("sym").data, expected_df)
 
-    @pytest.mark.xfail(reason="Does not throw and creates dataframe with unordered index.")
     def test_appended_df_interleaves_with_storage(self, lmdb_library):
         lib = lmdb_library
         initial_df = pd.DataFrame({"col": [1, 3]}, index=pd.DatetimeIndex([np.datetime64('2023-01-01'), np.datetime64('2023-01-03')], dtype="datetime64[ns]"))


### PR DESCRIPTION
#### Reference Issues/PRs
Resolve #1734

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
