### PR TITLE
Fix mono CI issue

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   get_commits_to_benchmark:
     name: Get tag commits  
-    runs-on: ubuntu-latest  
+    runs-on: ubuntu-22.04
     steps:  
       - name: Checkout code 
         uses: actions/checkout@v3.3.0
@@ -55,7 +55,7 @@ jobs:
     name: Publish benchmark results to gh-pages
     if: github.ref == 'refs/heads/master'
     needs: [benchmark_commits]  
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
 
@@ -89,7 +89,7 @@ jobs:
 
   code_coverage:
     needs: [cibw_docker_image]  
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     container:
         image: ${{needs.cibw_docker_image.outputs.tag}}
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
   common_config:
     needs: [cibw_docker_image]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -41,7 +41,7 @@ jobs:
           # Please declare any key you added below in build_steps.yaml's dummy matrix as well to aid the linting tools
           - linux_matrix:
               - os: linux
-                distro: ubuntu-latest
+                distro: ubuntu-22.04
                 cmake_preset_prefix: linux
                 cibw_build_suffix: manylinux_x86_64
                 build_dir: /tmp/cpp_build
@@ -275,7 +275,7 @@ jobs:
       always() &&
       !failure() &&
       !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: echo Dummy job to simplify PR merge checks configuration
       # FUTURE: add some test stats/reporting

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -16,7 +16,7 @@ jobs:
     if: |
       always() &&
       !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     services:

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -8,7 +8,7 @@ on:
       
 jobs:
   docs_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: TestPypi
     permissions:
       contents: write

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -5,7 +5,7 @@ on:
       environment: { type: environment, required: true }
 jobs:
   docs_publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{inputs.environment}}
     steps:
       - name: Checkout

--- a/.github/workflows/ec2_runner_jobs.yml
+++ b/.github/workflows/ec2_runner_jobs.yml
@@ -18,7 +18,7 @@ jobs:
   start-runner:
     if: inputs.job_type == 'start'
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: true
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -44,7 +44,7 @@ jobs:
   stop-runner:
     name: Stop self-hosted EC2 runner
     if: inputs.job_type == 'stop'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/persistent_storage.yml
+++ b/.github/workflows/persistent_storage.yml
@@ -84,7 +84,7 @@ jobs:
         
   cleanup:
     if: inputs.job_type == 'cleanup'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run: {shell: bash}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   # GitHub Composite Actions cannot access secrets and Reusable Workflows cannot return artifacts, so duplicate for now:
   release_notes:
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       SYMBOLS_ARTIFACT: /tmp/symbols.tar.zst # Use absolute path to workaround a bug in action-gh-release
     steps:
@@ -92,7 +92,7 @@ jobs:
 
   pypi:
     environment: ${{inputs.environment}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Gather wheels from run ${{inputs.run_id}}
         if: inputs.run_id > 0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ run-name: Tagging ${{github.ref_name}} as v${{inputs.version}}${{inputs.overwrit
 jobs:
   tag:
     environment: TestPypi  # Enforcing deployment branches permissions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
         checks: read
         contents: write


### PR DESCRIPTION
There have been some mono issues with ubuntu-latest, so we reverted to
ubuntu-22.04 for now.

The cibw-docker-image workflow was not updated because updating it
causes the rebuilt of the manylinux docker image which fails because of
CentOS 7 being EOL.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
