### PR TITLE
Update the version for upload and download artifact GH actions to v4

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -203,13 +203,13 @@ jobs:
   #         echo "CPP_COV_PERCENT=$(cat output.txt | grep 'TOTAL' | awk '{print $NF}' | tr -d '%')" >> $GITHUB_ENV
 
   #     - name: Upload Coverage
-  #       uses: actions/upload-artifact@v3.1.3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: cpp-coverage-artifact
   #         path: cpp/out/linux-debug-build/coverage.zip
 
   #     - name: Upload Python Coverage
-  #       uses: actions/upload-artifact@v3.1.3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: python-coverage-artifact
   #         path: python/python_cov.zip

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Store wheel artifact
         if: inputs.job_type == 'build-python-wheels'
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: wheel-${{env.CIBW_BUILD}}
           path: wheelhouse/*.whl
@@ -225,7 +225,7 @@ jobs:
         run: sudo chown -R $UID ${{matrix.build_dir}}
 
       - name: Archive build metadata
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         if: always()
         env:
           _exclusion: "\n!${{matrix.build_dir}}/**/"
@@ -285,7 +285,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Get wheel artifact
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: wheel-${{needs.compile.outputs.cibw_build}}
           path: ${{runner.temp}}
@@ -356,7 +356,7 @@ jobs:
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: crashdump-${{env.distinguishing_name}}
           path: ${{env.LOCALAPPDATA}}/CrashDumps/
@@ -368,7 +368,7 @@ jobs:
 
       - name: Upload the logs
         if: always()
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-${{env.distinguishing_name}}
           path: |


### PR DESCRIPTION
Update actions/upload-artifact and actions/download-artifact to v4 because v3 is depricated

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
