### PR TITLE
DBA tools for ReliableStorageLock

### DIFF
--- a/cpp/arcticdb/util/reliable_storage_lock-inl.hpp
+++ b/cpp/arcticdb/util/reliable_storage_lock-inl.hpp
@@ -56,9 +56,19 @@ inline AcquiredLockId get_next_id(std::optional<AcquiredLockId> maybe_prev) {
     return 0;
 }
 
+inline AcquiredLockId get_force_next_id(std::optional<AcquiredLockId> maybe_prev) {
+    // When taking a lock with force we use a higher lock id so we can force acquire it even if there is high lock contention.
+    return maybe_prev.value_or(0) + 10;
+}
+
 template <class ClockType>
 StreamId ReliableStorageLock<ClockType>::get_stream_id(AcquiredLockId lock_id) const {
     return fmt::format("{}{}{}", base_name_, SEPARATOR, lock_id);
+}
+
+template <class ClockType>
+RefKey ReliableStorageLock<ClockType>::get_ref_key(AcquiredLockId lock_id) const {
+    return RefKey{get_stream_id(lock_id), KeyType::ATOMIC_LOCK};
 }
 
 inline AcquiredLockId extract_lock_id_from_stream_id(const StreamId& stream_id) {
@@ -99,7 +109,7 @@ void ReliableStorageLock<ClockType>::clear_old_locks(const std::vector<AcquiredL
     // 5. Process B decides to clear lock 7 since it's not the latest
     // 6. Process A succeeds in taking lock 7
     for (auto lock_id : lock_ids) {
-        auto lock_key = RefKey{get_stream_id(lock_id), KeyType::ATOMIC_LOCK};
+        auto lock_key = get_ref_key(lock_id);
         if (get_expiration(lock_key) + REMOVE_AFTER_TIMEOUTS * timeout_ < now) {
             to_delete.emplace_back(lock_key);
         }
@@ -111,13 +121,14 @@ template <class ClockType>
 ReliableLockResult ReliableStorageLock<ClockType>::try_take_lock() const {
     auto [existing_locks, latest] = get_all_locks();
     if (latest.has_value()) {
-        auto expires = get_expiration(RefKey{get_stream_id(latest.value()), KeyType::ATOMIC_LOCK});
+        auto expires = get_expiration(get_ref_key(latest.value()));
         if (expires > ClockType::nanos_since_epoch()) {
             // An unexpired lock exists
             return LockInUse{};
         }
     }
-    return try_take_next_id(existing_locks, latest);
+    auto next_id = get_next_id(latest);
+    return try_take_id(existing_locks, next_id);
 }
 
 template<class ClockType>
@@ -153,7 +164,8 @@ ReliableLockResult ReliableStorageLock<ClockType>::try_extend_lock(AcquiredLockI
         // We have lost the lock while holding it (most likely due to timeout).
         return LockInUse{};
     }
-    return try_take_next_id(existing_locks, latest);
+    auto next_id = get_next_id(latest);
+    return try_take_id(existing_locks, next_id);
 }
 
 template <class ClockType>
@@ -172,10 +184,37 @@ void ReliableStorageLock<ClockType>::free_lock(AcquiredLockId acquired_lock) con
 }
 
 template <class ClockType>
-ReliableLockResult ReliableStorageLock<ClockType>::try_take_next_id(const std::vector<AcquiredLockId>& existing_locks, std::optional<AcquiredLockId> latest) const {
-    AcquiredLockId lock_id = get_next_id(latest);
+std::optional<ActiveLock> ReliableStorageLock<ClockType>::inspect_latest_lock() const {
+    auto [existing_locks, latest_lock_id] = get_all_locks();
+    if (latest_lock_id.has_value()) {
+        auto expiration = get_expiration(get_ref_key(latest_lock_id.value()));
+        return {{latest_lock_id.value(), expiration}};
+    }
+    return std::nullopt;
+}
+
+template <class ClockType>
+AcquiredLockId ReliableStorageLock<ClockType>::force_take_lock(timestamp custom_timeout) const {
+    auto [existing_locks, latest] = get_all_locks();
+    auto force_next_id = get_force_next_id(latest);
+    auto result = try_take_id(existing_locks, force_next_id, custom_timeout);
+    return util::variant_match(
+            result,
+            [&](AcquiredLock &acquired_lock) {
+                log::lock().info("Forcefully acquired a lock with id {}", acquired_lock);
+                return acquired_lock;
+            },
+            [&](LockInUse &) -> AcquiredLockId {
+                log::lock().error("Failed to acquire a lock with force.");
+                throw LostReliableLock{};
+            }
+    );
+}
+
+template <class ClockType>
+ReliableLockResult ReliableStorageLock<ClockType>::try_take_id(const std::vector<AcquiredLockId>& existing_locks, AcquiredLockId lock_id, std::optional<timestamp> timeout_override) const {
     auto lock_stream_id = get_stream_id(lock_id);
-    auto expiration = ClockType::nanos_since_epoch() + timeout_;
+    auto expiration = ClockType::nanos_since_epoch() + timeout_override.value_or(timeout_);
     try {
         store_->write_if_none_sync(KeyType::ATOMIC_LOCK, lock_stream_id, lock_segment(lock_stream_id, expiration));
     } catch (const AtomicOperationFailedException & e) {

--- a/cpp/arcticdb/util/reliable_storage_lock.hpp
+++ b/cpp/arcticdb/util/reliable_storage_lock.hpp
@@ -26,6 +26,15 @@ using LockInUse = std::monostate;
 
 using ReliableLockResult = std::variant<AcquiredLock, LockInUse>;
 
+struct ActiveLock {
+    AcquiredLockId lock_id;
+    timestamp expiration;
+
+    bool operator == (const ActiveLock& other) const {
+        return lock_id == other.lock_id && expiration == other.expiration;
+    }
+};
+
 // The ReliableStorageLock is a storage lock which relies on atomic If-None-Match Put and ListObject operations to
 // provide a more reliable lock than the StorageLock but it requires the backend to support atomic operations. It should
 // be completely consistent unless a process holding a lock gets paused for times comparable to the lock timeout.
@@ -45,12 +54,21 @@ public:
     ReliableLockResult try_extend_lock(AcquiredLockId acquired_lock) const;
     void free_lock(AcquiredLockId acquired_lock) const;
     timestamp timeout() const;
+    // Below APIs are for admin management of the lock
+    std::optional<ActiveLock> inspect_latest_lock() const;
+    // Forcefully takes a new lock without waiting for any timeouts. If custom_timeout is negative the resulting lock
+    // will be expired since creation (hence will result in forcefully freeing the locks).
+    AcquiredLockId force_take_lock(timestamp custom_timeout) const;
 private:
-    ReliableLockResult try_take_next_id(const std::vector<AcquiredLockId>& existing_locks, std::optional<AcquiredLockId> latest) const;
+    ReliableLockResult try_take_id(
+            const std::vector<AcquiredLockId>& existing_locks,
+            AcquiredLockId lock_id,
+            std::optional<timestamp> timeout_override = std::nullopt) const;
     std::pair<std::vector<AcquiredLockId>, std::optional<AcquiredLockId>> get_all_locks() const;
     timestamp get_expiration(RefKey lock_key) const;
     void clear_old_locks(const std::vector<AcquiredLockId>& acquired_locks) const;
     StreamId get_stream_id(AcquiredLockId acquired_lock) const;
+    RefKey get_ref_key(AcquiredLockId acquired_lock) const;
     std::string base_name_;
     std::shared_ptr<Store> store_;
     timestamp timeout_;


### PR DESCRIPTION
Adds the options to:
- inspect latest state of the lock
- force take or free the lock. This is done by not respecting the expiration and jumping a few ids forward.

Also adds a C++ test to verify the new APIs work as expected.

The APIs will be exposed for use in arcticdb-enterprise.

#### Reference Issues/PRs
Related to 8013103642 monday ticket

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
