### PR TITLE
Fix version release not attaching symbols for debug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,6 @@ jobs:
   release_notes:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04
-    env:
-      SYMBOLS_ARTIFACT: /tmp/symbols.tar.zst # Use absolute path to workaround a bug in action-gh-release
     steps:
       # Copy and pasted from the pypi job below, until GitHub adds selective artifact download
       - uses: actions/setup-node@v3.8.2
@@ -62,7 +60,12 @@ jobs:
       - id: compress
         name: Compress debug symbols
         if: steps.download.outcome == 'success'
-        run: tar -cvaf $SYMBOLS_ARTIFACT build-metadata-*
+        run: |
+          for file in build-metadata-build-python-wheels-*; do
+            identifier=$(echo "$file" | sed -E 's/build-metadata-build-python-wheels-(.*)/\1/')
+            output_file="/tmp/symbols-${identifier}.tar.zst"
+            tar --zstd -cf "$output_file" "$file"
+          done
         continue-on-error: true
 
       - name: Checkout # Needed by the release action
@@ -87,7 +90,7 @@ jobs:
 
             ---
             > The wheels are on [PyPI](https://pypi.org/project/arcticdb/). Below are for debugging:
-          files: ${{steps.compress.outcome == 'success' && env.SYMBOLS_ARTIFACT || ''}}
+          files: ${{steps.compress.outcome == 'success' && '/tmp/symbols*.tar.zst' || ''}}
 
 
   pypi:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Debug info has not been attached to the release note since v5.0. It's because the pipeline has archived all build symbols into one tar ball, which unfortunately, has exceeded the maximum individual size limit of attachement (2GB).
Since there are no overall size limit of attachement per release note (yet), this PR will simply attached all symbols to the release note individually.

#### Any other comments?
Evidence of successful attachement:
https://github.com/man-group/ArcticDB/releases/tag/untagged-c315883fbd8f587d2c5d

The test release note will be deleted along with the tag after merging this commit

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
