### PR TITLE
7898685792 Finalize staged data memory use improvements

### DIFF
--- a/cpp/arcticdb/pipeline/frame_slice.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice.hpp
@@ -173,11 +173,13 @@ private:
 
 // Collection of these objects is the input to batch_read_uncompressed
 struct RangesAndKey {
-    explicit RangesAndKey(const FrameSlice& frame_slice, entity::AtomKey&& key):
+    explicit RangesAndKey(const FrameSlice& frame_slice, entity::AtomKey&& key, bool is_incomplete):
     row_range_(frame_slice.rows()),
     col_range_(frame_slice.columns()),
-    key_(std::move(key)) {
+    key_(std::move(key)),
+    is_incomplete_(is_incomplete) {
     }
+
     explicit RangesAndKey(const RowRange& row_range, const ColRange& col_range, const entity::AtomKey& key):
             row_range_(row_range),
             col_range_(col_range),
@@ -203,6 +205,10 @@ struct RangesAndKey {
         return key_.end_time() - 1;
     }
 
+    bool is_incomplete() const {
+        return is_incomplete_;
+    }
+
     friend bool operator==(const RangesAndKey& left, const RangesAndKey& right) {
         return left.row_range_ == right.row_range_ && left.col_range_ == right.col_range_ && left.key_ == right.key_;
     }
@@ -214,6 +220,7 @@ struct RangesAndKey {
     RowRange row_range_;
     ColRange col_range_;
     entity::AtomKey key_;
+    bool is_incomplete_{false};
 };
 
 /*

--- a/cpp/arcticdb/version/version_core-inl.hpp
+++ b/cpp/arcticdb/version/version_core-inl.hpp
@@ -13,6 +13,7 @@
 #include <arcticdb/stream/merge.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/stream/segment_aggregator.hpp>
+#include <arcticdb/version/schema_checks.hpp>
 
 namespace arcticdb {
 
@@ -97,62 +98,6 @@ void merge_frames_for_keys(
             target_id, idx, std::move(segmentation_policy), index_keys, query, store, std::move(func));
     }, index, density_policy);
 
-}
-
-template <typename IndexType, typename SchemaType, typename SegmentationPolicy, typename DensityPolicy, typename IteratorType>
-void do_compact(
-    IteratorType target_start,
-    IteratorType target_end,
-    const std::shared_ptr<pipelines::PipelineContext>& pipeline_context,
-    std::vector<folly::Future<VariantKey>>& fut_vec,
-    std::vector<pipelines::FrameSlice>& slices,
-    const std::shared_ptr<Store>& store,
-    bool convert_int_to_float,
-    std::optional<size_t> segment_size,
-    bool validate_index){
-        auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
-        stream::SegmentAggregator<IndexType, SchemaType, SegmentationPolicy, DensityPolicy>
-        aggregator{
-            [&slices](pipelines::FrameSlice &&slice) {
-                slices.emplace_back(std::move(slice));
-            },
-            SchemaType{pipeline_context->descriptor(), index},
-            [&fut_vec, &store, &pipeline_context](SegmentInMemory &&segment) {
-                auto local_index_start = IndexType::start_value_for_segment(segment);
-                auto local_index_end = pipelines::end_index_generator(IndexType::end_value_for_segment(segment));
-                stream::StreamSink::PartialKey
-                pk{KeyType::TABLE_DATA, pipeline_context->version_id_, pipeline_context->stream_id_, local_index_start, local_index_end};
-                fut_vec.emplace_back(store->write(pk, std::move(segment)));
-            },
-            segment_size.has_value() ? SegmentationPolicy{*segment_size} : SegmentationPolicy{}
-        };
-
-        for(auto it = target_start; it != target_end; ++it) {
-            auto sk = [&it](){
-                if constexpr(std::is_same_v<IteratorType, pipelines::PipelineContext::iterator>)
-                    return it->slice_and_key();
-                else
-                    return *it;
-            }();
-            if (sk.slice().rows().diff() == 0) {
-                continue;
-            }
-
-            const auto& segment = sk.segment(store);
-            sorting::check<ErrorCode::E_UNSORTED_DATA>(
-                !validate_index || segment.descriptor().sorted() == SortedValue::ASCENDING ||
-                    segment.descriptor().sorted() == SortedValue::UNKNOWN,
-                "Cannot compact unordered segment."
-            );
-
-            aggregator.add_segment(
-                std::move(sk.segment(store)),
-                sk.slice(),
-                convert_int_to_float
-            );
-            sk.unset_segment();
-        }
-        aggregator.commit();
 }
 
 [[nodiscard]] inline ReadOptions defragmentation_read_options_generator(const WriteOptions &options){

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1896,8 +1896,9 @@ CheckOutcome check_schema_matches_incomplete(const StreamDescriptor& stream_desc
     if (!columns_match(stream_descriptor_incomplete, pipeline_context->descriptor())) {
         return Error{
             throw_error<ErrorCode::E_DESCRIPTOR_MISMATCH>,
-            fmt::format("When static schema is used all staged segments must have the same column and column types."
+            fmt::format("{} When static schema is used all staged segments must have the same column and column types."
                         "{} is different than {}",
+                        error_code_data<ErrorCode::E_DESCRIPTOR_MISMATCH>.name_,
                         stream_descriptor_incomplete,
                         pipeline_context->descriptor())
         };

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -222,7 +222,7 @@ struct Error {
 };
 
 using CheckOutcome = std::variant<Error, std::monostate>;
-using StaticSchemaCompactionChecks = folly::Function<CheckOutcome(const StreamDescriptor&, const pipelines::PipelineContext&)>;
+using StaticSchemaCompactionChecks = folly::Function<CheckOutcome(const StreamDescriptor&, const StreamDescriptor&)>;
 using CompactionWrittenKeys = std::vector<VariantKey>;
 using CompactionResult = std::variant<CompactionWrittenKeys, Error>;
 
@@ -284,7 +284,7 @@ template <typename IndexType, typename SchemaType, typename SegmentationPolicy, 
         }
 
         if constexpr (std::is_same_v<SchemaType, FixedSchema>) {
-            CheckOutcome outcome = checks(segment.descriptor(), *pipeline_context);
+            CheckOutcome outcome = checks(segment.descriptor(), pipeline_context->descriptor());
             if (std::holds_alternative<Error>(outcome)) {
                 auto written_keys = folly::collect(write_futures).get();
                 remove_written_keys(store.get(), std::move(written_keys));
@@ -304,7 +304,7 @@ template <typename IndexType, typename SchemaType, typename SegmentationPolicy, 
     return folly::collect(std::move(write_futures)).get();
 }
 
-CheckOutcome check_schema_matches_incomplete(const StreamDescriptor& stream_descriptor_incomplete, const pipelines::PipelineContext& pipeline_context);
+CheckOutcome check_schema_matches_incomplete(const StreamDescriptor& stream_descriptor_incomplete, const StreamDescriptor& pipeline_context);
 
 }
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -19,6 +19,7 @@
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/stream/stream_reader.hpp>
 #include <arcticdb/stream/aggregator.hpp>
+#include <arcticdb/stream/segment_aggregator.hpp>
 #include <arcticdb/entity/frame_and_descriptor.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
 
@@ -208,6 +209,102 @@ folly::Future<ReadVersionOutput> read_frame_for_version(
 );
 
 } //namespace arcticdb::version_store
+
+namespace arcticdb {
+
+struct Error {
+
+    explicit Error(folly::Function<void(std::string)> raiser, std::string msg);
+    void throw_error();
+
+    folly::Function<void(std::string)> raiser_;
+    std::string msg_;
+};
+
+using CheckOutcome = std::variant<Error, std::monostate>;
+using StaticSchemaCompactionChecks = folly::Function<CheckOutcome(const StreamDescriptor&, const pipelines::PipelineContext* const)>;
+using CompactionWrittenKeys = std::vector<VariantKey>;
+using CompactionResult = std::variant<CompactionWrittenKeys, Error>;
+
+void remove_written_keys(Store* store, CompactionWrittenKeys&& written_keys);
+
+template <typename IndexType, typename SchemaType, typename SegmentationPolicy, typename DensityPolicy, typename IteratorType>
+[[nodiscard]] CompactionResult do_compact(
+    IteratorType to_compact_start,
+    IteratorType to_compact_end,
+    const std::shared_ptr<pipelines::PipelineContext>& pipeline_context,
+    std::vector<pipelines::FrameSlice>& slices,
+    const std::shared_ptr<Store>& store,
+    bool convert_int_to_float,
+    std::optional<size_t> segment_size,
+    bool validate_index,
+    StaticSchemaCompactionChecks&& checks) {
+    CompactionResult result;
+    auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
+
+    std::vector<folly::Future<VariantKey>> write_futures;
+
+    stream::SegmentAggregator<IndexType, SchemaType, SegmentationPolicy, DensityPolicy>
+        aggregator{
+        [&slices](pipelines::FrameSlice &&slice) {
+            slices.emplace_back(std::move(slice));
+        },
+        SchemaType{pipeline_context->descriptor(), index},
+        [&write_futures, &store, &pipeline_context](SegmentInMemory &&segment) {
+            auto local_index_start = IndexType::start_value_for_segment(segment);
+            auto local_index_end = pipelines::end_index_generator(IndexType::end_value_for_segment(segment));
+            stream::StreamSink::PartialKey
+                pk{KeyType::TABLE_DATA, pipeline_context->version_id_, pipeline_context->stream_id_, local_index_start, local_index_end};
+
+            // TODO We should apply back pressure to the work we are generating here, to bound memory use
+            write_futures.emplace_back(store->write(pk, std::move(segment)));
+        },
+        segment_size.has_value() ? SegmentationPolicy{*segment_size} : SegmentationPolicy{}
+    };
+
+    for (auto it = to_compact_start; it != to_compact_end; ++it) {
+        auto sk = [&it]() {
+            if constexpr (std::is_same_v<IteratorType, pipelines::PipelineContext::iterator>)
+                return it->slice_and_key();
+            else
+                return *it;
+        }();
+        if (sk.slice().rows().diff() == 0) {
+            continue;
+        }
+
+        const SegmentInMemory& segment = sk.segment(store);
+
+        if(validate_index && segment.descriptor().sorted() != SortedValue::ASCENDING && segment.descriptor().sorted() != SortedValue::UNKNOWN) {
+            auto written_keys = folly::collect(write_futures).get();
+            remove_written_keys(store.get(), std::move(written_keys));
+            return Error{throw_error<ErrorCode::E_UNSORTED_DATA>, "Cannot compact unordered segment"};
+        }
+
+        if constexpr (std::is_same_v<SchemaType, FixedSchema>) {
+            CheckOutcome outcome = checks(segment.descriptor(), pipeline_context.get());
+            if (std::holds_alternative<Error>(outcome)) {
+                auto written_keys = folly::collect(write_futures).get();
+                remove_written_keys(store.get(), std::move(written_keys));
+                return std::get<Error>(std::move(outcome));
+            }
+        }
+
+        aggregator.add_segment(
+            std::move(sk.segment(store)),
+            sk.slice(),
+            convert_int_to_float
+        );
+        sk.unset_segment();
+    }
+
+    aggregator.commit();
+    return folly::collect(std::move(write_futures)).get();
+}
+
+CheckOutcome check_schema_matches_incomplete(const StreamDescriptor& stream_descriptor_incomplete, const pipelines::PipelineContext* const pipeline_context);
+
+}
 
 #define ARCTICDB_VERSION_CORE_H_
 #include <arcticdb/version/version_core-inl.hpp>

--- a/python/tests/unit/arcticdb/version_store/test_sort_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort_merge.py
@@ -23,6 +23,7 @@ def assert_delete_staged_data_clears_append_keys(lib, sym):
     lib.delete_staged_data(sym)
     assert len(get_append_keys(lib, sym)) == 0
 
+
 def test_merge_single_column(lmdb_library_static_dynamic):
     lib = lmdb_library_static_dynamic
 


### PR DESCRIPTION
Discussion: https://chat-man.slack.com/archives/C02NEG3V38X/p1732181354814409

Testing in https://github.com/man-group/ArcticDB/commit/0cc7090bfe0fac4aaf0ad232f95f14f7b0d9d989 shows that with Georgi's repro script with 1000 incomplete segments, the peak memory use went from 3200MB to 1200MB.

Running the repro script with 18_000 incompletes, the peak memory now stays at 1200GB. Previously, running this would OOM crash on a machine with 64GB of memory.

Future work:

- Backpressure - https://github.com/man-group/ArcticDB/pull/2013/files#diff-07407837d69849c0f3084af0394134f44646daae2e34ba042122d7bdc8a44d12R151 . There are still theoretical ways where memory use could grow, I think (if we have too many incomplete "write" futures live at once, since each holds a segment, and the IO executor has an unbounded queue size).