### PR TITLE
Bugfix 1818: Fix QueryBuilder equality checks

### DIFF
--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -865,7 +865,7 @@ class QueryBuilder:
     def __eq__(self, right):
         if not isinstance(right, QueryBuilder):
             return False
-        return self._optimisation == right._optimisation and self._python_clauses == right._python_clauses
+        return self._optimisation == right._optimisation and str(self) == str(right)
 
     def __str__(self):
         return " | ".join(str(clause) for clause in self.clauses)

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -17,6 +17,18 @@ from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.util.test import assert_frame_equal
 
 
+def test_query_builder_equality_checks():
+    q1 = QueryBuilder()
+    q2 = QueryBuilder()
+    q1 = q1[q1["date"] >= pd.Timestamp("2020-01-01")]
+    q2 = q2[q2["date"] >= pd.Timestamp("2020-01-01")]
+    assert q1 == q2
+
+    q2 = QueryBuilder()
+    q2 = q2[q2["date"] >= pd.Timestamp("2021-01-01")]
+    assert q1 != q2
+
+
 def test_querybuilder_getitem_idempotency(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_querybuilder_getitem_idempotency"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1818 

Previous implementation did not work due to implementation of `__eq__` on the `ExpressionNode` class being needed to behave not as a check but as a modifier, so that filters like this work:
```
q = QueryBuilder()
q = q[q["col"] == 0]
```