### PR TITLE
Slightly wider tolerance to arithmetic mismatches with Pandas with floats

### DIFF
--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -857,7 +857,7 @@ def assert_dfs_approximate(left: pd.DataFrame, right: pd.DataFrame):
             pd.testing.assert_series_equal(left_no_inf_and_nan[col], right_no_inf_and_nan[col], **check_equals_flags)
         else:
             if PANDAS_VERSION >= Version("1.1"):
-                check_equals_flags["rtol"] = 1e-4
+                check_equals_flags["rtol"] = 2e-4
             pd.testing.assert_series_equal(left_no_inf_and_nan[col], right_no_inf_and_nan[col], **check_equals_flags)
 
 


### PR DESCRIPTION
https://github.com/man-group/ArcticDB/actions/runs/13833112827/job/38702491974

To resolve this test flakiness,

```
FAILED tests/hypothesis/arcticdb/test_resample.py::test_resample - AssertionError: Series are different

Series values are different (100.0 %)
[index]: [1969-12-31T23:59:01.000000000]
[left]:  [2048000.0]
[right]: [2047795.2]
At positional index 0, first diff: 2048000.0 != 2047795.2
Falsifying example: test_resample(
    lmdb_version_store_v1=NativeVersionStore: Library: test_resample.885_2025-03-13T11_31_50_948217, Primary Storage: lmdb_storage.,
    df=
                                       col_float              col_int  col_uint
        1970-01-01 00:00:00.000000000        0.0 -9223372036827825664         0
        1970-01-01 00:00:00.000000001        0.0                    0         0
        1970-01-01 00:00:00.000000002        0.0                    0         0
        1970-01-01 00:00:00.000000003        0.0                  512         0
        1970-01-01 00:00:00.000000004        0.0  9223372036838064641         0
    ,
    rule='1min',
    origin='start',
    offset='1s',
)

You can reproduce this example by temporarily adding @reproduce_failure('6.72.4', b'AXicVY2JDQAgCAMpOqp7uJ1jiXx+TcmloQEQgXzMAQ6UQPXCEb70LsxdRGYb+xKBk8WoCVWTtQScj68WvaAKUg==') as a decorator on your test case
= 1 failed, 252 passed, 10 skipped, 1 xfailed, 1 xpassed, 72587 warnings in 1132.14s (0:18:52) =
```
