### PR TITLE
Change third-party action from version to git hash

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -16,7 +16,7 @@
         VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
       steps:
         - name: Get number of CPU cores
-          uses: SimenB/github-actions-cpu-cores@v2.0.0
+          uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8
           id: cpu-cores
 
         - name: Checkout Source


### PR DESCRIPTION
Safer to use githash as tag can be remade by author