### PR TITLE
Simplify our unpickling logic and add tests for Python 2 pickles

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1050,11 +1050,11 @@ class MsgPackNormalizer(Normalizer):
             # If stored in Python2 we want to use raw while unpacking.
             # https://github.com/msgpack/msgpack-python/blob/master/msgpack/_unpacker.pyx#L230
             data = unpackb(data, raw=True)
-            return Pickler.read(data, pickled_in_python2=True)
+            return Pickler.read(data)
 
         if code == MsgPackSerialization.PY_PICKLE_3:
             data = unpackb(data, raw=False)
-            return Pickler.read(data, pickled_in_python2=False)
+            return Pickler.read(data)
 
         return ExtType(code, data)
 
@@ -1070,21 +1070,8 @@ class MsgPackNormalizer(Normalizer):
 
 class Pickler(object):
     @staticmethod
-    def read(data, pickled_in_python2=False):
-        if isinstance(data, str):
-            return pickle.loads(data.encode("ascii"), encoding="bytes")
-        elif isinstance(data, str):
-            if not pickled_in_python2:
-                # Use the default encoding for python2 pickled objects similar to what's being done for PY2.
-                return pickle.loads(data, encoding="bytes")
-
-        try:
-            # This tries normal pickle.loads first then falls back to special Pandas unpickling. Pandas unpickling
-            # handles Pandas 1 vs Pandas 2 API breaks better.
-            return pd.read_pickle(io.BytesIO(data))
-        except UnicodeDecodeError as exc:
-            log.debug("Failed decoding with ascii, using latin-1.")
-            return pickle.loads(data, encoding="latin-1")
+    def read(data):
+        return pd.read_pickle(io.BytesIO(data))
 
     @staticmethod
     def write(obj):

--- a/python/tests/integration/arcticdb/version_store/test_metadata_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_metadata_support.py
@@ -33,6 +33,24 @@ def test_rt_df_with_small_meta(object_and_mem_and_lmdb_version_store):
     assert meta == vit.metadata
 
 
+class A:
+    def __init__(self, attrib):
+        self.attrib = attrib
+
+    def __eq__(self, other):
+        return self.attrib == other.attrib
+
+
+def test_rt_df_with_custom_meta(object_and_mem_and_lmdb_version_store):
+    lib = object_and_mem_and_lmdb_version_store
+
+    df = DataFrame(data=["A", "B", "C"])
+    meta = {"a_key": A("bananabread")}
+    lib.write("pandas", df, metadata=meta)
+    vit = lib.read("pandas")
+    assert meta == vit.metadata
+
+
 @pytest.mark.parametrize("log_level", ("error", "warn", "debug", "info", "ERROR", "eRror", "", None))
 def test_pickled_metadata_warning(lmdb_version_store_v1, log_level):
     import arcticdb.version_store._normalization as norm

--- a/python/tests/unit/arcticdb/version_store/pickles_generation/python2_pickles.py
+++ b/python/tests/unit/arcticdb/version_store/pickles_generation/python2_pickles.py
@@ -1,0 +1,40 @@
+"""How some of the Python 2 pickles in test_normalization.py were created.
+
+Executed from a Python 2 env with msgpack 0.6.2
+"""
+from email import errors # arbitrary module with some custom types to pickle
+import pickle
+import msgpack
+import sys
+
+major_version = sys.version[0]
+
+
+def custom_pack(obj):
+    # 102 is our extension code for pickled in Python 2
+    return msgpack.ExtType(102, msgpack.packb(pickle.dumps(obj)))
+
+
+def msgpack_packb(obj):
+    return msgpack.packb(obj, use_bin_type=True, strict_types=True, default=custom_pack)
+
+
+obj = errors.BoundaryError("bananas")
+title = "py" + major_version + "_obj.bin"
+with open(title, "wb") as f:
+    msgpack.dump(obj, f, default=custom_pack)
+
+obj = {"dict_key": errors.BoundaryError("bananas")}
+title = "py" + major_version + "_dict.bin"
+with open(title, "wb") as f:
+    msgpack.dump(obj, f, default=custom_pack)
+
+obj = "my_string"
+title = "py" + major_version + "_str.bin"
+with open(title, "wb") as f:
+    msgpack.dump(obj, f, default=custom_pack)
+
+obj = b"my_bytes"
+title = "py" + major_version + "_str_bytes.bin"
+with open(title, "wb") as f:
+    msgpack.dump(obj, f, default=custom_pack)


### PR DESCRIPTION
This is fixing the issue that Alex pointed out here https://github.com/man-group/ArcticDB/pull/2156#issuecomment-2624547655 .

We do not need the `str` case - the stuff we are decoding is always bytes - otherwise we would not be in the pickling fallback. Nor do we need to specify a `bytes` encoding when decoding Python 2 objects. The "latin-1" fallback case is handled by `pd.read_pickle` so it's redundant for us to have it too.

The tests I added also pass without my changes to `_normalization.py` and I think suffice to show there is no behaviour change here.

### Old Logic

Old logic for pickles inside the msgpack was:

- If pickled in python 2, unpack msgpack with raw=True, pickle.loads with encoding="ascii".
- If pickled in python 3, unpack msgpack with raw=False, pickle.loads with encoding="bytes".

Where raw means:

```
        """    :param bool raw:
                If true, unpack msgpack raw to Python bytes.
                Otherwise, unpack to Python str by decoding with UTF-8 encoding (default).

        """
```