### PR TITLE
Fix `batch_restore_version` failing to use correct next_version_id

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1515,7 +1515,7 @@ std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> LocalVersionedEngine
     util::check(stream_ids.size() == version_queries.size(), "Symbol vs version query size mismatch: {} != {}", stream_ids.size(), version_queries.size());
     auto sym_versions = get_sym_versions_from_query(stream_ids, version_queries);
     util::check(sym_versions.size() == version_queries.size(), "Restore versions requires specific version to be supplied");
-    auto previous = batch_get_latest_version(store(), version_map(), stream_ids, false);
+    auto previous = batch_get_latest_version(store(), version_map(), stream_ids, true);
     auto versions_to_restore = batch_get_specific_version(store(), version_map(), sym_versions);
     std::vector<folly::Future<std::pair<VersionedItem, TimeseriesDescriptor>>> fut_vec;
 

--- a/python/tests/unit/arcticdb/version_store/test_version_chain.py
+++ b/python/tests/unit/arcticdb/version_store/test_version_chain.py
@@ -19,7 +19,7 @@ from arcticdb_ext.exceptions import (
     SortingException,
 )
 
-@pytest.mark.parametrize("operation", ["update", "append", "sort_index", "delete_range"])
+@pytest.mark.parametrize("operation", ["update", "append", "sort_index", "delete_range", "restore_version", "batch_restore_version"])
 def test_version_chain_increasing(version_store_factory, operation):
     lib = version_store_factory()
     sym = "sym"
@@ -38,6 +38,10 @@ def test_version_chain_increasing(version_store_factory, operation):
             lib.version_store.sort_index(sym, False, False)
         elif operation == "delete_range":
             lib.delete(sym, date_range=(pd.Timestamp(1), pd.Timestamp(1)))
+        elif operation == "restore_version":
+            lib.restore_version(sym, 0)
+        elif operation == "batch_restore_version":
+            lib.batch_restore_version([sym], [0])
         else:
             raise "Unknown operation"
 


### PR DESCRIPTION
#### Reference Issues/PRs
This fixes a similar issue to the one fixed in #1796

#### What does this implement or fix?
`batch_restore_version` uses the last UNDELETED version to determine the next_version_id. This is wrong because the latest version might be deleted.

This pr adds tests for restore_version apis and fixes the issue with batch_restore_version (in two commits).

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
