### PR TITLE
Resampling using dynamic schema [Part 1]

### DIFF
--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -497,7 +497,7 @@ public:
         return data_.bytes();
     }
 
-    ColumnData data() const {
+    ColumnData  data() const {
         return ColumnData(&data_.buffer(), &shapes_.buffer(), type_, sparse_map_ ? &*sparse_map_ : nullptr);
     }
 

--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -166,16 +166,18 @@ public:
         ssize_t idx_{0};
         RawType* ptr_{nullptr};
 
-        [[nodiscard]] inline ssize_t idx() const {
+        Enumeration() = default;
+
+        [[nodiscard]] ssize_t idx() const {
             return idx_;
         }
 
-        inline RawType& value() {
+        RawType& value() {
             debug::check<ErrorCode::E_ASSERTION_FAILURE>(ptr_ != nullptr, "Dereferencing nullptr in enumerating ColumnDataIterator");
             return *ptr_;
         };
 
-        inline const RawType& value() const {
+        const RawType& value() const {
             debug::check<ErrorCode::E_ASSERTION_FAILURE>(ptr_ != nullptr, "Dereferencing nullptr in enumerating ColumnDataIterator");
             return *ptr_;
         };
@@ -188,14 +190,14 @@ public:
     };
 
     template <class T, IteratorType iterator_type>
-    using IteratorValueType_t = typename std::conditional_t<
+    using IteratorValueType_t = std::conditional_t<
             iterator_type == IteratorType::ENUMERATED,
             Enumeration<T>,
             PointerWrapper<T>
     >;
 
     template <class T, IteratorType iterator_type, bool constant>
-    using IteratorReferenceType_t = typename std::conditional_t<
+    using IteratorReferenceType_t = std::conditional_t<
         iterator_type == IteratorType::ENUMERATED,
             std::conditional_t<constant, const Enumeration<T>, Enumeration<T>>,
             std::conditional_t<constant, const T, T>
@@ -217,8 +219,7 @@ public:
         using base_type = base_iterator_type<TDT, iterator_type, iterator_density, constant>;
         using RawType = typename TDT::DataTypeTag::raw_type;
     public:
-        ColumnDataIterator() = delete;
-
+        ColumnDataIterator() = default;
         // Used to construct [c]begin iterators
         explicit ColumnDataIterator(ColumnData* parent):
         parent_(parent)

--- a/cpp/arcticdb/entity/types.cpp
+++ b/cpp/arcticdb/entity/types.cpp
@@ -56,4 +56,48 @@ std::size_t data_type_size(const TypeDescriptor& td, DataTypeMode mode) {
     return mode == DataTypeMode::EXTERNAL ? external_data_type_size(td) : internal_data_type_size(td);
 }
 
+TypeDescriptor FieldRef::type() const {
+    return type_;
+}
+
+std::string_view FieldRef::name() const {
+    return name_;
+}
+
+bool operator==(const FieldRef &left, const FieldRef &right) {
+    return left.type_ == right.type_ && left.name_ == right.name_;
+}
+
+FieldWrapper::FieldWrapper(TypeDescriptor type, std::string_view name) :
+    data_(Field::calc_size(name)) {
+    mutable_field().set(type, name);
+}
+
+const Field& FieldWrapper::field() const {
+    return *reinterpret_cast<const Field *>(data_.data());
+}
+
+const TypeDescriptor& FieldWrapper::type() const {
+    return field().type();
+}
+
+std::string_view FieldWrapper::name() const {
+    return field().name();
+}
+
+Field& FieldWrapper::mutable_field() {
+    return *reinterpret_cast<Field *>(data_.data());
+}
+
+FieldRef scalar_field(DataType type, std::string_view name) {
+    return {TypeDescriptor{type, Dimension::Dim0}, name};
+}
+
+bool operator==(const Field &l, const Field &r) {
+    return l.type() == r.type() && l.name() == r.name();
+}
+
+bool operator!=(const Field &l, const Field &r) {
+    return !(l == r);
+}
 } // namespace arcticdb

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -607,17 +607,9 @@ struct FieldRef {
     TypeDescriptor type_;
     std::string_view name_;
 
-    [[nodiscard]] TypeDescriptor type() const {
-        return type_;
-    }
-
-    [[nodiscard]] std::string_view name() const {
-        return name_;
-    }
-
-    friend bool operator==(const FieldRef &left, const FieldRef &right) {
-        return left.type_ == right.type_ && left.name_ == right.name_;
-    }
+    [[nodiscard]] TypeDescriptor type() const;
+    [[nodiscard]] std::string_view name() const;
+    friend bool operator==(const FieldRef &left, const FieldRef &right);
 };
 
 #pragma pack(push, 1)
@@ -690,45 +682,23 @@ public:
 
 struct FieldWrapper {
     std::vector<uint8_t> data_;
-    FieldWrapper(TypeDescriptor type, std::string_view name) :
-        data_(Field::calc_size(name)) {
-        mutable_field().set(type, name);
-    }
-
-    const Field &field() const {
-        return *reinterpret_cast<const Field *>(data_.data());
-    }
-
-    const TypeDescriptor& type() const {
-        return field().type();
-    }
-
-    const std::string_view name() const {
-        return field().name();
-    }
-
+    FieldWrapper(TypeDescriptor type, std::string_view name);
+    const Field &field() const;
+    const TypeDescriptor& type() const;
+    std::string_view name() const;
 private:
-    Field &mutable_field() {
-        return *reinterpret_cast<Field *>(data_.data());
-    }
+    Field &mutable_field();
 };
 
-inline FieldRef scalar_field(DataType type, std::string_view name) {
-    return {TypeDescriptor{type, Dimension::Dim0}, name};
-}
+FieldRef scalar_field(DataType type, std::string_view name);
 
 template<typename Callable>
 auto visit_field(const Field &field, Callable &&c) {
     return field.type().visit_tag(std::forward<Callable>(c));
 }
 
-inline bool operator==(const Field &l, const Field &r) {
-    return l.type() == r.type() && l.name() == r.name();
-}
-
-inline bool operator!=(const Field &l, const Field &r) {
-    return !(l == r);
-}
+bool operator==(const Field &l, const Field &r);
+bool operator!=(const Field &l, const Field &r);
 
 } // namespace entity
 

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -641,7 +641,7 @@ folly::Future<folly::Unit> reduce_and_fix_columns(
     if(frame.empty())
         return folly::Unit{};
 
-    bool dynamic_schema = opt_false(read_options.dynamic_schema_);
+    const bool dynamic_schema = opt_false(read_options.dynamic_schema_);
     auto slice_map = std::make_shared<FrameSliceMap>(context, dynamic_schema);
     DecodePathData shared_data;
 

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -19,9 +19,8 @@
 #include <arcticdb/stream/segment_aggregator.hpp>
 #include <arcticdb/util/test/random_throw.hpp>
 #include <ankerl/unordered_dense.h>
+#include <arcticdb/util/movable_priority_queue.hpp>
 #include <ranges>
-
-
 
 namespace arcticdb {
 
@@ -589,7 +588,7 @@ std::vector<std::vector<EntityId>> ResampleClause<closed_boundary>::structure_fo
             internal::check<ErrorCode::E_ASSERTION_FAILURE>(
                     idx < expected_fetch_counts.size(),
                     "Index {} in new_structure_offsets out of bounds >{}", idx, expected_fetch_counts.size() - 1);
-            expected_fetch_counts[idx]++;
+            ++expected_fetch_counts[idx];
         }
     }
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -621,7 +620,7 @@ std::vector<EntityId> ResampleClause<closed_boundary>::process(std::vector<Entit
     // slice is being computed by the call to process dealing with the row slices above these. Otherwise, this call
     // should do it
     const auto& front_slice = row_slices.front();
-    bool responsible_for_first_overlapping_bucket = front_slice.entity_fetch_count_->at(0) == 1;
+    const bool responsible_for_first_overlapping_bucket = front_slice.entity_fetch_count_->at(0) == 1;
     // Find the iterators into bucket_boundaries_ of the start of the first and the end of the last bucket this call to process is
     // responsible for calculating
     // All segments in a given row slice contain the same index column, so just grab info from the first one

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -676,7 +676,7 @@ std::vector<EntityId> ResampleClause<closed_boundary>::process(std::vector<Entit
             ++slice_index;
         }
         if (!input_agg_columns.empty()) {
-            const bool has_missing_columns = existing_columns.is_all_one_range(0, row_slices.size());
+            const bool has_missing_columns = !existing_columns.is_all_one_range(0, row_slices.size() - 1);
             auto aggregated_column = has_missing_columns ?
                 std::make_shared<Column>(aggregator.aggregate(input_index_columns, input_agg_columns, bucket_boundaries, *output_index_column, string_pool, existing_columns)) :
                 std::make_shared<Column>(aggregator.aggregate(input_index_columns, input_agg_columns, bucket_boundaries, *output_index_column, string_pool));

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -7,10 +7,8 @@
 
 #pragma once
 
-#include <arcticdb/entity/key.hpp>
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
-#include <arcticdb/pipeline/value.hpp>
 #include <arcticdb/processing/expression_context.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/entity/types.hpp>
@@ -19,20 +17,15 @@
 #include <arcticdb/processing/aggregation_interface.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/processing/sorted_aggregation.hpp>
-#include <arcticdb/processing/grouper.hpp>
 #include <arcticdb/stream/aggregator.hpp>
-#include <arcticdb/util/movable_priority_queue.hpp>
-#include <arcticdb/pipeline/index_utils.hpp>
 
 #include <folly/Poly.h>
-#include <folly/futures/Future.h>
 
 #include <vector>
-#include <unordered_map>
 #include <string>
 #include <variant>
 #include <memory>
-#include <atomic>
+
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/processing_unit.hpp
+++ b/cpp/arcticdb/processing/processing_unit.hpp
@@ -19,9 +19,6 @@
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/filter_segment.hpp>
-#include <arcticdb/util/composite.hpp>
-#include <arcticdb/util/string_utils.hpp>
-#include <arcticdb/util/variant.hpp>
 
 namespace arcticdb {
     enum class PipelineOptimisation : uint8_t {

--- a/cpp/arcticdb/processing/query_planner.hpp
+++ b/cpp/arcticdb/processing/query_planner.hpp
@@ -9,8 +9,10 @@
 
 #include <variant>
 #include <vector>
+#include <memory>
 
 #include <arcticdb/processing/clause.hpp>
+#include <arcticdb/processing/grouper.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/sorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.hpp
@@ -7,9 +7,10 @@
 
 #pragma once
 
-#include<memory>
+#include <memory>
 #include <optional>
 #include <vector>
+#include <span>
 
 #include <folly/Poly.h>
 
@@ -343,7 +344,20 @@ public:
                                    const Column& output_index_column,
                                    StringPool& string_pool) const;
 private:
-    [[nodiscard]] DataType generate_common_input_type(const std::vector<std::optional<ColumnWithStrings>>& input_agg_columns) const;
+    [[nodiscard]] Column aggregate_static_schema(
+        std::span<const std::shared_ptr<Column>> input_index_columns,
+        std::span<const std::optional<ColumnWithStrings>> input_agg_columns,
+        std::span<const timestamp> bucket_boundaries,
+        const Column& output_index_column,
+        StringPool& string_pool,
+        DataType common_input_type) const;
+    [[nodiscard]] Column aggregate_dynamic_schema(
+        std::span<const std::shared_ptr<Column>> input_index_columns,
+        std::span<const std::optional<ColumnWithStrings>> input_agg_columns,
+        std::span<const timestamp> bucket_boundaries,
+        const Column& output_index_column,
+        StringPool& string_pool) const;
+    [[nodiscard]] std::optional<DataType> generate_common_input_type(const std::vector<std::optional<ColumnWithStrings>>& input_agg_columns) const;
     void check_aggregator_supported_with_data_type(DataType data_type) const;
     [[nodiscard]] DataType generate_output_data_type(DataType common_input_data_type) const;
     [[nodiscard]] bool index_value_past_end_of_bucket(timestamp index_value, timestamp bucket_end) const;

--- a/cpp/arcticdb/processing/sorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.hpp
@@ -387,7 +387,6 @@ private:
     [[nodiscard]] std::optional<DataType> generate_common_input_type(std::span<const ColumnWithStrings> input_agg_columns) const;
     void check_aggregator_supported_with_data_type(DataType data_type) const;
     [[nodiscard]] DataType generate_output_data_type(DataType common_input_data_type) const;
-    [[nodiscard]] bool index_value_past_end_of_bucket(timestamp index_value, timestamp bucket_end) const;
 
     ColumnName input_column_name_;
     ColumnName output_column_name_;

--- a/cpp/arcticdb/processing/sorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.hpp
@@ -386,7 +386,6 @@ public:
 private:
     [[nodiscard]] std::optional<DataType> generate_common_input_type(std::span<const ColumnWithStrings> input_agg_columns) const;
     void check_aggregator_supported_with_data_type(DataType data_type) const;
-    [[nodiscard]] DataType generate_output_data_type(DataType common_input_data_type) const;
 
     ColumnName input_column_name_;
     ColumnName output_column_name_;

--- a/cpp/arcticdb/processing/sorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.hpp
@@ -30,7 +30,7 @@ struct ISortedAggregator {
         [[nodiscard]] ColumnName get_input_column_name() const { return folly::poly_call<0>(*this); };
         [[nodiscard]] ColumnName get_output_column_name() const { return folly::poly_call<1>(*this); };
         [[nodiscard]] Column aggregate(const std::vector<std::shared_ptr<Column>>& input_index_columns,
-                                       const std::vector<std::optional<ColumnWithStrings>>& input_agg_columns,
+                                       const std::vector<ColumnWithStrings>& input_agg_columns,
                                        const std::vector<timestamp>& bucket_boundaries,
                                        const Column& output_index_column,
                                        StringPool& string_pool) const {
@@ -339,25 +339,12 @@ public:
     [[nodiscard]] ColumnName get_output_column_name() const;
 
     [[nodiscard]] Column aggregate(const std::vector<std::shared_ptr<Column>>& input_index_columns,
-                                   const std::vector<std::optional<ColumnWithStrings>>& input_agg_columns,
+                                   const std::vector<ColumnWithStrings>& input_agg_columns,
                                    const std::vector<timestamp>& bucket_boundaries,
                                    const Column& output_index_column,
                                    StringPool& string_pool) const;
 private:
-    [[nodiscard]] Column aggregate_static_schema(
-        std::span<const std::shared_ptr<Column>> input_index_columns,
-        std::span<const std::optional<ColumnWithStrings>> input_agg_columns,
-        std::span<const timestamp> bucket_boundaries,
-        const Column& output_index_column,
-        StringPool& string_pool,
-        DataType common_input_type) const;
-    [[nodiscard]] Column aggregate_dynamic_schema(
-        std::span<const std::shared_ptr<Column>> input_index_columns,
-        std::span<const std::optional<ColumnWithStrings>> input_agg_columns,
-        std::span<const timestamp> bucket_boundaries,
-        const Column& output_index_column,
-        StringPool& string_pool) const;
-    [[nodiscard]] std::optional<DataType> generate_common_input_type(const std::vector<std::optional<ColumnWithStrings>>& input_agg_columns) const;
+    [[nodiscard]] std::optional<DataType> generate_common_input_type(std::span<const ColumnWithStrings> input_agg_columns) const;
     void check_aggregator_supported_with_data_type(DataType data_type) const;
     [[nodiscard]] DataType generate_output_data_type(DataType common_input_data_type) const;
     [[nodiscard]] bool index_value_past_end_of_bucket(timestamp index_value, timestamp bucket_end) const;

--- a/cpp/arcticdb/processing/sorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.hpp
@@ -368,31 +368,5 @@ private:
 
 } // namespace arcticdb
 
-namespace fmt {
 template<>
-struct formatter<arcticdb::AggregationOperator> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    auto format(const arcticdb::AggregationOperator& agg, FormatContext &ctx) const {
-        switch(agg) {
-            case arcticdb::AggregationOperator::SUM:
-                return fmt::format_to(ctx.out(), "SUM");
-            case arcticdb::AggregationOperator::MEAN:
-                return fmt::format_to(ctx.out(), "MEAN");
-            case arcticdb::AggregationOperator::MIN:
-                return fmt::format_to(ctx.out(), "MIN");
-            case arcticdb::AggregationOperator::MAX:
-                return fmt::format_to(ctx.out(), "MAX");
-            case arcticdb::AggregationOperator::FIRST:
-                return fmt::format_to(ctx.out(), "FIRST");
-            case arcticdb::AggregationOperator::LAST:
-                return fmt::format_to(ctx.out(), "LAST");
-            case arcticdb::AggregationOperator::COUNT:
-            default:
-                return fmt::format_to(ctx.out(), "COUNT");
-        }
-    }
-};
-} //namespace fmt
+struct fmt::formatter<arcticdb::AggregationOperator>;

--- a/cpp/arcticdb/processing/test/benchmark_clause.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_clause.cpp
@@ -12,8 +12,7 @@
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/util/test/generators.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
-#include <folly/futures/Future.h>
-#include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/processing/grouper.hpp>
 
 using namespace arcticdb;
 

--- a/cpp/arcticdb/processing/test/test_clause.cpp
+++ b/cpp/arcticdb/processing/test/test_clause.cpp
@@ -11,6 +11,7 @@
 #include <arcticdb/util/test/generators.hpp>
 #include <folly/futures/Future.h>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/processing/grouper.hpp>
 
 template<typename T>
 void segment_scalar_assert_all_values_equal(const arcticdb::ProcessingUnit& proc_unit, const arcticdb::ColumnName& name, const std::unordered_set<T>& expected, size_t expected_row_count) {

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -70,11 +70,11 @@ inline void expand_dense_buffer_using_bitmap(const util::BitMagic &bv, const uin
 }
 
 template <typename TagType>
-inline void default_initialize(uint8_t* data, size_t bytes) {
+void default_initialize(uint8_t* data, size_t bytes) {
     using RawType = typename TagType::DataTypeTag::raw_type;
-    const auto num_rows ARCTICDB_UNUSED = bytes / sizeof(RawType);
+    [[maybe_unused]] const auto num_rows = bytes / sizeof(RawType);
     constexpr auto data_type = TagType::DataTypeTag::data_type;
-    auto type_ptr ARCTICDB_UNUSED = reinterpret_cast<RawType*>(data);
+    [[maybe_unused]] auto type_ptr = reinterpret_cast<RawType*>(data);
     if constexpr (is_sequence_type(data_type)) {
         std::fill_n(type_ptr, num_rows, not_a_string());
     } else if constexpr (is_floating_point_type(data_type)) {

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -921,8 +921,9 @@ folly::Future<std::vector<SliceAndKey>> read_and_process(
         std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_))
     .via(&async::cpu_executor())
     .thenValue([component_manager, read_query, pipeline_context](std::vector<EntityId>&& processed_entity_ids) {
-        auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(*component_manager, std::move(processed_entity_ids));
-
+        auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+            *component_manager,
+            std::move(processed_entity_ids));
         if (ranges::any_of(read_query->clauses_, [](const std::shared_ptr<Clause>& clause) {
             return clause->clause_info().modifies_output_descriptor_;
         })) {
@@ -940,7 +941,7 @@ void add_index_columns_to_query(const ReadQuery& read_query, const TimeseriesDes
 
         std::vector<std::string> index_columns_to_add;
         for(const auto& index_column : index_columns) {
-            if(std::find(std::begin(*read_query.columns), std::end(*read_query.columns), index_column) == std::end(*read_query.columns))
+            if(ranges::find(*read_query.columns, index_column) == std::end(*read_query.columns))
                 index_columns_to_add.emplace_back(index_column);
         }
         read_query.columns->insert(std::begin(*read_query.columns), std::begin(index_columns_to_add), std::end(index_columns_to_add));

--- a/python/tests/unit/arcticdb/version_store/test_resample.py
+++ b/python/tests/unit/arcticdb/version_store/test_resample.py
@@ -19,13 +19,41 @@ from arcticdb.util.test import assert_frame_equal, generic_resample_test
 from packaging.version import Version
 from arcticdb.util._versions import IS_PANDAS_TWO, PANDAS_VERSION
 import itertools
-from pandas.api.types import is_float_dtype
+from pandas.api.types import (
+    is_float_dtype,
+    is_datetime64_ns_dtype as is_datetime_dtype,
+    is_integer_dtype,
+    is_string_dtype,
+    is_bool_dtype
+)
+import string
 
 pytestmark = pytest.mark.pipeline
 
 
-ALL_AGGREGATIONS = ["sum", "mean", "min", "max", "first", "last", "count"]
-DATETIME_AGGREGATIONS = ["mean", "min", "max", "first", "last", "count"]
+ALL_AGGREGATIONS = {"sum", "mean", "min", "max", "first", "last", "count"}
+
+def rand_data(dtype, count):
+    rng = np.random.default_rng(12345)
+    if is_float_dtype(dtype) or is_integer_dtype(dtype) or is_datetime_dtype(dtype):
+        return rng.integers(0, 100, count).astype(dtype)
+    elif is_string_dtype(dtype):
+        return np.array([''.join(rng.choice(list(string.ascii_letters), size=10)) for _ in range(count)])
+    elif is_bool_dtype(dtype):
+        return rng.choice([True, False], size=count).astype(dtype)
+    else:
+        raise BaseException(f"Unknown dtype {dtype}")
+
+
+def all_aggregations(dtype=None):
+    result = ALL_AGGREGATIONS.copy()
+    if dtype is None:
+        return result
+    elif is_datetime_dtype(dtype):
+        result.remove("sum")
+    elif is_string_dtype(dtype):
+        result.difference_update({"sum", "mean", "min", "max"})
+    return result
 
 def default_aggregation_value(aggregation: str, dtype: Union[np.dtype, str]):
     assert aggregation in ALL_AGGREGATIONS
@@ -36,17 +64,15 @@ def default_aggregation_value(aggregation: str, dtype: Union[np.dtype, str]):
     elif np.issubdtype(dtype, np.datetime64):
         return 0 if aggregation == "count" else pd.NaT
     elif np.issubdtype(dtype, np.str_):
-        pass
+        return 0 if aggregation == "count" else None
     elif pd.api.types.is_bool_dtype(dtype):
         return np.nan if aggregation == "mean" else 0
     else:
         raise "Unknown dtype"
 
-def all_aggregations_dict(col):
-    return {f"to_{agg}": (col, agg) for agg in ALL_AGGREGATIONS}
-
-def datetime_aggregations_dict(col):
-    return {f"to_{agg}": (col, agg) for agg in DATETIME_AGGREGATIONS}
+def all_aggregations_dict(col, dtype=None):
+    aggregations = all_aggregations(dtype)
+    return {f"to_{agg}": (col, agg) for agg in aggregations}
 
 # Pandas recommended way to resample and exclude buckets with no index values, which is our behaviour
 # See https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#sparse-resampling
@@ -502,24 +528,6 @@ def test_resampling_unsupported_aggregation_type_combos(lmdb_version_store_v1):
         lib.read(sym, query_builder=q)
 
 
-def test_resampling_dynamic_schema_missing_column(lmdb_version_store_dynamic_schema_v1):
-    lib = lmdb_version_store_dynamic_schema_v1
-    sym = "test_resampling_dynamic_schema_missing_column"
-
-    lib.write(sym, pd.DataFrame({"col_0": [0]}, index=[pd.Timestamp(0)]))
-    lib.append(sym, pd.DataFrame({"col_1": [1000]}, index=[pd.Timestamp(2000)]))
-
-    # Schema exception should be thrown regardless of whether there are any buckets that span segments or not
-    q = QueryBuilder()
-    q = q.resample("us").agg({"col_0": "sum"})
-    with pytest.raises(SchemaException):
-        lib.read(sym, query_builder=q)
-
-    q = QueryBuilder()
-    q = q.resample("s").agg({"col_1": "sum"})
-    with pytest.raises(SchemaException):
-        lib.read(sym, query_builder=q)
-
 
 def test_resampling_sparse_data(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
@@ -868,62 +876,36 @@ def test_min_with_one_infinity_element(lmdb_version_store_v1):
     assert np.isneginf(lib.read(sym, query_builder=q).data['col_min'][0])
 
 class TestDynamicSchema:
-    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool, "datetime64[ns]", str])
     def test_missing_column_segment_does_not_cross_bucket(self, lmdb_version_store_dynamic_schema_v1, dtype):
         lib = lmdb_version_store_dynamic_schema_v1
         sym = "sym"
 
         idx = pd.date_range(pd.Timestamp(0), periods=20, freq='ns')
-        initial_df = pd.DataFrame({"a": range(len(idx))}, index=idx)
+        initial_df = pd.DataFrame({"a": rand_data(dtype, len(idx))}, index=idx)
         lib.write(sym, initial_df)
 
         idx_to_append = pd.date_range(pd.Timestamp(40), periods=20, freq='ns')
-        data_to_append = {"a": range(len(idx_to_append)), "b": np.array(range(len(idx_to_append)), dtype=dtype)}
+        data_to_append = {"a": rand_data(dtype, len(idx)), "b": rand_data(dtype, len(idx))}
         df_to_append = pd.DataFrame(data_to_append, index=idx_to_append)
         lib.append(sym, df_to_append)
 
         q = QueryBuilder()
-        q = q.resample('10ns').agg(all_aggregations_dict("b"))
+        q = q.resample('10ns').agg(all_aggregations_dict("b", dtype))
         arctic_resampled = lib.read(sym, query_builder=q).data
         arctic_resampled = arctic_resampled.reindex(columns=sorted(arctic_resampled.columns))
 
         expected_slice_with_missing_column_idx = [pd.Timestamp(0), pd.Timestamp(10)]
         expected_slice_with_missing_column = pd.DataFrame({
-            f"to_{agg}": [default_aggregation_value(agg, dtype) for _ in range(len(expected_slice_with_missing_column_idx))] for agg in ALL_AGGREGATIONS
+            f"to_{agg}": [default_aggregation_value(agg, dtype) for _ in range(len(expected_slice_with_missing_column_idx))] for agg in all_aggregations(dtype)
         }, index=expected_slice_with_missing_column_idx)
-        expected_slice_containing_column = df_to_append.resample('10ns').agg(None, **all_aggregations_dict("b"))
+        expected_slice_containing_column = df_to_append.resample('10ns').agg(None, **all_aggregations_dict("b", dtype))
         expected = pd.concat([expected_slice_with_missing_column, expected_slice_containing_column])
         expected = expected.reindex(columns=sorted(expected.columns))
         assert_frame_equal(arctic_resampled, expected, check_dtype=False)
 
-    def test_missing_column_segment_does_not_cross_bucket_date(self, lmdb_version_store_dynamic_schema_v1):
-        # Datetime types do not support all aggregation types that is why they are separated in a separate test
-        lib = lmdb_version_store_dynamic_schema_v1
-        sym = "sym"
-
-        idx = pd.date_range(pd.Timestamp(0), periods=20, freq='ns')
-        initial_df = pd.DataFrame({"a": range(len(idx))}, index=idx)
-        lib.write(sym, initial_df)
-
-        idx_to_append = pd.date_range(pd.Timestamp(40), periods=20, freq='ns')
-        data_to_append = {"a": range(len(idx_to_append)), "b": np.array([pd.Timestamp(i) for i in range(len(idx_to_append))])}
-        df_to_append = pd.DataFrame(data_to_append, index=idx_to_append)
-        lib.append(sym, df_to_append)
-
-        q = QueryBuilder()
-        q = q.resample('10ns').agg(datetime_aggregations_dict("b"))
-        arctic_resampled = lib.read(sym, query_builder=q).data
-        arctic_resampled = arctic_resampled.reindex(columns=sorted(arctic_resampled.columns))
-
-        expected_slice_with_missing_column_idx = [pd.Timestamp(0), pd.Timestamp(10)]
-        expected_slice_with_missing_column = pd.DataFrame({
-            f"to_{agg}": [default_aggregation_value(agg, np.datetime64) for _ in range(len(expected_slice_with_missing_column_idx))] for agg in DATETIME_AGGREGATIONS
-        }, index=expected_slice_with_missing_column_idx)
-        expected_slice_containing_column = df_to_append.resample('10ns').agg(None, **datetime_aggregations_dict("b"))
-        expected = pd.concat([expected_slice_with_missing_column, expected_slice_containing_column])
-        expected = expected.reindex(columns=sorted(expected.columns))
-        assert_frame_equal(arctic_resampled, expected, check_dtype=False)
-    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool])
+    @pytest.mark.xfail(reason="Not decided whether to backfill or to leave empty")
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool, "datetime64[ns]", str])
     def test_date_range_select_missing_column(self, lmdb_version_store_dynamic_schema_v1, dtype):
         lib = lmdb_version_store_dynamic_schema_v1
         sym = "sym"
@@ -944,7 +926,7 @@ class TestDynamicSchema:
         expected = pd.DataFrame({}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(10)]))
         assert_frame_equal(arctic_resampled, expected)
 
-    @pytest.mark.parametrize("dtype", [np.float32])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool, "datetime64[ns]", str])
     def test_bucket_spans_two_segments(self, lmdb_version_store_dynamic_schema_v1, dtype):
 
         pd.set_option('display.max_rows', None)
@@ -955,21 +937,26 @@ class TestDynamicSchema:
         lib = lmdb_version_store_dynamic_schema_v1
         sym = "sym"
 
-        idx = pd.date_range(pd.Timestamp(1), periods=5, freq='ns')
-        initial_df = pd.DataFrame({"a": range(len(idx))}, index=idx)
+        idx = pd.date_range(pd.Timestamp(0), periods=5, freq='ns')
+        initial_df = pd.DataFrame({"a": rand_data(dtype, len(idx))}, index=idx)
         lib.write(sym, initial_df)
 
         idx_to_append = pd.date_range(pd.Timestamp(6), periods=4, freq='ns')
-        data_to_append = {"a": range(len(idx_to_append)), "b": np.array(range(-len(idx_to_append),0), dtype=dtype)}
+        data_to_append = {"a": rand_data(dtype, len(idx_to_append)), "b": rand_data(dtype, len(idx_to_append))}
         df_to_append = pd.DataFrame(data_to_append, index=idx_to_append)
         lib.append(sym, df_to_append)
 
-        print()
-        print(lib.read(sym).data)
-
         q = QueryBuilder()
-        q = q.resample('10ns').agg({"mx": ("b", "max")})
+        q = q.resample('10ns').agg(all_aggregations_dict("b", dtype))
         arctic_resampled = lib.read(sym, query_builder=q).data
         arctic_resampled = arctic_resampled.reindex(columns=sorted(arctic_resampled.columns))
-        print()
-        print(arctic_resampled)
+
+        # Resampling is performed on column b which is introduced in the second segment. That is why pandas resampling
+        # is performed only on the second segment. Another option would be to read the whole dataframe and run pandas
+        # resampling on it. However, this breaks for integer dtypes as they get backfilled (when they are missing from
+        # a segment) pandas will then pick this 0 as existing value this might affect all aggregations e.g. (pandas will
+        # count it while ArcticDB will igrnore it in the count clause)
+        expected = df_to_append.resample('10ns').agg(None, **all_aggregations_dict("b", dtype))
+        expected = expected.reindex(columns=sorted(expected.columns))
+
+        assert_frame_equal(arctic_resampled, expected, check_dtype=False)

--- a/python/tests/unit/arcticdb/version_store/test_resample.py
+++ b/python/tests/unit/arcticdb/version_store/test_resample.py
@@ -6,7 +6,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 from functools import partial
-from typing import Union
+from typing import Union, Optional
 
 import numpy as np
 import pandas as pd
@@ -45,7 +45,16 @@ def rand_data(dtype, count):
         raise BaseException(f"Unknown dtype {dtype}")
 
 
-def all_aggregations(dtype=None):
+def all_aggregations(dtype: Union[np.dtype, str] = None) -> set:
+    """
+    Get a set of all aggregation operations supported for a given dtype.
+
+    Parameters
+    ----------
+    dtype : Union[np.dtype, str]
+        Dtype to generate supported aggregations for. If None returns all aggregation operations.
+    """
+
     result = ALL_AGGREGATIONS.copy()
     if dtype is None:
         return result
@@ -56,6 +65,13 @@ def all_aggregations(dtype=None):
     return result
 
 def default_aggregation_value(aggregation: str, dtype: Union[np.dtype, str]):
+    """
+    Get the default value for an aggregation operation. This is used to back-fill Pandas dataframes when they are
+    compared against dynamic schema libraries. Dynamic schema allows for missing columns but Pandas does not. ArcticDB
+    will put these default values everywhere where we have an index value in a bucket but the segment does not contain
+    column data.
+    """
+
     assert aggregation in ALL_AGGREGATIONS
     if is_float_dtype(dtype):
         return 0 if aggregation == "count" else np.nan
@@ -70,7 +86,21 @@ def default_aggregation_value(aggregation: str, dtype: Union[np.dtype, str]):
     else:
         raise "Unknown dtype"
 
-def all_aggregations_dict(col, dtype=None):
+def all_aggregations_dict(col: str, dtype: Optional[Union[str, np.dtype]] = None):
+    """
+    Generate a dict that can be used as an argument to both QueryBuilder and Pandas resample methods. The dict will
+    contain all possible aggregation operations for a column
+
+    Parameters
+    ----------
+
+    col: str
+        The name of the column to create aggregation dict for
+    dtype: Optional[Union[str, np.dtype]]
+        The dtype of the column to create aggregation operations dict for. Some dtypes support only a subset of the
+        aggregations. If None it creates a dict with all possible aggregations.
+    """
+
     aggregations = all_aggregations(dtype)
     return {f"to_{agg}": (col, agg) for agg in aggregations}
 
@@ -896,44 +926,19 @@ class TestDynamicSchema:
         arctic_resampled = arctic_resampled.reindex(columns=sorted(arctic_resampled.columns))
 
         expected_slice_with_missing_column_idx = [pd.Timestamp(0), pd.Timestamp(10)]
+        # Pandas has no equivalent of dynamic schema and expects that the column will always be there, thus for the
+        # buckets where the column is missing we have to place the values manually by back-filling the column using the
+        # default value based on the type and the aggregator
         expected_slice_with_missing_column = pd.DataFrame({
-            f"to_{agg}": [default_aggregation_value(agg, dtype) for _ in range(len(expected_slice_with_missing_column_idx))] for agg in all_aggregations(dtype)
+            f"to_{agg}": [default_aggregation_value(agg, dtype) for _ in expected_slice_with_missing_column_idx] for agg in all_aggregations(dtype)
         }, index=expected_slice_with_missing_column_idx)
         expected_slice_containing_column = df_to_append.resample('10ns').agg(None, **all_aggregations_dict("b", dtype))
         expected = pd.concat([expected_slice_with_missing_column, expected_slice_containing_column])
         expected = expected.reindex(columns=sorted(expected.columns))
         assert_frame_equal(arctic_resampled, expected, check_dtype=False)
 
-    @pytest.mark.xfail(reason="Not decided whether to backfill or to leave empty")
-    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool, "datetime64[ns]", str])
-    def test_date_range_select_missing_column(self, lmdb_version_store_dynamic_schema_v1, dtype):
-        lib = lmdb_version_store_dynamic_schema_v1
-        sym = "sym"
-
-        idx = pd.date_range(pd.Timestamp(0), periods=20, freq='ns')
-        initial_df = pd.DataFrame({"a": range(len(idx))}, index=idx)
-        lib.write(sym, initial_df)
-
-        idx_to_append = pd.date_range(pd.Timestamp(40), periods=20, freq='ns')
-        data_to_append = {"a": range(len(idx_to_append)), "b": np.array(range(len(idx_to_append)), dtype=dtype)}
-        df_to_append = pd.DataFrame(data_to_append, index=idx_to_append)
-        lib.append(sym, df_to_append)
-
-        q = QueryBuilder()
-        q = q.resample('10ns').agg(all_aggregations_dict("b"))
-        arctic_resampled = lib.read(sym, query_builder=q, date_range=(None, pd.Timestamp(20))).data
-        arctic_resampled = arctic_resampled.reindex(columns=sorted(arctic_resampled.columns))
-        expected = pd.DataFrame({}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(10)]))
-        assert_frame_equal(arctic_resampled, expected)
-
     @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool, "datetime64[ns]", str])
     def test_bucket_spans_two_segments(self, lmdb_version_store_dynamic_schema_v1, dtype):
