### PR TITLE
Fix for STS support

### DIFF
--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -86,13 +86,23 @@ public:
     }
 
     std::string to_string() {
-        return util::variant_match(config_, [](std::monostate) {
+        return util::variant_match(config_, [](std::monostate) -> std::string {
             return "empty";
-        }, [](s3::S3Settings) {
-            return "s3";
-        }, [](s3::GCPXMLSettings) {
-            return "gcpxml";
+        }, [](s3::S3Settings s3) {
+            return fmt::format("{}", s3);
+        }, [](s3::GCPXMLSettings gcpxml) {
+            return fmt::format("{}", gcpxml);
         });
+    }
+
+    s3::S3Settings as_s3_settings() {
+        util::check(std::holds_alternative<s3::S3Settings>(config_), "Expected s3 settings but was {}", to_string());
+        return std::get<s3::S3Settings>(config_);
+    }
+
+    s3::GCPXMLSettings as_gcpxml_settings() {
+        util::check(std::holds_alternative<s3::GCPXMLSettings>(config_), "Expected gcpxml settings but was {}", to_string());
+        return std::get<s3::GCPXMLSettings>(config_);
     }
 
 private:

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -245,6 +245,8 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
             }
         ))
         .def("update", &NativeVariantStorage::update)
+        .def("as_s3_settings", &NativeVariantStorage::as_s3_settings)
+        .def("as_gcpxml_settings", &NativeVariantStorage::as_gcpxml_settings)
         .def("__repr__", &NativeVariantStorage::to_string);
 
     py::implicitly_convertible<NativeVariantStorage::VariantStorageConfig, NativeVariantStorage>();

--- a/cpp/arcticdb/storage/s3/s3_settings.hpp
+++ b/cpp/arcticdb/storage/s3/s3_settings.hpp
@@ -302,3 +302,61 @@ public:
 };
 
 }
+
+namespace fmt {
+template<>
+struct formatter<arcticdb::storage::s3::AWSAuthMethod> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    auto format(const arcticdb::storage::s3::AWSAuthMethod& method, FormatContext &ctx) const {
+        std::string desc;
+        switch(method) {
+            case arcticdb::storage::s3::AWSAuthMethod::DISABLED:
+                desc = "DISABLED";
+                break;
+            case arcticdb::storage::s3::AWSAuthMethod::DEFAULT_CREDENTIALS_PROVIDER_CHAIN:
+                desc = "DEFAULT_CREDENTIALS_PROVIDER_CHAIN";
+                break;
+            case arcticdb::storage::s3::AWSAuthMethod::STS_PROFILE_CREDENTIALS_PROVIDER:
+                desc = "STS_PROFILE_CREDENTIALS_PROVIDER";
+                break;
+        }
+        return format_to(ctx.out(), "AWSAuthMethod {}", desc);
+    }
+};
+
+template<>
+struct formatter<arcticdb::storage::s3::S3Settings> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    auto format(const arcticdb::storage::s3::S3Settings& settings, FormatContext &ctx) const {
+        return format_to(ctx.out(), "S3Settings endpoint={}, bucket={}, prefix={}, https={}, ssl={}, ca_cert_dir={}, "
+                                    "ca_cert_path={}, aws_auth={}, aws_profile={}",
+                                    settings.endpoint(), settings.bucket_name(), settings.prefix(), settings.https(),
+                                    settings.ssl(), settings.ca_cert_dir(), settings.ca_cert_path(), settings.aws_auth(),
+                                    settings.aws_profile());
+    }
+};
+
+template<>
+struct formatter<arcticdb::storage::s3::GCPXMLSettings> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    auto format(const arcticdb::storage::s3::GCPXMLSettings& settings, FormatContext &ctx) const {
+        return format_to(ctx.out(), "GCPXMLSettings endpoint={}, bucket={}, prefix={}, https={}, ssl={}, ca_cert_dir={}, "
+                                    "ca_cert_path={}, aws_auth={}",
+                         settings.endpoint(), settings.bucket(), settings.prefix(), settings.https(),
+                         settings.ssl(), settings.ca_cert_dir(), settings.ca_cert_path(), settings.aws_auth());
+    }
+};
+
+
+}

