### PR TITLE
Add API to remove Prometheus metrics

### DIFF
--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -8,6 +8,7 @@
 #include <arcticdb/entity/metrics.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/util/pb_util.hpp>
+#include <folly/gen/Base.h>
 
 #ifdef _WIN32
 #    include <Winsock.h> // for gethostname
@@ -95,123 +96,136 @@ namespace arcticdb {
         configured_ = true;
     }
 
-    // new mechanism, labels at runtime
     void PrometheusInstance::registerMetric(
             prometheus::MetricType type,
             const std::string& name,
             const std::string& help,
-            const std::map<std::string, std::string>& staticLabels,
+            const Labels& labels,
             const std::vector<double>& buckets_list
     ) {
         if (registry_.use_count() == 0) {
             return;
         }
 
+        std::scoped_lock lock{metrics_mutex_};
         if (type == prometheus::MetricType::Counter) {
             // Counter is actually a unique_ptr object which has a life of registry
             map_counter_[name] = &prometheus::BuildCounter()
                     .Name(name)
                     .Help(help)
-                    .Labels(staticLabels)
+                    .Labels(labels)
                     .Register(*registry_);
         } else if (type == prometheus::MetricType::Gauge) {
             map_gauge_[name] = &prometheus::BuildGauge()
                     .Name(name)
                     .Help(help)
-                    .Labels(staticLabels)
+                    .Labels(labels)
                     .Register(*registry_);
         } else if (type == prometheus::MetricType::Histogram) {
             map_histogram_[name].histogram = &prometheus::BuildHistogram()
                     .Name(name)
                     .Help(help)
-                    .Labels(staticLabels)
+                    .Labels(labels)
                     .Register(*registry_);
             map_histogram_[name].buckets_list = buckets_list;
         } else if (type == prometheus::MetricType::Summary) {
             map_summary_[name] = &prometheus::BuildSummary()
                     .Name(name)
                     .Help(help)
-                    .Labels(staticLabels)
+                    .Labels(labels)
                     .Register(*registry_);
         } else {
             arcticdb::log::version().warn("Unsupported metric type");
         }
 }
 
