### PR TITLE
Conversion from pyarrow `Expression`s to `QueryBuilder` expressions

### DIFF
--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -257,7 +257,7 @@ class ExpressionNode:
 
 
     @classmethod
-    def from_pyarrow_expression_str(cls, expression_str : str, function_map : Optional[Dict[str, Callable]] = None) -> "ExpressionNode":
+    def _from_pyarrow_expression_str(cls, expression_str : str, function_map : Optional[Dict[str, Callable]] = None) -> "ExpressionNode":
         """
         Builds an ExpressionNode from a pyarrow expression string.
 

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -377,8 +377,14 @@ def _(a: ast.BinOp, function_map) -> Any:
 @_ast_to_expression.register(ast.Compare)
 def _(a: ast.Compare, function_map) -> Any:
     # Compares in pyarrow Expression contain exactly one comparison (i.e. 1 < field("asdf") < 3 is not supported)
-    assert len(a.ops) == 1
-    assert len(a.comparators) == 1
+    check(
+        len(a.ops) == 1,
+        f"Received a series of {len(a.ops)} comparisons, but only series of 1 comparison is supported. "
+        "Use `(a < b) & (b < c)` instead of `a < b < c`.")
+    check(
+        len(a.comparators) == 1,
+        f"Received a series of {len(a.comparators)} comparators, but only series of 1 comparison is supported. "
+        "Use `(a < b) & (b < c)` instead of `a < b < c`.")
     op = a.ops[0]
     left = a.left
     right = a.comparators[0]
@@ -403,6 +409,16 @@ def _(a: ast.Compare, function_map) -> Any:
 @_ast_to_expression.register(ast.List)
 def _(a: ast.List, function_map) -> Any:
     return [_ast_to_expression(e, function_map) for e in a.elts]
+
+
+@_ast_to_expression.register(ast.Set)
+def _(a: ast.Set, function_map) -> Any:
+    return set([_ast_to_expression(e, function_map) for e in a.elts])
+
+
+@_ast_to_expression.register(ast.Tuple)
+def _(a: ast.Tuple, function_map) -> Any:
+    return tuple([_ast_to_expression(e, function_map) for e in a.elts])
 
 
 def is_supported_sequence(obj):

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_parse_pyarrow.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_parse_pyarrow.py
@@ -1,0 +1,136 @@
+import datetime
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+
+from arcticdb.version_store.processing import QueryBuilder, ExpressionNode
+from arcticdb.util.test import assert_frame_equal
+
+
+def df_with_all_column_types(num_rows=100):
+    data = {
+        "int_col": np.arange(num_rows, dtype=np.int64),
+        "float_col": [np.nan if i%20==5 else i for i in range(num_rows)],
+        "str_col": [f"str_{i}" for i in range(num_rows)],
+        "bool_col": [i%2 == 0 for i in range(num_rows)],
+        "datetime_col": pd.date_range(start=pd.Timestamp(2025, 1, 1), periods=num_rows)
+    }
+    index = pd.date_range(start=pd.Timestamp(2025, 1, 1), periods=num_rows)
+    return pd.DataFrame(data=data, index=index)
+
+
+def compare_against_pyarrow(pyarrow_expr_str, expected_adb_expr, lib, function_map = None, expect_equal=True):
+    adb_expr = ExpressionNode.from_pyarrow_expression_str(pyarrow_expr_str, function_map)
+    assert str(adb_expr) == str(expected_adb_expr)
+    pa_expr = eval(pyarrow_expr_str)
+
+    # Setup
+    sym = "sym"
+    df = df_with_all_column_types()
+    lib.write(sym, df)
+    pa_table = pa.Table.from_pandas(df)
+
+    # Apply filter to adb
+    q = QueryBuilder()
+    q = q[adb_expr]
+    adb_result = lib.read(sym, query_builder=q).data
+
+    # Apply filter to pyarrow
+    pa_result = pa_table.filter(pa_expr).to_pandas()
+
+    if expect_equal:
+        assert_frame_equal(adb_result, pa_result)
+    else:
+        assert len(adb_result) != len(pa_result)
+
+
+def test_basic_filters(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+
+    # Filter by boolean column
+    expr = f"pc.field('bool_col')"
+    expected_expr = ExpressionNode.column_ref('bool_col')
+    compare_against_pyarrow(expr, expected_expr, lib)
+
+    # Filter by comparison
+    for op in ["<", "<=", "==", ">=", ">"]:
+        expr = f"pc.field('int_col') {op} 50"
+        expected_expr = eval(f"ExpressionNode.column_ref('int_col') {op} 50")
+        compare_against_pyarrow(expr, expected_expr, lib)
+
+    # Filter with unary operators
+    expr = "~pc.field('bool_col')"
+    expected_expr = ~ExpressionNode.column_ref('bool_col')
+    compare_against_pyarrow(expr, expected_expr, lib)
+
+    # Filter with binary operators
+    for op in ["+", "-", "*", "/"]:
+        expr = f"pc.field('float_col') {op} 5.0 < 50.0"
+        expected_expr = eval(f"ExpressionNode.column_ref('float_col') {op} 5.0 < 50.0")
+        compare_against_pyarrow(expr, expected_expr, lib)
+
+    for op in ["&", "|"]:
+        expr = f"pc.field('bool_col') {op} (pc.field('int_col') < 50)"
+        expected_expr = eval(f"ExpressionNode.column_ref('bool_col') {op} (ExpressionNode.column_ref('int_col') < 50)")
+        compare_against_pyarrow(expr, expected_expr, lib)
+
+    # Filter with expression method calls
+    expr = "pc.field('str_col').isin(['str_0', 'str_10', 'str_20'])"
+    expected_expr = ExpressionNode.column_ref('str_col').isin(['str_0', 'str_10', 'str_20'])
+    compare_against_pyarrow(expr, expected_expr, lib)
+
+    expr = "pc.field('float_col').is_nan()"
+    expected_expr = ExpressionNode.column_ref('float_col').isnull()
+    # We expect a different result between adb and pyarrow because of the different nan/null handling
+    compare_against_pyarrow(expr, expected_expr, lib, expect_equal=False)
+
+    expr = "pc.field('float_col').is_null()"
+    expected_expr = ExpressionNode.column_ref('float_col').isnull()
+    compare_against_pyarrow(expr, expected_expr, lib)
+
+    expr = "pc.field('float_col').is_valid()"
+    expected_expr = ExpressionNode.column_ref('float_col').notnull()
+    compare_against_pyarrow(expr, expected_expr, lib)
+
+def test_complex_filters(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+
+    # Nested complex filters
+    expr = "((pc.field('float_col') * 2) > 20.0) & (pc.field('int_col') <= pc.scalar(60)) | pc.field('bool_col')"
+    expected_expr = (ExpressionNode.column_ref('float_col') * 2 > 20.0) & (ExpressionNode.column_ref('int_col') <= 60) | ExpressionNode.column_ref('bool_col')
+    compare_against_pyarrow(expr, expected_expr, lib)
+
+    expr = "((pc.field('float_col') / 2) > 20.0) & (pc.field('float_col') <= pc.scalar(60)) & pc.field('str_col').isin(['str_30', 'str_41', 'str_42', 'str_53', 'str_99'])"
+    expected_expr = (ExpressionNode.column_ref('float_col') / 2 > 20.0) & (ExpressionNode.column_ref('float_col') <= 60) & ExpressionNode.column_ref('str_col').isin(['str_30', 'str_41', 'str_42', 'str_53', 'str_99'])
+    compare_against_pyarrow(expr, expected_expr, lib)
+
+    # Filters with function calls
+    function_map = {
+        "datetime.datetime": datetime.datetime,
+        "abs": abs,
+    }
+    expr = "pc.field('datetime_col') < datetime.datetime(2025, 1, 20)"
+    expected_expr = ExpressionNode.column_ref('datetime_col') < datetime.datetime(2025, 1, 20)
+    compare_against_pyarrow(expr, expected_expr, lib, function_map)
+
+    expr = "(pc.field('datetime_col') < datetime.datetime(2025, 1, abs(-20))) & (pc.field('int_col') >= abs(-5))"
+    expected_expr = (ExpressionNode.column_ref('datetime_col') < datetime.datetime(2025, 1, abs(-20))) & (ExpressionNode.column_ref('int_col') >= abs(-5))
+    compare_against_pyarrow(expr, expected_expr, lib, function_map)
+
+def test_broken_filters():
+    # ill-formated filter
+    expr = "pc.field('float_col'"
+    with pytest.raises(ValueError):
+        ExpressionNode.from_pyarrow_expression_str(expr)
+
+    # pyarrow expressions only support single comparisons
+    expr = "1 < pc.field('int_col') < 10"
+    with pytest.raises(ValueError):
+        ExpressionNode.from_pyarrow_expression_str(expr)
+
+    # calling a mising function
+    expr = "some.missing.function(5)"
+    with pytest.raises(ValueError):
+        ExpressionNode.from_pyarrow_expression_str(expr)

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_parse_pyarrow.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_parse_pyarrow.py
@@ -22,7 +22,7 @@ def df_with_all_column_types(num_rows=100):
 
 
 def compare_against_pyarrow(pyarrow_expr_str, expected_adb_qb, lib, function_map = None, expect_equal=True):
-    adb_expr = ExpressionNode.from_pyarrow_expression_str(pyarrow_expr_str, function_map)
+    adb_expr = ExpressionNode._from_pyarrow_expression_str(pyarrow_expr_str, function_map)
     q = QueryBuilder()
     q = q[adb_expr]
     assert q == expected_adb_qb
@@ -133,14 +133,14 @@ def test_broken_filters():
     # ill-formated filter
     expr = "pc.field('float_col'"
     with pytest.raises(ValueError):
-        ExpressionNode.from_pyarrow_expression_str(expr)
+        ExpressionNode._from_pyarrow_expression_str(expr)
 
     # pyarrow expressions only support single comparisons
     expr = "1 < pc.field('int_col') < 10"
     with pytest.raises(ValueError):
-        ExpressionNode.from_pyarrow_expression_str(expr)
+        ExpressionNode._from_pyarrow_expression_str(expr)
 
     # calling a mising function
     expr = "some.missing.function(5)"
     with pytest.raises(ValueError):
-        ExpressionNode.from_pyarrow_expression_str(expr)
+        ExpressionNode._from_pyarrow_expression_str(expr)


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ref: 8471524478

#### What does this implement or fix?
Introduces `ExpressionNode._from_pyarrow_expression_str`.

This is required for predicate pushdown integration with polars. E.g. when we do:
```
lf = polars.scan_arcticdb(arctic_identifier)
lf = lf.filter(pl.col("float_col") <= 40.1)
lf.collect()
```
When calling `collect` the filter will get pushed down to our (to be implemented) `polars.scan_arcticdb` via a callback. The filter is given as a string which can be evaluated to a pyarrow expression. For reference string construction happens [here](https://github.com/pola-rs/polars/blob/4e286d8c83b0fcb56f0a7ea06d2eb731f179e01e/crates/polars-plan/src/plans/python/pyarrow.rs#L25).

I've decided to keep this conversion code in core arcticdb instead of polars for a few reasons:
- Gives us more flexibility if we decide to update our `QueryBuilder` expressions
- We'll have less code to maintain in a repository which is not ours
- Automated tests allow us to not accidentally break polars predicate pushdown to arcticdb

For additional reference see how pyiceberg handles predicate pushdown from polars [here](https://github.com/pola-rs/polars/blob/4e286d8c83b0fcb56f0a7ea06d2eb731f179e01e/py-polars/polars/io/iceberg.py#L197-L200)

And how this might fit in the prototype `polars.scan_arcticdb` implementation [here](https://github.com/IvoDD/polars/pull/1/files)


## Change Type (Required)
- [x] **Patch** (Bug fix or non-breaking improvement)
- [ ] **Minor** (New feature, but backward compatible)
- [ ] **Major** (Breaking changes)
- [ ] **Cherry pick**

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
