### PR TITLE
Get object sizes based on S3's ListObjects output (just with scan_object_sizes() to start with)

### DIFF
--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -665,4 +665,28 @@ struct RemoveBatchTask : BaseTask {
     }
 };
 
+struct ObjectSizesTask : BaseTask {
+    KeyType type_;
+    std::string prefix_;
+    std::shared_ptr<storage::Library> lib_;
+
+    ObjectSizesTask(
+        KeyType type,
+        std::string prefix,
+        std::shared_ptr<storage::Library> lib
+        ) :
+        type_(type),
+        prefix_(std::move(prefix)),
+        lib_(std::move(lib)) {
+        ARCTICDB_DEBUG(log::storage(), "Creating object sizes task for key type {} prefix {}", type_, prefix_);
+    }
+
+    ARCTICDB_MOVE_ONLY_DEFAULT(ObjectSizesTask)
+
+    folly::Future<storage::ObjectSizes> operator()() {
+        util::check(lib_->supports_object_size_calculation(), "ObjectSizesBytesTask should only be used with storages"
+                                                              " that natively support size calculation");
+        return lib_->get_object_sizes(type_, prefix_);
+    }
+};
 }

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -70,6 +70,15 @@ class Library {
         storages_->iterate_type(key_type, visitor, prefix);
     }
 
