### PR TITLE
Enhancement 1792: Use float64 as the result type for all division operations in the processing pipeline

### DIFF
--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -394,15 +394,14 @@ VariantData binary_operator(const ColumnWithStrings& col, const Value& val, Func
             }
             auto raw_value = *reinterpret_cast<const typename val_type_info::RawType*>(val.data_);
             using TargetType = typename type_arithmetic_promoted_type<typename col_type_info::RawType, typename val_type_info::RawType, std::remove_reference_t<decltype(func)>>::type;
-            using ReversedTargetType = typename type_arithmetic_promoted_type<typename val_type_info::RawType, typename col_type_info::RawType, std::remove_reference_t<decltype(func)>>::type;
             if constexpr(arguments_reversed) {
                 column_name = binary_operation_column_name(fmt::format("{}", raw_value), func, col.column_name_);
-                constexpr auto output_data_type = data_type_from_raw_type<ReversedTargetType>();
+                constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
                 output_column = std::make_unique<Column>(make_scalar_type(output_data_type), true);
                 Column::transform<typename col_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
                         *(col.column_),
                         *output_column,
-                        [&func, raw_value](auto input_value) -> ReversedTargetType {
+                        [&func, raw_value](auto input_value) -> TargetType {
                             return func.apply(raw_value, input_value);
                 });
             } else {

--- a/cpp/arcticdb/processing/test/test_arithmetic_type_promotion.cpp
+++ b/cpp/arcticdb/processing/test/test_arithmetic_type_promotion.cpp
@@ -434,111 +434,111 @@ TEST(ArithmeticTypePromotion, Times) {
 
 TEST(ArithmeticTypePromotion, Divide) {
     using namespace arcticdb;
-    // Floating point types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  float,  DivideOperator>::type, float>);
+    // Everything promotes to double
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  float,  DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<float,  double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, float,  DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<double, double, DivideOperator>::type, double>);
-    // Unsigned types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint8_t,  DivideOperator>::type, uint8_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint16_t, DivideOperator>::type, uint16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint32_t, DivideOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint64_t, DivideOperator>::type, uint64_t>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t,  DivideOperator>::type, uint16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint16_t, DivideOperator>::type, uint16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint32_t, DivideOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint64_t, DivideOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t,  DivideOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint16_t, DivideOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint32_t, DivideOperator>::type, uint32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint64_t, DivideOperator>::type, uint64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t,  DivideOperator>::type, uint64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint16_t, DivideOperator>::type, uint64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint32_t, DivideOperator>::type, uint64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint64_t, DivideOperator>::type, uint64_t>);
-    // Signed types should promote to the larger type width
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int8_t,  DivideOperator>::type, int8_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int16_t, DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int32_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t,  DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int16_t, DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int32_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t,  DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int16_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int32_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t,  DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int16_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int64_t, DivideOperator>::type, int64_t>);
-    // Mixed signed and unsigned types should promote to a signed type capable of exactly representing both types, capped at int64_t
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int8_t,  DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int16_t, DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int32_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t,  DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int16_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int32_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t,  DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int16_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t,  DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int16_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint8_t,  DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint16_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t,  DivideOperator>::type, int16_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint16_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t,  DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint16_t, DivideOperator>::type, int32_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint64_t, DivideOperator>::type, int64_t>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, int64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t,  DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint16_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint32_t, DivideOperator>::type, int64_t>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint64_t, DivideOperator>::type, int64_t>);
-    // Mixed integral and floating point types should promote to the floating point type
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  float, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, float, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, float, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, float, DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t,  DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint16_t, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint32_t, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint64_t, DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  float, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, float, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, float, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, float, DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, uint64_t, DivideOperator>::type, double>);
 
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t,  DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int16_t, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int32_t, DivideOperator>::type, float>);
-    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int64_t, DivideOperator>::type, float>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, uint64_t, DivideOperator>::type, double>);
+
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  float, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, float, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint32_t, float, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<uint64_t, float, DivideOperator>::type, double>);
+
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, uint64_t, DivideOperator>::type, double>);
+
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int8_t,  float, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int16_t, float, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int32_t, float, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<int64_t, float, DivideOperator>::type, double>);
+
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int8_t,  DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int16_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int32_t, DivideOperator>::type, double>);
+    static_assert(std::is_same_v<type_arithmetic_promoted_type<float, int64_t, DivideOperator>::type, double>);
 
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint8_t,  double, DivideOperator>::type, double>);
     static_assert(std::is_same_v<type_arithmetic_promoted_type<uint16_t, double, DivideOperator>::type, double>);


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #1792 
Fixes #1791 

#### What does this implement or fix?
Previously, dividing integers by integers in the processing pipeline (e.g. with `apply`) would perform integer division. This is true for all of `column/column`, `column/value`, and `value/column`.
This is not the same as the behaviour of Pandas or Polars. Worse, if the denominator was zero, this would cause a floating point exception on linux, and an integer overflow exception (#1791) on Windows.

This change makes the result a `float64` in all cases. If we want the previous behaviour to be accessible again, we should implement the integer division operator `//` in Python.