### PR TITLE
Fix regression in bool pickling

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -234,8 +234,6 @@ def _to_primitive(arr, arr_name, dynamic_strings, string_max_len=None, coerce_co
             casted_arr = coerce_string_column_to_fixed_length_array(arr, type(sample), string_max_len)
     elif dynamic_strings and sample is None:  # arr is entirely empty
         return arr
-    elif isinstance(sample, bool) or isinstance(sample, np.ndarray):
-        return arr
     else:
         raise ArcticDbNotYetImplemented(
             f"Failed to normalize column '{arr_name}' with dtype '{arr.dtype}'. Found first non-null value of type "

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -620,3 +620,17 @@ def test_norm_failure_error_message(lmdb_version_store_v1):
                [write_exception, batch_write_exception])
     assert all("pickle_on_failure" not in str(e.value) for e in
                [append_exception, batch_append_exception, update_exception])
+
+def test_bools_are_pickled(lmdb_version_store_allows_pickling):
+    lib = lmdb_version_store_allows_pickling
+    sym = "test_bools_are_pickled"
+
+    df = pd.DataFrame({"a": [True, False]})
+    lib.write(sym, df)
+    lib.get_info(sym)['type'] == 'pickled'
+    assert_frame_equal(df, lib.read(sym).data)
+
+    df = pd.DataFrame({"a": [True, False, np.nan]})
+    lib.write(sym, df)
+    lib.get_info(sym)['type'] == 'pickled'
+    assert_frame_equal(df, lib.read(sym).data)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -634,3 +634,17 @@ def test_bools_are_pickled(lmdb_version_store_allows_pickling):
     lib.write(sym, df)
     lib.get_info(sym)['type'] == 'pickled'
     assert_frame_equal(df, lib.read(sym).data)
+
+def test_arrays_are_pickled(lmdb_version_store_allows_pickling):
+    lib = lmdb_version_store_allows_pickling
+    sym = "test_arrays_are_pickled"
+
+    df = pd.DataFrame({"a": [np.array([1, 2])]})
+    lib.write(sym, df)
+    lib.get_info(sym)['type'] == 'pickled'
+    assert_frame_equal(df, lib.read(sym).data)
+
+    df = pd.DataFrame({"a": [[1, 2]]})
+    lib.write(sym, df)
+    lib.get_info(sym)['type'] == 'pickled'
+    assert_frame_equal(df, lib.read(sym).data)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -635,6 +635,14 @@ def test_bools_are_pickled(lmdb_version_store_allows_pickling):
     lib.get_info(sym)['type'] == 'pickled'
     assert_frame_equal(df, lib.read(sym).data)
 
+def test_bools_with_nan_throw_without_pickling(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_bools_throw_without_pickling"
+
+    df = pd.DataFrame({"a": [True, False, np.nan]})
+    with pytest.raises(Exception):
+        lib.write(sym, df)
+
 def test_arrays_are_pickled(lmdb_version_store_allows_pickling):
     lib = lmdb_version_store_allows_pickling
     sym = "test_arrays_are_pickled"
@@ -648,3 +656,12 @@ def test_arrays_are_pickled(lmdb_version_store_allows_pickling):
     lib.write(sym, df)
     lib.get_info(sym)['type'] == 'pickled'
     assert_frame_equal(df, lib.read(sym).data)
+
+def test_arrays_throw_without_pickling(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_arrays_throw_without_pickling"
+
+    df = pd.DataFrame({"a": [np.array([1, 2])]})
+
+    with pytest.raises(Exception):
+        lib.write(sym, df)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
When nullable booleans (which are now disabled) were introduced bool pickling stopped working. This reverts the previous behavior.
#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
