### PR TITLE
Ship failing tests

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -157,6 +157,13 @@ jobs:
         if: inputs.job_type == 'cpp-tests'
         run: cpp/out/install/arcticdb_rapidcheck_tests
 
+      - name: Collect arcticdb_rapidcheck_tests binary on failure
+        if: failure()
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: arcticdb_rapidcheck_tests_${{matrix.os}}
+          path: cpp/out/install/arcticdb_rapidcheck_tests*
+
       - name: C++ unit tests
         if: inputs.job_type == 'cpp-tests'
         run: |
@@ -168,6 +175,13 @@ jobs:
           [[ $(jq '.errors' test_unit_arcticdb.json) -eq 0 ]]
         env:
           ARCTICDB_memory_loglevel: INFO
+
+      - name: Collect test_unit_arcticdb binary on failure
+        if: failure()
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: test_unit_arcticdb_${{matrix.os}}
+          path: cpp/out/install/test_unit_arcticdb*
 
       # We don't do anything with the benchmarks automatically yet, but check that they at least compile and run.
       - name: Compile C++ Benchmarks

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -163,10 +163,6 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     }
 }
 
-TEST(DeliberatelyFailingTest, FailingTest) {
-    ASSERT_EQ(1, 0);
-}
-
 TEST_F(VersionStoreTest, SortMerge) {
     using namespace arcticdb;
     using namespace arcticdb::storage;

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -163,6 +163,10 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     }
 }
 
+TEST(DeliberatelyFailingTest, FailingTest) {
+    ASSERT_EQ(1, 0);
+}
+
 TEST_F(VersionStoreTest, SortMerge) {
     using namespace arcticdb;
     using namespace arcticdb::storage;


### PR DESCRIPTION
When the C++ unit tests fail, upload them as artifacts to allow proper investigation.

33acc24 added an example failing test that showed the upload working.