### PR TITLE
Remove `Change Type` template and change label names

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,12 +3,6 @@
 
 #### What does this implement or fix?
 
-## Change Type (Required)
-- [ ] **Patch** (Bug fix or non-breaking improvement)
-- [ ] **Minor** (New feature, but backward compatible)
-- [ ] **Major** (Breaking changes)
-- [ ] **Cherry pick**
-
 #### Any other comments?
 
 #### Checklist

--- a/.github/workflows/automated_release.calculate_next_version.yml
+++ b/.github/workflows/automated_release.calculate_next_version.yml
@@ -48,9 +48,9 @@ jobs:
         id: get_increment_type
         env:
           PULL_REQUESTS: ${{ steps.pull_requests.outputs.pull_requests }}
-          MAJOR_LABEL: major
-          MINOR_LABEL: minor
-          PATCH_LABEL: patch
+          MAJOR_LABEL: "api break"
+          MINOR_LABEL: "enhancement"
+          PATCH_LABEL: "bug"
         run: |
           if [ -z "$PULL_REQUESTS" ]; then
             echo "Error: No PRs found between branches" && exit 1

--- a/.github/workflows/automated_release.check_pr_labels.yml
+++ b/.github/workflows/automated_release.check_pr_labels.yml
@@ -15,7 +15,7 @@ jobs:
           mode: exactly
           count: 1
           labels: |
-            bug
-            enhancement
-            api break
+            patch
+            minor
+            major
           add_comment: true

--- a/.github/workflows/automated_release.check_pr_labels.yml
+++ b/.github/workflows/automated_release.check_pr_labels.yml
@@ -1,10 +1,10 @@
-name: Pull Request Labels
+name: Check Pull Request Labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
     branches: master
 jobs:
-  label:
+  check_labels:
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/automated_release.create_release_branch.yml
+++ b/.github/workflows/automated_release.create_release_branch.yml
@@ -33,6 +33,7 @@ jobs:
   create-next-release-branch:
     needs: [calculate-next-version, get-master-sha]
     runs-on: ubuntu-latest
+    environment: TestPypi # For the branch restrictions token
     permissions:
       contents: write
     outputs:
@@ -41,7 +42,7 @@ jobs:
     - name: Create branch ${{ needs.calculate-next-version.outputs.version }} from ${{ needs.get-master-sha.outputs.sha }}
       uses: peterjgrainger/action-create-branch@v2.2.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.TAGGING_TOKEN }}
       with:
         branch: ${{ needs.calculate-next-version.outputs.version }}
         sha: ${{ needs.get-master-sha.outputs.sha }}

--- a/.github/workflows/automated_release.create_release_branch.yml
+++ b/.github/workflows/automated_release.create_release_branch.yml
@@ -33,6 +33,8 @@ jobs:
   create-next-release-branch:
     needs: [calculate-next-version, get-master-sha]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       new_branch: ${{ needs.calculate-next-version.outputs.version }}
     steps:

--- a/.github/workflows/automated_release.parse_pr_template.yml
+++ b/.github/workflows/automated_release.parse_pr_template.yml
@@ -15,7 +15,7 @@ jobs:
           mode: exactly
           count: 1
           labels: |
-            patch
-            minor
-            major
+            bug
+            enhancement
+            api break
           add_comment: true

--- a/.github/workflows/automated_release.parse_pr_template.yml
+++ b/.github/workflows/automated_release.parse_pr_template.yml
@@ -1,81 +1,21 @@
-name: "Automated Release: Parse PR Change Type"
-
+name: Pull Request Labels
 on:
   pull_request:
-    branches:
-      - master
-    types: [opened, edited, reopened]
-
+    types: [opened, labeled, unlabeled, synchronize]
+    branches: master
 jobs:
-  parse-pr:
-    name: Parse PR and Add labels
-    permissions: 
-      pull-requests: write
+  label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - name: Get PR change type
-        id: detect-change
-        uses: actions/github-script@v7
+      - uses: mheap/github-action-required-labels@v5
         with:
