### PR TITLE
Make library manager an LRU cache

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -344,6 +344,7 @@ set(arcticdb_srcs
         util/spinlock.hpp
         util/key_utils.hpp
         util/lock_table.hpp
+        util/lru_cache.hpp
         util/magic_num.hpp
         util/movable_priority_queue.hpp
         util/movable_priority_queue.hpp
@@ -508,7 +509,7 @@ set(arcticdb_srcs
         version/symbol_list.cpp
         version/version_map_batch_methods.cpp
         storage/s3/ec2_utils.cpp
-        util/buffer_holder.cpp)
+        util/buffer_holder.cpp util/test/rapidcheck_lru_cache.cpp)
 
 add_library(arcticdb_core_object OBJECT ${arcticdb_srcs})
 
@@ -954,7 +955,7 @@ if(${TEST})
             python/python_handlers.cpp
             storage/test/common.hpp
             version/test/test_sort_index.cpp
-    )
+            util/test/rapidcheck_lru_cache.cpp)
 
     set(EXECUTABLE_PERMS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE) # 755
 
@@ -1061,7 +1062,7 @@ if(${TEST})
             util/test/rapidcheck_string_pool.cpp
             util/test/rapidcheck_main.cpp
             version/test/rapidcheck_version_map.cpp
-    )
+            util/test/rapidcheck_lru_cache.cpp)
 
     add_executable(arcticdb_rapidcheck_tests ${rapidcheck_srcs})
     install(TARGETS arcticdb_rapidcheck_tests RUNTIME

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -509,7 +509,7 @@ set(arcticdb_srcs
         version/symbol_list.cpp
         version/version_map_batch_methods.cpp
         storage/s3/ec2_utils.cpp
-        util/buffer_holder.cpp util/test/rapidcheck_lru_cache.cpp)
+        util/buffer_holder.cpp)
 
 add_library(arcticdb_core_object OBJECT ${arcticdb_srcs})
 
@@ -954,8 +954,7 @@ if(${TEST})
             version/test/version_map_model.hpp
             python/python_handlers.cpp
             storage/test/common.hpp
-            version/test/test_sort_index.cpp
-            util/test/rapidcheck_lru_cache.cpp)
+            version/test/test_sort_index.cpp)
 
     set(EXECUTABLE_PERMS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE) # 755
 
@@ -1061,8 +1060,8 @@ if(${TEST})
             util/test/rapidcheck_generators.cpp
             util/test/rapidcheck_string_pool.cpp
             util/test/rapidcheck_main.cpp
