### PR TITLE
Add a storage test to verify atomic operation support

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -59,8 +59,8 @@ class AzureStorage final : public Storage {
         return true;
     }
 
-    bool do_supports_atomic_writes() const final {
-        return false;
+    SupportsAtomicWrites do_supports_atomic_writes() const final {
+        return SupportsAtomicWrites::NO;
     }
 
     bool do_fast_delete() final {

--- a/cpp/arcticdb/storage/file/mapped_file_storage.hpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.hpp
@@ -54,8 +54,8 @@ class MappedFileStorage final : public SingleFileStorage {
         return false;
     };
 
-    bool do_supports_atomic_writes() const final {
-        return false;
+    SupportsAtomicWrites do_supports_atomic_writes() const final {
+        return SupportsAtomicWrites::NO;
     }
 
     std::string do_key_path(const VariantKey&) const override { return {}; }

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -56,8 +56,8 @@ class LmdbStorage final : public Storage {
         return false;
     };
 
-    bool do_supports_atomic_writes() const final {
-        return false;
+    SupportsAtomicWrites do_supports_atomic_writes() const final {
+        return SupportsAtomicWrites::NO;
     }
 
     inline bool do_fast_delete() final;

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -49,8 +49,8 @@ namespace arcticdb::storage::memory {
             return false;
         }
 
-        bool do_supports_atomic_writes() const final {
-            return false;
+        SupportsAtomicWrites do_supports_atomic_writes() const final {
+            return SupportsAtomicWrites::NO;
         }
 
         inline bool do_fast_delete() final;

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -51,8 +51,8 @@ class MongoStorage final : public Storage {
         return false;
     }
 
-    bool do_supports_atomic_writes() const final {
-        return false;
+    SupportsAtomicWrites do_supports_atomic_writes() const final {
+        return SupportsAtomicWrites::NO;
     }
 
     inline bool do_fast_delete() final;

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -68,8 +68,17 @@ using Range = folly::Range<It>;
                                                    error_message_suffix));
     }
 
-    if(err.GetExceptionName().find("NotImplemented") != std::string::npos) {
-        raise<ErrorCode::E_NOT_IMPLEMENTED_BY_STORAGE>(fmt::format("Operation is not implemented for storage: {}", error_message_suffix));
+    if (type == Aws::S3::S3Errors::UNKNOWN) {
+        // Unknown is a catchall which can contain several different important exception types which we want to identify
+        if (err.GetResponseCode() == Aws::Http::HttpResponseCode::PRECONDITION_FAILED) {
+            raise<ErrorCode::E_ATOMIC_OPERATION_FAILED>(
+                    fmt::format("Atomic operation failed: {}", error_message_suffix));
+        }
+
+        if (err.GetExceptionName().find("NotImplemented") != std::string::npos) {
+            raise<ErrorCode::E_NOT_IMPLEMENTED_BY_STORAGE>(
+                    fmt::format("Operation is not implemented for storage: {}", error_message_suffix));
+        }
     }
 
     if (err.ShouldRetry()) {

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -57,8 +57,8 @@ private:
         return true;
     }
 
-    bool do_supports_atomic_writes() const final {
-        return ConfigsMap::instance()->get_int("NfsStorage.SupportsAtomicWrites", 0) == 1;
+    SupportsAtomicWrites do_supports_atomic_writes() const final {
+        return SupportsAtomicWrites::NEEDS_TEST;
     }
 
     bool do_fast_delete() final {

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -75,11 +75,8 @@ class S3Storage final : public Storage, AsyncStorage {
         return true;
     }
 
-    bool do_supports_atomic_writes() const final {
-        // There is no way to differentiate whether an s3 backed supports atomic writes. As of Nov 2024 S3 and MinIO
-        // support atomic If-None-Match and If-Match put operations. Unfortunately if we're running on VAST or PURE
-        // these would just work like regular PUTs with no way to know.
-        return true;
+    SupportsAtomicWrites do_supports_atomic_writes() const final {
+        return SupportsAtomicWrites::NEEDS_TEST;
     };
 
     bool do_fast_delete() final {

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <random>
 
 #include <arcticdb/entity/key.hpp>
 #include <arcticdb/entity/variant_key.hpp>
@@ -10,12 +11,23 @@
 #include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/util/composite.hpp>
+#include <arcticdb/codec/codec.hpp>
 
 #include <folly/futures/Future.h>
 
 #include <span>
 
 namespace arcticdb::storage {
+
+enum class SupportsAtomicWrites {
+    NO,
+    YES,
+    // There can be no way to differentiate whether a storage supports atomic writes only from its config.
+    // As of Nov 2024 AWS S3 and MinIO support atomic write operations. Unfortunately if we're running on PURE or VAST
+    // (which are also S3) atomic writes would not work (either through an error or by silently wrongly succeeding).
+    // Thus we need the option to test whether a conditional write succeeds and hence the option NEEDS_TEST.
+    NEEDS_TEST
+};
 
 class Storage {
 public:
@@ -72,8 +84,54 @@ public:
         return do_supports_prefix_matching();
     }
 
-    [[nodiscard]] bool supports_atomic_writes() const {
-        return do_supports_atomic_writes();
+    [[nodiscard]] bool test_atomic_write_support() {
+        auto atomic_write_works_as_expected = false;
+
+        std::random_device rd;
+        std::mt19937_64 e2(rd());
+        std::uniform_int_distribution<uint64_t> dist;
+        // We use the configs map to get a custom suffix to allow inserting a fail trigger for tests
+        auto dummy_key_suffix = ConfigsMap::instance()->get_string("Storage.AtomicSupportTestSuffix", "");
+        auto dummy_key = RefKey(fmt::format("ATOMIC_TEST_{}_{}{}", dist(e2), dist(e2), dummy_key_suffix), KeyType::ATOMIC_LOCK);
+        auto dummy_segment = [&](){
+            SegmentInMemory segment_in_memory{stream_descriptor("test", stream::RowCountIndex(), {})};
+            segment_in_memory.end_row();
+            return encode_dispatch(std::move(segment_in_memory), proto::encoding::VariantCodec(), EncodingVersion::V1);
+        };
+        try {
+            write_if_none(KeySegmentPair{dummy_key, dummy_segment()});
+            try {
+                write_if_none(KeySegmentPair{dummy_key, dummy_segment()});
+                atomic_write_works_as_expected = false;
+            } catch (AtomicOperationFailedException&) {
+                // On the second write we should raise an AtomicOperationFailed because the key is already written.
+                atomic_write_works_as_expected = true;
+            }
+            remove(dummy_key, RemoveOpts{});
+        } catch (NotImplementedException&) {
+            atomic_write_works_as_expected = false;
+        }
+        return atomic_write_works_as_expected;
+    }
+
+    [[nodiscard]] bool supports_atomic_writes() {
+        if (supports_atomic_writes_.has_value()) {
+            return supports_atomic_writes_.value();
+        }
+        switch (do_supports_atomic_writes()) {
+            case SupportsAtomicWrites::NO:
+                supports_atomic_writes_ = false;
+                break;
+            case SupportsAtomicWrites::YES:
+                supports_atomic_writes_ = true;
+                break;
+            case SupportsAtomicWrites::NEEDS_TEST:
+                supports_atomic_writes_ = test_atomic_write_support();
+                break;
+            default:
+                util::raise_rte("Invalid SupportsAtomicWrites");
+        }
+        return supports_atomic_writes_.value();
     }
 
     bool fast_delete() {
@@ -130,7 +188,7 @@ private:
 
     virtual bool do_supports_prefix_matching() const = 0;
 
-    virtual bool do_supports_atomic_writes() const = 0;
+    virtual SupportsAtomicWrites do_supports_atomic_writes() const = 0;
 
     virtual bool do_fast_delete() = 0;
 
@@ -144,6 +202,7 @@ private:
 
     LibraryPath lib_path_;
     OpenMode mode_;
+    std::optional<bool> supports_atomic_writes_;
 };
 
 }

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -59,7 +59,7 @@ public:
         return primary().supports_prefix_matching();
     }
 
-    [[nodiscard]] bool supports_atomic_writes() const {
+    [[nodiscard]] bool supports_atomic_writes() {
         return primary().supports_atomic_writes();
     }
 

--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -182,6 +182,8 @@ using UnsortedDataException = ArcticSpecificException<ErrorCode::E_UNSORTED_DATA
 using UserInputException = ArcticCategorizedException<ErrorCategory::USER_INPUT>;
 using CompatibilityException = ArcticCategorizedException<ErrorCategory::COMPATIBILITY>;
 using CodecException = ArcticCategorizedException<ErrorCategory::CODEC>;
+using AtomicOperationFailedException = ArcticSpecificException<ErrorCode::E_ATOMIC_OPERATION_FAILED>;
+using UnsupportedAtomicOperationException = ArcticSpecificException<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>;
 using NotImplementedException = ArcticSpecificException<ErrorCode::E_NOT_IMPLEMENTED_BY_STORAGE>;
 
 template<ErrorCode error_code>
@@ -242,6 +244,16 @@ template<>
 template<>
 [[noreturn]] inline void throw_error<ErrorCode::E_UNSORTED_DATA>(const std::string& msg) {
     throw ArcticSpecificException<ErrorCode::E_UNSORTED_DATA>(msg);
+}
+
+template<>
+[[noreturn]] inline void throw_error<ErrorCode::E_ATOMIC_OPERATION_FAILED>(const std::string& msg) {
+    throw ArcticSpecificException<ErrorCode::E_ATOMIC_OPERATION_FAILED>(msg);
+}
+
+template<>
+[[noreturn]] inline void throw_error<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>(const std::string& msg) {
+    throw ArcticSpecificException<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>(msg);
 }
 
 template<>

--- a/cpp/arcticdb/util/reliable_storage_lock.hpp
+++ b/cpp/arcticdb/util/reliable_storage_lock.hpp
@@ -23,9 +23,8 @@ using AcquiredLockId = uint64_t;
 
 using AcquiredLock = AcquiredLockId;
 using LockInUse = std::monostate;
-using UnsupportedOperation = std::string;
 
-using ReliableLockResult = std::variant<AcquiredLock, LockInUse, UnsupportedOperation>;
+using ReliableLockResult = std::variant<AcquiredLock, LockInUse>;
 
 // The ReliableStorageLock is a storage lock which relies on atomic If-None-Match Put and ListObject operations to
 // provide a more reliable lock than the StorageLock but it requires the backend to support atomic operations. It should

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -39,7 +39,11 @@
     },
     {
       "name":  "aws-crt-cpp",
-      "version>=": "0.28.3"
+      "version>=": "0.29.7"
+    },
+    {
+      "name": "aws-c-mqtt",
+      "version>=": "0.11.0"
     },
     {
       "name": "aws-c-s3",
@@ -104,7 +108,7 @@
   ],
   "overrides": [
     { "name": "openssl", "version-string": "3.3.0" },
-    { "name": "aws-sdk-cpp", "version": "1.11.405" },
+    { "name": "aws-sdk-cpp", "version": "1.11.474" },
     { "name": "azure-core-cpp", "version": "1.12.0" },
     { "name": "benchmark", "version": "1.9.0" },
     { "name": "bitmagic", "version": "7.12.3" },


### PR DESCRIPTION
#### Reference Issues/PRs
Follow up to #2108

#### What does this implement or fix?
Adds a `Storage` level check which does on a random non-existent-key:
1. `write_if_none` which should succeed
2. `write_if_none` which should fail due to a precondition failed
3. `remove` to cleanup the key

If the test passes then we deem s3 storage as supporting atomic writes. The test only catches `AtomicOperationFailedException` and `NotImplementedByStorageException`. Any other (e.g. network related) exceptions are propagated up to be handled by users.

Since we now test that the storage raises exactly the `AtomicOperationFailedException` we only catch that specific exception when trying to acquire a lock. We still catch all possible `StorageException`s in the guard's heartbeating thread so we can exit gracefully in case of e.g. network related exception.

This also fixes the flaky `XAmzContentSHA256Mismatch` persistant storage lock test issues. It turns out the newer version of pybind changes the way the `Library` object got pickled and unpickled when sharing between processes and the subprocess `Library` objects shared some socket descriptors which lead to aws rightfully rejecting some requests.

This PR also upgrades the aws-sdk version. This is not useful for this particular PR but was done during investigating a red herring for the flaky tests and will be useful for 7963752098 nonetheless.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