-
-        pd.set_option('display.max_rows', None)
-        pd.set_option('display.max_columns', None)
-        pd.set_option('display.width', None)
-        pd.set_option('display.max_colwidth', None)
-
         lib = lmdb_version_store_dynamic_schema_v1
         sym = "sym"
 
@@ -957,6 +962,57 @@ class TestDynamicSchema:
         # a segment) pandas will then pick this 0 as existing value this might affect all aggregations e.g. (pandas will
         # count it while ArcticDB will igrnore it in the count clause)
         expected = df_to_append.resample('10ns').agg(None, **all_aggregations_dict("b", dtype))
+        expected = expected.reindex(columns=sorted(expected.columns))
+
+        assert_frame_equal(arctic_resampled, expected, check_dtype=False)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.int32, np.int64, bool, "datetime64[ns]", str])
+    def test_bucket_spans_multiple_segments(self, lmdb_version_store_dynamic_schema_v1, dtype):
+        lib = lmdb_version_store_dynamic_schema_v1
+        sym = "sym"
+
+        data = [
+            pd.DataFrame({"a": rand_data(dtype, 1)}, index=pd.DatetimeIndex([pd.Timestamp(0)])),
+            pd.DataFrame({"b": rand_data(dtype, 1)}, index=pd.DatetimeIndex([pd.Timestamp(1)])),
+            pd.DataFrame({"a": rand_data(dtype, 1)}, index=pd.DatetimeIndex([pd.Timestamp(2)])),
+            pd.DataFrame({"a": rand_data(dtype, 1)}, index=pd.DatetimeIndex([pd.Timestamp(3)])),
+            pd.DataFrame({"b": rand_data(dtype, 1)}, index=pd.DatetimeIndex([pd.Timestamp(4)])),
+            pd.DataFrame({"b": rand_data(dtype, 1)}, index=pd.DatetimeIndex([pd.Timestamp(5)])),
+            pd.DataFrame({"a": rand_data(dtype, 3), "b": rand_data(dtype, 3)}, index=pd.date_range(pd.Timestamp(5), periods=3, freq='ns'))
+        ]
+        for df in data:
+            lib.append(sym, df)
+
+        pandas_to_resample = pd.concat(filter(lambda df: "b" in df, data))
+        expected = pandas_to_resample.resample('10ns').agg(None, **all_aggregations_dict("b", dtype))
+        expected = expected.reindex(columns=sorted(expected.columns))
+
+        q = QueryBuilder()
+        q = q.resample('10ns').agg(all_aggregations_dict("b", dtype))
+        arctic_resampled = lib.read(sym, query_builder=q).data
+        arctic_resampled = arctic_resampled.reindex(columns=sorted(arctic_resampled.columns))
+
+        assert_frame_equal(expected, arctic_resampled, check_dtype=False)
+
+    def test_type_promotion(self, lmdb_version_store_dynamic_schema_v1):
+        lib = lmdb_version_store_dynamic_schema_v1
+        sym = "sym"
+        data = [
+            pd.DataFrame({"a": rand_data(np.int16, 15)}, pd.date_range(pd.Timestamp(0), periods=15, freq='ns')),
+            pd.DataFrame({"a": rand_data(np.int8, 15)}, pd.date_range(pd.Timestamp(15), periods=15, freq='ns')),
+            pd.DataFrame({"a": rand_data(np.int32, 15)}, pd.date_range(pd.Timestamp(30), periods=15, freq='ns')),
+            pd.DataFrame({"a": rand_data(np.float64, 15)}, pd.date_range(pd.Timestamp(45), periods=15, freq='ns'))
+        ]
+        for df in data:
+            lib.append(sym, df)
+
+        q = QueryBuilder()
+        q = q.resample('10ns').agg(all_aggregations_dict("a"))
+        arctic_resampled = lib.read(sym, query_builder=q).data
+        arctic_resampled = arctic_resampled.reindex(columns=sorted(arctic_resampled.columns))
+
+        pandas_to_resample = lib.read(sym).data
+        expected = pandas_to_resample.resample('10ns').agg(None, **all_aggregations_dict("a"))
         expected = expected.reindex(columns=sorted(expected.columns))
 
         assert_frame_equal(arctic_resampled, expected, check_dtype=False)


