### PR TITLE
Add flag to clear staged data on failure to both finalize functions

### DIFF
--- a/cpp/arcticdb/stream/append_map.hpp
+++ b/cpp/arcticdb/stream/append_map.hpp
@@ -74,6 +74,10 @@ void append_incomplete(
 
 std::optional<int64_t> latest_incomplete_timestamp(
     const std::shared_ptr<Store>& store,
-    const StreamId& stream_id
-    );
+    const StreamId& stream_id);
+
+std::vector<VariantKey> read_incomplete_keys_for_symbol(
+    const std::shared_ptr<Store>& store,
+    const StreamId& stream_id,
+    bool via_iteration);
 } //namespace arcticdb

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -550,6 +550,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::arg("user_meta") = std::nullopt,
              py::arg("prune_previous_versions") = false,
              py::arg("validate_index") = false,
+             py::arg("delete_staged_data_on_failure") = false,
              py::call_guard<SingleThreadMutexHolder>(), "Compact incomplete segments")
          .def("sort_merge",
              &PythonVersionStore::sort_merge,
@@ -560,6 +561,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::arg("via_iteration") = true,
              py::arg("sparsify") = false,
              py::arg("prune_previous_versions") = false,
+             py::arg("delete_staged_data_on_failure") = false,
              py::call_guard<SingleThreadMutexHolder>(), "sort_merge will sort and merge incomplete segments. The segments do not have to be ordered - incomplete segments can contain interleaved time periods but the final result will be fully ordered")
         .def("compact_library",
              &PythonVersionStore::compact_library,

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -14,20 +14,15 @@
 #include <arcticdb/pipeline/read_pipeline.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/async/tasks.hpp>
-#include <arcticdb/util/key_utils.hpp>
-#include <arcticdb/util/optional_defaults.hpp>
 #include <arcticdb/util/name_validation.hpp>
 #include <arcticdb/stream/append_map.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
 #include <arcticdb/pipeline/read_frame.hpp>
 #include <arcticdb/pipeline/read_options.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
-#include <arcticdb/stream/stream_writer.hpp>
-#include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/stream/schema.hpp>
 #include <arcticdb/pipeline/index_writer.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
-#include <arcticdb/pipeline/column_mapping.hpp>
 #include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/version/version_utils.hpp>
 #include <arcticdb/entity/merge_descriptors.hpp>
@@ -1394,30 +1389,55 @@ VersionedItem collate_and_write(
     });
 }
 
