### PR TITLE
Add s3 sts proxy support

### DIFF
--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <aws/sts/STSClient.h>
+
 #include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/storage_factory.hpp>
 #include <aws/core/Aws.h>
@@ -79,6 +81,10 @@ class S3Storage final : public Storage {
 
     std::shared_ptr<S3ApiInstance> s3_api_;
     std::unique_ptr<S3ClientWrapper> s3_client_;
+    //aws sdk annoyingly requires raw pointer being passed in the sts client factory to the s3 client
+    //thus sts_client_ should have same life span as s3_client_
+    std::unique_ptr<Aws::STS::STSClient> sts_client_;
+    
     std::string root_folder_;
     std::string bucket_name_;
     std::string region_;


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Add proxy support to AWS STS authentication

#### Any other comments?
`Aws::Auth::STSProfileCredentialsProvider` doesn't support proxy natively because proxy configuration hasn't been passed.
However, a manual sts client factory, which has the proxy config loaded, can be passed in the consturctor, to bring proxy support to the binaries.

End to end test will be added in a seperate PR.

Evidence:
```
(venv38) root@b3bc8b36aa29:/tmp/host# http_proxy="http://127.0.0.1:3128/" https_proxy="http://127.0.0.1:3128/" curl google
.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
(venv38) root@b3bc8b36aa29:/tmp/host# curl google.com
curl: (7) Failed to connect to google.com port 80 after 25 ms: Connection refused
(venv38) root@b3bc8b36aa29:/tmp/host# http_proxy="http://127.0.0.1:3128/" https_proxy="http://127.0.0.1:3128/" ipython
Python 3.8.20 (default, Sep  7 2024, 18:35:08)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.3 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import arcticdb as adb

In [2]: ac = adb.Arctic('s3://s3.eu-north-1.amazonaws.com:BUCKET?aws_auth=sts&aws_profile=PROFILE&path_prefix=PREFIX')
20241216 16:14:08.540374 7083 I arcticdb | S3 proxy set from env var '127.0.0.1'
20241216 16:14:08.540681 7083 I arcticdb | S3 proxy set from env var '127.0.0.1'

In [3]: ac.list_libraries()
Out[3]: []
```
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
