### PR TITLE
Use a new `E_NON_INCREASING_INDEX_VERSION` exception

### DIFF
--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -89,6 +89,7 @@ inline std::unordered_map<ErrorCategory, const char*> get_error_category_names()
     ERROR_CODE(5030, E_UNEXPECTED_AZURE_ERROR) \
     ERROR_CODE(5050, E_MONGO_BULK_OP_NO_REPLY) \
     ERROR_CODE(5051, E_UNEXPECTED_MONGO_ERROR) \
+    ERROR_CODE(5090, E_NON_INCREASING_INDEX_VERSION) \
     ERROR_CODE(6000, E_UNSORTED_DATA) \
     ERROR_CODE(7000, E_INVALID_USER_ARGUMENT) \
     ERROR_CODE(7001, E_INVALID_DECIMAL_STRING)   \
@@ -173,6 +174,7 @@ using S3RetryableException = ArcticSpecificException<ErrorCode::E_S3_RETRYABLE>;
 using UnexpectedAzureException = ArcticSpecificException<ErrorCode::E_UNEXPECTED_AZURE_ERROR>;
 using MongoOperationNoReplyException = ArcticSpecificException<ErrorCode::E_MONGO_BULK_OP_NO_REPLY>;
 using UnexpectedMongoException = ArcticSpecificException<ErrorCode::E_UNEXPECTED_MONGO_ERROR>;
+using NonIncreasingIndexVersionException = ArcticSpecificException<ErrorCode::E_NON_INCREASING_INDEX_VERSION>;
 using SortingException = ArcticCategorizedException<ErrorCategory::SORTING>;
 using UnsortedDataException = ArcticSpecificException<ErrorCode::E_UNSORTED_DATA>;
 using UserInputException = ArcticCategorizedException<ErrorCategory::USER_INPUT>;
@@ -222,6 +224,11 @@ template<>
 template<>
 [[noreturn]] inline void throw_error<ErrorCode::E_UNEXPECTED_MONGO_ERROR>(const std::string& msg) {
     throw ArcticSpecificException<ErrorCode::E_UNEXPECTED_MONGO_ERROR>(msg);
+}
+
+template<>
+[[noreturn]] inline void throw_error<ErrorCode::E_NON_INCREASING_INDEX_VERSION>(const std::string& msg) {
+    throw ArcticSpecificException<ErrorCode::E_NON_INCREASING_INDEX_VERSION>(msg);
 }
 
 template<>

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -385,7 +385,7 @@ TEST(VersionMap, FixRefKey) {
     EXPECT_THROW({
         // We should raise if we try to write a non-increasing index key
         version_map->write_version(store, key4, key3);
-    }, InternalException);
+    }, NonIncreasingIndexVersionException);
 
     store->remove_key_sync(RefKey{id, KeyType::VERSION_REF}, storage::RemoveOpts{});
     ASSERT_FALSE(version_map->check_ref_key(store, id));
@@ -414,15 +414,15 @@ TEST(VersionMap, FixRefKeyTombstones) {
     auto key2 = atom_key_with_version(id, 0, 1696590624387628801);
     EXPECT_THROW({
         version_map->write_version(store, key2, key1);
-    }, InternalException);
+    }, NonIncreasingIndexVersionException);
     auto key3 = atom_key_with_version(id, 0, 1696590624532320286);
     EXPECT_THROW({
         version_map->write_version(store, key3, key2);
-    }, InternalException);
+    }, NonIncreasingIndexVersionException);
     auto key4 = atom_key_with_version(id, 0, 1696590624554476875);
     EXPECT_THROW({
         version_map->write_version(store, key4, key3);
-    }, InternalException);
+    }, NonIncreasingIndexVersionException);
     auto key5 = atom_key_with_version(id, 1, 1696590624590123209);
     version_map->write_version(store, key5, key4);
     auto entry = version_map->check_reload(store, id, LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -507,8 +507,8 @@ public:
         if (validate_)
             entry->validate();
 
-        util::check(key.type() != KeyType::TABLE_INDEX || !entry->head_.has_value() || key.version_id() > entry->head_->version_id(),
-                    "Trying to write a non-increasing TABLE_INDEX key. New version: {}, Last version: {}",
+        storage::check<ErrorCode::E_NON_INCREASING_INDEX_VERSION>(key.type() != KeyType::TABLE_INDEX || !entry->head_.has_value() || key.version_id() > entry->head_->version_id(),
+                    "Trying to write TABLE_INDEX key with a non-increasing version. New version: {}, Last version: {}. This is most likely due to parallel writes to the same symbol, which is not supported.",
                     key.version_id(), entry->head_ ? entry->head_->version_id() : VariantId{""});
         auto journal_key = to_atom(std::move(journal_single_key(store, key, entry->head_)));
         write_to_entry(entry, key, journal_key);


### PR DESCRIPTION
The new exception type can be used to catch repeating an op log in
replication.

Apart from replication writing a non-increasing index version is most
likely due to parallel writes to the same symbol. We now indicate that
in the error message.


#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
