### PR TITLE
Add AWS STS authentication support

### DIFF
--- a/.github/actions/set_persistent_storage_env_vars/action.yml
+++ b/.github/actions/set_persistent_storage_env_vars/action.yml
@@ -29,6 +29,11 @@ runs:
         echo "ARCTICDB_REAL_S3_CLEAR=1" >> $GITHUB_ENV
         echo "ARCTICDB_REAL_S3_ACCESS_KEY=${{ inputs.aws_access_key }}" >> $GITHUB_ENV
         echo "ARCTICDB_REAL_S3_SECRET_KEY=${{ inputs.aws_secret_key }}" >> $GITHUB_ENV
+        ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX=$(shuf -i 0-999 -n 1)_$(date -u +'%Y-%m-%dT%H_%M_%S_%6N')
+        echo "ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX=${ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX}" >> $GITHUB_ENV
+        echo "ARCTICDB_REAL_S3_STS_TEST_USERNAME=gh_sts_test_user_${ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX}" >> $GITHUB_ENV
+        echo "ARCTICDB_REAL_S3_STS_TEST_ROLE=gh_sts_test_role_${ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX}" >> $GITHUB_ENV
+        echo "ARCTICDB_REAL_S3_STS_TEST_POLICY_NAME=gh_sts_test_policy_name_${ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX}" >> $GITHUB_ENV
         # Enable all debug logs
         # echo "ARCTICDB_all_loglevel=debug" >> $GITHUB_ENV
         # echo "ARCTICDB_AWS_LogLevel_int=6" >> $GITHUB_ENV

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -361,6 +361,16 @@ jobs:
           name: crashdump-${{env.distinguishing_name}}
           path: ${{env.LOCALAPPDATA}}/CrashDumps/
 
+      # Fallback if the clean up at test fixutre tear down fails due to crash or etc
+      - name: Remove AWS testing account and credentials
+        if: always() && inputs.persistent_storage == 'true'
+        run: |
+          python -c "
+          from arcticdb.storage_fixtures.s3 import real_s3_sts_clean_up
+          real_s3_sts_clean_up('${ARCTICDB_REAL_S3_STS_TEST_USERNAME}', '${ARCTICDB_REAL_S3_STS_TEST_ROLE}', '${ARCTICDB_REAL_S3_STS_TEST_POLICY_NAME}')
+          "
+        continue-on-error: true
+
       - name: Disk usage
         if: always()
         run: set +e ; du -m . "${PARALLEL_TEST_ROOT:-/tmp/parallel_test}" | sort -n | tail -n 100 || true; df -h

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_policy(PUSH)
     if (EXISTS "/usr/local/lib64/aws-c-cal/cmake/modules/FindLibCrypto.cmake") # Workaround old AWS SDK bug
         cmake_policy(SET CMP0045 OLD)
     endif()
-    find_package(AWSSDK REQUIRED COMPONENTS s3)
+    find_package(AWSSDK REQUIRED COMPONENTS s3 identity-management)
 cmake_policy(POP)
 
 find_package(Boost REQUIRED)
