### PR TITLE
Fix publish result curl fail

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -58,10 +58,31 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs: [benchmark_commits]  
     runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:22.04 # Native runner doesn't allow setting up the ca softlinks required below
     permissions:
       contents: write
 
     steps:
+      - name: Select Python
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: "3.10"
+
+      - name: Prepare environment
+        shell: bash -el {0}
+        run: |
+          apt update
+          apt install -y git
+          python -m pip install arcticdb[Testing] "protobuf<5"
+
+      - name: Setup softlink for SSL
+        shell: bash -el {0}
+        run: |
+            mkdir -p /etc/pki/tls
+            ln -s /usr/lib/ssl/certs /etc/pki/tls/certs
+            ln -s /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
+
       - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
@@ -74,11 +95,6 @@ jobs:
           bucket: "arcticdb-ci-benchmark-results"
           aws_access_key: "${{ secrets.AWS_S3_ACCESS_KEY }}"
           aws_secret_key: "${{ secrets.AWS_S3_SECRET_KEY }}"
-
-      - name: Install ArcticDB[Testing]
-        shell: bash -el {0}
-        run: |
-          pip install arcticdb[Testing] "protobuf<5"
 
       - name: Publish results to Github Pages
         shell: bash -el {0}


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
#1971 
#### What does this implement or fix?
Fix publish benchmark fails
#### Any other comments?
Test result: https://github.com/man-group/ArcticDB/actions/runs/11678805668 
The git command fails due to the testing branch is not `master`. The S3 exception blocking step has been cleared.

The publish benchmark step fails due to SSL CA cert cannot be found by ArcticDB. It's because of https://github.com/man-group/ArcticDB/issues/1129. 
Instead of modifying the script to add CA certs to the connection strings, adding the softlink of the CA certs (ubuntu style -> rhel style) is a more staight forward option.

Ubuntu docker container is needed to be used as the native runner image blocks adding softlinks at the required location. Thus the new environment setup step.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
