### PR TITLE
Customize s3 timouts with ConfigsMap

### DIFF
--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -227,8 +227,13 @@ auto get_s3_config(const ConfigType& conf) {
     client_configuration.maxConnections = conf.max_connections() == 0 ?
             ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", 16) :
             conf.max_connections();
-    client_configuration.connectTimeoutMs = conf.connect_timeout() == 0 ? 30000 : conf.connect_timeout();
-    client_configuration.requestTimeoutMs = conf.request_timeout() == 0 ? 200000 : conf.request_timeout();
+    client_configuration.connectTimeoutMs = ConfigsMap::instance()->get_int(
+            "S3.ConnectionTimeout",
+            conf.connect_timeout() == 0 ? 30000 : conf.connect_timeout());
+    client_configuration.requestTimeoutMs = ConfigsMap::instance()->get_int(
+            "S3.RequestTimeout",
+            conf.request_timeout() == 0 ? 200000 : conf.request_timeout());
+    client_configuration.lowSpeedLimit = ConfigsMap::instance()->get_int("S3.LowSpeedLimit", 1);
 
     const bool use_win_inet = ConfigsMap::instance()->get_int("S3Storage.UseWinINet", 0);
     if (use_win_inet) {


### PR DESCRIPTION
Now allows configuring custom:
- `S3.ConnectionTimeout`
- `S3.RequestTimeout`
- `S3.LowSpeedLimit`

This is useful for networking issues to allow failing faster with lower
timeout or for increasing the timeout if we expect to read large chunks.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