@@ -300,6 +300,7 @@ set(arcticdb_srcs
         storage/s3/nfs_backed_storage.hpp
         storage/s3/s3_client_wrapper.hpp
         storage/s3/s3_storage_tool.hpp
+        storage/s3/s3_settings.hpp
         storage/storage_factory.hpp
         storage/storage_options.hpp
         storage/storage.hpp

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -45,7 +45,7 @@ TEST(Async, SinkBasic) {
     as::LibraryIndex library_index{environment_name, config_resolver};
 
     as::UserAuth au{"abc"};
-    auto lib = library_index.get_library(library_path, as::OpenMode::WRITE, au);
+    auto lib = library_index.get_library(library_path, as::OpenMode::WRITE, au, as::NativeVariantStorage());
     auto codec_opt = std::make_shared<arcticdb::proto::encoding::VariantCodec>();
     aa::TaskScheduler sched{1};
 
@@ -76,7 +76,7 @@ TEST(Async, DeDupTest) {
     as::LibraryIndex library_index{environment_name, config_resolver};
 
     as::UserAuth au{"abc"};
-    auto lib = library_index.get_library(library_path, as::OpenMode::WRITE, au);
+    auto lib = library_index.get_library(library_path, as::OpenMode::WRITE, au, storage::NativeVariantStorage());
     auto codec_opt = std::make_shared<arcticdb::proto::encoding::VariantCodec>();
     aa::AsyncStore store(lib, *codec_opt, EncodingVersion::V2);
     auto seg = SegmentInMemory();
@@ -304,7 +304,7 @@ std::shared_ptr<arcticdb::Store> create_store(const storage::LibraryPath &librar
                   as::LibraryIndex &library_index,
                   const storage::UserAuth &user_auth,
                   std::shared_ptr<proto::encoding::VariantCodec> &codec_opt) {
-    auto lib = library_index.get_library(library_path, as::OpenMode::WRITE, user_auth);
+    auto lib = library_index.get_library(library_path, as::OpenMode::WRITE, user_auth, storage::NativeVariantStorage());
     auto store = aa::AsyncStore(lib, *codec_opt, EncodingVersion::V1);
     return std::make_shared<aa::AsyncStore<>>(std::move(store));
 }

--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -13,6 +13,7 @@
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
+#include <arcticdb/storage/s3/s3_settings.hpp>
 #include <sstream>
 
 namespace arcticdb::storage {
@@ -91,5 +92,17 @@ struct is_key_type<entity::VariantKey> : std::true_type {};
 template <typename T>
 inline constexpr bool is_key_type_v = is_key_type<T>::value;
 
+class NativeVariantStorage {
+public:
+    using VariantStorageConfig = std::variant<std::monostate, s3::S3Settings>;
+    explicit NativeVariantStorage(VariantStorageConfig config = std::monostate()) : config_(std::move(config)) {};
+    const VariantStorageConfig& variant() const {
+        return config_;
+    }
+    void update(const s3::S3Settings& config) {
+        config_ = config;
+    }
+private:
+    VariantStorageConfig config_;
+};
 }  //namespace arcticdb::storage
-

--- a/cpp/arcticdb/storage/config_resolvers.hpp
+++ b/cpp/arcticdb/storage/config_resolvers.hpp
@@ -27,7 +27,6 @@ class ConfigResolver {
     virtual void add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) = 0;
     virtual void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) = 0;
     virtual void initialize_environment(const EnvironmentName& environment_name) = 0;
-    virtual std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(const EnvironmentName& environment_name) const = 0;
     virtual std::string_view resolver_type() const = 0;
 };
 
@@ -62,9 +61,6 @@ class InMemoryConfigResolver final : public ConfigResolver {
 
     void add_library(const EnvironmentName& environment_name, const arcticdb::proto::storage::LibraryDescriptor& library_descriptor) override;
     void add_storage(const EnvironmentName& environment_name, const StorageName& storage_name, const arcticdb::proto::storage::VariantStorage& storage) override;
-    std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>> get_default_storages(const EnvironmentName&) const override {
-        return std::vector<std::pair<StorageName, arcticdb::proto::storage::VariantStorage>>();
-    }
 
     void initialize_environment(const EnvironmentName&) override { }
     std::string_view resolver_type()  const override { return "in_mem"; }

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -177,6 +177,7 @@ class Library {
     bool storage_fallthrough_ = false;
 };
 
+// for testing only
 inline std::shared_ptr<Library> create_library(const LibraryPath& library_path, OpenMode mode, const std::vector<arcticdb::proto::storage::VariantStorage>& storage_configs) {
     return std::make_shared<Library>(library_path, create_storages(library_path, mode, storage_configs));
 }

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -56,7 +56,8 @@ namespace arcticdb::storage {
         [[nodiscard]] std::shared_ptr<Library> get_library(
                 const LibraryPath& path,
                 const StorageOverride& storage_override,
-                bool ignore_cache);
+                bool ignore_cache,
+                const NativeVariantStorage& native_storage_config);
 
         void cleanup_library_if_open(const LibraryPath& path);
 

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -18,6 +18,8 @@
 #include <arcticdb/storage/library_index.hpp>
 #include <arcticdb/storage/config_resolvers.hpp>
 #include <arcticdb/storage/constants.hpp>
+#include <arcticdb/storage/s3/s3_storage.hpp>
+#include <arcticdb/storage/s3/s3_settings.hpp>
 
 namespace py = pybind11;
 
@@ -93,6 +95,56 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
     py::register_exception<UnsupportedLibraryOptionValue>(storage, "UnsupportedLibraryOptionValue", base_exception.ptr());
 
     storage.def("create_library_index", &create_library_index);
+
+    
+    py::enum_<s3::AWSAuthMethod>(storage, "AWSAuthMethod")
+        .value("DISABLED", s3::AWSAuthMethod::DISABLED)
+        .value("DEFAULT_CREDENTIALS_PROVIDER_CHAIN", s3::AWSAuthMethod::DEFAULT_CREDENTIALS_PROVIDER_CHAIN)
+        .value("STS_PROFILE_CREDENTIALS_PROVIDER", s3::AWSAuthMethod::STS_PROFILE_CREDENTIALS_PROVIDER);
+
+    enum class S3SettingsPickleOrder : uint32_t {
+        AWS_AUTH = 0,
+        AWS_PROFILE = 1
+    };
+
+    py::class_<s3::S3Settings>(storage, "S3Settings")
+        .def(py::init<s3::AWSAuthMethod, const std::string&>())
+        .def(py::pickle(
+            [](const s3::S3Settings &settings) {
+                return py::make_tuple(settings.aws_auth(), settings.aws_profile());
+            },
+            [](py::tuple t) {
+                util::check(t.size() == 2, "Invalid S3Settings pickle objects");
+                s3::S3Settings settings(t[static_cast<uint32_t>(S3SettingsPickleOrder::AWS_AUTH)].cast<s3::AWSAuthMethod>(), t[static_cast<uint32_t>(S3SettingsPickleOrder::AWS_PROFILE)].cast<std::string>());
+                return settings;
+            }
+        ))
+        .def_property_readonly("aws_profile", [](const s3::S3Settings &settings) { return settings.aws_profile(); })
+        .def_property_readonly("aws_auth", [](const s3::S3Settings &settings) { return settings.aws_auth(); });
+
+    py::class_<NativeVariantStorage>(storage, "NativeVariantStorage")
+        .def(py::init<>())
+        .def(py::init<NativeVariantStorage::VariantStorageConfig>())
+        .def(py::pickle(
+            [](const NativeVariantStorage &settings) {
+                return util::variant_match(settings.variant(),
+                    [] (const s3::S3Settings& settings) {
+                        return py::make_tuple(settings.aws_auth(), settings.aws_profile());
+                    },
+                    [](const auto &) {
+                        util::raise_rte("Invalid native storage setting type");
+                        return py::make_tuple();
+                    }
+                );
+            },
+            [](py::tuple t) {
+                util::check(t.size() == 2, "Invalid S3Settings pickle objects");
+                s3::S3Settings settings(t[static_cast<uint32_t>(S3SettingsPickleOrder::AWS_AUTH)].cast<s3::AWSAuthMethod>(), t[static_cast<uint32_t>(S3SettingsPickleOrder::AWS_PROFILE)].cast<std::string>());
+                return NativeVariantStorage(std::move(settings));
+            }
+        ))
+        .def("update", &NativeVariantStorage::update);
+    py::implicitly_convertible<NativeVariantStorage::VariantStorageConfig, NativeVariantStorage>();
 
     storage.def("create_mem_config_resolver", [](const py::object & env_config_map_py) -> std::shared_ptr<ConfigResolver> {
         arcticdb::proto::storage::EnvironmentConfigsMap ecm;
@@ -192,12 +244,14 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
         .def("get_library", [](
                 LibraryManager& library_manager, std::string_view library_path,
                 const StorageOverride& storage_override,
-                const bool ignore_cache) {
-            return library_manager.get_library(LibraryPath{library_path, '.'}, storage_override, ignore_cache);
+                const bool ignore_cache,
+                const NativeVariantStorage& native_storage_config) {
+            return library_manager.get_library(LibraryPath{library_path, '.'}, storage_override, ignore_cache, native_storage_config);
         },
              py::arg("library_path"),
              py::arg("storage_override") = StorageOverride{},
-             py::arg("ignore_cache") = false
+             py::arg("ignore_cache") = false,
+             py::arg("native_storage_map") = std::nullopt
         )
         .def("cleanup_library_if_open", [](LibraryManager& library_manager, std::string_view library_path) {
             return library_manager.cleanup_library_if_open(LibraryPath{library_path, '.'});
@@ -228,10 +282,10 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
                 res.emplace_back(lp.to_delim_path());
             }
             return res;
-        } )
-        .def("get_library", [](LibraryIndex &library_index, const std::string &library_path, OpenMode open_mode = OpenMode::DELETE) {
+        })
+        .def("get_library", [](LibraryIndex &library_index, const std::string &library_path, OpenMode open_mode = OpenMode::DELETE, const NativeVariantStorage& native_storage_config = NativeVariantStorage()) {
             LibraryPath path = LibraryPath::from_delim_path(library_path);
-            return library_index.get_library(path, open_mode, UserAuth{});
+            return library_index.get_library(path, open_mode, UserAuth{}, native_storage_config);
         })
         ;
 }

--- a/cpp/arcticdb/storage/s3/s3_settings.hpp
+++ b/cpp/arcticdb/storage/s3/s3_settings.hpp
@@ -1,0 +1,142 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <string>
+#include <arcticdb/entity/protobufs.hpp>
+
+namespace arcticdb::storage::s3 {
+
+enum class AWSAuthMethod : uint32_t {
+    DISABLED = 0,
+    DEFAULT_CREDENTIALS_PROVIDER_CHAIN = 1,
+    STS_PROFILE_CREDENTIALS_PROVIDER = 2
+};
+
+class S3Settings {
+private:
+    std::string bucket_name_;
+    std::string credential_name_;
+    std::string credential_key_;
+    std::string endpoint_;
+    uint32_t max_connections_;
+    uint32_t connect_timeout_;
+    uint32_t request_timeout_;
+    bool ssl_;
+    std::string prefix_;
+    bool https_;
+    std::string region_;
+    bool use_virtual_addressing_;
+    bool use_mock_storage_for_testing_;
+    std::string ca_cert_path_;
+    std::string ca_cert_dir_;
+    bool use_raw_prefix_;
+    AWSAuthMethod aws_auth_;
+    std::string aws_profile_;
+
+public:
+    explicit S3Settings(AWSAuthMethod aws_auth, const std::string& aws_profile) :
+        aws_auth_(aws_auth),
+        aws_profile_(aws_profile) {
+    }
+    explicit S3Settings(const arcticc::pb2::s3_storage_pb2::Config& config) {
+        update(config);
+    }
+    S3Settings update(const arcticc::pb2::s3_storage_pb2::Config& config){
+        bucket_name_ = config.bucket_name();
+        credential_name_ = config.credential_name();
+        credential_key_ = config.credential_key();
+        endpoint_ = config.endpoint();
+        max_connections_ = config.max_connections();
+        connect_timeout_ = config.connect_timeout();
+        request_timeout_ = config.request_timeout();
+        ssl_ = config.ssl();
+        prefix_ = config.prefix();
+        https_ = config.https();
+        region_ = config.region();
+        use_virtual_addressing_ = config.use_virtual_addressing();
+        use_mock_storage_for_testing_ = config.use_mock_storage_for_testing();
+        ca_cert_path_ = config.ca_cert_path();
+        ca_cert_dir_ = config.ca_cert_dir();
+        use_raw_prefix_ = config.use_raw_prefix();
+        return *this;
+    }
+
+    std::string bucket_name() const {
+        return bucket_name_;
+    }
+
+    std::string credential_name() const {
+        return credential_name_;
+    }
+
+    std::string credential_key() const {
+        return credential_key_;
+    }
+
+    std::string endpoint() const {
+        return endpoint_;
+    }
+
+    uint32_t max_connections() const {
+        return max_connections_;
+    }
+
+    uint32_t connect_timeout() const {
+        return connect_timeout_;
+    }
+
+    uint32_t request_timeout() const {
+        return request_timeout_;
+    }
+
+    bool ssl() const {
+        return ssl_;
+    }
+
+    std::string prefix() const {
+        return prefix_;
+    }
+
+    bool https() const {
+        return https_;
+    }
+
+    std::string region() const {
+        return region_;
+    }
+
+    bool use_virtual_addressing() const {
+        return use_virtual_addressing_;
+    }
+
+    bool use_mock_storage_for_testing() const {
+        return use_mock_storage_for_testing_;
+    }
+
+    std::string ca_cert_path() const {
+        return ca_cert_path_;
+    }
+
+    std::string ca_cert_dir() const {
+        return ca_cert_dir_;
+    }
+
+    AWSAuthMethod aws_auth() const {
+        return aws_auth_;
+    }
+
+    std::string aws_profile() const {
+        return aws_profile_;
+    }
+
+    bool use_raw_prefix() const {
+        return use_raw_prefix_;
+    }
+};
+}

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -9,6 +9,8 @@
 
 #include <locale>
 
+#include <aws/identity-management/auth/STSProfileCredentialsProvider.h>
+
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/s3/s3_api.hpp>
 #include <arcticdb/util/buffer_pool.hpp>
@@ -80,18 +82,26 @@ bool S3Storage::do_key_exists(const VariantKey& key) {
 
 namespace arcticdb::storage::s3 {
 
-S3Storage::S3Storage(const LibraryPath &library_path, OpenMode mode, const Config &conf) :
+S3Storage::S3Storage(const LibraryPath &library_path, OpenMode mode, const S3Settings &conf) :
     Storage(library_path, mode),
     s3_api_(S3ApiInstance::instance()),  // make sure we have an initialized AWS SDK
     root_folder_(object_store_utils::get_root_folder(library_path)),
     bucket_name_(conf.bucket_name()),
     region_(conf.region()) {
-
     auto creds = get_aws_credentials(conf);
 
     if (conf.use_mock_storage_for_testing()){
         ARCTICDB_RUNTIME_DEBUG(log::storage(), "Using Mock S3 storage");
         s3_client_ = std::make_unique<MockS3Client>();
+    }
+    else if (conf.aws_auth() == AWSAuthMethod::STS_PROFILE_CREDENTIALS_PROVIDER){
+        Aws::Config::ReloadCachedConfigFile(); // config files loaded in Aws::InitAPI; It runs once at first S3Storage object construct; reload to get latest
+        auto cred_provider = Aws::MakeShared<Aws::Auth::STSProfileCredentialsProvider>(
+                                "DefaultAWSCredentialsProviderChain", 
+                                conf.aws_profile(), 
+                                std::chrono::minutes(static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.STSTokenExpiryMin", 60)))
+                            );
+        s3_client_ = std::make_unique<RealS3Client>(cred_provider, get_s3_config(conf), Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, conf.use_virtual_addressing());
     }
     else if (creds.GetAWSAccessKeyId() == USE_AWS_CRED_PROVIDERS_TOKEN && creds.GetAWSSecretKey() == USE_AWS_CRED_PROVIDERS_TOKEN){
         ARCTICDB_RUNTIME_DEBUG(log::storage(), "Using AWS auth mechanisms");

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -15,6 +15,7 @@
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/s3/s3_api.hpp>
 #include <arcticdb/storage/s3/s3_client_wrapper.hpp>
+#include <arcticdb/storage/s3/s3_settings.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/composite.hpp>
@@ -30,9 +31,8 @@ const std::string USE_AWS_CRED_PROVIDERS_TOKEN = "_RBAC_";
 
 class S3Storage final : public Storage {
   public:
-    using Config = arcticdb::proto::s3_storage::Config;
 
-    S3Storage(const LibraryPath &lib, OpenMode mode, const Config &conf);
+    S3Storage(const LibraryPath &lib, OpenMode mode, const S3Settings &conf);
 
     /**
      * Full object path in S3 bucket.

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -16,6 +16,13 @@
 #include <arcticdb/util/pb_util.hpp>
 
 namespace arcticdb::storage {
+    
+std::shared_ptr<Storage> create_storage(
+    const LibraryPath &library_path,
+    OpenMode mode,
+    const s3::S3Settings& storage_config) {
+    return std::make_shared<s3::S3Storage>(library_path, mode, storage_config);
+}
 
 std::shared_ptr<Storage> create_storage(
     const LibraryPath &library_path,
@@ -25,10 +32,10 @@ std::shared_ptr<Storage> create_storage(
     std::shared_ptr<Storage> storage;
     auto type_name = util::get_arcticdb_pb_type_name(storage_descriptor.config());
 
-    if (type_name == s3::S3Storage::Config::descriptor()->full_name()) {
-        s3::S3Storage::Config s3_config;
+    if (type_name == arcticc::pb2::s3_storage_pb2::Config::descriptor()->full_name()) {
+        arcticc::pb2::s3_storage_pb2::Config s3_config;
         storage_descriptor.config().UnpackTo(&s3_config);
-        storage = std::make_shared<s3::S3Storage>(library_path, mode, s3_config);
+        storage = std::make_shared<s3::S3Storage>(library_path, mode, s3::S3Settings(s3_config));
     } else if (type_name == lmdb::LmdbStorage::Config::descriptor()->full_name()) {
         lmdb::LmdbStorage::Config lmbd_config;
         storage_descriptor.config().UnpackTo(&lmbd_config);

--- a/cpp/arcticdb/storage/storage_factory.hpp
+++ b/cpp/arcticdb/storage/storage_factory.hpp
@@ -15,7 +15,10 @@
 
 namespace arcticdb {
     namespace storage {
-
+        std::shared_ptr<Storage> create_storage(
+                const LibraryPath &library_path,
+                OpenMode mode,
+                const s3::S3Settings& storage_descriptor);
         std::shared_ptr<Storage> create_storage(
                 const LibraryPath& library_path,
                 OpenMode mode,

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -174,10 +174,21 @@ class Storages {
     OpenMode mode_;
 };
 
-inline std::shared_ptr<Storages> create_storages(const LibraryPath& library_path, OpenMode mode, const arcticdb::proto::storage::VariantStorage &storage_config) {
+inline std::shared_ptr<Storages> create_storages(const LibraryPath& library_path, OpenMode mode, const decltype(std::declval<arcticc::pb2::storage_pb2::LibraryConfig>().storage_by_id())& storage_configs, const NativeVariantStorage& native_storage_config) {
     Storages::StorageVector storages;
-    storages.push_back(create_storage(library_path, mode, storage_config));
-
+    for (const auto& [storage_id, storage_config]: storage_configs) {
+        util::variant_match(native_storage_config.variant(),
+            [&storage_config, &storages, &library_path, mode] (const s3::S3Settings& settings) {
+                util::check(storage_config.config().Is<arcticdb::proto::s3_storage::Config>(), "Only support S3 native settings");
+                arcticdb::proto::s3_storage::Config s3_storage;
+                storage_config.config().UnpackTo(&s3_storage);
+                storages.push_back(create_storage(library_path, mode, s3::S3Settings(settings).update(s3_storage)));
+            },
+            [&storage_config, &storages, &library_path, mode](const auto &) {
+                storages.push_back(create_storage(library_path, mode, storage_config));
+            }
+        );
+    }
     return std::make_shared<Storages>(std::move(storages), mode);
 }
 

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -140,7 +140,7 @@ TEST(TestS3Storage, proxy_env_var_parsing) {
 }
 
 TEST_F(ProxyEnvVarSetHttpProxyForHttpsEndpointFixture, test_config_resolution_proxy) {
-    arcticdb::storage::s3::S3Storage::Config s3_config;
+    arcticdb::proto::s3_storage::Config s3_config;
     s3_config.set_endpoint("https://test.endpoint.com");
     s3_config.set_https(true);
     auto ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config);
@@ -150,14 +150,14 @@ TEST_F(ProxyEnvVarSetHttpProxyForHttpsEndpointFixture, test_config_resolution_pr
 }
 
 TEST_F(ProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
-    arcticdb::storage::s3::S3Storage::Config s3_config_http;
+    arcticdb::proto::s3_storage::Config s3_config_http;
     s3_config_http.set_endpoint("http://test.endpoint.com");
     auto ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config_http);
     ASSERT_EQ(ret_cfg.proxyHost, "http-proxy-2.com");
     ASSERT_EQ(ret_cfg.proxyPort, 2222);
     ASSERT_EQ(ret_cfg.proxyScheme, Aws::Http::Scheme::HTTP);
 
-    arcticdb::storage::s3::S3Storage::Config s3_config_https;
+    arcticdb::proto::s3_storage::Config s3_config_https;
     s3_config_https.set_endpoint("https://test.endpoint.com");
     s3_config_https.set_https(true);
     ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config_https);
@@ -168,14 +168,14 @@ TEST_F(ProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
 
 TEST_F(ProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy) {
     SKIP_WIN("Env vars are not case-sensitive on Windows");
-    arcticdb::storage::s3::S3Storage::Config s3_config_http;
+    arcticdb::proto::s3_storage::Config s3_config_http;
     s3_config_http.set_endpoint("http://test.endpoint.com");
     auto ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config_http);
     ASSERT_EQ(ret_cfg.proxyHost, "http-proxy-1.com");
     ASSERT_EQ(ret_cfg.proxyPort, 2222);
     ASSERT_EQ(ret_cfg.proxyScheme, Aws::Http::Scheme::HTTP);
 
-    arcticdb::storage::s3::S3Storage::Config s3_config_https;
+    arcticdb::proto::s3_storage::Config s3_config_https;
     s3_config_https.set_endpoint("https://test.endpoint.com");
     s3_config_https.set_https(true);
     ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config_https);
@@ -185,7 +185,7 @@ TEST_F(ProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy) {
 }
 
 TEST_F(NoProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
-    arcticdb::storage::s3::S3Storage::Config s3_config;
+    arcticdb::proto::s3_storage::Config s3_config;
     s3_config.set_endpoint("http://test.endpoint.com");
     auto ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config);
 
@@ -196,7 +196,7 @@ TEST_F(NoProxyEnvVarUpperCaseFixture, test_config_resolution_proxy) {
 
 TEST_F(NoProxyEnvVarLowerCasePrecedenceFixture, test_config_resolution_proxy) {
     SKIP_WIN("Env vars are not case-sensitive on Windows");
-    arcticdb::storage::s3::S3Storage::Config s3_config;
+    arcticdb::proto::s3_storage::Config s3_config;
     s3_config.set_endpoint("http://test.endpoint.com");
     auto ret_cfg = arcticdb::storage::s3::get_s3_config(s3_config);
 
@@ -219,7 +219,7 @@ proto::s3_storage::Config get_test_s3_config(){
 class S3StorageFixture : public testing::Test {
 protected:
     S3StorageFixture():
-        store(LibraryPath("lib", '.'), OpenMode::DELETE, get_test_s3_config())
+        store(LibraryPath("lib", '.'), OpenMode::DELETE, S3Settings(get_test_s3_config()))
     {}
 
     S3Storage store;

--- a/cpp/arcticdb/storage/test/test_storage_exceptions.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_exceptions.cpp
@@ -95,7 +95,7 @@ public:
         cfg.set_use_mock_storage_for_testing(true);
         arcticdb::storage::LibraryPath library_path("lib", '.');
 
-        return std::make_unique<arcticdb::storage::s3::S3Storage>(library_path, arcticdb::storage::OpenMode::DELETE, cfg);
+        return std::make_unique<arcticdb::storage::s3::S3Storage>(library_path, arcticdb::storage::OpenMode::DELETE, arcticdb::storage::s3::S3Settings(cfg));
     }
 };
 

--- a/cpp/arcticdb/storage/test/test_storage_factory.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_factory.cpp
@@ -66,7 +66,7 @@ TEST(TestStorageFactory, LibraryIndex) {
     std::vector<ac::storage::LibraryPath> expected{l};
     ASSERT_EQ(expected, library_index.list_libraries("a"));
     as::UserAuth au{"abc"};
-    auto lib = library_index.get_library(l, as::OpenMode::WRITE, au);
+    auto lib = library_index.get_library(l, as::OpenMode::WRITE, au, as::NativeVariantStorage());
     ASSERT_EQ(l, lib->library_path());
     ASSERT_EQ(as::OpenMode::WRITE, lib->open_mode());
 }

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -313,13 +313,13 @@ inline std::pair<storage::LibraryPath, arcticdb::proto::storage::LibraryConfig> 
 }
 
 inline std::shared_ptr<storage::Library> test_library_from_config(const storage::LibraryPath& lib_path,  const arcticdb::proto::storage::LibraryConfig& lib_cfg) {
-    auto storage_cfg = lib_cfg.storage_by_id().at(lib_cfg.lib_desc().storage_ids(0));
+    auto storage_cfg = lib_cfg.storage_by_id();
     auto vs_cfg = lib_cfg.lib_desc().has_version()
             ? storage::LibraryDescriptor::VariantStoreConfig{lib_cfg.lib_desc().version()}
             : std::monostate{};
     return std::make_shared<storage::Library>(
             lib_path,
-            storage::create_storages(lib_path, storage::OpenMode::DELETE, storage_cfg),
+            storage::create_storages(lib_path, storage::OpenMode::DELETE, storage_cfg, storage::NativeVariantStorage()),
             std::move(vs_cfg)
             );
 

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -362,7 +362,7 @@ inline SegmentInMemory get_sparse_timeseries_segment_floats(const std::string& n
 inline auto get_test_config_data() {
     using namespace arcticdb::storage;
     LibraryPath path{"test", "store"};
-    auto storages = create_storages(path, OpenMode::DELETE, memory::pack_config());
+    auto storages = create_storages(path, OpenMode::DELETE, {memory::pack_config()});
     return std::make_tuple(path, std::move(storages));
 }
 

--- a/cpp/arcticdb/util/test/test_utils.hpp
+++ b/cpp/arcticdb/util/test/test_utils.hpp
@@ -198,7 +198,7 @@ class StorageGenerator {
     } else if (storage_ == "s3") {
       arcticdb::proto::s3_storage::Config cfg;
       cfg.set_use_mock_storage_for_testing(true);
-      return std::make_unique<storage::s3::S3Storage>(library_path, storage::OpenMode::WRITE, cfg);
+      return std::make_unique<storage::s3::S3Storage>(library_path, storage::OpenMode::WRITE, storage::s3::S3Settings(cfg));
     } else if (storage_ == "mongo") {
       arcticdb::proto::mongo_storage::Config cfg;
       cfg.set_use_mock_storage_for_testing(true);

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -39,7 +39,7 @@
       "name": "aws-sdk-cpp",
       "$version reason": "Minimum version in the baseline that works with aws-c-io above.",
       "default-features": false,
-      "features": [ "s3" ]
+      "features": [ "s3", "identity-management" ]
     },
     "boost-dynamic-bitset",
     "boost-interprocess",

--- a/docs/mkdocs/docs/api/arctic_uri.md
+++ b/docs/mkdocs/docs/api/arctic_uri.md
@@ -22,10 +22,12 @@ Available options for S3:
 | access                | S3 access key                                                                                                                                                   |
 | secret                | S3 secret access key                                                                                                                                            |
 | path_prefix           | Path within S3 bucket to use for data storage                                                                                                                   |
-| aws_auth              | If true, authentication to endpoint will be computed via AWS environment vars/config files. If no options are provided `aws_auth` will be assumed to be true.   |
+| aws_auth              | AWS authentication method. If setting is `default` (or `true` for backward compatibility), authentication to endpoint will be computed via [AWS default credential provider chain](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/credproviders.html). If setting is `sts`, AWS Security Token Service (STS) will be the authentication method used. If no options are provided AWS authentication will not be used and you should specify access and secret in the URI. More info is provided below |
+| aws_profile           | Only when `aws_auth` is set to be `sts`. AWS profile to be used with AWS Security Token Service (STS). More info is provided below |
 
 Note: When connecting to AWS, `region` can be automatically deduced from the endpoint if the given endpoint
 specifies the region and `region` is not set.
+
 
 ## Azure
 

--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -9,7 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 from abc import ABC, abstractmethod
 from typing import Iterable, List
 
-from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
+from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig, LibraryDescriptor
 from arcticdb.config import _DEFAULT_ENV
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.options import DEFAULT_ENCODING_VERSION, LibraryOptions, EnterpriseLibraryOptions
@@ -49,7 +49,7 @@ def set_library_options(lib_desc: "LibraryConfig", options: LibraryOptions,
 class ArcticLibraryAdapter(ABC):
     @abstractmethod
     def __init__(self, uri: str, encoding_version: EncodingVersion):
-        pass
+        self._native_cfg = None
 
     @abstractmethod
     def __repr__(self):
@@ -80,7 +80,7 @@ class ArcticLibraryAdapter(ABC):
         return NativeVersionStore.create_library_config(
             env_cfg, _DEFAULT_ENV, name, encoding_version=library_options.encoding_version
         )
-
+    
     @abstractmethod
     def add_library_to_env(self, env_cfg: EnvironmentConfigsMap, name: str):
         raise NotImplementedError

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -12,12 +12,12 @@ import ssl
 import platform
 
 from arcticdb.options import LibraryOptions
-from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryConfig
+from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap, LibraryDescriptor
 from arcticdb.version_store.helper import add_s3_library_to_env
 from arcticdb.config import _DEFAULT_ENV
 from arcticdb.version_store._store import NativeVersionStore
-from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter, set_library_options
-from arcticdb_ext.storage import StorageOverride, S3Override, CONFIG_LIBRARY_NAME
+from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter
+from arcticdb_ext.storage import StorageOverride, S3Override, CONFIG_LIBRARY_NAME, AWSAuthMethod, NativeVariantStorage, S3Settings as NativeS3Settings
 from arcticdb.encoding_version import EncodingVersion
 from collections import namedtuple
 from dataclasses import dataclass, fields
@@ -27,8 +27,8 @@ USE_AWS_CRED_PROVIDERS_TOKEN = "_RBAC_"
 
 
 def strtobool(value: str) -> bool:
-  value = value.lower()
-  return value in ("y", "yes", "on", "1", "true", "t")
+    value = value.lower()
+    return value in ("y", "yes", "on", "1", "true", "t")
 
 
 @dataclass
@@ -40,7 +40,8 @@ class ParsedQuery:
 
     access: Optional[str] = None
     secret: Optional[str] = None
-    aws_auth: Optional[bool] = False
+    aws_auth: Optional[AWSAuthMethod] = AWSAuthMethod.DISABLED
+    aws_profile: Optional[str] = None
 
     path_prefix: Optional[str] = None
 
@@ -49,8 +50,8 @@ class ParsedQuery:
 
     # winhttp is used as s3 backend support on Windows by default; winhttp itself maintains ca cert.
     # The options has no effect on Windows
-    CA_cert_path: Optional[str] = "" # CURLOPT_CAINFO in curl
-    CA_cert_dir: Optional[str] = "" # CURLOPT_CAPATH in curl
+    CA_cert_path: Optional[str] = ""  # CURLOPT_CAINFO in curl
+    CA_cert_dir: Optional[str] = ""  # CURLOPT_CAPATH in curl
 
     ssl: Optional[bool] = False
 
@@ -83,8 +84,10 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         self._https = uri.startswith("s3s")
         self._encoding_version = encoding_version
         if platform.system() != "Linux" and (self._query_params.CA_cert_path or self._query_params.CA_cert_dir):
-            raise ValueError("You have provided `ca_cert_path` or `ca_cert_dir` in the URI which is only supported on Linux. " \
-                             "Remove the setting in the connection URI and use your operating system defaults.")
+            raise ValueError(
+                "You have provided `ca_cert_path` or `ca_cert_dir` in the URI which is only supported on Linux. "
+                "Remove the setting in the connection URI and use your operating system defaults."
+            )
         self._ca_cert_path = self._query_params.CA_cert_path
         self._ca_cert_dir = self._query_params.CA_cert_dir
         if not self._ca_cert_path and not self._ca_cert_dir and platform.system() == "Linux":
@@ -99,6 +102,8 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             self._configure_aws()
 
         super().__init__(uri, self._encoding_version)
+        
+        self._native_cfg = NativeVariantStorage(NativeS3Settings(AWSAuthMethod.DISABLED, ""))
 
     def __repr__(self):
         return "S3(endpoint=%s, bucket=%s)" % (self._endpoint, self._bucket)
@@ -106,8 +111,16 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
     @property
     def config_library(self):
         env_cfg = EnvironmentConfigsMap()
-        _name = self._query_params.access if not self._query_params.aws_auth else USE_AWS_CRED_PROVIDERS_TOKEN
-        _key = self._query_params.secret if not self._query_params.aws_auth else USE_AWS_CRED_PROVIDERS_TOKEN
+        _name = (
+            self._query_params.access
+            if self._query_params.aws_auth == AWSAuthMethod.DISABLED
+            else USE_AWS_CRED_PROVIDERS_TOKEN
+        )
+        _key = (
+            self._query_params.secret
+            if self._query_params.aws_auth == AWSAuthMethod.DISABLED
+            else USE_AWS_CRED_PROVIDERS_TOKEN
+        )
         with_prefix = (
             f"{self._query_params.path_prefix}/{CONFIG_LIBRARY_NAME}" if self._query_params.path_prefix else False
         )
@@ -127,10 +140,13 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             ca_cert_path=self._ca_cert_path,
             ca_cert_dir=self._ca_cert_dir,
             ssl=self._ssl,
+            aws_auth=self._query_params.aws_auth,
+            aws_profile=self._query_params.aws_profile,
+            native_cfg=self._native_cfg,
         )
 
         lib = NativeVersionStore.create_store_from_config(
-            env_cfg, _DEFAULT_ENV, CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version
+            (env_cfg, self._native_cfg), _DEFAULT_ENV, CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version
         )
 
         return lib._library
@@ -139,7 +155,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         if query and query.startswith("?"):
             query = query.strip("?")
         elif not query:
-            return ParsedQuery(aws_auth=True)
+            return ParsedQuery(aws_auth="default")
 
         parsed_query = re.split("[;&]", query)
         parsed_query = {t.split("=", 1)[0]: t.split("=", 1)[1] for t in parsed_query}
@@ -159,6 +175,14 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
 
             if field_dict[key].type == Optional[bool] and field_dict[key] is not None:
                 parsed_query[key] = bool(strtobool(parsed_query[key][0]))
+            if field_dict[key].type == Optional[AWSAuthMethod]:
+                value = parsed_query[key]
+                if strtobool(value) or value.lower() == "default":
+                    parsed_query[key] = AWSAuthMethod.DEFAULT_CREDENTIALS_PROVIDER_CHAIN
+                elif value.lower() == "sts":
+                    parsed_query[key] = AWSAuthMethod.STS_PROFILE_CREDENTIALS_PROVIDER
+                else:
+                    parsed_query[key] = AWSAuthMethod.DISABLED
 
         if parsed_query.get("path_prefix"):
             parsed_query["path_prefix"] = parsed_query["path_prefix"].strip("/")
@@ -170,7 +194,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         s3_override = S3Override()
         # storage_override will overwrite access and key while reading config from storage
         # access and secret whether equals to _RBAC_ are used for determining aws_auth is true on C++ layer
-        if self._query_params.aws_auth:
+        if self._query_params.aws_auth == AWSAuthMethod.DEFAULT_CREDENTIALS_PROVIDER_CHAIN:
             s3_override.credential_name = USE_AWS_CRED_PROVIDERS_TOKEN
             s3_override.credential_key = USE_AWS_CRED_PROVIDERS_TOKEN
         else:
@@ -207,8 +231,16 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         return storage_override
 
     def add_library_to_env(self, env_cfg: EnvironmentConfigsMap, name: str):
-        _name = self._query_params.access if not self._query_params.aws_auth else USE_AWS_CRED_PROVIDERS_TOKEN
-        _key = self._query_params.secret if not self._query_params.aws_auth else USE_AWS_CRED_PROVIDERS_TOKEN
+        _name = (
+            self._query_params.access
+            if self._query_params.aws_auth == AWSAuthMethod.DISABLED
+            else USE_AWS_CRED_PROVIDERS_TOKEN
+        )
+        _key = (
+            self._query_params.secret
+            if self._query_params.aws_auth == AWSAuthMethod.DISABLED
+            else USE_AWS_CRED_PROVIDERS_TOKEN
+        )
 
         if self._query_params.path_prefix:
             # add time to prefix - so that the s3 root folder is unique and we can delete and recreate fast
@@ -231,6 +263,9 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             ca_cert_path=self._ca_cert_path,
             ca_cert_dir=self._ca_cert_dir,
             ssl=self._ssl,
+            aws_auth=self._query_params.aws_auth,
+            aws_profile=self._query_params.aws_profile,
+            native_cfg=self._native_cfg,
         )
 
     def _configure_aws(self):

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -96,7 +96,7 @@ class Arctic:
 
         storage_override = self._library_adapter.get_storage_override()
         lib = NativeVersionStore(
-            self._library_manager.get_library(lib_mgr_name, storage_override),
+            self._library_manager.get_library(lib_mgr_name, storage_override, native_storage_map=self._library_adapter._native_cfg),
             repr(self._library_adapter),
             lib_cfg=self._library_manager.get_library_config(lib_mgr_name, storage_override),
         )
@@ -317,7 +317,7 @@ class Arctic:
         storage_override = self._library_adapter.get_storage_override()
         new_cfg = self._library_manager.get_library_config(lib_mgr_name, storage_override)
         library._nvs._initialize(
-            self._library_manager.get_library(lib_mgr_name, storage_override, ignore_cache=True),
+            self._library_manager.get_library(lib_mgr_name, storage_override, ignore_cache=True, native_storage_map=self._library_adapter._native_cfg),
             library._nvs.env,
             new_cfg,
             library._nvs._custom_normalizer,

--- a/python/arcticdb/scripts/update_storage.py
+++ b/python/arcticdb/scripts/update_storage.py
@@ -19,7 +19,7 @@ def repair_library_if_necessary(ac, lib_name: str, run: bool) -> bool:
     """Returns True if library required repair."""
     storage_override = ac._library_adapter.get_storage_override()
     lib = NativeVersionStore(
-        ac._library_manager.get_library(lib_name, storage_override),
+        ac._library_manager.get_library(lib_name, storage_override, native_storage_map=ac._library_adapter._native_cfg),
         repr(ac._library_adapter),
         lib_cfg=ac._library_manager.get_library_config(lib_name, storage_override),
     )

--- a/python/arcticdb/storage_fixtures/api.py
+++ b/python/arcticdb/storage_fixtures/api.py
@@ -31,6 +31,8 @@ class ArcticUriFields(Enum):
     CA_PATH = "CA_PATH"
     PATH_PREFIX = "PATH_PREFIX"
     SSL = "SSL"
+    AWS_AUTH = "AWS_AUTH"
+    AWS_PROFILE = "AWS_PROFILE"
 
     def __str__(self):
         return self.value
@@ -87,12 +89,13 @@ class StorageFixture(_SaferContextManager):
         if name == "_unique_":
             name = name + str(len(libs_from_factory))
         assert (name not in libs_from_factory) or reuse_name, f"{name} is already in use"
-        cfg = create_cfg(name)
-        lib = cfg.env_by_id[Defaults.ENV].lib_by_path[name]
+        cfgs = create_cfg(name)
+        protobuf_cfg, native_cfg = NativeVersionStore.get_environment_cfg_and_native_cfg_from_tuple(cfgs)
+        lib = protobuf_cfg.env_by_id[Defaults.ENV].lib_by_path[name]
         # Use symbol list by default (can still be overridden by kwargs)
         lib.version.symbol_list = True
         apply_lib_cfg(lib, kwargs)
-        out = ArcticMemoryConfig(cfg, Defaults.ENV)[name]
+        out = ArcticMemoryConfig(protobuf_cfg, Defaults.ENV, native_cfg)[name]
         suffix = 0
         while f"{name}{suffix or ''}" in libs_from_factory:
             suffix += 1

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -12,27 +12,38 @@ import json
 import os
 import re
 import sys
-import trustme
-import subprocess
 import platform
 from tempfile import mkdtemp
+import boto3
+import time
 
 
 import requests
-from typing import NamedTuple, Optional, Any, Type
+from typing import Optional, Any, Type
 
 from .api import *
 from .utils import get_ephemeral_port, GracefulProcessUtils, wait_for_server_to_come_up, safer_rmtree, get_ca_cert_for_testing
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
 from arcticdb.version_store.helper import add_s3_library_to_env
+from arcticdb_ext.storage import AWSAuthMethod, NativeVariantStorage
+
 
 # All storage client libraries to be imported on-demand to speed up start-up of ad-hoc test runs
 
-Key = NamedTuple("Key", [("id", str), ("secret", str), ("user_name", str)])
 _PermissionCapableFactory: Type["MotoS3StorageFixtureFactory"] = None  # To be set later
 
 logging.getLogger("botocore").setLevel(logging.INFO)
+logger = logging.getLogger("S3 Storage Fixture")
 
+S3_CONFIG_PATH = os.path.expanduser(os.path.join("~", ".aws", "config"))
+S3_BACKUP_CONFIG_PATH = os.path.expanduser(os.path.join("~", ".aws", "bk_config"))
+
+
+class Key:
+    def __init__(self, *, id: str, secret: str, user_name: str):
+        self.id = id
+        self.secret = secret
+        self.user_name = user_name
 
 class S3Bucket(StorageFixture):
     _FIELD_REGEX = {
@@ -43,15 +54,22 @@ class S3Bucket(StorageFixture):
         ArcticUriFields.PATH_PREFIX: re.compile("[?&](path_prefix=)([^&]+)(&?)"),
         ArcticUriFields.CA_PATH: re.compile("[?&](CA_cert_path=)([^&]*)(&?)"),
         ArcticUriFields.SSL: re.compile("[?&](ssl=)([^&]+)(&?)"),
+        ArcticUriFields.AWS_AUTH: re.compile("[?&](aws_auth=)([^&]+)(&?)"),
+        ArcticUriFields.AWS_PROFILE: re.compile("[?&](aws_profile=)([^&]+)(&?)"),
     }
 
     key: Key
     _boto_bucket: Any = None
 
-    def __init__(self, factory: "BaseS3StorageFixtureFactory", bucket: str):
+    def __init__(self, 
+                 factory: "BaseS3StorageFixtureFactory", 
+                 bucket: str, 
+                 native_config: Optional[NativeVariantStorage] = None
+                 ):
         super().__init__()
         self.factory = factory
         self.bucket = bucket
+        self.native_config = native_config
 
         if isinstance(factory, _PermissionCapableFactory) and factory.enforcing_permissions:
             self.key = factory._create_user_get_key(bucket + "_user")
@@ -59,7 +77,16 @@ class S3Bucket(StorageFixture):
             self.key = factory.default_key
 
         secure, host, port = re.match(r"(?:http(s?)://)?([^:/]+)(?::(\d+))?", factory.endpoint).groups()
-        self.arctic_uri = f"s3{secure or ''}://{host}:{self.bucket}?access={self.key.id}&secret={self.key.secret}"
+        self.arctic_uri = f"s3{secure or ''}://{host}:{self.bucket}?"
+        
+        if factory.aws_auth == None or factory.aws_auth == AWSAuthMethod.DISABLED:
+            self.arctic_uri += f"access={self.key.id}&secret={self.key.secret}"
+        elif factory.aws_auth == AWSAuthMethod.STS_PROFILE_CREDENTIALS_PROVIDER:
+            assert factory.aws_profile is not None
+            self.arctic_uri += "aws_auth=sts"
+            self.arctic_uri += f"&aws_profile={factory.aws_profile}"
+        else:
+            self.arctic_uri += "aws_auth=default"
         if port:
             self.arctic_uri += f"&port={port}"
         if factory.default_prefix:
@@ -98,8 +125,11 @@ class S3Bucket(StorageFixture):
             ca_cert_path=self.factory.client_cert_file,
             is_nfs_layout=False,
             use_raw_prefix=self.factory.use_raw_prefix,
+            aws_auth=self.factory.aws_auth,
+            aws_profile=self.factory.aws_profile,
+            native_cfg=self.native_config,
         )# client_cert_dir is skipped on purpose; It will be tested manually in other tests
-        return cfg
+        return cfg, self.native_config
 
     def set_permission(self, *, read: bool, write: bool):
         factory = self.factory
@@ -154,7 +184,9 @@ class NfsS3Bucket(S3Bucket):
             ssl=self.factory.ssl,
             ca_cert_path=self.factory.client_cert_file,
             is_nfs_layout=True,
-            use_raw_prefix=self.factory.use_raw_prefix
+            use_raw_prefix=self.factory.use_raw_prefix,
+            aws_auth=self.factory.aws_auth,
+            aws_profile=self.factory.aws_profile,
         )# client_cert_dir is skipped on purpose; It will be tested manually in other tests
         return cfg
 
@@ -171,17 +203,22 @@ class BaseS3StorageFixtureFactory(StorageFixtureFactory):
     clean_bucket_on_fixture_exit = True
     use_mock_storage_for_testing = None  # If set to true allows error simulation
 
-    def __init__(self):
+    def __init__(self, native_config: Optional[dict] = None):
         self.client_cert_file = None
         self.client_cert_dir = None
         self.ssl = False
+        self.aws_auth = None
+        self.aws_profile = None
+        self.aws_policy_name = None
+        self.aws_role = None
+        self.aws_role_arn = None
+        self.sts_test_key = None
+        self.native_config = native_config
 
     def __str__(self):
         return f"{type(self).__name__}[{self.default_bucket or self.endpoint}]"
 
     def _boto(self, service: str, key: Key, api="client"):
-        import boto3
-
         ctor = getattr(boto3, api)
         return ctor(
             service_name=service,
@@ -193,28 +230,259 @@ class BaseS3StorageFixtureFactory(StorageFixtureFactory):
         )  # verify=False cannot skip verification on buggy boto3 in py3.6
 
     def create_fixture(self) -> S3Bucket:
-        return S3Bucket(self, self.default_bucket)
+        return S3Bucket(self, self.default_bucket, self.native_config)
 
     def cleanup_bucket(self, b: S3Bucket):
         # When dealing with a potentially shared bucket, we only clear our the libs we know about:
         b.slow_cleanup(failure_consequence="We will be charged unless we manually delete it. ")
 
 
-def real_s3_from_environment_variables(*, shared_path: bool):
-    out = BaseS3StorageFixtureFactory()
+def real_s3_from_environment_variables(shared_path: bool, native_config: Optional[NativeVariantStorage] = None, additional_suffix: str = ""):
+    out = BaseS3StorageFixtureFactory(native_config=native_config)
     out.endpoint = os.getenv("ARCTICDB_REAL_S3_ENDPOINT")
     out.region = os.getenv("ARCTICDB_REAL_S3_REGION")
     out.default_bucket = os.getenv("ARCTICDB_REAL_S3_BUCKET")
     access_key = os.getenv("ARCTICDB_REAL_S3_ACCESS_KEY")
     secret_key = os.getenv("ARCTICDB_REAL_S3_SECRET_KEY")
-    out.default_key = Key(access_key, secret_key, "unknown user")
+    out.default_key = Key(id=access_key, secret=secret_key, user_name="unknown user")
     out.clean_bucket_on_fixture_exit = os.getenv("ARCTICDB_REAL_S3_CLEAR").lower() in ["true", "1"]
     out.ssl = out.endpoint.startswith("https://")
     if shared_path:
         out.default_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX")
     else:
-        out.default_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX")
+        out.default_prefix = os.getenv('ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX', "") + additional_suffix
     return out
+
+
+def real_s3_sts_from_environment_variables(user_name: str, role_name: str, policy_name: str, profile_name: str, native_config: NativeVariantStorage, additional_suffix: str):
+    out = real_s3_from_environment_variables(False, native_config, additional_suffix)
+    iam_client = boto3.client("iam", aws_access_key_id=out.default_key.id, aws_secret_access_key=out.default_key.secret)
+    # Create IAM user
+    try:
+        iam_client.create_user(UserName=user_name)
+        out.sts_test_key = Key(id=None, secret=None, user_name=user_name)
+        logger.info("User created successfully.")
+    except iam_client.exceptions.EntityAlreadyExistsException:
+        logger.warn("User already exists.")
+    except Exception as e:
+        logger.error(f"Error creating user: {e}")
+        raise e
+
+    account_id = boto3.client("sts", aws_access_key_id=out.default_key.id, aws_secret_access_key=out.default_key.secret).get_caller_identity().get("Account")
+    # Create IAM role
+    assume_role_policy_document = {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com",
+                "AWS": account_id
+            },
+            "Action": "sts:AssumeRole"
+        }
+        ]
+    }
+
+    try:
+        role_response = iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(assume_role_policy_document)
+        )
+        out.aws_role_arn = role_response["Role"]["Arn"]
+        out.aws_role = role_name
+        logger.info("Role created successfully.")
+    except iam_client.exceptions.EntityAlreadyExistsException:
+        out.aws_role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"
+        logger.warn("Role already exists.")
+    except Exception as e:
+        logger.error(f"Error creating role: {e}")
+        raise e
+
+    # Create a policy for S3 bucket access
+    s3_access_policy_document = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["s3:ListBucket"],
+                "Resource": [f"arn:aws:s3:::{out.default_bucket}"]
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListObject"],
+                "Resource": [f"arn:aws:s3:::{out.default_bucket}/*"]
+            }
+        ]
+    }
+
+    try:
+        policy_response = iam_client.create_policy(
+            PolicyName=policy_name,
+            PolicyDocument=json.dumps(s3_access_policy_document)
+        )
+        out.aws_policy_name = policy_response["Policy"]["Arn"]
+        logger.info("Policy created successfully.")
+    except iam_client.exceptions.EntityAlreadyExistsException:
+        out.aws_policy_name = f"arn:aws:iam::{account_id}:policy/{policy_name}"
+        logger.warn("Policy already exists.")
+    except Exception as e:
+        logger.error(f"Error creating policy: {e}")
+        raise e
+
+    # Attach the policy to the role
+    try:
+        iam_client.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn=out.aws_policy_name
+        )
+        logger.info("Policy attached to role successfully.")
+    except Exception as e:
+        logger.error(f"Error attaching policy to role: {e}")
+        raise e
+
+    # Create an inline policy for the user to assume the role
+    assume_role_user_policy_document = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Resource": f"arn:aws:iam::{account_id}:role/{role_name}",
+            }
+        ]
+    }
+
+    try:
+        iam_client.put_user_policy(
+            UserName=user_name,
+            PolicyName="AssumeRolePolicy",
+            PolicyDocument=json.dumps(assume_role_user_policy_document)
+        )
+        logger.info("Inline policy to assume role attached to user successfully.")
+    except Exception as e:
+        logger.error(f"Error attaching inline policy to user: {e}")
+        raise e
+
+    logger.info("User created with role to access bucket.")
+
+    try:
+        access_key_response = iam_client.create_access_key(UserName=user_name)
+        out.sts_test_key.id = access_key_response["AccessKey"]["AccessKeyId"]
+        out.sts_test_key.secret = access_key_response["AccessKey"]["SecretAccessKey"]
+        logger.info("Access key created successfully.")
+    except Exception as e:
+        logger.error(f"Error creating access key: {e}")
+        raise e
+    
+    out.aws_auth = AWSAuthMethod.STS_PROFILE_CREDENTIALS_PROVIDER
+    out.aws_profile = profile_name
+    real_s3_sts_write_local_credentials(out)
+    return out
+
+
+def real_s3_sts_write_local_credentials(factory: BaseS3StorageFixtureFactory):
+    base_profile_name = factory.aws_profile + "_base"
+    aws_credentials = f"""
+[profile {factory.aws_profile}]
+role_arn = {factory.aws_role_arn}
+source_profile = {base_profile_name}
+
+[profile {base_profile_name}]
+aws_access_key_id = {factory.sts_test_key.id}
+aws_secret_access_key = {factory.sts_test_key.secret}
+"""
+    aws_dir = os.path.dirname(S3_CONFIG_PATH)
+    if not os.path.exists(aws_dir):
+        os.makedirs(aws_dir)
+
+    if os.path.exists(S3_CONFIG_PATH):
+        os.rename(S3_CONFIG_PATH, S3_BACKUP_CONFIG_PATH)
+
+    with open(S3_CONFIG_PATH, "w") as config_file:
+        config_file.write(aws_credentials)
+
+
+def real_s3_sts_resources_ready(factory: BaseS3StorageFixtureFactory): 
+    sts_client = boto3.client(
+        "sts",
+        aws_access_key_id=factory.sts_test_key.id,
+        aws_secret_access_key=factory.sts_test_key.secret
+    )
+    for _ in range(20):
+        try:
+            assumed_role = sts_client.assume_role(
+                RoleArn=factory.aws_role_arn,
+                RoleSessionName="TestSession"
+            )
+            logger.info("Boto3 assume role successful.")
+            s3_client = boto3.client(
+                "s3",
+                aws_access_key_id=assumed_role['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assumed_role['Credentials']['SecretAccessKey'],
+                aws_session_token=assumed_role['Credentials']['SessionToken']
+            )
+            response = s3_client.list_objects_v2(Bucket=factory.default_bucket)
+            logger.info(f"S3 list objects test successful: {response['ResponseMetadata']['HTTPStatusCode']}")
+            return
+        except:
+            logger.warn(f"Assume role failed. Retrying in 1 second...") # Don't print the exception as it could contain sensitive information, e.g. user id
+            time.sleep(1)
+
+    raise Exception("iam resources not ready")
+
+
+def real_s3_sts_clean_up(role_name: str, policy_name: str, user_name: str):
+    iam_client = boto3.client("iam", aws_access_key_id=os.getenv("ARCTICDB_REAL_S3_ACCESS_KEY"), aws_secret_access_key=os.getenv("ARCTICDB_REAL_S3_SECRET_KEY"))
+    logger.info("Starting cleanup process...")
+    try:
+        for policy in iam_client.list_attached_role_policies(RoleName=role_name)["AttachedPolicies"]:
+            iam_client.detach_role_policy(
+                RoleName=role_name,
+                PolicyArn=policy["PolicyArn"]
+            )
+            iam_client.delete_policy(
+                PolicyArn=policy["PolicyArn"]
+            )
+        logger.info("Policy deleted successfully.")
+    except Exception:
+        logger.error("Error deleting policy")
+
+    try:
+        iam_client.delete_role(
+            RoleName=role_name
+        )
+        logger.info("Role deleted successfully.")
+    except Exception:
+        logger.error("Error deleting role") # Role could be non-existent as creation of it may fail
+
+    
+    try:
+        for key in iam_client.list_access_keys(UserName=user_name)["AccessKeyMetadata"]:
+            iam_client.delete_access_key(
+                UserName=user_name,
+                AccessKeyId=key["AccessKeyId"]
+            )
+        logger.info("Access key deleted successfully.")
+    except Exception:
+        logger.error("Error deleting access key id")
+
+    try:
+        for policy_name in iam_client.list_user_policies(UserName=user_name)["PolicyNames"]:
+            iam_client.delete_user_policy(UserName=user_name, PolicyName=policy_name)
+        logger.info("Detached and deleted inline policy from user")
+
+        # Delete the user
+        iam_client.delete_user(
+            UserName=user_name
+        )
+        logger.info("User deleted successfully.")
+    except Exception:
+        logger.error("Error deleting user") # User could be non-existent as creation of it may fail
+
+        
+    if os.path.exists(S3_CONFIG_PATH) and os.path.exists(S3_BACKUP_CONFIG_PATH):
+        os.remove(S3_CONFIG_PATH)
+        os.rename(S3_BACKUP_CONFIG_PATH, S3_CONFIG_PATH)
 
 
 def mock_s3_with_error_simulation():
@@ -226,14 +494,14 @@ def mock_s3_with_error_simulation():
     out = BaseS3StorageFixtureFactory()
     out.use_mock_storage_for_testing = True
     # We set some values which don't matter since we're using the mock storage
-    out.default_key = Key("access key", "secret key", "unknown user")
+    out.default_key = Key(id="access key", secret="secret key", user_name="unknown user")
     out.endpoint = "http://test"
     out.region = "us-east-1"
     return out
 
 
 class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
-    default_key = Key("awd", "awd", "dummy")
+    default_key = Key(id="awd", secret="awd", user_name="dummy")
     _RO_POLICY: str
     _RW_POLICY: str
     host = "localhost"
@@ -253,7 +521,9 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
                  ssl_test_support: bool,
                  bucket_versioning: bool,
                  default_prefix: str = None,
-                 use_raw_prefix: bool = False):
+                 use_raw_prefix: bool = False,
+                 native_config: Optional[NativeVariantStorage] = None):
+        super().__init__(native_config)
         self.http_protocol = "https" if use_ssl else "http"
         self.ssl_test_support = ssl_test_support
         self.bucket_versioning = bucket_versioning
@@ -370,7 +640,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         iam = iam or self._iam_admin
         user_id = iam.create_user(UserName=user)["User"]["UserId"]
         response = iam.create_access_key(UserName=user)["AccessKey"]
-        return Key(response["AccessKeyId"], response["SecretAccessKey"], user)
+        return Key(id=response["AccessKeyId"], secret=response["SecretAccessKey"], username=user)
 
     @property
     def enforcing_permissions(self):
@@ -417,7 +687,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
                 }
             )
 
-        out = S3Bucket(self, bucket)
+        out = S3Bucket(self, bucket, self.native_config)
         self._live_buckets.append(out)
         return out
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -29,12 +29,12 @@ from arcticdb.preconditions import check
 from arcticdb.supported_types import DateRangeInput, ExplicitlySupportedDates
 from arcticdb.toolbox.library_tool import LibraryTool
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.storage import OpenMode as _OpenMode
 from arcticdb.encoding_version import EncodingVersion
 from arcticdb_ext.storage import (
     create_mem_config_resolver as _create_mem_config_resolver,
     LibraryIndex as _LibraryIndex,
     Library as _Library,
+    OpenMode as _OpenMode,
 )
 from arcticdb_ext.types import IndexKind
 from arcticdb.version_store.read_result import ReadResult
@@ -222,11 +222,11 @@ class NativeVersionStore:
     norm_failure_options_msg_append = "Data must be normalizable to be appended to existing data."
     norm_failure_options_msg_update = "Data must be normalizable to be used to update existing data."
 
-    def __init__(self, library, env, lib_cfg=None, open_mode=OpenMode.DELETE):
+    def __init__(self, library, env, lib_cfg=None, open_mode=OpenMode.DELETE, native_cfg=None):
         # type: (_Library, Optional[str], Optional[LibraryConfig], OpenMode)->None
         fail_on_missing = library.config.fail_on_missing_custom_normalizer if library.config is not None else False
         custom_normalizer = get_custom_normalizer(fail_on_missing)
-        self._initialize(library, env, lib_cfg, custom_normalizer, open_mode)
+        self._initialize(library, env, lib_cfg, custom_normalizer, open_mode, native_cfg)
 
     def _init_norm_failure_handler(self):
         # init normalization failure handler
@@ -245,7 +245,7 @@ class NativeVersionStore:
         else:
             raise ArcticDbNotYetImplemented("No other normalization failure handler")
 
-    def _initialize(self, library, env, lib_cfg, custom_normalizer, open_mode):
+    def _initialize(self, library, env, lib_cfg, custom_normalizer, open_mode, native_cfg=None):
         self._library = library
         self._cfg = library.config
         self.version_store = _PythonVersionStore(self._library)
@@ -254,11 +254,14 @@ class NativeVersionStore:
         self._custom_normalizer = custom_normalizer
         self._init_norm_failure_handler()
         self._open_mode = open_mode
+        self._native_cfg = native_cfg
+
 
     @classmethod
     def create_store_from_lib_config(cls, lib_cfg, env, open_mode=OpenMode.DELETE):
         lib = cls.create_lib_from_lib_config(lib_cfg, env, open_mode)
         return cls(library=lib, lib_cfg=lib_cfg, env=env, open_mode=open_mode)
+    
 
     @staticmethod
     def create_library_config(cfg, env, lib_name, encoding_version=EncodingVersion.V1):
@@ -272,22 +275,33 @@ class NativeVersionStore:
     def create_store_from_config(
         cls, cfg, env, lib_name, open_mode=OpenMode.DELETE, encoding_version=EncodingVersion.V1
     ):
-        lib_cfg = NativeVersionStore.create_library_config(cfg, env, lib_name, encoding_version=encoding_version)
-        lib = cls.create_lib_from_lib_config(lib_cfg, env, open_mode)
-        return cls(library=lib, lib_cfg=lib_cfg, env=env, open_mode=open_mode)
+        protobuf_cfg, native_cfg = NativeVersionStore.get_environment_cfg_and_native_cfg_from_tuple(cfg)
+        lib_cfg = NativeVersionStore.create_library_config(protobuf_cfg, env, lib_name, encoding_version=encoding_version)
+        lib = cls.create_lib_from_config((protobuf_cfg, native_cfg), env, lib_cfg.lib_desc.name, open_mode)
+        return cls(library=lib, lib_cfg=lib_cfg, env=env, open_mode=open_mode, native_cfg=native_cfg)
 
     @staticmethod
-    def create_lib_from_lib_config(lib_cfg, env, open_mode):
+    def create_lib_from_lib_config(lib_cfg, env, open_mode, native_cfg=None):
         envs_cfg = _env_config_from_lib_config(lib_cfg, env)
         cfg_resolver = _create_mem_config_resolver(envs_cfg)
         lib_idx = _LibraryIndex.create_from_resolver(env, cfg_resolver)
-        return lib_idx.get_library(lib_cfg.lib_desc.name, _OpenMode(open_mode))
+        return lib_idx.get_library(lib_cfg.lib_desc.name, _OpenMode(open_mode), native_cfg)
 
     @staticmethod
-    def create_lib_from_config(cfg, env, lib_name):
-        cfg_resolver = _create_mem_config_resolver(cfg)
+    def create_lib_from_config(cfg, env, lib_name, open_mode=OpenMode.DELETE):
+        protobuf_cfg, native_cfg = NativeVersionStore.get_environment_cfg_and_native_cfg_from_tuple(cfg)
+        cfg_resolver = _create_mem_config_resolver(protobuf_cfg)
         lib_idx = _LibraryIndex.create_from_resolver(env, cfg_resolver)
-        return lib_idx.get_library(lib_name, _OpenMode(OpenMode.DELETE))
+        return lib_idx.get_library(lib_name, _OpenMode(open_mode), native_cfg)
+
+
+    @staticmethod
+    def get_environment_cfg_and_native_cfg_from_tuple(cfgs):
+        if isinstance(cfgs, tuple):
+            return cfgs
+        else:
+            return cfgs, None
+        
 
     def __setstate__(self, state):
         lib_cfg = LibraryConfig()
@@ -296,12 +310,14 @@ class NativeVersionStore:
         custom_norm.__setstate__(state["custom_norm"])
         env = state["env"]
         open_mode = state["open_mode"]
+        native_cfg = state["native_cfg"]
         self._initialize(
-            library=NativeVersionStore.create_lib_from_lib_config(lib_cfg, env, open_mode),
+            library=NativeVersionStore.create_lib_from_lib_config(lib_cfg, env, open_mode, native_cfg),
             env=env,
             lib_cfg=lib_cfg,
             custom_normalizer=custom_norm,
             open_mode=open_mode,
+            native_cfg=native_cfg,
         )
 
     def __getstate__(self):
@@ -310,6 +326,7 @@ class NativeVersionStore:
             "lib_cfg": self._lib_cfg.SerializeToString(),
             "custom_norm": self._custom_normalizer.__getstate__() if self._custom_normalizer is not None else "",
             "open_mode": self._open_mode,
+            "native_cfg": self._native_cfg,
         }
 
     def __repr__(self):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -106,6 +106,30 @@ def test_s3_no_ssl_verification(monkeypatch, s3_no_ssl_storage, client_cert_file
     lib.write("sym", pd.DataFrame())
 
 
+@REAL_S3_TESTS_MARK
+def test_s3_sts_auth(real_s3_sts_storage):
+    ac = Arctic(real_s3_sts_storage.arctic_uri)
+    lib = ac.create_library("test")
+    df = pd.DataFrame({'a': [1, 2, 3]})
+    lib.write("sym", df)
+    assert_frame_equal(lib.read("sym").data, df)
+    lib = ac.get_library("test")
+    assert_frame_equal(lib.read("sym").data, df)
+
+    # Reload for testing a different codepath
+    ac = Arctic(real_s3_sts_storage.arctic_uri)
+    lib = ac.get_library("test")
+    assert_frame_equal(lib.read("sym").data, df)
+
+
+@REAL_S3_TESTS_MARK
+def test_s3_sts_auth_store(real_s3_sts_version_store):
+    lib = real_s3_sts_version_store
+    df = pd.DataFrame({'a': [1, 2, 3]})
+    lib.write("sym", df)
+    assert_frame_equal(lib.read("sym").data, df)
+
+
 @AZURE_TESTS_MARK
 @pytest.mark.parametrize('client_cert_file', no_ssl_parameter_display_status)
 @pytest.mark.parametrize('client_cert_dir', no_ssl_parameter_display_status)

--- a/python/tests/scripts/test_update_storage.py
+++ b/python/tests/scripts/test_update_storage.py
@@ -59,7 +59,8 @@ def test_upgrade_script_s3(s3_storage: S3Bucket):
     assert storage_config.credential_key == ""
 
 
-def test_upgrade_script_s3_rbac_ok(s3_storage: S3Bucket, monkeypatch):
+@pytest.mark.parametrize("default_credential_provider", ["1", "true"]) # true for testing backwards compatibility
+def test_upgrade_script_s3_rbac_ok(s3_storage: S3Bucket, monkeypatch, default_credential_provider):
     """Just _RBAC_ as creds is a placeholder. Leave config with that alone."""
     if os.name == "nt":
         if sys.version_info < (3, 9):
@@ -74,7 +75,7 @@ def test_upgrade_script_s3_rbac_ok(s3_storage: S3Bucket, monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", s3_storage.key.id)
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", s3_storage.key.secret)
 
-    uri = s3_storage.replace_uri_field(s3_storage.arctic_uri, ArcticUriFields.USER, "aws_auth=true", start=1)
+    uri = s3_storage.replace_uri_field(s3_storage.arctic_uri, ArcticUriFields.USER, f"aws_auth={default_credential_provider}", start=1)
     uri = s3_storage.replace_uri_field(uri, ArcticUriFields.PASSWORD, "", start=1, end=3)
     s3_storage.arctic_uri = uri
 


### PR DESCRIPTION
Copy of https://github.com/man-group/ArcticDB/pull/1814 so @poodlewars can review

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://github.com/man-group/ArcticDB/issues/1883

#### What does this implement or fix?
Add support of AWS STS authentication
Partially introduce static storage map along with the above

#### Any other comments?
STS is an AWS iam service which allows user account to gain access of resources by assuming role. 
First, the SDK will send assume role request to iam. If the authentication is successful, iam will reply with a temporary access key. With that access key, SDK will now have access to the resources. 
The above logic and the refresh of temporary access key are handled by the SDK.
P.S. the validity check of the temporary access key is made at the beginning of each IO only,

Maintainers of S3 C++ SDK has [refused](https://github.com/aws/aws-sdk-cpp/issues/150) to align this authentication method with other SDKs (e.g. boto3), which create 2 problems:
1. Role to be assumed is needed to specifed in the API but the role_arn, access key and id are needed to be specifed in the shared config file
2. The method is not added to the default credential provider chain. Although the SDK allows us to supply a customized chain with the STS authentication method, it has led to two drawbacks, which force me to switch to a dedicated option to switch on STS authentication:
* SDK will not auto refresh temporary credential. ArcticDB would be required to add a tedious key expiry detection and refresh logic
* Extra maintainece is required as the chain will need stay align with the default one to align the user experience with previous user experience

Detailed setup of the STS method can be referred to the content of this PR.
The test added in this PR requires real S3. Temporary user, policy and role are created for the test in the pipeline. 

The final caveat is seems the **config** file is loaded at the import of ArcticDB and not being refreshed at the entire lifecycle of the python interpreter. This has required a hack in the testing framework to always create the config file at the beginning of any tests. As it's real S3 test specific, it won't create any pain for day-to-day local development and general PR tests.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