-void PrometheusInstance::incrementCounter(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
+void PrometheusInstance::incrementCounter(const std::string& name, double value, const Labels& labels) {
     if (registry_.use_count() == 0)
         return;
 
-    if (map_counter_.count(name) != 0) {
-        // Add returns Counter&
-        map_counter_[name]->Add(labels).Increment(value);
+    std::scoped_lock lock{metrics_mutex_};
+    if (const auto it = map_counter_.find(name); it != map_counter_.end()) {
+        Counter* counter = &it->second->Add(labels);
+        all_counters_.insert({{name, labels}, counter});
+        counter->Increment(value);
     } else {
         arcticdb::log::version().warn("Unregistered counter metric {}", name);
     }
 }
 
-void PrometheusInstance::incrementCounter(const std::string& name, const std::map<std::string, std::string>& labels) {
+void PrometheusInstance::incrementCounter(const std::string& name, const Labels& labels) {
     if (registry_.use_count() == 0)
         return;
 
-    if (map_counter_.count(name) != 0) {
-        // Add returns Counter&
-        map_counter_[name]->Add(labels).Increment();
+    std::scoped_lock lock{metrics_mutex_};
+    if (const auto it = map_counter_.find(name); it != map_counter_.end()) {
+        Counter* counter = &it->second->Add(labels);
+        all_counters_.insert({{name, labels}, counter});
+        counter->Increment();
     } else {
         arcticdb::log::version().warn("Unregistered counter metric {}", name);
     }
 }
 
-void PrometheusInstance::setGauge(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
+void PrometheusInstance::setGauge(const std::string& name, double value, const Labels& labels) {
     if (registry_.use_count() == 0)
         return;
 
-    if (map_gauge_.count(name) != 0) {
-        map_gauge_[name]->Add(labels).Set(value);
+    std::scoped_lock lock{metrics_mutex_};
+    if (const auto it = map_gauge_.find(name); it != map_gauge_.end()) {
+        Gauge* gauge = &it->second->Add(labels);
+        all_gauges_.insert({{name, labels}, gauge});
+        gauge->Set(value);
     } else {
         arcticdb::log::version().warn("Unregistered gauge metric {}", name);
     }
 }
-void PrometheusInstance::setGaugeCurrentTime(const std::string& name, const std::map<std::string, std::string>& labels) {
+
+void PrometheusInstance::setGaugeCurrentTime(const std::string& name, const Labels& labels) {
     if (registry_.use_count() == 0)
         return;
 
-    if (map_gauge_.count(name) != 0) {
-        map_gauge_[name]->Add(labels).SetToCurrentTime();
+    std::scoped_lock lock{metrics_mutex_};
+    if (const auto it = map_gauge_.find(name); it != map_gauge_.end()) {
+        Gauge* gauge = &it->second->Add(labels);
+        all_gauges_.insert({{name, labels}, gauge});
+        gauge->SetToCurrentTime();
     } else {
         arcticdb::log::version().warn("Unregistered gauge metric {}", name);
     }
 }
-void PrometheusInstance::observeHistogram(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
+
+void PrometheusInstance::observeHistogram(const std::string& name, double value, const Labels& labels) {
     if (registry_.use_count() == 0)
         return;
-    if (auto it=map_histogram_.find(name); it != map_histogram_.end()) {
-        it->second.histogram->Add(labels, it->second.buckets_list).Observe(value);
+
+    std::scoped_lock lock{metrics_mutex_};
+    if (const auto it=map_histogram_.find(name); it != map_histogram_.end()) {
+        Histogram* histogram = &it->second.histogram->Add(labels, it->second.buckets_list);
+        all_histograms_.insert({{name, labels}, histogram});
+        histogram->Observe(value);
     } else {
         arcticdb::log::version().warn("Unregistered Histogram metric {}", name);
     }
 }
-void PrometheusInstance::DeleteHistogram(const std::string& name, const std::map<std::string, std::string>& labels) {
+
+void PrometheusInstance::observeSummary(const std::string& name, double value, const Labels& labels) {
     if (registry_.use_count() == 0)
         return;
 
-    if (auto it=map_histogram_.find(name); it != map_histogram_.end()) {
-        it->second.histogram->Remove(&it->second.histogram->Add(labels, it->second.buckets_list));
-    } else {
-        arcticdb::log::version().warn("Unregistered Histogram metric {}", name);
-    }
-}
-void PrometheusInstance::observeSummary(const std::string& name, double value, const std::map<std::string, std::string>& labels) {
-    if (registry_.use_count() == 0)
-        return;
-
-    if (map_summary_.count(name) != 0) {
-        //TODO DMK quantiles
-        map_summary_[name]->Add(labels,Summary::Quantiles{ {0.1, 0.05}, {0.2, 0.05}, {0.3, 0.05}, {0.4, 0.05}, {0.5, 0.05}, {0.6, 0.05}, {0.7, 0.05}, {0.8, 0.05}, {0.9, 0.05}, {0.9, 0.05}, {1.0, 0.05}}, std::chrono::seconds{SUMMARY_MAX_AGE}, SUMMARY_AGE_BUCKETS).Observe(value);
+    std::scoped_lock lock{metrics_mutex_};
+    if (const auto it = map_summary_.find(name); it != map_summary_.end()) {
+        Summary* summary = &it->second->Add(
+            labels,
+            Summary::Quantiles{ {0.1, 0.05}, {0.2, 0.05}, {0.3, 0.05}, {0.4, 0.05}, {0.5, 0.05}, {0.6, 0.05}, {0.7, 0.05}, {0.8, 0.05}, {0.9, 0.05}, {0.9, 0.05}, {1.0, 0.05}},
+            std::chrono::seconds{SUMMARY_MAX_AGE}, SUMMARY_AGE_BUCKETS);
+        all_summaries_.insert({{name, labels}, summary});
+        summary->Observe(value);
     } else {
         arcticdb::log::version().warn("Unregistered summary metric {}", name);
     }
 }
+
 std::string PrometheusInstance::getHostName() {
     char hostname[1024];
     if (::gethostname(hostname, sizeof(hostname))) {
@@ -234,4 +248,3 @@ std::vector<prometheus::MetricFamily> PrometheusInstance::get_metrics() {
 }
 
 } // Namespace arcticdb
-

--- a/cpp/arcticdb/entity/metrics.hpp
+++ b/cpp/arcticdb/entity/metrics.hpp
@@ -74,7 +74,7 @@ public:
 
 class PrometheusInstance {
 public:
-    using Labels = std::map<std::string, std::string>;
+    using Labels = prometheus::Labels;
 
     static std::shared_ptr<PrometheusInstance> instance();
 
@@ -182,11 +182,9 @@ public:
 
         struct MetricKeyHash {
             std::size_t operator()(const MetricKey& key) const noexcept {
-                auto hash = std::hash<std::string>()(key.name);
-                for (const auto& [name, value] : key.labels) {
-                    hash = folly::hash::commutative_hash_combine(hash, name, value);
-                }
-                return hash;
+                auto labels_hash = folly::hash::commutative_hash_combine_range(
+                    key.labels.begin(), key.labels.end());
+                return folly::hash::commutative_hash_combine(labels_hash, key.name);
             }
         };
 

--- a/cpp/arcticdb/entity/metrics.hpp
+++ b/cpp/arcticdb/entity/metrics.hpp
@@ -108,8 +108,8 @@ public:
             metrics_family = map_counter_;
             metrics = all_counters_;
         } else if constexpr(T::metric_type == prometheus::MetricType::Histogram) {
-            for (const auto& [name, value] : map_histogram_) {
-                metrics_family[name] = value.histogram;
+            for (const auto& [histogram_name, value] : map_histogram_) {
+                metrics_family[histogram_name] = value.histogram;
             }
             metrics = all_histograms_;
         } else if constexpr(T::metric_type == prometheus::MetricType::Gauge) {

--- a/cpp/arcticdb/entity/metrics.hpp
+++ b/cpp/arcticdb/entity/metrics.hpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <unordered_map>
 #include <memory>
+#include <utility>
 #include <fmt/format.h>
 
 namespace arcticdb {
@@ -109,7 +110,7 @@ public:
             metrics = all_counters_;
         } else if constexpr(T::metric_type == prometheus::MetricType::Histogram) {
             for (const auto& [histogram_name, value] : map_histogram_) {
-                metrics_family[histogram_name] = value.histogram;
+                metrics_family[histogram_name] = value.histogram_;
             }
             metrics = all_histograms_;
         } else if constexpr(T::metric_type == prometheus::MetricType::Gauge) {
@@ -159,8 +160,14 @@ public:
     private:
 
         struct HistogramInfo {
-            prometheus::Family<prometheus::Histogram>* histogram;
-            prometheus::Histogram::BucketBoundaries buckets_list;
+            HistogramInfo(prometheus::Family<prometheus::Histogram>* histogram,
+                          prometheus::Histogram::BucketBoundaries buckets_list) : histogram_(histogram),
+                          buckets_list_(std::move(buckets_list)) {
+
+            }
+
+            prometheus::Family<prometheus::Histogram>* histogram_;
+            prometheus::Histogram::BucketBoundaries buckets_list_;
         };
 
         template<typename T>

--- a/cpp/arcticdb/entity/test/test_metrics.cpp
+++ b/cpp/arcticdb/entity/test/test_metrics.cpp
@@ -49,3 +49,281 @@ TEST(Metrics, IncrementCounterSpecific) {
     ASSERT_EQ(metric.size(), 1);
     ASSERT_EQ(metric.at(0).counter.value, 12.0);
 }
+
+TEST(Metrics, RemoveCounter) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Counter, "name", "help");
+
+    // when
+    instance.incrementCounter("name", {{"a", "bcd"}});
+    instance.incrementCounter("name", {{"a", "efg"}});
+    instance.removeMetric<prometheus::Counter>("name", {{"a", "efg"}});
+    instance.removeMetric<prometheus::Counter>("other_name", {}); // don't complain
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res.at(0).name, "name");
+    auto metric = res.at(0).metric;
+    ASSERT_EQ(metric.size(), 1);
+    ASSERT_EQ(metric.at(0).label.at(0).name, "a");
+    ASSERT_EQ(metric.at(0).label.at(0).value, "bcd");
+    ASSERT_EQ(metric.at(0).counter.value, 1.0);
+}
+
+TEST(Metrics, RemoveCounterSpecific) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Counter, "name", "help");
+
+    // when
+    instance.incrementCounter("name", 3.0, {{"a", "bcd"}});
+    instance.incrementCounter("name", 4.0, {{"a", "bcd"}});
+    instance.incrementCounter("name", 2.0, {{"a", "efg"}});
+    instance.removeMetric<prometheus::Counter>("name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res.at(0).name, "name");
+    auto metric = res.at(0).metric;
+    ASSERT_EQ(metric.size(), 1);
+    ASSERT_EQ(metric.at(0).counter.value, 2.0);
+}
+
+TEST(Metrics, RemoveFamilyLabelsNotConsidered) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Counter, "name", "help",
+        {{"env", "dev"}, {"day_of_week", "monday"}});
+
+    // when
+    instance.incrementCounter("name", {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Counter>("name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_TRUE(res.empty());
+}
+
+TEST(Metrics, Gauge) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Gauge, "name", "help");
+
+    // when
+    instance.setGauge("name", 4.0, {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res.at(0).name, "name");
+    auto metric = res.at(0).metric;
+    ASSERT_EQ(metric.size(), 1);
+    ASSERT_EQ(metric.at(0).gauge.value, 4.0);
+}
+
+TEST(Metrics, RemoveGauge) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Gauge, "name", "help");
+
+    // when
+    instance.setGauge("name", 4.0, {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Gauge>("name", {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Gauge>("other_name", {}); // don't complain
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 0);
+}
+
+TEST(Metrics, RemoveMultipleGauges) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Gauge, "name", "help");
+    instance.registerMetric(prometheus::MetricType::Gauge, "other_name", "help");
+
+    // when
+    instance.setGauge("name", 4.0, {{"a", "bcd"}});
+    instance.setGauge("other_name", 4.0, {{"a", "bcd"}});
+    instance.setGauge("name", 4.0, {{"b", "bcd"}});
+    instance.setGauge("other_name", 4.0, {{"bcd", "a"}});
+    instance.removeMetric<prometheus::Gauge>("other_name", {{"bcd", "a"}});
+    instance.removeMetric<prometheus::Gauge>("name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 2);
+
+    auto first_metric = res.at(0).metric;
+    auto second_metric = res.at(1).metric;
+    auto expected_one = prometheus::ClientMetric::Label("a", "bcd");
+    auto expected_two = prometheus::ClientMetric::Label("b", "bcd");
+
+    auto actual_label_one = first_metric.at(0).label.at(0);
+    auto actual_label_two = second_metric.at(0).label.at(0);
+    ASSERT_NE(actual_label_one, actual_label_two);
+    ASSERT_TRUE(actual_label_one == expected_one || actual_label_one == expected_two);
+    ASSERT_TRUE(actual_label_two == expected_one || actual_label_two == expected_two);
+}
+
+TEST(Metrics, RemoveGaugeLabelsChecked) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Gauge, "name", "help");
+
+    // when
+    instance.setGauge("name", 4.0, {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Gauge>("name", {{"a", "zzz"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+}
+
+TEST(Metrics, RemoveGaugeNameFiltering) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Gauge, "name", "help");
+
+    // when
+    instance.setGauge("name", 4.0, {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Gauge>("not_this_name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+}
+
+TEST(Metrics, Summary) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Summary, "name", "help");
+    instance.registerMetric(prometheus::MetricType::Summary, "other_name", "help");
+
+    // when
+    instance.observeSummary("name", 4.0, {{"a", "bcd"}});
+    instance.observeSummary("name", 6.0, {{"a", "bcd"}});
+    instance.observeSummary("other_name", 3.0, {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 2);
+    ASSERT_EQ(res.at(0).name, "name");
+    auto metric = res.at(0).metric;
+    ASSERT_EQ(metric.size(), 1);
+    ASSERT_EQ(metric.at(0).summary.sample_sum, 10.0);
+    ASSERT_EQ(metric.at(0).summary.sample_count, 2);
+}
+
+TEST(Metrics, RemoveSummary) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Summary, "name", "help");
+    instance.registerMetric(prometheus::MetricType::Summary, "other_name", "help");
+
+    // when
+    instance.observeSummary("name", 4.0, {{"a", "bcd"}});
+    instance.observeSummary("name", 6.0, {{"a", "bcd"}});
+    instance.observeSummary("other_name", 3.0, {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Summary>("name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res.at(0).name, "other_name");
+}
+
+TEST(Metrics, RemoveSummaryAllLabelsChecked) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Summary, "name", "help");
+    instance.registerMetric(prometheus::MetricType::Summary, "other_name", "help");
+
+    // when
+    instance.observeSummary("name", 4.0, {{"a", "bcd"}, {"e", "ijk"}});
+
+    // The "e" label doesn't match so don't remove anything
+    instance.removeMetric<prometheus::Summary>("name", {{"a", "bcd"}, {"e", "fgh"}});
+    instance.removeMetric<prometheus::Summary>("name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+}
+
+TEST(Metrics, Histogram) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Histogram, "name", "help");
+    instance.registerMetric(prometheus::MetricType::Histogram, "other_name", "help");
+
+    // when
+    instance.observeHistogram("name", 4.0, {{"a", "bcd"}});
+    instance.observeHistogram("name", 6.0, {{"a", "bcd"}});
+    instance.observeHistogram("other_name", 3.0, {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 2);
+    ASSERT_EQ(res.at(0).name, "name");
+    auto metric = res.at(0).metric;
+    ASSERT_EQ(metric.size(), 1);
+    ASSERT_EQ(metric.at(0).histogram.sample_sum, 10.0);
+    ASSERT_EQ(metric.at(0).histogram.sample_count, 2);
+}
+
+TEST(Metrics, RemoveHistogram) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Histogram, "name", "help");
+    instance.registerMetric(prometheus::MetricType::Histogram, "other_name", "help");
+
+    // when
+    instance.observeHistogram("name", 4.0, {{"a", "bcd"}});
+    instance.observeHistogram("name", 6.0, {{"a", "bcd"}});
+    instance.observeHistogram("other_name", 3.0, {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Histogram>("name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res.at(0).name, "other_name");
+}
+
+TEST(Metrics, RemoveHistogramLabelsChecked) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Histogram, "name", "help");
+    instance.registerMetric(prometheus::MetricType::Histogram, "other_name", "help");
+
+    // when
+    instance.observeHistogram("name", 4.0, {{"a", "bcd"}});
+    instance.observeHistogram("name", 6.0, {{"a", "efg"}});
+    instance.observeHistogram("other_name", 3.0, {{"a", "bcd"}});
+    instance.removeMetric<prometheus::Histogram>("name", {{"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_EQ(res.size(), 2);
+    ASSERT_EQ(res.at(0).name, "name");
+    auto metric = res.at(0).metric;
+    ASSERT_EQ(metric.at(0).histogram.sample_sum, 6.0);
+    ASSERT_EQ(metric.at(0).label.at(0).value, "efg");
+}

--- a/cpp/arcticdb/entity/test/test_metrics.cpp
+++ b/cpp/arcticdb/entity/test/test_metrics.cpp
@@ -73,6 +73,21 @@ TEST(Metrics, RemoveCounter) {
     ASSERT_EQ(metric.at(0).counter.value, 1.0);
 }
 
+TEST(Metrics, RemoveCounterLabelsOutOfOrder) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Counter, "name", "help");
+
+    // when
+    instance.incrementCounter("name", {{"a", "bcd"}, {"e", "fgh"}});
+    instance.removeMetric<prometheus::Counter>("name", {{"e", "fgh"}, {"a", "bcd"}});
+
+    // then
+    auto res = instance.get_metrics();
+    ASSERT_TRUE(res.empty());
+}
+
 TEST(Metrics, RemoveCounterSpecific) {
     // given
     PrometheusInstance instance{};

--- a/cpp/arcticdb/entity/test/test_metrics.cpp
+++ b/cpp/arcticdb/entity/test/test_metrics.cpp
@@ -30,6 +30,23 @@ TEST(Metrics, IncrementCounterDefault) {
     ASSERT_EQ(metric.at(0).counter.value, 3.0);
 }
 
+TEST(Metrics, OverwriteFamilyLabelsNotPossible) {
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Counter, "name", "help", {{"env", "dev"}});
+    ASSERT_THROW(instance.incrementCounter("name", {{"env", "pre"}}), std::invalid_argument);
+    ASSERT_THROW(instance.incrementCounter("name", {{"env", "pre"}, {"another", "label"}}), std::invalid_argument);
+    instance.incrementCounter("name", {{"a", "bcd"}});
+}
+
+TEST(Metrics, RegisterTwice) {
+    // given
+    PrometheusInstance instance{};
+    instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
+    instance.registerMetric(prometheus::MetricType::Counter, "name", "help");
+    ASSERT_THROW(instance.registerMetric(prometheus::MetricType::Counter, "name", "help"), ArcticException);
+}
+
 TEST(Metrics, IncrementCounterSpecific) {
     // given
     PrometheusInstance instance{};


### PR DESCRIPTION
Introduce `void removeMetric(const std::string& name, const Labels& labels)` to `PrometheusInstance`.

This lets us remove metrics from the Prometheus registry.

The Prometheus SDK has a data model like:

```
Registry
|  The global registry of Prometheus metrics

-> [MetricFamily...] 
|  A list of metric "families". These are metrics that all share the same name, and a set of "base" labels. We create these when we
|  call registerMetric. Since we only call registerMetric once per metric name, we can safely key these in MetricFamilyMap just by
|  metric name.

---->[Metric...]
|      A list of metrics in the family. These metrics are published with the labels of their "family", plus any additional labels (eg 
|      those supplied when calling incrementCounter on a pre-registered metric).
```

We *do not* consider the labels on the `MetricFamily` when removing metrics because they apply to the entire `PrometheusInstance` and it is just an unnecessary chore to always include them when removing metrics.

To remove a metric, the SDK forces us to keep a handle on the metric from when it was created (with `Add`). The SDK's remove method just compares pointers and silently does not remove metrics unless the pointers match - there is no deep comparison. Therefore we keep additional state - a map of metric name and (metric-level) labels to the created metric. An alternative design would be to push this problem up a level and force users of the `PrometheusInstance` to maintain state around their metrics.

Motivation: arcticdb-enterprise#149