### PR TITLE
Fix string reference count leak

### DIFF
--- a/cpp/arcticdb/python/python_strings.hpp
+++ b/cpp/arcticdb/python/python_strings.hpp
@@ -27,7 +27,7 @@ class DynamicStringReducer  {
     size_t row_ = 0U;
     DecodePathData shared_data_;
     PythonHandlerData& handler_data_;
-    PyObject ** ptr_dest_;
+    PyObject** ptr_dest_;
     size_t total_rows_;
 public:
     DynamicStringReducer(
@@ -177,7 +177,7 @@ private:
                     }
 
                     allocated.try_emplace(offset, obj);
-                    for (auto c = 0U; c < count; ++c)
+                    for (auto c = 1U; c < count; ++c)
                         inc_ref(obj);
                 }
             }
@@ -202,7 +202,7 @@ private:
             for (const auto &[offset, count] : unique_counts) {
                 const auto sv = get_string_from_pool(offset, string_pool);
                 auto obj = StringCreator::create(sv, has_type_conversion);
-                for (auto c = 0U; c < count; ++c)
+                for (auto c = 1U; c < count; ++c)
                     inc_ref(obj);
 
                 py_strings.insert(std::make_pair(offset, obj));
@@ -229,11 +229,10 @@ private:
     }
 
     std::pair<size_t, size_t> write_strings_to_column_dense(
-        size_t ,
-        const Column& source_column,
-        const std::unique_ptr<py::none>& none,
-        const ankerl::unordered_dense::map<entity::position_t, PyObject*>& py_strings
-        ) {
+            size_t ,
+            const Column& source_column,
+            const std::unique_ptr<py::none>& none,
+            const ankerl::unordered_dense::map<entity::position_t, PyObject*>& py_strings) {
         auto data = source_column.data();
         auto src = data.cbegin<ScalarTagType<DataTypeTag<DataType::UINT64>>, IteratorType::REGULAR, IteratorDensity::DENSE>();
         auto end = data.cend<ScalarTagType<DataTypeTag<DataType::UINT64>>, IteratorType::REGULAR, IteratorDensity::DENSE>();


### PR DESCRIPTION
The various Python string creation methods already start from a ref-count of 1, so we need to increment from 1 not 0 in the string allocation code, otherwise the reference count reduction in the allocated frame is not enough to free the object