### PR TITLE
Dev build naming and tag action fix

### DIFF
--- a/.github/workflows/automated_release.create_developmental_release.yml
+++ b/.github/workflows/automated_release.create_developmental_release.yml
@@ -27,15 +27,43 @@ jobs:
     with:
       regex: ^v\d+\.\d+\.\d+rc\d+$
       from_branch: ${{ needs.get-master-sha.outputs.sha }}
-
+      
+  get-dev-number:
+    name: Get dev number
+    needs: calculate-next-version
+    runs-on: ubuntu-latest
+    outputs:
+      next_dev_number: ${{ steps.next-number.outputs.next_dev_number }}
+    steps:
+      - name: Get latest dev tag
+        id: latest_tag
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: ${{ github.repository }}
+          prefix: v${{ needs.calculate-next-version.outputs.version }}.dev
+          sort-tags: true
+        continue-on-error: true
+      
+      - name: Calculate next dev number
+        id: next-number
+        run: |
+          if [ -z "${{ steps.latest_tag.outputs.tag }}" ]; then
+            next_dev_number=0
+          else
+            LATEST_TAG="${{ steps.latest_tag.outputs.tag }}"
+            LATEST_TAG="${LATEST_TAG#v${{ needs.calculate-next-version.outputs.version }}.dev}"
+            next_dev_number=$((LATEST_TAG + 1))
+          fi
+          echo "next_dev_number=$next_dev_number" >> $GITHUB_OUTPUT
+    
   rc_release:
-    name: Tag and Release version ${{ needs.calculate-next-version.outputs.version }}.dev0+${{ needs.get-master-sha.outputs.sha }} from branch master(${{ needs.get-master-sha.outputs.sha }}) 
+    name: Tag and Release version ${{ needs.calculate-next-version.outputs.version }}.dev${{ needs.get-dev-number.outputs.next_dev_number }} from branch master(${{ needs.get-master-sha.outputs.sha }}) 
     secrets: inherit
     permissions:
       checks: read
       contents: write
     uses: ./.github/workflows/tag.yml
-    needs: [calculate-next-version, get-master-sha]
+    needs: [calculate-next-version, get-master-sha, get-dev-number]
     with:
-      version: ${{ needs.calculate-next-version.outputs.version }}.dev0+${{ needs.get-master-sha.outputs.sha }}
+      version: ${{ needs.calculate-next-version.outputs.version }}.dev${{ needs.get-dev-number.outputs.next_dev_number }}
       from_branch: master

--- a/.github/workflows/automated_release.create_release_branch.yml
+++ b/.github/workflows/automated_release.create_release_branch.yml
@@ -3,7 +3,8 @@ name: "Automated Release: Create next release branch"
 on:
   release:
     types: [released]
-run-name: "Automated release: ${{ github.event.release.tag_name }} released. Cutting the branch for the next version"
+  workflow_dispatch:
+
 jobs:
   get-master-sha:
     name: Get master sha

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v3.3.0
         with:
           token: ${{secrets.TAGGING_TOKEN}}
+          ref: ${{ env.FROM_BRANCH }}
 
       - name: Tag required version
         run: |


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
* Pypi doesn't allow sha to be part of the naming so removing it and instead incrementing `dev` number. `5.2.5.dev0` `5.2.5dev1` etc
* Release from release branch action wasn't working because tag action wasn't set up correctly. Proof of working: https://github.com/man-group/ArcticDB/actions/workflows/automated_release.full_version_cron.yml


## Change Type (Required)
- [x] **Patch** (Bug fix or non-breaking improvement)
- [ ] **Minor** (New feature, but backward compatible)
- [ ] **Major** (Breaking changes)
- [ ] **Cherry pick**

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
