### PR TITLE
Bugfix 4897570890562900007: Fix decoding of fields with >2^16 blocks

### DIFF
--- a/cpp/arcticdb/storage/memory_layout.hpp
+++ b/cpp/arcticdb/storage/memory_layout.hpp
@@ -101,15 +101,15 @@ enum class BitmapFormat : uint8_t {
 // pointer to the first block
 struct EncodedField {
     EncodedFieldType type_ = EncodedFieldType::UNKNOWN;
-    uint16_t shapes_count_ = 0u;
-    uint16_t values_count_ = 0u;
+    uint32_t shapes_count_ = 0u;
+    uint32_t values_count_ = 0u;
     uint32_t sparse_map_bytes_ = 0u;
     uint32_t items_count_ = 0u;
     BitmapFormat format_ = BitmapFormat::UNKNOWN;
     std::array<Block, 1> blocks_;
 };
 
-static_assert(sizeof(EncodedField) == 60);
+static_assert(sizeof(EncodedField) == 64);
 
 enum class EncodingVersion : uint16_t {
     V1 = 0,


### PR DESCRIPTION
Reference Issues/PRs
Fixes 4897570890562900007 on master

What does this implement or fix?
Allows for there being more than 2^16 blocks in an encoded field, observed with a large compacted symbol list key of a library with 10 million symbols.