### PR TITLE
Read and write snapshot metadata from the correct place

### DIFF
--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -39,11 +39,21 @@ void write_snapshot_entry(
         ARCTICDB_DEBUG(log::snapshot(), "Adding key {}", key);
         snapshot_agg.add_key(key);
     }
+
     // Serialize and store the python metadata in the journal entry for snapshot.
     if (!user_meta.is_none()) {
-        TimeseriesDescriptor timeseries_descriptor;
-        python_util::pb_from_python(user_meta, *timeseries_descriptor.mutable_proto().mutable_user_meta());
-        snapshot_agg.set_timeseries_descriptor(timeseries_descriptor);
+        arcticdb::proto::descriptors::UserDefinedMetadata user_meta_proto;
+        google::protobuf::Any output = {};
+        python_util::pb_from_python(user_meta, user_meta_proto);
+        output.PackFrom(user_meta_proto);
+        snapshot_agg.set_metadata(std::move(output));
+
+        // Bewared: Between v4.5.0 and v5.2.1 we only saved this metadata on the
+        // timeseries_descriptor user_metadata field and we need to keep support for data serialized like
+        // that.
+        // TimeseriesDescriptor timeseries_descriptor;
+        // python_util::pb_from_python(user_meta, *timeseries_descriptor.mutable_proto().mutable_user_meta());
+        // snapshot_agg.set_timeseries_descriptor(timeseries_descriptor);
     }
 
     snapshot_agg.finalize();

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -286,12 +286,17 @@ py::object get_metadata_from_segment(
 ) {
     py::object pyobj;
     if (segment.has_user_metadata()) {
+        // Between v4.5.0 and v5.2.1 we saved this metadata here (commit 516d16968f0)
         arcticdb::proto::descriptors::UserDefinedMetadata user_meta_proto;
-        pyobj = python_util::pb_to_python(segment.user_metadata());
-    } else {
-        pyobj = pybind11::none();
+        return python_util::pb_to_python(segment.user_metadata());
+    } else if (segment.metadata()) {
+        // Before v4.5.0 and after v5.2.1 we saved this metadata here
+        arcticdb::proto::descriptors::UserDefinedMetadata user_meta_proto;
+        if (segment.metadata()->UnpackTo(&user_meta_proto)) {
+            return python_util::pb_to_python(user_meta_proto);
+        }
     }
-    return pyobj;
+    return pybind11::none();
 }
 
 py::object get_metadata_for_snapshot(const std::shared_ptr<Store> &store, const VariantKey &snap_key) {

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -71,12 +71,12 @@ if platform.system() == "Linux":
 
 
 @pytest.fixture()
-def sym(request: pytest.FixtureRequest):
+def sym(request: "pytest.FixtureRequest"):
     return request.node.name + datetime.utcnow().strftime("%Y-%m-%dT%H_%M_%S_%f")
 
 
 @pytest.fixture()
-def lib_name(request: pytest.FixtureRequest) -> str:
+def lib_name(request: "pytest.FixtureRequest") -> str:
     name = re.sub(r"[^\w]", "_", request.node.name)[:30]
     return f"{name}.{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}"
 


### PR DESCRIPTION
Between v4.5.0 and v5.2.1 we changed to save snapshot metadata in the segment header in a `TimeseriesDescriptor` field. This was changed in the binary encoding change 516d16968f0 .

Before v4.5.0 we wrote it directly in a `UserDefinedMetadata` field.

This means that the current code falsely thinks that snapshots written before `v4.5.0` have no snapshot metadata.

This PR:

- Changes readers to check both places for any metadata, so we can read snapshot metadata written before `v4.5.0` again
- Changes writers back to writing directly in a `UserDefinedMetadata` field

This means that clients with versions between v4.5.0 and v5.2.1 will not see snapshot metadata written by modern versions (they will say it is `None`) and will need to upgrade.

Since the metadata gets saved in the `SegmentHeader` in both schemes, it is not possible to write data in a way that is compatible with both early readers and readers between `v4.5.0` and `v5.2.1`. We could make the alternative decision and break readers older than `v4.5.0`.

We should apply a similar change to `arcticc`'s reading code so it can understand snapshot metadata written by newer versions.