### PR TITLE
Support the ignore missing key read option in recurse_index_keys

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -928,6 +928,7 @@ if(${TEST})
             util/test/test_format_date.cpp
             util/test/test_hash.cpp
             util/test/test_id_transformation.cpp
+            util/test/test_key_utils.cpp
             util/test/test_ranges_from_future.cpp
             util/test/test_slab_allocator.cpp
             util/test/test_storage_lock.cpp

--- a/cpp/arcticdb/util/test/test_key_utils.cpp
+++ b/cpp/arcticdb/util/test/test_key_utils.cpp
@@ -1,0 +1,134 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+#include <gtest/gtest.h>
+#include <arcticdb/util/key_utils.hpp>
+#include <arcticdb/storage/test/in_memory_store.hpp>
+#include <arcticdb/util/test/generators.hpp>
+
+using namespace arcticdb;
+
+auto write_version_frame_with_three_segments(
+    const arcticdb::StreamId& stream_id,
+    arcticdb::VersionId v_id,
+    arcticdb::version_store::PythonVersionStore& pvs
+) {
+    using namespace arcticdb;
+    using namespace arcticdb::storage;
+    using namespace arcticdb::stream;
+    using namespace arcticdb::pipelines;
+
+    auto de_dup_map = std::make_shared<arcticdb::DeDupMap>();
+    SlicingPolicy slicing = FixedSlicer{100, 10};  // 100 cols per segment, 10 rows per segment
+    IndexPartialKey pk{stream_id, v_id};
+    auto wrapper = get_test_simple_frame(stream_id, 30, 0);  // 30 rows -> 3 segments
+    auto& frame = wrapper.frame_;
+    auto store = pvs._test_get_store();
+    auto var_key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
+    auto key = to_atom(var_key);
+    pvs.write_version_and_prune_previous(true, key, std::nullopt);
+    return key;
+}
+
+TEST(KeyUtils, RecurseIndexKeyNothingMissing) {
+    // Given
+    auto [version_store, mock_store] = python_version_store_in_memory();
+    storage::ReadKeyOpts opts;
+
+    StreamId first_id{"first"};
+    write_version_frame_with_three_segments(first_id, 0, version_store);
+    StreamId second_id{"second"};
+    write_version_frame_with_three_segments(second_id, 0, version_store);
+
+    std::vector<AtomKeyImpl> index_keys;
+    mock_store->iterate_type(KeyType::TABLE_INDEX, [&](auto&& vk) {
+        index_keys.emplace_back(std::get<AtomKeyImpl>(std::move(vk)));
+    });
+
+    std::vector<AtomKeyImpl> data_keys;
+    mock_store->iterate_type(KeyType::TABLE_DATA, [&](auto&& vk) {
+        data_keys.emplace_back(std::get<AtomKeyImpl>(std::move(vk)));
+    });
+
+    // When
+    auto res = recurse_index_keys(mock_store, index_keys, opts);
+
+    // Then
+    ASSERT_EQ(res.size(), 6);
+
+    // When
+    auto first_key = index_keys.at(0);
+    auto keys = std::vector<AtomKeyImpl>{first_key};
+    res = recurse_index_keys(mock_store, keys, opts);
+
+    // Then
+    ASSERT_EQ(res.size(), 3);
+}
+
+TEST(KeyUtils, RecurseIndexKeyDoNotIgnoreMissing) {
+    // Given
+    auto [version_store, mock_store] = python_version_store_in_memory();
+    storage::ReadKeyOpts opts;
+
+    StreamId first_id{"first"};
+    write_version_frame_with_three_segments(first_id, 0, version_store);
+    StreamId second_id{"second"};
+    write_version_frame_with_three_segments(second_id, 0, version_store);
+
+    std::vector<AtomKeyImpl> index_keys;
+    mock_store->iterate_type(KeyType::TABLE_INDEX, [&](auto&& vk) {
+        index_keys.emplace_back(std::get<AtomKeyImpl>(std::move(vk)));
+    });
+
+    storage::RemoveOpts remove_opts;
+    mock_store->remove_key(index_keys.at(1), remove_opts);
+
+    std::vector<AtomKeyImpl> data_keys;
+    mock_store->iterate_type(KeyType::TABLE_DATA, [&](auto&& vk) {
+        data_keys.emplace_back(std::get<AtomKeyImpl>(std::move(vk)));
+    });
+
+    // When & Then
+    ASSERT_THROW(recurse_index_keys(mock_store, index_keys, opts), storage::KeyNotFoundException);
+}
+
+TEST(KeyUtils, RecurseIndexKeyIgnoreMissing) {
+    // Given
+    auto [version_store, mock_store] = python_version_store_in_memory();
+
+    StreamId first_id{"first"};
+    write_version_frame_with_three_segments(first_id, 0, version_store);
+    StreamId second_id{"second"};
+    write_version_frame_with_three_segments(second_id, 0, version_store);
+
+    std::vector<AtomKeyImpl> index_keys;
+    AtomKeyImpl index_for_second;
+    mock_store->iterate_type(KeyType::TABLE_INDEX, [&](auto&& vk) {
+        AtomKey ak = std::get<AtomKeyImpl>(vk);
+        index_keys.push_back(ak);
+        if (ak.id() == second_id) {
+            index_for_second = ak;
+        }
+    });
+    ASSERT_EQ(index_keys.size(), 2);
+    ASSERT_EQ(index_for_second.id(), second_id);
+
+    storage::RemoveOpts remove_opts;
+    mock_store->remove_key(index_for_second, remove_opts);
+
+    std::vector<AtomKeyImpl> data_keys;
+    mock_store->iterate_type(KeyType::TABLE_DATA, [&](auto&& vk) {
+        data_keys.emplace_back(std::get<AtomKeyImpl>(vk));
+    });
+
+    // When
+    storage::ReadKeyOpts opts;
+    opts.ignores_missing_key_ = true;
+    auto res = recurse_index_keys(mock_store, index_keys, opts);
+
+    // Then
+    ASSERT_EQ(res.size(), 3);
+}


### PR DESCRIPTION
This is required for delayed deletes to work correctly - https://github.com/man-group/arcticdb-enterprise/pull/167 includes an end to end failing test to motivate this.

The issue is that if we have a snapshot being modified over time, replication might sync over its current state from the source storage before the index keys inside it. So delayed deletes needs to be tolerant to the fact that some of the keys it is asked to recurse may not actually exist.

I also noticed that `recurse_index_keys` requires all the index keys it is run over to be for the same symbol. I'm going to check that we are in fact doing that, and add some debug checks, as a follow up.


