### PR TITLE
Explicitly pin libabseil <20240722.0

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -30,6 +30,7 @@ dependencies:
   - cyrus-sasl
   - aws-sdk-cpp >=1.11.405
   - prometheus-cpp
+  - libabseil <20240722.0
   - libprotobuf
   - openssl
   - libcurl


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Newest build of the [libabseil feedstock](https://github.com/conda-forge/abseil-cpp-feedstock) is not linking correctly with libprotobuf.
See [this build](https://github.com/man-group/ArcticDB/actions/runs/12544849068/job/34981551302) for example, error is:
```
dyld[7654]: Symbol not found: __ZN4absl12lts_2024072212log_internal10LogMessagelsIiLi0EEERS2_RKT_
201
    Referenced from: <64A954D4-9681-37F3-97E6-0599C06DFC5B> /Users/runner/micromamba/envs/arcticdb/lib/libprotoc.28.2.0.dylib
202
    Expected in:     <E99B267F-7144-31DD-A5D4-F5B0B82894DA> /Users/runner/micromamba/envs/arcticdb/lib/libabsl_log_internal_message.2407.0.0.dylib
```

This PR is pinning libabseil to the previous version.

N.B.: The previous **build** (same version) of `libabseil` was linking correctly.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
