### PR TITLE
Limit 3 item ref key bypass to only when loading undeleted versions

### DIFF
--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -404,7 +404,7 @@ TEST(Async, CopyCompressedInterStoreNoSuchKeyOnWrite) {
     auto targets = std::vector<std::shared_ptr<arcticdb::Store>>{
         create_store(library_path, library_index, user_auth, codec_opt),
         create_store(library_path, failed_library_index, user_auth, codec_opt),
-        create_store(library_path, failed_library_index, user_auth, codec_opt)
+        create_store(library_path, library_index, user_auth, codec_opt)
     };
 
     // When - we write a key to the source
@@ -434,7 +434,11 @@ TEST(Async, CopyCompressedInterStoreNoSuchKeyOnWrite) {
     ASSERT_TRUE(std::holds_alternative<CopyCompressedInterStoreTask::FailedTargets>(res));
     
     // But it should still write the key to the non-failing target
-    auto read_result = targets[0]->read_sync(key);
-    ASSERT_EQ(std::get<RefKey>(read_result.first), key);
-    ASSERT_EQ(read_result.second.row_count(), row_count);
+    auto read_result_0 = targets[0]->read_sync(key);
+    ASSERT_EQ(std::get<RefKey>(read_result_0.first), key);
+    ASSERT_EQ(read_result_0.second.row_count(), row_count);
+
+    auto read_result_2 = targets[2]->read_sync(key);
+    ASSERT_EQ(std::get<RefKey>(read_result_2.first), key);
+    ASSERT_EQ(read_result_2.second.row_count(), row_count);
 }

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -333,6 +333,11 @@ inline bool penultimate_key_contains_required_version_id(const AtomKey& key, con
 }
 
 inline bool key_exists_in_ref_entry(const LoadStrategy& load_strategy, const VersionMapEntry& ref_entry, std::optional<AtomKey>& cached_penultimate_key) {
+    // The 3 item ref key bypass can be used only when we are loading undeleted versions
+    // because otherwise it might skip versions that are deleted but part of snapshots
+    if(load_strategy.load_objective_ != LoadObjective::UNDELETED_ONLY)
+        return false;
+
     if (load_strategy.load_type_ == LoadType::LATEST && is_index_key_type(ref_entry.keys_[0].type()))
         return true;
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Change the logic for the 3 item ref key optimization/bypass to be used only when loading undeleted versions.
Otherwise we might skip versions that have been deleted but are part of a snapshot.

Also removes a catch for KeyNotFoundException when writing keys as this catch might cause us to silently ignore real problems.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
