### PR TITLE
Code formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,197 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterReturnType: Automatic
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
+ColumnLimit:     120
+CommentPragmas: '^(util\:\:check| IWYU pragma:)'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: CurrentLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1100
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    Never
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - ARCTICDB_DEBUG
+  - ARCTICDB_TRACE
+  - ARCTICDB_RUNTIME_DEBUG
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -30,6 +30,28 @@ on:
     - "**/*.md"
 
 jobs:
+
+  run_linting_checks:
+    name: Linting checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0
+
+      - name: Install linters
+        run: |
+          python3 build_tooling/format.py --install-tools
+
+      - name: Lint Python
+        if: always()
+        run: |
+          python3 build_tooling/format.py --check --type python
+
+      - name: Lint C++
+        if: always()
+        run: |
+          python3 build_tooling/format.py --check --type cpp
+
   get_commits_to_benchmark:
     name: Get tag commits  
     runs-on: ubuntu-22.04

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -31,29 +31,6 @@ on:
 
 jobs:
 
-  run_linting_checks:
-    name: Linting checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.3.0
-
-      - name: Install linters
-        run: |
-          python3 build_tooling/format.py --install-tools
-
-      - name: Lint Python
-        if: always()
-        run: |
-          python3 build_tooling/format.py --check --type python \
-            || 1 # formatting not enforced yet
-
-      - name: Lint C++
-        if: always()
-        run: |
-          python3 build_tooling/format.py --check --type cpp \
-            || 1 # formatting not enforced yet
-
   get_commits_to_benchmark:
     name: Get tag commits  
     runs-on: ubuntu-22.04

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -45,12 +45,14 @@ jobs:
       - name: Lint Python
         if: always()
         run: |
-          python3 build_tooling/format.py --check --type python
+          python3 build_tooling/format.py --check --type python \
+            || 1 # formatting not enforced yet
 
       - name: Lint C++
         if: always()
         run: |
-          python3 build_tooling/format.py --check --type cpp
+          python3 build_tooling/format.py --check --type cpp \
+            || 1 # formatting not enforced yet
 
   get_commits_to_benchmark:
     name: Get tag commits  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,29 @@ jobs:
       cibuildwheel_ver: "2.21.3"
       force_update: false
 
+  run_linting_checks:
+    name: Linting checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0
+
+      - name: Install linters
+        run: |
+          python3 build_tooling/format.py --install-tools
+
+      - name: Lint Python
+        if: always()
+        run: |
+          python3 build_tooling/format.py --check --type python \
+            || true # formatting not enforced yet
+
+      - name: Lint C++
+        if: always()
+        run: |
+          python3 build_tooling/format.py --check --type cpp \
+            || true # formatting not enforced yet
+
   common_config:
     needs: [cibw_docker_image]
     runs-on: ubuntu-22.04

