### PR TITLE
Fix flaky asv append test

### DIFF
--- a/.github/actions/setup_deps/action.yml
+++ b/.github/actions/setup_deps/action.yml
@@ -9,8 +9,8 @@ runs:
         dnf update -y
         dnf remove -y 'gcc-toolset-13-*'
         dnf install -y zip flex bison gcc-toolset-10 gcc-toolset-10-gdb gcc-toolset-10-libatomic-devel krb5-devel cyrus-sasl-devel openssl-devel \
-        unzip tar epel-release jq wget libcurl-devel python3 \
-        python3-devel python3-pip perl-IPC-Cmd
+        unzip tar epel-release jq wget libcurl-devel \
+        python3.11-devel python3.11-pip perl-IPC-Cmd
 
         dnf groupinstall -y 'Development Tools'
 
@@ -19,7 +19,7 @@ runs:
         echo "CXX=/opt/rh/gcc-toolset-10/root/bin/g++" | tee -a $GITHUB_ENV
         echo "CMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-10/root/bin/g++" | tee -a $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rh/gcc-toolset-10/root/usr/lib64:/opt/rh/gcc-toolset-10/root/usr/lib:/opt/rh/gcc-toolset-10/root/usr/lib64/dyninst" | tee -a $GITHUB_ENV
-        echo "/opt/rh/devtoolset-10/root/usr/bin" | tee -a $GITHUB_PATH
+        echo "/opt/rh/devtoolset-10/root/usr/bin:/opt/python/cp311-cp311/bin" | tee -a $GITHUB_PATH
 
         echo $GITHUB_ENV
 

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -6,7 +6,7 @@ on:
         type: boolean
         default: false
 
-  schedule: # Schdeule the job to run at 12 a.m. daily
+  schedule: # Schedule the job to run at 12 a.m. daily
     - cron: '0 0 * * *'
 
   pull_request_target:

--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -31,8 +31,14 @@ jobs:
     defaults:
       run: {shell: bash}
     steps:  
+      - name: Initialize LFS
+        shell: bash -l {0}
+        run: |
+          dnf install -y git-lfs
+
       - uses: actions/checkout@v3.3.0
         with:
+          lfs: 'true'
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.ARCTICDB_TEST_PAT }}
@@ -46,14 +52,15 @@ jobs:
       - name: Install deps
         uses: ./.github/actions/setup_deps
 
-      # We are changing the python here because we want to use the default python to build (it is devel version)
-      # and this python for the rest of the testing
-      - name: Select Python (Linux)
-        shell: bash -el {0}
+      - name: Extra envs
+        shell: bash -l {0}
         run: |
-          ls /opt/python  
-          echo /opt/python/cp36-cp36m/bin >> $GITHUB_PATH
-
+          . build_tooling/vcpkg_caching.sh # Linux follower needs another call in CIBW
+          echo -e "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES
+          VCPKG_ROOT=$PLATFORM_VCPKG_ROOT" | tee -a $GITHUB_ENV
+          cmake -P cpp/CMake/CpuCount.cmake | sed 's/^-- //' | tee -a $GITHUB_ENV
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{vars.CMAKE_BUILD_PARALLEL_LEVEL}}
 
       - name: Set persistent storage variables
         uses: ./.github/actions/set_persistent_storage_env_vars

--- a/build_tooling/transform_asv_results.py
+++ b/build_tooling/transform_asv_results.py
@@ -5,7 +5,9 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import pandas as pd
+from numpy import inf
 from arcticdb.storage_fixtures.s3 import real_s3_from_environment_variables
 import json
 from pathlib import Path

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -11,7 +11,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -29,7 +29,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -47,7 +47,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -65,7 +65,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -83,7 +83,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -101,7 +101,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -119,7 +119,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -142,7 +142,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -166,7 +166,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -190,7 +190,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -214,7 +214,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -238,7 +238,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -262,7 +262,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -286,7 +286,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:36",
+        "setup_cache_key": "basic_functions:38",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -310,7 +310,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -333,7 +333,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -356,7 +356,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -379,7 +379,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -407,7 +407,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -436,7 +436,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -465,7 +465,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -494,7 +494,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -523,7 +523,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:137",
+        "setup_cache_key": "basic_functions:139",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -531,7 +531,7 @@
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_append_large": {
-        "code": "class ModificationFunctions:\n    def time_append_large(self, rows):\n        self.lib.append(f\"sym\", self.df_append_large)\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_append_large(self, lad: LargeAppendDataModify, rows):\n        large: pd.DataFrame = lad.df_append_large[rows].pop()\n        self.lib.append(f\"sym\", large)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_append_large",
         "number": 1,
