### PR TITLE
Support reading from prefixes that include a dot

### DIFF
--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -187,6 +187,7 @@ bool NfsBackedStorage::do_key_exists(const VariantKey& key) {
 
 NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
     Storage(library_path, mode),
+    s3_api_(s3::S3ApiInstance::instance()),
     root_folder_(object_store_utils::get_root_folder(library_path)),
     bucket_name_(conf.bucket_name()),
     region_(conf.region()) {
@@ -197,18 +198,24 @@ NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mod
     } else {
         s3_client_ = std::make_unique<s3::RealS3Client>(s3::get_aws_credentials(conf), s3::get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
     }
-    if (!conf.prefix().empty()) {
-        ARCTICDB_DEBUG(log::version(), "prefix found, using: {}", conf.prefix());
+
+    if (conf.prefix().empty()) {
+        ARCTICDB_DEBUG(log::version(), "prefix not found, will use {}", root_folder_);
+    } else if (conf.use_raw_prefix()) {
+        ARCTICDB_DEBUG(log::version(), "raw prefix found, using: {}", conf.prefix());
+        root_folder_ = conf.prefix();
+    } else {
         auto prefix_path = LibraryPath::from_delim_path(conf.prefix(), '.');
         root_folder_ = object_store_utils::get_root_folder(prefix_path);
-    } else {
-        ARCTICDB_DEBUG(log::version(), "prefix not found, will use {}", root_folder_);
+        ARCTICDB_DEBUG(log::version(), "parsed prefix found, using: {}", root_folder_);
     }
+
     // When linking against libraries built with pre-GCC5 compilers, the num_put facet is not initalized on the classic locale
     // Rather than change the locale globally, which might cause unexpected behaviour in legacy code, just add the required
     // facet here
     std::locale locale{ std::locale::classic(), new std::num_put<char>()};
     (void)std::locale::global(locale);
+    s3_api_.reset();
     ARCTICDB_DEBUG(log::storage(), "Opened NFS backed storage at {}", root_folder_);
 }
 

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -119,6 +119,39 @@ VariantKey unencode_object_id(const VariantKey& key) {
                         });
 }
 
+NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
+        Storage(library_path, mode),
+        s3_api_(s3::S3ApiInstance::instance()),  // make sure we have an initialized AWS SDK
+        root_folder_(object_store_utils::get_root_folder(library_path)),
+        bucket_name_(conf.bucket_name()),
+        region_(conf.region()) {
+
+    if (conf.use_mock_storage_for_testing()) {
+        log::storage().warn("Using Mock S3 storage for NfsBackedStorage");
+        s3_client_ = std::make_unique<s3::MockS3Client>();
+    } else {
+        s3_client_ = std::make_unique<s3::RealS3Client>(s3::get_aws_credentials(conf), s3::get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+    }
+
+    if (conf.prefix().empty()) {
+        ARCTICDB_DEBUG(log::version(), "prefix not found, will use {}", root_folder_);
+    } else if (conf.use_raw_prefix()) {
+        ARCTICDB_DEBUG(log::version(), "raw prefix found, using: {}", conf.prefix());
+        root_folder_ = conf.prefix();
+    } else {
+        auto prefix_path = LibraryPath::from_delim_path(conf.prefix(), '.');
+        root_folder_ = object_store_utils::get_root_folder(prefix_path);
+        ARCTICDB_DEBUG(log::version(), "parsed prefix found, using: {}", root_folder_);
+    }
+
+    // When linking against libraries built with pre-GCC5 compilers, the num_put facet is not initalized on the classic locale
+    // Rather than change the locale globally, which might cause unexpected behaviour in legacy code, just add the required
+    // facet here
+    std::locale locale{ std::locale::classic(), new std::num_put<char>()};
+    (void)std::locale::global(locale);
+    ARCTICDB_DEBUG(log::storage(), "Opened NFS backed storage at {}", root_folder_);
+}
+
 std::string NfsBackedStorage::name() const {
     return fmt::format("nfs_backed_storage-{}/{}/{}", region_, bucket_name_, root_folder_);
 }
@@ -182,41 +215,6 @@ bool NfsBackedStorage::do_iterate_type_until_match(KeyType key_type, const Itera
 bool NfsBackedStorage::do_key_exists(const VariantKey& key) {
     auto encoded_key = encode_object_id(key);
     return s3::detail::do_key_exists_impl(encoded_key, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
-}
-
-
-NfsBackedStorage::NfsBackedStorage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
-    Storage(library_path, mode),
-    s3_api_(s3::S3ApiInstance::instance()),
-    root_folder_(object_store_utils::get_root_folder(library_path)),
-    bucket_name_(conf.bucket_name()),
-    region_(conf.region()) {
-
-    if (conf.use_mock_storage_for_testing()) {
-        log::storage().warn("Using Mock S3 storage for NfsBackedStorage");
-        s3_client_ = std::make_unique<s3::MockS3Client>();
-    } else {
-        s3_client_ = std::make_unique<s3::RealS3Client>(s3::get_aws_credentials(conf), s3::get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
-    }
-
-    if (conf.prefix().empty()) {
-        ARCTICDB_DEBUG(log::version(), "prefix not found, will use {}", root_folder_);
-    } else if (conf.use_raw_prefix()) {
-        ARCTICDB_DEBUG(log::version(), "raw prefix found, using: {}", conf.prefix());
-        root_folder_ = conf.prefix();
-    } else {
-        auto prefix_path = LibraryPath::from_delim_path(conf.prefix(), '.');
-        root_folder_ = object_store_utils::get_root_folder(prefix_path);
-        ARCTICDB_DEBUG(log::version(), "parsed prefix found, using: {}", root_folder_);
-    }
-
-    // When linking against libraries built with pre-GCC5 compilers, the num_put facet is not initalized on the classic locale
-    // Rather than change the locale globally, which might cause unexpected behaviour in legacy code, just add the required
-    // facet here
-    std::locale locale{ std::locale::classic(), new std::num_put<char>()};
-    (void)std::locale::global(locale);
-    s3_api_.reset();
-    ARCTICDB_DEBUG(log::storage(), "Opened NFS backed storage at {}", root_folder_);
 }
 
 } //namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -60,6 +60,7 @@ private:
     const std::string& root_folder() const { return root_folder_; }
     const std::string& region() const { return region_; }
 
+    std::shared_ptr<s3::S3ApiInstance> s3_api_;
     std::unique_ptr<storage::s3::S3ClientWrapper> s3_client_;
     std::string root_folder_;
     std::string bucket_name_;

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -101,19 +101,24 @@ S3Storage::S3Storage(const LibraryPath &library_path, OpenMode mode, const Confi
         s3_client_ = std::make_unique<RealS3Client>(creds, get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, conf.use_virtual_addressing());
     }
 
-    if (!conf.prefix().empty()) {
-        ARCTICDB_RUNTIME_DEBUG(log::storage(), "S3 prefix found, using: {}", conf.prefix());
+    if (conf.prefix().empty()) {
+        ARCTICDB_DEBUG(log::version(), "prefix not found, will use {}", root_folder_);
+    } else if (conf.use_raw_prefix()) {
+            ARCTICDB_DEBUG(log::version(), "raw prefix found, using: {}", conf.prefix());
+            root_folder_ = conf.prefix();
+    } else {
         auto prefix_path = LibraryPath::from_delim_path(conf.prefix(), '.');
         root_folder_ = object_store_utils::get_root_folder(prefix_path);
-    } else {
-        ARCTICDB_RUNTIME_DEBUG(log::storage(), "S3 prefix not found, will use {}", root_folder_);
+        ARCTICDB_DEBUG(log::version(), "parsed prefix found, using: {}", root_folder_);
     }
+
     // When linking against libraries built with pre-GCC5 compilers, the num_put facet is not initalized on the classic locale
     // Rather than change the locale globally, which might cause unexpected behaviour in legacy code, just add the required
     // facet here
     std::locale locale{ std::locale::classic(), new std::num_put<char>()};
     (void)std::locale::global(locale);
     s3_api_.reset();
+    ARCTICDB_DEBUG(log::storage(), "Opened S3 backed storage at {}", root_folder_);
 }
 
 } // namespace arcticdb::storage::s3

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -82,7 +82,7 @@ namespace arcticdb::storage::s3 {
 
 S3Storage::S3Storage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
     Storage(library_path, mode),
-    s3_api_(S3ApiInstance::instance()),
+    s3_api_(S3ApiInstance::instance()),  // make sure we have an initialized AWS SDK
     root_folder_(object_store_utils::get_root_folder(library_path)),
     bucket_name_(conf.bucket_name()),
     region_(conf.region()) {
@@ -117,7 +117,6 @@ S3Storage::S3Storage(const LibraryPath &library_path, OpenMode mode, const Confi
     // facet here
     std::locale locale{ std::locale::classic(), new std::num_put<char>()};
     (void)std::locale::global(locale);
-    s3_api_.reset();
     ARCTICDB_DEBUG(log::storage(), "Opened S3 backed storage at {}", root_folder_);
 }
 

--- a/cpp/proto/arcticc/pb2/nfs_backed_storage.proto
+++ b/cpp/proto/arcticc/pb2/nfs_backed_storage.proto
@@ -25,4 +25,6 @@ message Config {
     string ca_cert_path = 13;
     string ca_cert_dir = 14;
     bool use_mock_storage_for_testing = 15;
+    // Whether to leave the prefix unchanged, or to translate the periods in it.
+    bool use_raw_prefix = 16;
 }

--- a/cpp/proto/arcticc/pb2/s3_storage.proto
+++ b/cpp/proto/arcticc/pb2/s3_storage.proto
@@ -25,4 +25,6 @@ message Config {
     bool use_mock_storage_for_testing = 13;
     string ca_cert_path = 14;
     string ca_cert_dir = 15;
+    // Whether to leave the prefix unchanged, or to translate the periods in it.
+    bool use_raw_prefix = 16;
 }

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -215,6 +215,7 @@ def add_mongo_library_to_env(cfg, lib_name, env_name, uri=None, description=None
 
 
 def get_s3_proto(
+    *,
     cfg,
     lib_name,
     env_name,
@@ -222,15 +223,16 @@ def get_s3_proto(
     credential_key,
     bucket_name,
     endpoint,
-    with_prefix=True,
-    is_https=False,
-    region=None,
-    use_virtual_addressing=False,
-    use_mock_storage_for_testing=None,
-    ca_cert_path=None,
-    ca_cert_dir=None,
-    ssl=False,
-    is_nfs_layout=False,
+    with_prefix,
+    is_https,
+    region,
+    use_virtual_addressing,
+    use_mock_storage_for_testing,
+    ca_cert_path,
+    ca_cert_dir,
+    ssl,
+    is_nfs_layout,
+    use_raw_prefix,
 ):
     env = cfg.env_by_id[env_name]
     if is_nfs_layout:
@@ -259,6 +261,8 @@ def get_s3_proto(
             s3.prefix = f"{lib_name}{time.time() * 1e9:.0f}"
     else:
         s3.prefix = lib_name
+
+    s3.use_raw_prefix = use_raw_prefix
 
     if region:
         s3.region = region
@@ -291,7 +295,8 @@ def add_s3_library_to_env(
     ca_cert_path=None,
     ca_cert_dir=None,
     ssl=False,
-    is_nfs_layout=False
+    is_nfs_layout=False,
+    use_raw_prefix=False,
 ):
     env = cfg.env_by_id[env_name]
     if with_prefix and isinstance(with_prefix, str) and (with_prefix.endswith("/") or "//" in with_prefix):
@@ -316,7 +321,8 @@ def add_s3_library_to_env(
         ca_cert_path=ca_cert_path,
         ca_cert_dir=ca_cert_dir,
         ssl=ssl,
-        is_nfs_layout=is_nfs_layout
+        is_nfs_layout=is_nfs_layout,
+        use_raw_prefix=use_raw_prefix,
     )
 
     _add_lib_desc_to_env(env, lib_name, sid, description)

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -71,7 +71,7 @@ def test_nfs_backed_s3_storage(lib_name, nfs_backed_s3_storage):
         assert re.match(bucketized_pattern, o.key), f"Object {o.key} does not match pattern {bucketized_pattern}"
 
 
-@pytest.fixture(scope="session", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
+@pytest.fixture(scope="function", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
 def s3_storage_dots_in_path(request):
     prefix = "some_path/.thing_with_a_dot/even.more.dots/end"
 

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -14,6 +14,9 @@ from arcticdb_ext.exceptions import StorageException
 from arcticdb_ext import set_config_string
 from arcticdb.util.test import create_df
 
+from arcticdb.storage_fixtures.s3 import MotoNfsBackedS3StorageFixtureFactory
+from arcticdb.storage_fixtures.s3 import MotoS3StorageFixtureFactory
+
 
 def test_s3_storage_failures(mock_s3_store_with_error_simulation):
     lib = mock_s3_store_with_error_simulation
@@ -66,3 +69,32 @@ def test_nfs_backed_s3_storage(lib_name, nfs_backed_s3_storage):
 
     for o in objects:
         assert re.match(bucketized_pattern, o.key), f"Object {o.key} does not match pattern {bucketized_pattern}"
+
+
+@pytest.fixture(scope="session", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
+def s3_storage_dots_in_path(request):
+    prefix = "some_path/.thing_with_a_dot/even.more.dots/end"
+
+    with request.param(
+            use_ssl=False,
+            ssl_test_support=False,
+            bucket_versioning=False,
+            default_prefix=prefix,
+            use_raw_prefix=True
+    ) as f:
+        with f.create_fixture() as g:
+            yield g
+
+
+def test_read_path_with_dot(lib_name, s3_storage_dots_in_path):
+    # Given
+    factory = s3_storage_dots_in_path.create_version_store_factory(lib_name)
+    lib = factory()
+
+    # When
+    expected = create_df()
+    lib.write("s", data=expected)
+
+    # Then - should be readable
+    res = lib.read("s").data
+    pd.testing.assert_frame_equal(res, expected)


### PR DESCRIPTION
See the Slack thread https://chat-man.slack.com/archives/C02RVQBD0N8/p1725630720710939 .

This is so that we can read directly from VAST snapshots, like:

```
from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
from arcticdb.version_store.helper import add_s3_library_to_env, Defaults, ArcticMemoryConfig
with_prefix = "LIB/.snapshot/<SNAP NAME>/<LIBRARY>"

cfg = EnvironmentConfigsMap()

add_s3_library_to_env(
    cfg,
    credential_name=name,
    credential_key=secret,
    lib_name=lib_name,
    env_name=Defaults.ENV,
    description=None,
    endpoint=endpoint,
    bucket_name=bucket,
    with_prefix=with_prefix,
    is_nfs_layout=True,
    use_raw_prefix=True
)

out = ArcticMemoryConfig(cfg, Defaults.ENV)[lib_name]
out.list_symbols()  # reading directly from the snapshot
```

I also fix a bug where we were not initializing the S3 API when using the NFS client.
