### PR TITLE
Allow metrics to be registered twice

### DIFF
--- a/cpp/arcticdb/entity/metrics.hpp
+++ b/cpp/arcticdb/entity/metrics.hpp
@@ -150,7 +150,7 @@ public:
 
     int push();
 
-    void configure(const MetricsConfig& config, const bool reconfigure = false);
+    void configure(const MetricsConfig& config);
 
     // Intended for testing.
     std::vector<prometheus::MetricFamily> get_metrics();
@@ -160,13 +160,15 @@ public:
     private:
 
         struct HistogramInfo {
+            HistogramInfo() = default;
+
             HistogramInfo(prometheus::Family<prometheus::Histogram>* histogram,
                           prometheus::Histogram::BucketBoundaries buckets_list) : histogram_(histogram),
                           buckets_list_(std::move(buckets_list)) {
 
             }
 
-            prometheus::Family<prometheus::Histogram>* histogram_;
+            prometheus::Family<prometheus::Histogram>* histogram_ = nullptr;
             prometheus::Histogram::BucketBoundaries buckets_list_;
         };
 

--- a/cpp/arcticdb/entity/test/test_metrics.cpp
+++ b/cpp/arcticdb/entity/test/test_metrics.cpp
@@ -44,7 +44,7 @@ TEST(Metrics, RegisterTwice) {
     PrometheusInstance instance{};
     instance.configure(MetricsConfig{"host", "port", "job", "instance", "local", MetricsConfig::Model::PUSH});
     instance.registerMetric(prometheus::MetricType::Counter, "name", "help");
-    ASSERT_THROW(instance.registerMetric(prometheus::MetricType::Counter, "name", "help"), ArcticException);
+    instance.registerMetric(prometheus::MetricType::Counter, "name", "help");
 }
 
 TEST(Metrics, IncrementCounterSpecific) {


### PR DESCRIPTION
Remove the reconfigure flag, it's never set to true in practice and it isn't implemented correctly.

Allow metrics to be re-registered, it's too annoying in the replication tests otherwise since the PrometheusInstance is static state.