### PR TITLE
Unify finalize methods

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1951,7 +1951,7 @@ class NativeVersionStore:
         metadata: Optional[Any] = None,
         prune_previous_version: Optional[bool] = None,
         validate_index: bool = False,
-    ):
+    ) -> VersionedItem:
         """
         Compact previously written un-indexed chunks of data, produced by a tick collector or parallel
         writes/appends.
@@ -1988,9 +1988,10 @@ class NativeVersionStore:
             "prune_previous_version", self._write_options(), global_default=False, existing_value=prune_previous_version
         )
         udm = normalize_metadata(metadata) if metadata is not None else None
-        return self.version_store.compact_incomplete(
+        vit = self.version_store.compact_incomplete(
             symbol, append, convert_int_to_float, via_iteration, sparsify, udm, prune_previous_version, validate_index
         )
+        return self._convert_thin_cxx_item_to_python(vit, metadata)
 
     @staticmethod
     def _get_index_columns_from_descriptor(descriptor):

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -985,7 +985,7 @@ class Library:
         """
         vit = self._nvs.version_store.sort_merge(
             symbol,
-            normalize_metadata(metadata),
+            normalize_metadata(metadata) if metadata is not None else None,
             mode == StagedDataFinalizeMethod.APPEND,
             prune_previous_versions=prune_previous_versions,
         )

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -903,7 +903,7 @@ class Library:
         prune_previous_versions: bool = False,
         metadata: Any = None,
         validate_index=True,
-    ):
+    ) -> VersionedItem:
         """
         Finalizes staged data, making it available for reads.
 
@@ -925,12 +925,18 @@ class Library:
             are non-overlapping with each other, and, in the case of `StagedDataFinalizeMethod.APPEND`, fall after the
             last index value in the previous version.
 
+        Returns
+        -------
+        VersionedItem
+            Structure containing metadata and version number of the written symbol in the store.
+            The data member will be None.
+
         See Also
         --------
         write
             Documentation on the ``staged`` parameter explains the concept of staged data in more detail.
         """
-        self._nvs.compact_incomplete(
+        return self._nvs.compact_incomplete(
             symbol,
             append=mode == StagedDataFinalizeMethod.APPEND,
             convert_int_to_float=False,

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -250,6 +250,7 @@ def test_staged_data(arctic_library, finalize_method):
     assert finalize_result_meta.metadata == metadata
     assert finalize_result_meta.symbol == sym_with_metadata
     assert finalize_result_meta.library == lib.name
+    assert finalize_result_meta.version == (1 if finalize_method == StagedDataFinalizeMethod.APPEND else 0)
 
     lib.finalize_staged_data(sym_without_metadata, finalize_method)
 

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -246,7 +246,11 @@ def test_staged_data(arctic_library, finalize_method):
     lib.write(sym_unfinalized, df_2, staged=True)
 
     metadata = {"hello": "world"}
-    lib.finalize_staged_data(sym_with_metadata, finalize_method, metadata=metadata)
+    finalize_result_meta = lib.finalize_staged_data(sym_with_metadata, finalize_method, metadata=metadata)
+    assert finalize_result_meta.metadata == metadata
+    assert finalize_result_meta.symbol == sym_with_metadata
+    assert finalize_result_meta.library == lib.name
+
     lib.finalize_staged_data(sym_without_metadata, finalize_method)
 
     assert set(lib.list_symbols()) == {sym_with_metadata, sym_without_metadata}

--- a/python/tests/unit/arcticdb/version_store/test_sort_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort_merge.py
@@ -20,7 +20,8 @@ def test_merge_single_column(lmdb_library):
     sym1 = "symbol_1"
     lib.write(sym1, df1, staged=True)
     lib.write(sym1, df2, staged=True)
-    lib.sort_and_finalize_staged_data(sym1)
+    metadata = {"meta": ["data"]}
+    sort_and_finalize_res = lib.sort_and_finalize_staged_data(sym1, metadata=metadata)
 
     expected_dates = [np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03'),
                       np.datetime64('2023-01-04'), np.datetime64('2023-01-05'), np.datetime64('2023-01-06')]
@@ -28,7 +29,10 @@ def test_merge_single_column(lmdb_library):
     expected_values = {"x": [1, 2, 3, 4, 5, 6]}
     expected_df = pd.DataFrame(expected_values, index=expected_dates)
     assert_frame_equal(lib.read(sym1).data, expected_df)
-
+    assert sort_and_finalize_res.metadata == {"meta": ["data"]}
+    assert sort_and_finalize_res.symbol == sym1
+    assert sort_and_finalize_res.library == lib.name
+    assert lib.read(sym1).metadata == metadata
 
 def test_merge_two_column(lmdb_library):
     lib = lmdb_library

--- a/python/tests/unit/arcticdb/version_store/test_sort_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort_merge.py
@@ -32,6 +32,7 @@ def test_merge_single_column(lmdb_library):
     assert sort_and_finalize_res.metadata == {"meta": ["data"]}
     assert sort_and_finalize_res.symbol == sym1
     assert sort_and_finalize_res.library == lib.name
+    assert sort_and_finalize_res.version == 0
     assert lib.read(sym1).metadata == metadata
 
 def test_merge_two_column(lmdb_library):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes:  #1753

#### What does this implement or fix?
Both `finalize_staged_data` and `sort_and_finalize_staged_data` now return `VersionedItem`.

`metadata` parameter was added to `sort_and_finalize_staged_data`
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
