### PR TITLE
Cherry pick for: 8234437666 Bound the number of data segments kept live in memory 

### DIFF
--- a/cpp/arcticdb/async/python_bindings.cpp
+++ b/cpp/arcticdb/async/python_bindings.cpp
@@ -23,6 +23,14 @@ void register_bindings(py::module &m) {
         }), "Number of threads used to execute tasks");
 
     async.def("print_scheduler_stats", &print_scheduler_stats);
+
+    async.def("reinit_task_scheduler", &arcticdb::async::TaskScheduler::reattach_instance);
+    async.def("cpu_thread_count", []() {
+        return arcticdb::async::TaskScheduler::instance()->cpu_thread_count();
+    });
+    async.def("io_thread_count", []() {
+        return arcticdb::async::TaskScheduler::instance()->io_thread_count();
+    });
 }
 
 } // namespace arcticdb::async

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -15,6 +15,7 @@
 #include <arcticdb/version/de_dup_map.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 
+#include <folly/synchronization/NativeSemaphore.h>
 #include <folly/futures/Future.h>
 // FIXME: winnt.h is included by folly/futures/Future.h at some point and adds unwanted macros
 #ifdef DELETE
@@ -89,6 +90,13 @@ struct StreamSink {
     [[nodiscard]] virtual folly::Future<entity::VariantKey> write(
         PartialKey pk,
         SegmentInMemory &&segment) = 0;
+
+    // shared_ptr for semaphore as executing futures need guarantees it is in a valid state, so need to participate
+    // in ownership
+    [[nodiscard]] virtual folly::Future<entity::VariantKey> write_maybe_blocking(
+        PartialKey pk,
+        SegmentInMemory&& segment,
+        std::shared_ptr<folly::NativeSemaphore> semaphore) = 0;
 
     virtual entity::VariantKey write_sync(
         PartialKey pk,

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1667,6 +1667,7 @@ VersionedItem sort_merge_impl(
 
     std::vector<FrameSlice> slices;
     std::vector<folly::Future<VariantKey>> fut_vec;
+    auto semaphore = std::make_shared<folly::NativeSemaphore>(n_segments_live_during_compaction());
     auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
     util::variant_match(index,
         [&](const stream::TimeseriesIndex &timeseries_index) {
@@ -1703,13 +1704,12 @@ VersionedItem sort_merge_impl(
                     slices.emplace_back(std::move(slice));
                 },
                 DynamicSchema{*pipeline_context->staged_descriptor_, index},
-                [pipeline_context, &fut_vec, &store](SegmentInMemory &&segment) {
-                    StreamDescriptor only_non_empty_cols;
+                [pipeline_context, &fut_vec, &store, &semaphore](SegmentInMemory &&segment) {
                     const auto local_index_start = TimeseriesIndex::start_value_for_segment(segment);
                     const auto local_index_end = TimeseriesIndex::end_value_for_segment(segment);
                     stream::StreamSink::PartialKey
                     pk{KeyType::TABLE_DATA, pipeline_context->version_id_, pipeline_context->stream_id_, local_index_start, local_index_end};
-                    fut_vec.emplace_back(store->write(pk, std::move(segment)));
+                    fut_vec.emplace_back(store->write_maybe_blocking(pk, std::move(segment), semaphore));
                 },
                 RowCountSegmentPolicy(write_options.segment_row_size)};
 
@@ -2073,6 +2073,16 @@ CheckOutcome check_schema_matches_incomplete(const StreamDescriptor& stream_desc
         };
     }
     return std::monostate{};
+}
+
+size_t n_segments_live_during_compaction() {
+    int64_t default_count = 2 * async::TaskScheduler::instance()->io_thread_count();
+    int64_t res = ConfigsMap::instance()->get_int("VersionStore.NumSegmentsLiveDuringCompaction", default_count);
+    log::version().debug("Allowing up to {} segments to be live during compaction", res);
+    static constexpr auto max_size = static_cast<int64_t>(folly::NativeSemaphore::value_max_v);
+    util::check(res < max_size, "At most {} live segments during compaction supported but were {}, adjust VersionStore.NumSegmentsLiveDuringCompaction", max_size, res);
+    util::check(res > 0, "VersionStore.NumSegmentsLiveDuringCompaction must be strictly positive but was {}", res);
+    return static_cast<size_t>(res);
 }
 
 }

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -261,6 +261,8 @@ void remove_written_keys(Store* store, CompactionWrittenKeys&& written_keys);
 
 bool is_segment_unsorted(const SegmentInMemory& segment);
 
+size_t n_segments_live_during_compaction();
+
 template <typename IndexType, typename SchemaType, typename SegmentationPolicy, typename DensityPolicy, typename IteratorType>
 [[nodiscard]] CompactionResult do_compact(
     IteratorType to_compact_start,
@@ -277,20 +279,20 @@ template <typename IndexType, typename SchemaType, typename SegmentationPolicy, 
 
     std::vector<folly::Future<VariantKey>> write_futures;
 
+    auto semaphore = std::make_shared<folly::NativeSemaphore>(n_segments_live_during_compaction());
     stream::SegmentAggregator<IndexType, SchemaType, SegmentationPolicy, DensityPolicy>
         aggregator{
         [&slices](pipelines::FrameSlice &&slice) {
             slices.emplace_back(std::move(slice));
         },
         SchemaType{pipeline_context->descriptor(), index},
-        [&write_futures, &store, &pipeline_context](SegmentInMemory &&segment) {
+        [&write_futures, &store, &pipeline_context, &semaphore](SegmentInMemory &&segment) {
             auto local_index_start = IndexType::start_value_for_segment(segment);
             auto local_index_end = pipelines::end_index_generator(IndexType::end_value_for_segment(segment));
             stream::StreamSink::PartialKey
                 pk{KeyType::TABLE_DATA, pipeline_context->version_id_, pipeline_context->stream_id_, local_index_start, local_index_end};
 
-            // TODO We should apply back pressure to the work we are generating here, to bound memory use
-            write_futures.emplace_back(store->write(pk, std::move(segment)));
+            write_futures.emplace_back(store->write_maybe_blocking(pk, std::move(segment), semaphore));
         },
         segment_size.has_value() ? SegmentationPolicy{*segment_size} : SegmentationPolicy{}
     };

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -17,19 +17,18 @@ import math
 import pandas as pd
 import pytest
 import random
-import string
 from collections import namedtuple
 from datetime import datetime
+
 from numpy.testing import assert_array_equal
 from pytz import timezone
 
 from arcticdb.exceptions import (
     ArcticDbNotYetImplemented,
-    ArcticNativeNotYetImplemented,
     InternalException,
     UserInputException,
 )
-from arcticdb import QueryBuilder, ReadRequest
+from arcticdb import QueryBuilder
 from arcticdb.flattener import Flattener
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._custom_normalizers import CustomNormalizer, register_normalizer


### PR DESCRIPTION
during compaction and sort_merge (#2167)

Monday: 8234437666

This is a simpler alternative to PR #2136 . The idea is to restrict the number of `write_futures` that we allow to accumulate during `compact_incomplete` or `sort_and_finalize_staged_data` since each write task (writing a table data key) holds its segment live in memory, so if a queue of work builds up we can use an unbounded amount of memory.

This behaviour in memory use is only observable with relatively high latency storages and large amounts of work. I've simulated it here with only 1000 incomplete segments, using a faked 3000ms write latency.

We often use `folly::window` to achieve this kind of thing, but that doesn't fit in well with the `SegmentAggregator` (because the number of futures we'll end up with is not known ahead of time).

Profiling scripts are available here
https://github.com/man-group/ArcticDB/commit/5e6a3e54fce49b6a9ff01db31b6c20d4d8cd870d

The conclusions from the profiling are:

```
All on my 20 core laptop (so IO pool size 30). All with 100k rows per incomplete. All with 1000 incompletes.

## Memory analysis: With 10sec sleep on writes

Using debug build.

Without fix 3.7GiB at peak
10 concurrent workers 125 MiB at peak
100 concurrent workers 755 MiB at peak
1000 concurrent workers 3.7GiB at peak

## Performance Analyis with 3sec sleep on writes

Using release build.

Without fix 120s
10 concurrent workers 325s
60 concurrent workers (proposed default for my machine) 120s
100 concurrent workers 119s
1000 concurrent workers 121s
```

Also tested with a single IO and CPU thread and the semaphore only having size 1 (to check we don't deadlock).

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
