### PR TITLE
Add a blocking task executor so that we can easily bound the number of tasks kept live in memory at once

### DIFF
--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -57,14 +57,18 @@ TaskSchedulerPtrWrapper::~TaskSchedulerPtrWrapper() {
     delete ptr_;
 }
 
-void print_scheduler_stats() {
+void print_scheduler_stats(spdlog::level::level_enum level) {
     auto cpu_stats = TaskScheduler::instance()->cpu_exec().getPoolStats();
-    log::schedule().info("CPU: Threads: {}\tIdle: {}\tActive: {}\tPending: {}\tTotal: {}\tMaxIdleTime: {}",
+    log::schedule().log(level, "CPU: Threads: {}\tIdle: {}\tActive: {}\tPending: {}\tTotal: {}\tMaxIdleTime: {}",
         cpu_stats.threadCount, cpu_stats.idleThreadCount, cpu_stats.activeThreadCount, cpu_stats.pendingTaskCount, cpu_stats.totalTaskCount, cpu_stats.maxIdleTime.count());
 
     auto io_stats = TaskScheduler::instance()->io_exec().getPoolStats();
-    log::schedule().info("IO: Threads: {}\tIdle: {}\tActive: {}\tPending: {}\tTotal: {}\tMaxIdleTime: {}",
+    log::schedule().log(level, "IO: Threads: {}\tIdle: {}\tActive: {}\tPending: {}\tTotal: {}\tMaxIdleTime: {}",
         io_stats.threadCount, io_stats.idleThreadCount, io_stats.activeThreadCount, io_stats.pendingTaskCount, io_stats.totalTaskCount, io_stats.maxIdleTime.count());
+
+    auto blocking_cpu_stats = TaskScheduler::instance()->blocking_cpu_exec().getPoolStats();
+    log::schedule().log(level, "Blocking CPU: Threads: {}\tIdle: {}\tActive: {}\tPending: {}\tTotal: {}\tMaxIdleTime: {}",
+                         blocking_cpu_stats.threadCount, blocking_cpu_stats.idleThreadCount, blocking_cpu_stats.activeThreadCount, blocking_cpu_stats.pendingTaskCount, blocking_cpu_stats.totalTaskCount, blocking_cpu_stats.maxIdleTime.count());
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -142,6 +142,22 @@ public:
         return write(key_type, stream_id, std::move(segment)).get();
     }
 
+    folly::Future<VariantKey>
+    write_maybe_blocking(PartialKey pk, SegmentInMemory &&segment) override {
+        return write(pk.key_type, pk.version_id, pk.stream_id, pk.start_index, pk.end_index,
+                     std::move(segment));
+    }
+
+    folly::Future<entity::VariantKey> write_maybe_blocking(
+        stream::KeyType key_type,
+        VersionId version_id,
+        const StreamId &stream_id,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory &&segment) override {
+        return write(key_type, version_id, stream_id, start_index, end_index, std::move(segment));
+    }
+
     entity::VariantKey write_if_none_sync(
             KeyType key_type,
             const StreamId& stream_id,

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -90,6 +90,18 @@ struct StreamSink {
         PartialKey pk,
         SegmentInMemory &&segment) = 0;
 
+    [[nodiscard]] virtual folly::Future<entity::VariantKey> write_maybe_blocking(
+        PartialKey pk,
+        SegmentInMemory &&segment) = 0;
+
+    [[nodiscard]] virtual folly::Future<entity::VariantKey> write_maybe_blocking(
+        stream::KeyType key_type,
+        VersionId version_id,
+        const StreamId &stream_id,
+        IndexValue start_index,
+        IndexValue end_index,
+        SegmentInMemory &&segment) = 0;
+
     virtual entity::VariantKey write_sync(
         PartialKey pk,
         SegmentInMemory &&segment) = 0;


### PR DESCRIPTION
Apply it to the finalize_staged_data process as a first example.

There are simpler ways to implement this in `do_compact` specifically (like completing a future before submitting a new one), and other places in the code use `folly::window` to do this, but this gives us a good way to handle these problems in a cross-cutting way. We might want to use the blocking queue more widely if this is successful.

This helped to reduce the memory used by `finalize_staged_data` with write delays, I'm going to do some more benchmarking then share the results here.

Monday: 8234437666