### PR TITLE
Update test_mem_leaks.py with higher mem limit

### DIFF
--- a/python/tests/stress/arcticdb/version_store/test_mem_leaks.py
+++ b/python/tests/stress/arcticdb/version_store/test_mem_leaks.py
@@ -710,7 +710,7 @@ if MEMRAY_SUPPORTED:
         yield (lib, symbol)
 
     @MEMRAY_TESTS_MARK
-    @pytest.mark.limit_leaks(location_limit="30 KB", filter_fn=is_relevant)
+    @pytest.mark.limit_leaks(location_limit="40 KB", filter_fn=is_relevant)
     def test_mem_leak_read_all_arctic_lib_memray(library_with_big_symbol_):
         """
         This is a new version of the initial test that reads the whole


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

As per our discussion increasing mem leak limit for a flaky test

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