+    bool supports_object_size_calculation() {
+        return storages_->supports_object_size_calculation();
+    }
+
+    ObjectSizes get_object_sizes(KeyType type, const std::string& prefix) {
+        ARCTICDB_SAMPLE(GetObjectSizes, 0)
+        return storages_->get_object_sizes(type, prefix);
+    }
+
     /**
      * Scan through every key of the given type until one matches the predicate.
      *

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -405,23 +405,30 @@ void do_update_impl(
     do_write_impl(std::move(kvs), root_folder, bucket_name, s3_client, std::forward<KeyBucketizer>(bucketizer));
 }
 
-inline auto default_prefix_handler() {
+inline PrefixHandler default_prefix_handler() {
     return [](const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
         return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
     };
 }
 
-template<class KeyBucketizer, class PrefixHandler>
-bool do_iterate_type_impl(
-    KeyType key_type,
-    const IterateTypePredicate& visitor,
+struct PathInfo {
+    PathInfo(std::string prefix, std::string key_type_dir, size_t path_to_key_size) :
+        key_prefix_(std::move(prefix)), key_type_dir_(std::move(key_type_dir)), path_to_key_size_(path_to_key_size) {
+
+    }
+
+    std::string key_prefix_;
+    std::string key_type_dir_;
+    size_t path_to_key_size_;
+};
+
+template<class KeyBucketizer>
+PathInfo calculate_path_info(
     const std::string& root_folder,
-    const std::string& bucket_name,
-    const S3ClientInterface& s3_client,
-    KeyBucketizer&& bucketizer,
-    PrefixHandler&& prefix_handler = default_prefix_handler(),
-    const std::string& prefix = std::string{}) {
-    ARCTICDB_SAMPLE(S3StorageIterateType, 0)
+    KeyType key_type,
+    const PrefixHandler& prefix_handler,
+    const std::string& prefix,
+    KeyBucketizer&& bucketizer) {
     auto key_type_dir = key_type_folder(root_folder, key_type);
     const auto path_to_key_size = key_type_dir.size() + 1 + bucketizer.bucketize_length(key_type);
     // if prefix is empty, add / to avoid matching both 'log' and 'logc' when key_type_dir is {root_folder}/log
@@ -438,19 +445,36 @@ bool do_iterate_type_impl(
                                                             : IndexDescriptorImpl::Type::TIMESTAMP,
                                  FormatType::TOKENIZED);
     auto key_prefix = prefix_handler(prefix, key_type_dir, key_descriptor, key_type);
-    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Searching for objects in bucket {} with prefix {}", bucket_name,
-                           key_prefix);
+
+    return {key_prefix, key_type_dir, path_to_key_size};
+}
+
+template<class KeyBucketizer>
+bool do_iterate_type_impl(
+    KeyType key_type,
+    const IterateTypePredicate& visitor,
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    const S3ClientInterface& s3_client,
+    KeyBucketizer&& bucketizer,
+    const PrefixHandler& prefix_handler = default_prefix_handler(),
+    const std::string& prefix = std::string{}) {
+    ARCTICDB_SAMPLE(S3StorageIterateType, 0)
+
+    auto path_info = calculate_path_info(root_folder, key_type, prefix_handler, prefix, std::move(bucketizer));
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Iterating over objects in bucket {} with prefix {}", bucket_name,
+                           path_info.key_prefix_);
 
     auto continuation_token = std::optional<std::string>();
     do {
-        auto list_objects_result = s3_client.list_objects(key_prefix, bucket_name, continuation_token);
+        auto list_objects_result = s3_client.list_objects(path_info.key_prefix_, bucket_name, continuation_token);
         if (list_objects_result.is_success()) {
             auto& output = list_objects_result.get_output();
 
             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Received object list");
 
             for (auto& s3_object_name : output.s3_object_names) {
-                auto key = s3_object_name.substr(path_to_key_size);
+                auto key = s3_object_name.substr(path_info.path_to_key_size_);
                 ARCTICDB_TRACE(log::version(), "Got object_list: {}, key: {}", s3_object_name, key);
                 auto k = variant_key_from_bytes(
                     reinterpret_cast<uint8_t *>(key.data()),
@@ -474,11 +498,53 @@ bool do_iterate_type_impl(
                                 error.GetMessage().c_str());
             // We don't raise on expected errors like NoSuchKey because we want to return an empty list
             // instead of raising.
-            raise_if_unexpected_error(error, key_prefix);
+            raise_if_unexpected_error(error, path_info.key_prefix_);
             return false;
         }
     } while (continuation_token.has_value());
     return false;
+}
+
+template<class KeyBucketizer>
+ObjectSizes do_calculate_sizes_for_type_impl(
+    KeyType key_type,
+    const std::string& root_folder,
+    const std::string& bucket_name,
+    const S3ClientInterface& s3_client,
+    KeyBucketizer&& bucketizer,
+    const PrefixHandler& prefix_handler = default_prefix_handler(),
+    const std::string& prefix = std::string{}) {
+    ARCTICDB_SAMPLE(S3StorageCalculateSizesForType, 0)
+
+    auto path_info = calculate_path_info(root_folder, key_type, prefix_handler, prefix, std::move(bucketizer));
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Calculating sizes for objects in bucket {} with prefix {}", bucket_name,
+                           path_info.key_prefix_);
+
+    auto continuation_token = std::optional<std::string>();
+    ObjectSizes res{key_type};
+    do {
+        auto list_objects_result = s3_client.list_objects(path_info.key_prefix_, bucket_name, continuation_token);
+        if (list_objects_result.is_success()) {
+            auto& output = list_objects_result.get_output();
+
+            ARCTICDB_RUNTIME_DEBUG(log::storage(), "Received object list");
+
+            for (auto& s3_object_size : output.s3_object_sizes) {
+                res.count_ += 1;
+                res.compressed_size_bytes_ += s3_object_size;
+            }
+            continuation_token = output.next_continuation_token;
+        } else {
+            const auto& error = list_objects_result.get_error();
+            log::storage().warn("Failed to iterate key type with key '{}' {}: {}",
+                                key_type,
+                                error.GetExceptionName().c_str(),
+                                error.GetMessage().c_str());
+            raise_if_unexpected_error(error, path_info.key_prefix_);
+        }
+    } while (continuation_token.has_value());
+
+    return res;
 }
 
 template<class KeyBucketizer>

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -525,7 +525,7 @@ ObjectSizes do_calculate_sizes_for_type_impl(
     do {
         auto list_objects_result = s3_client.list_objects(path_info.key_prefix_, bucket_name, continuation_token);
         if (list_objects_result.is_success()) {
-            auto& output = list_objects_result.get_output();
+            const auto& output = list_objects_result.get_output();
 
             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Received object list");
 

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -32,6 +32,8 @@ public:
 
     std::string name() const final;
 
+    bool supports_object_size_calculation() const final override;
+
 private:
     void do_write(KeySegmentPair& key_seg) final;
 
@@ -50,6 +52,8 @@ private:
     void do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts) final;
 
     bool do_iterate_type_until_match(KeyType key_type, const IterateTypePredicate& visitor, const std::string &prefix) final;
+
+    ObjectSizes do_get_object_sizes(KeyType key_type, const std::string& prefix) final;
 
     bool do_key_exists(const VariantKey& key) final;
 

--- a/cpp/arcticdb/storage/s3/s3_client_impl.cpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.cpp
@@ -299,11 +299,13 @@ S3Result<ListObjectsOutput> S3ClientImpl::list_objects(
         next_continuation_token = {result.GetNextContinuationToken()};
 
     auto s3_object_names = std::vector<std::string>();
+    auto s3_object_sizes = std::vector<uint64_t>();
     for (const auto &s3_object: result.GetContents()) {
         s3_object_names.emplace_back(s3_object.GetKey());
+        s3_object_sizes.emplace_back(s3_object.GetSize());
     }
 
-    ListObjectsOutput output = {s3_object_names, next_continuation_token};
+    ListObjectsOutput output = {s3_object_names, s3_object_sizes, next_continuation_token};
     return {output};
 }
 

--- a/cpp/arcticdb/storage/s3/s3_client_impl.cpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.cpp
@@ -305,8 +305,7 @@ S3Result<ListObjectsOutput> S3ClientImpl::list_objects(
         s3_object_sizes.emplace_back(s3_object.GetSize());
     }
 
-    ListObjectsOutput output = {s3_object_names, s3_object_sizes, next_continuation_token};
-    return {output};
+    return {ListObjectsOutput{std::move(s3_object_names), std::move(s3_object_sizes), next_continuation_token}};
 }
 
 }

--- a/cpp/arcticdb/storage/s3/s3_client_interface.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_interface.hpp
@@ -49,6 +49,7 @@ using S3Result = StorageResult<Output, Aws::S3::S3Error>;
 
 struct ListObjectsOutput{
     std::vector<std::string> s3_object_names;
+    std::vector<uint64_t> s3_object_sizes;
     // next_continuation_token indicates there are more s3_objects to be listed because they didn't fit in one response.
     // If set can be used to get the remaining s3_objects.
     std::optional<std::string> next_continuation_token;

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -29,6 +29,8 @@
 
 namespace arcticdb::storage::s3 {
 
+using PrefixHandler = std::function<std::string(const std::string&, const std::string&, const KeyDescriptor&, KeyType)>;
+
 const std::string USE_AWS_CRED_PROVIDERS_TOKEN = "_RBAC_";
 
 class S3Storage : public Storage, AsyncStorage {
@@ -48,6 +50,8 @@ class S3Storage : public Storage, AsyncStorage {
         return dynamic_cast<AsyncStorage*>(this);
     }
 
+    bool supports_object_size_calculation() const final override;
+
   protected:
     void do_write(KeySegmentPair& key_seg) final;
 
@@ -66,6 +70,8 @@ class S3Storage : public Storage, AsyncStorage {
     void do_remove(VariantKey&& variant_key, RemoveOpts opts);
 
     void do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts);
+
+    ObjectSizes do_get_object_sizes(KeyType key_type, const std::string& prefix) override final;
 
     bool do_iterate_type_until_match(KeyType key_type, const IterateTypePredicate& visitor, const std::string &prefix) final;
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -137,7 +137,7 @@ public:
           visitor(std::move(k));
           return false; // keep applying the visitor no matter what
         };
-      do_iterate_type_until_match(key_type, predicate_visitor, prefix);
+        do_iterate_type_until_match(key_type, predicate_visitor, prefix);
     }
 
     [[nodiscard]] virtual bool supports_object_size_calculation() const {
@@ -259,9 +259,9 @@ template<> struct formatter<ObjectSizes> {
     constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    auto format(const ObjectSizes &srv, FormatContext &ctx) const {
+    auto format(const ObjectSizes &sizes, FormatContext &ctx) const {
         return fmt::format_to(ctx.out(), "ObjectSizes key_type[{}] count[{}] compressed_size_bytes[{}]",
-                              srv.key_type_, srv.count_, srv.compressed_size_bytes_);
+                              sizes.key_type_, sizes.count_, sizes.compressed_size_bytes_);
     }
 };
 }

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -188,7 +188,12 @@ public:
         }
     }
 
-    ObjectSizes get_object_sizes(KeyType key_type, const std::string& prefix) {
+    ObjectSizes get_object_sizes(KeyType key_type, const std::string& prefix, bool primary_only = true) {
+        if (primary_only) {
+            auto storage_sizes = primary().get_object_sizes(key_type, prefix);
+            return {key_type, storage_sizes.count_, storage_sizes.compressed_size_bytes_};
+        }
+
         ObjectSizes res{key_type, 0, 0};
         for (const auto& storage : storages_) {
             auto storage_sizes = storage->get_object_sizes(key_type, prefix);

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -326,6 +326,10 @@ public:
         }
     }
 
+    [[nodiscard]] folly::Future<storage::ObjectSizes> get_object_sizes(KeyType, const std::string&) override {
+        util::raise_rte("get_object_sizes not implemented for InMemoryStore");
+    }
+
     bool scan_for_matching_key(
             KeyType,
             const IterateTypePredicate&) override {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1708,8 +1708,7 @@ std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes() {
         sizes.push_back(store->get_object_sizes(key_type, ""));
     });
 
-    folly::QueuedImmediateExecutor inline_executor;
-    return folly::collect(sizes_futs).via(&inline_executor).get();
+    return folly::collect(sizes_futs).via(&async::cpu_executor()).get();
 }
 
 std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> LocalVersionedEngine::scan_object_sizes_by_stream() {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1701,56 +1701,15 @@ timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
     return -1;
 }
 
-struct AtomicKeySizesInfo {
-    size_t count{0};
-    std::atomic<size_t> compressed_size;
-    std::atomic<size_t> uncompressed_size;
-};
-
-using KeySizeCalculators = std::vector<std::pair<VariantKey, stream::StreamSource::ReadContinuation>>;
-
-static void read_ignoring_key_not_found(Store& store, KeySizeCalculators&& calculators) {
-    if (calculators.empty()) {
-        return;
-    }
-
-    auto read_futures = store.batch_read_compressed(std::move(calculators), BatchReadArgs{});
-    std::vector<folly::Future<folly::Unit>> res;
-    res.reserve(read_futures.size());
-    for (auto&& fut : std::move(read_futures)) {
-        // Ignore some exceptions, someone might be deleting while we scan
-        res.push_back(std::move(fut)
-                          .thenValue([](auto&&) {return folly::Unit{};})
-                          .thenError(folly::tag_t<storage::KeyNotFoundException>{}, [](auto&&) { return folly::Unit{}; }));
-    }
-
-    folly::collect(res).get();
-}
-
-std::unordered_map<KeyType, KeySizesInfo> LocalVersionedEngine::scan_object_sizes() {
-    std::unordered_map<KeyType, AtomicKeySizesInfo> sizes;
-    foreach_key_type([&store=store(), &sizes=sizes](KeyType key_type) {
-        KeySizeCalculators key_size_calculators;
-        store->iterate_type(key_type, [&key_size_calculators, &sizes, &key_type](const VariantKey&& k) {
-            auto& sizes_info = sizes[key_type];
-            ++sizes_info.count;
-            key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [&sizes_info] (auto&& ks) {
-                auto key_seg = std::forward<decltype(ks)>(ks);
-                sizes_info.compressed_size += key_seg.segment().size();
-                const auto& desc = key_seg.segment().descriptor();
-                sizes_info.uncompressed_size += desc.uncompressed_bytes();
-                return key_seg.variant_key();
-            });
-        });
-
-        read_ignoring_key_not_found(*store, std::move(key_size_calculators));
+std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes() {
+    using ObjectSizes = storage::ObjectSizes;
+    std::vector<folly::Future<ObjectSizes>> sizes_futs;
+    foreach_key_type([&store=store(), &sizes=sizes_futs](KeyType key_type) {
+        sizes.push_back(store->get_object_sizes(key_type, ""));
     });
 
-    std::unordered_map<KeyType, KeySizesInfo> result;
-    for (const auto& [k, v] : sizes) {
-        result[k] = KeySizesInfo{v.count, v.compressed_size, v.uncompressed_size};
-    }
-    return result;
+    folly::QueuedImmediateExecutor inline_executor;
+    return folly::collect(sizes_futs).via(&inline_executor).get();
 }
 
 std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> LocalVersionedEngine::scan_object_sizes_by_stream() {
@@ -1759,7 +1718,7 @@ std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> LocalVer
     auto streams = symbol_list().get_symbols(store());
 
     foreach_key_type([&store=store(), &sizes, &mutex](KeyType key_type) {
-        KeySizeCalculators key_size_calculators;
+        stream::StreamSource::KeySizeCalculators key_size_calculators;
 
         store->iterate_type(key_type, [&key_size_calculators, &mutex, &sizes, key_type](const VariantKey&& k){
             key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [key_type, &sizes, &mutex] (auto&& ks) {
@@ -1783,7 +1742,7 @@ std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> LocalVer
 
         });
 
-        read_ignoring_key_not_found(*store, std::move(key_size_calculators));
+        store->read_ignoring_key_not_found(std::move(key_size_calculators));
     });
 
     return sizes;

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -373,7 +373,7 @@ public:
         const StreamId& stream_id, 
         const WriteOptions& write_options);
 
-    std::unordered_map<KeyType, KeySizesInfo> scan_object_sizes();
+    std::vector<storage::ObjectSizes> scan_object_sizes();
 
     std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> scan_object_sizes_by_stream();
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -517,6 +517,13 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def_readonly("uncompressed_size", &KeySizesInfo::uncompressed_size)
             .doc() = "Count of keys and their compressed and uncompressed sizes in bytes.";
 
+    py::class_<storage::ObjectSizes>(version, "ObjectSizes")
+        .def_readonly("key_type", &storage::ObjectSizes::key_type_)
+        .def_readonly("count", &storage::ObjectSizes::count_)
+        .def_readonly("compressed_size_bytes", &storage::ObjectSizes::compressed_size_bytes_)
+        .def("__repr__", [](storage::ObjectSizes object_sizes) {return fmt::format("{}", object_sizes);})
+        .doc() = "Count of keys and their uncompressed sizes in bytes for a given key type";
+
     py::class_<PythonVersionStore>(version, "PythonVersionStore")
         .def(py::init([](const std::shared_ptr<storage::Library>& library, std::optional<std::string>) {
                 return PythonVersionStore(library);
@@ -692,7 +699,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              &PythonVersionStore::scan_object_sizes_by_stream,
              py::call_guard<SingleThreadMutexHolder>(),
              "Scan the compressed sizes of all objects in the library, grouped by stream ID and KeyType. Sizes are in bytes. "
-             "Returns a dict {symbol_id: {KeyType: KeySizesInfo}")
+             "Returns a dict {symbol_id: {KeyType: KeySizesInfo}}")
         .def("find_version",
              &PythonVersionStore::get_version_to_read,
              py::call_guard<SingleThreadMutexHolder>(), "Check if a specific stream has been written to previously")


### PR DESCRIPTION
Monday: 8560764974

Limited to just `scan_object_sizes` to start with, to show the idea.

Calculate object sizes using functionality in the storage backend itself when possible. This PR calculates compressed sizes on S3 based on the `ListObjectsV2` output, so we don't need to read all the keys.

For storages where we haven't implemented anything fancy, just read all the (compressed) keys and check the compressed size on their header.

Remaining work:

- Use this approach for `scan_object_sizes_by_stream`
- Make sure we have testing against all backends especially NFS
- Implement `scan_object_sizes_for_stream`
- Native size calculations for LMDB and Azure
- Native size calculation for library size (LMDB has an API to do this "in one")
- `AdminTools` Python API on the v2 API, including search by regex. Docs page to explain the output.