### PR TITLE
Fix the timers macro, configure it with a cmake option

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -25,6 +25,7 @@ option(
 option(ARCTICDB_USING_ADDRESS_SANITIZER "Enable address sanitizer." OFF)
 option(ARCTICDB_USING_THREAD_SANITIZER "Enable thread sanitizer." OFF)
 option(ARCTICDB_USING_UB_SANITIZER "Enable undefined behavior sanitizer." OFF)
+option(ARCTICDB_LOG_PERFORMANCE "Whether to log performance timings." OFF)
 
 set(ARCTICDB_SANITIZER_FLAGS)
 if(${ARCTICDB_USING_ADDRESS_SANITIZER})
@@ -40,6 +41,10 @@ endif()
 if(${ARCTICDB_USING_UB_SANITIZER})
     list(APPEND ARCTICDB_SANITIZER_FLAGS "-fsanitize=undefined")
     message(STATUS "Building ArcticDB with UB Sanitizer")
+endif()
+
+if(${ARCTICDB_LOG_PERFORMANCE})
+    add_compile_definitions(ARCTICDB_LOG_PERFORMANCE)
 endif()
 
 if(ARCTICDB_SANITIZER_FLAGS)

--- a/cpp/arcticdb/entity/performance_tracing.hpp
+++ b/cpp/arcticdb/entity/performance_tracing.hpp
@@ -88,22 +88,22 @@ void set_remotery_thread_name(const char* task_name);
 
 #elif defined(ARCTICDB_LOG_PERFORMANCE)
 #define ARCTICDB_SAMPLE(name, flags) \
-arcticdb::ScopedTimer timer{#name, [](auto msg) { \
+arcticdb::ScopedTimer _timer{#name, [](auto msg) { \
     std::cout << msg; \
 }};
 
 #define ARCTICDB_SUBSAMPLE(name, flags) \
-arcticdb::ScopedTimer sub_timer_##name{#name, [](auto msg) { \
+arcticdb::ScopedTimer _sub_timer_##name{#name, [](auto msg) { \
 std::cout << msg; \
 }};
 
 #define ARCTICDB_SAMPLE_DEFAULT(name) \
-arcticdb::ScopedTimer default_timer{#name, [](auto msg) { \
+arcticdb::ScopedTimer _default_timer{#name, [](auto msg) { \
 std::cout << msg; \
 }};
 
 #define ARCTICDB_SUBSAMPLE_DEFAULT(name) \
-arcticdb::ScopedTimer sub_timer_##name{#name, [](auto msg) { \
+arcticdb::ScopedTimer _sub_timer_##name{#name, [](auto msg) { \
 std::cout << msg; \
 }};
 


### PR DESCRIPTION
The build failed with the timers enabled as new variables have been introduced in the normal code with names like `timer` that clash once the timer macros are compiled in.