@@ -544,18 +544,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "be3be12028b2f1a949589e618252e94a88e5f35b5aa90f5815fd8aaa324c8550",
+        "version": "b817d86d1bf76649691197bfaf1261a96a1a34c9a25f053d66f6dfcf14c6f279",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_append_short_wide": {
-        "code": "class ModificationFunctions:\n    def time_append_short_wide(self, rows):\n        self.lib_short_wide.append(\"short_wide_sym\", self.df_append_short_wide)\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_append_short_wide(self, lad: LargeAppendDataModify, rows):\n        large: pd.DataFrame = lad.df_append_short_wide[rows].pop()\n        self.lib_short_wide.append(\"short_wide_sym\", large)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_append_short_wide",
         "number": 1,
@@ -568,18 +568,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "3a2e1e7a4dc518468ba388f560231ac1a1366b212dbd3309e3e877606c5630e8",
+        "version": "3678115ad2d40bf19062212095071431ff63cedc159661ee3056be7cbf109f98",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_append_single": {
-        "code": "class ModificationFunctions:\n    def time_append_single(self, rows):\n        self.lib.append(f\"sym\", self.df_append_single)\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_append_single(self, lad: LargeAppendDataModify, rows):\n        self.lib.append(f\"sym\", self.df_append_single)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_append_single",
         "number": 1,
@@ -592,18 +592,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "c7f13a15b9074ab9bdb6f3e47ab97d75708938f005021b7a8fde82fe6902041d",
+        "version": "8f398155deb342c70fe4c65e8da636b1f18c9296632b4649aab8dae306aa8453",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_delete": {
-        "code": "class ModificationFunctions:\n    def time_delete(self, rows):\n        self.lib.delete(f\"sym\")\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_delete(self, lad: LargeAppendDataModify, rows):\n        self.lib.delete(f\"sym\")\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_delete",
         "number": 1,
@@ -616,18 +616,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "da4c95139bc0ae404ed6585b9e3398af8ed7e421cefcbeb9ff9ea6a77b85915a",
+        "version": "6d8afae2414e0f842495a7962f5950472814bde20e99eebc474db6953d8e1ae3",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_delete_short_wide": {
-        "code": "class ModificationFunctions:\n    def time_delete_short_wide(self, rows):\n        self.lib_short_wide.delete(\"short_wide_sym\")\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_delete_short_wide(self, lad: LargeAppendDataModify, rows):\n        self.lib_short_wide.delete(\"short_wide_sym\")\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_delete_short_wide",
         "number": 1,
@@ -640,18 +640,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "12254786f4a42e8bd488f48075cb70eddf4d87c8581271e2e2b526b7940123b9",
+        "version": "f867fc9cac4d0706b01166662af37434100460706d4f6118de0bc2e0e3087bae",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_update_half": {
-        "code": "class ModificationFunctions:\n    def time_update_half(self, rows):\n        self.lib.update(f\"sym\", self.df_update_half)\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_update_half(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(f\"sym\", self.df_update_half)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_update_half",
         "number": 1,
@@ -664,18 +664,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "f56b8677f5b90b49568e6865c0656b734b9b2a8054baa71b78eaed8f53cb3176",
+        "version": "6a011f58b79c483849a70576915c2d56deed1227d38489a21140341ca860ce33",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_update_short_wide": {
-        "code": "class ModificationFunctions:\n    def time_update_short_wide(self, rows):\n        self.lib_short_wide.update(\"short_wide_sym\", self.df_update_short_wide)\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_update_short_wide(self, lad: LargeAppendDataModify, rows):\n        self.lib_short_wide.update(\"short_wide_sym\", self.df_update_short_wide)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_update_short_wide",
         "number": 1,
@@ -688,18 +688,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "5db16777228d8de1ab4af9943d1ed0541c0b02c4dbcd888cfa3e26f37eb0215b",
+        "version": "111496c5bd4a4c498df28819d3cbcd9d699c4d3363ad3969f102a1d2076b3086",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_update_single": {
-        "code": "class ModificationFunctions:\n    def time_update_single(self, rows):\n        self.lib.update(f\"sym\", self.df_update_single)\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_update_single(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(f\"sym\", self.df_update_single)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_update_single",
         "number": 1,
