### PR TITLE
Fix issue with running only selected tests

### DIFF
--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -29,5 +29,5 @@ else
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
-        "$ARCTICDB_PYTEST_ARGS" 2>&1
+        $ARCTICDB_PYTEST_ARGS 2>&1
 fi


### PR DESCRIPTION
The job allows to run a selected test only takingan argument. However the quotes are making it not useful and cannot fulful purpos.

Now with this fix it is possible to run tests with such additional line:

-s -k myTest

That saves enormous time and efforts especially with tests with real storages

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
