### PR TITLE
Release the GIL during parallel writes to avoid deadlock

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1020,6 +1020,7 @@ void LocalVersionedEngine::write_parallel_frame(
     bool validate_index,
     bool sort_on_index,
     const std::optional<std::vector<std::string>>& sort_columns) const {
+    py::gil_scoped_release release_gil;
     WriteIncompleteOptions options{
         .validate_index=validate_index,
         .write_options=get_write_options(),


### PR DESCRIPTION
Normal writes release the GIL, but until this change staged writes did not.

We recently (v5.2.0) changed staged writes to behave more like normal writes, in particular they now use `WriteToSegmentTask` which needs to take the GIL to allocate data backed by Python unicode strings. This lead to a deadlock.

This change simply releases the GIL in the "main" thread when we start a staged write, just like we already do for a normal write.

I will make a subsequent change to add more test coverage based on a real example, and to check how we handle unicode across our other API methods.