### PR TITLE
Upgrade C++ test and benchmark workflow python to 38

### DIFF
--- a/.github/actions/setup_deps/action.yml
+++ b/.github/actions/setup_deps/action.yml
@@ -43,6 +43,7 @@ runs:
         which gcc
         which g++
         echo "python_in_use=/opt/python/cp38-cp38/bin/python" >> "$GITHUB_OUTPUT"
+        echo /opt/python/cp38-cp38/bin >> $GITHUB_PATH
 outputs:
   python_in_use:
     value: ${{ steps.install_deps.outputs.python_in_use }}

--- a/.github/actions/setup_deps/action.yml
+++ b/.github/actions/setup_deps/action.yml
@@ -4,13 +4,14 @@ runs:
   using: "composite"
   steps:
     - name: Install deps
+      id: install_deps
       shell: bash -l {0} 
       run: |
         dnf update -y
         dnf remove -y 'gcc-toolset-13-*'
         dnf install -y zip flex bison gcc-toolset-10 gcc-toolset-10-gdb gcc-toolset-10-libatomic-devel krb5-devel cyrus-sasl-devel openssl-devel \
-        unzip tar epel-release jq wget libcurl-devel python3 \
-        python3-devel python3-pip perl-IPC-Cmd
+        unzip tar epel-release jq wget libcurl-devel \
+        python38-devel python38-pip perl-IPC-Cmd
 
         dnf groupinstall -y 'Development Tools'
 
@@ -41,3 +42,7 @@ runs:
 
         which gcc
         which g++
+        echo "python_in_use=/opt/python/cp38-cp38/bin/python" >> "$GITHUB_OUTPUT"
+outputs:
+  python_in_use:
+    value: ${{ steps.install_deps.outputs.python_in_use }}

--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -46,15 +46,6 @@ jobs:
       - name: Install deps
         uses: ./.github/actions/setup_deps
 
-      # We are changing the python here because we want to use the default python to build (it is devel version)
-      # and this python for the rest of the testing
-      - name: Select Python (Linux)
-        shell: bash -el {0}
-        run: |
-          ls /opt/python  
-          echo /opt/python/cp38-cp38/bin >> $GITHUB_PATH
-
-
       - name: Set persistent storage variables
         uses: ./.github/actions/set_persistent_storage_env_vars
         with:

--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash -el {0}
         run: |
           ls /opt/python  
-          echo /opt/python/cp36-cp36m/bin >> $GITHUB_PATH
+          echo /opt/python/cp38-cp38/bin >> $GITHUB_PATH
 
 
       - name: Set persistent storage variables

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -89,6 +89,7 @@ jobs:
         continue-on-error: true
 
       - name: Install deps
+        id: install_deps
         if: matrix.os == 'linux' && inputs.job_type != 'build-python-wheels'
         uses: ./.github/actions/setup_deps
           
@@ -146,7 +147,7 @@ jobs:
         with:
           cmakeListsTxtPath: ${{github.workspace}}/cpp/CMakeLists.txt
           configurePreset: ${{env.ARCTIC_CMAKE_PRESET}}
-          configurePresetAdditionalArgs: "['-DVCPKG_INSTALL_OPTIONS=--clean-after-build']"
+          configurePresetAdditionalArgs: "['-DVCPKG_INSTALL_OPTIONS=--clean-after-build', '-DPython_EXECUTABLE=${{ steps.install_deps.outputs.python_in_use }}']"
           buildPreset: ${{env.ARCTIC_CMAKE_PRESET}}
 
       - name: Compile C++ tests


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Part of the project pybind11 >2.13.0 upgrade
After the upgrade, pybind11 will no longer support python3.6. So all CI - C++ test and analysis are needed to be upgraded.

The change is for pypi linux build only as other builds have moved on already.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