--- a/build_tooling/format.py
+++ b/build_tooling/format.py
@@ -1,0 +1,127 @@
+"""Linting tools for ArcticDB.
+
+Usage:
+
+First bootstrap by installing the linting tools:
+
+python build_tooling/format.py --install-tools
+
+Then see the help section for how to run the linters:
+
+python build_tooling/format.py --help
+
+Or just run them on everything:
+
+python build_tooling/format.py --in-place --type all
+
+"""
+import argparse
+import pathlib
+import sys
+import subprocess
+
+
+black_version = "24.8.0"
+clang_format_version = "19.1.2"
+
+
+def install_tools():
+    black = subprocess.run(["pip", "install", f"black=={black_version}"]).returncode
+    clang = subprocess.run(["pip", "install", f"clang-format=={clang_format_version}"]).returncode
+    return black or clang
+
+
+def lint_python(in_place: bool):
+    try:
+        import black
+        assert black.__version__ == black_version
+    except ImportError:
+        raise RuntimeError("black not installed. Run this script with --install-tools then try again")
+
+    if in_place:
+        return subprocess.run(["black", "-l", "120", "python/"]).returncode
+    else:
+        return subprocess.run(["black", "-l", "120", "--check", "python/"]).returncode
+
+
+def lint_cpp(in_place: bool):
+    try:
+        import clang_format
+    except ImportError:
+        raise RuntimeError("clang-format not installed. Run this script with --install-tools then try again")
+
+    files = []
+    root = pathlib.Path("cpp", "arcticdb")
+    for e in ("*.cpp", "*.hpp"):
+        for f in root.rglob(e):
+            files.append(str(f))
+
+    args = ["clang-format"]
+    if in_place:
+        args.append("-i")
+    else:
+        args.append("--dry-run")
+        args.append("-Werror")
+
+    print(f"Running {args} over {len(files)} files")
+    args += files
+
+    return subprocess.run(args).returncode
+
+
+def main(type: str, in_place: bool):
+    if type == "python":
+        return lint_python(in_place)
+    elif type == "cpp":
+        return lint_cpp(in_place)
+    else:
+        return lint_python(in_place) or lint_cpp(in_place)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="ArcticDBLint",
+        description="Linter for ArcticDB"
+    )
+    parser.add_argument(
+        '--install-tools',
+        action='store_true',
+        help="Install the linters we need"
+    )
+    parser.add_argument(
+        '-t',
+        '--type',
+        help="Type of files to format. {python,cpp,all}"
+    )
+    parser.add_argument(
+        '-c',
+        '--check',
+        action='store_true',
+        help="Just check that your code is compliant. Do not change files."
+    )
+    parser.add_argument(
+        '-i',
+        '--in-place',
+        action='store_true',
+        help="Apply linting rules to your working copy. Changes files."
+    )
+    args = parser.parse_args()
+
+    if args.install_tools:
+        sys.exit(install_tools())
+
+    if args.check and args.in_place:
+        raise RuntimeError("Cannot specify both --check and --in-place")
+    if not args.check and not args.in_place:
+        raise RuntimeError("Must specify exactly on of --check and --in-place")
+    if not args.type:
+        raise RuntimeError("Must specify --type")
+    if args.type not in ("python", "cpp", "all"):
+        raise RuntimeError("Invalid --type")
+
+    return_code = main(
+        type=args.type,
+        in_place=args.in_place,
+    )
+
+    sys.exit(return_code)

