### PR TITLE
Try to remove any toolset

### DIFF
--- a/.github/actions/setup_deps/action.yml
+++ b/.github/actions/setup_deps/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash -l {0} 
       run: |
         dnf update -y
-        dnf remove -y 'gcc-toolset-13-*'
+        dnf remove -y 'gcc-toolset-*'
         dnf install -y zip flex bison gcc-toolset-10 gcc-toolset-10-gdb gcc-toolset-10-libatomic-devel krb5-devel cyrus-sasl-devel openssl-devel \
         unzip tar epel-release jq wget libcurl-devel \
         python3.11-devel python3.11-pip perl-IPC-Cmd


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

GCC toolset 14 has been added to the manylinux image that we are using and that is breaking our flows.
This PR changes the flow to remove any toolset, not just 13.

N.B.: The proper fix would be to create our own dev image on top of the manylinux one

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
