### PR TITLE
Use `shell=True` for linux compat tests to fix feedstock runs

### DIFF
--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -146,9 +146,10 @@ class VenvLib:
 def old_venv(request):
     version = request.param
     path = os.path.join("venvs", version)
-    # The requirements_file needs to be relative to the [path] we use for the venv.
-    # Absolute paths break some Azure CI runners on conda forge
-    requirements_file = os.path.join("..", "..", "tests", "compat", f"requirements-{version}.txt")
+    # We need to expandvars because on some systems (e.g. Conda Feedstock) abspath uses env variables.
+    requirements_file = os.path.expandvars(
+        os.path.abspath(os.path.join("tests", "compat", f"requirements-{version}.txt"))
+    )
     with Venv(path, requirements_file, version) as old_venv:
         yield old_venv
 

--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -23,8 +23,15 @@ def is_running_on_windows():
 
 def run_shell_command(command : List[Union[str, os.PathLike]], cwd : Optional[os.PathLike] = None) -> subprocess.CompletedProcess:
     logger.info(f"Executing command: {command}")
-    # shell=True is required for running the correct python executable on Windows
-    result = subprocess.run(command, cwd=cwd, capture_output=True, shell=is_running_on_windows())
+    result = None
+    if is_running_on_windows():
+        # shell=True is required for running the correct python executable on Windows
+        result = subprocess.run(command, cwd=cwd, capture_output=True, shell=True)
+    else:
+        # On linux we need shell=True for conda feedstock runners (because otherwise they fail to expand path variables)
+        # But to correctly work with shell=True we need a single command string.
+        command_string = ' '.join(command)
+        result = subprocess.run(command_string, cwd=cwd, capture_output=True, shell=True, stdin=subprocess.DEVNULL)
     if result.returncode != 0:
         logger.warning(f"Command failed, stdout: {str(result.stdout)}, stderr: {str(result.stderr)}")
     return result
@@ -146,10 +153,8 @@ class VenvLib:
 def old_venv(request):
     version = request.param
     path = os.path.join("venvs", version)
-    # We need to expandvars because on some systems (e.g. Conda Feedstock) abspath uses env variables.
-    requirements_file = os.path.expandvars(
-        os.path.abspath(os.path.join("tests", "compat", f"requirements-{version}.txt"))
-    )
+    compat_dir = os.path.dirname(os.path.abspath(__file__))
+    requirements_file = os.path.join(compat_dir, f"requirements-{version}.txt")
     with Venv(path, requirements_file, version) as old_venv:
         yield old_venv
 


### PR DESCRIPTION
The issue with conda feedstock runners is they use some variable for
abspath, which doesn't get correctly expanded by `os.path.expandvar`.

This requires using `shell=True` for linux as well.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
