### PR TITLE
Fix sort index

### DIFF
--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -382,9 +382,10 @@ TEST(VersionMap, FixRefKey) {
     ASSERT_TRUE(version_map->check_ref_key(store, id));
 
     auto key4 = key3;
-    version_map->write_version(store, key4, key3);
-
-    ASSERT_FALSE(version_map->check_ref_key(store, id));
+    EXPECT_THROW({
+        // We should raise if we try to write a non-increasing index key
+        version_map->write_version(store, key4, key3);
+    }, InternalException);
 
     store->remove_key_sync(RefKey{id, KeyType::VERSION_REF}, storage::RemoveOpts{});
     ASSERT_FALSE(version_map->check_ref_key(store, id));
@@ -411,14 +412,19 @@ TEST(VersionMap, FixRefKeyTombstones) {
     auto key1 = atom_key_with_version(id, 0, 1696590624524585339);
     version_map->write_version(store, key1, std::nullopt);
     auto key2 = atom_key_with_version(id, 0, 1696590624387628801);
-    version_map->write_version(store, key2, key1);
+    EXPECT_THROW({
+        version_map->write_version(store, key2, key1);
+    }, InternalException);
     auto key3 = atom_key_with_version(id, 0, 1696590624532320286);
-    version_map->write_version(store, key3, key2);
+    EXPECT_THROW({
+        version_map->write_version(store, key3, key2);
+    }, InternalException);
     auto key4 = atom_key_with_version(id, 0, 1696590624554476875);
-    version_map->write_version(store, key4, key3);
+    EXPECT_THROW({
+        version_map->write_version(store, key4, key3);
+    }, InternalException);
     auto key5 = atom_key_with_version(id, 1, 1696590624590123209);
     version_map->write_version(store, key5, key4);
-    auto key6 = atom_key_with_version(id, 0, 1696590624612743245);
     auto entry = version_map->check_reload(store, id, LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);
     version_map->journal_single_key(store, key5, entry->head_.value());
 

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -38,6 +38,7 @@ auto write_version_frame(
     bool update_version_map = false,
     size_t start_val = 0,
     const std::optional<arcticdb::entity::AtomKey>& previous_key = std::nullopt,
+    bool prune_previous = false,
     const std::shared_ptr<arcticdb::DeDupMap>& de_dup_map = std::make_shared<arcticdb::DeDupMap>()
 ) {
     using namespace arcticdb;
@@ -53,7 +54,7 @@ auto write_version_frame(
     auto var_key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
     auto key = to_atom(var_key); // Moves
     if (update_version_map) {
-        pvs._test_get_version_map()->write_version(store, key, previous_key);
+        pvs.write_version_and_prune_previous(prune_previous, key, previous_key);
     }
 
     return key;
@@ -96,8 +97,8 @@ TEST(PythonVersionStore, WriteWithPruneVersions) {
 
     auto [version_store, mock_store] = python_version_store_in_memory();
 
-    auto key = write_version_frame({"test_versioned_engine_delete"}, 0, version_store, 30, true);
-    version_store._test_get_version_map()->write_and_prune_previous(mock_store, key, std::nullopt);
+    write_version_frame({"test_versioned_engine_delete"}, 0, version_store, 30, true);
+    write_version_frame({"test_versioned_engine_delete"}, 1, version_store, 30, true, 0, std::nullopt, true);
     // Should have pruned the previous version and have just one version
     ASSERT_EQ(mock_store->num_atom_keys_of_type(KeyType::TABLE_INDEX), 1);
 }

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -97,7 +97,8 @@ VersionedItem update_impl(
 
 VersionedItem delete_range_impl(
     const std::shared_ptr<Store>& store,
-    const AtomKey& prev,
+    const StreamId& stream_id,
+    const UpdateInfo& update_info,
     const UpdateQuery& query,
     const WriteOptions&& options,
     bool dynamic_schema);

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -501,6 +501,9 @@ public:
         if (validate_)
             entry->validate();
 
+        util::check(key.type() != KeyType::TABLE_INDEX || !entry->head_.has_value() || key.version_id() > entry->head_->version_id(),
+                    "Trying to write a non-increasing TABLE_INDEX key. New version: {}, Last version: {}",
+                    key.version_id(), entry->head_->version_id());
         auto journal_key = to_atom(std::move(journal_single_key(store, key, entry->head_)));
         write_to_entry(entry, key, journal_key);
         auto previous_index = entry->get_second_undeleted_index();

--- a/python/tests/unit/arcticdb/version_store/test_version_chain.py
+++ b/python/tests/unit/arcticdb/version_store/test_version_chain.py
@@ -1,0 +1,56 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import pytest
+
+from pandas import MultiIndex
+from arcticdb.version_store import NativeVersionStore
+from arcticdb_ext.exceptions import (
+    InternalException,
+    NormalizationException,
+    SortingException,
+)
+
+@pytest.mark.parametrize("operation", ["update", "append", "sort_index", "delete_range"])
+def test_version_chain_increasing(version_store_factory, operation):
+    lib = version_store_factory()
+    sym = "sym"
+
+    df = pd.DataFrame({"col": [1, 2, 3]}, index=pd.date_range(start=pd.Timestamp(0), periods=3, freq='ns'))
+    df_2 = pd.DataFrame({"col": [1, 2, 6]}, index=pd.date_range(start=pd.Timestamp(0), periods=3, freq='ns'))
+
+    def execute_operation():
+        if operation == "update":
+            df_update = pd.DataFrame({"col": [4, 5]}, index=pd.date_range(start=pd.Timestamp(1), periods=2, freq='ns'))
+            lib.update(sym, df_update)
+        elif operation == "append":
+            df_append = pd.DataFrame({"col": [4, 5]}, index=pd.date_range(start=pd.Timestamp(3), periods=2, freq='ns'))
+            lib.append(sym, df_append)
+        elif operation == "sort_index":
+            lib.version_store.sort_index(sym, False, False)
+        elif operation == "delete_range":
+            lib.delete(sym, date_range=(pd.Timestamp(1), pd.Timestamp(1)))
+        else:
+            raise "Unknown operation"
+
+
+    lib.write(sym, df)
+    assert lib.read(sym).version == 0
+
+    lib.write(sym, df_2)
+    assert lib.read(sym).version == 1
+
+    lib.delete_version(sym, 1)
+    assert lib.read(sym).version == 0
+
+    execute_operation()
+    assert lib.read(sym).version == 2
+


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?
Fixes the `sort_index` and `delete_range` wrong version bug.

Bug description:
We used to calculate the version to use for these two cases based on the last undeleted version which is wrong.
For example if we have the following version chain:
```
v0 <- v1 <- v2 <- tombstone (v2) <- tombstone (v1)
```
Calling `sort_index` or `delete_range` would result in us writing `v1` instead of the correct `v3`. This has various bad implications.

So this pr does the following:
1. One commit adds a test showcasing the bug and an assertion that all index keys should be increasing in version.
2. One commit which fixes the bug and uses the `UpdateInfo` construct as other modification methods.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
