### PR TITLE
Fix 1863

### DIFF
--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -275,7 +275,8 @@ std::vector<EntityId> AggregationClause::process(std::vector<EntityId>&& entity_
     GroupingMap grouping_map;
     // Iterating backwards as we are going to erase from this vector as we go along
     // This is to spread out deallocation of the input segments
-    for (auto it = row_slices.rbegin(); it != row_slices.rend(); ++it) {
+    auto it = row_slices.rbegin();
+    while(it != row_slices.rend()) {
         auto& row_slice = *it;
         auto partitioning_column = row_slice.get(ColumnName(grouping_column_));
         if (std::holds_alternative<ColumnWithStrings>(partitioning_column)) {
@@ -383,7 +384,7 @@ std::vector<EntityId> AggregationClause::process(std::vector<EntityId>&& entity_
         } else {
             util::raise_rte("Expected single column from expression");
         }
-        row_slices.erase(std::next(it).base());
+        it = static_cast<decltype(row_slices)::reverse_iterator>((row_slices.erase(std::next(it).base())));
     }
     SegmentInMemory seg;
     auto index_col = std::make_shared<Column>(make_scalar_type(grouping_data_type), grouping_map.size(), AllocationType::PRESIZED, Sparsity::NOT_PERMITTED);

--- a/cpp/arcticdb/util/test/test_key_utils.cpp
+++ b/cpp/arcticdb/util/test/test_key_utils.cpp
@@ -11,7 +11,7 @@
 
 using namespace arcticdb;
 
-auto write_version_frame_with_three_segments(
+static auto write_version_frame_with_three_segments(
     const arcticdb::StreamId& stream_id,
     arcticdb::VersionId v_id,
     arcticdb::version_store::PythonVersionStore& pvs
@@ -99,11 +99,11 @@ TEST(KeyUtils, RecurseIndexKeyIgnoreMissing) {
     // Given
     auto [version_store, mock_store] = python_version_store_in_memory();
 
-    StreamId first_id{"first"};
+    const StreamId first_id{"first"};
     write_version_frame_with_three_segments(first_id, 0, version_store);
-    StreamId second_id{"second"};
+    const StreamId second_id{"second"};
     write_version_frame_with_three_segments(second_id, 0, version_store);
-    StreamId third_id{"third"};
+    const StreamId third_id{"third"};
     write_version_frame_with_three_segments(third_id, 0, version_store);
 
     std::vector<AtomKeyImpl> index_keys;
@@ -118,13 +118,7 @@ TEST(KeyUtils, RecurseIndexKeyIgnoreMissing) {
     ASSERT_EQ(index_keys.size(), 3);
     ASSERT_EQ(index_for_second.id(), second_id);
 
-    storage::RemoveOpts remove_opts;
-    mock_store->remove_key(index_for_second, remove_opts);
-
-    std::vector<AtomKeyImpl> data_keys;
-    mock_store->iterate_type(KeyType::TABLE_DATA, [&](auto&& vk) {
-        data_keys.emplace_back(std::get<AtomKeyImpl>(vk));
-    });
+    mock_store->remove_key(index_for_second, storage::RemoveOpts{});
 
     // When
     storage::ReadKeyOpts opts;
@@ -135,10 +129,10 @@ TEST(KeyUtils, RecurseIndexKeyIgnoreMissing) {
     ASSERT_EQ(res.size(), 6);
     int count_first = 0;
     int count_third = 0;
-    for (const auto& r : res) {
-        if (r.id() == first_id) {
+    for (const AtomKey& atom_key : res) {
+        if (atom_key.id() == first_id) {
             count_first++;
-        } else if (r.id() == third_id) {
+        } else if (atom_key.id() == third_id) {
             count_third++;
         }
     }

--- a/cpp/arcticdb/util/test/test_key_utils.cpp
+++ b/cpp/arcticdb/util/test/test_key_utils.cpp
@@ -103,6 +103,8 @@ TEST(KeyUtils, RecurseIndexKeyIgnoreMissing) {
     write_version_frame_with_three_segments(first_id, 0, version_store);
     StreamId second_id{"second"};
     write_version_frame_with_three_segments(second_id, 0, version_store);
+    StreamId third_id{"third"};
+    write_version_frame_with_three_segments(third_id, 0, version_store);
 
     std::vector<AtomKeyImpl> index_keys;
     AtomKeyImpl index_for_second;
@@ -113,7 +115,7 @@ TEST(KeyUtils, RecurseIndexKeyIgnoreMissing) {
             index_for_second = ak;
         }
     });
-    ASSERT_EQ(index_keys.size(), 2);
+    ASSERT_EQ(index_keys.size(), 3);
     ASSERT_EQ(index_for_second.id(), second_id);
 
     storage::RemoveOpts remove_opts;
@@ -130,5 +132,16 @@ TEST(KeyUtils, RecurseIndexKeyIgnoreMissing) {
     auto res = recurse_index_keys(mock_store, index_keys, opts);
 
     // Then
-    ASSERT_EQ(res.size(), 3);
+    ASSERT_EQ(res.size(), 6);
+    int count_first = 0;
+    int count_third = 0;
+    for (const auto& r : res) {
+        if (r.id() == first_id) {
+            count_first++;
+        } else if (r.id() == third_id) {
+            count_third++;
+        }
+    }
+    ASSERT_EQ(3, count_first);
+    ASSERT_EQ(3, count_third);
 }

--- a/python/tests/unit/arcticdb/version_store/test_deletion.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion.py
@@ -5,10 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-import gc
 import sys
-import time
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -129,119 +126,36 @@ def test_delete_library_tool(version_store_factory, sym):
         assert len(lt.find_keys_for_id(kt, symbol)) == 0
 
 
-def test_prune_previous_memory_usage(lmdb_version_store_very_big_map):
-    """
-Baseline:
-
- Command being timed: "pytest -vs tests/unit/arcticdb/version_store/test_deletion.py::test_prune_previous_memory_usage"
-        User time (seconds): 65.78
-        System time (seconds): 15.60
-        Percent of CPU this job got: 64%
-        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:05.46
-        Average shared text size (kbytes): 0
-        Average unshared data size (kbytes): 0
-        Average stack size (kbytes): 0
-        Average total size (kbytes): 0
-        Maximum resident set size (kbytes): 1338220
-        Average resident set size (kbytes): 0
-        Major (requiring I/O) page faults: 336
-        Minor (reclaiming a frame) page faults: 6275974
-        Voluntary context switches: 210006
-        Involuntary context switches: 57078
-        Swaps: 0
-        File system inputs: 173144
-        File system outputs: 3713984
-        Socket messages sent: 0
-        Socket messages received: 0
-        Signals delivered: 0
-        Page size (bytes): 4096
-        Exit status: 0
-
-After naive changes:
-
-        Command being timed: "pytest -vs tests/unit/arcticdb/version_store/test_deletion.py::test_prune_previous_memory_usage"
-        User time (seconds): 74.67
-        System time (seconds): 17.44
-        Percent of CPU this job got: 66%
-        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:19.21
-        Average shared text size (kbytes): 0
-        Average unshared data size (kbytes): 0
-        Average stack size (kbytes): 0
-        Average total size (kbytes): 0
-        Maximum resident set size (kbytes): 3222008
-        Average resident set size (kbytes): 0
-        Major (requiring I/O) page faults: 2
-        Minor (reclaiming a frame) page faults: 6751291
-        Voluntary context switches: 203947
-        Involuntary context switches: 59912
-        Swaps: 0
-        File system inputs: 752
-        File system outputs: 3714992
-        Socket messages sent: 0
-        Socket messages received: 0
-        Signals delivered: 0
-        Page size (bytes): 4096
-        Exit status: 0
-
-    :param lmdb_version_store_very_big_map:
-    :return:
-    """
-    lib = lmdb_version_store_very_big_map
-    sym = "test_prune_previous_memory_usage"
-    num_versions = 8000
-    for idx in range(num_versions):
-        lib.append(sym, pd.DataFrame({"col": np.arange(idx, idx+1)}), write_if_missing=True)
-    assert len(lib.list_versions(sym)) == num_versions
-    gc.collect()
-    start = time.time()
-    lib.prune_previous_versions(sym)
-    print(f"Prune took {time.time() - start}s")
-    assert len(lib.list_versions(sym)) == 1
-
-
 def test_delete_snapshot(version_store_factory):
-    lmdb_version_store = version_store_factory(col_per_group=100, row_per_segment=10)
+    lmdb_version_store = version_store_factory(col_per_group=5, row_per_segment=10)
     lt = lmdb_version_store.library_tool()
 
-    symbol = "symbol"
-    other_symbol = "other_symbol"
+    symbol = "test_delete_snapshot"
     snap = "test_delete_snapshot_snap"
 
-    df1 = sample_dataframe(20)
+    df1 = sample_dataframe(1000)
     lmdb_version_store.write(symbol, df1)
-    lmdb_version_store.write(other_symbol, df1)
     lmdb_version_store.snapshot(snap)
 
-    df2 = sample_dataframe(30)
+    df2 = sample_dataframe(1000)
     lmdb_version_store.write(symbol, df2, prune_previous_version=True)
-    lmdb_version_store.write(other_symbol, df2, prune_previous_version=True)
 
     # Should not raise as it exists in a snapshot
     lmdb_version_store.read(symbol, 0)
-    lmdb_version_store.read(other_symbol, 0)
 
     assert_frame_equal(lmdb_version_store.read(symbol, as_of=snap).data, df1)
-    assert_frame_equal(lmdb_version_store.read(other_symbol, as_of=snap).data, df1)
-
-    for s in (symbol, other_symbol):
-        data_keys = lt.find_keys_for_id(KeyType.TABLE_DATA, s)
-        assert len(data_keys) == 5  # 20 rows in df1, 30 rows in df2, 10 rows per segment
 
     lmdb_version_store.delete_snapshot(snap)
     with pytest.raises(NoDataFoundException):
         lmdb_version_store.read(symbol, as_of=snap)
-        lmdb_version_store.read(other_symbol, as_of=snap)
 
-    for s in (symbol, other_symbol):
-        index_keys = lt.find_keys_for_id(KeyType.TABLE_INDEX, s)
-        assert len(index_keys) == 1
-        for k in index_keys:
-            assert k.version_id != 0
+    index_keys = lt.find_keys_for_id(KeyType.TABLE_INDEX, symbol)
+    for k in index_keys:
+        assert k.version_id != 0
 
-        data_keys = lt.find_keys_for_id(KeyType.TABLE_DATA, s)
-        assert len(data_keys) == 3  # 30 rows in df2, 10 rows per segment
-        for k in data_keys:
-            assert k.version_id == 1
+    data_keys = lt.find_keys_for_id(KeyType.TABLE_DATA, symbol)
+    for k in data_keys:
+        assert k.version_id != 0
 
 
 def test_tombstones_deleted_data_keys_prune(lmdb_version_store_prune_previous, sym):


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Fixes: #1958
Fixes: #1863
#### What does this implement or fix?

* Fix orphaned keys. recurse_index_keys does not assume that the all
  atom keys are for the same stream id anymore
* Fix AggregationClause::process vector iterator invalidation. Not
  related to the issue but C++ were crashing at runtime because of this.
  Calling erase invalidates the iterator in a loop.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
