### PR TITLE
Fix wrong docs for `use_symbol_list`

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2170,8 +2170,8 @@ class NativeVersionStore:
         prefix : `Optional[str]`, default=None
             filter symbols by the given prefix. Only supported by S3 backend for now.
         use_symbol_list: `Optional[bool]`, default=None
-            If True, ignore the symbol list and get all symbols using iteration.
-            ignored if all_symbols=True
+            If False, ignore the symbol list cache and get all symbols using iteration.
+            ignored if all_symbols=True. If None, uses the library config (which is True by default)
 
         Examples
         --------


### PR DESCRIPTION
Simple docs change to reflect actual behavior.
See real behavior here: https://github.com/man-group/ArcticDB/blob/f9d955f71fbb7439ddce8724dda5ec8e23f6c171/cpp/arcticdb/version/local_versioned_engine.cpp#L188-L191
