### PR TITLE
Fix off by one errors in staged segment validation

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -1468,11 +1468,13 @@ def test_chunks_overlap(lmdb_storage, lib_name):
     lt = lib._nvs.library_tool()
     append_keys = lt.find_keys_for_id(KeyType.APPEND_DATA, "test")
     assert len(append_keys) == 2
+    assert sorted([key.start_index for key in append_keys]) == [0, 1000]
+    assert [key.end_index for key in append_keys] == [1001, 1001]
+
     lib.finalize_staged_data("test")
 
     df = lib.read("test").data
     assert_frame_equal(df, data)
-    assert df.index.is_monotonic_increasing
 
 
 def test_chunks_overlap_1ns(lmdb_storage, lib_name):
@@ -1560,6 +1562,9 @@ def test_chunks_the_same(lmdb_storage, lib_name):
     lt = lib._nvs.library_tool()
     append_keys = lt.find_keys_for_id(KeyType.APPEND_DATA, "test")
     assert len(append_keys) == 3
+    assert sorted([key.start_index for key in append_keys]) == [1000, 1000, 1000]
+    assert sorted([key.end_index for key in append_keys]) == [1001, 1001, 2001]
+
     lib.finalize_staged_data("test")
 
     df = lib.read("test").data


### PR DESCRIPTION
Our validation when finalizing is too strict at the moment. The index start and end on the APPEND_DATA key is `[start_time, end_time+1]` of data contained within its segment. Our validation logic is not always substracting one from the end time on the key to get the true date range in the segment.

We need a similar change when detecting duplicate staged segments. If two staged segments, both covering a single duplicated index value, are staged, we should allow the write.