### PR TITLE
Default value for aws_auth

### DIFF
--- a/cpp/arcticdb/storage/s3/s3_settings.hpp
+++ b/cpp/arcticdb/storage/s3/s3_settings.hpp
@@ -45,9 +45,12 @@ public:
         aws_profile_(aws_profile) {
     }
 
-    explicit S3Settings(const arcticc::pb2::s3_storage_pb2::Config& config) {
+    explicit S3Settings(const arcticc::pb2::s3_storage_pb2::Config& config) : 
+        S3Settings(AWSAuthMethod::DISABLED, "")
+    {
         update(config);
     }
+    
     S3Settings update(const arcticc::pb2::s3_storage_pb2::Config& config){
         bucket_name_ = config.bucket_name();
         credential_name_ = config.credential_name();

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -140,6 +140,12 @@ TEST(TestS3Storage, proxy_env_var_parsing) {
     }
 }
 
+TEST(TestS3Storage, test_s3_settings_default_value) {
+    arcticdb::proto::s3_storage::Config s3_config;
+    arcticdb::storage::s3::S3Settings s3_settings(s3_config);
+    ASSERT_EQ(s3_settings.aws_auth(), arcticdb::storage::s3::AWSAuthMethod::DISABLED);
+}
+
 TEST_F(ProxyEnvVarSetHttpProxyForHttpsEndpointFixture, test_config_resolution_proxy) {
     arcticdb::proto::s3_storage::Config s3_config;
     s3_config.set_endpoint("https://test.endpoint.com");


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
It fixes the UB of uninitialized `AWSAuthMethod` in `S3Settings`.
Library could be unreadable due to wrong "default" S3 auth method if the particular consturctor is used.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
