### PR TITLE
Correctly handle `zoneinfo` timezones

### DIFF
--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -70,6 +70,10 @@ MEMRAY_TESTS_MARK = pytest.mark.skipif(
     not MEMRAY_SUPPORTED, reason="MEMRAY supports linux and macos and python 3.8 and above"
 )
 
+ZONE_INFO_MARK = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="zoneinfo module was introduced in Python 3.9")
+
 SSL_TESTS_MARK = pytest.mark.skipif(
     not SSL_TEST_SUPPORTED,
     reason="When SSL tests are enabled",


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2245

#### What does this implement or fix?
Correctly normalizes zoneinfo timezones. Currently if we write something as a pytz or a ZoneInfo timezone we'll read it back as a `pytz` to preserve old pytz behavior and not break old arctic readers.

[Consensus](https://github.com/pandas-dev/pandas/issues/34916#issuecomment-1595154742) is that people generally prefer `ZoneInfo` and we can change to always using `ZoneInfo` but we'll need to do so in next major release.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
