### PR TITLE
Don't warn about missing keys when reading symbol ref as it is common to try to read a non-existent symbol

### DIFF
--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -177,11 +177,14 @@ inline void read_symbol_ref(const std::shared_ptr<StreamSource>& store, const St
     std::pair<entity::VariantKey, SegmentInMemory> key_seg_pair;
     // Trying to read a missing ref key is expected e.g. when writing a previously missing symbol.
     // If the ref key is missing we keep the entry empty and should not raise warnings.
+    storage::ReadKeyOpts read_opts;
+    read_opts.dont_warn_about_missing_key = true;
+
     try {
-        key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION_REF});
+        key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION_REF}, read_opts);
     } catch (const storage::KeyNotFoundException&) {
         try {
-            key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION, true});
+            key_seg_pair = store->read_sync(RefKey{stream_id, KeyType::VERSION, true}, read_opts);
         } catch (const storage::KeyNotFoundException&) {
             return;
         }


### PR DESCRIPTION
Tested manually running this script:

```
from arcticdb import Arctic
import pandas as pd
import arcticdb_ext as ae
print(ae.__file__)

ac = Arctic("s3://172.17.0.2:9000:aseaton?access=3SePAqKdc1O7JgeDIJob&secret=...")
lib = ac.get_library("tst_logging", create_if_missing=True)

df = pd.DataFrame({"a": [1, 2, 3]})
lib.write("tst", df)

lib.has_symbol("aaa")
```

Before the change this logged,

```
(310) ➜  python git:(aseaton/8350109779/noisy-logging) ✗ python ./tst.py 
/home/alex/venvs/310/lib/python3.10/site-packages/arcticdb_ext.cpython-310-x86_64-linux-gnu.so
20250129 10:56:31.466366 175505 W arcticdb | Failed to find segment for key 'r:aaa' : No response body.
20250129 10:56:31.466924 175505 W arcticdb | Failed to find segment for key 'V:aaa' : No response body.
```

after the change this logged,

```
(310) ➜  python git:(aseaton/8350109779/noisy-logging) ✗ python ./tst.py 
/code/arcticdb.git/man_bug/python/arcticdb_ext.cpython-310-x86_64-linux-gnu.so
```

The suppression got dropped in https://github.com/man-group/ArcticDB/commit/32341ae7c5f283aeed2a7f92d38897287062e942 .

#### Reference Issues/PRs

8350109779