### PR TITLE
Test meaningful error message when reading incompletes from non-existent symbol

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_incompletes.py
+++ b/python/tests/unit/arcticdb/version_store/test_incompletes.py
@@ -50,9 +50,9 @@ def test_read_incompletes_no_indexed_data(lmdb_version_store_v1, batch):
 
 
 @pytest.mark.parametrize("batch", (True, False))
-def test_read_incompletes_non_existant_symbol(lmdb_version_store_v1, batch):
+def test_read_incompletes_non_existent_symbol(lmdb_version_store_v1, batch):
     lib = lmdb_version_store_v1
-    sym = "test_read_incompletes_non_existant_symbol"
+    sym = "test_read_incompletes_non_existent_symbol"
     # Incomplete reads require a date range
     date_range = (pd.Timestamp(0), pd.Timestamp(1))
     with pytest.raises(MissingDataException):


### PR DESCRIPTION
#### Reference Issues/PRs
Closes https://github.com/man-group/arcticdb-ursus/issues/8

#### What does this implement or fix?
Actual bug was fixed, probably in #1950, this just adds a test of the correct behaviour