### PR TITLE
Out of bounds checks for LibraryPath

### DIFF
--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -127,6 +127,7 @@ class LibraryPathImpl {
             return std::move(a) + delim + fmt::format("{}", b);
         };
 
+        util::check(rg.size() > 0, "Cannot have an empty LibraryPath");
         return std::accumulate(std::next(rg.begin()), rg.end(), fmt::format("{}", rg[0]), delim_fold);
     }
 
@@ -159,7 +160,7 @@ template<class StringViewable=DefaultStringViewable>
 inline bool operator==(const LibraryPathImpl<StringViewable> &l, const LibraryPathImpl<StringViewable> &r) {
     auto l_rg = l.as_range();
     auto r_rg = r.as_range();
-    return l.hash() == r.hash() && std::equal(l_rg.begin(), l_rg.end(), r_rg.begin());
+    return l.hash() == r.hash() && std::equal(l_rg.begin(), l_rg.end(), r_rg.begin(), r_rg.end());
 }
 
 using LibraryPath = LibraryPathImpl<DefaultStringViewable>;


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement or fix?
We've encountered some fairly obscure arcticc folly::Range out of bounds failures. They are very unlikely but still can potentially cause surprising errors.

This pr fixes one and raises a more meaningful error for another

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
