### PR TITLE
Refactor DataFrameNormalizer to improve performance

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -703,13 +703,14 @@ class DataFrameNormalizer(_PandasNormalizer):
                 current_dtype = arrays[0].dtype
 
                 for a in arrays[n_ind:]:
+                    a  = to_block(a)
                     if current_dtype == a.dtype:
-                        blocks.append(to_block(a))
+                        blocks.append(a)
                     else:
                         if blocks:
                             yield make_block(values=np.array(blocks), placement=slice(column_placement, column_placement + len(blocks)))
                         column_placement += len(blocks)
-                        blocks, current_dtype = [to_block(a)], a.dtype
+                        blocks, current_dtype = [a], a.dtype
 
                 if blocks:
                     yield make_block(values=np.array(blocks), placement=slice(column_placement, column_placement + len(blocks)))

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -758,7 +758,6 @@ class DataFrameNormalizer(_PandasNormalizer):
         else:
             df = self.df_without_consolidation(columns, item.data[0], item, n_indexes, data)
 
-        print(df)
         if denormed_columns is not None:
             df.columns = denormed_columns
         if norm_meta.common.columns.fake_name is False and len(norm_meta.common.columns.name) > 0:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1963 

#### What does this implement or fix?
This fix aims to reduce the number of calls to [make_block](https://github.com/man-group/ArcticDB/blob/master/python/arcticdb/version_store/_normalization.py#L704) and thus improve the performance of the post processing steps when there are multiple columns of the same type next to each other.

Note: there is not improvement when the columns are of different types

#### Any other comments?
Before the fix the code from the repro took:
```
8050444 function calls (7700439 primitive calls) in 4.323 seconds
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.002    0.002    2.822    2.822 _store.py:1831(_post_process_dataframe)
```

After the fix it took:
```
1679935 function calls (1503062 primitive calls) in 2.043 seconds
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.005    0.005    0.594    0.594 _store.py:1831(_post_process_dataframe)
```

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
