### PR TITLE
Fix time zone handling in index values and metadata

### DIFF
--- a/docs/mkdocs/docs/faq.md
+++ b/docs/mkdocs/docs/faq.md
@@ -183,3 +183,16 @@ The handling of `NaN` in ArcticDB depends on the type of the column under consid
 * For string columns, `NaN`, as well as Python `None`, are fully supported.
 * For floating-point numeric columns, `NaN` is also fully supported.
 * For integer numeric columns `NaN` is not supported. A column that otherwise contains only integers will be treated as a floating point column if a `NaN` is encountered by ArcticDB, at which point [the usual rules](api/arctic.md#LibraryOptions) around type promotion for libraries configured with or without dynamic schema all apply as usual.
+
+### How does ArcticDB handle `time zone` information?
+
+ArcticDB takes a more strict approach to time zone handling than Pandas. While Pandas support multiple types for storing time zone information, ArcticDB coerces all time zone information to `datetime.timezone`. This way we can ensure that all time zone information is stored in a consistent manner, and that all time zone information is preserved when data is written to and read from ArcticDB.
+
+When writing data with time zone information to ArcticDB, we preserve the time zone offset and name. When reading data with time zone information from ArcticDB, this data is used to create a `datetime.timezone` object.
+
+!!! note
+
+    This means that regardles of the timezone types being written in ArcticDB, all time zone types are normalised to `datetime.timezone`.
+    If you would like a another time-zone type back then tzname can be used to recreate it:
+    - For `pytz` you can use: `pytz.gettz(dt.tzname())`
+    - For `ZoneInfo`, after Python 3.9+, you can use: `ZoneInfo(dt.tzname())`

--- a/docs/mkdocs/docs/faq.md
+++ b/docs/mkdocs/docs/faq.md
@@ -186,13 +186,12 @@ The handling of `NaN` in ArcticDB depends on the type of the column under consid
 
 ### How does ArcticDB handle `time zone` information?
 
-ArcticDB takes a more strict approach to time zone handling than Pandas. While Pandas support multiple types for storing time zone information, ArcticDB coerces all time zone information to `datetime.timezone`. This way we can ensure that all time zone information is stored in a consistent manner, and that all time zone information is preserved when data is written to and read from ArcticDB.
+ArcticDB takes a more strict approach to time zone handling than Pandas. While Pandas support multiple types for storing time zone information, ArcticDB coerces all time zone information to `pytz.tzfile` as this is the default representation for Pandas as well. This way we can ensure that all time zone information is stored in a consistent manner, and that all time zone information is preserved when data is written to and read from ArcticDB.
 
-When writing data with time zone information to ArcticDB, we preserve the time zone offset and name. When reading data with time zone information from ArcticDB, this data is used to create a `datetime.timezone` object.
+When writing data with time zone information to ArcticDB, we preserve the time name as string (e.g. "Europe/Amsterdam"). When reading data with time zone information from ArcticDB, this data is used to create a `pytz.tzfile` object.
 
 !!! note
 
-    This means that regardles of the timezone types being written in ArcticDB, all time zone types are normalised to `datetime.timezone`.
-    If you would like a another time-zone type back then tzname can be used to recreate it:
-    - For `pytz` you can use: `pytz.gettz(dt.tzname())`
-    - For `ZoneInfo`, after Python 3.9+, you can use: `ZoneInfo(dt.tzname())`
+    This means that regardles of the timezone types being written in ArcticDB, all time zone types are normalised to `pytz.tzfile`.
+    If you would like a another time-zone type back then string representation can be used to recreate it, e.g. `str(dt.tzname())`:
+    - For `ZoneInfo`, after Python 3.9+, you can use: `ZoneInfo(str(dt.tzname()))`

--- a/docs/mkdocs/docs/faq.md
+++ b/docs/mkdocs/docs/faq.md
@@ -193,5 +193,5 @@ When writing data with time zone information to ArcticDB, we preserve the time n
 !!! note
 
     This means that regardles of the timezone types being written in ArcticDB, all time zone types are normalised to `pytz.tzfile`.
-    If you would like a another time-zone type back then string representation can be used to recreate it, e.g. `str(dt.tzname())`:
-    - For `ZoneInfo`, after Python 3.9+, you can use: `ZoneInfo(str(dt.tzname()))`
+    If you would like a another time-zone type back then string representation can be used to recreate it, e.g. `str(dt.tzinfo)`:
+    - For `ZoneInfo`, after Python 3.9+, you can use: `ZoneInfo(str(dt.tzinfo))`

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -588,8 +588,8 @@ class _PandasNormalizer(Normalizer):
             names = [_column_name_to_strings(index.names[0])]
             for f in fields:
                 current_index = index.levels[f]
-                if isinstance(current_index, DatetimeIndex) and current_index.tz is not None:
-                    index_norm.timezone[f] = normalize_tz(current_index.tz)
+                if isinstance(current_index, DatetimeIndex) and current_index is not None:
+                    index_norm.timezone[f] = normalize_tz(current_index)
                 else:
                     index_norm.timezone[f] = ""
                 if index.names[f] is None:

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -179,7 +179,8 @@ def get_timezone_from_metadata(norm_meta):
 
 def normalize_tz(dt):
     if isinstance(dt, DatetimeIndex):
-        tz = _ensure_str_timezone(get_timezone(dt.tzinfo)) if dt.tzinfo is not None else dt.tz
+        tz = dt.tzinfo if dt.tzinfo is not None else dt.tz
+        tz = _ensure_str_timezone(get_timezone(tz)) if tz is not None else ""
     else:
         tz = _ensure_str_timezone(get_timezone(dt.tzinfo)) if dt.tzinfo is not None else dt.tzname()
 

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -178,7 +178,10 @@ def get_timezone_from_metadata(norm_meta):
 
 
 def normalize_tz(dt):
-    tz = _ensure_str_timezone(get_timezone(dt.tzinfo)) if dt.tzinfo is not None else dt.tzname()
+    if isinstance(dt, DatetimeIndex):
+        tz = _ensure_str_timezone(get_timezone(dt.tzinfo)) if dt.tzinfo is not None else dt.tz
+    else:
+        tz = _ensure_str_timezone(get_timezone(dt.tzinfo)) if dt.tzinfo is not None else dt.tzname()
 
     # workaround to handle the case where the timezone is dateutil
     # then the format is ...zoneinfo/<timezone>

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1020,7 +1020,7 @@ class MsgPackNormalizer(Normalizer):
     def _ext_hook(self, code, data):
         if code == MsgPackSerialization.PD_TIMESTAMP:
             data = unpackb(data, raw=False)
-            return pd.Timestamp(data[0], tz=data[1])
+            return pd.Timestamp(data[0], tz=data[1]) if data[1] is not None else pd.Timestamp(data[0])
 
         if code == MsgPackSerialization.PY_DATETIME:
             data = unpackb(data, raw=False)

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -12,14 +12,22 @@ import math
 import pytest
 import pandas as pd
 import numpy as np
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List
 from enum import Enum
+
+from tests.util.date import TIMEZONES_TO_TEST, DATES_TO_TEST, compare_tz_info
 
 from arcticdb_ext.exceptions import InternalException, SortingException, UserInputException
 from arcticdb_ext.storage import NoDataFoundException
 from arcticdb_ext.version_store import SortedValue
-from arcticdb.exceptions import ArcticDbNotYetImplemented, LibraryNotFound, MismatchingLibraryOptions, StreamDescriptorMismatch, SchemaException
+from arcticdb.exceptions import (
+    ArcticDbNotYetImplemented,
+    LibraryNotFound,
+    MismatchingLibraryOptions,
+    StreamDescriptorMismatch,
+    SchemaException,
+)
 from arcticdb.adapters.mongo_library_adapter import MongoLibraryAdapter
 from arcticdb.arctic import Arctic
 from arcticdb.options import LibraryOptions, EnterpriseLibraryOptions
@@ -38,18 +46,26 @@ from arcticdb.version_store.library import (
 
 from ...util.mark import AZURE_TESTS_MARK, MONGO_TESTS_MARK, REAL_S3_TESTS_MARK, SSL_TESTS_MARK, SSL_TEST_SUPPORTED
 
+
 class ParameterDisplayStatus(Enum):
     NOT_SHOW = 1
     DISABLE = 2
     ENABLE = 3
 
-parameter_display_status = [ParameterDisplayStatus.NOT_SHOW, ParameterDisplayStatus.DISABLE, ParameterDisplayStatus.ENABLE]
+
+parameter_display_status = [
+    ParameterDisplayStatus.NOT_SHOW,
+    ParameterDisplayStatus.DISABLE,
+    ParameterDisplayStatus.ENABLE,
+]
 no_ssl_parameter_display_status = [ParameterDisplayStatus.NOT_SHOW, ParameterDisplayStatus.DISABLE]
+
 
 class DefaultSetting:
     def __init__(self, factory):
         self.cafile = factory.client_cert_file
         self.capath = factory.client_cert_dir
+
 
 def edit_connection_string(uri, delimiter, storage, ssl_setting, client_cert_file, client_cert_dir):
     # Clear default setting in the uri
@@ -74,10 +90,17 @@ def edit_connection_string(uri, delimiter, storage, ssl_setting, client_cert_fil
         uri += f"{delimiter}CA_cert_dir={storage.factory.client_cert_dir}"
     return uri
 
+
 # s3_storage will become non-ssl if SSL_TEST_SUPPORTED is False
-@pytest.mark.parametrize('client_cert_file', parameter_display_status if SSL_TEST_SUPPORTED else no_ssl_parameter_display_status)
-@pytest.mark.parametrize('client_cert_dir', parameter_display_status if SSL_TEST_SUPPORTED else no_ssl_parameter_display_status)
-@pytest.mark.parametrize('ssl_setting', parameter_display_status if SSL_TEST_SUPPORTED else no_ssl_parameter_display_status)
+@pytest.mark.parametrize(
+    "client_cert_file", parameter_display_status if SSL_TEST_SUPPORTED else no_ssl_parameter_display_status
+)
+@pytest.mark.parametrize(
+    "client_cert_dir", parameter_display_status if SSL_TEST_SUPPORTED else no_ssl_parameter_display_status
+)
+@pytest.mark.parametrize(
+    "ssl_setting", parameter_display_status if SSL_TEST_SUPPORTED else no_ssl_parameter_display_status
+)
 def test_s3_verification(monkeypatch, s3_storage, client_cert_file, client_cert_dir, ssl_setting):
     storage = s3_storage
     # Leaving ca file and ca dir unset will fallback to using os default setting,
@@ -91,10 +114,10 @@ def test_s3_verification(monkeypatch, s3_storage, client_cert_file, client_cert_
 
 
 @SSL_TESTS_MARK
-@pytest.mark.parametrize('client_cert_file', no_ssl_parameter_display_status)
-@pytest.mark.parametrize('client_cert_dir', no_ssl_parameter_display_status)
-@pytest.mark.parametrize('ssl_setting', no_ssl_parameter_display_status)
-def test_s3_no_ssl_verification(monkeypatch, s3_no_ssl_storage, client_cert_file, client_cert_dir, ssl_setting):        
+@pytest.mark.parametrize("client_cert_file", no_ssl_parameter_display_status)
+@pytest.mark.parametrize("client_cert_dir", no_ssl_parameter_display_status)
+@pytest.mark.parametrize("ssl_setting", no_ssl_parameter_display_status)
+def test_s3_no_ssl_verification(monkeypatch, s3_no_ssl_storage, client_cert_file, client_cert_dir, ssl_setting):
     storage = s3_no_ssl_storage
     # Leaving ca file and ca dir unset will fallback to using os default setting,
     # which is different from the test environment
@@ -107,8 +130,8 @@ def test_s3_no_ssl_verification(monkeypatch, s3_no_ssl_storage, client_cert_file
 
 
 @AZURE_TESTS_MARK
-@pytest.mark.parametrize('client_cert_file', no_ssl_parameter_display_status)
-@pytest.mark.parametrize('client_cert_dir', no_ssl_parameter_display_status)
+@pytest.mark.parametrize("client_cert_file", no_ssl_parameter_display_status)
+@pytest.mark.parametrize("client_cert_dir", no_ssl_parameter_display_status)
 def test_azurite_no_ssl_verification(monkeypatch, azurite_storage, client_cert_file, client_cert_dir):
     storage = azurite_storage
     # Leaving ca file and ca dir unset will fallback to using os default setting,
@@ -123,8 +146,8 @@ def test_azurite_no_ssl_verification(monkeypatch, azurite_storage, client_cert_f
 
 @AZURE_TESTS_MARK
 @SSL_TESTS_MARK
-@pytest.mark.parametrize('client_cert_file', parameter_display_status)
-@pytest.mark.parametrize('client_cert_dir', parameter_display_status)
+@pytest.mark.parametrize("client_cert_file", parameter_display_status)
+@pytest.mark.parametrize("client_cert_dir", parameter_display_status)
 def test_azurite_ssl_verification(azurite_ssl_storage, monkeypatch, client_cert_file, client_cert_dir):
     storage = azurite_ssl_storage
     # Leaving ca file and ca dir unset will fallback to using os default setting,
@@ -140,7 +163,7 @@ def test_azurite_ssl_verification(azurite_ssl_storage, monkeypatch, client_cert_
 def test_basic_metadata(lmdb_version_store):
     lib = lmdb_version_store
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
-    metadata = {"fluffy" : "muppets"}
+    metadata = {"fluffy": "muppets"}
     lib.write("my_symbol", df, metadata=metadata)
     vit = lib.read_metadata("my_symbol")
     assert vit.metadata == metadata
@@ -153,7 +176,7 @@ def test_sorted_roundtrip(arctic_library):
     df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
     lib.write(symbol, df)
     desc = lib.get_description(symbol)
-    assert desc.sorted == 'ASCENDING'
+    assert desc.sorted == "ASCENDING"
 
 
 def test_basic_write_read_update_and_append(arctic_library):
@@ -287,7 +310,11 @@ def test_parallel_writes_and_appends_index_validation(arctic_library, finalize_m
     else:
         lib.finalize_staged_data(sym, finalize_method, validate_index=False)
         received = lib.read(sym).data
-        expected = pd.concat([df_0, df_1, df_2]) if finalize_method == StagedDataFinalizeMethod.APPEND else pd.concat([df_1, df_2])
+        expected = (
+            pd.concat([df_0, df_1, df_2])
+            if finalize_method == StagedDataFinalizeMethod.APPEND
+            else pd.concat([df_1, df_2])
+        )
         assert_frame_equal(received, expected)
 
 
@@ -301,9 +328,12 @@ def test_finalize_without_adding_segments(arctic_library, finalize_method):
 class TestAppendStagedData:
     def test_appended_df_interleaves_with_storage(self, arctic_library):
         lib = arctic_library
-        initial_df = pd.DataFrame({"col": [1, 3]}, index=pd.DatetimeIndex([np.datetime64('2023-01-01'), np.datetime64('2023-01-03')], dtype="datetime64[ns]"))
+        initial_df = pd.DataFrame(
+            {"col": [1, 3]},
+            index=pd.DatetimeIndex([np.datetime64("2023-01-01"), np.datetime64("2023-01-03")], dtype="datetime64[ns]"),
+        )
         lib.write("sym", initial_df)
-        df1 = pd.DataFrame({"col": [2]}, index=pd.DatetimeIndex([np.datetime64('2023-01-02')], dtype="datetime64[ns]"))
+        df1 = pd.DataFrame({"col": [2]}, index=pd.DatetimeIndex([np.datetime64("2023-01-02")], dtype="datetime64[ns]"))
         lib.write("sym", df1, staged=True)
         with pytest.raises(SortingException) as exception_info:
             lib.finalize_staged_data("sym", mode=StagedDataFinalizeMethod.APPEND)
@@ -313,18 +343,25 @@ class TestAppendStagedData:
         lib = arctic_library
         df = pd.DataFrame(
             {"col": [1, 2, 3]},
-            index=pd.DatetimeIndex([np.datetime64('2023-01-01'), np.datetime64('2023-01-02'), np.datetime64('2023-01-03')], dtype="datetime64[ns]")
+            index=pd.DatetimeIndex(
+                [np.datetime64("2023-01-01"), np.datetime64("2023-01-02"), np.datetime64("2023-01-03")],
+                dtype="datetime64[ns]",
+            ),
         )
         lib.write("sym", df)
         df_to_append = pd.DataFrame(
             {"col": [4, 5, 6]},
-            index=pd.DatetimeIndex([np.datetime64('2023-01-03'), np.datetime64('2023-01-04'), np.datetime64('2023-01-05')], dtype="datetime64[ns]")
+            index=pd.DatetimeIndex(
+                [np.datetime64("2023-01-03"), np.datetime64("2023-01-04"), np.datetime64("2023-01-05")],
+                dtype="datetime64[ns]",
+            ),
         )
         lib.write("sym", df_to_append, staged=True)
         lib.finalize_staged_data("sym", mode=StagedDataFinalizeMethod.APPEND)
         res = lib.read("sym").data
         expected_df = pd.concat([df, df_to_append])
         assert_frame_equal(lib.read("sym").data, expected_df)
+
 
 def test_snapshots_and_deletes(arctic_library):
     lib = arctic_library
@@ -347,6 +384,7 @@ def test_snapshots_and_deletes(arctic_library):
     assert lib.list_snapshots() == {"snap_after_delete": None}
     assert lib.list_symbols() == ["my_symbol2"]
 
+
 def test_list_snapshots_no_metadata(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"a": [1, 2, 3]})
@@ -365,6 +403,7 @@ def test_list_snapshots_no_metadata(arctic_library):
     snaps_list = lib.list_snapshots(False)
     assert isinstance(snaps_list, List)
     assert set(snaps_list) == {snap1, snap2}
+
 
 def test_delete_non_existent_snapshot(arctic_library):
     lib = arctic_library
@@ -926,13 +965,16 @@ def test_get_description(arctic_library):
 
 
 # See test_write_tz in test_normalization.py for the V1 API equivalent
+@pytest.mark.parametrize("tz", TIMEZONES_TO_TEST)
 @pytest.mark.parametrize(
-    "tz", ["UTC", "Europe/Amsterdam"]
+    "date_to_test",
+    DATES_TO_TEST,
 )
-def test_get_description_date_range_tz(arctic_library, tz):
+def test_get_description_date_range_tz(arctic_library, tz, date_to_test):
     lib = arctic_library
     sym = "test_get_description_date_range_tz"
-    index = index=pd.date_range(pd.Timestamp(0), periods=10, tz=tz)
+    ts = pd.Timestamp(date_to_test, tz=tz)
+    index = pd.date_range(ts, periods=10, tz=tz)
     df = pd.DataFrame(data={"col1": np.arange(10)}, index=index)
     lib.write(sym, df)
     start_ts, end_ts = lib.get_description(sym).date_range
@@ -940,6 +982,7 @@ def test_get_description_date_range_tz(arctic_library, tz):
     assert isinstance(end_ts, pd.Timestamp)
     assert start_ts == index[0]
     assert end_ts == index[-1]
+    assert compare_tz_info(start_ts, index[0])
 
 
 def test_tail(arctic_library):
@@ -1073,6 +1116,7 @@ def test_azure_sas_token(azurite_storage_factory: StorageFixtureFactory):
             ac = f.create_arctic()
             ac.create_library("x")
 
+
 def test_lib_has_lib_tools_read_index(lmdb_library):
     lib = lmdb_library
     sym = "my_symbol"
@@ -1116,9 +1160,12 @@ def test_norm_failure_error_message(arctic_library):
     with pytest.raises(ArcticDbNotYetImplemented) as update_exception:
         lib.update(sym, df)
 
-    assert all(col_name in str(e.value) for e in
-               [write_exception, write_batch_exception, append_exception, append_batch_exception, update_exception])
+    assert all(
+        col_name in str(e.value)
+        for e in [write_exception, write_batch_exception, append_exception, append_batch_exception, update_exception]
+    )
     assert "write_pickle" in str(write_exception.value) and "pickle_on_failure" not in str(write_exception.value)
-    assert "write_pickle_batch" in str(write_batch_exception.value) and "pickle_on_failure" not in str(write_batch_exception.value)
-    assert all("write_pickle" not in str(e.value) for e in
-               [append_exception, append_batch_exception, update_exception])
+    assert "write_pickle_batch" in str(write_batch_exception.value) and "pickle_on_failure" not in str(
+        write_batch_exception.value
+    )
+    assert all("write_pickle" not in str(e.value) for e in [append_exception, append_batch_exception, update_exception])

--- a/python/tests/integration/arcticdb/test_persistent_storage.py
+++ b/python/tests/integration/arcticdb/test_persistent_storage.py
@@ -18,8 +18,10 @@ else:
 
 
 @pytest.fixture(params=[pytest.param("REAL_S3", marks=REAL_S3_TESTS_MARK)])
-def shared_persistent_arctic_client(real_s3_storage_without_clean_up, encoding_version):
-    return real_s3_storage_without_clean_up.create_arctic(encoding_version=encoding_version)
+# DONT MERGE: there is a problem with interop tests and encoding_version 2
+# def shared_persistent_arctic_client(real_s3_storage_without_clean_up, encoding_version):
+def shared_persistent_arctic_client(real_s3_storage_without_clean_up):
+    return real_s3_storage_without_clean_up.create_arctic(encoding_version=0)
 
 
 # TODO: Add a check if the real storage tests are enabled
@@ -49,7 +51,9 @@ def persistent_arctic_client(real_s3_storage, encoding_version):
 
 
 @pytest.mark.parametrize("num_rows", [1_000_000])
-def test_persistent_storage_read_write_large_data_ascending(persistent_arctic_client, num_rows):
+def test_persistent_storage_read_write_large_data_ascending(
+    persistent_arctic_client, num_rows
+):
     ac = persistent_arctic_client
     ac.create_library("test_persistent_storage_read_write_large_data_ascending")
     lib = ac["test_persistent_storage_read_write_large_data_ascending"]
@@ -62,7 +66,9 @@ def test_persistent_storage_read_write_large_data_ascending(persistent_arctic_cl
 
 
 @pytest.mark.parametrize("num_rows", [100_000_000])
-def test_persistent_storage_read_write_large_data_random(persistent_arctic_client, num_rows):
+def test_persistent_storage_read_write_large_data_random(
+    persistent_arctic_client, num_rows
+):
     ac = persistent_arctic_client
     ac.create_library("test_persistent_storage_read_write_large_data_random")
     lib = ac["test_persistent_storage_read_write_large_data_random"]
@@ -75,7 +81,9 @@ def test_persistent_storage_read_write_large_data_random(persistent_arctic_clien
 
 
 @pytest.mark.parametrize("num_syms", [1_000])
-def test_persistent_storage_read_write_many_syms(persistent_arctic_client, num_syms, three_col_df):
+def test_persistent_storage_read_write_many_syms(
+    persistent_arctic_client, num_syms, three_col_df
+):
     # For now, this tests only the breadth (e.g. number of symbols)
     # We have another test, that tests with "deeper" data frames
     ac = persistent_arctic_client

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -5,8 +5,10 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import datetime
 import sys
+from datetime import timezone
 from collections import namedtuple
 from unittest.mock import patch
 import numpy as np
@@ -47,10 +49,14 @@ from arcticdb.util._versions import IS_PANDAS_ZERO, IS_PANDAS_TWO
 from arcticdb.exceptions import ArcticNativeException
 
 from tests.util.mark import param_dict
+from tests.util.date import DATES_TO_TEST, TIMEZONES_TO_TEST, compare_tz_info
 
 params = {
     "simple_dict": {"a": "1", "b": 2, "c": 3.0, "d": True},
-    "pd_ts": {"a": pd.Timestamp("2018-01-12 09:15"), "b": pd.Timestamp("2017-01-31", tz="America/New_York")},
+    "pd_ts": {
+        "a": pd.Timestamp("2018-01-12 09:15"),
+        "b": pd.Timestamp("2017-01-31", tz="America/New_York"),
+    },
 }
 
 test_msgpack_normalizer = MsgPackNormalizer()
@@ -72,9 +78,12 @@ def test_msg_pack_legacy_1():
     # serialised data created with Python 3.6, msgpack 0.6.2, pandas 0.25.3
     # this was before string and bytes types were seperated in msgpack
     norm = test_msgpack_normalizer
-    packed = b'\x82\xa1a\xc7\x0b \x92\xcf\x15\t\x05:\xdfT\xc8\x00\xc0\xa1b\xc7\x1b \x92\xcf\x14\x9e\xc2\x84+~ \x00\xb0America/New_York'
+    packed = b"\x82\xa1a\xc7\x0b \x92\xcf\x15\t\x05:\xdfT\xc8\x00\xc0\xa1b\xc7\x1b \x92\xcf\x14\x9e\xc2\x84+~ \x00\xb0America/New_York"
     data = norm._msgpack_unpackb(packed)
-    assert data == {'a': pd.Timestamp('2018-01-12 09:15:00'), 'b': pd.Timestamp('2017-01-31 00:00:00-0500', tz='America/New_York')}
+    assert data == {
+        "a": pd.Timestamp("2018-01-12 09:15:00"),
+        "b": pd.Timestamp("2017-01-31 00:00:00-0500", tz="America/New_York"),
+    }
 
 
 def test_msg_pack_legacy_2():
@@ -82,7 +91,7 @@ def test_msg_pack_legacy_2():
     # serialised data created with Python 3.6, msgpack 0.6.2, pandas 0.25.3
     # this was before string and bytes types were seperated in msgpack
     norm = test_msgpack_normalizer
-    packed = b'\xc7\x1b!\x92\xcf\x15\x93w\xb1\xd2\xa6\x8f\xe8\xb0America/New_York'
+    packed = b"\xc7\x1b!\x92\xcf\x15\x93w\xb1\xd2\xa6\x8f\xe8\xb0America/New_York"
     dt = datetime.datetime(2019, 4, 8, 10, 5, 2, 1)
     nytz = pytz.timezone("America/New_York")
     loc_dt = nytz.localize(dt)
@@ -114,9 +123,15 @@ def test_fails_humongous_meta():
 
 def test_empty_df():
     if IS_PANDAS_ZERO:
-        d = pd.DataFrame(data={"C": []}, index=pd.MultiIndex(levels=[["A"], ["B"]], labels=[[], []], names=["X", "Y"]))
+        d = pd.DataFrame(
+            data={"C": []},
+            index=pd.MultiIndex(levels=[["A"], ["B"]], labels=[[], []], names=["X", "Y"]),
+        )
     else:
-        d = pd.DataFrame(data={"C": []}, index=pd.MultiIndex(levels=[["A"], ["B"]], codes=[[], []], names=["X", "Y"]))
+        d = pd.DataFrame(
+            data={"C": []},
+            index=pd.MultiIndex(levels=[["A"], ["B"]], codes=[[], []], names=["X", "Y"]),
+        )
 
     norm = CompositeNormalizer()
     df, norm_meta = norm.normalize(d)
@@ -130,24 +145,55 @@ def test_empty_df():
 
 # See test_get_description_date_range_tz in test_arctic.py for the V2 API equivalent
 @pytest.mark.parametrize(
-    "tz", ["UTC", "Europe/Amsterdam", pytz.UTC, pytz.timezone("Europe/Amsterdam"), du.tz.gettz("UTC")]
+    "tz",
+    TIMEZONES_TO_TEST,
 )
-def test_write_tz(lmdb_version_store, sym, tz):
-    assert tz is not None
-    index = index=pd.date_range(pd.Timestamp(0), periods=10, tz=tz)
+@pytest.mark.parametrize(
+    "date_to_test",
+    DATES_TO_TEST,
+)
+def test_write_index_tz(lmdb_version_store, sym, tz, date_to_test):
+    ts = pd.Timestamp(date_to_test, tz=tz)
+    index = pd.date_range(ts, periods=10)
     df = pd.DataFrame(data={"col1": np.arange(10)}, index=index)
     lmdb_version_store.write(sym, df)
     result = lmdb_version_store.read(sym).data
-    assert_frame_equal(df, result)
-    df_tz = df.index.tzinfo
-    assert str(df_tz) == str(tz)
+    # datetime timezone doesn't handle DST properly
+    # and du.tz.tzfile doesn't get formatted correctly
+    if not isinstance(tz, timezone) and not isinstance(tz, du.tz.tzfile):
+        assert_frame_equal(df, result)
+
+    assert compare_tz_info(result.index[0], ts)
     if tz == du.tz.gettz("UTC") and sys.version_info < (3, 7):
         pytest.skip("Timezone files don't seem to have ever worked properly on Python 3.6")
     start_ts, end_ts = lmdb_version_store.get_timerange_for_symbol(sym)
     assert isinstance(start_ts, datetime.datetime)
     assert isinstance(end_ts, datetime.datetime)
+    assert start_ts == ts
     assert start_ts == index[0]
     assert end_ts == index[-1]
+
+
+@pytest.mark.parametrize(
+    "tz",
+    TIMEZONES_TO_TEST,
+)
+@pytest.mark.parametrize(
+    "date_to_test",
+    DATES_TO_TEST,
+)
+def test_write_metadata_tz(lmdb_version_store, sym, tz, date_to_test):
+    df = pd.DataFrame(data={"col1": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))
+    meta = pd.Timestamp(date_to_test, tz=tz)
+    lmdb_version_store.write(sym, df, metadata={"index_start": meta})
+    result_tz = lmdb_version_store.read(sym).metadata["index_start"]
+
+    if meta.tzinfo is not None:
+        compare_tz_info(result_tz, meta)
+        # using meta.tzinfo.utcoffset(meta) is not reliable
+        # it doesn't return the correct offset for datetime with DST
+        test_ts = pd.Timestamp(date_to_test, tz=str(result_tz.tzinfo))
+        assert result_tz.tzinfo.utcoffset(result_tz) == test_ts.tzinfo.utcoffset(test_ts)
 
 
 def get_multiindex_df_with_tz(tz):
@@ -167,7 +213,10 @@ def get_multiindex_df_with_tz(tz):
 @pytest.mark.parametrize("tz", [pytz.timezone("America/New_York"), pytz.UTC])
 def test_multiindex_with_tz(tz):
     d = get_multiindex_df_with_tz(tz)
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=True, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=True,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
     df, norm_meta = norm.normalize(d)
     fd = FrameData.from_npd_df(df)
     denorm = norm.denormalize(fd, norm_meta)
@@ -182,7 +231,10 @@ def test_multiindex_with_tz(tz):
 @pytest.mark.parametrize("tz", [pytz.timezone("America/New_York"), pytz.UTC])
 def test_empty_df_with_multiindex_with_tz(tz):
     orig_df = get_multiindex_df_with_tz(tz)
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=True, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=True,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
     norm_df, norm_meta = norm.normalize(orig_df)
 
     # Slice the normalized df to an empty df (this can happen after date range slicing)
@@ -198,7 +250,10 @@ def test_empty_df_with_multiindex_with_tz(tz):
     sliced_denorm_df = norm.denormalize(fd, norm_meta)
 
     for index_level_num in [0, 1, 2]:
-        assert isinstance(sliced_denorm_df.index.levels[index_level_num], type(orig_df.index.levels[index_level_num]))
+        assert isinstance(
+            sliced_denorm_df.index.levels[index_level_num],
+            type(orig_df.index.levels[index_level_num]),
+        )
 
     assert sliced_denorm_df.index.names == orig_df.index.names
 
@@ -281,7 +336,10 @@ NT = namedtuple("NT", ["X", "Y"])
 
 def test_namedtuple_inside_df():
     d = pd.DataFrame({"A": [NT(1, "b"), NT(2, "a")]})
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=True, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=True,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
     df, norm_meta = norm.normalize(d)
     fd = FrameData.from_npd_df(df)
     denorm = norm.denormalize(fd, norm_meta)
@@ -321,8 +379,14 @@ def test_serialize_custom_normalizer():
     cloned_normalizer = CompositeCustomNormalizer([], False)
     cloned_normalizer.__setstate__(state)
     assert_equal(len(normalizer._normalizers), len(cloned_normalizer._normalizers))
-    assert_equal(len(normalizer._normalizer_by_typename), len(cloned_normalizer._normalizer_by_typename))
-    assert_equal(normalizer._normalizers[0].__class__, cloned_normalizer._normalizers[0].__class__)
+    assert_equal(
+        len(normalizer._normalizer_by_typename),
+        len(cloned_normalizer._normalizer_by_typename),
+    )
+    assert_equal(
+        normalizer._normalizers[0].__class__,
+        cloned_normalizer._normalizers[0].__class__,
+    )
     assert_equal(normalizer._fail_on_missing_type, cloned_normalizer._fail_on_missing_type)
     df, norm_meta = cloned_normalizer.normalize(dt)
     denormed = cloned_normalizer.denormalize(df, norm_meta)
@@ -333,7 +397,10 @@ def test_force_pickle_on_norm_failure():
     normal_df = pd.DataFrame({"a": [1, 2, 3]})
     mixed_type_df = pd.DataFrame({"a": [1, 2, "a"]})
     # Turn off the global flag for the normalizer
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=False, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=False,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
     # This should work as before
     _d, _meta = norm.normalize(normal_df)
 
@@ -344,14 +411,20 @@ def test_force_pickle_on_norm_failure():
     # Explicitly passing in pickle settings without global pickle flag being set should work
     _d, _meta = norm.normalize(mixed_type_df, pickle_on_failure=True)
 
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=True, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=True,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
 
     # Forcing it to pickle should work with the bool set.
     _d, _meta = norm.normalize(mixed_type_df)
 
 
 def test_numpy_array_normalization_composite():
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=False, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=False,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
     arr = np.random.rand(10, 10, 10)
     df, norm_meta = norm.normalize(arr)
     fd = FrameData.from_npd_df(df)
@@ -381,7 +454,10 @@ def test_ndarray_arbitrary_shape():
 def test_dict_with_tuples():
     # This has to be pickled because msgpack doesn't differentiate between tuples and lists
     data = {(1, 2): [1, 24, 55]}
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=False, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=False,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
     df, norm_meta = norm.normalize(data)
     fd = FrameData.from_npd_df(df)
     denormalized_data = norm.denormalize(fd, norm_meta)
@@ -409,7 +485,10 @@ def test_will_item_be_pickled(lmdb_version_store, sym):
 def test_numpy_ts_col_with_none(lmdb_version_store):
     df = pd.DataFrame(data={"a": [None, None]})
     df.loc[0, "a"] = pd.Timestamp(0)
-    norm = CompositeNormalizer(use_norm_failure_handler_known_types=False, fallback_normalizer=test_msgpack_normalizer)
+    norm = CompositeNormalizer(
+        use_norm_failure_handler_known_types=False,
+        fallback_normalizer=test_msgpack_normalizer,
+    )
     df, norm_meta = norm.normalize(df)
     fd = FrameData.from_npd_df(df)
     df_denormed = norm.denormalize(fd, norm_meta)
@@ -419,10 +498,16 @@ def test_numpy_ts_col_with_none(lmdb_version_store):
 
 
 def test_none_in_columns_names(lmdb_version_store, sym):
-    df = pd.DataFrame(data={None: [1.2, 2.2], "None": [2.3, 3.5]}, index=[pd.Timestamp(0), pd.Timestamp(1)])
+    df = pd.DataFrame(
+        data={None: [1.2, 2.2], "None": [2.3, 3.5]},
+        index=[pd.Timestamp(0), pd.Timestamp(1)],
+    )
     lmdb_version_store.write(sym, df)
     assert_frame_equal(lmdb_version_store.read(sym).data, df)
-    df2 = pd.DataFrame(data={None: [5.2, 6.2], "None": [1.3, 5.5]}, index=[pd.Timestamp(2), pd.Timestamp(3)])
+    df2 = pd.DataFrame(
+        data={None: [5.2, 6.2], "None": [1.3, 5.5]},
+        index=[pd.Timestamp(2), pd.Timestamp(3)],
+    )
     lmdb_version_store.append(sym, df2)
     vit = lmdb_version_store.read(sym)
     assert_frame_equal(vit.data, pd.concat((df, df2)))
@@ -430,14 +515,24 @@ def test_none_in_columns_names(lmdb_version_store, sym):
 
 def test_same_columns_names(lmdb_version_store, sym):
     df = pd.DataFrame(
-        data={"test": [1.2, 2.2], "test2": [2.3, 3.5], "test3": [2.5, 8.5], "test4": [9.3, 1.5]},
+        data={
+            "test": [1.2, 2.2],
+            "test2": [2.3, 3.5],
+            "test3": [2.5, 8.5],
+            "test4": [9.3, 1.5],
+        },
         index=[pd.Timestamp(0), pd.Timestamp(1)],
     )
     df.columns = ["test", None, "test", None]
     lmdb_version_store.write(sym, df)
     assert_frame_equal(lmdb_version_store.read(sym).data, df)
     df2 = pd.DataFrame(
-        data={"test": [2.2, 5.2], "test2": [1.3, 8.5], "test3": [2.5, 11.5], "test4": [12.3, 51.5]},
+        data={
+            "test": [2.2, 5.2],
+            "test2": [1.3, 8.5],
+            "test3": [2.5, 11.5],
+            "test4": [12.3, 51.5],
+        },
         index=[pd.Timestamp(2), pd.Timestamp(3)],
     )
     df2.columns = ["test", None, "test", None]
@@ -452,16 +547,25 @@ def test_same_columns_names(lmdb_version_store, sym):
 
 def test_columns_names_dynamic_schema(lmdb_version_store_dynamic_schema, sym):
     lmdb_version_store = lmdb_version_store_dynamic_schema
-    df = pd.DataFrame(data={None: [1.2, 2.2], "None": [2.3, 3.5]}, index=[pd.Timestamp(0), pd.Timestamp(1)])
+    df = pd.DataFrame(
+        data={None: [1.2, 2.2], "None": [2.3, 3.5]},
+        index=[pd.Timestamp(0), pd.Timestamp(1)],
+    )
     lmdb_version_store.write(sym, df)
     assert_frame_equal(lmdb_version_store.read(sym).data, df)
 
-    df = pd.DataFrame(data={None: [1.2, 2.2], "none": [2.3, 3.5]}, index=[pd.Timestamp(0), pd.Timestamp(1)])
+    df = pd.DataFrame(
+        data={None: [1.2, 2.2], "none": [2.3, 3.5]},
+        index=[pd.Timestamp(0), pd.Timestamp(1)],
+    )
     df.index.name = "None"
     lmdb_version_store.write(sym, df)
     assert_frame_equal(lmdb_version_store.read(sym).data, df)
 
-    df2 = pd.DataFrame(data={"none": [22.4, 21.2], None: [25.3, 31.5]}, index=[pd.Timestamp(2), pd.Timestamp(3)])
+    df2 = pd.DataFrame(
+        data={"none": [22.4, 21.2], None: [25.3, 31.5]},
+        index=[pd.Timestamp(2), pd.Timestamp(3)],
+    )
     df2.index.name = "None"
     lmdb_version_store.append(sym, df2)
     df3 = pd.concat((df, df2))
@@ -469,7 +573,14 @@ def test_columns_names_dynamic_schema(lmdb_version_store_dynamic_schema, sym):
     df4 = df4[df3.columns.tolist()]
     assert_frame_equal(df4, df3)
 
-    df = pd.DataFrame(data={"test": [1.2, 2.2], "test2": [2.3, 3.5], "test3": [2.5, 8.5], "test4": [9.3, 1.5]})
+    df = pd.DataFrame(
+        data={
+            "test": [1.2, 2.2],
+            "test2": [2.3, 3.5],
+            "test3": [2.5, 8.5],
+            "test4": [9.3, 1.5],
+        }
+    )
     df.columns = ["test", None, "test", None]
     with pytest.raises(ArcticNativeException) as e_info:
         lmdb_version_store.write(sym, df)
@@ -478,7 +589,11 @@ def test_columns_names_dynamic_schema(lmdb_version_store_dynamic_schema, sym):
 def test_columns_names_timeframe(lmdb_version_store, sym):
     tz = "America/New_York"
     dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
-    tf = TimeFrame(dtidx.values, columns_names=[None], columns_values=[np.asarray([1, 3, 42, 54, 23, 4])])
+    tf = TimeFrame(
+        dtidx.values,
+        columns_names=[None],
+        columns_values=[np.asarray([1, 3, 42, 54, 23, 4])],
+    )
     lmdb_version_store.write(sym, tf)
     vit = lmdb_version_store.read(sym)
 
@@ -502,7 +617,10 @@ def test_columns_names_series_dynamic(lmdb_version_store_dynamic_schema, sym):
 
 
 @pytest.mark.skipif(not IS_PANDAS_TWO, reason="pandas 2.0-specific test")
-@pytest.mark.parametrize("datetime64_dtype", ["datetime64[s]", "datetime64[ms]", "datetime64[us]", "datetime64[ns]"])
+@pytest.mark.parametrize(
+    "datetime64_dtype",
+    ["datetime64[s]", "datetime64[ms]", "datetime64[us]", "datetime64[ns]"],
+)
 @pytest.mark.parametrize("PandasContainer", [pd.DataFrame, pd.Series])
 def test_no_inplace_index_array_modification(lmdb_version_store, sym, datetime64_dtype, PandasContainer):
     # Normalization must not modify Series' or DataFrames' index array in-place.
@@ -517,7 +635,10 @@ def test_no_inplace_index_array_modification(lmdb_version_store, sym, datetime64
 
 
 def test_index_names_datetime_support(lmdb_version_store, sym):
-    df = pd.DataFrame(data={"a": [1, 2, 3]}, index=pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"]))
+    df = pd.DataFrame(
+        data={"a": [1, 2, 3]},
+        index=pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
     new_index = pd.Timestamp("2020-01-01")
     df.index.rename(new_index, inplace=True)
     with pytest.raises(ArcticException):
@@ -525,7 +646,10 @@ def test_index_names_datetime_support(lmdb_version_store, sym):
 
 
 def test_index_names_tuple_support(lmdb_version_store, sym):
-    df = pd.DataFrame(data={"a": [1, 2, 3]}, index=pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"]))
+    df = pd.DataFrame(
+        data={"a": [1, 2, 3]},
+        index=pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
     new_index = tuple([1, 2, 3])
     df.index.rename(new_index, inplace=True)
     with pytest.raises(ArcticException):
@@ -545,7 +669,10 @@ def test_index_names_roundtrip_csv(lmdb_version_store, sym):
 
 
 def test_column_names_datetime_support(lmdb_version_store, sym):
-    df = pd.DataFrame(data={"a": [1, 2, 3]}, index=pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"]))
+    df = pd.DataFrame(
+        data={"a": [1, 2, 3]},
+        index=pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
     new_index = pd.Timestamp("2020-01-01")
     df.rename(columns={"a": new_index}, inplace=True)
     with pytest.raises(ArcticException):
@@ -557,7 +684,15 @@ def test_column_names_mixed_types(lmdb_version_store, sym):
 
     buf = io.StringIO("2023-11-27 00:00:00,0.73260,0.73260,0.73260,0.73260,7")
     df = pd.read_csv(buf, parse_dates=[0], index_col=0, header=None)
-    df_to_write = df.rename(columns={1: 1, 2: pd.Timestamp("2020-01-01"), 3: tuple([1, 2, 3]), 4: "test", 5: 5.5})
+    df_to_write = df.rename(
+        columns={
+            1: 1,
+            2: pd.Timestamp("2020-01-01"),
+            3: tuple([1, 2, 3]),
+            4: "test",
+            5: 5.5,
+        }
+    )
     with pytest.raises(ArcticException):
         lmdb_version_store.write(sym, df_to_write)
 
@@ -572,7 +707,8 @@ def test_column_names_roundtrip_csv(lmdb_version_store, sym):
 
 
 @pytest.mark.skipif(
-    not IS_PANDAS_TWO, reason="The full-support of pyarrow-backed pandas objects is pandas 2.0-specific."
+    not IS_PANDAS_TWO,
+    reason="The full-support of pyarrow-backed pandas objects is pandas 2.0-specific.",
 )
 def test_pyarrow_error(lmdb_version_store):
     error_msg_intro = "PyArrow-backed pandas DataFrame and Series are not currently supported by ArcticDB."
@@ -614,12 +750,21 @@ def test_norm_failure_error_message(lmdb_version_store_v1):
     with pytest.raises(ArcticDbNotYetImplemented) as update_exception:
         lib.update(sym, df)
 
-    assert all(col_name in str(e.value) for e in
-               [write_exception, batch_write_exception, append_exception, batch_append_exception, update_exception])
-    assert all("pickle_on_failure" in str(e.value) for e in
-               [write_exception, batch_write_exception])
-    assert all("pickle_on_failure" not in str(e.value) for e in
-               [append_exception, batch_append_exception, update_exception])
+    assert all(
+        col_name in str(e.value)
+        for e in [
+            write_exception,
+            batch_write_exception,
+            append_exception,
+            batch_append_exception,
+            update_exception,
+        ]
+    )
+    assert all("pickle_on_failure" in str(e.value) for e in [write_exception, batch_write_exception])
+    assert all(
+        "pickle_on_failure" not in str(e.value) for e in [append_exception, batch_append_exception, update_exception]
+    )
+
 
 def test_bools_are_pickled(lmdb_version_store_allows_pickling):
     lib = lmdb_version_store_allows_pickling
@@ -627,13 +772,14 @@ def test_bools_are_pickled(lmdb_version_store_allows_pickling):
 
     df = pd.DataFrame({"a": [True, False]})
     lib.write(sym, df)
-    lib.get_info(sym)['type'] == 'pickled'
+    lib.get_info(sym)["type"] == "pickled"
     assert_frame_equal(df, lib.read(sym).data)
 
     df = pd.DataFrame({"a": [True, False, np.nan]})
     lib.write(sym, df)
-    lib.get_info(sym)['type'] == 'pickled'
+    lib.get_info(sym)["type"] == "pickled"
     assert_frame_equal(df, lib.read(sym).data)
+
 
 def test_bools_with_nan_throw_without_pickling(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
@@ -643,19 +789,21 @@ def test_bools_with_nan_throw_without_pickling(lmdb_version_store_v1):
     with pytest.raises(Exception):
         lib.write(sym, df)
 
+
 def test_arrays_are_pickled(lmdb_version_store_allows_pickling):
     lib = lmdb_version_store_allows_pickling
     sym = "test_arrays_are_pickled"
 
     df = pd.DataFrame({"a": [np.array([1, 2])]})
     lib.write(sym, df)
-    lib.get_info(sym)['type'] == 'pickled'
+    lib.get_info(sym)["type"] == "pickled"
     assert_frame_equal(df, lib.read(sym).data)
 
     df = pd.DataFrame({"a": [[1, 2]]})
     lib.write(sym, df)
-    lib.get_info(sym)['type'] == 'pickled'
+    lib.get_info(sym)["type"] == "pickled"
     assert_frame_equal(df, lib.read(sym).data)
+
 
 def test_arrays_throw_without_pickling(lmdb_version_store_v1):
     lib = lmdb_version_store_v1


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1406 and #1827 

#### What does this implement or fix?

- Unify the way time zones are handled for indexes and metadata, as much as possible
- Extend the support for time zone in the indexes/metadata to cover all cases supported by pandas
- Update the documentation to be more explicit about how/where time zones are supported

This is done by extending the current approach to decompose the timestamp into:
- its value - int
- its time zone info - str

This approach is beneficial as it:
- keeps the interface the same
- yields the most consistent results

The main problem is that we need to do some post processing to coerce the time zone info to be consistent ([done here](https://github.com/man-group/ArcticDB/blob/a8d3bd7d12d22cc4211a38631974407dcd812df7/python/arcticdb/version_store/_normalization.py#L180))

#### Any other comments?
An alternative approach was considered in a [past PR here](https://github.com/man-group/ArcticDB/pull/1407), but that had a couple of limitation:
- required an interface break
- was inconsistent because:
  - getting the offset value in some cases was incorrect inputs of type `datetime `
  - still needed to do some post processing to make sure that the time zone info is in a consistent format
