### PR TITLE
Add interface to pass a cached entry to tombstone all

### DIFF
--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -945,6 +945,45 @@ TEST(VersionMap, CompactionUpdateCache) {
     assert_keys_in_entry_and_store(entry, 2, 20, 3);
 }
 
+TEST(VersionMap, TombstoneAllFromEntry) {
+    using namespace arcticdb;
+    StreamId id{"test"};
+    auto store = std::make_shared<InMemoryStore>();
+    auto version_map = std::make_shared<VersionMap>();
+    auto entry = std::make_shared<VersionMapEntry>();
+
+    auto key1 = atom_key_with_version(id, 0, 0);
+    version_map->do_write(store, key1, entry);
+
+    auto key2 = atom_key_with_version(id, 1, 1);
+    version_map->do_write(store, key2, entry);
+
+    auto dummy_key = atom_key_builder()
+        .version_id(1)
+        .build(id, KeyType::VERSION);
+
+    // without cached entry
+    // Tombstone all should fail to delete anything since the ref key is not set
+    version_map->tombstone_from_key_or_all(store, id, dummy_key);
+
+    auto [maybe_prev, deleted] = get_latest_version(store, version_map, id);
+    ASSERT_FALSE(maybe_prev.has_value());
+    ASSERT_FALSE(deleted);
+    auto version_id = get_next_version_from_key(maybe_prev);
+    ASSERT_EQ(version_id, 0);
+
+
+    // With cached entry from the write ops  
+    // Tombstone all should succeed as we are not relying on the ref key      
+    version_map->tombstone_from_key_or_all(store, id, dummy_key, entry);
+
+    auto [maybe_prev_cached_entry, deleted_cached_entry] = get_latest_version(store, version_map, id);
+    ASSERT_TRUE(maybe_prev_cached_entry.has_value());
+    ASSERT_TRUE(deleted_cached_entry);
+    version_id = get_next_version_from_key(maybe_prev_cached_entry);
+    ASSERT_EQ(version_id, 2);
+}
+
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"
 
 TEST_F(VersionMapStore, StressTestWrite) {

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -254,13 +254,19 @@ public:
     std::pair<VersionId, std::vector<AtomKey>> tombstone_from_key_or_all(
             std::shared_ptr<Store> store,
             const StreamId& stream_id,
-            std::optional<AtomKey> first_key_to_tombstone = std::nullopt
+            std::optional<AtomKey> first_key_to_tombstone = std::nullopt,
+            std::optional<std::shared_ptr<VersionMapEntry>> cached_entry = std::nullopt
             ) {
-        auto entry = check_reload(
-            store,
-            stream_id,
-            LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY},
-            __FUNCTION__);
+        std::shared_ptr<VersionMapEntry> entry;
+        if (cached_entry)
+            entry = cached_entry.value();
+        else
+            entry = check_reload(
+                    store,
+                    stream_id,
+                    LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY},
+                    __FUNCTION__);
+
         auto output = tombstone_from_key_or_all_internal(store, stream_id, first_key_to_tombstone, entry);
 
         if (validate_)

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -258,15 +258,15 @@ public:
             std::optional<std::shared_ptr<VersionMapEntry>> cached_entry = std::nullopt
             ) {
         std::shared_ptr<VersionMapEntry> entry;
-        if (cached_entry)
+        if (cached_entry) {
             entry = cached_entry.value();
-        else
+        } else {
             entry = check_reload(
                     store,
                     stream_id,
                     LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY},
                     __FUNCTION__);
-
+        }
         auto output = tombstone_from_key_or_all_internal(store, stream_id, first_key_to_tombstone, entry);
 
         if (validate_)


### PR DESCRIPTION
#### Reference Issues/PRs
Needed for enterprise issue https://github.com/man-group/ArcticDB/issues/151

#### What does this implement or fix?
There are use cases where we want to:
- add an index key
- add a version key for it (**don't add a ref key here**)
- tombstone them
- add a ref key for the tombstone

Currently, the tombstone all operation relies on the ref key load and reconstruct the version chain (through `check_reload`).
This PR adds a way to pass a `cached_entry` with the index key and version key (or any other keys) already written, so we don't need to rely on the ref key.

The added test illustrates the current behavior (without the cached entry) and the desired new behavior of the functionality.

#### Any other comments?
Another way to achieve this would be to use `load_via_iteration` but this seems like a more flexible approach to me, especially as we would have an entry already on hand, if we are writing any individual keys.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
