### PR TITLE
Allow customizing the most useful AWS SDK settings.

### DIFF
--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -235,11 +235,13 @@ auto get_s3_config(const ConfigType& conf) {
     client_configuration.maxConnections = conf.max_connections() == 0 ?
             ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", 16) :
             conf.max_connections();
-    client_configuration.connectTimeoutMs = conf.connect_timeout() == 0 ?
-                                          ConfigsMap::instance()->get_int("S3Storage.ConnectTimeoutMs", 30000) :
-                                          conf.connect_timeout();
+
+
+    client_configuration.connectTimeoutMs = ConfigsMap::instance()->get_int("S3Storage.ConnectTimeoutMs",
+                                                conf.connect_timeout() == 0 ? 30000 : conf.connect_timeout());
     client_configuration.httpRequestTimeoutMs = ConfigsMap::instance()->get_int("S3Storage.HttpRequestTimeoutMs", 0);
-    client_configuration.requestTimeoutMs = ConfigsMap::instance()->get_int("S3Storage.RequestTimeoutMs", 200000);
+    client_configuration.requestTimeoutMs = ConfigsMap::instance()->get_int("S3Storage.RequestTimeoutMs",
+                                                                            conf.request_timeout() == 0 ? 200000 : conf.request_timeout());
     client_configuration.lowSpeedLimit = ConfigsMap::instance()->get_int("S3Storage.LowSpeedLimit", 1);
 
     const bool use_win_inet = ConfigsMap::instance()->get_int("S3Storage.UseWinINet", 0);

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -235,8 +235,12 @@ auto get_s3_config(const ConfigType& conf) {
     client_configuration.maxConnections = conf.max_connections() == 0 ?
             ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", 16) :
             conf.max_connections();
-    client_configuration.connectTimeoutMs = conf.connect_timeout() == 0 ? 30000 : conf.connect_timeout();
-    client_configuration.requestTimeoutMs = conf.request_timeout() == 0 ? 200000 : conf.request_timeout();
+    client_configuration.connectTimeoutMs = conf.connect_timeout() == 0 ?
+                                          ConfigsMap::instance()->get_int("S3Storage.ConnectTimeoutMs", 30000) :
+                                          conf.connect_timeout();
+    client_configuration.httpRequestTimeoutMs = ConfigsMap::instance()->get_int("S3Storage.HttpRequestTimeoutMs", 0);
+    client_configuration.requestTimeoutMs = ConfigsMap::instance()->get_int("S3Storage.RequestTimeoutMs", 200000);
+    client_configuration.lowSpeedLimit = ConfigsMap::instance()->get_int("S3Storage.LowSpeedLimit", 1);
 
     const bool use_win_inet = ConfigsMap::instance()->get_int("S3Storage.UseWinINet", 0);
     if (use_win_inet) {


### PR DESCRIPTION
`ARCTICDB_S3Storage_HttpRequestTimeoutMs_int=3000`

suffices to resolve the slowness issues users have been reporting with VAST.

I've given the new settings a default in line with the SDK defaults - https://sdk.amazonaws.com/cpp/api/LATEST/aws-cpp-sdk-core/html/struct_aws_1_1_client_1_1_client_configuration.html .

Similar PR from @IvoDD  - https://github.com/man-group/ArcticDB/pull/1872/files