### PR TITLE
Remove KeyNotFoundException catch in CopyCompressedInterStoreTask

### DIFF
--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -375,8 +375,6 @@ private:
                     target_store->write_compressed_sync(key_segment_pair);
                 } catch (const storage::DuplicateKeyException& e) {
                     log::storage().debug("Key {} already exists on the target: {}", variant_key_view(key_to_read_), e.what());
-                } catch (const storage::KeyNotFoundException& e) {
-                    log::storage().debug("Key {} not found on the source: {}", variant_key_view(key_to_read_), e.what());
                 } catch (const std::exception& e) {
                     auto name = target_store->name();
                     log::storage().error("Failed to write key {} to store {}: {}", variant_key_view(key_to_read_), name, e.what());

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -21,6 +21,13 @@
 #include <string>
 #include <vector>
 
+#include <arcticdb/storage/s3/s3_api.hpp>
+#include <arcticdb/storage/s3/s3_storage.hpp>
+#include <arcticdb/storage/s3/s3_mock_client.hpp>
+#include <arcticdb/storage/s3/detail-inl.hpp>
+#include <arcticdb/storage/storage_mock_client.hpp>
+#include <aws/core/Aws.h>
+
 using namespace arcticdb;
 namespace aa = arcticdb::async;
 namespace as = arcticdb::storage;
@@ -359,4 +366,75 @@ TEST(Async, CopyCompressedInterStore) {
         ASSERT_EQ(std::get<RefKey>(read_result.first), key);
         ASSERT_EQ(read_result.second.row_count(), row_count);
     }
+}
+
+TEST(Async, CopyCompressedInterStoreNoSuchKeyOnWrite) {
+    using namespace arcticdb::async;
+
+    // Given
+    as::EnvironmentName environment_name{"research"};
+    as::StorageName storage_name("storage_name");
+    as::LibraryPath library_path{"a", "b"};
+    namespace ap = arcticdb::pipelines;
+
+    auto config = proto::nfs_backed_storage::Config();
+    config.set_use_mock_storage_for_testing(true);
+
+    auto env_config = arcticdb::get_test_environment_config(
+        library_path, storage_name, environment_name, std::make_optional(config));
+    auto config_resolver = as::create_in_memory_resolver(env_config);
+    as::LibraryIndex library_index{environment_name, config_resolver};
+
+    auto failed_config = proto::s3_storage::Config();
+    failed_config.set_use_mock_storage_for_testing(true);
+
+    auto failed_env_config = arcticdb::get_test_environment_config(
+        library_path, storage_name, environment_name, std::make_optional(failed_config));
+    auto failed_config_resolver = as::create_in_memory_resolver(failed_env_config);
+    as::LibraryIndex failed_library_index{environment_name, failed_config_resolver};
+
+    as::UserAuth user_auth{"abc"};
+    auto codec_opt = std::make_shared<arcticdb::proto::encoding::VariantCodec>();
+
+    auto source_store = create_store(library_path, library_index, user_auth, codec_opt);
+
+    std::string failureSymbol = storage::s3::MockS3Client::get_failure_trigger("sym", storage::StorageOperation::WRITE, Aws::S3::S3Errors::NO_SUCH_KEY);
+    
+    // Prepare 2 targets to fail and 1 to succeed
+    auto targets = std::vector<std::shared_ptr<arcticdb::Store>>{
+        create_store(library_path, library_index, user_auth, codec_opt),
+        create_store(library_path, failed_library_index, user_auth, codec_opt),
+        create_store(library_path, failed_library_index, user_auth, codec_opt)
+    };
+
+    // When - we write a key to the source
+    const arcticdb::entity::RefKey& key = arcticdb::entity::RefKey{failureSymbol, KeyType::VERSION_REF};
+    auto segment_in_memory = get_test_frame<arcticdb::stream::TimeseriesIndex>("symbol", {}, 10, 0).segment_;
+    auto row_count = segment_in_memory.row_count();
+    ASSERT_GT(row_count, 0);
+    auto segment = encode_dispatch(std::move(segment_in_memory), *codec_opt, arcticdb::EncodingVersion::V1);
+    (void)segment.calculate_size();
+    source_store->write_compressed_sync(as::KeySegmentPair{key, std::move(segment)});
+
+    // Copy the key
+    CopyCompressedInterStoreTask task{
+        key,
+        std::nullopt,
+        false,
+        false,
+        source_store,
+        targets,
+        std::shared_ptr<BitRateStats>()
+    };
+
+    arcticdb::async::TaskScheduler sched{1};
+    auto res = sched.submit_io_task(std::move(task)).get();
+
+    // It should report that it failed to copy
+    ASSERT_TRUE(std::holds_alternative<CopyCompressedInterStoreTask::FailedTargets>(res));
+    
+    // But it should still write the key to the non-failing target
+    auto read_result = targets[0]->read_sync(key);
+    ASSERT_EQ(std::get<RefKey>(read_result.first), key);
+    ASSERT_EQ(read_result.second.row_count(), row_count);
 }


### PR DESCRIPTION
#### Reference Issues/PRs
Needed for enterprise issue #151

#### What does this implement or fix?
Remove the catch for KeyNotFoundException when writing a key to the targets.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
