### PR TITLE
Make python 3.10 default for persistence storage test

### DIFF
--- a/.github/workflows/persistent_storage.yml
+++ b/.github/workflows/persistent_storage.yml
@@ -5,7 +5,7 @@ on:
       job_type:          {required: true, type: string, description: Selects the steps to enable}
       matrix:            {type: string, description: JSON string to feed into the matrix}
       python_deps_ids:   {default: '[""]', type: string, description: Follower test matrix parameter. JSON string.}
-      python3:           {default: -1, type: number, description: Python 3 minor version}
+      python3:           {default: 10, type: number, description: Python 3 minor version}
       arcticdb_version:  {default: "", type: string, description: The version of ArcticDB that will be installed and used for seed/verify }
       # TODO: Maybe we should add these as GitHub variables
       bucket:            {default: 'arcticdb-ci-test-bucket-02', type: string, description: The name of the S3 bucket that we will test against}
@@ -33,22 +33,17 @@ jobs:
             - ${{fromJSON(inputs.matrix)[0]}} # The items after 0 are for tests only
     runs-on: ${{matrix.distro}}
     env:
-      python_impl_name: ${{inputs.python3 > 0 && format('cp3{0}', inputs.python3) || 'default'}}
+      python_impl_name: ${{format('cp3{0}', inputs.python3)}}
     defaults:
       run: {shell: bash}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
 
-      - name: Select Python (Linux)
-        if: matrix.os == 'linux'
-        run: echo /opt/python/${{env.python_impl_name}}*/bin >> $GITHUB_PATH
-
-      - name: Select Python (Windows)
-        if: matrix.os == 'windows'
+      - name: Select Python
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: "3.${{inputs.python3}}"
+          python-version: ${{format('3.{0}', inputs.python3)}}
 
       - name: Install latest release
         if: inputs.arcticdb_version == 'latest'
@@ -91,8 +86,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.3.0
 
-      - name: Select Python (Linux)
-        run: echo /opt/python/${{env.python_impl_name}}*/bin >> $GITHUB_PATH
+      - name: Select Python
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: ${{inputs.python3 > 0 && format('3.{0}', inputs.python3) || '3.10'}}
+
 
       - name: Install latest release
         run: |


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
python 3.12 has been made to be the default python for github ubuntu runner. We don't support it yet so we need to make python 3.10 to be the default python used in persistent storage test.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
