### PR TITLE
Add custom overlay fixing clang builds for bitmagic

### DIFF
--- a/cpp/third_party/vcpkg_overlays/bitmagic/fix-clang.patch
+++ b/cpp/third_party/vcpkg_overlays/bitmagic/fix-clang.patch
@@ -1,0 +1,32 @@
+From fab01f43eca266bf56efb1aca659773c911a83fb Mon Sep 17 00:00:00 2001
+From: Anatoliy Kuznetsov <anatoliy.kuznetsov@gmail.com>
+Date: Tue, 3 Sep 2024 15:29:08 -0400
+Subject: [PATCH] fixed clang compilation issues
+
+---
+ src/bm.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/bm.h b/src/bm.h
+index 70996e53..05bb139c 100644
+--- a/src/bm.h
++++ b/src/bm.h
+@@ -523,7 +523,7 @@ class bvector
+         {
+             bvect_ = ii.bvect_;
+             if (!buf_)
+-                buf_ = bvect_->allocate_tempblock();
++                buf_ = (value_type*) bvect_->blockman_.get_allocator().alloc_bit_block();
+             buf_size_ = ii.buf_size_;
+             ::memcpy(buf_, ii.buf_, buf_size_ * sizeof(*buf_));
+             sorted_ = ii.sorted_;
+@@ -534,7 +534,7 @@ class bvector
+         {
+             bvect_ = ii.bvect_;
+             if (buf_)
+-                bvect_->free_tempblock(buf_);
++                bvect_->blockman_.get_allocator().free_bit_block((bm::word_t*)buf_);
+             buf_ = ii.buf_; ii.buf_ = 0;
+             buf_size_ = ii.buf_size_;
+             sorted_ = ii.sorted_;
+

--- a/cpp/third_party/vcpkg_overlays/bitmagic/portfile.cmake
+++ b/cpp/third_party/vcpkg_overlays/bitmagic/portfile.cmake
@@ -1,0 +1,15 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tlk00/BitMagic
+    REF "v${VERSION}"
+    SHA512 d034f66b8631d09cb0be11b96f5f12dea416ef2cfca42ed7f0865aeb65102a4951821805ec65bee793541ce1a665e5d11ba4bedb0d79956c0eee6c856afb29b2
+    HEAD_REF master
+    PATCHES
+       fix-clang.patch
+
+)
+
+file(GLOB HEADER_LIST "${SOURCE_PATH}/src/*.h")
+file(INSTALL ${HEADER_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/cpp/third_party/vcpkg_overlays/bitmagic/vcpkg.json
+++ b/cpp/third_party/vcpkg_overlays/bitmagic/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "bitmagic",
+  "version": "7.13.4",
+  "description": "Algorithms and tools for Algebra of Sets for information retrieval, indexing of databases, scientific algorithms, ranking, clustering, unsupervised machine learning and signal processing.",
+  "homepage": "http://bitmagic.io"
+}


### PR DESCRIPTION
#### Reference Issues/PRs
Bitmagic is failing ArcitcDB builds. The issue is reported [here](https://github.com/tlk00/BitMagic/issues/76) and is fixed in master. A ticket to port the fix into vcpkg is made [here](https://github.com/microsoft/vcpkg/issues/41935). Use custom overlay while waiting for proper port.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