--- a/cpp/arcticdb/storage/s3/s3_settings.hpp
+++ b/cpp/arcticdb/storage/s3/s3_settings.hpp
@@ -323,7 +323,7 @@ struct formatter<arcticdb::storage::s3::AWSAuthMethod> {
                 desc = "STS_PROFILE_CREDENTIALS_PROVIDER";
                 break;
         }
-        return format_to(ctx.out(), "AWSAuthMethod {}", desc);
+        return fmt::format_to(ctx.out(), "AWSAuthMethod {}", desc);
     }
 };
 
@@ -335,7 +335,7 @@ struct formatter<arcticdb::storage::s3::S3Settings> {
 
     template<typename FormatContext>
     auto format(const arcticdb::storage::s3::S3Settings& settings, FormatContext &ctx) const {
-        return format_to(ctx.out(), "S3Settings endpoint={}, bucket={}, prefix={}, https={}, ssl={}, ca_cert_dir={}, "
+        return fmt::format_to(ctx.out(), "S3Settings endpoint={}, bucket={}, prefix={}, https={}, ssl={}, ca_cert_dir={}, "
                                     "ca_cert_path={}, aws_auth={}, aws_profile={}",
                                     settings.endpoint(), settings.bucket_name(), settings.prefix(), settings.https(),
                                     settings.ssl(), settings.ca_cert_dir(), settings.ca_cert_path(), settings.aws_auth(),
@@ -351,7 +351,7 @@ struct formatter<arcticdb::storage::s3::GCPXMLSettings> {
 
     template<typename FormatContext>
     auto format(const arcticdb::storage::s3::GCPXMLSettings& settings, FormatContext &ctx) const {
-        return format_to(ctx.out(), "GCPXMLSettings endpoint={}, bucket={}, prefix={}, https={}, ssl={}, ca_cert_dir={}, "
+        return fmt::format_to(ctx.out(), "GCPXMLSettings endpoint={}, bucket={}, prefix={}, https={}, ssl={}, ca_cert_dir={}, "
                                     "ca_cert_path={}, aws_auth={}",
                          settings.endpoint(), settings.bucket(), settings.prefix(), settings.https(),
                          settings.ssl(), settings.ca_cert_dir(), settings.ca_cert_path(), settings.aws_auth());

--- a/python/arcticdb/adapters/__init__.py
+++ b/python/arcticdb/adapters/__init__.py
@@ -1,4 +1,6 @@
 from arcticdb.adapters.lmdb_library_adapter import LMDBLibraryAdapter
 from arcticdb.adapters.s3_library_adapter import S3LibraryAdapter
+from arcticdb.adapters.gcpxml_library_adapter import GCPXMLLibraryAdapter
+from arcticdb.adapters.in_memory_library_adapter import InMemoryLibraryAdapter
 from arcticdb.adapters.azure_library_adapter import AzureLibraryAdapter
 from arcticdb.adapters.mongo_library_adapter import MongoLibraryAdapter

--- a/python/arcticdb/adapters/gcpxml_library_adapter.py
+++ b/python/arcticdb/adapters/gcpxml_library_adapter.py
@@ -217,3 +217,7 @@ class GCPXMLLibraryAdapter(ArcticLibraryAdapter):
             env_name="local",
             with_prefix=with_prefix,
         )
+
+    @property
+    def path_prefix(self):
+        return self._path_prefix

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -48,7 +48,7 @@ class ParsedQuery:
     access: Optional[str] = None
     secret: Optional[str] = None
     aws_auth: Optional[AWSAuthMethod] = AWSAuthMethod.DISABLED
-    aws_profile: Optional[str] = None
+    aws_profile: str = ""
 
     path_prefix: Optional[str] = None
 
@@ -111,7 +111,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         super().__init__(uri, self._encoding_version)
 
     def native_config(self):
-        return NativeVariantStorage(NativeS3Settings(AWSAuthMethod.DISABLED, "", False))
+        return NativeVariantStorage(NativeS3Settings(self._query_params.aws_auth, self._query_params.aws_profile, False))
 
     def __repr__(self):
         return "S3(endpoint=%s, bucket=%s)" % (self._endpoint, self._bucket)
@@ -163,7 +163,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         if query and query.startswith("?"):
             query = query.strip("?")
         elif not query:
-            return ParsedQuery(aws_auth="default")
+            return ParsedQuery()
 
         parsed_query = re.split("[;&]", query)
         parsed_query = {t.split("=", 1)[0]: t.split("=", 1)[1] for t in parsed_query}

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -296,11 +296,6 @@ def get_s3_proto(
             "use_internal_client_wrapper_for_testing can only be set if native_cfg is provided"
         )
 
-    if native_cfg:
-        aws_auth = AWSAuthMethod.DISABLED if aws_auth is None else aws_auth
-        aws_profile = "" if aws_profile is None else aws_profile
-        native_cfg.update(NativeS3Settings(aws_auth, aws_profile, use_internal_client_wrapper_for_testing))
-
     sid, storage = get_storage_for_lib_name(s3.prefix, env)
     storage.config.Pack(s3, type_url_prefix="cxx.arctic.org")
     return sid

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -42,7 +42,7 @@ from arcticdb.storage_fixtures.s3 import (
 )
 from arcticdb.storage_fixtures.mongo import auto_detect_server
 from arcticdb.storage_fixtures.in_memory import InMemoryStorageFixture
-from arcticdb_ext.storage import NativeVariantStorage, AWSAuthMethod
+from arcticdb_ext.storage import NativeVariantStorage, AWSAuthMethod, S3Settings as NativeS3Settings
 from arcticdb_ext import set_config_int
 from arcticdb.version_store._normalization import MsgPackNormalizer
 from arcticdb.util.test import create_df
@@ -176,8 +176,7 @@ def wrapped_s3_storage_factory() -> Generator[MotoS3StorageFixtureFactory, None,
         use_ssl=False,
         ssl_test_support=False,
         bucket_versioning=False,
-        use_internal_client_wrapper_for_testing=True,
-        native_config=NativeVariantStorage(),
+        native_config=NativeVariantStorage(NativeS3Settings(AWSAuthMethod.DISABLED, "", True)), # True: use_internal_client_wrapper_for_testing
     ) as f:
         yield f
 

--- a/python/tests/unit/arcticdb/test_library_adapters.py
+++ b/python/tests/unit/arcticdb/test_library_adapters.py
@@ -1,0 +1,105 @@
+import pytest
+from arcticdb.adapters import S3LibraryAdapter, GCPXMLLibraryAdapter
+from arcticdb.encoding_version import EncodingVersion
+from arcticdb_ext.storage import AWSAuthMethod
+
+
+def test_s3_native_cfg_sdk_default():
+    adapter = S3LibraryAdapter("s3://my_endpoint:my_bucket?aws_auth=true&aws_profile=my_profile",
+                               encoding_version=EncodingVersion.V1)
+
+    native_config = adapter.native_config().as_s3_settings()
+
+    assert native_config.aws_auth == AWSAuthMethod.DEFAULT_CREDENTIALS_PROVIDER_CHAIN
+    assert native_config.aws_profile == "my_profile"
+
+
+def test_s3_native_cfg_sts():
+    adapter = S3LibraryAdapter("s3://my_endpoint:my_bucket?aws_auth=sts&aws_profile=my_profile",
+                               encoding_version=EncodingVersion.V1)
+
+    native_config = adapter.native_config().as_s3_settings()
+
+    assert native_config.aws_auth == AWSAuthMethod.STS_PROFILE_CREDENTIALS_PROVIDER
+    assert native_config.aws_profile == "my_profile"
+
+
+def test_s3_native_cfg_off():
+    adapter = S3LibraryAdapter("s3://my_endpoint:my_bucket?access=my_access&secret=my_secret",
+                               encoding_version=EncodingVersion.V1)
+
+    native_config = adapter.native_config().as_s3_settings()
+
+    assert native_config.aws_auth == AWSAuthMethod.DISABLED
+    assert adapter._query_params.access == "my_access"
+    assert adapter._query_params.secret == "my_secret"
+
+
+def test_s3_repr():
+    adapter = S3LibraryAdapter("s3://my_endpoint:my_bucket?aws_auth=sts&aws_profile=my_profile",
+                               encoding_version=EncodingVersion.V1)
+    assert repr(adapter) == "S3(endpoint=my_endpoint, bucket=my_bucket)"
+
+
+def test_s3_config_library():
+    adapter = S3LibraryAdapter("s3://my_endpoint:my_bucket?aws_auth=sts&aws_profile=my_profile",
+                               encoding_version=EncodingVersion.V1)
+    cfg_library = adapter.config_library
+    assert cfg_library.library_path == "_arctic_cfg"
+
+
+def test_s3_path_prefix():
+    adapter = S3LibraryAdapter("s3://my_endpoint:my_bucket?aws_auth=true&path_prefix=my_prefix",
+                               encoding_version=EncodingVersion.V1)
+    assert adapter.path_prefix == "my_prefix"
+
+
+def test_gcpxml_native_cfg_sdk_default():
+    adapter = GCPXMLLibraryAdapter("gcpxml://my_endpoint:my_bucket?aws_auth=true",
+                                   encoding_version=EncodingVersion.V1)
+
+    native_config = adapter.native_config().as_gcpxml_settings()
+
+    assert native_config.aws_auth == AWSAuthMethod.DEFAULT_CREDENTIALS_PROVIDER_CHAIN
+
+
+def test_gcpxml_native_cfg_sdk_default_profile_not_supported():
+    with pytest.raises(ValueError):
+        GCPXMLLibraryAdapter("gcpxml://my_endpoint:my_bucket?aws_auth=true&aws_profile=my_profile",
+                               encoding_version=EncodingVersion.V1)
+
+
+def test_gcpxml_native_cfg_sts():
+    with pytest.raises(ValueError):
+        GCPXMLLibraryAdapter("gcpxml://my_endpoint:my_bucket?aws_auth=sts&aws_profile=my_profile",
+                               encoding_version=EncodingVersion.V1)
+
+
+def test_gcpxml_native_cfg_keys():
+    adapter = GCPXMLLibraryAdapter("gcpxml://my_endpoint:my_bucket?access=my_access&secret=my_secret",
+                                   encoding_version=EncodingVersion.V1)
+
+    native_config = adapter.native_config().as_gcpxml_settings()
+
+    assert native_config.aws_auth == AWSAuthMethod.DISABLED
+    assert native_config.access == "my_access"
+    assert native_config.secret == "my_secret"
+
+
+def test_gcp_repr():
+    adapter = GCPXMLLibraryAdapter("gcpxml://my_endpoint:my_bucket?aws_auth=true",
+                               encoding_version=EncodingVersion.V1)
+    assert repr(adapter) == "GCPXML(endpoint=my_endpoint, bucket=my_bucket)"
+
+
+def test_gcp_config_library():
+    adapter = GCPXMLLibraryAdapter("gcpxml://my_endpoint:my_bucket?aws_auth=true",
+                               encoding_version=EncodingVersion.V1)
+    cfg_library = adapter.config_library
+    assert cfg_library.library_path == "_arctic_cfg"
+
+
+def test_gcp_path_prefix():
+    adapter = GCPXMLLibraryAdapter("gcpxml://my_endpoint:my_bucket?aws_auth=true&path_prefix=my_prefix",
+                               encoding_version=EncodingVersion.V1)
+    assert adapter.path_prefix == "my_prefix"


### PR DESCRIPTION
The change to support GCP #2176 accidentally broke STS support with S3.

The issue was that the native settings,

```
def native_config
```

just returned a dummy object. This was fine for the config library as it got overridden later correctly (so listing libraries worked) but was not overridden for normal libraries (so actually working with a library failed).

I've just removed all this complexity of overriding and made the `native_config` call always return something valid.

This call in `helper.py` is needless (and confusing) now, so I've removed it.

```
        native_cfg.update(NativeS3Settings(aws_auth, aws_profile, use_internal_client_wrapper_for_testing))
```

I've also added a set of unit tests, which caught a surprising number of small issues that are hopefully clear from the changeset, and some better Python reprs for debugging the settings.

This commit https://github.com/man-group/ArcticDB/commit/5f5addf0294f6066e2467fdb073cffa3bf7e0903 shows my notes on the STS setup and the repro script I used for an end to end test of STS support.