### PR TITLE
Only publish benchmark results for master builds

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -53,7 +53,7 @@ jobs:
 
   publish_benchmark_results_to_gh_pages:  
     name: Publish benchmark results to gh-pages
-    if: ${{ github.ref == 'refs/heads/master' && github.head_ref == '' }}  # only publish for the scheduled master builds, head_ref only populated for PR builds https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs
+    if: ${{ github.event_name != 'pull_request_target' }} # only publish for the scheduled master builds
     needs: [benchmark_commits]
     runs-on: ubuntu-22.04
     container:


### PR DESCRIPTION
Old logic was wrong as github.ref can be the base of the PR when event triggering the run was pull_request_target.

Tested with dummy PR 2159 in to this branch.