### PR DESCRIPTION
#### Reference Issues/PRs
This enables using the QueryBuilder to resample libraries where dynamic schema is enabled. This requires handling two cases which are different in comparison to static schema.

1. Type propagation. It turns out that it works without any functional changes in the code.
2. Missing columns. Dynamic schema allows for segments to contain only a subset of all columns in the symbol. This case needed additional care. 

*Handling missing columns*
Two changes make this possible. First is in `std::vector<EntityId> ResampleClause<closed_boundary>::process(std::vector<EntityId>&& entity_ids)` it now builds a bitmap per column. The bitmap has length equal to the number index segments (as we have it as invariant that the index cannot be sparse) and has a bit set to 1 if the column appears in a particular segment. The vector of segments passed for aggregation has length equal to the number of set bits in the bitset. If all bits are set to 1 we go down the static schema way which is a bit more efficient otherwise we go down the path of "not all segments have the column"

The second change is in `Column SortedAggregator<aggregation_operator, closed_boundary>::aggregate`. Now it has two overloads. One taking a dense vector of columns. Where the i-th column corresponds to the i-th index segment. And a second overload that takes a vector of columns whose size is less than the number of index segments and a bitmap. The length of the bitmap is equal to the count of the index segments. We then iterate over the set bits in the bitmap.

The initial idea used std::vector<std::optional<Column>> but this makes the "dense" codepath a bit better.

*Code refactoring*
There's some code refactoring going on. Mostly moving things from `sorted_aggregation.hpp` to `sorted_aggregation.cpp`. Some of the functions did not require the state of `SortedAggregator` and were made free functions.

*Missing behavior*
The current implementation has a flaws related to using date_range

1. If `date_range` is passed to the QueryBuilder and the date range does not contain some column (which is otherwise in the data frame) we will return either an empty dataframe (if no other columns are being aggregated) or a dataframe not containing that column. More sensible behavior would be to backfill the missing buckets with a default value based on the dtype and the aggregator.
2. Type propagation takes into account only the segments using in the aggregation and the dtypes from the segment descriptor. This means that different date ranges can result in dataframes whose columns have different dtypes. More sensible behavior would be to use the timeseries descriptor.

@alexowens90 is working on making the TSD easily available. Both of the above can be implemented after that.

#### What does this implement or fix?

## Change Type (Required)
- [ ] **Patch** (Bug fix or non-breaking improvement)
- [ ] **Minor** (New feature, but backward compatible)
- [ ] **Major** (Breaking changes)
- [ ] **Cherry pick**

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