--- a/docs/mkdocs/docs/technical/linting.md
+++ b/docs/mkdocs/docs/technical/linting.md
@@ -1,0 +1,66 @@
+## Linting Tools
+
+We use Black for Python and clang-format for C++.
+
+The `.clang-format` file in the root of this repo is based on LLVM style with some minor tweaks.
+
+### Running Linters
+
+Activate a Python3 virtual environment and run the following from the project root to
+install the linters:
+
+```
+python build_tooling/format.py --install-tools  # install the linters
+```
+
+Then check your formatting:
+
+```
+python build_tooling/format.py --check --type python
+python build_tooling/format.py --check --type cpp
+```
+
+To reformat your working copy, run:
+
+```
+python build_tooling/format.py --in-place --type python
+python build_tooling/format.py --in-place --type cpp
+
+# Or just do everything at once,
+python build_tooling/format.py --in-place --type all
+```
+
+#### CLion Integration
+
+#### C++
+
+Our formatting rules should be detected automatically, so you can use the CLion formatter on C++. See
+[here](https://clang.llvm.org/docs/ClangFormat.html#clion-integration).
+
+Just select "Enable ClangFormat" in Settings | Editor | Code Style.
+
+Documentation on formatting in CLion is [here](https://www.jetbrains.com/help/clion/reformat-and-rearrange-code.html).
+
+#### Python
+
+Add Black as an external tool. After installing it with the steps above, run:
+
+`which black`.
+
+For me, this shows:
+
+```
+/home/alex/venvs/310/bin/black
+```
+
+Then follow the steps [here](https://black.readthedocs.io/en/stable/integrations/editors.html#as-external-tool) to add
+that Black binary.
+
+### CI
+
+We run the formatting checks as the first step in `analysis_workflow.yml`, on an Ubuntu host, in a Python 3.10 venv.
+
+If your checks pass locally then they should pass on the CI.
+
+In the past we have had issues with compatibility of the linters across operating systems and Python versions, so for
+the most stable results run the linting checks in Linux (eg WSL) in a Python 3.10 venv.

--- a/docs/mkdocs/docs/technical/linting.md
+++ b/docs/mkdocs/docs/technical/linting.md
@@ -30,6 +30,42 @@ python build_tooling/format.py --in-place --type cpp
 python build_tooling/format.py --in-place --type all
 ```
 
+### Rebasing Old Work
+
+You may have old work that isn't auto-formatted that you need to rebase and merge. Steps taken from [this blog](https://blog.scottlogic.com/2019/03/04/retroactively-applying-prettier-to-existing-branches.html)
+can help.
+
+First push a copy of your branch somewhere so you have a backup in case this goes horribly wrong.
+
+Suppose that `master` has the formatting enforced.
+
+With your feature branch checked out, rebase to just before the auto-formatting and squash commits:
+
+```
+git rebase -i --onto <code formatting commit SHA>~1 origin/master
+# Now squash everything in to one commit
+```
+
+You will need to fix any genuine conflicts at this point.
+
+Now rebase, applying the formatter. Run this from a venv with the linters installed. The "theirs" strategy means to
+prefer the feature branch.
+
+```
+git rebase \
+  --strategy-option=theirs \
+  --exec '`which python` ./build_tooling/format.py --type all --in-place && git add cpp/ python/ && git commit --amend --no-edit' \
+  --onto <code formatting commit SHA> origin/master
+```
+
+You should now have a single commit with the correct formatting, that you can then rebase as normal on to master,
+
+```
+git rebase origin/master
+```
+
+and resolve any genuine conflicts as usual.
+
 #### CLion Integration
 
 #### C++

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import glob
 import platform
 import shutil
 import re
-from pathlib import Path
 from tempfile import mkdtemp
 from setuptools import setup, Command, find_namespace_packages
 from setuptools import Extension, find_packages


### PR DESCRIPTION
Enforce code formatting with Black and clang-format. See the `linting.md` file I added in `docs/` for notes on usage and changes from the default settings.

No changes to default Black formatting except for line length 120.

clang-format file is generated from

```
clang-format -style=llvm -dump-config > .clang-format
```

This PR doesn't actually reformat the codebase yet. I'll do that as a last step once we're happy with the approach. This PR shows the effect though https://github.com/man-group/ArcticDB/pull/1822.

### Rebasing Feature Branches Evidence

This is all documented in `linting.md`.

Example showing how to rebase existing work,

Steps taken from [this blog](https://blog.scottlogic.com/2019/03/04/retroactively-applying-prettier-to-existing-branches.html)

Branch code-formatting-rules-effect has had the formatting enforced.

On this branch we have the scripts but we don't have the new format yet.

We make a change in `bit_rate_stats.hpp`

```
(310) ➜  under_review git:(code-formatting-how-to-rebase) ✗ g commit -m "Change bit_rate_stats.hpp"           
[code-formatting-how-to-rebase e9cee156a] Change bit_rate_stats.hpp
 1 file changed, 1 insertion(+), 1 deletion(-)
```

We then want to rebase on to `code-formatting-rules-effect`

First squash commits when you rebase to just before the code formatting change:

```
git rebase -i code-formatting-rules-effect~1
# Now squash everything in to one commit
```

Now rebase, applying the formatter. Run this from a venv with the linters installed.

```
git rebase \
  --strategy-option=theirs \
  --exec '`which python` ./build_tooling/format.py --type all --in-place && git add cpp/ python/ && git commit --amend --no-edit' \
  origin/code-formatting-rules-effect
```

Now our change shows correctly,

https://github.com/man-group/ArcticDB/compare/code-formatting-rules-effect...code-formatting-how-to-rebase?expand=1

even though the formatter changed the same line as us.