### PR TITLE
Fix error during publishing

### DIFF
--- a/build_tooling/transform_asv_results.py
+++ b/build_tooling/transform_asv_results.py
@@ -7,7 +7,9 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import pandas as pd
-from numpy import inf
+
+# Importing inf and nan so they can be evaluated correctly during extraction
+from numpy import inf, nan
 from arcticdb.storage_fixtures.s3 import real_s3_from_environment_variables
 import json
 from pathlib import Path


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
ASV has started writing `np.nan`s to the `JSON`s.
When we try to evaluate them during publishing, it fails because they are not defined. 
This PRs defines them as was done for `np.inf `  in a previous PR

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
