### PR TITLE
Enhancement: Implement  for NFS and Azure storages

### DIFF
--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -391,6 +391,12 @@ bool AzureStorage::do_key_exists(const VariantKey& key) {
     return detail::do_key_exists_impl(key, root_folder_, *azure_client_);
 }
 
+std::string AzureStorage::do_key_path(const VariantKey& key) const {
+    auto b = FlatBucketizer{};
+    auto key_type_dir = key_type_folder(root_folder_, variant_key_type(key));
+    return object_path(b.bucketize(key_type_dir, key), key);
+}
+
 } // namespace azure
 
 } // namespace arcticdb::storage

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -67,7 +67,7 @@ class AzureStorage final : public Storage {
         return false;
     }
 
-    std::string do_key_path(const VariantKey&) const final { return {}; };
+    std::string do_key_path(const VariantKey&) const final;
 
   private:
     std::unique_ptr<AzureClientWrapper> azure_client_;

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -154,6 +154,12 @@ std::string NfsBackedStorage::name() const {
     return fmt::format("nfs_backed_storage-{}/{}/{}", region_, bucket_name_, root_folder_);
 }
 
+std::string NfsBackedStorage::do_key_path(const VariantKey& key) const {
+    auto b = NfsBucketizer{};
+    auto key_type_dir = key_type_folder(root_folder_, variant_key_type(key));
+    return object_path(b.bucketize(key_type_dir, key), key);
+}
+
 void NfsBackedStorage::do_write(KeySegmentPair&& key_seg) {
     auto enc = KeySegmentPair{encode_object_id(key_seg.variant_key()), key_seg.segment_ptr()};
     s3::detail::do_write_impl(std::move(enc), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -65,7 +65,7 @@ private:
         return false;
     }
 
-    std::string do_key_path(const VariantKey&) const final { return {}; };
+    std::string do_key_path(const VariantKey&) const final;
 
     auto& client() { return s3_client_; }
     const std::string& bucket_name() const { return bucket_name_; }

--- a/cpp/arcticdb/storage/test/test_azure_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_azure_storage.cpp
@@ -84,3 +84,17 @@ TEST_F(AzureMockStorageFixture, test_matching_key_type_prefix_list) {
 
     ASSERT_EQ(list_in_store(store, entity::KeyType::LOG), log_symbols);
 }
+
+TEST_F(AzureMockStorageFixture, test_key_path) {
+    std::vector<VariantKey> res;
+
+    store.iterate_type(KeyType::TABLE_DATA, [&](VariantKey &&found_key) {
+        res.emplace_back(found_key);
+    }, "");
+
+    for(auto vk: res) {
+        auto key_path = store.key_path(vk);
+        ASSERT_TRUE(key_path.size() > 0);
+        ASSERT_TRUE(key_path.starts_with(store.library_path().to_delim_path('/')));
+    }
+}

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1050,7 +1050,7 @@ class MsgPackNormalizer(Normalizer):
             # If stored in Python2 we want to use raw while unpacking.
             # https://github.com/msgpack/msgpack-python/blob/master/msgpack/_unpacker.pyx#L230
             data = unpackb(data, raw=True)
-                return Pickler.read(data)
+            return Pickler.read(data)
 
         if code == MsgPackSerialization.PY_PICKLE_3:
             data = unpackb(data, raw=False)

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -198,7 +198,7 @@ def test_prefix():
     return "test_bucket_prefix"
 
 
-@pytest.fixture(scope="session",
+@pytest.fixture(scope="function",
                 params=[MotoNfsBackedS3StorageFixtureFactory,
                         MotoS3StorageFixtureFactory])
 def storage_bucket(test_prefix, request):


### PR DESCRIPTION
#### Reference Issues/PRs
Expose `Library.get_key_path` for NFS and Azure storages.

#### What does this implement or fix?
get_key_path will be used to determine where each key is located. This can help to set hard quotas for the platforms that support path based quotas, like VAST.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
