### PR TITLE
8066268338 Key segment pair refactor - do not move the segment out of the KeySegmentPair as it is a shared resource

### DIFF
--- a/cpp/arcticdb/async/async_store.cpp
+++ b/cpp/arcticdb/async/async_store.cpp
@@ -7,26 +7,24 @@
 
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/entity/variant_key.hpp>
-#include <arcticdb/codec/segment.hpp>
 #include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/version/de_dup_map.hpp>
 
 namespace arcticdb::async {
-std::pair<entity::VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
+DeDupLookupResult lookup_match_in_dedup_map(
     const std::shared_ptr<DeDupMap> &de_dup_map,
-    storage::KeySegmentPair&& key_seg) {
+    storage::KeySegmentPair& key_seg) {
     std::optional<AtomKey> de_dup_key;
     if (!de_dup_map || !(de_dup_key = de_dup_map->get_key_if_present(key_seg.atom_key()))) {
         ARCTICDB_DEBUG(log::version(),
                        "No existing key with same contents: writing new object {}",
                        key_seg.atom_key());
-        return std::make_pair(std::move(key_seg.atom_key()), std::make_optional(std::move(key_seg.segment())));
-
+        return key_seg;
     } else {
         ARCTICDB_DEBUG(log::version(),
                        "Found existing key with same contents: using existing object {}",
                        *de_dup_key);
-        return std::make_pair(*de_dup_key, std::nullopt);
+        return *de_dup_key;
     }
 }
 }

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -24,9 +24,13 @@ namespace arcticdb::toolbox::apy{
 
 namespace arcticdb::async {
 
-std::pair<VariantKey, std::optional<Segment>> lookup_match_in_dedup_map(
+using ExistingObject = entity::VariantKey;
+using NewObject = storage::KeySegmentPair;
+using DeDupLookupResult = std::variant<ExistingObject, NewObject>;
+
+DeDupLookupResult lookup_match_in_dedup_map(
     const std::shared_ptr<DeDupMap> &de_dup_map,
-    storage::KeySegmentPair&& key_seg);
+    storage::KeySegmentPair& key_seg);
 
 template <typename Callable>
 auto read_and_continue(const VariantKey& key, std::shared_ptr<storage::Library> library, const storage::ReadKeyOpts& opts, Callable&& c) {
@@ -161,7 +165,7 @@ folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair ks) override
 }
 
 void write_compressed_sync(storage::KeySegmentPair ks) override {
-    library_->write(std::move(ks));
+    library_->write(ks);
 }
 
 folly::Future<entity::VariantKey> update(const entity::VariantKey &key,
@@ -363,7 +367,6 @@ std::vector<folly::Future<bool>> batch_key_exists(
 folly::Future<SliceAndKey> async_write(
             folly::Future<std::tuple<PartialKey, SegmentInMemory, pipelines::FrameSlice>> &&input_fut,
             const std::shared_ptr<DeDupMap> &de_dup_map) override {
-        using KeyOptSegment = std::pair<VariantKey, std::optional<Segment>>;
         return std::move(input_fut).thenValue([this] (auto&& input) {
             auto [key, seg, slice] = std::forward<decltype(input)>(input);
             auto key_seg = EncodeAtomTask{
@@ -374,17 +377,20 @@ folly::Future<SliceAndKey> async_write(
                 encoding_version_}();
             return std::pair<storage::KeySegmentPair, FrameSlice>(std::move(key_seg), std::move(slice));
         })
-        .thenValue([de_dup_map](auto &&ks) -> std::pair<KeyOptSegment, pipelines::FrameSlice> {
-            auto [key_seg, slice] = std::forward<decltype(ks)>(ks);
-            return std::make_pair(lookup_match_in_dedup_map(de_dup_map, std::move(key_seg)), std::move(slice));
+        .thenValue([de_dup_map](auto &&ks) -> std::pair<DeDupLookupResult, pipelines::FrameSlice> {
+            auto& [key_seg, slice] = ks;
+            return std::make_pair<>(lookup_match_in_dedup_map(de_dup_map, key_seg), std::move(slice));
         })
         .via(&async::io_executor())
-        .thenValue([lib=library_](auto &&item) {
-            auto [key_opt_segment, slice] = std::forward<decltype(item)>(item);
-            if (key_opt_segment.second)
-                lib->write({VariantKey{key_opt_segment.first}, std::move(*key_opt_segment.second)});
-
-            return SliceAndKey{slice, to_atom(key_opt_segment.first)};
+        .thenValue([lib=library_](auto&& item) {
+            auto& [dedup_lookup, slice] = item;
+            return util::variant_match(dedup_lookup,
+               [&](NewObject& obj) {
+                   lib->write(obj);
+                   return SliceAndKey{slice, obj.atom_key()};
+               }, [&](ExistingObject& obj) {
+                    return SliceAndKey{slice, to_atom(std::move(obj))};
+               });
         });
     }
 

--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -37,7 +37,7 @@ namespace arcticdb::async {
 
     pipelines::SegmentAndSlice DecodeSliceTask::decode_into_slice(storage::KeySegmentPair&& key_segment_pair) {
         auto key = key_segment_pair.atom_key();
-        auto& seg = key_segment_pair.segment();
+        auto& seg = *key_segment_pair.segment_ptr();
         ARCTICDB_DEBUG(log::storage(), "ReadAndDecodeAtomTask decoding segment of size {} with key {}",
                        seg.size(),
                        key);

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -183,7 +183,7 @@ struct WriteSegmentTask : BaseTask {
     VariantKey operator()(storage::KeySegmentPair &&key_seg) const {
         ARCTICDB_SAMPLE(WriteSegmentTask, 0)
         auto k = key_seg.variant_key();
-        lib_->write(std::move(key_seg));
+        lib_->write(key_seg);
         return k;
     }
 };
@@ -200,7 +200,7 @@ struct WriteIfNoneTask : BaseTask {
     VariantKey operator()(storage::KeySegmentPair &&key_seg) const {
         ARCTICDB_SAMPLE(WriteSegmentTask, 0)
         auto k = key_seg.variant_key();
-        lib_->write_if_none(std::move(key_seg));
+        lib_->write_if_none(key_seg);
         return k;
     }
 };
@@ -219,7 +219,7 @@ struct UpdateSegmentTask : BaseTask {
     VariantKey operator()(storage::KeySegmentPair &&key_seg) const {
         ARCTICDB_SAMPLE(UpdateSegmentTask, 0)
         auto k = key_seg.variant_key();
-        lib_->update(std::move(key_seg), opts_);
+        lib_->update(key_seg, opts_);
         return k;
     }
 };
@@ -305,9 +305,9 @@ struct CopyCompressedTask : BaseTask {
     VariantKey copy() {
         return std::visit([this](const auto &source_key) {
             auto key_seg = lib_->read_sync(source_key);
-            auto target_key_seg = stream::make_target_key<ClockType>(key_type_, stream_id_, version_id_, source_key, std::move(key_seg.segment()));
+            auto target_key_seg = stream::make_target_key<ClockType>(key_type_, stream_id_, version_id_, source_key, std::move(*key_seg.segment_ptr()));
             auto return_key = target_key_seg.variant_key();
-            lib_->write(std::move(target_key_seg));
+            lib_->write(target_key_seg);
             return return_key;
         }, source_key_);
     }
@@ -440,7 +440,7 @@ struct DecodeSegmentTask : BaseTask {
         ARCTICDB_DEBUG(log::storage(), "ReadAndDecodeAtomTask decoding segment with key {}",
                              variant_key_view(key_seg.variant_key()));
 
-        return {key_seg.variant_key(), decode_segment(std::move(key_seg.segment()))};
+        return {key_seg.variant_key(), decode_segment(*key_seg.segment_ptr())};
     }
 };
 
@@ -523,17 +523,10 @@ struct DecodeMetadataTask : BaseTask {
 
     DecodeMetadataTask() = default;
 
-    std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> operator()(storage::KeySegmentPair &&ks) const {
+    std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>> operator()(storage::KeySegmentPair &&key_seg) const {
         ARCTICDB_SAMPLE(ReadMetadataTask, 0)
-        auto key_seg = std::move(ks);
         ARCTICDB_DEBUG(log::storage(), "ReadAndDecodeMetadataTask decoding segment with key {}", variant_key_view(key_seg.variant_key()));
-
-        auto meta = decode_metadata_from_segment(key_seg.segment());
-        std::pair<VariantKey, std::optional<google::protobuf::Any>> output;
-        output.first = key_seg.variant_key();
-        output.second = std::move(meta);
-
-        return output;
+        return std::make_pair<>(key_seg.variant_key(), decode_metadata_from_segment(key_seg.segment()));
     }
 };
 
@@ -542,16 +535,15 @@ struct DecodeTimeseriesDescriptorTask : BaseTask {
 
     DecodeTimeseriesDescriptorTask() = default;
 
-    std::pair<VariantKey, TimeseriesDescriptor> operator()(storage::KeySegmentPair &&ks) const {
+    std::pair<VariantKey, TimeseriesDescriptor> operator()(storage::KeySegmentPair &&key_seg) const {
         ARCTICDB_SAMPLE(DecodeTimeseriesDescriptorTask, 0)
-        auto key_seg = std::move(ks);
         ARCTICDB_DEBUG(log::storage(), "DecodeTimeseriesDescriptorTask decoding segment with key {}", variant_key_view(key_seg.variant_key()));
 
-        auto maybe_desc = decode_timeseries_descriptor(key_seg.segment());
+        auto maybe_desc = decode_timeseries_descriptor(*key_seg.segment_ptr());
 
         util::check(static_cast<bool>(maybe_desc), "Failed to decode timeseries descriptor");
         return std::make_pair(
-            std::move(key_seg.variant_key()),
+            key_seg.variant_key(),
             std::move(*maybe_desc));
 
     }
@@ -562,15 +554,14 @@ struct DecodeMetadataAndDescriptorTask : BaseTask {
 
     DecodeMetadataAndDescriptorTask() = default;
 
-    std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor> operator()(storage::KeySegmentPair &&ks) const {
+    std::tuple<VariantKey, std::optional<google::protobuf::Any>, StreamDescriptor> operator()(storage::KeySegmentPair &&key_seg) const {
         ARCTICDB_SAMPLE(ReadMetadataAndDescriptorTask, 0)
         ARCTICDB_DEBUG_THROW(5)
-        auto key_seg = std::move(ks);
         ARCTICDB_DEBUG(log::storage(), "DecodeMetadataAndDescriptorTask decoding segment with key {}", variant_key_view(key_seg.variant_key()));
 
-        auto [any, descriptor] = decode_metadata_and_descriptor_fields(key_seg.segment());
+        auto [any, descriptor] = decode_metadata_and_descriptor_fields(*key_seg.segment_ptr());
         return std::make_tuple(
-            std::move(key_seg.variant_key()),
+            key_seg.variant_key(),
             std::move(any),
             std::move(descriptor)
             );
@@ -603,7 +594,7 @@ struct WriteCompressedTask : BaseTask {
     ARCTICDB_MOVE_ONLY_DEFAULT(WriteCompressedTask)
 
     folly::Future<folly::Unit> write() {
-        lib_->write(std::move(kv_));
+        lib_->write(kv_);
         return folly::makeFuture();
     }
 
@@ -628,7 +619,7 @@ struct WriteCompressedBatchTask : BaseTask {
 
     folly::Future<folly::Unit> write() {
         for(auto&& kv : kvs_)
-            lib_->write(std::move(kv));
+            lib_->write(kv);
 
         return folly::makeFuture();
     }

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -560,8 +560,7 @@ void decode_into_memory_segment(
         decode_v1(segment, hdr, res, desc);
 }
 
-SegmentInMemory decode_segment(Segment&& s) {
-    auto segment = std::move(s);
+SegmentInMemory decode_segment(Segment& segment) {
     auto &hdr = segment.header();
     ARCTICDB_TRACE(log::codec(), "Decoding descriptor: {}", segment.descriptor());
     auto descriptor = segment.descriptor();

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -57,7 +57,7 @@ EncodedFieldCollection decode_encoded_fields(
     const uint8_t* data,
     const uint8_t* begin ARCTICDB_UNUSED);
 
-SegmentInMemory decode_segment(Segment&& segment);
+SegmentInMemory decode_segment(Segment& segment);
 
 void decode_into_memory_segment(
     const Segment& segment,

--- a/cpp/arcticdb/codec/python_bindings.cpp
+++ b/cpp/arcticdb/codec/python_bindings.cpp
@@ -103,7 +103,7 @@ Segment encode_segment(SegmentInMemory segment_in_memory, const py::object &opts
 }
 
 SegmentInMemory decode_python_segment(Segment& segment) {
-    return decode_segment(std::move(segment));
+    return decode_segment(segment);
 }
 
 class BufferPairDataSink {

--- a/cpp/arcticdb/codec/test/test_codec.cpp
+++ b/cpp/arcticdb/codec/test/test_codec.cpp
@@ -319,7 +319,7 @@ TYPED_TEST(SegmentStringEncodingTest, EncodeSingleString) {
     constexpr EncodingVersion encoding_version = TypeParam::value;
     Segment seg = encode_dispatch(s.clone(), opt, encoding_version);
 
-    SegmentInMemory res = decode_segment(std::move(seg));
+    SegmentInMemory res = decode_segment(seg);
     ASSERT_EQ(copy.string_at(0, 1), res.string_at(0, 1));
     ASSERT_EQ(std::string("happy"), res.string_at(0, 1));
 }
@@ -346,7 +346,7 @@ TYPED_TEST(SegmentStringEncodingTest, EncodeStringsBasic) {
     constexpr EncodingVersion encoding_version = TypeParam::value;
     Segment seg = encode_dispatch(SegmentInMemory{s}, opt, encoding_version);
 
-    SegmentInMemory res = decode_segment(std::move(seg));
+    SegmentInMemory res = decode_segment(seg);
     ASSERT_EQ(copy.string_at(0, 1), res.string_at(0, 1));
     ASSERT_EQ(std::string("happy"), res.string_at(0, 1));
     ASSERT_EQ(copy.string_at(1, 3), res.string_at(1, 3));

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -488,12 +488,11 @@ void check_data_left_for_subsequent_fields(
 void decode_into_frame_static(
     SegmentInMemory &frame,
     PipelineContextRow &context,
-    Segment &&s,
+    const Segment& seg,
     const DecodePathData& shared_data,
     std::any& handler_data,
     const ReadQuery& read_query,
     const ReadOptions& read_options) {
-    auto seg = std::move(s);
     ARCTICDB_SAMPLE_DEFAULT(DecodeIntoFrame)
     const uint8_t *data = seg.buffer().data();
     const uint8_t *begin = data;
@@ -626,14 +625,13 @@ void handle_type_promotion(
 void decode_into_frame_dynamic(
     SegmentInMemory& frame,
     PipelineContextRow& context,
-    Segment&& s,
+    const Segment& seg,
     const DecodePathData& shared_data,
     std::any& handler_data,
     const ReadQuery& read_query,
     const ReadOptions& read_options
 ) {
     ARCTICDB_SAMPLE_DEFAULT(DecodeIntoFrame)
-    auto seg = std::move(s);
     const uint8_t *data = seg.buffer().data();
     const uint8_t *begin = data;
     const uint8_t *end = begin + seg.buffer().bytes();
@@ -887,9 +885,9 @@ folly::Future<SegmentInMemory> fetch_data(
             [row=row, frame=frame, dynamic_schema=dynamic_schema, shared_data, &handler_data, read_query, read_options](auto &&ks) mutable {
                 auto key_seg = std::forward<storage::KeySegmentPair>(ks);
                 if(dynamic_schema) {
-                    decode_into_frame_dynamic(frame, row, std::move(key_seg.segment()), shared_data, handler_data, read_query, read_options);
+                    decode_into_frame_dynamic(frame, row, key_seg.segment(), shared_data, handler_data, read_query, read_options);
                 } else {
-                    decode_into_frame_static(frame, row, std::move(key_seg.segment()), shared_data, handler_data, read_query, read_options);
+                    decode_into_frame_static(frame, row, key_seg.segment(), shared_data, handler_data, read_query, read_options);
                 }
 
                 return key_seg.variant_key();

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -85,16 +85,16 @@ folly::Future<SegmentInMemory> fetch_data(
 void decode_into_frame_static(
     SegmentInMemory &frame,
     PipelineContextRow &context,
-    Segment &&seg,
+    const Segment& seg,
     const DecodePathData& shared_data,
     std::any& handler_data,
     const ReadQuery& read_query,
     const ReadOptions& read_options);
 
 void decode_into_frame_dynamic(
-    SegmentInMemory &frame,
+    const SegmentInMemory &frame,
     PipelineContextRow &context,
-    Segment &&seg,
+    const Segment& seg,
     const DecodePathData& shared_data,
     std::any& handler_data,
     const ReadQuery& read_query,

--- a/cpp/arcticdb/storage/azure/azure_client_impl.cpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.cpp
@@ -47,7 +47,7 @@ Azure::Storage::Blobs::BlobClientOptions RealAzureClient::get_client_options(con
 
 void RealAzureClient::write_blob(
         const std::string& blob_name,
-        Segment&& segment,
+        Segment& segment,
         const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
         unsigned int request_timeout) {
 

--- a/cpp/arcticdb/storage/azure/azure_client_impl.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.hpp
@@ -26,7 +26,7 @@ public:
 
     void write_blob(
             const std::string& blob_name,
-            Segment&& segment,
+            Segment& segment,
             const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
             unsigned int request_timeout) override;
 

--- a/cpp/arcticdb/storage/azure/azure_client_interface.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_interface.hpp
@@ -50,7 +50,7 @@ public:
     using Config = arcticdb::proto::azure_storage::Config;
     virtual void write_blob(
             const std::string& blob_name,
-            Segment&& segment,
+            Segment& segment,
             const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
             unsigned int request_timeout) = 0;
 

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -154,7 +154,7 @@ void do_read_impl(
     auto blob_name = object_path(bucketizer.bucketize(key_type_dir, variant_key), variant_key);
     try {
         Segment segment = azure_client.read_blob(blob_name, download_option, request_timeout);
-        visitor(variant_key, segment);
+        visitor(variant_key, std::move(segment));
         ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(variant_key), variant_key_view(variant_key));
     }
     catch (const Azure::Core::RequestFailedException& e) {

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -102,7 +102,7 @@ void raise_if_unexpected_error(const Azure::Core::RequestFailedException& e, con
 
 template<class KeyBucketizer>
 void do_write_impl(
-    KeySegmentPair&& key_seg,
+    KeySegmentPair& key_seg,
     const std::string& root_folder,
     AzureClientWrapper& azure_client,
     KeyBucketizer&& bucketizer,
@@ -116,10 +116,9 @@ void do_write_impl(
     ARCTICDB_SUBSAMPLE(AzureStorageWriteValues, 0)
     auto& k = key_seg.variant_key();
     auto blob_name = object_path(bucketizer.bucketize(key_type_dir, k), k);
-    auto& seg = key_seg.segment();
 
     try {
-        azure_client.write_blob(blob_name, std::move(seg), upload_option, request_timeout);
+        azure_client.write_blob(blob_name, *key_seg.segment_ptr(), upload_option, request_timeout);
     }
     catch (const Azure::Core::RequestFailedException& e) {
         raise_azure_exception(e, blob_name);
@@ -128,14 +127,14 @@ void do_write_impl(
 
 template<class KeyBucketizer>
 void do_update_impl(
-    KeySegmentPair&& key_seg,
+    KeySegmentPair& key_seg,
     const std::string& root_folder,
     AzureClientWrapper& azure_client,
     KeyBucketizer&& bucketizer,
     const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
     unsigned int request_timeout) {
     // azure updates the key if it already exists
-    do_write_impl(std::move(key_seg), root_folder, azure_client, bucketizer, upload_option, request_timeout);
+    do_write_impl(key_seg, root_folder, azure_client, bucketizer, upload_option, request_timeout);
 }
 
 template<class KeyBucketizer>
@@ -154,7 +153,8 @@ void do_read_impl(
     auto key_type_dir = key_type_folder(root_folder, variant_key_type(variant_key));
     auto blob_name = object_path(bucketizer.bucketize(key_type_dir, variant_key), variant_key);
     try {
-        visitor(variant_key, azure_client.read_blob(blob_name, download_option, request_timeout));
+        Segment segment = azure_client.read_blob(blob_name, download_option, request_timeout);
+        visitor(variant_key, segment);
         ARCTICDB_DEBUG(log::storage(), "Read key {}: {}", variant_key_type(variant_key), variant_key_view(variant_key));
     }
     catch (const Azure::Core::RequestFailedException& e) {
@@ -333,8 +333,8 @@ std::string AzureStorage::name() const {
     return fmt::format("azure_storage-{}/{}", container_name_, root_folder_);
 }
 
-void AzureStorage::do_write(KeySegmentPair&& key_seg) {
-    detail::do_write_impl(std::move(key_seg),
+void AzureStorage::do_write(KeySegmentPair& key_seg) {
+    detail::do_write_impl(key_seg,
                           root_folder_,
                           *azure_client_,
                           FlatBucketizer{},
@@ -342,8 +342,8 @@ void AzureStorage::do_write(KeySegmentPair&& key_seg) {
                           request_timeout_);
 }
 
-void AzureStorage::do_update(KeySegmentPair&& key_seg, UpdateOpts) {
-    detail::do_update_impl(std::move(key_seg),
+void AzureStorage::do_update(KeySegmentPair& key_seg, UpdateOpts) {
+    detail::do_update_impl(key_seg,
                            root_folder_,
                            *azure_client_,
                            FlatBucketizer{},

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -35,13 +35,13 @@ class AzureStorage final : public Storage {
     std::string name() const final;
 
   protected:
-    void do_write(KeySegmentPair&& key_seg) final;
+    void do_write(KeySegmentPair& key_seg) final;
 
-    void do_write_if_none(KeySegmentPair&& kv [[maybe_unused]]) final {
+    void do_write_if_none(KeySegmentPair& kv [[maybe_unused]]) final {
         storage::raise<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>("Atomic operations are only supported for s3 backend");
     };
 
-    void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) final;
+    void do_update(KeySegmentPair& key_seg, UpdateOpts opts) final;
 
     void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) final;
 

--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -22,7 +22,7 @@ class Segment;
 
 namespace arcticdb::storage {
 
-using ReadVisitor = std::function<void(const entity::VariantKey&, Segment&)>;
+using ReadVisitor = std::function<void(const entity::VariantKey&, Segment&&)>;
 
 struct EnvironmentNameTag {};
 using EnvironmentName = util::StringWrappingValue<EnvironmentNameTag>;

--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -22,7 +22,7 @@ class Segment;
 
 namespace arcticdb::storage {
 
-using ReadVisitor = std::function<void(const entity::VariantKey&, Segment&&)>;
+using ReadVisitor = std::function<void(const entity::VariantKey&, Segment&)>;
 
 struct EnvironmentNameTag {};
 using EnvironmentName = util::StringWrappingValue<EnvironmentNameTag>;

--- a/cpp/arcticdb/storage/file/mapped_file_storage.cpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.cpp
@@ -101,7 +101,7 @@ void MappedFileStorage::do_read(VariantKey&& variant_key, const ReadVisitor& vis
         util::check(maybe_offset.has_value(), "Failed to find key {} in file", variant_key);
         auto [offset, bytes] = std::move(maybe_offset.value());
         auto segment = Segment::from_bytes(file_.data() + offset, bytes);
-        visitor(variant_key, segment);
+        visitor(variant_key, std::move(segment));
 }
 
 KeySegmentPair MappedFileStorage::do_read(VariantKey&& variant_key, storage::ReadKeyOpts) {

--- a/cpp/arcticdb/storage/file/mapped_file_storage.hpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.hpp
@@ -34,13 +34,13 @@ class MappedFileStorage final : public SingleFileStorage {
   private:
     void do_write_raw(const uint8_t* data, size_t bytes) override;
 
-    void do_write(KeySegmentPair&& key_seg) override;
+    void do_write(KeySegmentPair& key_seg) override;
 
-    void do_write_if_none(KeySegmentPair&& kv [[maybe_unused]]) final {
+    void do_write_if_none(KeySegmentPair& kv [[maybe_unused]]) final {
         storage::raise<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>("Atomic operations are only supported for s3 backend");
     };
 
-    void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) override;
+    void do_update(KeySegmentPair& key_seg, UpdateOpts opts) override;
 
     void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, storage::ReadKeyOpts opts) override;
 
@@ -74,7 +74,7 @@ class MappedFileStorage final : public SingleFileStorage {
 
     void do_load_header(size_t header_offset, size_t header_size) override;
 
-    uint64_t write_segment(Segment&& seg);
+    uint64_t write_segment(Segment& seg);
 
     uint8_t* do_read_raw(size_t offset, size_t bytes) override;
 

--- a/cpp/arcticdb/storage/key_segment_pair.hpp
+++ b/cpp/arcticdb/storage/key_segment_pair.hpp
@@ -36,12 +36,6 @@ namespace arcticdb::storage {
 
         ARCTICDB_MOVE_COPY_DEFAULT(KeySegmentPair)
 
-        // TODO aseaton remove
-        Segment& segment() {
-            util::check(segment_, "Attempting to access segment_ but it has not been set");
-            return *segment_;
-        }
-
         [[nodiscard]] std::shared_ptr<Segment> segment_ptr() const {
           return segment_;
         }

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -81,29 +81,29 @@ class Library {
         return storages_->scan_for_matching_key(key_type, predicate);
     }
 
-    void write(KeySegmentPair&& key_seg) {
+    void write(KeySegmentPair& key_seg) {
         ARCTICDB_SAMPLE(LibraryWrite, 0)
         if (open_mode() < OpenMode::WRITE) {
             throw LibraryPermissionException(library_path_, open_mode(), "write");
         }
 
-        storages_->write(std::move(key_seg));
+        storages_->write(key_seg);
     }
 
-    void write_if_none(KeySegmentPair&& kv) {
+    void write_if_none(KeySegmentPair& kv) {
         if (open_mode() < OpenMode::WRITE) {
             throw LibraryPermissionException(library_path_, open_mode(), "write");
         }
 
-        storages_->write_if_none(std::move(kv));
+        storages_->write_if_none(kv);
     }
 
-    void update(KeySegmentPair&& key_seg, storage::UpdateOpts opts) {
+    void update(KeySegmentPair& key_seg, storage::UpdateOpts opts) {
         ARCTICDB_SAMPLE(LibraryUpdate, 0)
         if (open_mode() < OpenMode::WRITE)
             throw LibraryPermissionException(library_path_, open_mode(), "update");
 
-        storages_->update(std::move(key_seg), opts);
+        storages_->update(key_seg, opts);
     }
 
     folly::Future<folly::Unit> read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_impl.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_impl.cpp
@@ -39,7 +39,7 @@ std::optional<Segment> RealLmdbClient::read(const std::string&, std::string& pat
     return segment;
 }
 
-void RealLmdbClient::write(const std::string&, std::string& path, arcticdb::Segment&& seg,
+void RealLmdbClient::write(const std::string&, std::string& path, arcticdb::Segment& seg,
                            ::lmdb::txn& txn, ::lmdb::dbi& dbi, int64_t overwrite_flag) {
     MDB_val mdb_key{path.size(), path.data()};
 

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_impl.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_impl.hpp
@@ -34,7 +34,7 @@ public:
     void write(
             const std::string& db_name,
             std::string& path,
-            Segment&& segment,
+            Segment& segment,
             ::lmdb::txn& txn,
             ::lmdb::dbi& dbi,
             int64_t overwrite_flag) override;

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_interface.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_interface.hpp
@@ -37,7 +37,7 @@ public:
     virtual void write(
             const std::string& db_name,
             std::string& path,
-            Segment&& segment,
+            Segment& segment,
             ::lmdb::txn& txn,
             ::lmdb::dbi& dbi,
             int64_t overwrite_flag) = 0;

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -179,7 +179,7 @@ void LmdbStorage::do_read(VariantKey&& key, const ReadVisitor& visitor, storage:
             ARCTICDB_SUBSAMPLE(LmdbStorageVisitSegment, 0)
             segment->set_keepalive(std::any{LmdbKeepalive{lmdb_instance_, std::move(txn)}});
             ARCTICDB_DEBUG(log::storage(), "Read key {}: {}, with {} bytes of data",variant_key_type(key), variant_key_view(key), segment->size());
-            visitor(key, *segment);
+            visitor(key, std::move(*segment));
         } else {
             ARCTICDB_DEBUG(log::storage(), "Failed to find segment for key {}", variant_key_view(key));
             failed_read.emplace(key);

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -77,7 +77,7 @@ static void raise_lmdb_exception(const ::lmdb::error& e, const std::string& obje
     return *(lmdb_instance_->dbi_by_key_type_.at(db_name));
 }
 
-void LmdbStorage::do_write_internal(KeySegmentPair&& key_seg, ::lmdb::txn& txn) {
+void LmdbStorage::do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn) {
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
 
     auto db_name = fmt::format(FMT_COMPILE("{}"), key_seg.key_type());
@@ -86,10 +86,10 @@ void LmdbStorage::do_write_internal(KeySegmentPair&& key_seg, ::lmdb::txn& txn) 
     ARCTICDB_SUBSAMPLE(LmdbStorageWriteValues, 0)
     ARCTICDB_DEBUG(log::storage(), "Lmdb storage writing segment with key {}", key_seg.key_view());
     auto k = to_serialized_key(key_seg.variant_key());
-    auto& seg = key_seg.segment();
+    auto& seg = *key_seg.segment_ptr();
     int64_t overwrite_flag = std::holds_alternative<RefKey>(key_seg.variant_key()) ? 0 : MDB_NOOVERWRITE;
     try {
-        lmdb_client_->write(db_name, k, std::move(seg), txn, dbi, overwrite_flag);
+        lmdb_client_->write(db_name, k, seg, txn, dbi, overwrite_flag);
     } catch (const ::lmdb::key_exist_error& e) {
         throw DuplicateKeyException(fmt::format("Key already exists: {}: {}", key_seg.variant_key(), e.what()));
     } catch (const ::lmdb::error& ex) {
@@ -101,17 +101,17 @@ std::string LmdbStorage::name() const {
     return fmt::format("lmdb_storage-{}", lib_dir_.string());
 }
 
-void LmdbStorage::do_write(KeySegmentPair&& key_seg) {
+void LmdbStorage::do_write(KeySegmentPair& key_seg) {
     ARCTICDB_SAMPLE(LmdbStorageWrite, 0)
     std::lock_guard<std::mutex> lock{*write_mutex_};
     auto txn = ::lmdb::txn::begin(env()); // scoped abort on exception, so no partial writes
     ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
-    do_write_internal(std::move(key_seg), txn);
+    do_write_internal(key_seg, txn);
     ARCTICDB_SUBSAMPLE(LmdbStorageCommit, 0)
     txn.commit();
 }
 
-void LmdbStorage::do_update(KeySegmentPair&& key_seg, UpdateOpts opts) {
+void LmdbStorage::do_update(KeySegmentPair& key_seg, UpdateOpts opts) {
     ARCTICDB_SAMPLE(LmdbStorageUpdate, 0)
     std::lock_guard<std::mutex> lock{*write_mutex_};
     auto txn = ::lmdb::txn::begin(env());
@@ -128,7 +128,7 @@ void LmdbStorage::do_update(KeySegmentPair&& key_seg, UpdateOpts opts) {
         std::string err_message = fmt::format("do_update called with upsert=false on non-existent key(s): {}", failed_deletes);
         throw KeyNotFoundException(failed_deletes, err_message);
     }
-    do_write_internal(std::move(key_seg), txn);
+    do_write_internal(key_seg, txn);
     ARCTICDB_SUBSAMPLE(LmdbStorageCommit, 0)
     txn.commit();
 }
@@ -179,7 +179,7 @@ void LmdbStorage::do_read(VariantKey&& key, const ReadVisitor& visitor, storage:
             ARCTICDB_SUBSAMPLE(LmdbStorageVisitSegment, 0)
             segment->set_keepalive(std::any{LmdbKeepalive{lmdb_instance_, std::move(txn)}});
             ARCTICDB_DEBUG(log::storage(), "Read key {}: {}, with {} bytes of data",variant_key_type(key), variant_key_view(key), segment->size());
-            visitor(key, std::move(*segment));
+            visitor(key, *segment);
         } else {
             ARCTICDB_DEBUG(log::storage(), "Failed to find segment for key {}", variant_key_view(key));
             failed_read.emplace(key);

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -36,13 +36,13 @@ class LmdbStorage final : public Storage {
     std::string name() const final;
 
   private:
-    void do_write(KeySegmentPair&& key_seg) final;
+    void do_write(KeySegmentPair& key_seg) final;
 
-    void do_write_if_none(KeySegmentPair&& kv [[maybe_unused]]) final {
+    void do_write_if_none(KeySegmentPair& kv [[maybe_unused]]) final {
         storage::raise<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>("Atomic operations are only supported for s3 backend");
     };
 
-    void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) final;
+    void do_update(KeySegmentPair& key_seg, UpdateOpts opts) final;
 
     void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, storage::ReadKeyOpts opts) final;
 
@@ -79,7 +79,7 @@ class LmdbStorage final : public Storage {
     void warn_if_lmdb_already_open();
 
     // _internal methods assume the write mutex is already held
-    void do_write_internal(KeySegmentPair&& key_seg, ::lmdb::txn& txn);
+    void do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn);
     boost::container::small_vector<VariantKey, 1> do_remove_internal(std::span<VariantKey> variant_key, ::lmdb::txn& txn, RemoveOpts opts);
     std::unique_ptr<std::mutex> write_mutex_;
     std::shared_ptr<LmdbInstance> lmdb_instance_;

--- a/cpp/arcticdb/storage/memory/memory_storage.cpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.cpp
@@ -74,7 +74,7 @@ void MemoryStorage::do_update(KeySegmentPair& key_seg, UpdateOpts opts) {
 
 void MemoryStorage::do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts) {
     auto key_seg = do_read(std::move(variant_key), ReadKeyOpts{});
-    visitor(key_seg.variant_key(), *key_seg.segment_ptr());
+    visitor(key_seg.variant_key(), std::move(*key_seg.segment_ptr()));
 }
 
 KeySegmentPair MemoryStorage::do_read(VariantKey&& variant_key, ReadKeyOpts) {

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -27,13 +27,13 @@ namespace arcticdb::storage::memory {
         std::string name() const final;
 
     private:
-        void do_write(KeySegmentPair&& key_seg) final;
+        void do_write(KeySegmentPair& key_seg) final;
 
-        void do_write_if_none(KeySegmentPair&& kv [[maybe_unused]]) final {
+        void do_write_if_none(KeySegmentPair& kv [[maybe_unused]]) final {
             storage::raise<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>("Atomic operations are only supported for s3 backend");
         };
 
-        void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) final;
+        void do_update(KeySegmentPair& key_seg, UpdateOpts opts) final;
 
         void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) final;
 

--- a/cpp/arcticdb/storage/mock/azure_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/azure_mock_client.cpp
@@ -63,7 +63,7 @@ void MockAzureClient::write_blob(
         throw *maybe_exception;
     }
 
-    azure_contents.insert_or_assign(blob_name, std::move(segment));
+    azure_contents.insert_or_assign(blob_name, segment.clone());
 }
 
 Segment MockAzureClient::read_blob(

--- a/cpp/arcticdb/storage/mock/azure_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/azure_mock_client.cpp
@@ -54,7 +54,7 @@ std::optional<Azure::Core::RequestFailedException> has_failure_trigger(const std
 
 void MockAzureClient::write_blob(
         const std::string& blob_name,
-        arcticdb::Segment&& segment,
+        arcticdb::Segment& segment,
         const Azure::Storage::Blobs::UploadBlockBlobFromOptions&,
         unsigned int) {
 

--- a/cpp/arcticdb/storage/mock/azure_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/azure_mock_client.hpp
@@ -23,7 +23,7 @@ class MockAzureClient : public AzureClientWrapper {
 public:
     void write_blob(
         const std::string& blob_name,
-        Segment&& segment,
+        Segment& segment,
         const Azure::Storage::Blobs::UploadBlockBlobFromOptions& upload_option,
         unsigned int request_timeout) override;
 

--- a/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
@@ -91,7 +91,7 @@ std::optional<Segment> MockLmdbClient::read(const std::string& db_name, std::str
     return std::make_optional<Segment>(lmdb_contents_.at(key).clone());
 }
 
-void MockLmdbClient::write(const std::string& db_name, std::string& path, arcticdb::Segment&& segment,
+void MockLmdbClient::write(const std::string& db_name, std::string& path, arcticdb::Segment& segment,
                            ::lmdb::txn&, ::lmdb::dbi&, int64_t) {
     LmdbKey key = {db_name, path};
             raise_if_has_failure_trigger(key, StorageOperation::WRITE);
@@ -99,7 +99,7 @@ void MockLmdbClient::write(const std::string& db_name, std::string& path, arctic
     if(has_key(key)) {
         raise_key_exists_error(lmdb_operation_string(StorageOperation::WRITE));
     } else {
-        lmdb_contents_.try_emplace(key, std::move(segment));
+        lmdb_contents_.try_emplace(key, segment.clone());
     }
 }
 

--- a/cpp/arcticdb/storage/mock/lmdb_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/lmdb_mock_client.hpp
@@ -54,7 +54,7 @@ public:
     void write(
             const std::string& db_name,
             std::string& path,
-            Segment&& segment,
+            Segment& segment,
             ::lmdb::txn& txn,
             ::lmdb::dbi& dbi,
             int64_t overwrite_flag) override;

--- a/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
@@ -99,7 +99,7 @@ bool MockMongoClient::has_key(const MongoKey& key) {
 bool MockMongoClient::write_segment(
         const std::string& database_name,
         const std::string& collection_name,
-        storage::KeySegmentPair&& key_seg) {
+        storage::KeySegmentPair& key_seg) {
     auto key = MongoKey(database_name, collection_name, key_seg.variant_key());
 
     auto failure = has_failure_trigger(key, StorageOperation::WRITE);
@@ -108,14 +108,14 @@ bool MockMongoClient::write_segment(
         return false;
     }
 
-    mongo_contents.insert_or_assign(std::move(key), std::move(key_seg.segment()));
+    mongo_contents.insert_or_assign(std::move(key), key_seg.segment().clone());
     return true;
 }
 
 UpdateResult MockMongoClient::update_segment(
         const std::string& database_name,
         const std::string& collection_name,
-        storage::KeySegmentPair&& key_seg,
+        storage::KeySegmentPair& key_seg,
         bool upsert) {
     auto key = MongoKey(database_name, collection_name, key_seg.variant_key());
 
@@ -130,7 +130,7 @@ UpdateResult MockMongoClient::update_segment(
         return {0}; // upsert is false, don't update and return 0 as modified_count
     }
 
-    mongo_contents.insert_or_assign(std::move(key), std::move(key_seg.segment()));
+    mongo_contents.insert_or_assign(std::move(key), key_seg.segment().clone());
     return {key_found ? 1 : 0};
 }
 

--- a/cpp/arcticdb/storage/mock/mongo_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/mongo_mock_client.hpp
@@ -78,12 +78,12 @@ public:
     bool write_segment(
             const std::string& database_name,
             const std::string& collection_name,
-            storage::KeySegmentPair&& key_seg) override;
+            storage::KeySegmentPair& key_seg) override;
 
     UpdateResult update_segment(
             const std::string& database_name,
             const std::string& collection_name,
-            storage::KeySegmentPair&& key_seg,
+            storage::KeySegmentPair& key_seg,
             bool upsert) override;
 
     std::optional<KeySegmentPair> read_segment(

--- a/cpp/arcticdb/storage/mock/s3_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/s3_mock_client.cpp
@@ -99,7 +99,7 @@ folly::Future<S3Result<Segment>> MockS3Client::get_object_async(
 
 S3Result<std::monostate> MockS3Client::put_object(
         const std::string &s3_object_name,
-        Segment &&segment,
+        Segment& segment,
         const std::string &bucket_name,
         PutHeader header) {
     std::scoped_lock<std::mutex> lock(mutex_);
@@ -121,7 +121,7 @@ S3Result<std::monostate> MockS3Client::put_object(
     // When we write Segments we occasionally don't fill in the size_. This is fine as it's not needed for writing.
     // However, it is required when reading so we need to calculate it. It's easier to do on write.
     [[maybe_unused]] auto size = segment.calculate_size();
-    s3_contents_.insert_or_assign({bucket_name, s3_object_name}, std::make_optional<Segment>(std::move(segment)));
+    s3_contents_.insert_or_assign({bucket_name, s3_object_name}, std::make_optional<Segment>(segment.clone()));
 
     return {std::monostate()};
 }

--- a/cpp/arcticdb/storage/mock/s3_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/s3_mock_client.hpp
@@ -68,7 +68,7 @@ public:
 
     S3Result<std::monostate> put_object(
         const std::string& s3_object_name,
-        Segment&& segment,
+        Segment& segment,
         const std::string& bucket_name,
         PutHeader header = PutHeader::NONE) override;
 

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -136,7 +136,7 @@ auto build_document(storage::KeySegmentPair &kv) {
     /*thread_local*/ std::vector<uint8_t> buffer{};
     buffer.resize(total_size);
     bsoncxx::types::b_binary data = {};
-    kv.segment_ptr()->write_to(buffer.data());
+    segment.write_to(buffer.data());
     data.size = uint32_t(total_size);
     data.bytes = buffer.data();
 

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -131,12 +131,12 @@ auto build_document(storage::KeySegmentPair &kv) {
     using builder::stream::document;
 
     const auto &key = kv.variant_key();
-    auto &segment = kv.segment();
+    Segment& segment = *kv.segment_ptr();
     const auto total_size = segment.calculate_size();
     /*thread_local*/ std::vector<uint8_t> buffer{};
     buffer.resize(total_size);
     bsoncxx::types::b_binary data = {};
-    kv.segment().write_to(buffer.data());
+    kv.segment_ptr()->write_to(buffer.data());
     data.size = uint32_t(total_size);
     data.bytes = buffer.data();
 
@@ -185,12 +185,12 @@ class MongoClientImpl {
     bool write_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg);
+        storage::KeySegmentPair& key_seg);
 
     UpdateResult update_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg,
+        storage::KeySegmentPair& key_seg,
         bool upsert);
 
     std::optional<KeySegmentPair> read_segment(
@@ -247,7 +247,7 @@ class MongoClientImpl {
 bool MongoClientImpl::write_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg) {
+        storage::KeySegmentPair& key_seg) {
     using namespace bsoncxx::builder::stream;
     using bsoncxx::builder::stream::document;
     ARCTICDB_SUBSAMPLE(MongoStorageWriteGetClient, 0)
@@ -276,7 +276,7 @@ bool MongoClientImpl::write_segment(
 UpdateResult MongoClientImpl::update_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg,
+        storage::KeySegmentPair& key_seg,
         bool upsert) {
     using namespace bsoncxx::builder::stream;
     using bsoncxx::builder::stream::document;
@@ -452,16 +452,16 @@ MongoClient::~MongoClient() {
 bool MongoClient::write_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg) {
-    return client_->write_segment(database_name, collection_name, std::move(key_seg));
+        storage::KeySegmentPair& key_seg) {
+    return client_->write_segment(database_name, collection_name, key_seg);
 }
 
 UpdateResult MongoClient::update_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg,
+        storage::KeySegmentPair& key_seg,
         bool upsert) {
-    return client_->update_segment(database_name, collection_name, std::move(key_seg), upsert);
+    return client_->update_segment(database_name, collection_name, key_seg, upsert);
 }
 
 std::optional<KeySegmentPair> MongoClient::read_segment(

--- a/cpp/arcticdb/storage/mongo/mongo_client.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.hpp
@@ -30,12 +30,12 @@ class MongoClient : public MongoClientWrapper {
     bool write_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg) override;
+        storage::KeySegmentPair& key_seg) override;
 
     UpdateResult update_segment(
         const std::string &database_name,
         const std::string &collection_name,
-        storage::KeySegmentPair&& key_seg,
+        storage::KeySegmentPair& key_seg,
         bool upsert) override;
 
     std::optional<KeySegmentPair> read_segment(

--- a/cpp/arcticdb/storage/mongo/mongo_client_interface.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client_interface.hpp
@@ -42,12 +42,12 @@ public:
     virtual bool write_segment(
             const std::string &database_name,
             const std::string &collection_name,
-            storage::KeySegmentPair&& key_seg) = 0;
+            storage::KeySegmentPair& key_seg) = 0;
 
     virtual UpdateResult update_segment(
             const std::string &database_name,
             const std::string &collection_name,
-            storage::KeySegmentPair&& key_seg,
+            storage::KeySegmentPair& key_seg,
             bool upsert) = 0;
 
     virtual std::optional<KeySegmentPair> read_segment(

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -112,7 +112,7 @@ void MongoStorage::do_update(KeySegmentPair &key_seg, UpdateOpts opts) {
 
 void MongoStorage::do_read(VariantKey &&variant_key, const ReadVisitor &visitor, ReadKeyOpts opts) {
     auto key_seg = do_read(std::move(variant_key), opts);
-    visitor(key_seg.variant_key(), *key_seg.segment_ptr());
+    visitor(key_seg.variant_key(), std::move(*key_seg.segment_ptr()));
 }
 
 KeySegmentPair MongoStorage::do_read(VariantKey&& variant_key, ReadKeyOpts opts) {

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -29,13 +29,13 @@ class MongoStorage final : public Storage {
     std::string name() const final;
 
   private:
-    void do_write(KeySegmentPair&& key_seg) final;
+    void do_write(KeySegmentPair& key_seg) final;
 
-    void do_write_if_none(KeySegmentPair&& kv [[maybe_unused]]) final {
+    void do_write_if_none(KeySegmentPair& kv [[maybe_unused]]) final {
         storage::raise<ErrorCode::E_UNSUPPORTED_ATOMIC_OPERATION>("Atomic operations are only supported for s3 backend");
     };
 
-    void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) final;
+    void do_update(KeySegmentPair& key_seg, UpdateOpts opts) final;
 
     void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) final;
 

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -122,7 +122,7 @@ inline void raise_if_unexpected_error(const Aws::S3::S3Error& err, const std::st
 
 template<class KeyBucketizer>
 void do_write_impl(
-    KeySegmentPair&& key_seg,
+    KeySegmentPair& key_seg,
     const std::string& root_folder,
     const std::string& bucket_name,
     S3ClientInterface& s3_client,
@@ -135,9 +135,9 @@ void do_write_impl(
     ARCTICDB_SUBSAMPLE(S3StorageWriteValues, 0)
     auto& k = key_seg.variant_key();
     auto s3_object_name = object_path(bucketizer.bucketize(key_type_dir, k), k);
-    auto& seg = key_seg.segment();
+    auto seg = key_seg.segment_ptr();
 
-    auto put_object_result = s3_client.put_object(s3_object_name, std::move(seg), bucket_name);
+    auto put_object_result = s3_client.put_object(s3_object_name, *seg, bucket_name);
 
     if (!put_object_result.is_success()) {
         auto& error = put_object_result.get_error();
@@ -148,13 +148,13 @@ void do_write_impl(
 
 template<class KeyBucketizer>
 void do_update_impl(
-    KeySegmentPair&& key_seg,
+    KeySegmentPair& key_seg,
     const std::string& root_folder,
     const std::string& bucket_name,
     S3ClientInterface& s3_client,
     KeyBucketizer&& bucketizer) {
     // s3 updates the key if it already exists. We skip the check for key not found to save a round-trip.
-    do_write_impl(std::move(key_seg), root_folder, bucket_name, s3_client, std::forward<KeyBucketizer>(bucketizer));
+    do_write_impl(key_seg, root_folder, bucket_name, s3_client, std::forward<KeyBucketizer>(bucketizer));
 }
 
 template<class KeyBucketizer, class KeyDecoder>
@@ -225,7 +225,7 @@ void do_read_impl(
     KeyDecoder&& key_decoder,
     ReadKeyOpts opts) {
     auto key_seg = do_read_impl(std::move(variant_key), root_folder, bucket_name, s3_client, std::forward<KeyBucketizer>(bucketizer), std::forward<KeyDecoder>(key_decoder), opts);
-    visitor(key_seg.variant_key(), std::move(key_seg.segment()));
+    visitor(key_seg.variant_key(), *key_seg.segment_ptr());
 }
 
 struct FailedDelete {
@@ -315,7 +315,7 @@ void do_remove_impl(
 
 template<class KeyBucketizer>
 void do_write_if_none_impl(
-                KeySegmentPair &&kv,
+                KeySegmentPair &kv,
                 const std::string &root_folder,
                 const std::string &bucket_name,
                 S3ClientInterface &s3_client,
@@ -324,9 +324,9 @@ void do_write_if_none_impl(
             auto key_type_dir = key_type_folder(root_folder, kv.key_type());
             auto &k = kv.variant_key();
             auto s3_object_name = object_path(bucketizer.bucketize(key_type_dir, k), k);
-            auto &seg = kv.segment();
+            auto& seg = *kv.segment_ptr();
 
-            auto put_object_result = s3_client.put_object(s3_object_name, std::move(seg), bucket_name, PutHeader::IF_NONE_MATCH);
+            auto put_object_result = s3_client.put_object(s3_object_name, seg, bucket_name, PutHeader::IF_NONE_MATCH);
 
             if (!put_object_result.is_success()) {
                 auto& error = put_object_result.get_error();

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -225,7 +225,7 @@ void do_read_impl(
     KeyDecoder&& key_decoder,
     ReadKeyOpts opts) {
     auto key_seg = do_read_impl(std::move(variant_key), root_folder, bucket_name, s3_client, std::forward<KeyBucketizer>(bucketizer), std::forward<KeyDecoder>(key_decoder), opts);
-    visitor(key_seg.variant_key(), *key_seg.segment_ptr());
+    visitor(key_seg.variant_key(), std::move(*key_seg.segment_ptr()));
 }
 
 struct FailedDelete {

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -154,14 +154,14 @@ std::string NfsBackedStorage::name() const {
     return fmt::format("nfs_backed_storage-{}/{}/{}", region_, bucket_name_, root_folder_);
 }
 
-void NfsBackedStorage::do_write(KeySegmentPair&& key_seg) {
+void NfsBackedStorage::do_write(KeySegmentPair& key_seg) {
     auto enc = KeySegmentPair{encode_object_id(key_seg.variant_key()), key_seg.segment_ptr()};
-    s3::detail::do_write_impl(std::move(enc), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
+    s3::detail::do_write_impl(enc, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
 }
 
-void NfsBackedStorage::do_update(KeySegmentPair&& key_seg, UpdateOpts) {
+void NfsBackedStorage::do_update(KeySegmentPair& key_seg, UpdateOpts) {
     auto enc = KeySegmentPair{encode_object_id(key_seg.variant_key()), key_seg.segment_ptr()};
-    s3::detail::do_update_impl(std::move(enc), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
+    s3::detail::do_update_impl(enc, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
 }
 
 void NfsBackedStorage::do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -33,13 +33,13 @@ public:
     std::string name() const final;
 
 private:
-    void do_write(KeySegmentPair&& key_seg) final;
+    void do_write(KeySegmentPair& key_seg) final;
 
-    void do_write_if_none(KeySegmentPair&& kv [[maybe_unused]]) final {
+    void do_write_if_none(KeySegmentPair& kv [[maybe_unused]]) final {
         storage::raise<ErrorCode::E_NOT_IMPLEMENTED_BY_STORAGE>("do_write_if_none not implemented for NFS backed storage");
     };
 
-    void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) final;
+    void do_update(KeySegmentPair& key_seg, UpdateOpts opts) final;
 
     void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) final;
 

--- a/cpp/arcticdb/storage/s3/s3_client_impl.cpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.cpp
@@ -176,7 +176,7 @@ folly::Future<S3Result<Segment>> S3ClientImpl::get_object_async(
 
 S3Result<std::monostate> S3ClientImpl::put_object(
         const std::string &s3_object_name,
-        Segment &&segment,
+        Segment& segment,
         const std::string &bucket_name,
         PutHeader header) {
 

--- a/cpp/arcticdb/storage/s3/s3_client_impl.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.hpp
@@ -45,7 +45,7 @@ public:
 
     S3Result<std::monostate> put_object(
             const std::string& s3_object_name,
-            Segment&& segment,
+            Segment& segment,
             const std::string& bucket_name,
             PutHeader header = PutHeader::NONE) override;
 

--- a/cpp/arcticdb/storage/s3/s3_client_interface.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_interface.hpp
@@ -85,7 +85,7 @@ public:
 
     virtual S3Result<std::monostate> put_object(
         const std::string& s3_object_name,
-        Segment&& segment,
+        Segment& segment,
         const std::string& bucket_name,
         PutHeader header = PutHeader::NONE) = 0;
 

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -70,7 +70,7 @@ KeySegmentPair S3Storage::do_read(VariantKey&& variant_key, ReadKeyOpts opts) {
 folly::Future<folly::Unit> S3Storage::do_async_read(entity::VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {
     auto identity = [](auto&& k) { return k; };		
     return detail::do_async_read_impl(std::move(variant_key), root_folder_, bucket_name_, client(), FlatBucketizer{}, std::move(identity), opts).thenValue([&visitor] (auto&& key_seg) {
-        visitor(key_seg.variant_key(), *key_seg.segment_ptr());
+        visitor(key_seg.variant_key(), std::move(*key_seg.segment_ptr()));
         return folly::Unit{};
     });
 }

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -45,16 +45,16 @@ std::string S3Storage::get_key_path(const VariantKey& key) const {
     // to most of them
 }
 
-void S3Storage::do_write(KeySegmentPair&& key_seg) {
-    detail::do_write_impl(std::move(key_seg), root_folder_, bucket_name_, client(), FlatBucketizer{});
+void S3Storage::do_write(KeySegmentPair& key_seg) {
+    detail::do_write_impl(key_seg, root_folder_, bucket_name_, client(), FlatBucketizer{});
 }
 
-void S3Storage::do_write_if_none(KeySegmentPair&& kv) {
-    detail::do_write_if_none_impl(std::move(kv), root_folder_, bucket_name_, *s3_client_, FlatBucketizer{});
+void S3Storage::do_write_if_none(KeySegmentPair& kv) {
+    detail::do_write_if_none_impl(kv, root_folder_, bucket_name_, *s3_client_, FlatBucketizer{});
 }
 
-void S3Storage::do_update(KeySegmentPair&& key_seg, UpdateOpts) {
-    detail::do_update_impl(std::move(key_seg), root_folder_, bucket_name_, client(), FlatBucketizer{});
+void S3Storage::do_update(KeySegmentPair& key_seg, UpdateOpts) {
+    detail::do_update_impl(key_seg, root_folder_, bucket_name_, client(), FlatBucketizer{});
 }
 
 void S3Storage::do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {
@@ -70,7 +70,7 @@ KeySegmentPair S3Storage::do_read(VariantKey&& variant_key, ReadKeyOpts opts) {
 folly::Future<folly::Unit> S3Storage::do_async_read(entity::VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {
     auto identity = [](auto&& k) { return k; };		
     return detail::do_async_read_impl(std::move(variant_key), root_folder_, bucket_name_, client(), FlatBucketizer{}, std::move(identity), opts).thenValue([&visitor] (auto&& key_seg) {
-        visitor(key_seg.variant_key(), std::move(key_seg.segment()));
+        visitor(key_seg.variant_key(), *key_seg.segment_ptr());
         return folly::Unit{};
     });
 }

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -49,11 +49,11 @@ class S3Storage final : public Storage, AsyncStorage {
     }
 
   private:
-    void do_write(KeySegmentPair&& key_seg) final;
+    void do_write(KeySegmentPair& key_seg) final;
 
-    void do_write_if_none(KeySegmentPair&& kv) final;
+    void do_write_if_none(KeySegmentPair& kv) final;
 
-    void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) final;
+    void do_update(KeySegmentPair& key_seg, UpdateOpts opts) final;
 
     void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) final;
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -42,18 +42,21 @@ public:
     Storage(Storage&&) = default;
     Storage& operator=(Storage&&) = delete;
 
-    void write(KeySegmentPair&& key_seg) {
+    template<typename T>
+    void write(T&& key_seg) {
         ARCTICDB_SAMPLE(StorageWrite, 0)
-        return do_write(std::move(key_seg));
+        return do_write(key_seg);
     }
 
-    void write_if_none(KeySegmentPair&& kv) {
-        return do_write_if_none(std::move(kv));
+    template<typename T>
+    void write_if_none(T&& kv) {
+        return do_write_if_none(kv);
     }
 
-    void update(KeySegmentPair&& key_seg, UpdateOpts opts) {
+    template<typename T>
+    void update(T&& key_seg, UpdateOpts opts) {
         ARCTICDB_SAMPLE(StorageUpdate, 0)
-        return do_update(std::move(key_seg), opts);
+        return do_update(key_seg, opts);
     }
 
     void read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {
@@ -179,11 +182,11 @@ private:
         return atomic_write_works_as_expected;
     }
 
-    virtual void do_write(KeySegmentPair&& key_seg) = 0;
+    virtual void do_write(KeySegmentPair& key_seg) = 0;
 
-    virtual void do_write_if_none(KeySegmentPair&& kv) = 0;
+    virtual void do_write_if_none(KeySegmentPair& kv) = 0;
 
-    virtual void do_update(KeySegmentPair&& key_seg, UpdateOpts opts) = 0;
+    virtual void do_update(KeySegmentPair& key_seg, UpdateOpts opts) = 0;
 
     virtual void do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) = 0;
 

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -41,18 +41,18 @@ public:
         storages_(std::move(storages)), mode_(mode) {
     }
 
-    void write(KeySegmentPair&& key_seg) {
+    void write(KeySegmentPair& key_seg) {
         ARCTICDB_SAMPLE(StoragesWrite, 0)
-        primary().write(std::move(key_seg));
+        primary().write(key_seg);
     }
 
-    void write_if_none(KeySegmentPair&& kv) {
-        primary().write_if_none(std::move(kv));
+    void write_if_none(KeySegmentPair& kv) {
+        primary().write_if_none(kv);
     }
 
-    void update(KeySegmentPair&& key_seg, storage::UpdateOpts opts) {
+    void update(KeySegmentPair& key_seg, storage::UpdateOpts opts) {
         ARCTICDB_SAMPLE(StoragesUpdate, 0)
-        primary().update(std::move(key_seg), opts);
+        primary().update(key_seg, opts);
     }
 
     [[nodiscard]] bool supports_prefix_matching() const {

--- a/cpp/arcticdb/storage/test/test_local_storages.cpp
+++ b/cpp/arcticdb/storage/test/test_local_storages.cpp
@@ -54,9 +54,9 @@ TEST_P(LocalStorageTestSuite, CoreFunctions) {
 
   as::KeySegmentPair res;
   storage->read(k, [&](auto &&k, auto &&seg) {
-    res.set_key(k);
-    res.segment() = std::move(seg);
-    res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+    auto key_copy = k;
+    res = as::KeySegmentPair{std::move(key_copy), std::move(seg)};
+    res.segment_ptr()->force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
   }, storage::ReadKeyOpts{});
 
   res = storage->read(k, as::ReadKeyOpts{});
@@ -78,9 +78,9 @@ TEST_P(LocalStorageTestSuite, CoreFunctions) {
 
   as::KeySegmentPair update_res;
   storage->read(k, [&](auto &&k, auto &&seg) {
-    update_res.set_key(k);
-    update_res.segment() = std::move(seg);
-    update_res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+    auto key_copy = k;
+    update_res = as::KeySegmentPair{std::move(key_copy), std::move(seg)};
+    update_res.segment_ptr()->force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
   }, as::ReadKeyOpts{});
 
   update_res = storage->read(k, as::ReadKeyOpts{});
@@ -135,12 +135,12 @@ TEST_P(LocalStorageTestSuite, Strings) {
 
   as::KeySegmentPair res;
   storage->read(save_k, [&](auto &&k, auto &&seg) {
-    res.set_key(k);
-    res.segment() = std::move(seg);
-    res.segment().force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
+    auto key_copy = k;
+    res = as::KeySegmentPair{std::move(key_copy), std::move(seg)};
+    res.segment_ptr()->force_own_buffer(); // necessary since the non-owning buffer won't survive the visit
   }, as::ReadKeyOpts{});
 
-  SegmentInMemory res_mem = decode_segment(std::move(res.segment()));
+  SegmentInMemory res_mem = decode_segment(*res.segment_ptr());
   ASSERT_EQ(s.string_at(0, 1), res_mem.string_at(0, 1));
   ASSERT_EQ(std::string("happy"), res_mem.string_at(0, 1));
   ASSERT_EQ(s.string_at(1, 3), res_mem.string_at(1, 3));

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -52,7 +52,6 @@ ReadResult LibraryTool::read(const VariantKey& key) {
 Segment LibraryTool::read_to_segment(const VariantKey& key) {
     auto kv = store()->read_compressed_sync(key);
     util::check(kv.has_segment(), "Failed to read key: {}", key);
-    kv.segment_ptr()->force_own_buffer();
     return kv.segment().clone();
 }
 

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -37,7 +37,7 @@ async::AsyncStore<>& LibraryTool::async_store() {
 
 ReadResult LibraryTool::read(const VariantKey& key) {
     auto segment = read_to_segment(key);
-    auto segment_in_memory = decode_segment(std::move(segment));
+    auto segment_in_memory = decode_segment(segment);
     auto frame_and_descriptor = frame_and_descriptor_from_segment(std::move(segment_in_memory));
     auto atom_key = util::variant_match(
             key,
@@ -52,8 +52,8 @@ ReadResult LibraryTool::read(const VariantKey& key) {
 Segment LibraryTool::read_to_segment(const VariantKey& key) {
     auto kv = store()->read_compressed_sync(key);
     util::check(kv.has_segment(), "Failed to read key: {}", key);
-    kv.segment().force_own_buffer();
-    return std::move(kv.segment());
+    kv.segment_ptr()->force_own_buffer();
+    return kv.segment().clone();
 }
 
 std::optional<google::protobuf::Any> LibraryTool::read_metadata(const VariantKey& key){
@@ -89,7 +89,7 @@ SegmentInMemory LibraryTool::overwrite_append_data(
         std::holds_alternative<AtomKey>(key) && std::get<AtomKey>(key).type() == KeyType::APPEND_DATA,
         "Can only override APPEND_DATA keys. Received: {}", key);
     auto old_segment = read_to_segment(key);
-    auto old_segment_in_memory = decode_segment(std::move(old_segment));
+    auto old_segment_in_memory = decode_segment(old_segment);
     const auto& tsd = old_segment_in_memory.index_descriptor();
     std::optional<AtomKey> next_key = std::nullopt;
     if (tsd.proto().has_next_key()){

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -79,7 +79,7 @@ void tombstone_snapshot(
 
 void tombstone_snapshot(
         const std::shared_ptr<StreamSink>& store,
-        storage::KeySegmentPair&& key_segment_pair,
+        storage::KeySegmentPair& key_segment_pair,
         bool log_changes) {
     store->remove_key(key_segment_pair.ref_key()).get(); // Make the snapshot "disappear" to normal APIs
     if (log_changes) {

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -40,7 +40,7 @@ void tombstone_snapshot(
 
 void tombstone_snapshot(
         const std::shared_ptr<stream::StreamSink>& store,
-        storage::KeySegmentPair&& key_segment_pair,
+        storage::KeySegmentPair& key_segment_pair,
         bool log_changes
         );
 


### PR DESCRIPTION
This allows us to re-enable some tests in `arcticdb-enterprise` https://github.com/man-group/arcticdb-enterprise/pull/new/aseaton/keysegmentpair-refactor-enterprise . 

The changes are:

- Remove the mutable `Segment& segment()` in the `KeySegmentPair` - this was often used to move out of the `Segment` owned by the shared pointer in `KeySegmentPair`
- Pass `KeySegmentPair` by lvalue rather than rvalue reference where possible. The `Task` layer still needs rvalue references as that is what Folly expects (rightly, the Folly executors need to have ownership).
- Refactor `lookup_match_in_dedup_match` to return a variant
- Unrelated tidy up to `DecodeMetadataTask`
- `clone()` segments when adding them to the in in-memory and mock storages

In particular this lets `CopyCompressedInterstore` safely copy the same `KeySegmentPair` to several targets, whereas before the `Segment` could be moved from during the copy to each target.