### PR TITLE
Fix bug where libraries created with 4.5.0 are unreadable by newer versions

### DIFF
--- a/cpp/arcticdb/storage/storage_override.hpp
+++ b/cpp/arcticdb/storage/storage_override.hpp
@@ -102,7 +102,8 @@ public:
         ssl_ = ssl;
     }
 
-    void modify_storage_config(arcticdb::proto::storage::VariantStorage& storage) const {
+    void modify_storage_config(arcticdb::proto::storage::VariantStorage& storage,
+                                bool override_https) const {
         if(storage.config().Is<arcticdb::proto::s3_storage::Config>()) {
             arcticdb::proto::s3_storage::Config s3_storage;
             storage.config().UnpackTo(&s3_storage);
@@ -116,6 +117,10 @@ public:
             s3_storage.set_ca_cert_path(ca_cert_path_);
             s3_storage.set_ca_cert_dir(ca_cert_dir_);
             s3_storage.set_ssl(ssl_);
+
+            if(override_https) {
+                s3_storage.set_https(https_);
+            }
 
             util::pack_to_any(s3_storage, *storage.mutable_config());
         }
@@ -161,7 +166,8 @@ public:
         ca_cert_dir_ = ca_cert_dir;
     }
 
-    void modify_storage_config(arcticdb::proto::storage::VariantStorage& storage) const {
+    void modify_storage_config(arcticdb::proto::storage::VariantStorage& storage,
+                                bool override_https ARCTICDB_UNUSED) const {
         if(storage.config().Is<arcticdb::proto::azure_storage::Config>()) {
             arcticdb::proto::azure_storage::Config azure_storage;
             storage.config().UnpackTo(&azure_storage);
@@ -198,7 +204,8 @@ public:
         map_size_ = map_size;
     }
 
-    void modify_storage_config(arcticdb::proto::storage::VariantStorage& storage) const {
+    void modify_storage_config(arcticdb::proto::storage::VariantStorage& storage,
+                                bool override_https ARCTICDB_UNUSED) const {
         if(storage.config().Is<arcticdb::proto::lmdb_storage::Config>()) {
             arcticdb::proto::lmdb_storage::Config lmdb_storage;
             storage.config().UnpackTo(&lmdb_storage);

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -33,7 +33,7 @@ from arcticdb.version_store.library import (
     ArcticInvalidApiUsageException,
 )
 
-from tests.util.mark import AZURE_TESTS_MARK, MONGO_TESTS_MARK, REAL_S3_TESTS_MARK
+from tests.util.mark import AZURE_TESTS_MARK, MONGO_TESTS_MARK, REAL_S3_TESTS_MARK, SSL_TEST_SUPPORTED
 from tests.util.storage_test import get_s3_storage_config
 
 from arcticdb.options import ModifiableEnterpriseLibraryOption, ModifiableLibraryOption
@@ -306,7 +306,8 @@ def test_do_not_persist_s3_details(s3_storage):
     """We apply an in-memory overlay for these instead. In particular we should absolutely not persist credentials
     in the storage."""
 
-    assert s3_storage.arctic_uri.startswith("s3s://")
+    if SSL_TEST_SUPPORTED:
+        assert s3_storage.arctic_uri.startswith("s3s://")
     ac = Arctic(s3_storage.arctic_uri)
     lib = ac.create_library("test")
     lib.write("sym", pd.DataFrame())
@@ -325,7 +326,10 @@ def test_do_not_persist_s3_details(s3_storage):
     assert s3_storage.region == ""
     assert not s3_storage.use_virtual_addressing
     # HTTS is persisted on purpose to support backwards compatibility
-    assert s3_storage.https
+    if SSL_TEST_SUPPORTED:
+        assert s3_storage.https
+    else:
+        assert not s3_storage.https
 
     assert "sym" in ac["test"].list_symbols()
 

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -306,6 +306,7 @@ def test_do_not_persist_s3_details(s3_storage):
     """We apply an in-memory overlay for these instead. In particular we should absolutely not persist credentials
     in the storage."""
 
+    assert s3_storage.arctic_uri.startswith("s3s://")
     ac = Arctic(s3_storage.arctic_uri)
     lib = ac.create_library("test")
     lib.write("sym", pd.DataFrame())
@@ -321,10 +322,10 @@ def test_do_not_persist_s3_details(s3_storage):
     assert s3_storage.request_timeout == 0
     assert not s3_storage.ssl
     assert s3_storage.prefix.startswith("test")
-    # HTTS is persisted on purpose to support backwards compatibility
-    # assert not s3_storage.https
     assert s3_storage.region == ""
     assert not s3_storage.use_virtual_addressing
+    # HTTS is persisted on purpose to support backwards compatibility
+    assert s3_storage.https
 
     assert "sym" in ac["test"].list_symbols()
 


### PR DESCRIPTION
#### Reference Issues/PRs
Needed to fix #1846 on 4.5.1rc

#### What does this implement or fix?
Fixes a bug where newer versions are not able to read libraries created by 4.5.0

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