@@ -712,18 +712,18 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "cf62fa8a658e2f2ab16d286992423dd8d69334415ab61600906c6e9dc0185597",
+        "version": "c45c168d5713f3028a9a5b97959d52116c8d228870ad580be06d86336d2476c6",
         "warmup_time": -1
     },
     "basic_functions.ModificationFunctions.time_update_upsert": {
-        "code": "class ModificationFunctions:\n    def time_update_upsert(self, rows):\n        self.lib.update(f\"sym\", self.df_update_upsert, upsert=True)\n\n    def setup(self, rows):\n        def get_time_at_fraction_of_df(fraction, rows=rows):\n            end_time = pd.Timestamp(\"1/1/2023\")\n            time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction-1)))\n            return end_time + time_delta\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1))\n        self.df_append_large = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(2))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n        self.df_append_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS, \"s\", get_time_at_fraction_of_df(2, rows=ModificationFunctions.WIDE_DF_ROWS)\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            lib.write(\"sym\", self.init_dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)",
+        "code": "class ModificationFunctions:\n    def time_update_upsert(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(f\"sym\", self.df_update_upsert, upsert=True)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n    \n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows//2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
         "min_run_count": 2,
         "name": "basic_functions.ModificationFunctions.time_update_upsert",
         "number": 1,
@@ -736,14 +736,14 @@
                 "1500000"
             ]
         ],