-          script: |
-            const prBody = context.payload.pull_request.body || "";
-            let changeType = "unknown";
-
-            if (prBody.includes("[x] **Major**")) {
-              changeType = "major";
-            } else if (prBody.includes("[x] **Minor**")) {
-              changeType = "minor";
-            } else if (prBody.includes("[x] **Patch**")) {
-              changeType = "patch";
-            } else {
-              core.setFailed("No valid change type found in PR body.");
-            }
-            
-            core.setOutput("change_type", changeType);
-            core.info(`Change type is: ${changeType}`);
-      - name: Set label
-        id: set-label
-        uses: actions/github-script@v7
-        env:
-          MAJOR_LABEL_NAME: major
-          MINOR_LABEL_NAME: minor
-          PATCH_LABEL_NAME: patch
-        with:
-          script: |
-            const changeType = "${{ steps.detect-change.outputs.change_type }}";
-            let labelName = "";
-            const majorLabel = "${{ env.MAJOR_LABEL_NAME }}";
-            const minorLabel = "${{ env.MINOR_LABEL_NAME }}";
-            const patchLabel = "${{ env.PATCH_LABEL_NAME }}";
-            if (changeType === "major") {
-              labelName = majorLabel;
-            } else if (changeType === "minor") {
-              labelName = minorLabel;
-            } else if (changeType === "patch") {
-              labelName = patchLabel;
-            } else {
-              core.setFail("Unknown Change Type Label");
-            }
-            core.info(`Desired label name is ${labelName}`)
-            const pr = context.payload.pull_request;
-
-            const labelsToRemove = [majorLabel, minorLabel, patchLabel];
-            await Promise.all(labelsToRemove.map(async (label) => {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  name: label,
-                });
-              } catch (error) {
-                core.debug(`Error removing label '${label}': ${error.message}`);
-              }
-            }));
-
-            github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              labels: [labelName],
-            });
+          mode: exactly
+          count: 1
+          labels: |
+            patch
+            minor
+            major
+          add_comment: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - id: changelog
         name: Release Changelog Builder
-        uses: mikepenz/release-changelog-builder-action@v3.7.3
+        uses: mikepenz/release-changelog-builder-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/build_tooling/change_log.json
+++ b/build_tooling/change_log.json
@@ -1,6 +1,10 @@
 {
 "categories": [
     {
+        "title": "## ⚠️ Breaking Changes",
+        "labels": ["api break"]
+    },
+    {
         "title": "## 🚀 Features",
         "labels": ["enhancement"]
     },

--- a/build_tooling/change_log.json
+++ b/build_tooling/change_log.json
@@ -2,15 +2,15 @@
 "categories": [
     {
         "title": "## ⚠️ Breaking Changes",
-        "labels": ["api break"]
+        "labels": ["api break", "major"]
     },
     {
         "title": "## 🚀 Features",
-        "labels": ["enhancement"]
+        "labels": ["enhancement", "minor"]
     },
     {
         "title": "## 🐛 Fixes",
-        "labels": ["bug"]
+        "labels": ["bug", "patch"]
     }
 ],
 "pr_template": "- ${{TITLE}} (#${{NUMBER}})",

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -64,7 +64,6 @@ plugins:
             group_by_category: true
             docstring_options:
               ignore_init_summary: false
-              allow_section_blank_line: true
             docstring_section_style: spacy
             heading_level: 2
             inherited_members: true


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
* Remove template and only rely on manually adding labels with the CI checks failing if none are provided. As discussed here https://github.com/man-group/ArcticDB/pull/2174/files#r1962142382
* Add label names to the existing ones that are used for changelog generation: 
  * `major` or `api break`
  * `minor` or `enhancement`
  * `patch` or `bug`
* Fix permissions for automatic branch creation
* Fix changelog builder not ignoring `rc` releases when comparing to previous release.
* Enforced branch protection for the release branch so it is only creatable by admins (and the workflow user's special token) https://github.com/man-group/ArcticDB/settings/rules/3823486
* Fix docs build (remove unsupported option) 

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
