### PR TITLE
Skip lmdb compat tests for versions <= 4.5.0

### DIFF
--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -11,6 +11,7 @@ from ..util.mark import (
     MONGO_TESTS_MARK,
     VENV_COMPAT_TESTS_MARK,
 )
+from packaging.version import Version
 
 logger = logging.getLogger("Compatibility tests")
 
@@ -173,9 +174,10 @@ def arctic_uri(request):
 
 @pytest.fixture()
 def old_venv_and_arctic_uri(old_venv, arctic_uri):
-    if old_venv.version == "1.6.2" and arctic_uri.startswith("mongo"):
-        pytest.skip("Mongo storage backend is not supported on 1.6.2")
-    if old_venv.version == "4.5.0" and arctic_uri.startswith("mongo"):
-        # TODO: Replace 4.5.0 with 4.5.1 when it is released and re-enable mongo.
-        pytest.skip("Mongo storage backend has a desctruction bug present in 4.5.0, which can cause flaky segfaults.")
+    # TODO: Replace 4.5.0 with 4.5.1 when it is released to re-enable both mongo and lmdb.
+    if Version(old_venv.version) <= Version("4.5.0") and arctic_uri.startswith("mongo"):
+        pytest.skip("Mongo storage backend has a desctruction bug present until 4.5.0, which can cause flaky segfaults.")
+    if Version(old_venv.version) <= Version("4.5.0") and arctic_uri.startswith("lmdb"):
+        pytest.skip("LMDB storage backend has a desctruction bug present until 4.5.0, which can cause flaky segfaults.")
+
     return old_venv, arctic_uri


### PR DESCRIPTION
All versions up to 4.5.0 have segfaults in lmdb destructor. We skip lmdb backend compatibility tests for these versions to avoid flaky tests.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
