### PR TITLE
Accept strings for the mode when finalizing staged data

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1281,7 +1281,7 @@ class Library:
     def finalize_staged_data(
         self,
         symbol: str,
-        mode: Optional[StagedDataFinalizeMethod] = StagedDataFinalizeMethod.WRITE,
+        mode: Optional[Union[StagedDataFinalizeMethod, str]] = StagedDataFinalizeMethod.WRITE,
         prune_previous_versions: bool = False,
         metadata: Any = None,
         validate_index = True,
@@ -1289,9 +1289,9 @@ class Library:
     ) -> VersionedItem:
         """
         Finalizes staged data, making it available for reads. All staged segments must be ordered and non-overlapping.
-        ``finalize_staged_data`` is less time consuming than ``sort_and_finalize_staged_data``.
+        ``finalize_staged_data`` is less time-consuming than ``sort_and_finalize_staged_data``.
 
-        If ``mode`` is ``StagedDataFinalizeMethod.APPEND`` the index of the first row of the new segment must be equal to or greater
+        If ``mode`` is ``StagedDataFinalizeMethod.APPEND`` or ``APPEND`` the index of the first row of the new segment must be equal to or greater
         than the index of the last row in the existing data.
 
         If ``Static Schema`` is used all staged block must have matching schema (same column names, same dtype, same column ordering)
@@ -1310,9 +1310,9 @@ class Library:
         symbol : `str`
             Symbol to finalize data for.
 
-        mode : `StagedDataFinalizeMethod`, default=StagedDataFinalizeMethod.WRITE
-            Finalize mode. Valid options are WRITE or APPEND. Write collects the staged data and writes them to a
-            new version. Append collects the staged data and appends them to the latest version.
+        mode : Union[`StagedDataFinalizeMethod`, str], default=StagedDataFinalizeMethod.WRITE
+            Finalize mode. Valid options are StagedDataFinalizeMethod.WRITE or StagedDataFinalizeMethod.APPEND. Write collects the staged data and writes them to a
+            new version. Append collects the staged data and appends them to the latest version. Also accepts "WRITE" and "APPEND".
         prune_previous_versions: bool, default=False
             Removes previous (non-snapshotted) versions from the database.
         metadata : Any, default=None
@@ -1383,9 +1383,12 @@ class Library:
         2024-01-03    3
         2024-01-04    4
         """
