### PR TITLE
Use Pandas unpickling to handle Pandas 1 vs Pandas 2 API differences better

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 import copy
 import datetime
+import io
 from datetime import timedelta
 import math
 
@@ -1054,7 +1055,9 @@ class Pickler(object):
                 return pickle.loads(data, encoding="bytes")
 
         try:
-            return pickle.loads(data)
+            # This tries normal pickle.loads first then falls back to special Pandas unpickling. Pandas unpickling
+            # handles Pandas 1 vs Pandas 2 API breaks better.
+            return pd.read_pickle(io.BytesIO(data))
         except UnicodeDecodeError as exc:
             log.debug("Failed decoding with ascii, using latin-1.")
             return pickle.loads(data, encoding="latin-1")

--- a/python/tests/compat/arcticdb/test_compatibility.py
+++ b/python/tests/compat/arcticdb/test_compatibility.py
@@ -1,6 +1,5 @@
-import numpy as np
+from packaging import version
 import pandas as pd
-import pytest
 from arcticdb.arctic import Arctic
 from arcticdb.util.test import assert_frame_equal
 from arcticdb_ext import set_config_int
@@ -54,6 +53,7 @@ def test_compat_write_read(old_venv_and_arctic_uri, lib_name):
         read_df = curr.lib.read(sym).data
         assert_frame_equal(read_df, df_2)
 
+
 def test_modify_old_library_option_with_current(old_venv_and_arctic_uri, lib_name):
     old_venv, arctic_uri = old_venv_and_arctic_uri
     sym = "sym"
@@ -88,3 +88,33 @@ def test_modify_old_library_option_with_current(old_venv_and_arctic_uri, lib_nam
     with CurrentVersion(arctic_uri, lib_name) as curr:
         cfg_after_use = LibraryTool.read_unaltered_lib_cfg(curr.ac._library_manager, lib_name)
         assert(cfg_after_use == expected_cfg)
+
+
+def test_pandas_pickling(v1_venv, s3_ssl_disabled_storage, lib_name):
+    arctic_uri = s3_ssl_disabled_storage.arctic_uri
+
+    # Create library using old version and write pickled Pandas 1 metadata
+    old_ac = v1_venv.create_arctic(arctic_uri)
+    old_ac.create_library(lib_name)
+    old_ac.execute([f"""
+import pandas as pd
+from packaging import version
+pandas_version = version.parse(pd.__version__)
+assert pandas_version < version.Version("2.0.0")
+df = pd.DataFrame({{"a": [1, 2, 3]}})
+idx = pd.Int64Index([1, 2, 3])
+df.index = idx
+lib = ac.get_library("{lib_name}")
+lib.write("sym", df, metadata={{"abc": df}})
+"""])
+
+    pandas_version = version.parse(pd.__version__)
+    assert pandas_version > version.Version("2.0.0")
+    # Check we can read with Pandas 2
+    with CurrentVersion(arctic_uri, lib_name) as curr:
+        sym = "sym"
+        read_df = curr.lib.read(sym).metadata["abc"]
+        expected_df = pd.DataFrame({"a": [1, 2, 3]})
+        idx = pd.Index([1, 2, 3], dtype="int64")
+        expected_df.index = idx
+        assert_frame_equal(read_df, expected_df)

--- a/python/tests/compat/conftest.py
+++ b/python/tests/compat/conftest.py
@@ -193,6 +193,16 @@ def old_venv(request, tmp_path):
         yield old_venv
 
 
+@pytest.fixture
+def v1_venv(tmp_path):
+    version = "1.6.2"
+    path = os.path.join("venvs", tmp_path, version)
+    compat_dir = os.path.dirname(os.path.abspath(__file__))
+    requirements_file = os.path.join(compat_dir, f"requirements-{version}.txt")
+    with Venv(path, requirements_file, version) as old_venv:
+        yield old_venv
+
+
 @pytest.fixture(
     params=[
         "lmdb",
@@ -214,7 +224,7 @@ def arctic_uri(request):
         return storage_fixture.arctic_uri
 
 
-@pytest.fixture()
+@pytest.fixture
 def old_venv_and_arctic_uri(old_venv, arctic_uri):
     if arctic_uri.startswith("mongo") and "1.6.2" in old_venv.version:
         pytest.skip("Mongo storage backend is not supported in 1.6.2")

--- a/python/tests/compat/requirements-1.6.2.txt
+++ b/python/tests/compat/requirements-1.6.2.txt
@@ -1,6 +1,6 @@
 arcticdb==1.6.2
 numpy <2
-pandas
+pandas <2
 attrs
 protobuf <5
 msgpack >=0.5.0


### PR DESCRIPTION
For pickled dataframes, such as Pandas objects saved in our `metadata`.