### PR TITLE
Automatically build docs on release

### DIFF
--- a/.github/workflows/build_docs_on_release.yml
+++ b/.github/workflows/build_docs_on_release.yml
@@ -44,7 +44,6 @@ jobs:
             DOCS_TAG_NAME=v${{ steps.tag_name.outputs.tag }}-docs
             git tag $DOCS_TAG_NAME
             git push origin $DOCS_TAG_NAME
-        continue-on-error: true
 
   build-docs:
     needs: check-inputs

--- a/.github/workflows/build_docs_on_release.yml
+++ b/.github/workflows/build_docs_on_release.yml
@@ -1,0 +1,56 @@
+name: "Build Docs on Release"
+
+on:
+  release:
+    types: [released]
+
+run-name: "Build and Publish Docs for release ${{ github.event.release.tag_name }}"
+jobs:
+  check-inputs:
+    name: Check inputs
+    runs-on: ubuntu-latest
+    outputs:
+        version: ${{ steps.tag_name.outputs.tag }}
+        latest: ${{ github.event.release.tag_name == steps.latest_tag.outputs.tag }}
+
+    steps:
+      - name: Get latest released tag
+        id: latest_tag
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: ${{ github.repository }}
+          regex: ^v\d+\.\d+\.\d+$
+          sort-tags: true
+          releases-only: true
+
+      - name: Verify release tag
+        id: tag_name
+        run: |
+          TAG_NAME=${{ github.event.release.tag_name }}
+          if [[ ! $TAG_NAME =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
+            echo "Error: Release tag name is not in the correct format. Expected: vX.Y.Z, Actual: $TAG_NAME"
+            exit 1
+          fi
+          echo "tag=${TAG_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            ref: v${{ steps.tag_name.outputs.tag }}
+
+      - name: Create docs tag
+        id: create_docs_tag
+        run: |
+            DOCS_TAG_NAME=v${{ steps.tag_name.outputs.tag }}-docs
+            git tag $DOCS_TAG_NAME
+            git push origin $DOCS_TAG_NAME
+        continue-on-error: true
+
+  build-docs:
+    needs: check-inputs
+    name: "Build docs with version: ${{ needs.check-inputs.outputs.version }}, latest: ${{ needs.check-inputs.outputs.latest }}"
+    uses: ./.github/workflows/docs_build.yml
+    with:
+      version: ${{ needs.check-inputs.outputs.version }}
+      latest: ${{ needs.check-inputs.outputs.latest }}
+      deploy: true

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -5,7 +5,11 @@ on:
       version: { type: string, required: false, description: "The version to build (used in git and pypi). git-tag='v{version}-docs'.  If not specified then use selected branch and wheel from the last successful build."}
       latest: { type: boolean, required: false, description: Alias this version as the 'latest' stable docs.  This should be set for the latest stable release.}
       deploy: { type: boolean, required: false, description: Push the built docs to the docs-pages branch on github.}
-
+  workflow_call:
+    inputs:
+      version: { type: string, required: true, description: "The version to build (used in git and pypi). git-tag='v{version}-docs'."}
+      latest: { type: boolean, required: true, description: Alias this version as the 'latest' stable docs.  This should be set for the latest stable release.}
+      deploy: { type: boolean, required: true, description: Push the built docs to the docs-pages branch on github.}
 jobs:
   docs_build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
When a new release is published, check if it is latest release, create the docs tag (vX.Y.Z-docs) and run the `docs-build` action (which builds the docs with the corresponding version)
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
