### PR TITLE
Enhancement 1895: Fully parallelise processing in read_batch

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -910,6 +910,7 @@ if(${TEST})
             processing/test/test_filter_and_project_sparse.cpp
             processing/test/test_has_valid_type_promotion.cpp
             processing/test/test_operation_dispatch.cpp
+            processing/test/test_parallel_processing.cpp
             processing/test/test_resample.cpp
             processing/test/test_set_membership.cpp
             processing/test/test_signed_unsigned_comparison.cpp

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -251,12 +251,6 @@ folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descr
     return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
 }
 
-folly::Future<std::pair<VariantKey, TimeseriesDescriptor>> read_timeseries_descriptor_for_incompletes(
-        const entity::VariantKey &key,
-        storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) override {
-    return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorForIncompletesTask{});
-}
-
 folly::Future<bool> key_exists(entity::VariantKey &&key) {
     return async::submit_io_task(KeyExistsTask{std::move(key), library_});
 }

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -551,28 +551,6 @@ struct DecodeTimeseriesDescriptorTask : BaseTask {
     }
 };
 
-struct DecodeTimeseriesDescriptorForIncompletesTask : BaseTask {
-    ARCTICDB_MOVE_ONLY_DEFAULT(DecodeTimeseriesDescriptorForIncompletesTask)
-
-    DecodeTimeseriesDescriptorForIncompletesTask() = default;
-
-    std::pair<VariantKey, TimeseriesDescriptor> operator()(storage::KeySegmentPair &&ks) const {
-        ARCTICDB_SAMPLE(DecodeTimeseriesDescriptorForIncompletesTask, 0)
-        auto key_seg = std::move(ks);
-        ARCTICDB_DEBUG(
-                log::storage(),
-                "DecodeTimeseriesDescriptorForIncompletesTask decoding segment with key {}",
-                variant_key_view(key_seg.variant_key()));
-
-        auto maybe_desc = decode_timeseries_descriptor_for_incompletes(key_seg.segment());
-
-        util::check(static_cast<bool>(maybe_desc), "Failed to decode timeseries descriptor");
-        return std::make_pair(
-                std::move(key_seg.variant_key()),
-                std::move(*maybe_desc));
-    }
-};
-
 struct DecodeMetadataAndDescriptorTask : BaseTask {
     ARCTICDB_MOVE_ONLY_DEFAULT(DecodeMetadataAndDescriptorTask)
 

--- a/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
+++ b/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
@@ -125,8 +125,8 @@ TEST_F(IngestionStressStore, ScalarIntAppend) {
     ro.allow_sparse_ = true;
     ro.set_dynamic_schema(true);
     ro.set_incompletes(true);
-    ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(symbol, VersionQuery{}, read_query, ro, handler_data);
@@ -213,8 +213,8 @@ TEST_F(IngestionStressStore, ScalarIntDynamicSchema) {
     read_options.set_dynamic_schema(true);
     read_options.set_allow_sparse(true);
     read_options.set_incompletes(true);
-    ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options, handler_data);
@@ -266,8 +266,8 @@ TEST_F(IngestionStressStore, DynamicSchemaWithStrings) {
     read_options.set_dynamic_schema(true);
     read_options.set_allow_sparse(true);
     read_options.set_incompletes(true);
-    ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(symbol, VersionQuery{}, read_query, read_options, handler_data);

--- a/cpp/arcticdb/pipeline/frame_slice.cpp
+++ b/cpp/arcticdb/pipeline/frame_slice.cpp
@@ -20,7 +20,7 @@ namespace arcticdb::pipelines {
 
 void SliceAndKey::ensure_segment(const std::shared_ptr<Store>& store) const {
      if(!segment_)
-         segment_ = store->read(*key_).get().second;
+         segment_ = store->read_sync(*key_).second;
  }
 
  SegmentInMemory& SliceAndKey::segment(const std::shared_ptr<Store>& store) {

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -46,7 +46,7 @@ inline ReadResult read_result_from_single_frame(FrameAndDescriptor& frame_and_de
     auto descriptor = std::make_shared<StreamDescriptor>(frame_and_desc.frame_.descriptor());
     pipeline_context->begin()->set_descriptor(std::move(descriptor));
     auto handler_data = TypeHandlerRegistry::instance()->get_handler_data();
-    reduce_and_fix_columns(pipeline_context, frame_and_desc.frame_, ReadOptions{}, handler_data);
+    reduce_and_fix_columns(pipeline_context, frame_and_desc.frame_, ReadOptions{}, handler_data).get();
     apply_type_handlers(frame_and_desc.frame_, handler_data);
     return create_python_read_result(VersionedItem{key}, std::move(frame_and_desc));
 }

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -70,8 +70,8 @@ void mark_index_slices(
     bool dynamic_schema,
     bool column_groups);
 
-folly::Future<std::vector<VariantKey>> fetch_data(
-    const SegmentInMemory& frame,
+folly::Future<SegmentInMemory> fetch_data(
+    SegmentInMemory&& frame,
     const std::shared_ptr<PipelineContext> &context,
     const std::shared_ptr<stream::StreamSource>& ssource,
     bool dynamic_schema,
@@ -92,7 +92,7 @@ void decode_into_frame_dynamic(
     const DecodePathData& shared_data,
     std::any& handler_data);
 
-void reduce_and_fix_columns(
+folly::Future<folly::Unit> reduce_and_fix_columns(
     std::shared_ptr<PipelineContext> &context,
     SegmentInMemory &frame,
     const ReadOptions& read_options,

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <unordered_set>
 
+#include <folly/futures/FutureSplitter.h>
+
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/processing/component_manager.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
@@ -241,5 +243,12 @@ ProcessingUnit gather_entities(ComponentManager& component_manager, std::vector<
 std::vector<EntityId> push_entities(ComponentManager& component_manager, ProcessingUnit&& proc, EntityFetchCount entity_fetch_count=1);
 
 std::vector<EntityId> flatten_entities(std::vector<std::vector<EntityId>>&& entity_ids_vec);
+
+std::vector<folly::FutureSplitter<pipelines::SegmentAndSlice>> split_futures(
+        std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures);
+
+std::shared_ptr<std::vector<EntityFetchCount>> generate_segment_fetch_counts(
+        const std::vector<std::vector<size_t>>& processing_unit_indexes,
+        size_t num_segments);
 
 }//namespace arcticdb

--- a/cpp/arcticdb/processing/component_manager.cpp
+++ b/cpp/arcticdb/processing/component_manager.cpp
@@ -14,17 +14,26 @@ namespace arcticdb {
 
 std::vector<EntityId> ComponentManager::get_new_entity_ids(size_t count) {
     std::vector<EntityId> ids(count);
-    std::lock_guard<std::mutex> lock(mtx_);
+    std::unique_lock lock(mtx_);
     registry_.create(ids.begin(), ids.end());
     return ids;
 }
 
-void ComponentManager::erase_entity(EntityId id) {
-    // Ideally would call registry_.destroy(id), or at least registry_.erase<std::shared_ptr<SegmentInMemory>>(id)
-    // at this point. However, they are both slower than this, so just decrement the ref count of the only
-    // sizeable component, so that when the shared pointer goes out of scope in the calling function, the
-    // memory is freed
-    registry_.get<std::shared_ptr<SegmentInMemory>>(id).reset();
+void ComponentManager::decrement_entity_fetch_count(EntityId id) {
+    if (registry_.get<std::atomic<EntityFetchCount>>(id).fetch_sub(1) == 1) {
+        // This entity will never be accessed again
+        // Ideally would call registry_.destroy(id), or at least registry_.erase<std::shared_ptr<SegmentInMemory>>(id)
+        // at this point. However, they are both slower than this, and would require taking a unique_lock on the
+        // shared_mutex, so just decrement the ref count of the only sizeable component, so that when the shared pointer
+        // goes out of scope in the calling function, the memory is freed
+        registry_.get<std::shared_ptr<SegmentInMemory>>(id).reset();
+        debug::check<ErrorCode::E_ASSERTION_FAILURE>(!registry_.get<std::shared_ptr<SegmentInMemory>>(id),
+                                                     "SegmentInMemory memory retained in ComponentManager");
+    }
+}
+
+void ComponentManager::update_entity_fetch_count(EntityId id, EntityFetchCount count) {
+    registry_.get<std::atomic<EntityFetchCount>>(id).store(count);
 }
 
 

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <atomic>
+#include <shared_mutex>
 
 #include <entt/entity/registry.hpp>
 
@@ -23,8 +24,6 @@ using bucket_id = uint8_t;
 
 using namespace entt::literals;
 
-constexpr auto remaining_entity_fetch_count_id = "remaining_entity_fetch_count"_hs;
-
 class ComponentManager {
 public:
     ComponentManager() = default;
@@ -35,16 +34,16 @@ public:
     // Add a single entity with the components defined by args
     template<class... Args>
     void add_entity(EntityId id, Args... args) {
-        std::lock_guard<std::mutex> lock(mtx_);
+        std::unique_lock lock(mtx_);
         ([&]{
             registry_.emplace<Args>(id, args);
             // Store the initial entity fetch count component as a "first-class" entity, accessible by
             // registry_.get<EntityFetchCount>(id), as this is external facing (used by resample)
             // The remaining entity fetch count below will be decremented each time an entity is fetched, but is never
-            // accessed externally, so make this a named component.
+            // accessed externally. Stored as an atomic to minimise the requirement to take the shared_mutex with a
+            // unique_lock.
             if constexpr (std::is_same_v<Args, EntityFetchCount>) {
-                auto&& remaining_entity_fetch_count_registry = registry_.storage<EntityFetchCount>(remaining_entity_fetch_count_id);
-                remaining_entity_fetch_count_registry.emplace(id, args);
+                registry_.emplace<std::atomic<EntityFetchCount>>(id, args);
             }
         }(), ...);
     }
@@ -55,7 +54,7 @@ public:
     std::vector<EntityId> add_entities(Args... args) {
         std::vector<EntityId> ids;
         size_t entity_count{0};
-        std::lock_guard<std::mutex> lock(mtx_);
+        std::unique_lock lock(mtx_);
         ([&]{
             if (entity_count == 0) {
                 // Reserve memory for the result on the first pass
@@ -70,8 +69,9 @@ public:
             }
             registry_.insert<typename Args::value_type>(ids.cbegin(), ids.cend(), args.begin());
             if constexpr (std::is_same_v<typename Args::value_type, EntityFetchCount>) {
-                auto&& remaining_entity_fetch_count_registry = registry_.storage<EntityFetchCount>(remaining_entity_fetch_count_id);
-                remaining_entity_fetch_count_registry.insert(ids.cbegin(), ids.cend(), args.begin());
+                for (auto&& [idx, id]: folly::enumerate(ids)) {
+                    registry_.emplace<std::atomic<EntityFetchCount>>(id, args[idx]);
+                }
             }
         }(), ...);
         return ids;
@@ -79,24 +79,23 @@ public:
 
     template<typename T>
     void replace_entities(const std::vector<EntityId>& ids, T value) {
+        std::unique_lock lock(mtx_);
         for (auto id: ids) {
             registry_.replace<T>(id, value);
             if constexpr (std::is_same_v<T, EntityFetchCount>) {
-                auto&& remaining_entity_fetch_count_registry = registry_.storage<EntityFetchCount>(remaining_entity_fetch_count_id);
-                // For some reason named storages don't have a replace API
-                remaining_entity_fetch_count_registry.patch(id, [value](EntityFetchCount& entity_fetch_count){ entity_fetch_count = value; });
+                update_entity_fetch_count(id, value);
             }
         }
     }
 
     template<typename T>
     void replace_entities(const std::vector<EntityId>& ids, const std::vector<T>& values) {
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(ids.size() == values.size(), "Received vectors of differing lengths in ComponentManager::replace_entities");
+        std::unique_lock lock(mtx_);
         for (auto [idx, id]: folly::enumerate(ids)) {
             registry_.replace<T>(id, values[idx]);
             if constexpr (std::is_same_v<T, EntityFetchCount>) {
-                auto&& remaining_entity_fetch_count_registry = registry_.storage<EntityFetchCount>(remaining_entity_fetch_count_id);
-                // For some reason named storages don't have a replace API
-                remaining_entity_fetch_count_registry.patch(id, [&values, idx](EntityFetchCount& entity_fetch_count){ entity_fetch_count = values[idx]; });
+                update_entity_fetch_count(id, values[idx]);
             }
         }
     }
@@ -107,8 +106,7 @@ public:
         std::vector<std::tuple<Args...>> tuple_res;
         tuple_res.reserve(ids.size());
         {
-            std::lock_guard<std::mutex> lock(mtx_);
-            auto&& remaining_entity_fetch_count_registry = registry_.storage<EntityFetchCount>(remaining_entity_fetch_count_id);
+            std::shared_lock lock(mtx_);
             // Using view.get theoretically and empirically faster than registry_.get
             auto view = registry_.view<const Args...>();
             for (auto id: ids) {
@@ -116,11 +114,7 @@ public:
             }
             if (decrement_fetch_count) {
                 for (auto id: ids) {
-                    auto& remaining_entity_fetch_count = remaining_entity_fetch_count_registry.get(id);
-                    // This entity will never be accessed again
-                    if (--remaining_entity_fetch_count == 0) {
-                        erase_entity(id);
-                    }
+                    decrement_entity_fetch_count(id);
                 }
             }
         }
@@ -138,10 +132,11 @@ public:
     }
 
 private:
-    void erase_entity(EntityId id);
+    void decrement_entity_fetch_count(EntityId id);
+    void update_entity_fetch_count(EntityId id, EntityFetchCount count);
 
     entt::registry registry_;
-    std::mutex mtx_;
+    std::shared_mutex mtx_;
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/test/test_parallel_processing.cpp
+++ b/cpp/arcticdb/processing/test/test_parallel_processing.cpp
@@ -1,0 +1,166 @@
+/* Copyright 2024 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/processing/clause.hpp>
+#include <arcticdb/processing/component_manager.hpp>
+#include <arcticdb/version/version_core.hpp>
+
+using namespace arcticdb;
+using namespace arcticdb::pipelines;
+
+struct RowSliceClause {
+    // Simple clause that accepts and produces segments partitioned by row-slice, which is representative of a lot of
+    // the real clauses we support. In place of doing any processing, the process method just sleeps for a random amount
+    // of time and then increments the stream id of each input segment.
+    ClauseInfo clause_info_;
+    std::shared_ptr<ComponentManager> component_manager_;
+
+    RowSliceClause() = default;
+    ARCTICDB_MOVE_COPY_DEFAULT(RowSliceClause)
+
+    [[nodiscard]] std::vector<std::vector<size_t>> structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys) {
+        return structure_by_row_slice(ranges_and_keys);
+    }
+
+    [[nodiscard]] std::vector<std::vector<EntityId>> structure_for_processing(std::vector<std::vector<EntityId>>&& entity_ids_vec) {
+        log::version().warn("RowSliceClause::structure_for_processing called");
+        return structure_by_row_slice(*component_manager_, std::move(entity_ids_vec));
+    }
+
+    [[nodiscard]] std::vector<EntityId> process(std::vector<EntityId>&& entity_ids) const {
+        std::mt19937_64 eng{std::random_device{}()};
+        std::uniform_int_distribution<> dist{10, 100};
+        auto sleep_ms = dist(eng);
+        log::version().warn("RowSliceClause::process sleeping for {}ms", sleep_ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds{sleep_ms});
+        if (entity_ids.empty()) {
+            return {};
+        }
+        auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(*component_manager_, std::move(entity_ids));
+        for (const auto& segment: proc.segments_.value()) {
+            auto id = std::get<int64_t>(segment->descriptor().id());
+            ++id;
+            segment->descriptor().set_id(id);
+        }
+        return push_entities(*component_manager_, std::move(proc));
+    }
+
+    [[nodiscard]] const ClauseInfo& clause_info() const {
+        return clause_info_;
+    }
+
+    void set_processing_config(ARCTICDB_UNUSED const ProcessingConfig&) {}
+
+    void set_component_manager(std::shared_ptr<ComponentManager> component_manager) {
+        component_manager_ = component_manager;
+    }
+};
+
+struct RestructuringClause {
+    // Simple clause that accepts non row-slice structured segments to stress the restructuring process (fan-in/fan-out)
+    // process method is the same as the RowSliceClause above
+    ClauseInfo clause_info_;
+    std::shared_ptr<ComponentManager> component_manager_;
+
+    RestructuringClause() {
+        clause_info_.input_structure_ = ProcessingStructure::ALL;
+    };
+    ARCTICDB_MOVE_COPY_DEFAULT(RestructuringClause)
+
+    [[nodiscard]] std::vector<std::vector<size_t>> structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys) {
+        return structure_by_row_slice(ranges_and_keys);
+    }
+
+    [[nodiscard]] std::vector<std::vector<EntityId>> structure_for_processing(std::vector<std::vector<EntityId>>&& entity_ids_vec) {
+        log::version().warn("RestructuringClause::structure_for_processing called");
+        return structure_by_row_slice(*component_manager_, std::move(entity_ids_vec));
+    }
+
+    [[nodiscard]] std::vector<EntityId> process(std::vector<EntityId>&& entity_ids) const {
+        std::mt19937_64 eng{std::random_device{}()};
+        std::uniform_int_distribution<> dist{10, 100};
+        auto sleep_ms = dist(eng);
+        log::version().warn("RestructuringClause::process sleeping for {}ms", sleep_ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds{sleep_ms});
+        if (entity_ids.empty()) {
+            return {};
+        }
+        auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(*component_manager_, std::move(entity_ids));
+        for (const auto& segment: proc.segments_.value()) {
+            auto id = std::get<int64_t>(segment->descriptor().id());
+            ++id;
+            segment->descriptor().set_id(id);
+        }
+        return push_entities(*component_manager_, std::move(proc));
+    }
+
+    [[nodiscard]] const ClauseInfo& clause_info() const {
+        return clause_info_;
+    }
+
+    void set_processing_config(ARCTICDB_UNUSED const ProcessingConfig&) {}
+
+    void set_component_manager(std::shared_ptr<ComponentManager> component_manager) {
+        component_manager_ = component_manager;
+    }
+};
+
+TEST(Clause, ScheduleClauseProcessingStress) {
+    // Extensible stress test of schedule_clause_processing. Useful for ensuring a lack of deadlock when running on
+    // threadpools with 1 or multiple cores. Dummy clauses provided above used to stress the fan-in/fan-out behaviour.
+    // Could be extended to profile and compare different scheduling algorithms and threadpool implementations if we
+    // want to move away from folly.
+    using namespace arcticdb::version_store;
+    auto num_clauses = 5;
+    std::mt19937_64 eng{std::random_device{}()};
+    std::uniform_int_distribution<> dist{0, 1};
+
+    auto clauses = std::make_shared<std::vector<std::shared_ptr<Clause>>>();
+    for (auto unused=0; unused<num_clauses; ++unused) {
+        if (dist(eng) == 0) {
+            clauses->emplace_back(std::make_shared<Clause>(RowSliceClause()));
+        } else {
+            clauses->emplace_back(std::make_shared<Clause>(RestructuringClause()));
+        }
+    }
+
+    auto component_manager = std::make_shared<ComponentManager>();
+    for (auto& clause: *clauses) {
+        clause->set_component_manager(component_manager);
+    }
+
+    size_t num_segments{2};
+    std::vector<folly::Promise<SegmentAndSlice>> segment_and_slice_promises(num_segments);
+    std::vector<folly::Future<SegmentAndSlice>> segment_and_slice_futures;
+    std::vector<std::vector<size_t>> processing_unit_indexes;
+    for (size_t idx = 0; idx < num_segments; ++idx) {
+        segment_and_slice_futures.emplace_back(segment_and_slice_promises[idx].getFuture());
+        processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
+    }
+
+    auto processed_entity_ids_fut = schedule_clause_processing(component_manager,
+                                                               std::move(segment_and_slice_futures),
+                                                               std::move(processing_unit_indexes),
+                                                               clauses);
+
+    for (size_t idx = 0; idx < segment_and_slice_promises.size(); ++idx) {
+        SegmentInMemory segment;
+        segment.descriptor().set_id(static_cast<int64_t>(idx));
+        segment_and_slice_promises[idx].setValue(SegmentAndSlice(RangesAndKey({idx, idx+1}, {0, 1}, {}), std::move(segment)));
+    }
+
+    auto processed_entity_ids = std::move(processed_entity_ids_fut).get();
+    auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(*component_manager, std::move(processed_entity_ids));
+    ASSERT_EQ(proc.segments_.value().size(), num_segments);
+    NumericId start_id{0};
+    for (const auto& segment: proc.segments_.value()) {
+        auto id = std::get<NumericId>(segment->descriptor().id());
+        ASSERT_EQ(id, start_id++ + num_clauses);
+    }
+}

--- a/cpp/arcticdb/storage/test/test_memory_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_memory_storage.cpp
@@ -27,7 +27,7 @@ TEST(InMemory, ReadTwice) {
     auto test_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
     version_store.write_versioned_dataframe_internal(symbol, std::move(test_frame.frame_), false, false, false);
 
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result1 = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}, handler_data);

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -82,11 +82,6 @@ struct StreamSource {
     virtual folly::Future<std::pair<VariantKey, TimeseriesDescriptor>>
         read_timeseries_descriptor(const entity::VariantKey& key,
                                    storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
-
-    virtual folly::Future<std::pair<VariantKey, TimeseriesDescriptor>>
-    read_timeseries_descriptor_for_incompletes(const entity::VariantKey& key,
-                               storage::ReadKeyOpts opts = storage::ReadKeyOpts{}) = 0;
-
 };
 
 } // namespace arcticdb::stream

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -141,7 +141,7 @@ public:
     ReadVersionOutput read_dataframe_version_internal(
         const StreamId &stream_id,
         const VersionQuery& version_query,
-        ReadQuery& read_query,
+        const std::shared_ptr<ReadQuery>& read_query,
         const ReadOptions& read_options,
         std::any& handler_data) override;
 
@@ -192,7 +192,7 @@ public:
         std::optional<AtomKey>&& key);
 
     folly::Future<std::pair<VariantKey, std::optional<google::protobuf::Any>>> get_metadata_async(
-        folly::Future<std::optional<AtomKey>>&& version_fut,
+        folly::Future<std::optional<AtomKey>>&& opt_index_key_fut,
         const StreamId& stream_id,
         const VersionQuery& version_query);
 
@@ -200,7 +200,7 @@ public:
         AtomKey&& key);
 
     folly::Future<DescriptorItem> get_descriptor_async(
-        folly::Future<std::optional<AtomKey>>&& version_fut,
+        folly::Future<std::optional<AtomKey>>&& opt_index_key_fut,
         const StreamId& stream_id,
         const VersionQuery& version_query);
 
@@ -285,12 +285,6 @@ public:
         std::vector<std::shared_ptr<ReadQuery>>& read_queries,
         const ReadOptions& read_options,
         std::any& handler_data);
-
-    std::vector<std::variant<ReadVersionOutput, DataError>> temp_batch_read_internal_direct(
-        const std::vector<StreamId>& stream_ids,
-        const std::vector<VersionQuery>& version_queries,
-        std::vector<std::shared_ptr<ReadQuery>>& read_queries,
-        const ReadOptions& read_options);
 
     std::vector<std::variant<DescriptorItem, DataError>> batch_read_descriptor_internal(
             const std::vector<StreamId>& stream_ids,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -179,8 +179,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
 
     version.def("write_dataframe_to_file", &write_dataframe_to_file);
     version.def("read_dataframe_from_file",
-        [] (StreamId sid, const std::string(path), ReadQuery& read_query){
-            return adapt_read_df(read_dataframe_from_file(sid, path, read_query));
+        [] (StreamId sid, const std::string(path), std::shared_ptr<ReadQuery> read_query){
+            auto handler_data = TypeHandlerRegistry::instance()->get_handler_data();
+            return adapt_read_df(read_dataframe_from_file(sid, path, read_query, handler_data));
         });
 
     using FrameDataWrapper = arcticdb::pipelines::FrameDataWrapper;
@@ -615,7 +616,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             &PythonVersionStore::write_dataframe_specific_version,
              py::call_guard<SingleThreadMutexHolder>(), "Write a specific  version of this dataframe to the store")
         .def("read_dataframe_version",
-             [&](PythonVersionStore& v,  StreamId sid, const VersionQuery& version_query, ReadQuery& read_query, const ReadOptions& read_options) {
+             [&](PythonVersionStore& v,  StreamId sid, const VersionQuery& version_query, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options) {
                 auto handler_data = TypeHandlerRegistry::instance()->get_handler_data();
                 return adapt_read_df(v.read_dataframe_version(sid, version_query, read_query, read_options, handler_data));
               },
@@ -715,7 +716,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
                  const std::vector<VersionQuery>& version_queries,
                  std::vector<std::shared_ptr<ReadQuery>>& read_queries,
                  const ReadOptions& read_options){
-                 return python_util::adapt_read_dfs(v.batch_read(stream_ids, version_queries, read_queries, read_options));
+                 auto handler_data = TypeHandlerRegistry::instance()->get_handler_data();
+                 return python_util::adapt_read_dfs(v.batch_read(stream_ids, version_queries, read_queries, read_options, handler_data));
              },
              py::call_guard<SingleThreadMutexHolder>(), "Read a dataframe from the store")
         .def("batch_read_keys",

--- a/cpp/arcticdb/version/test/test_sparse.cpp
+++ b/cpp/arcticdb/version/test/test_sparse.cpp
@@ -84,8 +84,8 @@ TEST_F(SparseTestStore, SimpleRoundtrip) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -176,8 +176,8 @@ TEST_F(SparseTestStore, SimpleRoundtripBackwardsCompat) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -227,8 +227,8 @@ TEST_F(SparseTestStore, DenseToSparse) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -276,8 +276,8 @@ TEST_F(SparseTestStore, SimpleRoundtripStrings) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
     const auto& frame = read_result.frame_data.frame();;
@@ -330,8 +330,8 @@ TEST_F(SparseTestStore, Multiblock) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -383,8 +383,8 @@ TEST_F(SparseTestStore, Segment) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -443,8 +443,8 @@ TEST_F(SparseTestStore, SegmentWithExistingIndex) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -503,9 +503,9 @@ TEST_F(SparseTestStore, SegmentAndFilterColumn) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.columns = {"time", "first"};
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->columns = {"time", "first"};
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -560,8 +560,8 @@ TEST_F(SparseTestStore, SegmentWithRangeFilter) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
     read_options.set_incompletes(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = IndexRange(timestamp{3000}, timestamp{6999});
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = IndexRange(timestamp{3000}, timestamp{6999});
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -614,8 +614,8 @@ TEST_F(SparseTestStore, Compact) {
 
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
@@ -673,8 +673,8 @@ TEST_F(SparseTestStore, CompactWithStrings) {
 
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
-    pipelines::ReadQuery read_query;
-    read_query.row_filter = universal_range();
+    auto read_query = std::make_shared<ReadQuery>();
+    read_query->row_filter = universal_range();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(stream_id, pipelines::VersionQuery{}, read_query, read_options, handler_data);
     const auto& frame = read_result.frame_data.frame();

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -256,7 +256,7 @@ TEST_F(VersionStoreTest, CompactIncompleteDynamicSchema) {
     }
 
     auto vit = test_store_->compact_incomplete(symbol, false, false, true, false);
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = test_store_->read_dataframe_version(symbol, VersionQuery{}, read_query, ReadOptions{}, handler_data);
@@ -366,8 +366,9 @@ TEST_F(VersionStoreTest, StressBatchReadUncompressed) {
     std::vector<std::shared_ptr<ReadQuery>> read_queries;
     ReadOptions read_options;
     register_native_handler_data_factory();
+    auto handler_data = get_type_handler_data();
     read_options.set_batch_throw_on_error(true);
-    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, read_options);
+    auto latest_versions = test_store_->batch_read(symbols, std::vector<VersionQuery>(10), read_queries, read_options, handler_data);
     for(auto&& [idx, version] : folly::enumerate(latest_versions)) {
         auto expected = get_test_simple_frame(std::get<ReadResult>(version).item.symbol(), 10, idx);
         bool equal = expected.segment_ == std::get<ReadResult>(version).frame_data.frame();
@@ -531,7 +532,7 @@ TEST(VersionStore, UpdateWithin) {
     auto update_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}, handler_data);
@@ -574,7 +575,7 @@ TEST(VersionStore, UpdateBefore) {
     auto update_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}, handler_data);
@@ -617,7 +618,7 @@ TEST(VersionStore, UpdateAfter) {
     auto update_frame =  get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}, handler_data);
@@ -661,7 +662,7 @@ TEST(VersionStore, UpdateIntersectBefore) {
         get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}, handler_data);
@@ -705,7 +706,7 @@ TEST(VersionStore, UpdateIntersectAfter) {
         get_test_frame<stream::TimeseriesIndex>(symbol, fields, update_range.diff(), update_range.first, update_val);
     version_store.update_internal(symbol, UpdateQuery{}, std::move(update_frame.frame_), false, false, false);
 
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, ReadOptions{}, handler_data);
@@ -759,7 +760,7 @@ TEST(VersionStore, UpdateWithinSchemaChange) {
 
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options, handler_data);
@@ -822,7 +823,7 @@ TEST(VersionStore, UpdateWithinTypeAndSchemaChange) {
 
     ReadOptions read_options;
     read_options.set_dynamic_schema(true);
-    ReadQuery read_query;
+    auto read_query = std::make_shared<ReadQuery>();
     register_native_handler_data_factory();
     auto handler_data = get_type_handler_data();
     auto read_result = version_store.read_dataframe_version_internal(symbol, VersionQuery{}, read_query, read_options, handler_data);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -769,8 +769,8 @@ std::vector<std::variant<ReadResult, DataError>> PythonVersionStore::batch_read(
     const std::vector<StreamId>& stream_ids,
     const std::vector<VersionQuery>& version_queries,
     std::vector<std::shared_ptr<ReadQuery>>& read_queries,
-    const ReadOptions& read_options) {
-    auto handler_data = TypeHandlerRegistry::instance()->get_handler_data();
+    const ReadOptions& read_options,
+    std::any& handler_data) {
     auto read_versions_or_errors = batch_read_internal(stream_ids, version_queries, read_queries, read_options, handler_data);
     std::vector<std::variant<ReadResult, DataError>> res;
     for (auto&& [idx, read_version_or_error]: folly::enumerate(read_versions_or_errors)) {
@@ -834,7 +834,7 @@ void PythonVersionStore::delete_snapshot_sync(const SnapshotId& snap_name, const
 ReadResult PythonVersionStore::read_dataframe_version(
     const StreamId &stream_id,
     const VersionQuery& version_query,
-    ReadQuery& read_query,
+    const std::shared_ptr<ReadQuery>& read_query,
     const ReadOptions& read_options,
     std::any& handler_data) {
 
@@ -1151,13 +1151,15 @@ void write_dataframe_to_file(
 ReadResult read_dataframe_from_file(
         const StreamId &stream_id,
         const std::string& path,
-        ReadQuery& read_query) {
+        const std::shared_ptr<ReadQuery>& read_query,
+        std::any& handler_data) {
     auto opt_version_and_frame = read_dataframe_from_file_internal(
         stream_id,
         path,
         read_query,
         ReadOptions{},
-        codec::default_lz4_codec());
+        codec::default_lz4_codec(),
+        handler_data);
 
     return create_python_read_result(opt_version_and_frame.versioned_item_, std::move(opt_version_and_frame.frame_and_descriptor_));
 }

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -167,7 +167,7 @@ class PythonVersionStore : public LocalVersionedEngine {
     ReadResult read_dataframe_version(
         const StreamId &stream_id,
         const VersionQuery& version_query,
-        ReadQuery& read_query,
+        const std::shared_ptr<ReadQuery>& read_query,
         const ReadOptions& read_options,
         std::any& handler_data);
 
@@ -297,7 +297,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::vector<StreamId>& stream_ids,
         const std::vector<VersionQuery>& version_queries,
         std::vector<std::shared_ptr<ReadQuery>>& read_queries,
-        const ReadOptions& read_options);
+        const ReadOptions& read_options,
+        std::any& handler_data);
 
     std::vector<std::variant<std::pair<VersionedItem, py::object>, DataError>> batch_read_metadata(
         const std::vector<StreamId>& stream_ids,
@@ -349,7 +350,8 @@ void write_dataframe_to_file(
 ReadResult read_dataframe_from_file(
     const StreamId &stream_id,
     const std::string& path,
-    ReadQuery& read_query);
+    const std::shared_ptr<ReadQuery>& read_query,
+    std::any& handler_data);
 
 struct ManualClockVersionStore : PythonVersionStore {
     ManualClockVersionStore(const std::shared_ptr<storage::Library>& library) :

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -101,7 +101,7 @@ public:
     virtual ReadVersionOutput read_dataframe_version_internal(
         const StreamId &stream_id,
         const VersionQuery& version_query,
-        ReadQuery& read_query,
+        const std::shared_ptr<ReadQuery>& read_query,
         const ReadOptions& read_options,
         std::any& handler_data) = 0;
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -94,13 +94,18 @@ class VersionedItem:
         For data retrieval (read) operations, contains the data read.
         For data modification operations, the value might not be populated.
     version: int
-        For data retrieval operations, the version the `as_of` argument resolved to.
+        For data retrieval operations, the version the `as_of` argument resolved to. In the special case where no
+        versions have been written yet, but data is being read exclusively from incomplete segments, this will be
+        2^64-1.
         For data modification operations, the version the data has been written under.
     metadata: Any
         The metadata saved alongside `data`.
         Availability depends on the method used and may be different from that of `data`.
     host: Optional[str]
         Informational / for backwards compatibility.
+    timestamp: Optional[int]
+        The time in nanoseconds since epoch that this version was written. In the special case where no versions have
+        been written yet, but data is being read exclusively from incomplete segments, this will be 0.
     """
 
     symbol: str = attr.ib()
@@ -1859,7 +1864,7 @@ class NativeVersionStore:
             original_data = Flattener().create_original_obj_from_metastruct_new(meta_struct, key_map)
 
             return VersionedItem(
-                symbol=vitem.symbol,
+                symbol=meta_struct["symbol"],
                 library=vitem.library,
                 data=original_data,
                 version=vitem.version,

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -19,6 +19,12 @@ from arcticdb.storage_fixtures.s3 import MotoNfsBackedS3StorageFixtureFactory
 from arcticdb.storage_fixtures.s3 import MotoS3StorageFixtureFactory
 
 
+pytestmark = pytest.mark.skipif(
+    sys.version_info.major == 3 and sys.version_info.minor == 6 and sys.platform == "linux",
+    reason="Test setup segfaults"
+)
+
+
 def test_s3_storage_failures(mock_s3_store_with_error_simulation):
     lib = mock_s3_store_with_error_simulation
     symbol_fail_write = "symbol#Failure_Write_99_0"
@@ -54,8 +60,6 @@ def test_s3_running_on_aws_fast_check(lib_name, s3_storage_factory, run_on_aws):
         assert lib_tool.inspect_env_variable("AWS_EC2_METADATA_DISABLED") == "true"
 
 
-@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 6 and sys.platform == "linux",
-                    reason="Test setup segfaults")
 def test_nfs_backed_s3_storage(lib_name, nfs_backed_s3_storage):
     # Given
     lib = nfs_backed_s3_storage.create_version_store_factory(lib_name)()

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -9,6 +9,7 @@ import re
 
 import pytest
 import pandas as pd
+import sys
 
 from arcticdb_ext.exceptions import StorageException
 from arcticdb_ext import set_config_string
@@ -53,6 +54,8 @@ def test_s3_running_on_aws_fast_check(lib_name, s3_storage_factory, run_on_aws):
         assert lib_tool.inspect_env_variable("AWS_EC2_METADATA_DISABLED") == "true"
 
 
+@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 6 and sys.platform == "linux",
+                    reason="Test setup segfaults")
 def test_nfs_backed_s3_storage(lib_name, nfs_backed_s3_storage):
     # Given
     lib = nfs_backed_s3_storage.create_version_store_factory(lib_name)()

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1274,7 +1274,8 @@ def equals(x, y):
         assert x == y
 
 
-def test_recursively_written_data(basic_store):
+@pytest.mark.parametrize("batch", (True, False))
+def test_recursively_written_data(basic_store, batch):
     samples = [
         {"a": np.arange(5), "b": np.arange(8)},  # dict of np arrays
         (np.arange(5), np.arange(6)),  # tuple of np arrays
@@ -1283,41 +1284,64 @@ def test_recursively_written_data(basic_store):
     ]
 
     for idx, sample in enumerate(samples):
-        basic_store.write("sym_recursive" + str(idx), sample, recursive_normalizers=True)
-        basic_store.write("sym_pickle" + str(idx), sample)  # pickled writes
-        recursive_data = basic_store.read("sym_recursive" + str(idx)).data
-        pickled_data = basic_store.read("sym_pickle" + str(idx)).data
-        equals(sample, recursive_data)
-        equals(pickled_data, recursive_data)
+        recursive_sym = "sym_recursive" + str(idx)
+        pickled_sym = "sym_pickled" + str(idx)
+        basic_store.write(recursive_sym, sample, recursive_normalizers=True)
+        basic_store.write(pickled_sym, sample)  # pickled writes
+        if batch:
+            recursive_vit = basic_store.batch_read([recursive_sym])[recursive_sym]
+            pickled_vit = basic_store.batch_read([pickled_sym])[pickled_sym]
+        else:
+            recursive_vit = basic_store.read(recursive_sym)
+            pickled_vit = basic_store.read(pickled_sym)
+        equals(sample, recursive_vit.data)
+        equals(pickled_vit.data, recursive_vit.data)
+        assert recursive_vit.symbol == recursive_sym
+        assert pickled_vit.symbol == pickled_sym
 
 
-def test_recursively_written_data_with_metadata(basic_store):
+@pytest.mark.parametrize("batch", (True, False))
+def test_recursively_written_data_with_metadata(basic_store, batch):
     samples = [
         {"a": np.arange(5), "b": np.arange(8)},  # dict of np arrays
         (np.arange(5), np.arange(6)),  # tuple of np arrays
     ]
 
     for idx, sample in enumerate(samples):
-        vit = basic_store.write(
-            "sym_recursive" + str(idx), sample, metadata={"something": 1}, recursive_normalizers=True
-        )
-        recursive_data = basic_store.read("sym_recursive" + str(idx)).data
-        equals(sample, recursive_data)
-        assert vit.metadata == {"something": 1}
+        sym = "sym_recursive" + str(idx)
+        metadata = {"something": 1}
+        basic_store.write(sym, sample, metadata=metadata, recursive_normalizers=True)
+        if batch:
+            vit = basic_store.batch_read([sym])[sym]
+        else:
+            vit = basic_store.read(sym)
+        equals(sample, vit.data)
+        assert vit.symbol == sym
+        assert vit.metadata == metadata
 
 
-def test_recursively_written_data_with_nones(basic_store):
+@pytest.mark.parametrize("batch", (True, False))
+def test_recursively_written_data_with_nones(basic_store, batch):
     sample = {"a": np.arange(5), "b": np.arange(8), "c": None}
+    recursive_sym = "sym_recursive"
+    pickled_sym = "sym_pickled"
+    basic_store.write(recursive_sym, sample, recursive_normalizers=True)
+    basic_store.write(pickled_sym, sample)  # pickled writes
+    if batch:
+        recursive_vit = basic_store.batch_read([recursive_sym])[recursive_sym]
+        pickled_vit = basic_store.batch_read([pickled_sym])[pickled_sym]
+    else:
+        recursive_vit = basic_store.read(recursive_sym)
+        pickled_vit = basic_store.read(pickled_sym)
+    equals(sample, recursive_vit.data)
+    equals(pickled_vit.data, recursive_vit.data)
+    assert recursive_vit.symbol == recursive_sym
+    assert pickled_vit.symbol == pickled_sym
 
-    basic_store.write("sym_recursive", sample, recursive_normalizers=True)
-    basic_store.write("sym_pickle", sample)  # pickled writes
-    recursive_data = basic_store.read("sym_recursive").data
-    pickled_data = basic_store.read("sym_recursive").data
-    equals(sample, recursive_data)
-    equals(pickled_data, recursive_data)
 
-
-def test_recursive_nested_data(basic_store):
+@pytest.mark.parametrize("batch", (True, False))
+def test_recursive_nested_data(basic_store, batch):
+    sym = "test_recursive_nested_data"
     sample_data = {"a": {"b": {"c": {"d": np.arange(24)}}}}
     fl = Flattener()
     assert fl.can_flatten(sample_data)
@@ -1326,8 +1350,13 @@ def test_recursive_nested_data(basic_store):
     assert len(to_write) == 1
     equals(list(to_write.values())[0], np.arange(24))
 
-    basic_store.write("s", sample_data, recursive_normalizers=True)
-    equals(basic_store.read("s").data, sample_data)
+    basic_store.write(sym, sample_data, recursive_normalizers=True)
+    if batch:
+        vit = basic_store.batch_read([sym])[sym]
+    else:
+        vit = basic_store.read(sym)
+    equals(vit.data, sample_data)
+    assert vit.symbol == sym
 
 
 def test_named_tuple_flattening_rejected():
@@ -1374,13 +1403,20 @@ def test_recursive_normalizer_with_custom_class():
     assert fl.is_normalizable_to_nested_structure(list_like_obj)
 
 
-def test_really_large_symbol_for_recursive_data(basic_store):
+@pytest.mark.parametrize("batch", (True, False))
+def test_really_large_symbol_for_recursive_data(basic_store, batch):
+    sym = "s" * 100
     data = {"a" * 100: {"b" * 100: {"c" * 1000: {"d": np.arange(5)}}}}
-    basic_store.write("s" * 100, data, recursive_normalizers=True)
+    basic_store.write(sym, data, recursive_normalizers=True)
     fl = Flattener()
     metastruct, to_write = fl.create_meta_structure(data, "s" * 100)
     assert len(list(to_write.keys())[0]) < fl.MAX_KEY_LENGTH
-    equals(basic_store.read("s" * 100).data, data)
+    if batch:
+        vit = basic_store.batch_read([sym])[sym]
+    else:
+        vit = basic_store.read(sym)
+    equals(vit.data, data)
+    assert vit.symbol == sym
 
 
 def test_too_much_recursive_metastruct_data(monkeypatch, lmdb_version_store_v1):

--- a/python/tests/unit/arcticdb/version_store/test_incompletes.py
+++ b/python/tests/unit/arcticdb/version_store/test_incompletes.py
@@ -14,12 +14,13 @@ from arcticdb.util.test import assert_frame_equal
 @pytest.mark.parametrize("batch", (True, False))
 def test_read_incompletes_with_indexed_data(lmdb_version_store_v1, batch):
     lib = lmdb_version_store_v1
+    lib_tool = lib.library_tool()
     sym = "test_read_incompletes_with_indexed_data"
     num_rows = 10
     df = pd.DataFrame({"col": np.arange(num_rows)}, pd.date_range("2024-01-01", periods=num_rows))
     lib.write(sym, df.iloc[:num_rows // 2])
     for idx in range(num_rows // 2, num_rows):
-        lib.write(sym, df.iloc[idx: idx+1], incomplete=True)
+        lib_tool.append_incomplete(sym, df.iloc[idx: idx+1])
     assert lib.has_symbol(sym)
     if batch:
         received_vit = lib.batch_read([sym], date_ranges=[(df.index[1], df.index[-2])], incomplete=True)[sym]
@@ -32,11 +33,12 @@ def test_read_incompletes_with_indexed_data(lmdb_version_store_v1, batch):
 @pytest.mark.parametrize("batch", (True, False))
 def test_read_incompletes_no_indexed_data(lmdb_version_store_v1, batch):
     lib = lmdb_version_store_v1
+    lib_tool = lib.library_tool()
     sym = "test_read_incompletes_no_indexed_data"
     num_rows = 10
     df = pd.DataFrame({"col": np.arange(num_rows)}, pd.date_range("2024-01-01", periods=num_rows))
     for idx in range(num_rows):
-        lib.write(sym, df.iloc[idx: idx+1], incomplete=True)
+        lib_tool.append_incomplete(sym, df.iloc[idx: idx+1])
     assert not lib.has_symbol(sym)
     if batch:
         received_vit = lib.batch_read([sym], date_ranges=[(df.index[1], df.index[-2])], incomplete=True)[sym]

--- a/python/tests/unit/arcticdb/version_store/test_incompletes.py
+++ b/python/tests/unit/arcticdb/version_store/test_incompletes.py
@@ -1,0 +1,46 @@
+"""
+Copyright 2024 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from arcticdb.util.test import assert_frame_equal
+
+
+@pytest.mark.parametrize("batch", (True, False))
+def test_read_incompletes_with_indexed_data(lmdb_version_store_v1, batch):
+    lib = lmdb_version_store_v1
+    sym = "test_read_incompletes_with_indexed_data"
+    num_rows = 10
+    df = pd.DataFrame({"col": np.arange(num_rows)}, pd.date_range("2024-01-01", periods=num_rows))
+    lib.write(sym, df.iloc[:num_rows // 2])
+    for idx in range(num_rows // 2, num_rows):
+        lib.write(sym, df.iloc[idx: idx+1], incomplete=True)
+    assert lib.has_symbol(sym)
+    if batch:
+        received_vit = lib.batch_read([sym], date_ranges=[(df.index[1], df.index[-2])], incomplete=True)[sym]
+    else:
+        received_vit = lib.read(sym, date_range=(df.index[1], df.index[-2]), incomplete=True)
+    assert received_vit.symbol == sym
+    assert_frame_equal(df.iloc[1:-1], received_vit.data)
+
+
+@pytest.mark.parametrize("batch", (True, False))
+def test_read_incompletes_no_indexed_data(lmdb_version_store_v1, batch):
+    lib = lmdb_version_store_v1
+    sym = "test_read_incompletes_no_indexed_data"
+    num_rows = 10
+    df = pd.DataFrame({"col": np.arange(num_rows)}, pd.date_range("2024-01-01", periods=num_rows))
+    for idx in range(num_rows):
+        lib.write(sym, df.iloc[idx: idx+1], incomplete=True)
+    assert not lib.has_symbol(sym)
+    if batch:
+        received_vit = lib.batch_read([sym], date_ranges=[(df.index[1], df.index[-2])], incomplete=True)[sym]
+    else:
+        received_vit = lib.read(sym, date_range=(df.index[1], df.index[-2]), incomplete=True)
+    assert received_vit.symbol == sym
+    assert_frame_equal(df.iloc[1:-1], received_vit.data)


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #1895 
Fixes https://github.com/man-group/arcticdb-man/issues/171
Fixes #1936 
Fixes #1939 
Fixes #1940 

#### What does this implement or fix?
Schedules all work asynchronously in batch reads when processing is involved, as well as when all symbols are being read directly. Previously, symbols were processed sequentially, leading to idle CPUs when processing lots of smaller symbols.

This works by making `read_frame_for_version`  schedule work and return futures, rather than actually performing the processing. This implementation can then be used for all 4 combinations of batch/non-batch and direct/with processing reads, significantly simplifying the code and removing the now redundant `async_read_direct` (the fact that there were two different implementations to achieve effectively the same thing is what led to 2 of the bugs in the first place).

Several bugs that were discovered during the implementation (flagged above) have also been fixed.

Further work in this area covered in #1968 