### PR TITLE
Skip azure compat tests

### DIFF
--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -182,8 +182,9 @@ def arctic_uri(request):
 
 @pytest.fixture()
 def old_venv_and_arctic_uri(old_venv, arctic_uri):
-    if Version(old_venv.version) <= Version("4.5.0") and arctic_uri.startswith("mongo"):
-        pytest.skip("Mongo storage backend has a desctruction bug present until 4.5.0, which can cause flaky segfaults.")
+    if arctic_uri.startswith("mongo"):
+        # TODO: We tought the bug was fixed in 4.5.1 but it's still present.
+        pytest.skip("Mongo storage backend has a desctruction bug, which can cause flaky segfaults.")
     if Version(old_venv.version) <= Version("4.5.0") and arctic_uri.startswith("lmdb"):
         pytest.skip("LMDB storage backend has a desctruction bug present until 4.5.0, which can cause flaky segfaults.")
     if arctic_uri.startswith("azure"):

--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -182,13 +182,12 @@ def arctic_uri(request):
 
 @pytest.fixture()
 def old_venv_and_arctic_uri(old_venv, arctic_uri):
+    # TODO: Once #1979 is understood and fixed reenable mongo, lmdb and azure for versions which have the fix.
     if arctic_uri.startswith("mongo"):
-        # TODO: We tought the bug was fixed in 4.5.1 but it's still present.
-        pytest.skip("Mongo storage backend has a desctruction bug, which can cause flaky segfaults.")
-    if Version(old_venv.version) <= Version("4.5.0") and arctic_uri.startswith("lmdb"):
-        pytest.skip("LMDB storage backend has a desctruction bug present until 4.5.0, which can cause flaky segfaults.")
+        pytest.skip("Mongo storage backend has a probable desctruction bug, which can cause flaky segfaults.")
+    if arctic_uri.startswith("lmdb"):
+        pytest.skip("LMDB storage backend has a probable desctruction bug, which can cause flaky segfaults.")
     if arctic_uri.startswith("azure"):
-        # TODO: Once #1979 is understood and fixed reenable azure on versions which have the fix.
         pytest.skip("Azure storage backend has probable a desctruction bug, which can cause flaky segfaults.")
 
     return old_venv, arctic_uri

--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -140,7 +140,7 @@ class VenvLib:
     scope="session",
     params=[
         pytest.param("1.6.2", marks=VENV_COMPAT_TESTS_MARK),
-        pytest.param("4.5.0", marks=VENV_COMPAT_TESTS_MARK),
+        pytest.param("4.5.1", marks=VENV_COMPAT_TESTS_MARK),
     ] # TODO: Extend this list with other old versions
 )
 def old_venv(request):
@@ -176,10 +176,12 @@ def arctic_uri(request):
 
 @pytest.fixture()
 def old_venv_and_arctic_uri(old_venv, arctic_uri):
-    # TODO: Replace 4.5.0 with 4.5.1 when it is released to re-enable both mongo and lmdb.
     if Version(old_venv.version) <= Version("4.5.0") and arctic_uri.startswith("mongo"):
         pytest.skip("Mongo storage backend has a desctruction bug present until 4.5.0, which can cause flaky segfaults.")
     if Version(old_venv.version) <= Version("4.5.0") and arctic_uri.startswith("lmdb"):
         pytest.skip("LMDB storage backend has a desctruction bug present until 4.5.0, which can cause flaky segfaults.")
+    if arctic_uri.startswith("azure"):
+        # TODO: Once #1979 is understood and fixed reenable azure on versions which have the fix.
+        pytest.skip("Azure storage backend has probable a desctruction bug, which can cause flaky segfaults.")
 
     return old_venv, arctic_uri

--- a/python/tests/compat/requirements-4.5.0.txt
+++ b/python/tests/compat/requirements-4.5.0.txt
@@ -1,3 +1,0 @@
-arcticdb==4.5.0
-numpy<2
-pyarrow

--- a/python/tests/compat/requirements-4.5.1.txt
+++ b/python/tests/compat/requirements-4.5.1.txt
@@ -1,0 +1,3 @@
+arcticdb==4.5.1
+numpy<2
+pyarrow


### PR DESCRIPTION
#### Reference Issues/PRs
Skips azure compat test to make #1979 compat tests non-flaky but we still need to fix the bug from #1979.

#### What does this implement or fix?
I've packaged up a few other improvements in this pr as well:
- Skips the azure tests
- Replaces the 4.5.0 version with a 4.5.1, this should allow us to run lmdb and mongo compat tests without segfaults.
- Use `shell=True` and an `abspath` to successfully run on conda feedstock linux runners. This was tested to work in [here](https://github.com/conda-forge/arcticdb-feedstock/pull/322), although for some reason still doesn't work on mac. We'll fix the mac issues later.
- Also running 4.5.1 uncovered that the mongo segfault is not entirely fixed. Skipping mongo similarly to azure tests.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