-            version/test/rapidcheck_version_map.cpp
-            util/test/rapidcheck_lru_cache.cpp)
+            util/test/rapidcheck_lru_cache.cpp
+            version/test/rapidcheck_version_map.cpp)
 
     add_executable(arcticdb_rapidcheck_tests ${rapidcheck_srcs})
     install(TARGETS arcticdb_rapidcheck_tests RUNTIME

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -885,7 +885,7 @@ std::vector<std::vector<EntityId>> MergeClause::structure_for_processing(std::ve
     const RowRange row_range{min_start_row, max_end_row};
     const ColRange col_range{min_start_col, max_end_col};
     std::vector<std::vector<EntityId>> ret;
-    std::visit([this, &ret, &input_streams, &comp=compare, stream_id=stream_id_, &row_range, &col_range](auto idx, auto density) {
+    std::visit([this, &ret, &input_streams, stream_id=stream_id_, &row_range, &col_range](auto idx, auto density) {
             if (dynamic_schema_) {
                 merge_impl<decltype(idx), decltype(density), decltype(input_streams), true>(
                     component_manager_,

--- a/cpp/arcticdb/storage/library_manager.cpp
+++ b/cpp/arcticdb/storage/library_manager.cpp
@@ -39,9 +39,10 @@ struct StorageVisitor {
     }
 };
 
-void apply_storage_override(const StorageOverride& storage_override,
-                                   arcticdb::proto::storage::LibraryConfig& lib_cfg_proto,
-                                   bool override_https) {
+void apply_storage_override(
+        const StorageOverride& storage_override,
+        arcticdb::proto::storage::LibraryConfig& lib_cfg_proto,
+        bool override_https) {
     util::variant_match(
             storage_override.variant(),
             StorageVisitor<S3Override>{lib_cfg_proto, override_https},
@@ -79,9 +80,11 @@ bool is_storage_config_ok(const arcticdb::proto::storage::VariantStorage& storag
 } // anonymous namespace
 
 LibraryManager::LibraryManager(const std::shared_ptr<storage::Library>& library) :
-            store_(std::make_shared<async::AsyncStore<util::SysClock>>(library, codec::default_lz4_codec(),
-                    encoding_version(library->config()))),
-                    open_libraries_() {
+            store_(std::make_shared<async::AsyncStore<util::SysClock>>(
+                library,
+                codec::default_lz4_codec(),
+                encoding_version(library->config()))),
+                open_libraries_(ConfigsMap::instance()->get_int("LibraryManager.CacheSize", 100)) {
 }
 
 void LibraryManager::write_library_config(const py::object& lib_cfg, const LibraryPath& path, const StorageOverride& storage_override,
@@ -207,34 +210,30 @@ std::shared_ptr<Library> LibraryManager::get_library(const LibraryPath& path,
     if (!ignore_cache) {
         // Check global cache first, important for LMDB to only open once from a given process
         std::lock_guard<std::mutex> lock{open_libraries_mutex_};
-        if (auto cached = open_libraries_.find(path); cached != open_libraries_.end()) {
-            return cached -> second;
+        if (auto cached = open_libraries_.get(path); cached) {
+            return *cached;
         }
     }
 
     arcticdb::proto::storage::LibraryConfig config = get_config_internal(path, {storage_override});
 
-    std::vector<arcticdb::proto::storage::VariantStorage> st;
+    std::vector<arcticdb::proto::storage::VariantStorage> storage_configs;
     for(const auto& storage: config.storage_by_id()){
-        st.emplace_back(storage.second);
+        storage_configs.emplace_back(storage.second);
     }
-    auto storages = create_storages(path, OpenMode::DELETE, st);
 
+    auto storages = create_storages(path, OpenMode::DELETE, storage_configs);
     auto lib = std::make_shared<Library>(path, std::move(storages), config.lib_desc().version());
-
-    {
-        std::lock_guard<std::mutex> lock{open_libraries_mutex_};
-        open_libraries_[path] = lib;
-    }
+    open_libraries_.put(path, lib);
 
     return lib;
 }
 
 void LibraryManager::cleanup_library_if_open(const LibraryPath &path) {
     std::lock_guard<std::mutex> lock{open_libraries_mutex_};
-    if (auto it = open_libraries_.find(path); it != open_libraries_.end()) {
-        it->second->cleanup();
-        open_libraries_.erase(it);
+    if (auto library = open_libraries_.get(path); library) {
+        library.value()->cleanup();
+        open_libraries_.remove(path);
     }
 }
 

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -11,7 +11,7 @@
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/library_path.hpp>
 #include <arcticdb/storage/storage_override.hpp>
-
+#include <arcticdb/util/lru_cache.hpp>
 
 namespace arcticdb::storage {
     enum class ModifiableLibraryOption {
@@ -69,7 +69,7 @@ namespace arcticdb::storage {
         [[nodiscard]] arcticdb::proto::storage::LibraryConfig get_config_internal(const LibraryPath& path, const std::optional<StorageOverride>& storage_override) const;
 
         std::shared_ptr<Store> store_;
-        std::unordered_map<LibraryPath, std::shared_ptr<Library>> open_libraries_;
+        LRUCache<LibraryPath, std::shared_ptr<Library>> open_libraries_;
         std::mutex open_libraries_mutex_;  // for open_libraries_
     };
 }

--- a/cpp/arcticdb/util/lru_cache.hpp
+++ b/cpp/arcticdb/util/lru_cache.hpp
@@ -18,7 +18,7 @@ class LRUCache {
     struct Node {
         KeyType key;
         ValueType value;
-        Node(KeyType&& k, ValueType&& v) : key(std::move(k)), value(std::move(v)) {}
+        Node(const KeyType& k, ValueType&& v) : key(k), value(std::move(v)) {}
     };
 
     size_t capacity_;
@@ -60,7 +60,7 @@ public:
         cache_.erase(it);
     }
 
-    void put(KeyType key, ValueType value) {
+    void put(const KeyType& key, ValueType value) {
         std::unique_lock lock(mutex_);
         ARCTICDB_DEBUG(log::inmem(), "Adding key {}", key);
         auto it = cache_.find(key);
@@ -73,7 +73,7 @@ public:
                 cache_.erase(list_.back().key);
                 list_.pop_back();
             }
-            list_.emplace_front(std::move(key), std::move(value));
+            list_.emplace_front(key, std::move(value));
             cache_[list_.front().key] = list_.begin();
         }
     }

--- a/cpp/arcticdb/util/lru_cache.hpp
+++ b/cpp/arcticdb/util/lru_cache.hpp
@@ -1,0 +1,82 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+#include <mutex>
+#include <memory>
+
+#include <ankerl/unordered_dense.h>
+#include <arcticdb/util/constructors.hpp>
+#include <arcticdb/log/log.hpp>
+
+namespace arcticdb {
+
+template <typename KeyType, typename ValueType>
+class LRUCache {
+    struct Node {
+        KeyType key;
+        ValueType value;
+        Node(KeyType&& k, ValueType&& v) : key(std::move(k)), value(std::move(v)) {}
+    };
+
+    size_t capacity_;
+    mutable std::list<Node> list_;
+    mutable std::shared_mutex mutex_;
+    ankerl::unordered_dense::map<KeyType, typename std::list<Node>::iterator> cache_;
+
+public:
+    explicit LRUCache(size_t capacity) noexcept : capacity_(capacity) {}
+
+    ARCTICDB_NO_MOVE_OR_COPY(LRUCache)
+
+    [[nodiscard]] size_t capacity() const noexcept {
+        return capacity_;
+    }
+
+    [[nodiscard]] std::optional<ValueType> get(const KeyType& key) const {
+        std::shared_lock lock(mutex_);
+        ARCTICDB_DEBUG(log::inmem(), "Looking for key {}", key);
+        auto it = cache_.find(key);
+        if (it == cache_.end()) {
+            ARCTICDB_DEBUG(log::inmem(), "Key {} does not exist", key);
+            return std::nullopt;
+        }
+
+        ARCTICDB_DEBUG(log::inmem(), "Key {} found", key);
+        list_.splice(list_.begin(), list_, it->second);
+        return it->second->value;
+    }
+
+    void remove(const KeyType& key) {
+        std::unique_lock lock(mutex_);
+        ARCTICDB_DEBUG(log::inmem(), "Removing key {}", key);
+        auto it = cache_.find(key);
+        if (it == cache_.end())
+            return;
+
+        list_.erase(it->second);
+        cache_.erase(it);
+    }
+
+    void put(KeyType key, ValueType value) {
+        std::unique_lock lock(mutex_);
+        ARCTICDB_DEBUG(log::inmem(), "Adding key {}", key);
+        auto it = cache_.find(key);
+        if (it != cache_.end()) {
+            it->second->value = std::move(value);
+            list_.splice(list_.begin(), list_, it->second);
+        } else {
+            if (cache_.size() >= capacity_) {
+                ARCTICDB_DEBUG(log::inmem(), "Evicting key {}", list_.back().key);
+                cache_.erase(list_.back().key);
+                list_.pop_back();
+            }
+            list_.emplace_front(std::move(key), std::move(value));
+            cache_[list_.front().key] = list_.begin();
+        }
+    }
+};
+
+}

--- a/cpp/arcticdb/util/lru_cache.hpp
+++ b/cpp/arcticdb/util/lru_cache.hpp
@@ -4,7 +4,7 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-#include <mutex>
+#include <shared_mutex>
 #include <memory>
 
 #include <ankerl/unordered_dense.h>

--- a/cpp/arcticdb/util/test/rapidcheck_lru_cache.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_lru_cache.cpp
@@ -1,0 +1,61 @@
+#include <unordered_map>
+#include <list>
+#include <optional>
+#include <vector>
+#include <arcticdb/util/lru_cache.hpp>
+
+
+#include <gtest/gtest.h>
+#include <arcticdb/util/test/rapidcheck.hpp>
+#include <rapidcheck.h>
+
+RC_GTEST_PROP(LRUCacheTest, BehavesCorrectly, (const std::vector<int>& keys)) {
+    using namespace arcticdb;
+    const size_t capacity = 10;
+    arcticdb::LRUCache<int, int> cache(capacity);
+    auto values = keys;
+
+    RC_PRE(!keys.empty());
+
+    std::map<int, int> reference;
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        int key = keys[i];
+        int value = values[i];
+
+        cache.put(key, value);
+
+        if (reference.size() + 1 > capacity) {
+            auto oldest = std::min_element(reference.begin(), reference.end());
+            reference.erase(oldest);
+        }
+
+        reference[key] = value;
+
+        // Check get
+        for (const auto& [k, v] : reference) {
+            auto result = cache.get(k);
+            RC_ASSERT(result.has_value());
+            RC_ASSERT(result.value() == v);
+        }
+
+        // Check non-existent key
+        int non_existent_key = 0;
+        while (reference.find(non_existent_key) != reference.end()) {
+            non_existent_key++;
+        }
+        RC_ASSERT(!cache.get(non_existent_key).has_value());
+
+        // Check remove
+        if (!reference.empty() && i % 2 == 0) {
+            auto it = reference.begin();
+            std::advance(it, i % reference.size());
+            int key_to_remove = it->first;
+            cache.remove(key_to_remove);
+            reference.erase(key_to_remove);
+            RC_ASSERT(!cache.get(key_to_remove).has_value());
+        }
+    }
+
+    RC_ASSERT(cache.capacity() == capacity);
+}


### PR DESCRIPTION
At the moment as we open more and more libraries we never close them, meaning that we can run out of filehandles.