### PR TITLE
Handle KeyNotFoundException in recurse_index_key

### DIFF
--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -117,10 +117,16 @@ ankerl::unordered_dense::set<AtomKey> recurse_segment(const std::shared_ptr<stre
 inline ankerl::unordered_dense::set<AtomKey> recurse_index_key(const std::shared_ptr<stream::StreamSource>& store,
                                                      const IndexTypeKey& index_key,
                                                      const std::optional<VersionId>& version_id=std::nullopt) {
-    auto segment = store->read_sync(index_key).second;
-    auto res = recurse_segment(store, segment, version_id);
-    res.emplace(index_key);
-    return res;
+    ankerl::unordered_dense::set<AtomKey> res;
+    try {
+        auto segment = store->read_sync(index_key).second;
+        res = recurse_segment(store, segment, version_id);
+        res.emplace(index_key);
+        return res;
+    } catch (const storage::KeyNotFoundException& e) {
+        log::storage().debug("Key {} not found in store", index_key);
+        return res;
+    }
 }
 
 inline ankerl::unordered_dense::set<AtomKey> recurse_segment(const std::shared_ptr<stream::StreamSource>& store,

--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -124,7 +124,7 @@ inline ankerl::unordered_dense::set<AtomKey> recurse_index_key(const std::shared
         res.emplace(index_key);
         return res;
     } catch (const storage::KeyNotFoundException& e) {
-        log::storage().debug("Key {} not found in store", index_key);
+        log::storage().debug("Key {} not found in store: {}", index_key, e.what());
         return res;
     }
 }


### PR DESCRIPTION
#### Reference Issues/PRs
Needed for PR #146 in the enterprise repo

#### What does this implement or fix?
Handles the case where any of the index keys that are being recursed are no longed present.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
