### PR TITLE
Use relative paths for compat tests

### DIFF
--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -146,7 +146,9 @@ class VenvLib:
 def old_venv(request):
     version = request.param
     path = os.path.join("venvs", version)
-    requirements_file = os.path.abspath(os.path.join("tests", "compat", f"requirements-{version}.txt"))
+    # The requirements_file needs to be relative to the [path] we use for the venv.
+    # Absolute paths break some Azure CI runners on conda forge
+    requirements_file = os.path.join("..", "..", "tests", "compat", f"requirements-{version}.txt")
     with Venv(path, requirements_file, version) as old_venv:
         yield old_venv
 


### PR DESCRIPTION
The absolute paths were breaking some Azure conda-forge runners because abspath was prefixing the path with `$SRC_DIR` which did not get expanded on linux.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