+        if not (mode is None or isinstance(mode, StagedDataFinalizeMethod) or mode == "WRITE" or mode == "APPEND"):
+            raise ArcticInvalidApiUsageException("mode must be a StagedDataFinalizeMethod enum or 'WRITE'/'APPEND'")
+
         return self._nvs.compact_incomplete(
             symbol,
-            append=mode == StagedDataFinalizeMethod.APPEND,
+            append=mode == StagedDataFinalizeMethod.APPEND or mode == "APPEND",
             convert_int_to_float=False,
             metadata=metadata,
             prune_previous_version=prune_previous_versions,

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1291,7 +1291,7 @@ class Library:
         Finalizes staged data, making it available for reads. All staged segments must be ordered and non-overlapping.
         ``finalize_staged_data`` is less time-consuming than ``sort_and_finalize_staged_data``.
 
-        If ``mode`` is ``StagedDataFinalizeMethod.APPEND`` or ``APPEND`` the index of the first row of the new segment must be equal to or greater
+        If ``mode`` is ``StagedDataFinalizeMethod.APPEND`` or ``append`` the index of the first row of the new segment must be equal to or greater
         than the index of the last row in the existing data.
 
         If ``Static Schema`` is used all staged block must have matching schema (same column names, same dtype, same column ordering)
@@ -1312,7 +1312,7 @@ class Library:
 
         mode : Union[`StagedDataFinalizeMethod`, str], default=StagedDataFinalizeMethod.WRITE
             Finalize mode. Valid options are StagedDataFinalizeMethod.WRITE or StagedDataFinalizeMethod.APPEND. Write collects the staged data and writes them to a
-            new version. Append collects the staged data and appends them to the latest version. Also accepts "WRITE" and "APPEND".
+            new version. Append collects the staged data and appends them to the latest version. Also accepts "write" and "append".
         prune_previous_versions: bool, default=False
             Removes previous (non-snapshotted) versions from the database.
         metadata : Any, default=None
@@ -1383,12 +1383,12 @@ class Library:
         2024-01-03    3
         2024-01-04    4
         """
-        if not (mode is None or isinstance(mode, StagedDataFinalizeMethod) or mode == "WRITE" or mode == "APPEND"):
-            raise ArcticInvalidApiUsageException("mode must be a StagedDataFinalizeMethod enum or 'WRITE'/'APPEND'")
+        if mode not in [StagedDataFinalizeMethod.APPEND, StagedDataFinalizeMethod.WRITE, "write", "append", None]:
+            raise ArcticInvalidApiUsageException("mode must be one of StagedDataFinalizeMethod.WRITE, StagedDataFinalizeMethod.APPEND, 'write', 'append'")
 
         return self._nvs.compact_incomplete(
             symbol,
-            append=mode == StagedDataFinalizeMethod.APPEND or mode == "APPEND",
+            append=mode == StagedDataFinalizeMethod.APPEND or mode == "append",
             convert_int_to_float=False,
             metadata=metadata,
             prune_previous_version=prune_previous_versions,

--- a/python/tests/integration/arcticdb/test_finalize_staged_data.py
+++ b/python/tests/integration/arcticdb/test_finalize_staged_data.py
@@ -415,6 +415,31 @@ def test_finalize_staged_data_long_scenario(basic_arctic_library):
     cachedParts.verify_finalized_data(lib,symbol)
 
 
+@pytest.mark.parametrize("mode" , [StagedDataFinalizeMethod.WRITE, "write", None])
+def test_finalize_staged_data_mode_write(basic_arctic_library, mode):
+    lib = basic_arctic_library
+    symbol = "symbol"
+    df_initial = sample_dataframe('2020-1-1', [1,2,3], [4, 5, 6])
+    df_staged = sample_dataframe('2020-1-4', [7, 8, 9])
+    lib.write(symbol, df_initial)
+    lib.write(symbol, df_staged, staged=True)
+    assert_frame_equal(lib.read(symbol).data, df_initial)
+
+    lib.finalize_staged_data(symbol="symbol", mode=mode)
+    assert_frame_equal(lib.read(symbol).data, df_staged)
 
 
+@pytest.mark.parametrize("mode" , [StagedDataFinalizeMethod.APPEND, "append"])
+def test_finalize_staged_data_mode_append(basic_arctic_library, mode):
+    lib = basic_arctic_library
+    symbol = "symbol"
+    df_initial = sample_dataframe('2020-1-1', [1,2,3], [4, 5, 6])
+    df_staged = sample_dataframe('2020-1-4', [7, 8, 9], [10, 11, 12])
+    lib.write(symbol, df_initial)
+    lib.write(symbol, df_staged, staged=True)
+    assert_frame_equal(lib.read(symbol).data, df_initial)
+
+    lib.finalize_staged_data(symbol="symbol", mode=mode)
+    expected = pd.concat([df_initial, df_staged])
+    assert_frame_equal(lib.read(symbol).data, expected)
 

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -8,10 +8,12 @@ As of the Change Date specified in that file, in accordance with the Business So
 import time
 
 from pandas import Timestamp
+from unittest.mock import MagicMock
 import pytest
 
 from arcticdb.exceptions import NoSuchVersionException, NoDataFoundException
 from arcticdb.util.test import distinct_timestamps
+from arcticdb.version_store.library import StagedDataFinalizeMethod, ArcticInvalidApiUsageException
 
 
 def test_read_descriptor(lmdb_version_store, one_col_df):
@@ -89,3 +91,38 @@ def test_get_num_rows_pickled(lmdb_version_store):
     symbol = "test_get_num_rows_pickled"
     lmdb_version_store.write(symbol, 1)
     assert lmdb_version_store.get_num_rows(symbol) is None
+
+
+@pytest.mark.parametrize(
+    "input_mode, expected_append",
+    [
+        ("WRITE", False),
+        ("APPEND", True),
+        (None, False),
+        (StagedDataFinalizeMethod.APPEND, True),
+        (StagedDataFinalizeMethod.WRITE, False),
+        ([], None),
+        {"write", None},
+    ],
+)
+def test_finalize_staged_data(arctic_library_lmdb, input_mode, expected_append):
+    symbol = "sym"
+    arctic_library_lmdb._nvs = MagicMock()
+
+    if expected_append is None:
+        with pytest.raises(ArcticInvalidApiUsageException):
+            arctic_library_lmdb.finalize_staged_data(symbol, input_mode)
+        return
+
+    arctic_library_lmdb.finalize_staged_data(symbol, input_mode)
+
+    default_args = {
+        "convert_int_to_float": False,
+        "metadata": None,
+        "prune_previous_version": False,
+        "validate_index": True,
+        "delete_staged_data_on_failure": False,
+    }
+
+    arctic_library_lmdb._nvs.compact_incomplete.assert_called_once_with(symbol, append=expected_append, **default_args)
+

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -96,23 +96,16 @@ def test_get_num_rows_pickled(lmdb_version_store):
 @pytest.mark.parametrize(
     "input_mode, expected_append",
     [
-        ("WRITE", False),
-        ("APPEND", True),
+        ("write", False),
+        ("append", True),
         (None, False),
         (StagedDataFinalizeMethod.APPEND, True),
         (StagedDataFinalizeMethod.WRITE, False),
-        ([], None),
-        {"write", None},
-    ],
+    ]
 )
 def test_finalize_staged_data(arctic_library_lmdb, input_mode, expected_append):
     symbol = "sym"
     arctic_library_lmdb._nvs = MagicMock()
-
-    if expected_append is None:
-        with pytest.raises(ArcticInvalidApiUsageException):
-            arctic_library_lmdb.finalize_staged_data(symbol, input_mode)
-        return
 
     arctic_library_lmdb.finalize_staged_data(symbol, input_mode)
 
@@ -126,3 +119,10 @@ def test_finalize_staged_data(arctic_library_lmdb, input_mode, expected_append):
 
     arctic_library_lmdb._nvs.compact_incomplete.assert_called_once_with(symbol, append=expected_append, **default_args)
 
+
+@pytest.mark.parametrize("input_mode", ["wRite", "something", 3])
+def test_finalize_staged_data_incorrect_args(arctic_library_lmdb, input_mode):
+    symbol = "sym"
+    arctic_library_lmdb._nvs = MagicMock()
+    with pytest.raises(ArcticInvalidApiUsageException):
+        arctic_library_lmdb.finalize_staged_data(symbol, input_mode)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Monday ref 8645841959
Support strings for finalize staged data `mode` argument in addition to enum
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
