### PR TITLE
Bugfix 1841: Correctly roundtrip None and empty string pd.Series names

### DIFF
--- a/cpp/proto/arcticc/pb2/descriptors.proto
+++ b/cpp/proto/arcticc/pb2/descriptors.proto
@@ -163,6 +163,8 @@ message NormalizationMetadata {
 
         // Pandas series support arbitrary objects but restricting to a string seems reasonable
         string name = 1;
+        // Backwards-compatible way of treating name as optional
+        bool has_name = 9;
 
         oneof index_type {
             PandasIndex index = 2;

--- a/cpp/proto/arcticc/pb2/descriptors.proto
+++ b/cpp/proto/arcticc/pb2/descriptors.proto
@@ -192,6 +192,7 @@ message NormalizationMetadata {
 
         map<string, ColumnName> col_names = 7;
         PandasIndex columns = 8;
+        // Note that 9 is taken above by has_name, so the next added field should be 10
     }
 
     message PandasDataFrame {

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -588,8 +588,10 @@ class SeriesNormalizer(_PandasNormalizer):
             empty_types=empty_types
         )
         norm.series.CopyFrom(norm.df)
-        if item.name:
+        if item.name is not None:
             norm.series.common.name = _column_name_to_strings(item.name)
+            norm.series.common.has_name = True
+        # else protobuf bools default to False
 
         return NormalizedInput(item=df, metadata=norm)
 
@@ -600,10 +602,19 @@ class SeriesNormalizer(_PandasNormalizer):
 
         series = pd.Series() if df.columns.empty else df.iloc[:, 0]
 
-        if norm_meta.common.name:
-            series.name = norm_meta.common.name
+        if hasattr(norm_meta.common, "has_name"):
+            # Series was written by newer client that understands the has_name field
+            if norm_meta.common.has_name:
+                series.name = norm_meta.common.name
+            else:
+                series.name = None
         else:
-            series.name = None
+            # Series was written by an older client. We can't distinguish between None and empty strings as names, so
+            # maintain the old behaviour which converted empty string names to None
+            if norm_meta.common.name:
+                series.name = norm_meta.common.name
+            else:
+                series.name = None
 
         return series
 

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -485,6 +485,15 @@ def test_columns_names_timeframe(lmdb_version_store, sym):
     assert tf == vit.data
 
 
+@pytest.mark.parametrize("name", (None, "", "non_empty"))
+def test_roundtrip_series_name(lmdb_version_store_v1, name):
+    lib = lmdb_version_store_v1
+    sym = "test_roundtrip_series_name"
+    series = pd.Series(np.arange(1), name=name)
+    lib.write(sym, series)
+    assert_series_equal(series, lib.read(sym).data)
+
+
 def test_columns_names_series(lmdb_version_store, sym):
     dr = pd.date_range("2020-01-01", "2020-12-31", name="date")
     date_series = pd.Series(dr, index=dr)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -494,6 +494,16 @@ def test_roundtrip_series_name(lmdb_version_store_v1, name):
     assert_series_equal(series, lib.read(sym).data)
 
 
+@pytest.mark.parametrize("name", (None, "", "non_empty"))
+def test_roundtrip_index_name(lmdb_version_store_v1, name):
+    lib = lmdb_version_store_v1
+    sym = "test_roundtrip_index_name"
+    df = pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)])
+    df.index.name = name
+    lib.write(sym, df)
+    assert_frame_equal(df, lib.read(sym).data)
+
+
 def test_columns_names_series(lmdb_version_store, sym):
     dr = pd.date_range("2020-01-01", "2020-12-31", name="date")
     date_series = pd.Series(dr, index=dr)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1841 