-        "repeat": 0,
-        "rounds": 2,
+        "repeat": 3,
+        "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:235",
+        "setup_cache_key": "basic_functions:278",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "80de9b1982a498c300177d02874a8626152eccb57cd0ba4228a5bb168e7608c8",
+        "version": "7f139bf03457104abe937914aa3572503ed52330b3a271d82112696060331d8f",
         "warmup_time": -1
     },
     "bi_benchmarks.BIBenchmarks.peakmem_query_groupby_city_count_all": {

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -231,6 +231,7 @@ class ModificationFunctions:
     rounds = 1
     number = 1 # We do a single run between setup and teardown because we e.g. can't delete a symbol twice
     repeat = 3
+    warmup_time=0
     timeout = 6000
     ARCTIC_DIR = "modification_functions"
     ARCTIC_DIR_ORIGINAL = "modification_functions_original"

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -232,6 +232,7 @@ class ModificationFunctions:
     number = 1 # We do a single run between setup and teardown because we e.g. can't delete a symbol twice
     repeat = 3
     warmup_time=0
+    
     timeout = 6000
     ARCTIC_DIR = "modification_functions"
     ARCTIC_DIR_ORIGINAL = "modification_functions_original"

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -349,11 +349,11 @@ class ModificationFunctions:
         self.lib.append(f"sym", self.df_append_single)
 
     def time_append_large(self, lad: LargeAppendDataModify, rows):
-        large: pd.DataFrame = lad.df_append_large[rows].pop()
+        large: pd.DataFrame = lad.df_append_large[rows].pop(0)
         self.lib.append(f"sym", large)
 
     def time_append_short_wide(self, lad: LargeAppendDataModify, rows):
-        large: pd.DataFrame = lad.df_append_short_wide[rows].pop()
+        large: pd.DataFrame = lad.df_append_short_wide[rows].pop(0)
         self.lib_short_wide.append("short_wide_sym", large)
 
     def time_delete(self, lad: LargeAppendDataModify, rows):

--- a/python/benchmarks/bi_benchmarks.py
+++ b/python/benchmarks/bi_benchmarks.py
@@ -185,7 +185,3 @@ class BIBenchmarks:
 
     def peakmem_query_groupby_city_count_filter_two_aggregations(self, times_bigger):
         return self.query_groupby_city_count_filter_two_aggregations(times_bigger)
-        
-
-
-

--- a/python/benchmarks/finalize_staged_data.py
+++ b/python/benchmarks/finalize_staged_data.py
@@ -7,11 +7,11 @@ from tests.stress.arcticdb.version_store.test_stress_finalize_stage_data import 
 from arcticdb.util.utils import TimestampNumber
 """
 
+import sys
 from arcticdb.arctic import Arctic
 from arcticdb.util.utils import CachedDFGenerator, TimestampNumber, stage_chunks
 from arcticdb.version_store.library import Library, StagedDataFinalizeMethod
 from .common import *
-from asv_runner.benchmarks.mark import SkipNotImplemented
 
 class FinalizeStagedData:
     '''
@@ -74,32 +74,36 @@ class FinalizeStagedData:
     def teardown(self, cache:CachedDFGenerator, param:int):
         self.ac.delete_library(self.lib_name)
 
-class FinalizeStagedDataWiderDataframeX3(FinalizeStagedData):
-    '''
-        The test is meant to be executed with 3 times wider dataframe than the base test
-    '''
+if sys.version_info >= (3, 8):
+    ## asv 0.6.0 or later is required for skipping (Python > 3.6)
+    from asv_runner.benchmarks.mark import SkipNotImplemented
 
-    def setup_cache(self):
-        # Generating dataframe with all kind of supported data type
-        cachedDF = CachedDFGenerator(350000, [5, 25, 50]) # 3 times wider DF with bigger string columns
-        return cachedDF
-    
-    def setup(self, cache:CachedDFGenerator, param:int):
-        if (not SLOW_TESTS):
-            raise SkipNotImplemented ("Slow tests are skipped")
-        super().setup(cache,param)
+    class FinalizeStagedDataWiderDataframeX3(FinalizeStagedData):
+        '''
+            The test is meant to be executed with 3 times wider dataframe than the base test
+        '''
 
-    def time_finalize_staged_data(self, cache:CachedDFGenerator, param:int):
-        if (not SLOW_TESTS):
-            raise SkipNotImplemented ("Slow tests are skipped")
-        super().time_finalize_staged_data(cache,param)
+        def setup_cache(self):
+            # Generating dataframe with all kind of supported data type
+            cachedDF = CachedDFGenerator(350000, [5, 25, 50]) # 3 times wider DF with bigger string columns
+            return cachedDF
+        
+        def setup(self, cache:CachedDFGenerator, param:int):
+            if (not SLOW_TESTS):
+                raise SkipNotImplemented ("Slow tests are skipped")
+            super().setup(cache,param)
 
-    def peakmem_finalize_staged_data(self, cache:CachedDFGenerator, param:int):
-        if (not SLOW_TESTS):
-            raise SkipNotImplemented ("Slow tests are skipped")
-        super().peakmem_finalize_staged_data(cache,param)
+        def time_finalize_staged_data(self, cache:CachedDFGenerator, param:int):
+            if (not SLOW_TESTS):
+                raise SkipNotImplemented ("Slow tests are skipped")
+            super().time_finalize_staged_data(cache,param)
 
-    def teardown(self, cache:CachedDFGenerator, param:int):
-        if (SLOW_TESTS):
-            # Run only on slow tests
-            self.ac.delete_library(self.lib_name)
+        def peakmem_finalize_staged_data(self, cache:CachedDFGenerator, param:int):
+            if (not SLOW_TESTS):
+                raise SkipNotImplemented ("Slow tests are skipped")
+            super().peakmem_finalize_staged_data(cache,param)
+
+        def teardown(self, cache:CachedDFGenerator, param:int):
+            if (SLOW_TESTS):
+                # Run only on slow tests
+                self.ac.delete_library(self.lib_name)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   FIX Flaky asv append test 
  </summary>
  
The append dataframes are now generated in setup_cache() function, Each new append dataframe has now start segment that is after the previous one. 

As the append dfs are now generated only once the totoal time is lower. Each test now runs 3 instead of 2 times and eventually this should flatten the graphics also

NOTE: Due to the fact that setup_cache() now returns result, there is one additional parameter that (that result) that is added to signature of other functions. Only append functions are using it for now.

ASV time testing in more details with examples for ArcticDB: https://github.com/man-group/ArcticDB/wiki/Running-ASV-Benchmarks

raceback (most recent call last):

File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/asv/benchmark.py", line 1293, in main_run_server

main_run(run_args)

File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/asv/benchmark.py", line 1167, in main_run

result = benchmark.do_run()

File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/asv/benchmark.py", line 573, in do_run

return self.run(*self._current_params)

File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/asv/benchmark.py", line 673, in run

min_run_count=self.min_run_count)

File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/asv/benchmark.py", line 726, in benchmark_timing

timing = timer.timeit(number)

File "/opt/python/cp36-cp36m/lib/python3.6/timeit.py", line 178, in timeit

timing = self.inner(it, self.timer)

File "", line 6, in inner

File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/asv/benchmark.py", line 627, in

func = lambda: self.func(*param)

File "/__w/ArcticDB/ArcticDB/python/benchmarks/basic_functions.py", line 309, in time_append_large

self.lib.append(f"sym", self.df_append_large)

File "/__w/ArcticDB/ArcticDB/python/.asv/env/541b6fbd95fdb429e84621bc981fbd19/lib/python3.6/site-packages/arcticdb/version_store/library.py", line 744, in append

validate_index=validate_index,

File "/__w/ArcticDB/ArcticDB/python/.asv/env/541b6fbd95fdb429e84621bc981fbd19/lib/python3.6/site-packages/arcticdb/version_store/_store.py", line 711, in append

symbol, item, norm_meta, udm, write_if_missing, prune_previous_version, validate_index

arcticdb_ext.exceptions.InternalException: E_ASSERTION_FAILURE Can't append dataframe with start index 2023-01-01 00:00:01.0 to existing sequence ending at 2023-01-12 13:46:40.0

asv: benchmark failed (exit status 1)
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
