### PR TITLE
Handle missing version entry in overwrite_symbol_tree

### DIFF
--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -470,7 +470,7 @@ public:
         auto entry = std::make_shared<VersionMapEntry>();
         try {
             entry = check_reload(store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);
-        } catch (const storage::NoSuchKeyException& e) {
+        } catch (const storage::KeyNotFoundException& e) {
             log::version().debug("Failed to load version entry for symbol {} in overwrite_symbol_tree, creating new entry, exception: {}", stream_id, e.what());
         }
         auto old_entry = *entry;

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -481,7 +481,11 @@ public:
             if (validate_)
                 entry->validate();
         }
-        remove_entry_version_keys(store, old_entry, stream_id);
+        try {
+            remove_entry_version_keys(store, old_entry, stream_id);
+        } catch (const storage::KeyNotFoundException& e) {
+            log::version().debug("Failed to remove version keys for symbol {} in overwrite_symbol_tree, exception: {}", stream_id, e.what());
+        }
     }
 
     /**

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -467,7 +467,12 @@ public:
 
     void overwrite_symbol_tree(
             std::shared_ptr<Store> store, const StreamId& stream_id, const std::vector<AtomKey>& index_keys) {
-        auto entry = check_reload(store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);
+        auto entry = std::make_shared<VersionMapEntry>();
+        try {
+            entry = check_reload(store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__);
+        } catch (const storage::NoSuchKeyException& e) {
+            log::version().debug("Failed to load version entry for symbol {} in overwrite_symbol_tree, creating new entry, exception: {}", stream_id, e.what());
+        }
         auto old_entry = *entry;
         if (!index_keys.empty()) {
             entry->keys_.assign(std::begin(index_keys), std::end(index_keys));


### PR DESCRIPTION
#### Reference Issues/PRs
ref monday ticket: 8256121333

#### What does this implement or fix?
Modify the `overwrite_symbol_tree` function to gracefully handle cases where a version entry does not exist or points to a missing key for a given stream ID. 
When no entry is found, a new entry is created.
This is not a problem as we intend to overwrite it regardless.

#### Any other comments?
Relevant tests have been added with the enterprise [PR #210](https://github.com/man-group/arcticdb-enterprise/pull/210)

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
