### PR TITLE
Skip the compat tests in Conda

### DIFF
--- a/python/tests/compat/arcticdb/test_compatibility.py
+++ b/python/tests/compat/arcticdb/test_compatibility.py
@@ -6,6 +6,11 @@ from arcticdb.util.test import assert_frame_equal
 from arcticdb_ext import set_config_int, unset_config_int
 from arcticdb.options import ModifiableEnterpriseLibraryOption
 from arcticdb.toolbox.library_tool import LibraryTool
+from tests.util.mark import ARCTICDB_USING_CONDA
+
+
+if ARCTICDB_USING_CONDA:
+    pytest.skip("These tests rely on pip based environments", allow_module_level=True)
 
 
 class CurrentVersion:


### PR DESCRIPTION
## Change Type (Required)
- [x] **Patch** (Bug fix or non-breaking improvement)
- [ ] **Minor** (New feature, but backward compatible)
- [ ] **Major** (Breaking changes)
- [ ] **Cherry pick**

They aren't reliable at the moment, see https://github.com/conda-forge/arcticdb-feedstock/pull/396/checks?check_run_id=37543268460 

Since they rely on pip anyway to setup the venv, it's probably best to just skip them in Conda.