### PR TITLE
Claim more disk space for wheel building

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -104,7 +104,11 @@ jobs:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{vars.CMAKE_BUILD_PARALLEL_LEVEL}}
 
       # ========================= Leader steps =========================
-      - name: Remove GitHub default packages # To save space
+      - name: Remove GitHub default packages (baseimage) # To save space
+        if: inputs.job_type == 'build-python-wheels' && matrix.os == 'linux'
+        uses: jlumbroso/free-disk-space@main
+
+      - name: Remove GitHub default packages (manylinux) # To save space
         if: inputs.job_type == 'cpp-tests' && matrix.os == 'linux'
         run: |
           du -m /mnt/usr/local/lib/ | sort -n | tail -n 50


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Depended by https://github.com/man-group/ArcticDB/issues/1230

#### What does this implement or fix?
This is not enough disk space after upgrading `cibuildwheel` to v2.21.3 (for the support of python 3.12)
We are using manylinux to build our wheel, so we can get rid of almost everything on the base runner image.
In the long term it will be better if we can switch to self-host runner, as the new action added in this PR could break our pipeline if gh has decided to do something crazy things with the base image.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
