### PR TITLE
Update alias-type for netlify hosting

### DIFF
--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -47,6 +47,8 @@ extra_css:
 plugins:
   - search
   - autorefs
+  - mike:
+      alias_type: copy
   - mkdocs-jupyter:
       ignore_h1_titles: True
       include_source: True


### PR DESCRIPTION
Symbolic links don't work on netlify.  `copy` will create a copy of the versioned docs under `latest`.