### PR TITLE
STS timeout test

### DIFF
--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -237,7 +237,9 @@ class BaseS3StorageFixtureFactory(StorageFixtureFactory):
         b.slow_cleanup(failure_consequence="We will be charged unless we manually delete it. ")
 
 
-def real_s3_from_environment_variables(shared_path: bool, native_config: Optional[NativeVariantStorage] = None, additional_suffix: str = ""):
+def real_s3_from_environment_variables(shared_path: bool, 
+                                       native_config: Optional[NativeVariantStorage] = None, 
+                                       additional_suffix: str = "") -> BaseS3StorageFixtureFactory:
     out = BaseS3StorageFixtureFactory(native_config=native_config)
     out.endpoint = os.getenv("ARCTICDB_REAL_S3_ENDPOINT")
     out.region = os.getenv("ARCTICDB_REAL_S3_REGION")
@@ -254,7 +256,12 @@ def real_s3_from_environment_variables(shared_path: bool, native_config: Optiona
     return out
 
 
-def real_s3_sts_from_environment_variables(user_name: str, role_name: str, policy_name: str, profile_name: str, native_config: NativeVariantStorage, additional_suffix: str):
+def real_s3_sts_from_environment_variables(user_name: str, 
+                                           role_name: str, 
+                                           policy_name: str, 
+                                           profile_name: str, 
+                                           native_config: NativeVariantStorage, 
+                                           additional_suffix: str) -> BaseS3StorageFixtureFactory:
     out = real_s3_from_environment_variables(False, native_config, additional_suffix)
     iam_client = boto3.client("iam", aws_access_key_id=out.default_key.id, aws_secret_access_key=out.default_key.secret)
     # Create IAM user
@@ -370,6 +377,7 @@ def real_s3_sts_from_environment_variables(user_name: str, role_name: str, polic
 
     try:
         access_key_response = iam_client.create_access_key(UserName=user_name)
+        logger.info(f"Response access key: {access_key_response}")
         out.sts_test_key.id = access_key_response["AccessKey"]["AccessKeyId"]
         out.sts_test_key.secret = access_key_response["AccessKey"]["SecretAccessKey"]
         logger.info("Access key created successfully.")

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -267,13 +267,13 @@ def real_s3_sts_from_environment_variables(user_name: str,
     # Create IAM user
     try:
         iam_client.create_user(UserName=user_name)
-        out.sts_test_key = Key(id=None, secret=None, user_name=user_name)
         logger.info(f"User created successfully: {user_name}")
     except iam_client.exceptions.EntityAlreadyExistsException:
         logger.warn(f"User already exists: {user_name}")
     except Exception as e:
         logger.error(f"Error creating user: {e}")
         raise e
+    out.sts_test_key = Key(id=None, secret=None, user_name=user_name)
 
     account_id = boto3.client("sts", aws_access_key_id=out.default_key.id, aws_secret_access_key=out.default_key.secret).get_caller_identity().get("Account")
     logger.info(f"Account id: {account_id}")

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -269,7 +269,7 @@ def real_s3_sts_from_environment_variables(user_name: str,
         iam_client.create_user(UserName=user_name)
         logger.info(f"User created successfully: {user_name}")
     except iam_client.exceptions.EntityAlreadyExistsException:
-        logger.warn(f"User already exists: {user_name}")
+        logger.warning(f"User already exists: {user_name}")
     except Exception as e:
         logger.error(f"Error creating user: {e}")
         raise e

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -140,10 +140,14 @@ def dataframe_dump_to_log(label_for_df, df: pd.DataFrame):
         a problems in test code or arctic
     """
     print("-" * 80)
-    print('dataframe : , ', label_for_df)
-    print(df.to_csv())
-    print("column definitions : ")
-    print(df.dtypes)
+    if isinstance(df,pd.DataFrame):
+        print('dataframe : , ', label_for_df)
+        print(df.to_csv())
+        print("column definitions : ")
+        print(df.dtypes)
+    else:
+        print(f"Not a dataframe passed : {type(df)}")
+        print(df)
     print("-" * 80)
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -217,12 +217,10 @@ def mock_s3_storage_with_error_simulation(mock_s3_storage_with_error_simulation_
 
 @pytest.fixture(scope="session")
 def real_s3_storage_factory() -> BaseS3StorageFixtureFactory:
-def real_s3_storage_factory() -> BaseS3StorageFixtureFactory:
     return real_s3_from_environment_variables(shared_path=False, additional_suffix=f"{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}")
 
 
 @pytest.fixture(scope="session")
-def real_s3_shared_path_storage_factory() -> BaseS3StorageFixtureFactory:
 def real_s3_shared_path_storage_factory() -> BaseS3StorageFixtureFactory:
     return real_s3_from_environment_variables(shared_path=True, additional_suffix=f"{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}")
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -242,7 +242,7 @@ def real_s3_library(real_s3_storage, lib_name) -> Library:
 
 
 @pytest.fixture(scope="session") # Config loaded at the first ArcticDB binary import, so we need to set it up before any tests
-def real_s3_sts_storage_factory():
+def real_s3_sts_storage_factory() -> Generator[BaseS3StorageFixtureFactory, None, None]:
     sts_test_credentials_prefix = os.getenv("ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX", f"{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}")
     username = os.getenv("ARCTICDB_REAL_S3_STS_TEST_USERNAME", f"gh_sts_test_user_{sts_test_credentials_prefix}")
     role_name = os.getenv("ARCTICDB_REAL_S3_STS_TEST_ROLE", f"gh_sts_test_role_{sts_test_credentials_prefix}")
@@ -266,7 +266,7 @@ def real_s3_sts_storage_factory():
 
 
 @pytest.fixture
-def real_s3_sts_storage(real_s3_sts_storage_factory) -> Generator[BaseS3StorageFixtureFactory, None, None]:
+def real_s3_sts_storage(real_s3_sts_storage_factory) -> Generator[S3Bucket, None, None]:
     with real_s3_sts_storage_factory.create_fixture() as f:
         yield f
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -217,10 +217,12 @@ def mock_s3_storage_with_error_simulation(mock_s3_storage_with_error_simulation_
 
 @pytest.fixture(scope="session")
 def real_s3_storage_factory() -> BaseS3StorageFixtureFactory:
+def real_s3_storage_factory() -> BaseS3StorageFixtureFactory:
     return real_s3_from_environment_variables(shared_path=False, additional_suffix=f"{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}")
 
 
 @pytest.fixture(scope="session")
+def real_s3_shared_path_storage_factory() -> BaseS3StorageFixtureFactory:
 def real_s3_shared_path_storage_factory() -> BaseS3StorageFixtureFactory:
     return real_s3_from_environment_variables(shared_path=True, additional_suffix=f"{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}")
 
@@ -377,14 +379,14 @@ def arctic_library_lmdb(arctic_client_lmdb, lib_name) -> Library:
 @pytest.fixture(
     scope="function",
     params=[
-        "lmdb",
-        "mem",
+      #  "lmdb",
+      #  "mem",
         pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
     ],
 )
-def basic_arctic_client(request, encoding_version) -> Arctic:
+def basic_arctic_client(request) -> Arctic:
     storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage")
-    ac = storage_fixture.create_arctic(encoding_version=encoding_version)
+    ac = storage_fixture.create_arctic()
     assert not ac.list_libraries()
     return ac
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -379,14 +379,14 @@ def arctic_library_lmdb(arctic_client_lmdb, lib_name) -> Library:
 @pytest.fixture(
     scope="function",
     params=[
-      #  "lmdb",
-      #  "mem",
+        "lmdb",
+        "mem",
         pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
     ],
 )
-def basic_arctic_client(request) -> Arctic:
+def basic_arctic_client(request, encoding_version) -> Arctic:
     storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage")
-    ac = storage_fixture.create_arctic()
+    ac = storage_fixture.create_arctic(encoding_version=encoding_version)
     assert not ac.list_libraries()
     return ac
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -41,6 +41,7 @@ from arcticdb.storage_fixtures.s3 import (
 from arcticdb.storage_fixtures.mongo import auto_detect_server
 from arcticdb.storage_fixtures.in_memory import InMemoryStorageFixture
 from arcticdb_ext.storage import NativeVariantStorage
+from arcticdb_ext import set_config_int, get_config_int
 from arcticdb.version_store._normalization import MsgPackNormalizer
 from arcticdb.util.test import create_df
 from arcticdb.arctic import Arctic
@@ -247,6 +248,7 @@ def real_s3_sts_storage_factory():
     role_name = os.getenv("ARCTICDB_REAL_S3_STS_TEST_ROLE", f"gh_sts_test_role_{sts_test_credentials_prefix}")
     policy_name = os.getenv("ARCTICDB_REAL_S3_STS_TEST_POLICY_NAME", f"gh_sts_test_policy_name_{sts_test_credentials_prefix}")
     profile_name = "sts_test_profile"
+    set_config_int("S3Storage.STSTokenExpiryMin", 15)
     try:
         f = real_s3_sts_from_environment_variables(
             user_name=username, 

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -33,6 +33,7 @@ from arcticdb.storage_fixtures.mongo import MongoDatabase
 from arcticdb.util.test import assert_frame_equal
 from arcticdb.storage_fixtures.s3 import S3Bucket
 from arcticdb.version_store.library import (
+    Library,
     WritePayload,
     ArcticUnsupportedDataTypeException,
     ReadRequest,
@@ -115,9 +116,11 @@ def test_s3_no_ssl_verification(monkeypatch, s3_no_ssl_storage, client_cert_file
     lib = ac.create_library("test")
     lib.write("sym", pd.DataFrame())
 
+
 @REAL_S3_TESTS_MARK
-def test_s3_sts_auth(real_s3_sts_storage):
-    library = "test"
+def test_s3_sts_auth(lib_name, real_s3_sts_storage):
+    library = lib_name
+    logger.info(f"Library to create: {library}")
     ac = Arctic(real_s3_sts_storage.arctic_uri)
     ac.delete_library(library) # make sure we delete any previously existing library
     lib = ac.create_library(library)
@@ -131,11 +134,12 @@ def test_s3_sts_auth(real_s3_sts_storage):
     ac = Arctic(real_s3_sts_storage.arctic_uri)
     lib = ac.get_library(library)
     assert_frame_equal(lib.read("sym").data, df)
-    ac.delete_library(library) # make sure we delete any previously existing library
+    ac.delete_library(library) 
 
 @SLOW_TESTS_MARK
 @REAL_S3_TESTS_MARK
-def test_s3_sts_expiry_check(real_s3_sts_storage):
+def test_s3_sts_expiry_check(lib_name, real_s3_sts_storage):
+    library = lib_name
     """
     The test will obtain token at minimum expiration time of 15 minutes.
     Then will loop reading content of a symbol for 15+3 minuets minutes. If the 
@@ -143,7 +147,8 @@ def test_s3_sts_expiry_check(real_s3_sts_storage):
     has been renewed.
     """
     symbol = "sym"
-    library = "expire"
+    library = lib_name
+    logger.info(f"Library to create: {library}")
     # Precondition check
     min_exp_time_min = 15 # This is minimum expiry time, set at fixture level
     value = get_config_int("S3Storage.STSTokenExpiryMin")
@@ -168,11 +173,13 @@ def test_s3_sts_expiry_check(real_s3_sts_storage):
         logger.info(f"sleeping 30 sec")
         time.sleep(30)
         logger.info(f"Read successful at {datetime.now()}. Time remaining: {complete_at - datetime.now()}")
+        logger.info(f"Should complete at: {complete_at}")
 
     data: pd.DataFrame = lib.read(symbol).data
     assert_frame_equal(df, data)
     logger.info(f"Connection did not expire")
-    ac.delete_library(library)
+    logger.info(f"Library to remove: {library}")
+    ac.delete_library(library) 
 
 @REAL_S3_TESTS_MARK
 def test_s3_sts_auth_store(real_s3_sts_version_store):

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -155,7 +155,7 @@ def test_s3_sts_expiry_check(lib_name, real_s3_sts_storage):
     logger.info(f"S3Storage.STSTokenExpiryMin = {value}")
     logger.info(f"Current process id = {psutil.Process()}")
     logger.info(f"Minimum possible is {min_exp_time_min} minutes. Test will fail if bigger")
-    assert 15 <= value 
+    assert min_exp_time_min >= value 
 
     ac = Arctic(real_s3_sts_storage.arctic_uri)
     ac.delete_library(library) # make sure we delete any previously existing library
@@ -164,7 +164,7 @@ def test_s3_sts_expiry_check(lib_name, real_s3_sts_storage):
     lib.write(symbol, df)
 
     now = datetime.now()
-    complete_at = now + timedelta(minutes=min_exp_time_min+3)
+    complete_at = now + timedelta(minutes=min_exp_time_min+5)
     logger.info(f"Test will complete at {complete_at}")
 
     data: pd.DataFrame = lib.read(symbol).data

--- a/python/tests/stress/arcticdb/version_store/test_stress_finalize_staged_data.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_finalize_staged_data.py
@@ -85,6 +85,9 @@ def finalize_monotonic_unique_chunks(ac_library, iterations):
     print(f"Writing to symbol initially {num_rows_initially} rows")
     df = cachedDF.generate_dataframe_timestamp_indexed(num_rows_initially, total_number_rows, cachedDF.TIME_UNIT)
 
+    iterations = [500, 1000, 1500, 2000] 
+    if ("amazonaws" in lib.arctic_instance_desc.lower()):
+        iterations = [x // 10 for x in iterations]
     cnt = 0
     for iter in iterations :
         res = Results()


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

The test obtains token and iterativly loops into read cycle for time with 3 minutes longer than the token duration. If all goes well the test will reach its end, implicitly verifying that token was refreshed ... Since the minimum token duration is 15 minutes  those tests are very time expensive.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