+void delete_incomplete_keys(PipelineContext* pipeline_context, Store* store) {
+    std::vector<entity::VariantKey> keys_to_delete;
+    keys_to_delete.reserve(pipeline_context->slice_and_keys_.size() - pipeline_context->incompletes_after());
+    for (auto sk = pipeline_context->incompletes_begin(); sk != pipeline_context->end(); ++sk) {
+        const auto& slice_and_key = sk->slice_and_key();
+        if (ARCTICDB_LIKELY(slice_and_key.key().type() == KeyType::APPEND_DATA)) {
+            keys_to_delete.emplace_back(slice_and_key.key());
+        } else {
+            log::storage().error(
+                "Delete incomplete keys procedure tries to delete a wrong key type {}. Key type must be {}.",
+                slice_and_key.key(),
+                KeyType::APPEND_DATA
+            );
+        }
+    }
+    store->remove_keys(keys_to_delete).get();
+}
+
 class IncompleteKeysRAII {
 public:
-    IncompleteKeysRAII(std::shared_ptr<PipelineContext> pipeline_context, std::shared_ptr<Store> store)
+    IncompleteKeysRAII() = default;
+    IncompleteKeysRAII(
+        std::shared_ptr<PipelineContext> pipeline_context,
+        std::shared_ptr<Store> store,
+        const CompactIncompleteOptions* options)
             : context_(pipeline_context),
-              store_(store) {
+              store_(store),
+              options_(options) {
     }
+    ARCTICDB_MOVE_ONLY_DEFAULT(IncompleteKeysRAII)
 
-    ~IncompleteKeysRAII(){
-        std::vector<entity::VariantKey> keys_to_delete;
-        for (auto sk = context_->incompletes_begin(); sk != context_->end(); ++sk) {
-            const auto& slice_and_key = sk->slice_and_key();
-            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                slice_and_key.key().type() == KeyType::APPEND_DATA,
-                "Deleting incorrect key type {}",
-                slice_and_key.key().type()
-            );
-            keys_to_delete.emplace_back(slice_and_key.key());
+    ~IncompleteKeysRAII() {
+        if (context_ && store_) {
+            if (context_->incompletes_after_) {
+                delete_incomplete_keys(context_.get(), store_.get());
+            } else {
+                // If an exception is thrown before read_incompletes_to_pipeline the keys won't be placed inside the
+                // context thus they must be read manually.
+                const std::vector<VariantKey> entries =
+                    read_incomplete_keys_for_symbol(store_, context_->stream_id_, options_->via_iteration_);
+                store_->remove_keys(entries).get();
+            }
         }
-        store_->remove_keys(keys_to_delete).get();
     }
 
 private:
-    std::shared_ptr<PipelineContext> context_;
-    std::shared_ptr<Store> store_;
+    std::shared_ptr<PipelineContext> context_ = nullptr;
+    std::shared_ptr<Store> store_ = nullptr;
+    const CompactIncompleteOptions* options_ = nullptr;
 };
 
 VersionedItem sort_merge_impl(
@@ -1433,6 +1453,9 @@ VersionedItem sort_merge_impl(
     ReadQuery read_query;
 
     std::optional<SortedValue> previous_sorted_value;
+    const IncompleteKeysRAII incomplete_keys_raii = options.delete_staged_data_on_failure_
+        ? IncompleteKeysRAII{pipeline_context, store, &options}
+        : IncompleteKeysRAII{};
     if(options.append_ && update_info.previous_index_key_.has_value()) {
         read_indexed_keys_to_pipeline(store, pipeline_context, *(update_info.previous_index_key_), read_query, ReadOptions{});
         if (!write_options.dynamic_schema) {
@@ -1443,8 +1466,6 @@ VersionedItem sort_merge_impl(
         }
         previous_sorted_value.emplace(pipeline_context->desc_->sorted());
     }
-    pipeline_context->incompletes_after_ = pipeline_context->slice_and_keys_.size();
-    IncompleteKeysRAII incomplete_keys(pipeline_context, store);
     const auto num_versioned_rows = pipeline_context->total_rows_;
 
     const bool has_incomplete_segments = read_incompletes_to_pipeline(
@@ -1535,7 +1556,9 @@ VersionedItem sort_merge_impl(
         keys,
         pipeline_context->incompletes_after(),
         norm_meta);
-
+    if (!options.delete_staged_data_on_failure_) {
+        delete_incomplete_keys(pipeline_context.get(), store.get());
+    }
     return vit;
 }
 
@@ -1556,6 +1579,9 @@ VersionedItem compact_incomplete_impl(
 
     std::optional<SegmentInMemory> last_indexed;
     std::optional<SortedValue> previous_sorted_value;
+    const IncompleteKeysRAII incomplete_keys_raii = options.delete_staged_data_on_failure_
+        ? IncompleteKeysRAII{pipeline_context, store, &options}
+        : IncompleteKeysRAII{};
     if(options.append_ && update_info.previous_index_key_.has_value()) {
         read_indexed_keys_to_pipeline(store, pipeline_context, *(update_info.previous_index_key_), read_query, read_options);
         if (!write_options.dynamic_schema) {
@@ -1566,7 +1592,6 @@ VersionedItem compact_incomplete_impl(
         }
         previous_sorted_value.emplace(pipeline_context->desc_->sorted());
     }
-    IncompleteKeysRAII incomplete_keys(pipeline_context, store);
 
     const bool has_incomplete_segments = read_incompletes_to_pipeline(
         store,
@@ -1578,7 +1603,6 @@ VersionedItem compact_incomplete_impl(
         options.sparsify_,
         write_options.dynamic_schema
     );
-
     user_input::check<ErrorCode::E_NO_STAGED_SEGMENTS>(
         has_incomplete_segments,
         "Finalizing staged data is not allowed with empty staging area"
@@ -1627,7 +1651,9 @@ VersionedItem compact_incomplete_impl(
         keys,
         pipeline_context->incompletes_after(),
         user_meta);
-
+    if (!options.delete_staged_data_on_failure_) {
+        delete_incomplete_keys(pipeline_context.get(), store.get());
+    }
     return vit;
 }
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -36,6 +36,7 @@ struct CompactIncompleteOptions {
     bool via_iteration_;
     bool sparsify_;
     bool validate_index_{true}; // Default value as unused in sort_merge
+    bool delete_staged_data_on_failure_{false};
 };
 
 struct ReadVersionOutput {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -706,7 +706,8 @@ VersionedItem PythonVersionStore::compact_incomplete(
         bool sparsify /*= false */,
         const std::optional<py::object>& user_meta /* = std::nullopt */,
         bool prune_previous_versions,
-        bool validate_index) {
+        bool validate_index,
+        bool delete_staged_data_on_failure) {
     std::optional<arcticdb::proto::descriptors::UserDefinedMetadata> meta;
     if (user_meta && !user_meta->is_none()) {
         meta = std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>();
@@ -718,7 +719,8 @@ VersionedItem PythonVersionStore::compact_incomplete(
         .convert_int_to_float_=convert_int_to_float,
         .via_iteration_=via_iteration,
         .sparsify_=sparsify,
-        .validate_index_=validate_index
+        .validate_index_=validate_index,
+        .delete_staged_data_on_failure_=delete_staged_data_on_failure
     };
     return compact_incomplete_dynamic(stream_id, meta, options);
 }
@@ -730,8 +732,8 @@ VersionedItem PythonVersionStore::sort_merge(
         bool convert_int_to_float,
         bool via_iteration,
         bool sparsify,
-        bool prune_previous_versions
-) {
+        bool prune_previous_versions,
+        bool delete_staged_data_on_failure) {
     std::optional<arcticdb::proto::descriptors::UserDefinedMetadata> meta;
     if (!user_meta.is_none()) {
         meta = std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>();
@@ -742,7 +744,8 @@ VersionedItem PythonVersionStore::sort_merge(
         .append_=append,
         .convert_int_to_float_=convert_int_to_float,
         .via_iteration_=via_iteration,
-        .sparsify_=sparsify
+        .sparsify_=sparsify,
+        .delete_staged_data_on_failure_=delete_staged_data_on_failure
     };
     return sort_merge_internal(stream_id, meta, options);
 }

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -130,7 +130,8 @@ class PythonVersionStore : public LocalVersionedEngine {
             bool sparsify = false,
             const std::optional<py::object>& user_meta = std::nullopt,
             bool prune_previous_versions = false,
-            bool validate_index = false);
+            bool validate_index = false,
+            bool delete_staged_data_on_failure=false);
 
     void write_parallel(
         const StreamId& stream_id,
@@ -176,7 +177,8 @@ class PythonVersionStore : public LocalVersionedEngine {
             bool convert_int_to_float,
             bool via_iteration,
             bool sparsify,
-            bool prune_previous_versions);
+            bool prune_previous_versions,
+            bool delete_staged_data_on_failure);
 
     std::pair<VersionedItem, py::object> read_metadata(
         const StreamId& stream_id,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1956,6 +1956,7 @@ class NativeVersionStore:
         metadata: Optional[Any] = None,
         prune_previous_version: Optional[bool] = None,
         validate_index: bool = False,
+        delete_staged_data_on_failure: bool = False
     ) -> VersionedItem:
         """
         Compact previously written un-indexed chunks of data, produced by a tick collector or parallel
@@ -1984,6 +1985,15 @@ class NativeVersionStore:
             If True, will verify that the index of the symbol after this operation supports date range searches and
             update operations. This requires that the indexes of the incomplete segments are non-overlapping with each
             other, and, in the case of append=True, fall after the last index value in the previous version.
+        delete_staged_data_on_failure : bool, default=False
+            Determines the handling of staged data when an exception occurs during the execution of the 
+            ``compact_incomplete`` function.
+
+            - If set to True, all staged data for the specified symbol will be deleted if an exception occurs.
+            - If set to False, the staged data will be retained and will be used in subsequent calls to 
+              ``compact_incomplete``.
+
+            To manually delete staged data, use the ``remove_incomplete`` function.
         Returns
         -------
         VersionedItem
@@ -1994,7 +2004,7 @@ class NativeVersionStore:
         )
         udm = normalize_metadata(metadata) if metadata is not None else None
         vit = self.version_store.compact_incomplete(
-            symbol, append, convert_int_to_float, via_iteration, sparsify, udm, prune_previous_version, validate_index
+            symbol, append, convert_int_to_float, via_iteration, sparsify, udm, prune_previous_version, validate_index, delete_staged_data_on_failure
         )
         return self._convert_thin_cxx_item_to_python(vit, metadata)
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1120,9 +1120,25 @@ class Library:
         prune_previous_versions: bool = False,
         metadata: Any = None,
         validate_index = True,
+        delete_staged_data_on_failure: bool = False
     ) -> VersionedItem:
         """
-        Finalizes staged data, making it available for reads.
+        Finalizes staged data, making it available for reads. All staged segments must be ordered and non-overlapping.
+        ``finalize_staged_data`` is less time consuming than ``sort_and_finalize_staged_data``.
+
+        If ``mode`` is ``StagedDataFinalizeMethod.APPEND`` the index of the first row of the new segment must be equal to or greater
+        than the index of the last row in the existing data.
+
+        If ``Static Schema`` is used all staged block must have matching schema (same column names, same dtype, same column ordering)
+        and must match the existing data if mode is ``StagedDataFinalizeMethod.APPEND``. For more information about schema options see
+        documentation for ``arcticdb.LibraryOptions.dynamic_schema``
+
+        If the symbol does not exist both ``StagedDataFinalizeMethod.APPEND`` and ``StagedDataFinalizeMethod.WRITE`` will create it.
+
+        Calling ``finalize_staged_data`` without having staged data for the symbol will throw ``UserInputException``. Use
+        ``get_staged_symbols`` to check if there are staged segments for the symbol.
+
+        Calling ``finalize_staged_data`` if any of the staged segments contains NaT in its index will throw ``SortingException``.
 
         Parameters
         ----------
@@ -1141,7 +1157,15 @@ class Library:
             supports date range searches and update operations. This requires that the indexes of the staged segments
             are non-overlapping with each other, and, in the case of `StagedDataFinalizeMethod.APPEND`, fall after the
             last index value in the previous version.
+        delete_staged_data_on_failure : bool, default=False
+            Determines the handling of staged data when an exception occurs during the execution of the 
+            ``finalize_staged_data`` function.
 
+            - If set to True, all staged data for the specified symbol will be deleted if an exception occurs.
+            - If set to False, the staged data will be retained and will be used in subsequent calls to 
+              ``finalize_staged_data``.
+
+            To manually delete staged data, use the ``delete_staged_data`` function.
         Returns
         -------
         VersionedItem
@@ -1150,18 +1174,48 @@ class Library:
 
         Raises
         ------
-        UserInputException
-            If all of the following conditions are met:
+        SortingException
 
-            1. Static schema is used.
-            2. The width of the DataFrame exceeds the value of `LibraryOptions.columns_per_segment`.
-            3. The symbol contains data that was not written by `sort_and_finalize_staged_data`.
-            4. Finalize mode is append
+            - If any two staged segments for a given symbol have overlapping indexes
+            - If any staged segment for a given symbol is not sorted
+            - If the first index value of the new segment is not greater or equal than the last index value of
+                the existing data when ``StagedDataFinalizeMethod.APPEND`` is used.
+            - If any staged segment contains NaT in the index
+
+        UserInputException
+
+            - If there are no staged segments when ``finalize_staged_data`` is called
+            - If all of the following conditions are met:
+
+                1. Static schema is used.
+                2. The width of the DataFrame exceeds the value of ``LibraryOptions.columns_per_segment``.
+                3. The symbol contains data that was not written by `finalize_staged_data`.
+                4. Finalize mode is append
+
+        SchemaException
+
+            - If static schema is used and not all staged segments have matching schema.
+            - If static schema is used, mode is ``StagedDataFinalizeMethod.APPEND`` and the schema of the new segment
+                is not the same as the schema of the existing data
+            - If dynamic schema is used and different segments have the same column names but their dtypes don't have a
+                common type (e.g string and any numeric type)
 
         See Also
         --------
         write
             Documentation on the ``staged`` parameter explains the concept of staged data in more detail.
+
+        Examples
+        --------
+        >>> lib.write("sym", pd.DataFrame({"col": [3, 4]}, index=pd.DatetimeIndex([pd.Timestamp(2024, 1, 3), pd.Timestamp(2024, 1, 4)])), staged=True)
+        >>> lib.write("sym", pd.DataFrame({"col": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(2024, 1, 1), pd.Timestamp(2024, 1, 2)])), staged=True)
+        >>> lib.finalize_staged_data("sym")
+        >>> lib.read("sym").data
+                    col
+        2024-01-01    1
+        2024-01-02    2
+        2024-01-03    3
+        2024-01-04    4
         """
         return self._nvs.compact_incomplete(
             symbol,
@@ -1170,6 +1224,7 @@ class Library:
             metadata=metadata,
             prune_previous_version=prune_previous_versions,
             validate_index=validate_index,
+            delete_staged_data_on_failure=delete_staged_data_on_failure
         )
 
     def sort_and_finalize_staged_data(
@@ -1178,15 +1233,30 @@ class Library:
         mode: Optional[StagedDataFinalizeMethod] = StagedDataFinalizeMethod.WRITE,
         prune_previous_versions: bool = False,
         metadata: Any = None,
+        delete_staged_data_on_failure: bool = False
     ) -> VersionedItem:
         """
-        sort_merge will sort and finalize staged data. This differs from `finalize_staged_data` in that it
-        can support staged segments with interleaved time periods - the end result will be ordered. This requires
-        performing a full sort in memory so can be time consuming.
+        Sorts and merges all staged data, making it available for reads. This differs from `finalize_staged_data` in that it
+        can support staged segments with interleaved time periods and staged segments which are not internally sorted. The
+        end result will be sorted. This requires performing a full sort in memory so can be time consuming.
+
+        If ``mode`` is ``StagedDataFinalizeMethod.APPEND`` the index of the first row of the sorted block must be equal to or greater
+        than the index of the last row in the existing data.
+
+        If ``Static Schema`` is used all staged block must have matching schema (same column names, same dtype, same column ordering)
+        and must match the existing data if mode is ``StagedDataFinalizeMethod.APPEND``. For more information about schema options see
+        documentation for ``arcticdb.LibraryOptions.dynamic_schema``
+
+        If the symbol does not exist both ``StagedDataFinalizeMethod.APPEND`` and ``StagedDataFinalizeMethod.WRITE`` will create it.
+
+        Calling ``sort_and_finalize_staged_data`` without having staged data for the symbol will throw ``UserInputException``. Use 
+        ``get_staged_symbols`` to check if there are staged segments for the symbol.
+
+        Calling ``sort_and_finalize_staged_data`` if any of the staged segments contains NaT in its index will throw ``SortingException``.
 
         Parameters
         ----------
-        symbol : `str`
+        symbol : str
             Symbol to finalize data for.
 
         mode : `StagedDataFinalizeMethod`, default=StagedDataFinalizeMethod.WRITE
@@ -1199,6 +1269,15 @@ class Library:
         metadata : Any, default=None
             Optional metadata to persist along with the symbol.
 
+        delete_staged_data_on_failure : bool, default=False
+            Determines the handling of staged data when an exception occurs during the execution of the 
+            `sort_and_finalize_staged_data` function.
+
+            - If set to True, all staged data for the specified symbol will be deleted if an exception occurs.
+            - If set to False, the staged data will be retained and will be used in subsequent calls to 
+              ``sort_and_finalize_staged_data``.
+
+            To manually delete staged data, use the ``delete_staged_data`` function.
         Returns
         -------
         VersionedItem
@@ -1207,24 +1286,53 @@ class Library:
 
         Raises
         ------
+        SortingException
+
+            - If the first index value of the sorted block is not greater or equal than the last index value of
+                the existing data when ``StagedDataFinalizeMethod.APPEND`` is used.
+            - If any staged segment contains NaT in the index
+
         UserInputException
-            If all of the following conditions are met:
-    
-            1. Static schema is used.
-            2. The width of the DataFrame exceeds the value of `LibraryOptions.columns_per_segment`.
-            3. The symbol contains data that was not written by `sort_and_finalize_staged_data`.
-            4. Finalize mode is append
+
+            - If there are no staged segments when ``sort_and_finalize_staged_data`` is called
+            - If all of the following conditions are met:
+
+                1. Static schema is used.
+                2. The width of the DataFrame exceeds the value of ``LibraryOptions.columns_per_segment``.
+                3. The symbol contains data that was not written by `sort_and_finalize_staged_data`.
+                4. Finalize mode is append
+
+        SchemaException
+
+            - If static schema is used and not all staged segments have matching schema.
+            - If static schema is used, mode is ``StagedDataFinalizeMethod.APPEND`` and the schema of the sorted and merged
+                staged segment is not the same as the schema of the existing data
+            - If dynamic schema is used and different segments have the same column names but their dtypes don't have a
+                common type (e.g string and any numeric type)
 
         See Also
         --------
         write
             Documentation on the ``staged`` parameter explains the concept of staged data in more detail.
+
+        Examples
+        --------
+        >>> lib.write("sym", pd.DataFrame({"col": [2, 4]}, index=pd.DatetimeIndex([pd.Timestamp(2024, 1, 2), pd.Timestamp(2024, 1, 4)])), staged=True)
+        >>> lib.write("sym", pd.DataFrame({"col": [3, 1]}, index=pd.DatetimeIndex([pd.Timestamp(2024, 1, 3), pd.Timestamp(2024, 1, 1)])), staged=True)
+        >>> lib.sort_and_finalize_staged_data("sym")
+        >>> lib.read("sym").data
+                    col
+        2024-01-01    1
+        2024-01-02    2
+        2024-01-03    3
+        2024-01-04    4
         """
         vit = self._nvs.version_store.sort_merge(
             symbol,
             normalize_metadata(metadata) if metadata is not None else None,
             mode == StagedDataFinalizeMethod.APPEND,
             prune_previous_versions=prune_previous_versions,
+            delete_staged_data_on_failure=delete_staged_data_on_failure
         )
         return self._nvs._convert_thin_cxx_item_to_python(vit, metadata)
 

--- a/python/tests/hypothesis/arcticdb/test_sort_merge.py
+++ b/python/tests/hypothesis/arcticdb/test_sort_merge.py
@@ -67,20 +67,20 @@ def assert_equal(left, right, dynamic=False):
 
 def assert_cannot_finalize_without_staged_data(lib, symbol, mode):
     with pytest.raises(UserInputException) as exception_info:
-        lib.sort_and_finalize_staged_data(symbol, mode=mode)
+        lib.sort_and_finalize_staged_data(symbol, mode=mode, delete_staged_data_on_failure=True)
     assert "E_NO_STAGED_SEGMENTS" in str(exception_info.value)
     assert len(get_append_keys(lib, symbol)) == 0
   
 def assert_nat_is_not_supported(lib, symbol, mode):
     with pytest.raises(UnsortedDataException) as exception_info:
-        lib.sort_and_finalize_staged_data(symbol, mode=mode)
+        lib.sort_and_finalize_staged_data(symbol, mode=mode, delete_staged_data_on_failure=True)
     assert "E_UNSORTED_DATA" in str(exception_info.value)
     assert len(get_append_keys(lib, symbol)) == 0
 
 
 def assert_staged_columns_are_incompatible(lib, symbol, mode):
     with pytest.raises(SchemaException) as exception_info:
-        lib.sort_and_finalize_staged_data(symbol, mode)
+        lib.sort_and_finalize_staged_data(symbol, mode, delete_staged_data_on_failure=True)
     assert "E_DESCRIPTOR_MISMATCH" in str(exception_info.value)
     assert len(get_append_keys(lib, symbol)) == 0
 
@@ -99,7 +99,7 @@ def merge_and_sort_segment_list(segment_list, int_columns_in_df=None):
 
 def assert_appended_data_does_not_overlap_with_storage(lib, symbol):
     with pytest.raises(UnsortedDataException) as exception_info:
-        lib.sort_and_finalize_staged_data(symbol, mode=StagedDataFinalizeMethod.APPEND)
+        lib.sort_and_finalize_staged_data(symbol, mode=StagedDataFinalizeMethod.APPEND, delete_staged_data_on_failure=True)
     assert "E_UNSORTED_DATA" in str(exception_info.value)
     assert "append" in str(exception_info.value)
     assert len(get_append_keys(lib, symbol)) == 0


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Add flag to clear all staged data for a symbol if an exception is thrown during sort and finalize or finalize. The default values is False (keep staged data) in order to preserve current behavior.

Add docstrings for sort and finalize and finalize
Closes  #1850
Closes #1839
Closes #1849 
#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
