### PR TITLE
GCP real storage tests

### DIFF
--- a/.github/actions/set_persistent_storage_env_vars/action.yml
+++ b/.github/actions/set_persistent_storage_env_vars/action.yml
@@ -64,8 +64,8 @@ runs:
             echo "ARCTICDB_PERSISTENT_STORAGE_TESTS_TYPE=aws_s3"  >> $GITHUB_ENV
             echo "PYTEST_ADD_TO_COMMAND_LINE= -m storage"  >> $GITHUB_ENV
         fi
-        if [[ "${{inputs.persistent_storage}}" == "GCP" ]]; then 
-            echo "Storage tests will run with AWS_S3"
+        if [[ "${{inputs.persistent_storage}}" == "GCPXML" ]]; then 
+            echo "Storage tests will run with GCP"
             echo "ARCTICDB_STORAGE_GCP=1"  >> $GITHUB_ENV
             # NO S3
             echo "ARCTICDB_STORAGE_AWS_S3=0"  >> $GITHUB_ENV

--- a/.github/actions/set_persistent_storage_env_vars/action.yml
+++ b/.github/actions/set_persistent_storage_env_vars/action.yml
@@ -2,12 +2,17 @@ name: 'Set Persistent storages env variables'
 description: 'Set the necessary variables for Persistent storage tests'
 inputs:
   bucket:            {default: 'arcticdb-ci-test-bucket-02', type: string, description: The name of the S3 bucket that we will test against}
+  bucket_gcp:        {default: 'arcticdb-github', type: string, description: The name of the GCP bucket that we will test against}
   endpoint:          {default: 'https://s3.eu-west-1.amazonaws.com', type: string, description: The address of the S3 endpoint}
+  endpoint_gcp:      {default: 'gcpxml://storage.googleapis.com', type: string, description: The address of the GCP endpoint}
   region:            {default: 'eu-west-1', type: string, description: The S3 region of the bucket}
   aws_access_key:    {required: true, type: string, description: The value for the AWS Access key}      
   aws_secret_key:    {required: true, type: string, description: The value for the AWS Secret key}
+  gcp_access_key:    {required: true, type: string, description: The value for the GCP Access key}      
+  gcp_secret_key:    {required: true, type: string, description: The value for the GCP Secret key}
   strategy_branch:   {default: 'ignore', type: string, description: a unique combination of the parameters for the given job strategy branch, e.g. linux_cp36} 
   shared_storage_prefix:   {default: 'none', type: string, description: a prefix string that will be used for persistent storage}
+  persistent_storage:      {default: "no", type: string, description: Specifies whether the python tests should tests against real storages e.g. AWS S3  }
 runs:
   using: "composite"
   steps:
@@ -27,6 +32,7 @@ runs:
         fi
         # This is a path that should be used for specific job and its tests to avoid cross contamination and race conditions
         echo "ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX=ci_tests/${{ github.ref_name }}_${{ github.run_id }}_${{ inputs.strategy_branch }}" >> $GITHUB_ENV
+
         # S3 Specific
         echo "ARCTICDB_REAL_S3_BUCKET=${{ inputs.bucket }}" >> $GITHUB_ENV
         echo "ARCTICDB_REAL_S3_ENDPOINT=${{ inputs.endpoint }}" >> $GITHUB_ENV
@@ -39,6 +45,36 @@ runs:
         echo "ARCTICDB_REAL_S3_STS_TEST_USERNAME=gh_sts_test_user_${ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX}" >> $GITHUB_ENV
         echo "ARCTICDB_REAL_S3_STS_TEST_ROLE=gh_sts_test_role_${ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX}" >> $GITHUB_ENV
         echo "ARCTICDB_REAL_S3_STS_TEST_POLICY_NAME=gh_sts_test_policy_name_${ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX}" >> $GITHUB_ENV
+
+        # GCP Specific
+        echo "ARCTICDB_REAL_GCP_ACCESS_KEY=${{ inputs.gcp_access_key }}" >> $GITHUB_ENV
+        echo "ARCTICDB_REAL_GCP_SECRET_KEY=${{ inputs.gcp_secret_key }}" >> $GITHUB_ENV
+        echo "ARCTICDB_REAL_GCP_BUCKET=${{ inputs.bucket_gcp }}" >> $GITHUB_ENV
+        echo "ARCTICDB_REAL_GCP_ENDPOINT=${{ inputs.endpoint_gcp }}" >> $GITHUB_ENV
+        echo "ARCTICDB_REAL_GCP_CLEAR=1" >> $GITHUB_ENV
+
+        # Against what storage type to run test?
+        if [[ "${{input.persistent_storage}}" == "AWS_S3" ]]; then 
+            echo "Storage tests will run with AWS_S3"
+            echo "ARCTICDB_STORAGE_AWS_S3=1"  >> $GITHUB_ENV
+            # NO GCP
+            echo "ARCTICDB_STORAGE_GCP=0"  >> $GITHUB_ENV
+            # No local tests
+            echo "ARCTICDB_LOCAL_STORAGE_TESTS_ENABLED=0"  >> $GITHUB_ENV
+            echo "ARCTICDB_PERSISTENT_STORAGE_TESTS_TYPE=aws_s3"  >> $GITHUB_ENV
+            echo "PYTEST_ADD_TO_COMMAND_LINE= -m storage"  >> $GITHUB_ENV
+        fi
+        if [[ "${{input.persistent_storage}}" == "GCP" ]]; then 
+            echo "Storage tests will run with AWS_S3"
+            echo "ARCTICDB_STORAGE_GCP=1"  >> $GITHUB_ENV
+            # NO S3
+            echo "ARCTICDB_STORAGE_AWS_S3=0"  >> $GITHUB_ENV
+            # No local tests
+            echo "ARCTICDB_LOCAL_STORAGE_TESTS_ENABLED=0"  >> $GITHUB_ENV
+            echo "ARCTICDB_PERSISTENT_STORAGE_TESTS_TYPE=gcp"  >> $GITHUB_ENV
+            echo "PYTEST_ADD_TO_COMMAND_LINE= -m storage "  >> $GITHUB_ENV
+        fi
+
         # Enable all debug logs
         # echo "ARCTICDB_all_loglevel=debug" >> $GITHUB_ENV
         # echo "ARCTICDB_AWS_LogLevel_int=6" >> $GITHUB_ENV

--- a/.github/actions/set_persistent_storage_env_vars/action.yml
+++ b/.github/actions/set_persistent_storage_env_vars/action.yml
@@ -54,7 +54,7 @@ runs:
         echo "ARCTICDB_REAL_GCP_CLEAR=1" >> $GITHUB_ENV
 
         # Against what storage type to run test?
-        if [[ "${{input.persistent_storage}}" == "AWS_S3" ]]; then 
+        if [[ "${{inputs.persistent_storage}}" == "AWS_S3" ]]; then 
             echo "Storage tests will run with AWS_S3"
             echo "ARCTICDB_STORAGE_AWS_S3=1"  >> $GITHUB_ENV
             # NO GCP
@@ -64,7 +64,7 @@ runs:
             echo "ARCTICDB_PERSISTENT_STORAGE_TESTS_TYPE=aws_s3"  >> $GITHUB_ENV
             echo "PYTEST_ADD_TO_COMMAND_LINE= -m storage"  >> $GITHUB_ENV
         fi
-        if [[ "${{input.persistent_storage}}" == "GCP" ]]; then 
+        if [[ "${{inputs.persistent_storage}}" == "GCP" ]]; then 
             echo "Storage tests will run with AWS_S3"
             echo "ARCTICDB_STORAGE_GCP=1"  >> $GITHUB_ENV
             # NO S3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,14 @@ on:
   workflow_dispatch:
     inputs:
       persistent_storage:
-        description: Run the persistent storage tests
-        type: boolean
+        description: Run the persistent storage tests?
+        type: choice
+        options:
+          - 'no'
+          - 'AWS_S3'
+          - 'GCPXML'
+        default: 'no'
+
       pypi_publish:
         type: boolean
       publish_env:

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -9,7 +9,7 @@ on:
       cibw_version:      {required: false, type: string, description: build-python-wheels only. Must match the cibw_image_tag}
       python_deps_ids:   {default: '[""]', type: string, description: build-python-wheels test matrix parameter. JSON string.}
       python3:           {default: -1, type: number, description: Python 3 minor version}
-      persistent_storage:      {default: "false", type: string, description: Specifies whether the python tests should tests against real storages e.g. AWS S3  }
+      persistent_storage:      {default: "no", type: string, description: Specifies whether the python tests should tests against real storages e.g. AWS S3  }
       pytest_xdist_mode: {default: "", type: string, description: additional argument to pass for pytest-xdist}
       pytest_args:       {default: "", type: string, description: a way to rewrite the pytest args to change what tests are being run}
 jobs:
@@ -334,15 +334,18 @@ jobs:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{vars.CMAKE_BUILD_PARALLEL_LEVEL}}
 
       - name: Set persistent storage variables
-        if: inputs.persistent_storage == 'true'
+        if: inputs.persistent_storage != 'no'
         uses: ./.github/actions/set_persistent_storage_env_vars
         with:
           aws_access_key: "${{ secrets.AWS_S3_ACCESS_KEY }}"
           aws_secret_key: "${{ secrets.AWS_S3_SECRET_KEY }}"
+          gcp_access_key: "${{ secrets.GCP_S3_ACCESS_KEY }}"
+          gcp_secret_key: "${{ secrets.GCP_S3_SECRET_KEY }}"
+          persistent_storage: "${{ inputs.persistent_storage }}"
           strategy_branch: "${{ env.distinguishing_name }}"
         
       - name: Set s3 sts persistent storage variables for Windows
-        if: inputs.persistent_storage == 'true' && matrix.os == 'windows'
+        if: inputs.persistent_storage != 'no' && matrix.os == 'windows'
         uses: ./.github/actions/set_s3_sts_persistent_storage_env_vars
         with:
           aws_access_key: "${{ secrets.AWS_S3_ACCESS_KEY }}"

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -18,13 +18,13 @@ cd $PARALLEL_TEST_ROOT
 
 export ARCTICDB_RAND_SEED=$RANDOM
 
-if [ -z "$ARCTICDB_PYTEST_ARGS" ] && [ -z "$PYTEST_ADD_TO_COMMAND_LINE" ]; then
+if [ -z "$ARCTICDB_PYTEST_ARGS" ]; then
     echo "Executing tests with no additional arguments"
     $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
-        "$@" 2>&1 | sed -r "s#^(tests/.*/([^/]+\.py))?#\2#"
+        $PYTEST_ADD_TO_COMMAND_LINE "$@" 2>&1 | sed -r "s#^(tests/.*/([^/]+\.py))?#\2#"
 else
     echo "Executing tests with additional pytest argiments:"
     echo "from user: $ARCTICDB_PYTEST_ARGS"

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -18,16 +18,20 @@ cd $PARALLEL_TEST_ROOT
 
 export ARCTICDB_RAND_SEED=$RANDOM
 
-if [ -z "$ARCTICDB_PYTEST_ARGS" ]; then
+if [ -z "$ARCTICDB_PYTEST_ARGS" ] && [ -z "$PYTEST_ADD_TO_COMMAND_LINE" ]; then
+    echo "Executing tests with no additional arguments"
     $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
         "$@" 2>&1 | sed -r "s#^(tests/.*/([^/]+\.py))?#\2#"
 else
+    echo "Executing tests with additional pytest argiments:"
+    echo "from user: $ARCTICDB_PYTEST_ARGS"
+    echo "from automation: $PYTEST_ADD_TO_COMMAND_LINE"
     $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
-        $ARCTICDB_PYTEST_ARGS 2>&1
+        $PYTEST_ADD_TO_COMMAND_LINE $ARCTICDB_PYTEST_ARGS 2>&1
 fi

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -43,6 +43,12 @@ std::shared_ptr<Storage> create_storage(
         arcticc::pb2::s3_storage_pb2::Config s3_config;
         storage_descriptor.config().UnpackTo(&s3_config);
         storage = std::make_shared<s3::S3Storage>(library_path, mode, s3::S3Settings(s3_config));
+    } else if (type_name == arcticc::pb2::gcp_storage_pb2::Config::descriptor()->full_name()) {
+        arcticc::pb2::gcp_storage_pb2::Config gcp_config;
+        storage_descriptor.config().UnpackTo(&gcp_config);
+        s3::GCPXMLSettings native_settings{};
+        native_settings.set_prefix(gcp_config.prefix());
+        storage = std::make_shared<s3::GCPXMLStorage>(library_path, mode, native_settings);
     } else if (type_name == lmdb::LmdbStorage::Config::descriptor()->full_name()) {
         lmdb::LmdbStorage::Config lmbd_config;
         storage_descriptor.config().UnpackTo(&lmbd_config);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,9 @@ exclude = '''
 
 [tool.pytest.ini_options]
 markers = [
-    "pipeline",
+    "storage: marks a test as a test against real storage (deselect with: -m 'not storage')",
+    "authentication: marks a test for authentication group (deselect with: -m 'not authentication')",
+    "pipeline: Pipeline tests (deselect with: -m 'not pipeline')",
+    "skip_fixture_params: will instruct fixture that supports excluding fixture values, which values to be excluded",
+    "only_fixture_params: will instruct fixture supporting that to include only parameters from the list",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,5 @@ markers = [
     "pipeline: Pipeline tests (deselect with: -m 'not pipeline')",
     "skip_fixture_params: will instruct fixture that supports excluding fixture values, which values to be excluded",
     "only_fixture_params: will instruct fixture supporting that to include only parameters from the list",
+    "bug_ids: allows specifying bug ids list the tests is based on or depends"
 ]

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -36,7 +36,7 @@ from .utils import (
     get_ca_cert_for_testing,
 )
 from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
-from arcticdb.version_store.helper import add_s3_library_to_env
+from arcticdb.version_store.helper import add_gcp_library_to_env, add_s3_library_to_env
 from arcticdb_ext.storage import AWSAuthMethod, NativeVariantStorage
 
 
@@ -203,14 +203,53 @@ class NfsS3Bucket(S3Bucket):
 
 
 class GcpS3Bucket(S3Bucket):
+
     def __init__(
         self,
-        factory: "BaseS3StorageFixtureFactory",
+        factory: "BaseGCPStorageFixtureFactory",
         bucket: str,
         native_config: Optional[NativeVariantStorage] = None,
     ):
-        super().__init__(factory, bucket, native_config=native_config)
-        self.arctic_uri = self.arctic_uri.replace("s3", "gcpxml", 1)
+        StorageFixture.__init__(self)
+        self.factory = factory
+        self.bucket = bucket
+        self.native_config = native_config
+
+        host, port = re.match(r"(?:gcpxml://)?([^:/]+)(?::(\d+))?", factory.endpoint).groups()
+        self.arctic_uri = f"gcpxml://{host}:{self.bucket}?"
+
+        self.key = factory.default_key
+
+        if factory.aws_auth == None or factory.aws_auth == AWSAuthMethod.DISABLED:
+            self.arctic_uri += f"access={self.key.id}&secret={self.key.secret}"
+        else:
+            self.arctic_uri += "aws_auth=default"
+        if port:
+            self.arctic_uri += f"&port={port}"
+        if factory.default_prefix:
+            self.arctic_uri += f"&path_prefix={factory.default_prefix}"
+        if factory.ssl:
+            self.arctic_uri += "&ssl=True"
+        if platform.system() == "Linux":
+            if factory.client_cert_file:
+                self.arctic_uri += f"&CA_cert_path={self.factory.client_cert_file}"
+            # client_cert_dir is skipped on purpose; It will be tested manually in other tests
+
+    def create_test_cfg(self, lib_name: str) -> EnvironmentConfigsMap:
+        cfg = EnvironmentConfigsMap()
+        if self.factory.default_prefix:
+            with_prefix = f"{self.factory.default_prefix}/{lib_name}"
+        else:
+            with_prefix = False
+
+        add_gcp_library_to_env(
+            cfg=cfg,
+            lib_name=lib_name,
+            env_name=Defaults.ENV,
+            with_prefix=with_prefix
+        )  # client_cert_dir is skipped on purpose; It will be tested manually in other tests
+        return cfg, self.native_config
+
 
 
 class BaseS3StorageFixtureFactory(StorageFixtureFactory):
@@ -263,6 +302,40 @@ class BaseS3StorageFixtureFactory(StorageFixtureFactory):
             b.slow_cleanup(failure_consequence="The following delete bucket call will also fail. ")
 
 
+class BaseGCPStorageFixtureFactory(StorageFixtureFactory):
+    """Logic and fields common to real and mock S3"""
+
+    endpoint: str
+    region: str
+    default_key: Key
+    default_bucket: Optional[str] = None
+    default_prefix: Optional[str] = None
+    use_raw_prefix: bool = False
+    clean_bucket_on_fixture_exit = True
+    use_mock_storage_for_testing = None  # If set to true allows error simulation
+    use_internal_client_wrapper_for_testing = None  # If set to true uses the internal client wrapper for testing
+
+    def __init__(self, native_config: Optional[dict] = None):
+        self.client_cert_file = None
+        self.client_cert_dir = None
+        self.ssl = False
+        self.aws_auth = None
+        self.native_config = native_config
+
+    def __str__(self):
+        return f"{type(self).__name__}[{self.default_bucket or self.endpoint}]"
+
+    def create_fixture(self) -> GcpS3Bucket:
+        return GcpS3Bucket(self, self.default_bucket, self.native_config)
+
+    def cleanup_bucket(self, b: GcpS3Bucket):
+        # When dealing with a potentially shared bucket, we only clear our the libs we know about:
+        if not self.use_mock_storage_for_testing:
+            # We are not writing to buckets in this case
+            # and if we try to delete the bucket, it will fail
+            b.slow_cleanup(failure_consequence="The following delete bucket call will also fail. ")
+
+
 def real_s3_from_environment_variables(
     shared_path: bool, native_config: Optional[NativeVariantStorage] = None, additional_suffix: str = ""
 ) -> BaseS3StorageFixtureFactory:
@@ -275,6 +348,24 @@ def real_s3_from_environment_variables(
     out.default_key = Key(id=access_key, secret=secret_key, user_name="unknown user")
     out.clean_bucket_on_fixture_exit = os.getenv("ARCTICDB_REAL_S3_CLEAR").lower() in ["true", "1"]
     out.ssl = out.endpoint.startswith("https://")
+    if shared_path:
+        out.default_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX")
+    else:
+        out.default_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX", "") + additional_suffix
+    return out
+
+def real_gcp_from_environment_variables(
+    shared_path: bool, native_config: Optional[NativeVariantStorage] = None, additional_suffix: str = ""
+) -> BaseGCPStorageFixtureFactory:
+    out = BaseGCPStorageFixtureFactory(native_config=native_config)
+    out.endpoint = os.getenv("ARCTICDB_REAL_GCP_ENDPOINT")
+    out.region = os.getenv("ARCTICDB_REAL_GCP_REGION")
+    out.default_bucket = os.getenv("ARCTICDB_REAL_GCP_BUCKET")
+    access_key = os.getenv("ARCTICDB_REAL_GCP_ACCESS_KEY")
+    secret_key = os.getenv("ARCTICDB_REAL_GCP_SECRET_KEY")
+    out.default_key = Key(id=access_key, secret=secret_key, user_name="unknown user")
+    out.clean_bucket_on_fixture_exit = os.getenv("ARCTICDB_REAL_GCP_CLEAR", "1").lower() in ["true", "1"]
+    out.ssl = out.endpoint.startswith("https://") if out.endpoint is not None else False
     if shared_path:
         out.default_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX")
     else:

--- a/python/arcticdb/util/utils.py
+++ b/python/arcticdb/util/utils.py
@@ -5,10 +5,14 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 from datetime import timedelta
+import inspect
+import logging
+import os
 import random
 import string
 import time
-import sys 
+import sys
+from typing import Dict 
 if sys.version_info >= (3, 8): 
     from typing import Literal, Any, List, Tuple, Union, get_args
 else: 
@@ -20,10 +24,74 @@ import pandas as pd
 from arcticdb.util.test import create_datetime_index, get_sample_dataframe, random_integers, random_string
 from arcticdb.version_store.library import Library
 
+
 # Types supported by arctic
 ArcticIntType = Union[np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64]
 ArcticFloatType = Union[np.float64, np.float32]
 ArcticTypes = Union[ArcticIntType, ArcticFloatType, str]
+
+
+class GitHubSanitizingHandler(logging.StreamHandler):
+    """
+    The handler sanitizes messages only when execution is in GitHub
+    """
+
+    def emit(self, record: logging.LogRecord):
+        # Sanitize the message here
+        record.msg = self.sanitize_message(record.msg)
+        super().emit(record)
+
+    @staticmethod
+    def sanitize_message(message: str) -> str:
+        if (os.getenv("GITHUB_ACTIONS") == "true") and isinstance(message, str):
+            # Use regex to find and replace sensitive access keys
+            sanitized_message = re.sub(r'(secret=)[^\s&]+', r'\1***', message)
+            sanitized_message = re.sub(r'(access=)[^\s&]+', r'\1***', sanitized_message)
+            return sanitized_message
+        return message
+
+
+loggers:Dict[str, logging.Logger] = {}
+
+
+def get_logger(bencmhark_cls: Union[str, Any] = None):
+    """
+    Creates logger instance with associated console handler.
+    The logger name can be either passed as string or class,
+    or if not automatically will assume the caller module name
+    """
+    logLevel = logging.INFO
+    if bencmhark_cls:
+        if isinstance(bencmhark_cls, str):
+            value = bencmhark_cls
+        else:
+            value = type(bencmhark_cls).__name__
+        name = value
+    else:
+        frame = inspect.stack()[1]
+        module = inspect.getmodule(frame[0])
+        name = module.__name__
+
+    logger = loggers.get(name, None)
+    if logger :
+        return logger
+    logger = logging.getLogger(name)    
+    logger.setLevel(logLevel)
+    console_handler = GitHubSanitizingHandler()
+    console_handler.setLevel(logLevel)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    loggers[name] = logger
+    return logger
+
+
+class GitHubSanitizingException(Exception):
+    def __init__(self, message: str):
+        # Sanitize the message
+        sanitized_message = GitHubSanitizingHandler.sanitize_message(message)
+        super().__init__(sanitized_message)
+
 
 class  TimestampNumber:
     """

--- a/python/arcticdb/util/utils.py
+++ b/python/arcticdb/util/utils.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 import os
 import random
+import re
 import string
 import time
 import sys

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    storage: marks a test as a test against real storage (deselect with '-m "not storage"')
+    authentication: marks a test for authentication group (deselect with '-m "not authentication"')
+    pipeline: Pipeline tests (deselect with '-m "not pipeline"')
+    skip_fixture_value: will instruct fixture that supports excluding fixture values, which values to be excluded

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-markers =
-    storage: marks a test as a test against real storage (deselect with '-m "not storage"')
-    authentication: marks a test for authentication group (deselect with '-m "not authentication"')
-    pipeline: Pipeline tests (deselect with '-m "not pipeline"')
-    skip_fixture_params: will instruct fixture that supports excluding fixture values, which values to be excluded
-    only_fixture_params: will instruct fixture supporting that to include only parameters from the list

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -3,4 +3,5 @@ markers =
     storage: marks a test as a test against real storage (deselect with '-m "not storage"')
     authentication: marks a test for authentication group (deselect with '-m "not authentication"')
     pipeline: Pipeline tests (deselect with '-m "not pipeline"')
-    skip_fixture_value: will instruct fixture that supports excluding fixture values, which values to be excluded
+    skip_fixture_params: will instruct fixture that supports excluding fixture values, which values to be excluded
+    only_fixture_params: will instruct fixture supporting that to include only parameters from the list

--- a/python/tests/compat/arcticdb/test_lib_naming.py
+++ b/python/tests/compat/arcticdb/test_lib_naming.py
@@ -2,6 +2,7 @@ import pytest
 import sys
 from arcticdb_ext.exceptions import UserInputException
 from arcticdb.util.test import sample_dataframe
+from tests.enduser.test_authentication import get_logger
 from tests.util.mark import SLOW_TESTS_MARK
 
 
@@ -9,29 +10,40 @@ from tests.util.mark import SLOW_TESTS_MARK
 @pytest.mark.parametrize("prefix", ["", "prefix"])
 @pytest.mark.parametrize("suffix", ["", "suffix"])
 @pytest.mark.storage
+@pytest.mark.skip_fixture_value(["real_gcp"], "Skipped because of issues with lib names containing \\n and \\r")
 def test_create_library_with_all_chars(arctic_client_v1, prefix, suffix):
+    logger = get_logger("test_create_library_with_all_chars")
     ac = arctic_client_v1
     if sys.platform == "win32" and "lmdb" in ac.get_uri():
         pytest.skip(reason="Github actions runners run out of disk space on Windows in this test with lmdb")
     # Create library names with each character (except '\' because Azure replaces it with '/' in some cases)
     names = [f"{prefix}{chr(i)}{suffix}" for i in range(256) if chr(i) != "\\"]
 
+    failed = False
     created_libraries = set()
     try:
-        for name in names:
+        for cnt, name in enumerate(names):
+            logger.info(f"Iteration: {cnt}/{len(names)}")
             try:
                 ac.create_library(name)
                 created_libraries.add(name)
+                logger.info(f"added lib with name: {repr(name)}")
             # We should only fail with UserInputException (indicating that name validation failed)
             except UserInputException:
-                pass
+                logger.info(f"exception handled UserInput exception added lib with name: {repr(name)}")
+            except Exception:
+                logger.info(f"!!!!!! FAILED with name: {repr(name)}")
 
         result = set(ac.list_libraries())
         assert all(name in result for name in created_libraries)
     finally:
-        for lib in created_libraries:
+        logger.info("Delete started")
+        for cnt, lib in enumerate(created_libraries):
+            logger.info(f"Deletion: {cnt}/{len(created_libraries)} lib_name [{repr(lib)}] ")
             ac.delete_library(lib)
+        logger.info("Delete ended")
 
+    assert not failed, "There is at least one failure look at the result"
 
 @SLOW_TESTS_MARK
 @pytest.mark.parametrize("prefix", ["", "prefix"])

--- a/python/tests/compat/arcticdb/test_lib_naming.py
+++ b/python/tests/compat/arcticdb/test_lib_naming.py
@@ -10,7 +10,7 @@ from tests.util.mark import SLOW_TESTS_MARK
 @pytest.mark.parametrize("prefix", ["", "prefix"])
 @pytest.mark.parametrize("suffix", ["", "suffix"])
 @pytest.mark.storage
-@pytest.mark.skip_fixture_value(["real_gcp"], "Skipped because of issues with lib names containing \\n and \\r")
+@pytest.mark.skip_fixture_params(["real_gcp"], "Skipped because of issues with lib names containing \\n and \\r")
 def test_create_library_with_all_chars(arctic_client_v1, prefix, suffix):
     logger = get_logger("test_create_library_with_all_chars")
     ac = arctic_client_v1

--- a/python/tests/compat/arcticdb/test_lib_naming.py
+++ b/python/tests/compat/arcticdb/test_lib_naming.py
@@ -1,8 +1,8 @@
 import pytest
 import sys
+from arcticdb.util.utils import get_logger
 from arcticdb_ext.exceptions import UserInputException
 from arcticdb.util.test import sample_dataframe
-from tests.enduser.test_authentication import get_logger
 from tests.util.mark import SLOW_TESTS_MARK
 
 

--- a/python/tests/compat/arcticdb/test_lib_naming.py
+++ b/python/tests/compat/arcticdb/test_lib_naming.py
@@ -8,6 +8,7 @@ from tests.util.mark import SLOW_TESTS_MARK
 @SLOW_TESTS_MARK
 @pytest.mark.parametrize("prefix", ["", "prefix"])
 @pytest.mark.parametrize("suffix", ["", "suffix"])
+@pytest.mark.storage
 def test_create_library_with_all_chars(arctic_client_v1, prefix, suffix):
     ac = arctic_client_v1
     if sys.platform == "win32" and "lmdb" in ac.get_uri():
@@ -35,6 +36,7 @@ def test_create_library_with_all_chars(arctic_client_v1, prefix, suffix):
 @SLOW_TESTS_MARK
 @pytest.mark.parametrize("prefix", ["", "prefix"])
 @pytest.mark.parametrize("suffix", ["", "suffix"])
+@pytest.mark.storage
 def test_symbol_names_with_all_chars(object_version_store, prefix, suffix):
     # Create symbol names with each character (except '\' because Azure replaces it with '/' in some cases)
     names = [f"{prefix}{chr(i)}{suffix}" for i in range(256) if chr(i) != "\\"]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -460,12 +460,14 @@ def filter_out_unwanted_mark(request, current_param):
       @pytest.mark.only_<fixture_param_name>
     """
     only_marks = [mark for mark in request.node.iter_markers() if mark.name.startswith("only_")]
-    found = False
-    for only_mark in only_marks:
-        if only_mark.name == f"only_{current_param}":
-            found = True
-    if not found:
-        pytest.skip(f"Skipping {current_param} parameter due to custom test mark.")
+    if only_marks: 
+        # Only when defined at least one only_ mark evaluate what should stay
+        found = False
+        for only_mark in only_marks:
+            if only_mark.name == f"only_{current_param}":
+                found = True
+        if not found:
+            pytest.skip(f"Skipping {current_param} parameter due to custom test mark.")
 
 @pytest.fixture(
     scope="function",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -314,8 +314,21 @@ def real_s3_shared_path_storage_factory() -> BaseS3StorageFixtureFactory:
 
 
 @pytest.fixture(scope="session")
+def real_gcp_shared_path_storage_factory() -> BaseS3StorageFixtureFactory:
+    return real_gcp_from_environment_variables(
+        shared_path=True,
+        additional_suffix=f"{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}",
+    )
+
+
+@pytest.fixture(scope="session")
 def real_s3_storage_without_clean_up(real_s3_shared_path_storage_factory) -> S3Bucket:
     return real_s3_shared_path_storage_factory.create_fixture()
+
+
+@pytest.fixture(scope="session")
+def real_gcp_storage_without_clean_up(real_gcp_shared_path_storage_factory) -> S3Bucket:
+    return real_gcp_shared_path_storage_factory.create_fixture()
 
 
 @pytest.fixture(scope="session")
@@ -328,6 +341,11 @@ def real_s3_storage(real_s3_storage_factory) -> Generator[S3Bucket, None, None]:
 def real_gcp_storage(real_gcp_storage_factory) -> Generator[GcpS3Bucket, None, None]:
     with real_gcp_storage_factory.create_fixture() as f:
         yield f
+
+
+@pytest.fixture(scope="session")
+def real_s3_library(real_s3_storage, lib_name) -> Library:
+    return real_s3_storage.create_arctic().create_library(lib_name)
 
 
 @pytest.fixture(scope="session")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -475,7 +475,13 @@ def filter_out_unwanted_mark(request, current_param):
             if only_mark.name == f"only_{current_param}":
                 found = True
         if not found:
-            pytest.skip(f"Skipping {current_param} parameter due to custom test mark.")
+            pytest.skip(reason = f"Skipping {current_param} parameter due to custom test mark.")
+
+    skip_fixture_value_mark = request.node.get_closest_marker("skip_fixture_value")
+    if skip_fixture_value_mark:
+            values_to_skip = skip_fixture_value_mark.args[0]
+            if current_param in values_to_skip:
+                pytest.skip(reason = f"Skipping fixture value: {request.param} as per 'skip_fixture_value' mark")
 
 @pytest.fixture(
     scope="function",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -460,27 +460,28 @@ def mem_storage() -> Generator[InMemoryStorageFixture, None, None]:
 # region ==================================== `Arctic` API Fixtures ====================================
 
 def filter_out_unwanted_mark(request, current_param):
-    """
+    """ Exclude specific fixture parameters or include only certain
+
     Provides ability tp filter out unwanted fixture parameter
     To do that add to test as many of the marks you want to stay using:
     
-      @pytest.mark.only_<fixture_param_name>
-    """
-    only_marks = [mark for mark in request.node.iter_markers() if mark.name.startswith("only_")]
-    if only_marks: 
-        # Only when defined at least one only_ mark evaluate what should stay
-        found = False
-        for only_mark in only_marks:
-            if only_mark.name == f"only_{current_param}":
-                found = True
-        if not found:
-            pytest.skip(reason = f"Skipping {current_param} parameter due to custom test mark.")
+      @pytest.mark.only_fixture_params([<fixture_param_names_list>], )
 
-    skip_fixture_value_mark = request.node.get_closest_marker("skip_fixture_value")
+    Or alternatively you can exclude as many as wanted:
+      @pytest.mark.skip_fixture_params([<fixture_param_names_list>], )
+    """
+    only_fixtures = request.node.get_closest_marker("only_fixture_params")
+    if only_fixtures: 
+        # Only when defined at least one only_ mark evaluate what should stay
+        values_to_include = only_fixtures.args[0]
+        if not current_param in values_to_include:
+            pytest.skip(reason = f"Skipping {current_param} param as not included in test 'only_fixture_params' mark.")
+
+    skip_fixture_value_mark = request.node.get_closest_marker("skip_fixture_params")
     if skip_fixture_value_mark:
-            values_to_skip = skip_fixture_value_mark.args[0]
-            if current_param in values_to_skip:
-                pytest.skip(reason = f"Skipping fixture value: {request.param} as per 'skip_fixture_value' mark")
+        values_to_skip = skip_fixture_value_mark.args[0]
+        if current_param in values_to_skip:
+            pytest.skip(reason = f"Skipping param: {current_param} as per 'skip_fixture_params' mark")
 
 @pytest.fixture(
     scope="function",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -441,8 +441,12 @@ def filter_out_unwanted_mark(request, current_param):
     
       @pytest.mark.only_<fixture_param_name>
     """
-    only_mark = request.node.get_closest_marker(f"only_{current_param}")
-    if only_mark is None:
+    only_marks = [mark for mark in request.node.iter_markers() if mark.name.startswith("only_")]
+    found = False
+    for only_mark in only_marks:
+        if only_mark.name == f"only_{current_param}":
+            found = True
+    if not found:
         pytest.skip(f"Skipping {current_param} parameter due to custom test mark.")
 
 @pytest.fixture(

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -7,7 +7,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import enum
-from typing import Callable, Generator
+from typing import Callable, Generator, Union
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.version_store.library import Library
 import hypothesis
@@ -303,6 +303,14 @@ def real_gcp_storage_factory() -> BaseGCPStorageFixtureFactory:
         shared_path=False,
         additional_suffix=f"{random.randint(0, 999)}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}",
     )
+
+
+@pytest.fixture(scope="session",
+                params=[pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
+                        pytest.param("real_gcp", marks=REAL_GCP_TESTS_MARK)])
+def real_storage_factory(request) -> Union[BaseGCPStorageFixtureFactory, BaseGCPStorageFixtureFactory]:
+    storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage_factory")
+    return storage_fixture
 
 
 @pytest.fixture(scope="session")
@@ -821,6 +829,7 @@ def version_store_and_real_s3_basic_store_factory(request):
         pytest.param("version_store_factory", marks=LMDB_TESTS_MARK),
         pytest.param("in_memory_store_factory",marks=MEM_TESTS_MARK),
         pytest.param("real_s3_store_factory", marks=REAL_S3_TESTS_MARK),
+        pytest.param("real_gcp_store_factory", marks=REAL_GCP_TESTS_MARK),
     ]
 )
 def basic_store_factory(request) -> Callable[..., NativeVersionStore]:

--- a/python/tests/enduser/test_authentication.py
+++ b/python/tests/enduser/test_authentication.py
@@ -1,0 +1,113 @@
+import arcticdb as adb
+import os
+import pytest
+import logging
+import re
+
+from tests.util.storage_test import real_gcp_credentials, real_s3_credentials
+
+
+class GitHubSanitizingHandler(logging.StreamHandler):
+    """
+    The handler sanitizes messages only when execution is in GitHub
+    """
+
+    def emit(self, record: logging.LogRecord):
+        # Sanitize the message here
+        record.msg = self.sanitize_message(record.msg)
+        super().emit(record)
+
+    @staticmethod
+    def sanitize_message(message: str) -> str:
+        if (os.getenv("GITHUB_ACTIONS") == "true") and isinstance(message, str):
+            # Use regex to find and replace sensitive access keys
+            sanitized_message = re.sub(r'(secret=)[^\s&]+', r'\1***', message)
+            sanitized_message = re.sub(r'(access=)[^\s&]+', r'\1***', sanitized_message)
+            return sanitized_message
+        return message
+
+
+class GitHubSanitizingException(Exception):
+    def __init__(self, message: str):
+        # Sanitize the message
+        sanitized_message = GitHubSanitizingHandler.sanitize_message(message)
+        super().__init__(sanitized_message)
+
+
+def get_logger(logger_name):
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.DEBUG)
+    handler = GitHubSanitizingHandler()
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)    
+
+
+s3_enpoint, s3_bucket, s3_region, s3_access_key, s3_secret_key, s3_prefix, s3_clear = real_s3_credentials(shared_path=False)
+gcp_enpoint, gcp_bucket, gcp_region, gcp_access_key, gcp_secret_key, gcp_prefix, gcp_clear = real_gcp_credentials(shared_path=False)
+
+
+access_mark = "*access*"
+secret_mark = "*secret*"
+
+
+def execute_uri_test(uri:str, expected: str, access: str, secret: str):
+    uri = uri.replace(access_mark, access)
+    uri = uri.replace(secret_mark, secret)
+    result = None
+    try:
+        ac = adb.Arctic(uri)
+        ac.list_libraries()
+    except Exception as e: 
+        result = str(e)
+
+    if expected is None:
+        if result is not None:
+            raise GitHubSanitizingException(f"Uri {uri} expected to PASS, but it failed with {result}")
+    else:
+        if expected not in result:
+            raise GitHubSanitizingException(
+                f"Uri {uri} expected to FAIL with [{expected}].\n Failed with error: {result}")
+      
+
+@pytest.mark.parametrize("uri,expected", [
+    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&path_prefix=abc", None),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False", None),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", "InvalidAccessKeyId"),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secrets={secret_mark}", "Invalid S3 URI. Invalid query parameter"),
+    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}1", "SignatureDoesNotMatch"),
+    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}1&secret={secret_mark}", "InvalidAccessKeyId"),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}", "AccessDenied: Access Denied for object"),
+    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?secret={secret_mark}", "E_PERMISSION Permission error"),
+])
+@pytest.mark.storage
+@pytest.mark.authentication
+def test_arcticdb_s3_uri(uri:str, expected: str):
+    execute_uri_test(uri, expected, s3_access_key, s3_secret_key)
+
+
+@pytest.mark.parametrize("uri,expected", [
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}", None),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}", None),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&path_prefix=abc", None),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False", None),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", "InvalidAccessKeyId"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secrets={secret_mark}", "Invalid GCPXML URI. Invalid query parameter"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}", "Secret or awsauth=true must be specified in GCPXML"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}1", "SignatureDoesNotMatch"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}1fds&secret={secret_mark}", "S3Error#22 SignatureDoesNotMatch"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?secret={secret_mark}", None),
+])
+@pytest.mark.storage
+@pytest.mark.authentication
+def test_arcticdb_gcpxml_uri(uri:str, expected: str):
+    execute_uri_test(uri, expected, gcp_access_key, gcp_secret_key)
+
+
+@pytest.mark.storage
+@pytest.mark.authentication
+def test_arcticdb_s3_config_file():
+    pass
+

--- a/python/tests/enduser/test_authentication.py
+++ b/python/tests/enduser/test_authentication.py
@@ -121,6 +121,8 @@ def test_arcticdb_gcpxml_uri_bad(uri:str, expected: str):
     execute_uri_test(uri, expected, gcp_access_key, gcp_secret_key)
 
 
+@REAL_S3_TESTS_MARK
+@REAL_GCP_TESTS_MARK
 @pytest.mark.storage
 @pytest.mark.authentication
 def test_arcticdb_s3_config_file(tmpdir):

--- a/python/tests/enduser/test_authentication.py
+++ b/python/tests/enduser/test_authentication.py
@@ -1,60 +1,39 @@
+from pathlib import Path
 import arcticdb as adb
 import os
 import pytest
 import logging
 import re
 
+from arcticdb.util.utils import GitHubSanitizingException, get_logger
 from tests.util.mark import REAL_GCP_TESTS_MARK, REAL_S3_TESTS_MARK
 from tests.util.storage_test import real_gcp_credentials, real_s3_credentials
 
 
-class GitHubSanitizingHandler(logging.StreamHandler):
-    """
-    The handler sanitizes messages only when execution is in GitHub
-
-    Enhancements should be mode as early as possible
-    """
-
-    def emit(self, record: logging.LogRecord):
-        # Sanitize the message here
-        record.msg = self.sanitize_message(record.msg)
-        super().emit(record)
-
-    @staticmethod
-    def sanitize_message(message: str) -> str:
-        if (os.getenv("GITHUB_ACTIONS") == "true") and isinstance(message, str):
-            # Use regex to find and replace sensitive access keys
-            sanitized_message = re.sub(r'(secret=)[^\s&]+', r'\1***', message)
-            sanitized_message = re.sub(r'(access=)[^\s&]+', r'\1***', sanitized_message)
-            return sanitized_message
-        return message
+logger = get_logger()
 
 
-class GitHubSanitizingException(Exception):
-    def __init__(self, message: str):
-        # Sanitize the message
-        sanitized_message = GitHubSanitizingHandler.sanitize_message(message)
-        super().__init__(sanitized_message)
+s3_enpoint, s3_bucket, s3_region, s3_access_key, s3_secret_key, s3_prefix, s3_clear = \
+    real_s3_credentials(shared_path=False)
+gcp_enpoint, gcp_bucket, gcp_region, gcp_access_key, gcp_secret_key, gcp_prefix, gcp_clear = \
+    real_gcp_credentials(shared_path=False)
 
-
-def get_logger(logger_name):
-    """
-    This logger is sanitizing logger, which can handle masking secrets.
-    Should be extended when needed and used wherever it is needed
-    """
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.DEBUG)
-    handler = GitHubSanitizingHandler()
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)    
-    return logger
-
-s3_enpoint, s3_bucket, s3_region, s3_access_key, s3_secret_key, s3_prefix, s3_clear = real_s3_credentials(shared_path=False)
-gcp_enpoint, gcp_bucket, gcp_region, gcp_access_key, gcp_secret_key, gcp_prefix, gcp_clear = real_gcp_credentials(shared_path=False)
 
 access_mark = "*access*"
 secret_mark = "*secret*"
+
+
+def check_creds_file_exists_on_machine():
+    # Default locations based on OS
+    home_dir = Path.home()
+    if os.name == 'nt':  # Windows
+        default_path = home_dir / ".aws" / "credentials"
+    else:  # Linux and macOS
+        default_path = home_dir / ".aws" / "credentials"
+
+    if default_path.exists():
+        pytest.skip("The test can be executed only on machine \
+                    where no AWS credentials file exists")
 
 
 def execute_uri_test(uri:str, expected: str, access: str, secret: str):
@@ -62,6 +41,7 @@ def execute_uri_test(uri:str, expected: str, access: str, secret: str):
     uri = uri.replace(secret_mark, secret)
     result = None
     try:
+
         ac = adb.Arctic(uri)
         ac.list_libraries()
     except Exception as e: 
@@ -79,19 +59,28 @@ def execute_uri_test(uri:str, expected: str, access: str, secret: str):
 @pytest.mark.parametrize("uri,expected", [
     (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
     (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&path_prefix=abc", None),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False", None),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", "InvalidAccessKeyId"),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secrets={secret_mark}", "Invalid S3 URI. Invalid query parameter"),
-    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}1", "SignatureDoesNotMatch"),
-    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}1&secret={secret_mark}", "InvalidAccessKeyId"),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}", "AccessDenied: Access Denied for object"),
-    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?secret={secret_mark}", "E_PERMISSION Permission error"),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&path_prefix=abc", 
+     None),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False",
+      None),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", 
+     "E_PERMISSION Permission error"),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secrets={secret_mark}", 
+     "Invalid S3 URI. Invalid query parameter"),
+    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}1", 
+     "SignatureDoesNotMatch"),
+    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}1&secret={secret_mark}", 
+     "InvalidAccessKeyId"),
+    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}", 
+     "AccessDenied: Access Denied for object"),
+    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?secret={secret_mark}", 
+     "E_PERMISSION Permission error"),
 ])
 @REAL_S3_TESTS_MARK
 @pytest.mark.storage
 @pytest.mark.authentication
 def test_arcticdb_s3_uri(uri:str, expected: str):
+    check_creds_file_exists_on_machine()
     execute_uri_test(uri, expected, s3_access_key, s3_secret_key)
 
 
@@ -99,23 +88,91 @@ def test_arcticdb_s3_uri(uri:str, expected: str):
     (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}", None),
     (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}", None),
     (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&path_prefix=abc", None),
-    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False", None),
-    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", "InvalidAccessKeyId"),
-    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secrets={secret_mark}", "Invalid GCPXML URI. Invalid query parameter"),
-    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}", "Secret or awsauth=true must be specified in GCPXML"),
-    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}1", "SignatureDoesNotMatch"),
-    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}1fds&secret={secret_mark}", "S3Error#22 SignatureDoesNotMatch"),
-    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?secret={secret_mark}", None),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", 
+     "Specified both access and awsauth=true in the GCPXML Arctic URI"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secrets={secret_mark}", 
+     "Invalid GCPXML URI. Invalid query parameter"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}", 
+     "Secret or awsauth=true must be specified in GCPXML"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}1", 
+     "SignatureDoesNotMatch"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}1fds&secret={secret_mark}", 
+     "S3Error#22 SignatureDoesNotMatch"),
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?secret={secret_mark}", "Access token or awsauth=true must be specified in GCPXML"),
 ])
 @pytest.mark.storage
 @pytest.mark.authentication
 @REAL_GCP_TESTS_MARK
 def test_arcticdb_gcpxml_uri(uri:str, expected: str):
+    check_creds_file_exists_on_machine()
+    execute_uri_test(uri, expected, gcp_access_key, gcp_secret_key)
+
+
+@pytest.mark.parametrize("uri,expected", [
+    (f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False", None),
+])
+@pytest.mark.storage
+@pytest.mark.authentication
+@pytest.mark.bug_ids(["8796367702"])
+@REAL_GCP_TESTS_MARK
+@pytest.mark.xfail(condition=True, reason="gcpxml does not allow value true to aws_auth query param")
+def test_arcticdb_gcpxml_uri_bad(uri:str, expected: str):
+    check_creds_file_exists_on_machine()
     execute_uri_test(uri, expected, gcp_access_key, gcp_secret_key)
 
 
 @pytest.mark.storage
 @pytest.mark.authentication
-def test_arcticdb_s3_config_file():
-    pass
+def test_arcticdb_s3_config_file(tmpdir):
 
+    uri_gcp=f"gcpxml://storage.googleapis.com:{gcp_bucket}?aws_auth=true"
+    uri_aws=f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?aws_auth=true"
+
+
+    def prepare_creds_file(access, secret):
+        data = f"[default]\n"
+        data += f"aws_access_key_id = {access}\n"
+        data += f"aws_secret_access_key = {secret}\n"
+        return data
+    
+    def execute_test(uri:str, data: str, will_pass: bool ):
+        file = tmpdir.join("frog")
+        file.write(data)
+        file_path = file.strpath
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = file_path
+        crashed = False
+        try:
+            ac = adb.Arctic(uri)
+            ac.list_libraries()
+        except Exception as e:
+            crashed = True
+        assert will_pass != crashed
+
+    check_creds_file_exists_on_machine()
+
+    data = prepare_creds_file(gcp_access_key, "")
+    execute_test(uri_gcp, data, False)
+
+    data = prepare_creds_file(gcp_access_key, gcp_secret_key)
+    execute_test(uri_gcp, data, True)
+
+    data = prepare_creds_file("", gcp_secret_key)
+    execute_test(uri_gcp, data, False)
+
+    data = prepare_creds_file(gcp_access_key, gcp_secret_key)
+    execute_test(uri_gcp, data, True)
+
+    data = prepare_creds_file(gcp_secret_key, gcp_access_key)
+    execute_test(uri_gcp, data, False)
+
+    data = prepare_creds_file(s3_access_key, s3_secret_key)
+    execute_test(uri_gcp, data, False)
+
+    data = prepare_creds_file(s3_access_key, s3_secret_key)
+    execute_test(uri_aws, data, True)
+
+    data = prepare_creds_file(gcp_access_key, gcp_secret_key)
+    execute_test(uri_aws, data, False)
+
+    data = prepare_creds_file(gcp_access_key, gcp_secret_key)
+    execute_test(uri_gcp, data, True)

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -153,6 +153,7 @@ def test_(
 )
 @SLOW_TESTS_MARK
 @pytest.mark.skip(reason="Needs to be fixed with issue #496")
+@pytest.mark.storage
 def test_append_with_defragmentation(
     sym,
     col_per_append_df,

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -145,6 +145,8 @@ def test_s3_no_ssl_verification(
 
 
 @REAL_S3_TESTS_MARK
+@pytest.mark.storage
+@pytest.mark.authentication
 def test_s3_sts_auth(lib_name, real_s3_sts_storage):
     ac = Arctic(real_s3_sts_storage.arctic_uri)
     try:
@@ -171,6 +173,7 @@ def test_s3_sts_auth(lib_name, real_s3_sts_storage):
 
 @SLOW_TESTS_MARK
 @REAL_S3_TESTS_MARK
+@pytest.mark.storage
 def test_s3_sts_expiry_check(lib_name, real_s3_sts_storage):
     """
     The test will obtain token at minimum expiration time of 15 minutes.
@@ -219,6 +222,7 @@ def test_s3_sts_expiry_check(lib_name, real_s3_sts_storage):
 
 
 @REAL_S3_TESTS_MARK
+@pytest.mark.storage
 def test_s3_sts_auth_store(real_s3_sts_version_store):
     lib = real_s3_sts_version_store
     df = pd.DataFrame({"a": [1, 2, 3]})

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -276,6 +276,7 @@ def test_basic_metadata(lmdb_version_store):
     assert vit.metadata == metadata
 
 
+@pytest.mark.storage
 def test_sorted_roundtrip(arctic_library):
     lib = arctic_library
 
@@ -286,6 +287,7 @@ def test_sorted_roundtrip(arctic_library):
     assert desc.sorted == "ASCENDING"
 
 
+@pytest.mark.storage
 def test_basic_write_read_update_and_append(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -329,6 +331,7 @@ def test_basic_write_read_update_and_append(arctic_library):
     assert read_metadata.version == 1
 
 
+@pytest.mark.storage
 def test_write_metadata_with_none(arctic_library):
     lib = arctic_library
     symbol = "symbol"
@@ -349,6 +352,7 @@ def test_write_metadata_with_none(arctic_library):
 
 
 @pytest.mark.parametrize("finalize_method", (StagedDataFinalizeMethod.WRITE, StagedDataFinalizeMethod.APPEND))
+@pytest.mark.storage
 def test_staged_data(arctic_library, finalize_method):
     lib = arctic_library
     sym_with_metadata = "sym_with_metadata"
@@ -397,6 +401,7 @@ def test_staged_data(arctic_library, finalize_method):
 
 @pytest.mark.parametrize("finalize_method", (StagedDataFinalizeMethod.APPEND, StagedDataFinalizeMethod.WRITE))
 @pytest.mark.parametrize("validate_index", (True, False, None))
+@pytest.mark.storage
 def test_parallel_writes_and_appends_index_validation(arctic_library, finalize_method, validate_index):
     lib = arctic_library
     sym = "test_parallel_writes_and_appends_index_validation"
@@ -426,6 +431,7 @@ def test_parallel_writes_and_appends_index_validation(arctic_library, finalize_m
 
 
 @pytest.mark.parametrize("finalize_method", (StagedDataFinalizeMethod.APPEND, StagedDataFinalizeMethod.WRITE))
+@pytest.mark.storage
 def test_finalize_without_adding_segments(arctic_library, finalize_method):
     lib = arctic_library
     with pytest.raises(UserInputException) as exception_info:
@@ -433,6 +439,7 @@ def test_finalize_without_adding_segments(arctic_library, finalize_method):
 
 
 class TestAppendStagedData:
+    @pytest.mark.storage
     def test_appended_df_interleaves_with_storage(self, arctic_library):
         lib = arctic_library
         initial_df = pd.DataFrame(
@@ -446,6 +453,7 @@ class TestAppendStagedData:
             lib.finalize_staged_data("sym", mode=StagedDataFinalizeMethod.APPEND)
         assert "append" in str(exception_info.value)
 
+    @pytest.mark.storage
     def test_appended_df_start_same_as_df_end(self, arctic_library):
         lib = arctic_library
         df = pd.DataFrame(
@@ -470,6 +478,7 @@ class TestAppendStagedData:
         assert_frame_equal(lib.read("sym").data, expected_df)
 
 
+@pytest.mark.storage
 def test_snapshots_and_deletes(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -492,6 +501,7 @@ def test_snapshots_and_deletes(arctic_library):
     assert lib.list_symbols() == ["my_symbol2"]
 
 
+@pytest.mark.storage
 def test_list_snapshots_no_metadata(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"a": [1, 2, 3]})
@@ -512,6 +522,7 @@ def test_list_snapshots_no_metadata(arctic_library):
     assert set(snaps_list) == {snap1, snap2}
 
 
+@pytest.mark.storage
 def test_delete_non_existent_snapshot(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -520,6 +531,7 @@ def test_delete_non_existent_snapshot(arctic_library):
         lib.delete_snapshot("test")
 
 
+@pytest.mark.storage
 def test_prune_previous_versions(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -532,6 +544,7 @@ def test_prune_previous_versions(arctic_library):
     assert lib["symbol"].metadata == {"tres": "interessant"}
 
 
+@pytest.mark.storage
 def test_do_not_prune_previous_versions_by_default(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -543,6 +556,7 @@ def test_do_not_prune_previous_versions_by_default(arctic_library):
     assert len(lib.list_versions("symbol")) == 5
 
 
+@pytest.mark.storage
 def test_delete_version(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -554,6 +568,7 @@ def test_delete_version(arctic_library):
     assert lib["symbol"].metadata == {"very": "interesting"}
 
 
+@pytest.mark.storage
 def test_list_versions_write_append_update(arctic_library):
     lib = arctic_library
     # Note: can only update timeseries dataframes
@@ -570,6 +585,7 @@ def test_list_versions_write_append_update(arctic_library):
     assert len(lib.list_versions("symbol")) == 3
 
 
+@pytest.mark.storage
 def test_list_versions_latest_only(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -579,6 +595,7 @@ def test_list_versions_latest_only(arctic_library):
     assert len(lib.list_versions("symbol", latest_only=True)) == 1
 
 
+@pytest.mark.storage
 def test_non_existent_list_versions_latest_only(arctic_library):
     lib = arctic_library
     assert len(lib.list_versions("symbol", latest_only=True)) == 0
@@ -588,6 +605,7 @@ def test_non_existent_list_versions_latest_only(arctic_library):
     assert len(lib.list_versions("symbol2", latest_only=True)) == 0
 
 
+@pytest.mark.storage
 def test_delete_version_with_snapshot(arctic_library):
     lib = arctic_library
     sym = "test_delete_version_with_snapshot"
@@ -602,6 +620,7 @@ def test_delete_version_with_snapshot(arctic_library):
                 getattr(lib, method)(sym, as_of=as_of)
 
 
+@pytest.mark.storage
 def test_list_versions_with_snapshot(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -620,6 +639,7 @@ def test_list_versions_with_snapshot(arctic_library):
     assert versions["symbol", 1].date > versions["symbol", 0].date
 
 
+@pytest.mark.storage
 def test_list_versions_without_snapshot(arctic_library):
     lib = arctic_library
     lib.write("symbol", pd.DataFrame())
@@ -630,6 +650,7 @@ def test_list_versions_without_snapshot(arctic_library):
     assert versions["symbol", 0].snapshots == []
 
 
+@pytest.mark.storage
 def test_delete_version_that_does_not_exist(arctic_library):
     lib = arctic_library
 
@@ -643,6 +664,7 @@ def test_delete_version_that_does_not_exist(arctic_library):
         lib.delete("symbol", versions=1)
 
 
+@pytest.mark.storage
 def test_delete_date_range(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [5, 6, 7, 8]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
@@ -712,6 +734,7 @@ class A:
         return self.id == other.id
 
 
+@pytest.mark.storage
 def test_write_object_with_pickle_mode(arctic_library):
     """Writing in pickle mode should succeed when the user uses the dedicated method."""
     lib = arctic_library
@@ -719,6 +742,7 @@ def test_write_object_with_pickle_mode(arctic_library):
     assert lib["test_1"].data.id == "id_1"
 
 
+@pytest.mark.storage
 def test_write_object_without_pickle_mode(arctic_library):
     """Writing outside of pickle mode should fail when the user does not use the dedicated method."""
     lib = arctic_library
@@ -726,6 +750,7 @@ def test_write_object_without_pickle_mode(arctic_library):
         lib.write("test_1", A("id_1"))
 
 
+@pytest.mark.storage
 def test_write_list_without_pickle_mode(arctic_library):
     """Writing outside of pickle mode should fail when the user does not use the dedicated method."""
     lib = arctic_library
@@ -733,6 +758,7 @@ def test_write_list_without_pickle_mode(arctic_library):
         lib.write("test_1", [1, 2, 3])
 
 
+@pytest.mark.storage
 def test_write_non_native_frame_with_pickle_mode(arctic_library):
     """Writing with pickle mode should work when the user calls the dedicated method."""
     lib = arctic_library
@@ -742,6 +768,7 @@ def test_write_non_native_frame_with_pickle_mode(arctic_library):
     assert_frame_equal(loaded, df[["col1"]])
 
 
+@pytest.mark.storage
 def test_write_non_native_frame_without_pickle_mode(arctic_library):
     """Writing outside of pickle mode should fail when the user does not use the dedicated method."""
     lib = arctic_library
@@ -750,6 +777,7 @@ def test_write_non_native_frame_without_pickle_mode(arctic_library):
         lib.write("test_1", df)
 
 
+@pytest.mark.storage
 def test_write_with_unpacking(arctic_library):
     """Check the syntactic sugar that lets us unpack WritePayload in `write` calls using *."""
     lib = arctic_library
@@ -770,6 +798,7 @@ def test_write_with_unpacking(arctic_library):
     assert symbol_2_loaded.metadata == "great_metadata"
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_with_write(arctic_library):
     lib = arctic_library
     # When
@@ -794,6 +823,7 @@ def test_prune_previous_versions_with_write(arctic_library):
     assert v3.empty
 
 
+@pytest.mark.storage
 def test_append_documented_example(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3]}, index=pd.date_range(start="1/1/2018", end="1/3/2018"))
@@ -811,6 +841,7 @@ def test_append_documented_example(arctic_library):
     assert_frame_equal(lib.read("symbol", as_of=0).data, df)
 
 
+@pytest.mark.storage
 def test_append_prune_previous_versions(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3]}, index=pd.date_range(start="1/1/2018", end="1/3/2018"))
@@ -826,6 +857,7 @@ def test_append_prune_previous_versions(arctic_library):
     assert ("symbol", 1) in symbols
 
 
+@pytest.mark.storage
 def test_update_documented_example(arctic_library):
     """Test the example given on the `update` docstring."""
     lib = arctic_library
@@ -850,6 +882,7 @@ def test_update_documented_example(arctic_library):
     assert_frame_equal(lib.read("symbol", as_of=0).data, df)
 
 
+@pytest.mark.storage
 def test_update_prune_previous_versions(arctic_library):
     """Test that updating and pruning previous versions does indeed clear previous versions."""
     lib = arctic_library
@@ -868,6 +901,7 @@ def test_update_prune_previous_versions(arctic_library):
     assert ("symbol", 1) in symbols
 
 
+@pytest.mark.storage
 def test_update_with_daterange(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
@@ -881,6 +915,7 @@ def test_update_with_daterange(arctic_library):
     assert_frame_equal(result, update_df)
 
 
+@pytest.mark.storage
 def test_update_with_daterange_no_width(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
@@ -896,6 +931,7 @@ def test_update_with_daterange_no_width(arctic_library):
     )
 
 
+@pytest.mark.storage
 def test_update_with_daterange_multi_index(arctic_library):
     lib = arctic_library
     # Given
@@ -944,6 +980,7 @@ def test_update_with_daterange_multi_index(arctic_library):
     assert_frame_equal(result, pd.DataFrame({"column": [1, 100, 200, 300, 6]}, index=expected_index))
 
 
+@pytest.mark.storage
 def test_update_with_daterange_multi_index_no_width(arctic_library):
     lib = arctic_library
 
@@ -977,6 +1014,7 @@ def test_update_with_daterange_multi_index_no_width(arctic_library):
     assert_frame_equal(result, pd.DataFrame({"column": [1, 100, 200, 4, 5]}, index=index))
 
 
+@pytest.mark.storage
 def test_update_with_daterange_restrictive(arctic_library):
     """Here the update_df cover more dates than date_range. We should only touch data that lies within date_range."""
     lib = arctic_library
@@ -995,6 +1033,7 @@ def test_update_with_daterange_restrictive(arctic_library):
     assert_frame_equal(expected, result)
 
 
+@pytest.mark.storage
 def test_update_with_upsert(arctic_library):
     lib = arctic_library
     with pytest.raises(Exception):
@@ -1019,6 +1058,7 @@ def test_read_with_read_request_form(arctic_library):
     assert_frame_equal(result.data, pd.DataFrame({"A": [1, 2]}))
 
 
+@pytest.mark.storage
 def test_has_symbol(arctic_library):
     lib = arctic_library
     lib.write("symbol", pd.DataFrame())
@@ -1032,6 +1072,7 @@ def test_has_symbol(arctic_library):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SKIP_WIN Numpy strings not supported yet")
+@pytest.mark.storage
 def test_numpy_string(arctic_library):
     arctic_library.write("symbol", np.array(["ab", "cd", "efg"]))
     res = arctic_library.read("symbol").data
@@ -1039,11 +1080,13 @@ def test_numpy_string(arctic_library):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="SKIP_WIN Numpy strings not supported yet")
+@pytest.mark.storage
 def test_numpy_string_fails_on_windows(arctic_library):
     with pytest.raises(ArcticDbNotYetImplemented):
         arctic_library.write("symbol", np.array(["ab", "cd", "efg"]))
 
 
+@pytest.mark.storage
 def test_get_description(arctic_library):
     lib = arctic_library
 
@@ -1094,6 +1137,7 @@ def test_get_description_multiindex(lmdb_library, names):
 
 # See test_write_tz in test_normalization.py for the V1 API equivalent
 @pytest.mark.parametrize("tz", ["UTC", "Europe/Amsterdam"])
+@pytest.mark.storage
 def test_get_description_date_range_tz(arctic_library, tz):
     lib = arctic_library
     sym = "test_get_description_date_range_tz"
@@ -1107,6 +1151,7 @@ def test_get_description_date_range_tz(arctic_library, tz):
     assert end_ts == index[-1]
 
 
+@pytest.mark.storage
 def test_tail(arctic_library):
     lib = arctic_library
 
@@ -1138,6 +1183,7 @@ def test_tail(arctic_library):
     )
 
 
+@pytest.mark.storage
 def test_dedup(arctic_client, lib_name):
     ac = arctic_client
     errors = []
@@ -1156,6 +1202,7 @@ def test_dedup(arctic_client, lib_name):
     assert not errors, "errors occurred:\n" + "\n".join(errors)
 
 
+@pytest.mark.storage
 def test_segment_slicing(arctic_client, lib_name):
     ac = arctic_client
     rows_per_segment = 5
@@ -1262,6 +1309,7 @@ def test_mongo_connection_string_format(connection_string):
 
 
 # See test of same name in test_normalization.py for V1 API equivalent
+@pytest.mark.storage
 def test_norm_failure_error_message(arctic_library):
     lib = arctic_library
     sym = "test_norm_failure_error_message"

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -61,6 +61,7 @@ def generate_dataframe(columns, dt, num_days, num_rows_per_day):
     return pd.concat(dataframes)
 
 
+@pytest.mark.storage
 def test_write_meta_batch_with_as_ofs(arctic_library):
     lib = arctic_library
     num_symbols = 2
@@ -88,6 +89,7 @@ def test_write_meta_batch_with_as_ofs(arctic_library):
             assert results_list[idx].metadata == {"meta_" + str(sym): version}
 
 
+@pytest.mark.storage
 def test_write_metadata_batch_with_none(arctic_library):
     lib = arctic_library
     symbol = "symbol_"
@@ -116,6 +118,7 @@ def test_write_metadata_batch_with_none(arctic_library):
         assert results_read[sym].version == 0
 
 
+@pytest.mark.storage
 def test_read_meta_batch_with_as_ofs(arctic_library):
     lib = arctic_library
 
@@ -142,6 +145,7 @@ def test_read_meta_batch_with_as_ofs(arctic_library):
     assert batch[3].metadata == {"meta2": 1}
 
 
+@pytest.mark.storage
 def test_read_metadata_batch_with_none(arctic_library):
     lib = arctic_library
 
@@ -164,6 +168,7 @@ def test_read_metadata_batch_with_none(arctic_library):
     assert batch[1].version == 0
 
 
+@pytest.mark.storage
 def test_read_metadata_batch_missing_keys(arctic_library):
     lib = arctic_library
 
@@ -209,6 +214,7 @@ def test_read_metadata_batch_missing_keys(arctic_library):
     assert batch[2].metadata == {"meta3": 0}
 
 
+@pytest.mark.storage
 def test_read_metadata_batch_symbol_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -231,6 +237,7 @@ def test_read_metadata_batch_symbol_doesnt_exist(arctic_library):
     assert batch[1].error_category == ErrorCategory.MISSING_DATA
 
 
+@pytest.mark.storage
 def test_read_metadata_batch_version_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -263,6 +270,7 @@ class A:
         return self.id == other.id
 
 
+@pytest.mark.storage
 def test_write_batch_with_pickle_mode(arctic_library):
     """Writing in pickle mode should succeed when the user uses the dedicated method."""
     lib = arctic_library
@@ -275,6 +283,7 @@ def test_write_batch_with_pickle_mode(arctic_library):
     assert lib["test_2"].metadata == "the metadata"
 
 
+@pytest.mark.storage
 def test_write_object_in_batch_without_pickle_mode(arctic_library):
     """Writing outside of pickle mode should fail when the user does not use the dedicated method."""
     lib = arctic_library
@@ -287,6 +296,7 @@ def test_write_object_in_batch_without_pickle_mode(arctic_library):
     )
 
 
+@pytest.mark.storage
 def test_write_object_in_batch_without_pickle_mode_many_symbols(arctic_library):
     """Writing outside of pickle mode should fail when the user does not use the dedicated method."""
     lib = arctic_library
@@ -296,6 +306,7 @@ def test_write_object_in_batch_without_pickle_mode_many_symbols(arctic_library):
     assert "(and more)... 10 data in total have bad types." in message
 
 
+@pytest.mark.storage
 def test_write_batch_duplicate_symbols(arctic_library):
     """Should throw and not write if duplicate symbols are provided."""
     lib = arctic_library
@@ -310,6 +321,7 @@ def test_write_batch_duplicate_symbols(arctic_library):
     assert not lib.list_symbols()
 
 
+@pytest.mark.storage
 def test_write_pickle_batch_duplicate_symbols(arctic_library):
     """Should throw and not write if duplicate symbols are provided."""
     lib = arctic_library
@@ -324,6 +336,7 @@ def test_write_pickle_batch_duplicate_symbols(arctic_library):
     assert not lib.list_symbols()
 
 
+@pytest.mark.storage
 def test_write_pickle_batch_dataerror(library_factory):
     """Only way to trigger a DataError response with write_pickle_batch is to enable dedup and delete previous version's
     index key."""
@@ -359,6 +372,7 @@ def test_write_pickle_batch_dataerror(library_factory):
     assert vit.data == 4
 
 
+@pytest.mark.storage
 def test_write_batch(library_factory):
     """Should be able to write different size of batch of data."""
     lib = library_factory(LibraryOptions(rows_per_segment=10))
@@ -389,6 +403,7 @@ def test_write_batch(library_factory):
         assert_frame_equal(read_batch_result[sym].data, original_dataframe)
 
 
+@pytest.mark.storage
 def test_write_batch_dedup(library_factory):
     """Should be able to write different size of batch of data reusing deduplicated data from previous versions."""
     lib = library_factory(LibraryOptions(rows_per_segment=10, dedup=True))
@@ -429,6 +444,7 @@ def test_write_batch_dedup(library_factory):
             assert data_key_version[s] == 0
 
 
+@pytest.mark.storage
 def test_write_batch_missing_keys_dedup(library_factory):
     """When there is duplicate data to reuse for the current write, we need to access the index key of the previous
     versions in order to refer to the corresponding keys for the deduplicated data."""
@@ -471,6 +487,7 @@ def test_write_batch_missing_keys_dedup(library_factory):
     assert_frame_equal(read_dataframe.data, df2)
 
 
+@pytest.mark.storage
 def test_delete_batch(library_factory, sym):
     lib = library_factory(LibraryOptions(rows_per_segment=2))
     df = pd.DataFrame({"y": np.arange(1000)})
@@ -480,6 +497,7 @@ def test_delete_batch(library_factory, sym):
     assert not lib_tool.find_keys_for_id(KeyType.TABLE_DATA, sym)
 
 
+@pytest.mark.storage
 def test_append_batch(library_factory):
     lib = library_factory(LibraryOptions(rows_per_segment=10))
     assert lib._nvs._lib_cfg.lib_desc.version.write_options.segment_row_size == 10
@@ -527,6 +545,7 @@ def test_append_batch(library_factory):
         assert_frame_equal(read_dataframe.data, original_dataframe)
 
 
+@pytest.mark.storage
 def test_append_batch_missing_keys(arctic_library):
     lib = arctic_library
 
@@ -569,6 +588,7 @@ def test_append_batch_missing_keys(arctic_library):
     assert_frame_equal(read_dataframe.data, pd.concat([df2_write, df2_append]))
 
 
+@pytest.mark.storage
 def test_read_batch_time_stamp(arctic_library):
     """Should be able to read data in batch mode using a timestamp."""
     lib = arctic_library
@@ -603,6 +623,7 @@ def test_read_batch_time_stamp(arctic_library):
         assert_frame_equal(d1.data, d2)
 
 
+@pytest.mark.storage
 def test_read_batch_mixed_request_supported(arctic_library):
     lib = arctic_library
 
@@ -624,6 +645,7 @@ def test_read_batch_mixed_request_supported(arctic_library):
     assert batch[3].data.empty
 
 
+@pytest.mark.storage
 def test_read_batch_with_columns(arctic_library):
     lib = arctic_library
 
@@ -637,6 +659,7 @@ def test_read_batch_with_columns(arctic_library):
     assert_frame_equal(pd.DataFrame({"B": [4, 5, 6], "C": [7, 8, 9]}), batch[0].data)
 
 
+@pytest.mark.storage
 def test_read_batch_overall_query_builder(arctic_library):
     lib = arctic_library
 
@@ -652,6 +675,7 @@ def test_read_batch_overall_query_builder(arctic_library):
     assert_frame_equal(batch[1].data, pd.DataFrame({"a": [4]}))
 
 
+@pytest.mark.storage
 def test_read_batch_per_symbol_query_builder(arctic_library):
     lib = arctic_library
 
@@ -669,6 +693,7 @@ def test_read_batch_per_symbol_query_builder(arctic_library):
     assert_frame_equal(batch[1].data, pd.DataFrame({"a": [4, 6]}))
 
 
+@pytest.mark.storage
 def test_read_batch_as_of(arctic_library):
     lib = arctic_library
 
@@ -685,6 +710,7 @@ def test_read_batch_as_of(arctic_library):
     assert type(batch[1]) == PythonVersionedItem
 
 
+@pytest.mark.storage
 def test_batch_methods_with_negative_as_of(arctic_library):
     lib = arctic_library
     sym = "test_batch_methods_with_negative_as_of"
@@ -707,6 +733,7 @@ def test_batch_methods_with_negative_as_of(arctic_library):
     assert res[1] == lib.get_description(sym, as_of=0)
 
 
+@pytest.mark.storage
 def test_read_batch_date_ranges(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
@@ -727,6 +754,7 @@ def test_read_batch_date_ranges(arctic_library):
     )
 
 
+@pytest.mark.storage
 def test_read_batch_date_ranges_dates_not_times(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
@@ -747,6 +775,7 @@ def test_read_batch_date_ranges_dates_not_times(arctic_library):
     )
 
 
+@pytest.mark.storage
 def test_read_batch_row_ranges(arctic_library):
     lib = arctic_library
     df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range(start="1/1/2018", end="1/4/2018"))
@@ -767,6 +796,7 @@ def test_read_batch_row_ranges(arctic_library):
     )
 
 
+@pytest.mark.storage
 def test_read_batch_overall_query_builder_and_per_request_query_builder_raises(arctic_library):
     lib = arctic_library
 
@@ -781,6 +811,7 @@ def test_read_batch_overall_query_builder_and_per_request_query_builder_raises(a
         lib.read_batch([ReadRequest("s", query_builder=q_1)], query_builder=q_2)
 
 
+@pytest.mark.storage
 def test_read_batch_unhandled_type(arctic_library):
     """Only str and ReadRequest are supported."""
     lib = arctic_library
@@ -789,6 +820,7 @@ def test_read_batch_unhandled_type(arctic_library):
         lib.read_batch([1])
 
 
+@pytest.mark.storage
 def test_read_batch_symbol_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -807,6 +839,7 @@ def test_read_batch_symbol_doesnt_exist(arctic_library):
     assert batch[1].error_category == ErrorCategory.MISSING_DATA
 
 
+@pytest.mark.storage
 def test_read_batch_version_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -834,6 +867,7 @@ def test_read_batch_version_doesnt_exist(arctic_library):
     assert batch[2].error_category == ErrorCategory.MISSING_DATA
 
 
+@pytest.mark.storage
 def test_read_batch_missing_keys(arctic_library):
     lib = arctic_library
 
@@ -882,6 +916,7 @@ def test_read_batch_missing_keys(arctic_library):
     assert batch[2].error_category == ErrorCategory.STORAGE
 
 
+@pytest.mark.storage
 def test_write_metadata_batch_missing_keys(arctic_library):
     lib = arctic_library
 
@@ -916,6 +951,7 @@ def test_write_metadata_batch_missing_keys(arctic_library):
     assert batch[1].error_category == ErrorCategory.STORAGE
 
 
+@pytest.mark.storage
 def test_read_batch_query_builder_missing_keys(arctic_library):
     lib = arctic_library
 
@@ -966,6 +1002,7 @@ def test_read_batch_query_builder_missing_keys(arctic_library):
     assert batch[2].error_category == ErrorCategory.STORAGE
 
 
+@pytest.mark.storage
 def test_get_description_batch_missing_keys(arctic_library):
     lib = arctic_library
 
@@ -1017,6 +1054,7 @@ def test_get_description_batch_missing_keys(arctic_library):
     assert batch[2].sorted == "ASCENDING"
 
 
+@pytest.mark.storage
 def test_get_description_batch_symbol_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -1045,6 +1083,7 @@ def test_get_description_batch_symbol_doesnt_exist(arctic_library):
     assert batch[1].error_category == ErrorCategory.MISSING_DATA
 
 
+@pytest.mark.storage
 def test_get_description_batch_version_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -1084,6 +1123,7 @@ def test_get_description_batch_version_doesnt_exist(arctic_library):
     assert batch[2].error_category == ErrorCategory.MISSING_DATA
 
 
+@pytest.mark.storage
 def test_read_batch_query_builder_symbol_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -1103,6 +1143,7 @@ def test_read_batch_query_builder_symbol_doesnt_exist(arctic_library):
     assert batch[1].error_category == ErrorCategory.MISSING_DATA
 
 
+@pytest.mark.storage
 def test_read_batch_query_builder_version_doesnt_exist(arctic_library):
     lib = arctic_library
 
@@ -1132,6 +1173,7 @@ def test_read_batch_query_builder_version_doesnt_exist(arctic_library):
     assert batch[2].error_category == ErrorCategory.MISSING_DATA
 
 
+@pytest.mark.storage
 def test_delete_version_with_snapshot_batch(arctic_library):
     lib = arctic_library
     sym = "test_delete_version_with_snapshot_batch"
@@ -1152,6 +1194,7 @@ def test_delete_version_with_snapshot_batch(arctic_library):
         assert isinstance(lib.get_description_batch([read_info_request])[0], DataError)
 
 
+@pytest.mark.storage
 def test_get_description_batch(arctic_library):
     lib = arctic_library
 
@@ -1212,6 +1255,7 @@ def test_get_description_batch(arctic_library):
         assert info.sorted == "ASCENDING"
 
 
+@pytest.mark.storage
 def test_get_description_batch_multiple_versions(arctic_library):
     lib = arctic_library
 
@@ -1272,6 +1316,7 @@ def test_get_description_batch_multiple_versions(arctic_library):
         assert info.sorted == "ASCENDING"
 
 
+@pytest.mark.storage
 def test_get_description_batch_high_amount(arctic_library):
     lib = arctic_library
     num_symbols = 10
@@ -1311,6 +1356,7 @@ def test_get_description_batch_high_amount(arctic_library):
                 assert tz == pytz.UTC
 
 
+@pytest.mark.storage
 def test_get_description_batch_empty_nat(arctic_library):
     lib = arctic_library
     num_symbols = 10
@@ -1323,6 +1369,7 @@ def test_get_description_batch_empty_nat(arctic_library):
         assert np.isnat(results_list[sym].date_range[1])
 
 
+@pytest.mark.storage
 def test_read_batch_mixed_with_snapshots(arctic_library):
     num_symbols = 10
     num_versions = 10

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -47,6 +47,7 @@ from tests.util.storage_test import get_s3_storage_config
 from arcticdb.options import ModifiableEnterpriseLibraryOption, ModifiableLibraryOption
 
 
+@pytest.mark.storage
 def test_library_creation_deletion(arctic_client, lib_name):
     ac = arctic_client
     ac.create_library(lib_name)
@@ -76,6 +77,7 @@ def test_library_creation_deletion(arctic_client, lib_name):
         ac.delete_library(lib_name)
 
 
+@pytest.mark.storage
 def test_get_library(arctic_client, lib_name):
     ac = arctic_client
     # Throws if library doesn't exist
@@ -272,6 +274,7 @@ def test_modify_options_background_deletion(lmdb_storage, lib_name):
     assert len(lt.find_keys(KeyType.TABLE_DATA))
 
 
+@pytest.mark.storage
 def test_create_library_with_invalid_name(arctic_client_v1, lib_name):
     ac = arctic_client_v1
     try:
@@ -332,6 +335,7 @@ def test_do_not_persist_s3_details(s3_storage):
         ac.delete_library("test")
 
 
+@pytest.mark.storage
 def test_library_options(arctic_client, lib_name):
     ac = arctic_client
     ac.create_library(f"{lib_name}_default_options")
@@ -366,6 +370,7 @@ def test_library_options(arctic_client, lib_name):
     assert lib._nvs._lib_cfg.lib_desc.version.encoding_version == EncodingVersion.V2
 
 
+@pytest.mark.storage
 def test_separation_between_libraries(arctic_client_v1, lib_name):
     # This fails for mem-backed without the library caching implemented in
     # issue #520 then re-implemented in issue #889

--- a/python/tests/integration/arcticdb/test_finalize_staged_data.py
+++ b/python/tests/integration/arcticdb/test_finalize_staged_data.py
@@ -124,6 +124,7 @@ def concat_all_arrays(*arrays):
 
 @pytest.mark.skip(reason="Problem with named indexes Monday#7941575430")
 @pytest.mark.parametrize("new_version" , [True, False])
+@pytest.mark.storage
 def test_finalize_empty_dataframe(basic_arctic_library, new_version):
     """
         Primary goal of the test is to finalize with staged empty array that has
@@ -378,6 +379,7 @@ def test_finalize_with_upcast_type_new_columns(lmdb_library_dynamic_schema):
     verify_dataframe_column(df=result, row_name="NUMBER2", max_type=last_type_c, expected_array_of_column_values=arr_all_c)
 
 
+@pytest.mark.storage
 def test_finalize_staged_data_long_scenario(basic_arctic_library):
     """
         The purpose of of the test is to assure all staged segments along with their data

--- a/python/tests/integration/arcticdb/test_persistent_storage.py
+++ b/python/tests/integration/arcticdb/test_persistent_storage.py
@@ -1,7 +1,8 @@
 import pytest
 import os
+from arcticdb.storage_fixtures.api import StorageFixture
 from arcticdb.util.test import assert_frame_equal
-from tests.util.mark import PERSISTENT_STORAGE_TESTS_ENABLED, REAL_S3_TESTS_MARK
+from tests.util.mark import PERSISTENT_STORAGE_TESTS_ENABLED, REAL_GCP_TESTS_MARK, REAL_S3_TESTS_MARK
 from tests.util.storage_test import (
     get_seed_libraries,
     generate_pseudo_random_dataframe,
@@ -17,12 +18,14 @@ else:
     LIBRARIES = []
 
 
-@pytest.fixture(params=[pytest.param("REAL_S3", marks=REAL_S3_TESTS_MARK)])
+@pytest.fixture(params=[pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
+                        pytest.param("real_gcp", marks=REAL_GCP_TESTS_MARK)])
 # Only test with encoding version 0 (a.k.a.) for now
 # because there is a problem when older versions try to read configs with a written encoding version
 # def shared_persistent_arctic_client(real_s3_storage_without_clean_up, encoding_version):
-def shared_persistent_arctic_client(real_s3_storage_without_clean_up):
-    return real_s3_storage_without_clean_up.create_arctic()
+def shared_persistent_arctic_client(request):
+    storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage_without_clean_up")
+    return storage_fixture.create_arctic()
 
 
 # TODO: Add a check if the real storage tests are enabled

--- a/python/tests/integration/arcticdb/test_persistent_storage.py
+++ b/python/tests/integration/arcticdb/test_persistent_storage.py
@@ -1,9 +1,9 @@
-import time
+from typing import Generator
 import pytest
 import os
-from arcticdb.arctic import Arctic
-from arcticdb.storage_fixtures.api import StorageFixture
+from arcticdb.arctic import Arctic, Library
 from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.utils import get_logger
 from tests.conftest import real_gcp_storage, real_gcp_storage_without_clean_up, real_s3_storage, real_s3_storage_without_clean_up
 from tests.util.mark import PERSISTENT_STORAGE_TESTS_ENABLED
 from tests.util.storage_test import (
@@ -22,6 +22,8 @@ if PERSISTENT_STORAGE_TESTS_ENABLED:
 else:
     LIBRARIES = []
 
+
+logger = get_logger("persistant_tests")
 
 # Only test with encoding version 0 (a.k.a.) for now
 # because there is a problem when older versions try to read configs with a written encoding version
@@ -43,7 +45,7 @@ def shared_persistent_arctic_client(request):
 def test_real_storage_read(shared_persistent_arctic_client, library):
     ac = shared_persistent_arctic_client
     lib = ac[library]
-    print(f"Storage type: {persistent_test_type()}")
+    logger.info(f"Storage type: {persistent_test_type()}")
     read_persistent_library(lib)
 
 
@@ -51,7 +53,7 @@ def test_real_storage_read(shared_persistent_arctic_client, library):
 def test_real_storage_write(shared_persistent_arctic_client):
     strategy_branch = os.getenv("ARCTICDB_PERSISTENT_STORAGE_STRATEGY_BRANCH")
     library_to_write_to = f"test_{strategy_branch}"
-    print(f"Storage type: {persistent_test_type()}")
+    logger.info(f"Storage type: {persistent_test_type()}")
     ac = shared_persistent_arctic_client
     # There shouldn't be a library with this name present, so delete just in case
     ac.delete_library(library_to_write_to)
@@ -61,82 +63,70 @@ def test_real_storage_write(shared_persistent_arctic_client):
 
 
 @pytest.fixture
-def persistent_arctic_client(request, encoding_version):
+def persistent_arctic_library(request, encoding_version, lib_name) -> Generator[Library, None, None]:
     try:
         if persistent_test_type() == PersistentTestType.GCP:
-            return request.getfixturevalue(real_gcp_storage.__name__).create_arctic(encoding_version=encoding_version)
+            ac: Arctic = request.getfixturevalue(real_gcp_storage.__name__).create_arctic(encoding_version=encoding_version)
         elif persistent_test_type() == PersistentTestType.AWS_S3:
-            return request.getfixturevalue(real_s3_storage.__name__).create_arctic(encoding_version=encoding_version)
+            ac: Arctic =  request.getfixturevalue(real_s3_storage.__name__).create_arctic(encoding_version=encoding_version)
     except Exception as e:
+        logger.info("An error occurred", exc_info=True)
         pytest.skip("No persistence tests selected or error during configuration.")   
+    
+    lib: Library = ac.create_library(lib_name)
+    yield lib
+    ac.delete_library(lib_name)
 
 
 @pytest.mark.parametrize("num_rows", [1_000_000])
 @pytest.mark.storage
-def test_persistent_storage_read_write_large_data_ascending(persistent_arctic_client, num_rows):
-    ac: Arctic = persistent_arctic_client
-    lib_name = "test_persistent_storage_read_write_large_data_ascending1"
-    lib = ac.create_library(lib_name)
+def test_persistent_storage_read_write_large_data_ascending(persistent_arctic_library, num_rows):
+    lib = persistent_arctic_library
 
-    print(f"Storage type: {persistent_test_type()}")
+    logger.info(f"Storage type: {persistent_test_type()}")
     sym = str(num_rows)
     orig_df = generate_ascending_dataframe(num_rows)
-    print(f"Generation complete for {num_rows} rows")
+    logger.info(f"Generation complete for {num_rows} rows")
     lib.write(sym, orig_df)
-    print(f"Write complete")
+    logger.info(f"Write complete")
     result_df = lib.read(sym).data
-    print(f"Read complete")
+    logger.info(f"Read complete")
     assert_frame_equal(result_df, orig_df)
-    print(f"Comparison complete")
-    ac.delete_library(lib_name)
-    print(f"Delete complete")
+    logger.info(f"Comparison complete")
 
 
 @pytest.mark.parametrize("num_rows", [100_000_000])
 @pytest.mark.storage
-def test_persistent_storage_read_write_large_data_random(persistent_arctic_client, num_rows):
-    ac = persistent_arctic_client
-    lib_name = "test_persistent_storage_read_write_large_data_random"
-    print(f"Storage type: {persistent_test_type()}")
-    ac.create_library(lib_name)
-    lib = ac[lib_name]
+def test_persistent_storage_read_write_large_data_random(persistent_arctic_library, num_rows):
+    lib = persistent_arctic_library
 
     sym = str(num_rows)
     orig_df = generate_pseudo_random_dataframe(num_rows)
-    print(f"Generation complete for {num_rows} rows")
+    logger.info(f"Generation complete for {num_rows} rows")
     lib.write(sym, orig_df)
-    print(f"Write complete")
+    logger.info(f"Write complete")
     result_df = lib.read(sym).data
-    print(f"Read complete")
+    logger.info(f"Read complete")
     assert_frame_equal(result_df, orig_df)
-    print(f"Comparison complete")
-    ac.delete_library(lib_name)
-    print(f"Delete complete")
+    logger.info(f"Comparison complete")
 
 
 @pytest.mark.parametrize("num_syms", [1_000])
 @pytest.mark.storage
-def test_persistent_storage_read_write_many_syms(persistent_arctic_client, num_syms, three_col_df):
+def test_persistent_storage_read_write_many_syms(persistent_arctic_library, num_syms, three_col_df):
     # For now, this tests only the breadth (e.g. number of symbols)
     # We have another test, that tests with "deeper" data frames
-    ac: Arctic = persistent_arctic_client
-
-    lib_name = "test_persistent_storage_read_write_many_syms"
-    print(f"Storage type: {persistent_test_type()}")
-    ac.create_library(lib_name)
-    lib = ac[lib_name]
+    lib = persistent_arctic_library
     df = three_col_df()
-    print(f"Writing {num_syms} symbols")
+    logger.info(f"Writing {num_syms} symbols")
     payloads = [WritePayload(f"{sym}_sym", df) for sym in range(num_syms)]
     lib.write_batch(payloads)
 
-    print(f"Reading {num_syms} symbols")
+    logger.info(f"Reading {num_syms} symbols")
     read_reqs = [ReadRequest(f"{sym}_sym") for sym in range(num_syms)]
     results = lib.read_batch(read_reqs)
 
-    print(f"Comparing {num_syms} symbols")
+    logger.info(f"Comparing {num_syms} symbols")
     for res in results:
         result_df = res.data
         assert_frame_equal(result_df, df)
-
-    ac.delete_library(lib_name)

--- a/python/tests/integration/arcticdb/test_persistent_storage.py
+++ b/python/tests/integration/arcticdb/test_persistent_storage.py
@@ -28,6 +28,7 @@ def shared_persistent_arctic_client(real_s3_storage_without_clean_up):
 # TODO: Add a check if the real storage tests are enabled
 @pytest.mark.parametrize("library", LIBRARIES)
 @REAL_S3_TESTS_MARK
+@pytest.mark.storage
 def test_real_s3_storage_read(shared_persistent_arctic_client, library):
     ac = shared_persistent_arctic_client
     lib = ac[library]
@@ -35,6 +36,7 @@ def test_real_s3_storage_read(shared_persistent_arctic_client, library):
 
 
 @REAL_S3_TESTS_MARK
+@pytest.mark.storage
 def test_real_s3_storage_write(shared_persistent_arctic_client):
     strategy_branch = os.getenv("ARCTICDB_PERSISTENT_STORAGE_STRATEGY_BRANCH")
     library_to_write_to = f"test_{strategy_branch}"
@@ -52,6 +54,7 @@ def persistent_arctic_client(real_s3_storage, encoding_version):
 
 
 @pytest.mark.parametrize("num_rows", [1_000_000])
+@pytest.mark.storage
 def test_persistent_storage_read_write_large_data_ascending(persistent_arctic_client, num_rows):
     ac = persistent_arctic_client
     ac.create_library("test_persistent_storage_read_write_large_data_ascending")
@@ -65,6 +68,7 @@ def test_persistent_storage_read_write_large_data_ascending(persistent_arctic_cl
 
 
 @pytest.mark.parametrize("num_rows", [100_000_000])
+@pytest.mark.storage
 def test_persistent_storage_read_write_large_data_random(persistent_arctic_client, num_rows):
     ac = persistent_arctic_client
     ac.create_library("test_persistent_storage_read_write_large_data_random")
@@ -78,6 +82,7 @@ def test_persistent_storage_read_write_large_data_random(persistent_arctic_clien
 
 
 @pytest.mark.parametrize("num_syms", [1_000])
+@pytest.mark.storage
 def test_persistent_storage_read_write_many_syms(persistent_arctic_client, num_syms, three_col_df):
     # For now, this tests only the breadth (e.g. number of symbols)
     # We have another test, that tests with "deeper" data frames

--- a/python/tests/integration/arcticdb/test_persistent_storage.py
+++ b/python/tests/integration/arcticdb/test_persistent_storage.py
@@ -51,9 +51,11 @@ def test_real_s3_storage_write(shared_persistent_arctic_client):
     write_persistent_library(lib, latest=True)
 
 
-@pytest.fixture(params=[pytest.param("REAL_S3", marks=REAL_S3_TESTS_MARK)])
-def persistent_arctic_client(real_s3_storage, encoding_version):
-    return real_s3_storage.create_arctic(encoding_version=encoding_version)
+@pytest.fixture(params=[pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
+                        pytest.param("real_gcp", marks=REAL_GCP_TESTS_MARK)])
+def persistent_arctic_client(request, encoding_version):
+    storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage")
+    return storage_fixture.create_arctic(encoding_version=encoding_version)
 
 
 @pytest.mark.parametrize("num_rows", [1_000_000])

--- a/python/tests/integration/arcticdb/test_persistent_storage.py
+++ b/python/tests/integration/arcticdb/test_persistent_storage.py
@@ -1,12 +1,17 @@
+import time
 import pytest
 import os
+from arcticdb.arctic import Arctic
 from arcticdb.storage_fixtures.api import StorageFixture
 from arcticdb.util.test import assert_frame_equal
-from tests.util.mark import PERSISTENT_STORAGE_TESTS_ENABLED, REAL_GCP_TESTS_MARK, REAL_S3_TESTS_MARK
+from tests.conftest import real_gcp_storage, real_gcp_storage_without_clean_up, real_s3_storage, real_s3_storage_without_clean_up
+from tests.util.mark import PERSISTENT_STORAGE_TESTS_ENABLED
 from tests.util.storage_test import (
+    PersistentTestType,
     get_seed_libraries,
     generate_pseudo_random_dataframe,
     generate_ascending_dataframe,
+    persistent_test_type,
     read_persistent_library,
     write_persistent_library,
 )
@@ -18,31 +23,35 @@ else:
     LIBRARIES = []
 
 
-@pytest.fixture(params=[pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
-                        pytest.param("real_gcp", marks=REAL_GCP_TESTS_MARK)])
 # Only test with encoding version 0 (a.k.a.) for now
 # because there is a problem when older versions try to read configs with a written encoding version
 # def shared_persistent_arctic_client(real_s3_storage_without_clean_up, encoding_version):
+@pytest.fixture
 def shared_persistent_arctic_client(request):
-    storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage_without_clean_up")
-    return storage_fixture.create_arctic()
-
+    try:
+        if persistent_test_type() == PersistentTestType.GCP:
+            return request.getfixturevalue(real_gcp_storage_without_clean_up.__name__).create_arctic()
+        elif persistent_test_type() == PersistentTestType.AWS_S3:
+            return request.getfixturevalue(real_s3_storage_without_clean_up.__name__).create_arctic()
+    except Exception as e:
+        print(e)
+        pytest.skip("No persistence tests selected or error during configuration.")
 
 # TODO: Add a check if the real storage tests are enabled
 @pytest.mark.parametrize("library", LIBRARIES)
-@REAL_S3_TESTS_MARK
 @pytest.mark.storage
-def test_real_s3_storage_read(shared_persistent_arctic_client, library):
+def test_real_storage_read(shared_persistent_arctic_client, library):
     ac = shared_persistent_arctic_client
     lib = ac[library]
+    print(f"Storage type: {persistent_test_type()}")
     read_persistent_library(lib)
 
 
-@REAL_S3_TESTS_MARK
 @pytest.mark.storage
-def test_real_s3_storage_write(shared_persistent_arctic_client):
+def test_real_storage_write(shared_persistent_arctic_client):
     strategy_branch = os.getenv("ARCTICDB_PERSISTENT_STORAGE_STRATEGY_BRANCH")
     library_to_write_to = f"test_{strategy_branch}"
+    print(f"Storage type: {persistent_test_type()}")
     ac = shared_persistent_arctic_client
     # There shouldn't be a library with this name present, so delete just in case
     ac.delete_library(library_to_write_to)
@@ -51,39 +60,58 @@ def test_real_s3_storage_write(shared_persistent_arctic_client):
     write_persistent_library(lib, latest=True)
 
 
-@pytest.fixture(params=[pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
-                        pytest.param("real_gcp", marks=REAL_GCP_TESTS_MARK)])
+@pytest.fixture
 def persistent_arctic_client(request, encoding_version):
-    storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage")
-    return storage_fixture.create_arctic(encoding_version=encoding_version)
+    try:
+        if persistent_test_type() == PersistentTestType.GCP:
+            return request.getfixturevalue(real_gcp_storage.__name__).create_arctic(encoding_version=encoding_version)
+        elif persistent_test_type() == PersistentTestType.AWS_S3:
+            return request.getfixturevalue(real_s3_storage.__name__).create_arctic(encoding_version=encoding_version)
+    except Exception as e:
+        pytest.skip("No persistence tests selected or error during configuration.")   
 
 
 @pytest.mark.parametrize("num_rows", [1_000_000])
 @pytest.mark.storage
 def test_persistent_storage_read_write_large_data_ascending(persistent_arctic_client, num_rows):
-    ac = persistent_arctic_client
-    ac.create_library("test_persistent_storage_read_write_large_data_ascending")
-    lib = ac["test_persistent_storage_read_write_large_data_ascending"]
+    ac: Arctic = persistent_arctic_client
+    lib_name = "test_persistent_storage_read_write_large_data_ascending1"
+    lib = ac.create_library(lib_name)
 
+    print(f"Storage type: {persistent_test_type()}")
     sym = str(num_rows)
     orig_df = generate_ascending_dataframe(num_rows)
+    print(f"Generation complete for {num_rows} rows")
     lib.write(sym, orig_df)
+    print(f"Write complete")
     result_df = lib.read(sym).data
+    print(f"Read complete")
     assert_frame_equal(result_df, orig_df)
+    print(f"Comparison complete")
+    ac.delete_library(lib_name)
+    print(f"Delete complete")
 
 
 @pytest.mark.parametrize("num_rows", [100_000_000])
 @pytest.mark.storage
 def test_persistent_storage_read_write_large_data_random(persistent_arctic_client, num_rows):
     ac = persistent_arctic_client
-    ac.create_library("test_persistent_storage_read_write_large_data_random")
-    lib = ac["test_persistent_storage_read_write_large_data_random"]
+    lib_name = "test_persistent_storage_read_write_large_data_random"
+    print(f"Storage type: {persistent_test_type()}")
+    ac.create_library(lib_name)
+    lib = ac[lib_name]
 
     sym = str(num_rows)
     orig_df = generate_pseudo_random_dataframe(num_rows)
+    print(f"Generation complete for {num_rows} rows")
     lib.write(sym, orig_df)
+    print(f"Write complete")
     result_df = lib.read(sym).data
+    print(f"Read complete")
     assert_frame_equal(result_df, orig_df)
+    print(f"Comparison complete")
+    ac.delete_library(lib_name)
+    print(f"Delete complete")
 
 
 @pytest.mark.parametrize("num_syms", [1_000])
@@ -91,9 +119,12 @@ def test_persistent_storage_read_write_large_data_random(persistent_arctic_clien
 def test_persistent_storage_read_write_many_syms(persistent_arctic_client, num_syms, three_col_df):
     # For now, this tests only the breadth (e.g. number of symbols)
     # We have another test, that tests with "deeper" data frames
-    ac = persistent_arctic_client
-    ac.create_library("test_persistent_storage_read_write_many_syms")
-    lib = ac["test_persistent_storage_read_write_many_syms"]
+    ac: Arctic = persistent_arctic_client
+
+    lib_name = "test_persistent_storage_read_write_many_syms"
+    print(f"Storage type: {persistent_test_type()}")
+    ac.create_library(lib_name)
+    lib = ac[lib_name]
     df = three_col_df()
     print(f"Writing {num_syms} symbols")
     payloads = [WritePayload(f"{sym}_sym", df) for sym in range(num_syms)]
@@ -107,3 +138,5 @@ def test_persistent_storage_read_write_many_syms(persistent_arctic_client, num_s
     for res in results:
         result_df = res.data
         assert_frame_equal(result_df, df)
+
+    ac.delete_library(lib_name)

--- a/python/tests/integration/arcticdb/test_read_batch_more.py
+++ b/python/tests/integration/arcticdb/test_read_batch_more.py
@@ -46,6 +46,7 @@ def generate_mixed_dataframe(num_rows: int, seed=0):
     return result
 
 
+@pytest.mark.storage
 def test_read_batch_2tables_7reads_different_slices(arctic_library):
     """
         Test aims to check if combined read of couple of DF, with several 
@@ -136,6 +137,7 @@ def test_read_batch_2tables_7reads_different_slices(arctic_library):
     assert_frame_equal(df2_0_allfilters, batch[7].data)
 
 @pytest.mark.xfail(reason = "ArcticDB#1970")
+@pytest.mark.storage
 def test_read_batch_query_with_and(arctic_library):
     """
         A very small test to isolate the problem with usage of "and" 
@@ -160,6 +162,7 @@ def test_read_batch_query_with_and(arctic_library):
     assert batch[0].symbol == symbol
     assert isinstance(batch[0], DataError)
 
+@pytest.mark.storage
 def test_read_batch_metadata_on_different_version(arctic_library):
     """
         Here we test if read of metadata over several different states of DB with
@@ -223,6 +226,8 @@ def test_read_batch_metadata_on_different_version(arctic_library):
     assert_frame_equal_rebuild_index_first(df_till1, batch[3].data)
     assert_frame_equal_rebuild_index_first(df_all, batch[2].data)
 
+
+@pytest.mark.storage
 def test_read_batch_multiple_symbols_all_types_data_query_metadata(arctic_library):
     """
         This test aims to combine usage of metadata along with query builder applied in 
@@ -316,6 +321,8 @@ def test_read_batch_multiple_symbols_all_types_data_query_metadata(arctic_librar
         assert dfqapplied.shape[0] == batch[7].data.shape[0]
         assert dfqapplied.columns.to_list() == batch[7].data.columns.to_list()
 
+
+@pytest.mark.storage
 def test_read_batch_multiple_wrong_things_at_once(arctic_library):
     """
         Check that many types of errors cannot prevent exraction of many other
@@ -364,7 +371,9 @@ def test_read_batch_multiple_wrong_things_at_once(arctic_library):
     df = df1_0.query(qdf)
     assert_frame_equal_rebuild_index_first(df, batch[5].data)
 
+
 @pytest.mark.xfail(reason = "ArcticDB#2004")
+@pytest.mark.storage
 def test_read_batch_query_and_columns_returned_order(arctic_library):
     '''
         Column order is expected to match the 'columns' attribute lits
@@ -387,7 +396,9 @@ def test_read_batch_query_and_columns_returned_order(arctic_library):
     df_filtered = q(df)[columns]
     assert_frame_equal_rebuild_index_first(df_filtered, batch[0].data)
 
+
 @pytest.mark.xfail(reason = "ArcticDB#2005")
+@pytest.mark.storage
 def test_read_batch_query_and_columns_wrong_column_names_passed(arctic_library):
     '''
         Allong with existing column names if we pass non exising names of 
@@ -410,6 +421,8 @@ def test_read_batch_query_and_columns_wrong_column_names_passed(arctic_library):
 
     assert isinstance(batch[0], DataError)    
 
+
+@pytest.mark.storage
 def test_read_batch_query_and_columns(arctic_library):
 
     def q1(q):

--- a/python/tests/integration/arcticdb/test_storage_lock.py
+++ b/python/tests/integration/arcticdb/test_storage_lock.py
@@ -15,10 +15,10 @@ from multiprocessing import Process
 one_sec = 1_000_000_000
 
 
-def slow_increment_task(real_s3_storage_factory, lib_name, symbol, sleep_time):
+def slow_increment_task(real_storage_factory, lib_name, symbol, sleep_time):
     # We need to explicitly build the library object in each process, otherwise the s3 library doesn't get copied
     # properly between processes, and we get spurious `XAmzContentSHA256Mismatch` errors.
-    fixture = real_s3_storage_factory.create_fixture()
+    fixture = real_storage_factory.create_fixture()
     lib = fixture.create_arctic()[lib_name]
     lock = ReliableStorageLock("test_lock", lib._nvs._library, 10 * one_sec)
     lock_manager = ReliableStorageLockManager()
@@ -33,8 +33,8 @@ def slow_increment_task(real_s3_storage_factory, lib_name, symbol, sleep_time):
 @pytest.mark.parametrize("num_processes,max_sleep", [(100, 1), (5, 20)])
 @REAL_S3_TESTS_MARK
 @pytest.mark.storage
-def test_many_increments(real_s3_storage_factory, lib_name, num_processes, max_sleep):
-    fixture = real_s3_storage_factory.create_fixture()
+def test_many_increments(real_storage_factory, lib_name, num_processes, max_sleep):
+    fixture = real_storage_factory.create_fixture()
     lib = fixture.create_arctic().create_library(lib_name)
     init_df = pd.DataFrame({"col": [0]})
     symbol = "counter"
@@ -42,7 +42,7 @@ def test_many_increments(real_s3_storage_factory, lib_name, num_processes, max_s
     lib.write(symbol, init_df)
 
     processes = [
-        Process(target=slow_increment_task, args=(real_s3_storage_factory, lib_name, symbol, 0 if i % 2 == 0 else max_sleep))
+        Process(target=slow_increment_task, args=(real_storage_factory, lib_name, symbol, 0 if i % 2 == 0 else max_sleep))
         for i in range(num_processes)
     ]
     for p in processes:

--- a/python/tests/integration/arcticdb/test_storage_lock.py
+++ b/python/tests/integration/arcticdb/test_storage_lock.py
@@ -32,6 +32,7 @@ def slow_increment_task(real_s3_storage_factory, lib_name, symbol, sleep_time):
 
 @pytest.mark.parametrize("num_processes,max_sleep", [(100, 1), (5, 20)])
 @REAL_S3_TESTS_MARK
+@pytest.mark.storage
 def test_many_increments(real_s3_storage_factory, lib_name, num_processes, max_sleep):
     fixture = real_s3_storage_factory.create_fixture()
     lib = fixture.create_arctic().create_library(lib_name)

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -65,6 +65,7 @@ def assert_equal(received, expected):
     assert received.equals(expected)
 
 
+@pytest.mark.storage
 def test_simple_flow(basic_store_no_symbol_list, symbol):
     df = sample_dataframe()
     modified_df = pd.DataFrame({"col": [1, 2, 3, 4]})
@@ -80,6 +81,7 @@ def test_simple_flow(basic_store_no_symbol_list, symbol):
     assert basic_store_no_symbol_list.list_symbols() == basic_store_no_symbol_list.list_versions() == []
 
 
+@pytest.mark.storage
 def test_special_chars(object_version_store):
     """Test chars with special URI encoding under RFC 3986"""
     errors = []
@@ -97,6 +99,7 @@ def test_special_chars(object_version_store):
 
 
 @pytest.mark.parametrize("breaking_char", [chr(0), "\0", "*", "<", ">"])
+@pytest.mark.storage
 def test_s3_breaking_chars(object_version_store, breaking_char):
     """Test that chars that are not supported are raising the appropriate exception and that we fail on write without
     corrupting the db.
@@ -110,6 +113,7 @@ def test_s3_breaking_chars(object_version_store, breaking_char):
 
 
 @pytest.mark.parametrize("unhandled_char", [chr(0), chr(30), chr(127), chr(128)])
+@pytest.mark.storage
 def test_unhandled_chars_default(object_version_store, unhandled_char):
     """Test that by default, the problematic chars are raising an exception"""
     sym = f"prefix{unhandled_char}postfix"
@@ -121,6 +125,7 @@ def test_unhandled_chars_default(object_version_store, unhandled_char):
 
 
 @pytest.mark.parametrize("unhandled_char", [chr(0), chr(30), chr(127), chr(128)])
+@pytest.mark.storage
 def test_unhandled_chars_update_upsert(object_version_store, unhandled_char):
     df = pd.DataFrame(
         {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
@@ -133,6 +138,7 @@ def test_unhandled_chars_update_upsert(object_version_store, unhandled_char):
 
 
 @pytest.mark.parametrize("unhandled_char", [chr(0), chr(30), chr(127), chr(128)])
+@pytest.mark.storage
 def test_unhandled_chars_append(object_version_store, unhandled_char):
     df = pd.DataFrame(
         {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
@@ -145,6 +151,7 @@ def test_unhandled_chars_append(object_version_store, unhandled_char):
 
 
 @pytest.mark.parametrize("unhandled_char", [chr(127), chr(128)])
+@pytest.mark.storage
 def test_unhandled_chars_already_present_write(object_version_store, three_col_df, unhandled_char):
     sym = f"prefix{unhandled_char}postfix"
     with config_context("VersionStore.NoStrictSymbolCheck", 1):
@@ -156,6 +163,7 @@ def test_unhandled_chars_already_present_write(object_version_store, three_col_d
 
 
 @pytest.mark.parametrize("unhandled_char", [chr(127), chr(128)])
+@pytest.mark.storage
 def test_unhandled_chars_already_present_append(object_version_store, three_col_df, unhandled_char):
     sym = f"prefix{unhandled_char}postfix"
     with config_context("VersionStore.NoStrictSymbolCheck", 1):
@@ -169,6 +177,7 @@ def test_unhandled_chars_already_present_append(object_version_store, three_col_
 
 
 @pytest.mark.parametrize("unhandled_char", [chr(127), chr(128)])
+@pytest.mark.storage
 def test_unhandled_chars_already_present_update(object_version_store, unhandled_char):
     df = pd.DataFrame(
         {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
@@ -188,6 +197,7 @@ def test_unhandled_chars_already_present_update(object_version_store, unhandled_
 
 
 # See AN-765 for why we need no_symbol_list fixture
+@pytest.mark.storage
 def test_large_symbols(basic_store_no_symbol_list):
     # The following restrictions should be checked in the cpp layer's name_validation
     MAX_SYMBOL_SIZE = 254
@@ -200,6 +210,7 @@ def test_large_symbols(basic_store_no_symbol_list):
     assert basic_store_no_symbol_list.read(valid_sized_sym).data == 1
 
 
+@pytest.mark.storage
 def test_empty_symbol_name_2(object_version_store):
     lib = object_version_store
     df = sample_dataframe()
@@ -247,6 +258,7 @@ def test_empty_snapshot_name(lmdb_version_store_v1, method):
     assert "snapshot" in str(e.value).lower()
 
 
+@pytest.mark.storage
 def test_with_prune(object_and_mem_and_lmdb_version_store, symbol):
     version_store = object_and_mem_and_lmdb_version_store
     df = sample_dataframe()
@@ -270,6 +282,7 @@ def test_with_prune(object_and_mem_and_lmdb_version_store, symbol):
     assert_equal(version_store.read(symbol, as_of="my_snap2").data, final_df)
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_explicit_method(basic_store, symbol):
     # Given
     df = sample_dataframe()
@@ -292,6 +305,7 @@ def test_prune_previous_versions_explicit_method(basic_store, symbol):
     assert_equal(basic_store.read(symbol, as_of="my_snap").data, modified_df)
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_nothing_to_do(basic_store, symbol):
     df = sample_dataframe()
     basic_store.write(symbol, df)
@@ -306,6 +320,7 @@ def test_prune_previous_versions_nothing_to_do(basic_store, symbol):
     assert len([ver for ver in basic_store.list_versions(symbol) if not ver["deleted"]]) == 1
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_no_snapshot(basic_store, symbol):
     # Given
     df = sample_dataframe()
@@ -325,6 +340,7 @@ def test_prune_previous_versions_no_snapshot(basic_store, symbol):
     assert len([ver for ver in basic_store.list_versions() if not ver["deleted"]]) == 1
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_multiple_times(basic_store, symbol):
     # Given
     df = sample_dataframe()
@@ -349,6 +365,7 @@ def test_prune_previous_versions_multiple_times(basic_store, symbol):
     assert len([ver for ver in basic_store.list_versions() if not ver["deleted"]]) == 1
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_write_batch(basic_store):
     """Verify that the batch write method correctly prunes previous versions when the corresponding option is specified."""
     # Given
@@ -379,6 +396,7 @@ def test_prune_previous_versions_write_batch(basic_store):
     assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 4
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_batch_write_metadata(basic_store):
     """Verify that the batch write metadata method correctly prunes previous versions when the corresponding option is specified."""
     # Given
@@ -409,6 +427,7 @@ def test_prune_previous_versions_batch_write_metadata(basic_store):
     assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
 
 
+@pytest.mark.storage
 def test_prune_previous_versions_append_batch(basic_store):
     """Verify that the batch append method correctly prunes previous versions when the corresponding option is specified."""
     # Given
@@ -439,6 +458,7 @@ def test_prune_previous_versions_append_batch(basic_store):
     assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 4
 
 
+@pytest.mark.storage
 def test_deleting_unknown_symbol(basic_store, symbol):
     df = sample_dataframe()
 
@@ -450,6 +470,7 @@ def test_deleting_unknown_symbol(basic_store, symbol):
     basic_store.delete("does_not_exist")
 
 
+@pytest.mark.storage
 def test_negative_cases(basic_store, symbol):
     df = sample_dataframe()
     # To stay consistent with arctic this doesn't throw.
@@ -497,6 +518,7 @@ def test_list_symbols_regex(request, lib_type):
     assert list(sorted(lib.list_symbols())) == sorted(["asdf", "furble"])
 
 
+@pytest.mark.storage
 def test_list_symbols_prefix(object_version_store):
     blahs = ["blah_asdf201901", "blah_asdf201802", "blah_asdf201803", "blah_asdf201903"]
     nahs = ["nah_asdf201801", "nah_asdf201802", "nah_asdf201803"]
@@ -508,17 +530,20 @@ def test_list_symbols_prefix(object_version_store):
     assert set(object_version_store.list_symbols(prefix="nah_")) == set(nahs)
 
 
+@pytest.mark.storage
 def test_mixed_df_without_pickling_enabled(basic_store):
     mixed_type_df = pd.DataFrame({"a": [1, 2, "a"]})
     with pytest.raises(Exception):
         basic_store.write("sym", mixed_type_df)
 
 
+@pytest.mark.storage
 def test_dataframe_fallback_with_pickling_enabled(basic_store_allows_pickling):
     mixed_type_df = pd.DataFrame({"a": [1, 2, "a", None]})
     basic_store_allows_pickling.write("sym", mixed_type_df)
 
 
+@pytest.mark.storage
 def test_range_index(basic_store, sym):
     d1 = {
         "x": np.arange(10, 20, dtype=np.int64),
@@ -539,6 +564,7 @@ def test_range_index(basic_store, sym):
 
 @pytest.mark.pipeline
 @pytest.mark.parametrize("use_date_range_clause", [True, False])
+@pytest.mark.storage
 def test_date_range(basic_store, use_date_range_clause):
     initial_timestamp = pd.Timestamp("2019-01-01")
     df = pd.DataFrame(data=np.arange(100), index=pd.date_range(initial_timestamp, periods=100))
@@ -587,6 +613,7 @@ def test_date_range(basic_store, use_date_range_clause):
 
 @pytest.mark.pipeline
 @pytest.mark.parametrize("use_date_range_clause", [True, False])
+@pytest.mark.storage
 def test_date_range_none(basic_store, use_date_range_clause):
     sym = "date_test2"
     rows = 100
@@ -606,6 +633,7 @@ def test_date_range_none(basic_store, use_date_range_clause):
 
 @pytest.mark.pipeline
 @pytest.mark.parametrize("use_date_range_clause", [True, False])
+@pytest.mark.storage
 def test_date_range_start_equals_end(basic_store, use_date_range_clause):
     sym = "date_test2"
     rows = 100
@@ -628,6 +656,7 @@ def test_date_range_start_equals_end(basic_store, use_date_range_clause):
 
 @pytest.mark.pipeline
 @pytest.mark.parametrize("use_date_range_clause", [True, False])
+@pytest.mark.storage
 def test_date_range_row_sliced(basic_store_tiny_segment, use_date_range_clause):
     lib = basic_store_tiny_segment
     sym = "test_date_range_row_sliced"
@@ -656,6 +685,7 @@ def test_date_range_row_sliced(basic_store_tiny_segment, use_date_range_clause):
     assert_equal(expected, received)
 
 
+@pytest.mark.storage
 def test_get_info(basic_store):
     sym = "get_info_test"
     df = pd.DataFrame(data={"col1": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))
@@ -669,6 +699,7 @@ def test_get_info(basic_store):
     assert info["index_type"] == "index"
 
 
+@pytest.mark.storage
 def test_get_info_version(object_and_mem_and_lmdb_version_store):
     lib = object_and_mem_and_lmdb_version_store
     # given
@@ -690,6 +721,7 @@ def test_get_info_version(object_and_mem_and_lmdb_version_store):
     assert info_1["last_update"] > info_0["last_update"]
 
 
+@pytest.mark.storage
 def test_get_info_date_range(basic_store):
     # given
     sym = "test_get_info_date_range"
@@ -709,6 +741,7 @@ def test_get_info_date_range(basic_store):
     assert info_0["date_range"] == basic_store.get_timerange_for_symbol(sym, version=0)
 
 
+@pytest.mark.storage
 def test_get_info_version_no_columns_nat(basic_store):
     sym = "test_get_info_version_no_columns_nat"
     column_names = ["a", "b", "c"]
@@ -720,6 +753,7 @@ def test_get_info_version_no_columns_nat(basic_store):
     assert np.isnat(info["date_range"][1])
 
 
+@pytest.mark.storage
 def test_get_info_version_empty_nat(basic_store):
     sym = "test_get_info_version_empty_nat"
     basic_store.write(sym, pd.DataFrame())
@@ -728,6 +762,7 @@ def test_get_info_version_empty_nat(basic_store):
     assert np.isnat(info["date_range"][1])
 
 
+@pytest.mark.storage
 def test_get_info_non_timestamp_index_date_range(basic_store):
     lib = basic_store
     sym = "test_get_info_non_timestamp_index_date_range"
@@ -743,6 +778,7 @@ def test_get_info_non_timestamp_index_date_range(basic_store):
     assert np.isnat(info["date_range"][1])
 
 
+@pytest.mark.storage
 def test_get_info_unsorted_timestamp_index_date_range(basic_store):
     lib = basic_store
     sym = "test_get_info_unsorted_timestamp_index_date_range"
@@ -758,6 +794,7 @@ def test_get_info_unsorted_timestamp_index_date_range(basic_store):
     assert np.isnat(info["date_range"][1])
 
 
+@pytest.mark.storage
 def test_get_info_pickled(basic_store):
     lib = basic_store
     sym = "test_get_info_pickled"
@@ -770,6 +807,7 @@ def test_get_info_pickled(basic_store):
     assert info["rows"] is None
 
 
+@pytest.mark.storage
 def test_batch_get_info_pickled(basic_store):
     lib = basic_store
     sym = "test_get_info_pickled"
@@ -782,6 +820,7 @@ def test_batch_get_info_pickled(basic_store):
     assert info["rows"] is None
 
 
+@pytest.mark.storage
 def test_update_times(basic_store):
     # given
     df = pd.DataFrame(data={"col1": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))
@@ -802,6 +841,7 @@ def test_update_times(basic_store):
     assert update_times_versioned[0] < update_times_versioned[1] < update_times_versioned[2]
 
 
+@pytest.mark.storage
 def test_get_info_multi_index(basic_store):
     dtidx = pd.date_range(pd.Timestamp("2016-01-01"), periods=3)
     vals = np.arange(3, dtype=np.uint32)
@@ -816,6 +856,7 @@ def test_get_info_multi_index(basic_store):
     assert info["index_type"] == "multi_index"
 
 
+@pytest.mark.storage
 def test_get_info_index_column(basic_store, sym):
     df = pd.DataFrame([[1, 2, 3, 4, 5, 6]], columns=["A", "B", "C", "D", "E", "F"])
 
@@ -840,6 +881,7 @@ def test_get_info_index_column(basic_store, sym):
     assert info["col_names"]["columns"] == ["C", "D", "E", "F"]
 
 
+@pytest.mark.storage
 def test_empty_pd_series(basic_store):
     sym = "empty_s"
     series = pd.Series()
@@ -851,6 +893,7 @@ def test_empty_pd_series(basic_store):
     assert basic_store.read(sym).data.empty
 
 
+@pytest.mark.storage
 def test_empty_df(basic_store):
     sym = "empty_s"
     df = pd.DataFrame()
@@ -863,6 +906,7 @@ def test_empty_df(basic_store):
     assert basic_store.read(sym).data.empty
 
 
+@pytest.mark.storage
 def test_empty_ndarr(basic_store):
     sym = "empty_s"
     ndarr = np.array([])
@@ -882,6 +926,7 @@ def test_partial_read_pickled_df(basic_store):
         basic_store.read("blah", date_range=(DateRange(pd.Timestamp("1970-01-01"), pd.Timestamp("2027-12-31"))))
 
 
+@pytest.mark.storage
 def test_is_pickled(basic_store):
     will_be_pickled = [1, 2, 3]
     basic_store.write("blah", will_be_pickled)
@@ -892,6 +937,7 @@ def test_is_pickled(basic_store):
     assert basic_store.is_symbol_pickled("normal") is False
 
 
+@pytest.mark.storage
 def test_is_pickled_by_version(basic_store):
     symbol = "test"
     will_be_pickled = [1, 2, 3]
@@ -905,6 +951,7 @@ def test_is_pickled_by_version(basic_store):
     assert basic_store.is_symbol_pickled(symbol, 1) is False
 
 
+@pytest.mark.storage
 def test_is_pickled_by_snapshot(basic_store):
     symbol = "test"
     will_be_pickled = [1, 2, 3]
@@ -922,6 +969,7 @@ def test_is_pickled_by_snapshot(basic_store):
     assert basic_store.is_symbol_pickled(symbol, snap2) is False
 
 
+@pytest.mark.storage
 def test_is_pickled_by_timestamp(basic_store):
     symbol = "test"
     will_be_pickled = [1, 2, 3]
@@ -939,6 +987,7 @@ def test_is_pickled_by_timestamp(basic_store):
     assert basic_store.is_symbol_pickled(symbol, pd.Timestamp(np.iinfo(np.int64).max)) is False
 
 
+@pytest.mark.storage
 def test_list_versions(object_and_mem_and_lmdb_version_store):
     version_store = object_and_mem_and_lmdb_version_store
     version_store.write("a", 1)  # a, v0
@@ -970,6 +1019,7 @@ def test_list_versions(object_and_mem_and_lmdb_version_store):
     assert get_tuples_from_version_info(version_store.list_versions(snapshot="snap3")) == {("a", 2), ("b", 1), ("c", 1)}
 
 
+@pytest.mark.storage
 def test_list_versions_deleted_flag(basic_store):
     basic_store.write("symbol", pd.DataFrame(), metadata=1)
     basic_store.write("symbol", pd.DataFrame(), metadata=2, prune_previous_version=False)
@@ -995,6 +1045,7 @@ def test_list_versions_deleted_flag(basic_store):
     assert versions[2]["snapshots"] == ["snapshot"]
 
 
+@pytest.mark.storage
 def test_list_versions_with_snapshots(basic_store):
     lib = basic_store
     lib.write("a", 0)  # v0
@@ -1016,6 +1067,7 @@ def test_list_versions_with_snapshots(basic_store):
     assert set([v["snapshots"] for v in items_for_a if v["version"] == 1][0]) == {"snap2", "snap3"}
 
 
+@pytest.mark.storage
 def test_read_ts(basic_store):
     with distinct_timestamps(basic_store) as first_write_timestamps:
         basic_store.write("a", 1)  # v0
@@ -1052,6 +1104,7 @@ def test_read_ts(basic_store):
     assert vitem.data == 1
 
 
+@pytest.mark.storage
 def test_negative_strides(basic_store_tiny_segment):
     lmdb_version_store = basic_store_tiny_segment
     negative_stride_np = np.array([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]], np.int32)[::-1]
@@ -1064,6 +1117,7 @@ def test_negative_strides(basic_store_tiny_segment):
     assert_equal(negative_stride_df, vit2.data)
 
 
+@pytest.mark.storage
 def test_dynamic_strings(basic_store):
     row = pd.Series(["A", "B", "C", "Aaba", "Baca", "CABA", "dog", "cat"])
     df = pd.DataFrame({"x": row})
@@ -1072,6 +1126,7 @@ def test_dynamic_strings(basic_store):
     assert_equal(vit.data, df)
 
 
+@pytest.mark.storage
 def test_dynamic_strings_non_contiguous(basic_store):
     df = sample_dataframe_only_strings(100, 0, 100)
     series = df.iloc[-1]
@@ -1081,6 +1136,7 @@ def test_dynamic_strings_non_contiguous(basic_store):
     assert_series_equal(vit.data, series)
 
 
+@pytest.mark.storage
 def test_dynamic_strings_with_none(basic_store):
     row = pd.Series(
         [
@@ -1104,6 +1160,7 @@ def test_dynamic_strings_with_none(basic_store):
     assert_equal(vit.data, df)
 
 
+@pytest.mark.storage
 def test_dynamic_strings_with_none_first_element(basic_store):
     row = pd.Series(
         [
@@ -1128,6 +1185,7 @@ def test_dynamic_strings_with_none_first_element(basic_store):
     assert_equal(vit.data, df)
 
 
+@pytest.mark.storage
 def test_dynamic_strings_with_all_nones(basic_store):
     df = pd.DataFrame({"x": [None, None]})
     basic_store.write("strings", df, dynamic_strings=True)
@@ -1136,6 +1194,7 @@ def test_dynamic_strings_with_all_nones(basic_store):
     assert data.data["x"][1] is None
 
 
+@pytest.mark.storage
 def test_dynamic_strings_with_all_nones_update(basic_store):
     df = pd.DataFrame(
         {"col_1": ["a", "b"], "col_2": [0.1, 0.2]}, index=[pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")]
@@ -1161,6 +1220,7 @@ def test_dynamic_strings_with_all_nones_update(basic_store):
     assert data.data["col_1"][pd.Timestamp("2022-01-02")] == "b"
 
 
+@pytest.mark.storage
 def test_dynamic_strings_with_nan(basic_store):
     row = pd.Series(
         [
@@ -1186,6 +1246,7 @@ def test_dynamic_strings_with_nan(basic_store):
     assert_equal(vit.data, df)
 
 
+@pytest.mark.storage
 def test_metadata_with_snapshots(basic_store):
     symbol_metadata1 = {"test": "data_meta"}
     symbol_metadata2 = {"test": "should_not_be_returned"}
@@ -1207,6 +1268,7 @@ def test_named_tuple_flattening_rejected():
     assert fl.can_flatten(nt) is False
 
 
+@pytest.mark.storage
 def test_batch_operations(object_version_store_prune_previous):
     multi_data = {"sym1": np.arange(8), "sym2": np.arange(9), "sym3": np.arange(10)}
 
@@ -1219,6 +1281,7 @@ def test_batch_operations(object_version_store_prune_previous):
         equals(result["sym3"].data, np.arange(10))
 
 
+@pytest.mark.storage
 def test_batch_write(basic_store_tombstone_and_sync_passive):
     lmdb_version_store = basic_store_tombstone_and_sync_passive
     multi_data = {"sym1": np.arange(8), "sym2": np.arange(9), "sym3": np.arange(10)}
@@ -1243,6 +1306,7 @@ def test_batch_write(basic_store_tombstone_and_sync_passive):
     assert len(lmdb_version_store.list_versions()) == 6
 
 
+@pytest.mark.storage
 def test_batch_write_then_read(basic_store):
     symbol = "sym_d_1"
     data = pd.Series(index=[0], data=[1])
@@ -1256,6 +1320,7 @@ def test_batch_write_then_read(basic_store):
     basic_store.read(symbol)
 
 
+@pytest.mark.storage
 def test_batch_write_then_list_symbol_without_cache(basic_store_factory):
     factory = basic_store_factory
     lib = factory(symbol_list=False, segment_row_size=10)
@@ -1267,6 +1332,7 @@ def test_batch_write_then_list_symbol_without_cache(basic_store_factory):
         assert set(lib.list_symbols()) == set(symbols)
 
 
+@pytest.mark.storage
 def test_batch_write_missing_keys_dedup(basic_store_factory):
     """When there is duplicate data to reuse for the current write, we need to access the index key of the previous
     versions in order to refer to the corresponding keys for the deduplicated data."""
@@ -1286,6 +1352,7 @@ def test_batch_write_missing_keys_dedup(basic_store_factory):
         lib.batch_write(["s1", "s2"], [df1, df2])
 
 
+@pytest.mark.storage
 def test_batch_write_metadata_missing_keys(basic_store):
     lib = basic_store
 
@@ -1303,6 +1370,7 @@ def test_batch_write_metadata_missing_keys(basic_store):
         _ = lib.batch_write_metadata(["s1", "s2"], [{"s1_meta": 1}, {"s2_meta": 1}])
 
 
+@pytest.mark.storage
 def test_batch_read_metadata_missing_keys(basic_store):
     lib = basic_store
 
@@ -1332,6 +1400,7 @@ def test_batch_read_metadata_missing_keys(basic_store):
         _ = lib.batch_read_metadata(["s2"], [0])
 
 
+@pytest.mark.storage
 def test_batch_read_metadata_multi_missing_keys(basic_store):
     lib = basic_store
     lib_tool = lib.library_tool()
@@ -1344,6 +1413,7 @@ def test_batch_read_metadata_multi_missing_keys(basic_store):
         _ = lib.batch_read_metadata_multi(["s1"], [None])
 
 
+@pytest.mark.storage
 def test_batch_read_missing_keys(basic_store):
     lib = basic_store
     lib.version_store._set_validate_version_map()
@@ -1372,6 +1442,7 @@ def test_batch_read_missing_keys(basic_store):
         _ = lib.batch_read(["s1", "s2", "s3"], [None, None, 0])
 
 
+@pytest.mark.storage
 def test_batch_get_info_missing_keys(basic_store):
     lib = basic_store
     lib.version_store._set_validate_version_map()
@@ -1399,6 +1470,7 @@ def test_batch_get_info_missing_keys(basic_store):
         _ = lib.batch_get_info(["s2"], [0])
 
 
+@pytest.mark.storage
 def test_batch_roundtrip_metadata(basic_store_tombstone_and_sync_passive):
     lib = basic_store_tombstone_and_sync_passive
 
@@ -1424,6 +1496,7 @@ def test_batch_roundtrip_metadata(basic_store_tombstone_and_sync_passive):
         assert returned.metadata == metadatas[sym]
 
 
+@pytest.mark.storage
 def test_write_composite_data_with_user_meta(basic_store):
     multi_data = {"sym1": np.arange(8), "sym2": np.arange(9), "sym3": np.arange(10)}
     basic_store.write("sym", multi_data, metadata={"a": 1})
@@ -1432,6 +1505,7 @@ def test_write_composite_data_with_user_meta(basic_store):
     equals(vitem.data["sym1"], np.arange(8))
 
 
+@pytest.mark.storage
 def test_force_delete(basic_store):
     df1 = sample_dataframe()
     basic_store.write("sym1", df1)
@@ -1449,6 +1523,7 @@ def test_force_delete(basic_store):
     assert_equal(basic_store.read("sym1", as_of=0).data, df1)
 
 
+@pytest.mark.storage
 def test_force_delete_with_delayed_deletes(basic_store_delayed_deletes):
     df1 = sample_dataframe()
     basic_store_delayed_deletes.write("sym1", df1)
@@ -1466,12 +1541,14 @@ def test_force_delete_with_delayed_deletes(basic_store_delayed_deletes):
     assert_equal(basic_store_delayed_deletes.read("sym1", as_of=0).data, df1)
 
 
+@pytest.mark.storage
 def test_dataframe_with_NaN_in_timestamp_column(basic_store):
     normal_df = pd.DataFrame({"col": [pd.Timestamp("now"), pd.NaT]})
     basic_store.write("normal", normal_df)
     assert_equal(normal_df, basic_store.read("normal").data)
 
 
+@pytest.mark.storage
 def test_dataframe_with_nan_and_nat_in_timestamp_column(basic_store):
     df_with_NaN_mixed_in_ts = pd.DataFrame({"col": [pd.Timestamp("now"), pd.NaT, np.nan]})
     basic_store.write("mixed_nan", df_with_NaN_mixed_in_ts)
@@ -1480,12 +1557,14 @@ def test_dataframe_with_nan_and_nat_in_timestamp_column(basic_store):
     isinstance(returned_df["col"][2], type(pd.NaT))
 
 
+@pytest.mark.storage
 def test_dataframe_with_nan_and_nat_only(basic_store):
     df_with_nan_and_nat_only = pd.DataFrame({"col": [pd.NaT, pd.NaT, np.nan]})  # Sample will be pd.NaT
     basic_store.write("nan_nat", df_with_nan_and_nat_only)
     assert_equal(basic_store.read("nan_nat").data, pd.DataFrame({"col": [pd.NaT, pd.NaT, pd.NaT]}))
 
 
+@pytest.mark.storage
 def test_coercion_to_float(basic_store):
     lib = basic_store
     df = pd.DataFrame({"col": [np.nan, "1", np.nan]})
@@ -1505,6 +1584,7 @@ def test_coercion_to_float(basic_store):
     assert returned["col"].dtype != np.object_
 
 
+@pytest.mark.storage
 def test_coercion_to_str_with_dynamic_strings(basic_store):
     # assert that the getting sample function is not called
     lib = basic_store
@@ -1527,7 +1607,7 @@ def test_coercion_to_str_with_dynamic_strings(basic_store):
         lib.write("sym_coerced", df, dynamic_strings=True, coerce_columns={"col": str})
         sample_mock.assert_not_called()
 
-
+@pytest.mark.storage
 def test_find_version(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_find_version"
@@ -1578,6 +1658,7 @@ def test_find_version(lmdb_version_store_v1):
     assert lib._find_version(sym, as_of=v3_time.after).version == 3
 
 
+@pytest.mark.storage
 def test_library_deletion_lmdb(basic_store):
     # lmdb uses fast deletion
     basic_store.write("a", 1)
@@ -1592,6 +1673,7 @@ def test_library_deletion_lmdb(basic_store):
     assert lib_tool.count_keys(KeyType.TABLE_INDEX) == 0
 
 
+@pytest.mark.storage
 def test_resolve_defaults(basic_store_factory):
     lib = basic_store_factory()
     proto_cfg = lib._lib_cfg.lib_desc.version.write_options
@@ -1605,6 +1687,7 @@ def test_resolve_defaults(basic_store_factory):
     del os.environ["recursive_normalizers"]
 
 
+@pytest.mark.storage
 def test_batch_read_meta(basic_store_tombstone_and_sync_passive):
     lib = basic_store_tombstone_and_sync_passive
     for idx in range(10):
@@ -1619,6 +1702,7 @@ def test_batch_read_meta(basic_store_tombstone_and_sync_passive):
     assert results_dict["sym2"].data is None
 
 
+@pytest.mark.storage
 def test_batch_read_metadata_symbol_doesnt_exist(basic_store_tombstone_and_sync_passive):
     lib = basic_store_tombstone_and_sync_passive
     for idx in range(10):
@@ -1630,6 +1714,7 @@ def test_batch_read_metadata_symbol_doesnt_exist(basic_store_tombstone_and_sync_
     assert "sym_doesnotexist" not in results_dict
 
 
+@pytest.mark.storage
 def test_list_versions_with_deleted_symbols(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("a", 1)
@@ -1649,6 +1734,7 @@ def test_list_versions_with_deleted_symbols(basic_store_tombstone_and_pruning):
     assert lib.read("a").data == 2
 
 
+@pytest.mark.storage
 def test_read_with_asof_version_for_snapshotted_version(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("a", 1)
@@ -1665,6 +1751,7 @@ def test_read_with_asof_version_for_snapshotted_version(basic_store_tombstone_an
     assert lib.read("a", as_of=0).data == 1
 
 
+@pytest.mark.storage
 def test_get_tombstone_deletion_state_without_delayed_del(basic_store_factory, sym):
     lib = basic_store_factory(use_tombstones=True, delayed_deletes=False)
     lib.write(sym, 1)
@@ -1691,6 +1778,7 @@ def test_get_tombstone_deletion_state_without_delayed_del(basic_store_factory, s
     assert len(tombstoned_version_map) == 3
 
 
+@pytest.mark.storage
 def test_get_tombstone_deletion_state_with_delayed_del(basic_store_factory, sym):
     lib = basic_store_factory(use_tombstones=True, delayed_deletes=True)
     lib.write(sym, 1)
@@ -1717,6 +1805,7 @@ def test_get_tombstone_deletion_state_with_delayed_del(basic_store_factory, sym)
     assert len(tombstoned_version_map) == 3
 
 
+@pytest.mark.storage
 def test_get_timerange_for_symbol(basic_store, sym):
     lib = basic_store
     initial_timestamp = pd.Timestamp("2019-01-01")
@@ -1726,6 +1815,7 @@ def test_get_timerange_for_symbol(basic_store, sym):
     assert mints == datetime(2019, 1, 1)
 
 
+@pytest.mark.storage
 def test_get_timerange_for_symbol_tz(basic_store, sym):
     lib = basic_store
     dt1 = timezone("US/Eastern").localize(datetime(2021, 4, 1))
@@ -1737,6 +1827,7 @@ def test_get_timerange_for_symbol_tz(basic_store, sym):
     assert maxts == dt2
 
 
+@pytest.mark.storage
 def test_get_timerange_for_symbol_dst(basic_store, sym):
     lib = basic_store
     dst = pd.DataFrame({"a": [0, 1]}, index=[datetime(2021, 4, 1), datetime(2021, 4, 1, 3)])
@@ -1746,6 +1837,7 @@ def test_get_timerange_for_symbol_dst(basic_store, sym):
     assert maxts == datetime(2021, 4, 1, 3)
 
 
+@pytest.mark.storage
 def test_batch_read_meta_with_tombstones(basic_store_tombstone_and_sync_passive):
     lib = basic_store_tombstone_and_sync_passive
     lib.write("sym1", 1, {"meta1": 1})
@@ -1761,6 +1853,7 @@ def test_batch_read_meta_with_tombstones(basic_store_tombstone_and_sync_passive)
     assert lib.read_metadata("sym1").metadata == results_dict["sym1"].metadata
 
 
+@pytest.mark.storage
 def test_batch_read_meta_with_pruning(basic_store_factory):
     lib = basic_store_factory(use_tombstones=True, prune_previous_version=True, sync_passive=True)
     lib.write("sym1", 1, {"meta1": 1})
@@ -1777,6 +1870,7 @@ def test_batch_read_meta_with_pruning(basic_store_factory):
     assert lib.read_metadata("sym1").metadata == results_dict["sym1"].metadata
 
 
+@pytest.mark.storage
 def test_batch_read_meta_multiple_versions(object_version_store):
     lib = object_version_store
     lib.write("sym1", 1, {"meta1": 1})
@@ -1798,6 +1892,7 @@ def test_batch_read_meta_multiple_versions(object_version_store):
     assert results_dict["sym2"][3].metadata == {"meta2": 4}
 
 
+@pytest.mark.storage
 def test_list_symbols(basic_store):
     lib = basic_store
 
@@ -1810,6 +1905,7 @@ def test_list_symbols(basic_store):
     assert set(lib.list_symbols(regex="a")) == set(lib.list_symbols(regex="a", use_symbol_list=False))
 
 
+@pytest.mark.storage
 def test_get_index(object_version_store):
     lib = object_version_store
 
@@ -1835,6 +1931,7 @@ def test_get_index(object_version_store):
     assert idx.iloc[0]["version_id"] == 0
 
 
+@pytest.mark.storage
 def test_read_empty_index(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_read_empty_index"
@@ -1842,6 +1939,7 @@ def test_read_empty_index(lmdb_version_store_v1):
     assert len(lib.read_index(sym)) == 0
 
 
+@pytest.mark.storage
 def test_snapshot_empty_segment(basic_store):
     lib = basic_store
 
@@ -1857,6 +1955,7 @@ def test_snapshot_empty_segment(basic_store):
     assert lib.has_symbol("c") is False
 
 
+@pytest.mark.storage
 def test_columns_as_nparray(basic_store, sym):
     lib = basic_store
     d = {"col1": [1, 2], "col2": [3, 4]}
@@ -1876,6 +1975,7 @@ def test_columns_as_nparray(basic_store, sym):
     assert all(vit.data["col2"] == [3, 4])
 
 
+@pytest.mark.storage
 def test_dynamic_schema_similar_index_column(basic_store_dynamic_schema):
     lib = basic_store_dynamic_schema
     dr = pd.date_range("2020-01-01", "2020-01-31", name="date")
@@ -1885,6 +1985,7 @@ def test_dynamic_schema_similar_index_column(basic_store_dynamic_schema):
     assert_series_equal(returned, date_series)
 
 
+@pytest.mark.storage
 def test_dynamic_schema_similar_index_column_dataframe(basic_store_dynamic_schema):
     lib = basic_store_dynamic_schema
     dr = pd.date_range("2020-01-01", "2020-01-31", name="date")
@@ -1894,6 +1995,7 @@ def test_dynamic_schema_similar_index_column_dataframe(basic_store_dynamic_schem
     assert_equal(returned, date_series)
 
 
+@pytest.mark.storage
 def test_dynamic_schema_similar_index_column_dataframe_multiple_col(basic_store_dynamic_schema):
     lib = basic_store_dynamic_schema
     dr = pd.date_range("2020-01-01", "2020-01-31", name="date")
@@ -1903,6 +2005,7 @@ def test_dynamic_schema_similar_index_column_dataframe_multiple_col(basic_store_
     assert_equal(returned, date_series)
 
 
+@pytest.mark.storage
 def test_restore_version(basic_store_tiny_segment):
     lib = basic_store_tiny_segment
     # Triggers bug https://github.com/man-group/ArcticDB/issues/469 by freezing time
@@ -1935,6 +2038,7 @@ def test_restore_version_not_found(basic_store, ver):
         lib.restore_version("abc", ver)
 
 
+@pytest.mark.storage
 def test_restore_version_latest_is_noop(basic_store):
     symbol = "test_restore_version"
     df1 = get_sample_dataframe(2, 4)
@@ -1954,6 +2058,7 @@ def test_restore_version_latest_is_noop(basic_store):
     assert latest.version == 1
 
 
+@pytest.mark.storage
 def test_restore_version_ndarray(basic_store):
     symbol = "test_restore_version_ndarray"
     arr1 = np.array([0, 2, 4])
@@ -1970,6 +2075,7 @@ def test_restore_version_ndarray(basic_store):
     assert latest.metadata == metadata
 
 
+@pytest.mark.storage
 def test_batch_restore_version(basic_store_tombstone):
     lmdb_version_store = basic_store_tombstone
     symbols = []
@@ -1998,6 +2104,7 @@ def test_batch_restore_version(basic_store_tombstone):
         assert_equal(read_df, dfs[d])
 
 
+@pytest.mark.storage
 def test_batch_append(basic_store_tombstone, three_col_df):
     lmdb_version_store = basic_store_tombstone
     multi_data = {"sym1": three_col_df(), "sym2": three_col_df(1), "sym3": three_col_df(2)}
@@ -2023,6 +2130,7 @@ def test_batch_append(basic_store_tombstone, three_col_df):
         assert vit.metadata == append_metadata[sym]
 
 
+@pytest.mark.storage
 def test_batch_append_with_throw_exception(basic_store, three_col_df):
     multi_data = {"sym1": three_col_df(), "sym2": three_col_df(1)}
     with pytest.raises(NoSuchVersionException):
@@ -2035,6 +2143,7 @@ def test_batch_append_with_throw_exception(basic_store, three_col_df):
 
 @pytest.mark.pipeline
 @pytest.mark.parametrize("use_date_range_clause", [True, False])
+@pytest.mark.storage
 def test_batch_read_date_range(basic_store_tombstone_and_sync_passive, use_date_range_clause):
     lmdb_version_store = basic_store_tombstone_and_sync_passive
     symbols = []
@@ -2109,6 +2218,7 @@ def test_batch_read_row_range(lmdb_version_store_v1, use_row_range_clause):
         assert_equal(df, dfs[idx].iloc[row_range[0] : row_range[1]])
 
 
+@pytest.mark.storage
 def test_batch_read_columns(basic_store_tombstone_and_sync_passive):
     lmdb_version_store = basic_store_tombstone_and_sync_passive
     columns_of_interest = ["strings", "uint8"]
@@ -2133,6 +2243,7 @@ def test_batch_read_columns(basic_store_tombstone_and_sync_passive):
         assert_equal_value(vit.data, dfs[x][columns_of_interest])
 
 
+@pytest.mark.storage
 def test_batch_read_symbol_doesnt_exist(basic_store):
     sym1 = "sym1"
     sym2 = "sym2"
@@ -2141,6 +2252,7 @@ def test_batch_read_symbol_doesnt_exist(basic_store):
         _ = basic_store.batch_read([sym1, sym2])
 
 
+@pytest.mark.storage
 def test_batch_read_version_doesnt_exist(basic_store):
     sym1 = "sym1"
     sym2 = "sym2"
@@ -2150,6 +2262,7 @@ def test_batch_read_version_doesnt_exist(basic_store):
         _ = basic_store.batch_read([sym1, sym2], as_ofs=[0, 1])
 
 
+@pytest.mark.storage
 def test_read_batch_deleted_version_doesnt_exist(basic_store):
     sym1 = "mysymbol"
     basic_store.write(sym1, 0)
@@ -2163,6 +2276,7 @@ def test_read_batch_deleted_version_doesnt_exist(basic_store):
         basic_store.batch_read([sym1], as_ofs=[0])
 
 
+@pytest.mark.storage
 def test_index_keys_start_end_index(basic_store, sym):
     idx = pd.date_range("2022-01-01", periods=100, freq="D")
     df = pd.DataFrame({"a": range(len(idx))}, index=idx)
@@ -2174,6 +2288,7 @@ def test_index_keys_start_end_index(basic_store, sym):
     assert key.end_index == 1649548800000000001
 
 
+@pytest.mark.storage
 def test_dynamic_schema_column_hash_update(basic_store_column_buckets):
     lib = basic_store_column_buckets
     idx = pd.date_range("2022-01-01", periods=10, freq="D")
@@ -2209,6 +2324,7 @@ def test_dynamic_schema_column_hash_update(basic_store_column_buckets):
     assert_equal(vit.data, df)
 
 
+@pytest.mark.storage
 def test_dynamic_schema_column_hash_append(basic_store_column_buckets):
     lib = basic_store_column_buckets
     idx = pd.date_range("2022-01-01", periods=10, freq="D")
@@ -2240,6 +2356,7 @@ def test_dynamic_schema_column_hash_append(basic_store_column_buckets):
     assert_equal(vit.data, new_df)
 
 
+@pytest.mark.storage
 def test_dynamic_schema_column_hash(basic_store_column_buckets):
     lib = basic_store_column_buckets
     idx = pd.date_range("2022-01-01", periods=10, freq="D")
@@ -2264,6 +2381,7 @@ def test_dynamic_schema_column_hash(basic_store_column_buckets):
     assert_equal(df[["a", "c"]], read_df)
 
 
+@pytest.mark.storage
 def test_list_versions_without_snapshots(basic_store):
     lib = basic_store
     lib.write("symbol_1", 0)
@@ -2284,6 +2402,7 @@ def test_list_versions_without_snapshots(basic_store):
 
 @pytest.mark.parametrize("batch", (True, False))
 @pytest.mark.parametrize("method", ("append", "update"))  # "write" is implied
+@pytest.mark.storage
 def test_modification_methods_dont_return_input_data(basic_store, batch, method):  # AN-650
     lib: NativeVersionStore = basic_store
 
@@ -2311,6 +2430,7 @@ def test_modification_methods_dont_return_input_data(basic_store, batch, method)
 @pytest.mark.skipif(sys.platform == "darwin", reason="Test broken on MacOS (issue #692)")
 @pytest.mark.parametrize("method", ("append", "update"))
 @pytest.mark.parametrize("num", (5, 50, 1001))
+@pytest.mark.storage
 def test_diff_long_stream_descriptor_mismatch(basic_store, method, num):
     lib: NativeVersionStore = basic_store
     lib.write("x", pd.DataFrame({f"col{i}": [i, i + 1, i + 2] for i in range(num)}, index=pd.date_range(0, periods=3)))
@@ -2331,6 +2451,7 @@ def test_diff_long_stream_descriptor_mismatch(basic_store, method, num):
                 assert f"FD<name=col{i}, type=TD<type=UTF" in msg
 
 
+@pytest.mark.storage
 def test_wrong_df_col_order(basic_store):
     lib = basic_store
 
@@ -2343,6 +2464,7 @@ def test_wrong_df_col_order(basic_store):
         lib.append(sym, df2)
 
 
+@pytest.mark.storage
 def test_get_non_existing_columns_in_series(basic_store, sym):
     lib = basic_store
     dst = pd.Series(index=pd.date_range(pd.Timestamp("2022-01-01"), pd.Timestamp("2022-02-01")), data=0.0)
@@ -2350,6 +2472,7 @@ def test_get_non_existing_columns_in_series(basic_store, sym):
     assert basic_store.read(sym, columns=["col1"]).data.empty
 
 
+@pytest.mark.storage
 def test_get_existing_columns_in_series(basic_store, sym):
     lib = basic_store
     dst = pd.Series(index=pd.date_range(pd.Timestamp("2022-01-01"), pd.Timestamp("2022-02-01")), data=0.0, name="col1")
@@ -2371,6 +2494,7 @@ def remove_most_recent_version_key(version_store, symbol):
     assert version_keys[0].version_id == 0
 
 
+@pytest.mark.storage
 def test_missing_first_version_key_single(basic_store):
     symbol = "test_missing_first_version_key_single"
     lib = basic_store
@@ -2413,6 +2537,7 @@ def test_update_with_missing_version_key(version_store_factory):
     assert_equal(vit.data, df)
 
 
+@pytest.mark.storage
 def test_append_with_missing_version_key(basic_store):
     symbol = "test_append_with_missing_version_key"
     df1 = pd.DataFrame({"x": np.arange(1, 10, dtype=np.int64)})
@@ -2429,6 +2554,7 @@ def test_append_with_missing_version_key(basic_store):
     assert_equal(vit.data, df1)
 
 
+@pytest.mark.storage
 def test_missing_first_version_key_batch(basic_store):
     lib = basic_store
 
@@ -2463,6 +2589,7 @@ def test_missing_first_version_key_batch(basic_store):
 
 
 @pytest.mark.parametrize("use_caching", [True, False])
+@pytest.mark.storage
 def test_version_chain_cache(basic_store, use_caching):
     timeout = sys.maxsize if use_caching else 0
     lib = basic_store

--- a/python/tests/integration/arcticdb/version_store/test_categorical.py
+++ b/python/tests/integration/arcticdb/version_store/test_categorical.py
@@ -17,6 +17,7 @@ from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticdb.util.test import assert_frame_equal
 
 
+@pytest.mark.storage
 def test_categorical(basic_store, sym):
     c = pd.Categorical(["a", "b", "c", "a", "b", "c"])
     df = pd.DataFrame({"int": np.arange(6), "cat": c})
@@ -29,6 +30,7 @@ def test_categorical(basic_store, sym):
     assert read_df.cat.dtype == "category"
 
 
+@pytest.mark.storage
 def test_categorical_multiple_col(basic_store, sym):
     c = pd.Categorical(["a", "b", "c", "a", "b", "c"])
     c1 = pd.Categorical(["a", "b", "b", "a", "b", "c"])
@@ -48,6 +50,7 @@ def test_categorical_multiple_col(basic_store, sym):
     assert_frame_equal(df, read_df)
 
 
+@pytest.mark.storage
 def test_categorical_multiple_col_read_subset(basic_store, sym):
     c = pd.Categorical(["a", "b", "c", "a", "b", "c"])
     c1 = pd.Categorical(["a", "b", "b", "a", "b", "c"])
@@ -65,6 +68,7 @@ def test_categorical_multiple_col_read_subset(basic_store, sym):
     assert_frame_equal(df[["cat1"]], read_df)
 
 
+@pytest.mark.storage
 def test_categorical_with_None(basic_store, sym):
     c = pd.Categorical(["a", "b", "c", "a", "b", "c", None])
     df = pd.DataFrame({"int": np.arange(7), "cat": c})
@@ -78,6 +82,7 @@ def test_categorical_with_None(basic_store, sym):
     assert_frame_equal(df, read_df)
 
 
+@pytest.mark.storage
 def test_categorical_empty(basic_store, sym):
     c = pd.Categorical([])
     df = pd.DataFrame({"cat": c})
@@ -94,6 +99,7 @@ def test_categorical_empty(basic_store, sym):
     assert_frame_equal(df, read_df)
 
 
+@pytest.mark.storage
 def test_categorical_with_integers(basic_store, sym):
     c = pd.Categorical(np.arange(6))
     df = pd.DataFrame({"int": np.arange(6), "cat_int": c})
@@ -121,6 +127,7 @@ def test_categorical_with_integers(basic_store, sym):
     assert_frame_equal(df, read_df)
 
 
+@pytest.mark.storage
 def test_categorical_with_integers_and_strings(basic_store, sym):
     c = pd.Categorical(np.arange(6))
     c1 = pd.Categorical(["a", "b", "b", "a", "b", "c"])
@@ -150,6 +157,7 @@ def test_categorical_with_integers_and_strings(basic_store, sym):
     assert_frame_equal(df, read_df)
 
 
+@pytest.mark.storage
 def test_categorical_batch_write(basic_store):
     lib = basic_store
     symbols = ["test_categorical_batch_write_1", "test_categorical_batch_write_2"]
@@ -162,6 +170,7 @@ def test_categorical_batch_write(basic_store):
         assert_frame_equal(lib.read(symbol).data, dfs[idx])
 
 
+@pytest.mark.storage
 def test_categorical_append(basic_store):
     lib = basic_store
     symbol = "test_categorical_append"
@@ -172,6 +181,7 @@ def test_categorical_append(basic_store):
         lib.append(symbol, append_df)
 
 
+@pytest.mark.storage
 def test_categorical_update(basic_store):
     lib = basic_store
     symbol = "test_categorical_update"
@@ -182,6 +192,7 @@ def test_categorical_update(basic_store):
         lib.update(symbol, append_df)
 
 
+@pytest.mark.storage
 def test_categorical_series(basic_store):
     lib = basic_store
     symbol = "test_categorical_series"
@@ -192,6 +203,7 @@ def test_categorical_series(basic_store):
         lib.append(symbol, append_series)
 
 
+@pytest.mark.storage
 def test_categorical_multi_index(basic_store):
     lib = basic_store
     symbol = "test_categorical_multi_index"

--- a/python/tests/integration/arcticdb/version_store/test_dedup.py
+++ b/python/tests/integration/arcticdb/version_store/test_dedup.py
@@ -34,6 +34,7 @@ def comp_dict(d1, d2):
             assert d1[k] == d2[k]
 
 
+@pytest.mark.storage
 def test_basic_de_dup(basic_store_factory):
     lib = basic_store_factory(column_group_size=2, segment_row_size=2, de_duplication=True)
     symbol = "test_basic_de_dup"
@@ -59,6 +60,7 @@ def test_basic_de_dup(basic_store_factory):
     assert len(get_data_keys(lib, symbol)) == num_elements
 
 
+@pytest.mark.storage
 def test_de_dup_same_value_written(basic_store_factory):
     lib = basic_store_factory(column_group_size=2, segment_row_size=2, de_duplication=True)
     symbol = "test_de_dup_same_value_written"
@@ -82,6 +84,7 @@ def test_de_dup_same_value_written(basic_store_factory):
     assert len(get_data_keys(lib, symbol)) == num_keys
 
 
+@pytest.mark.storage
 def test_de_dup_with_delete(basic_store_factory):
     lib = basic_store_factory(column_group_size=2, segment_row_size=2, de_duplication=True)
     symbol = "test_de_dup_with_delete"
@@ -138,6 +141,7 @@ def test_de_dup_with_delete(basic_store_factory):
     assert len(get_data_keys(lib, symbol)) == num_elements
 
 
+@pytest.mark.storage
 def test_de_dup_with_snapshot(basic_store_factory):
     lib = basic_store_factory(column_group_size=2, segment_row_size=2, de_duplication=True)
     symbol = "test_de_dup_with_snapshot"
@@ -179,6 +183,7 @@ def test_de_dup_with_snapshot(basic_store_factory):
     assert_frame_equal(lib.read(symbol, as_of="my_snap").data, new_df)
 
 
+@pytest.mark.storage
 def test_de_dup_with_tombstones(basic_store_factory):
     lib = basic_store_factory(column_group_size=2, segment_row_size=2, de_duplication=True, use_tombstones=True)
     symbol = "test_de_dup_with_tombstones"
@@ -238,6 +243,7 @@ def test_de_dup_with_tombstones(basic_store_factory):
     assert len(get_data_keys(lib, symbol)) == 3 * num_elements / 2
 
 
+@pytest.mark.storage
 def test_snapshot_dedup_basic(basic_store_factory):
     lib = basic_store_factory(
         column_group_size=2, segment_row_size=2, de_duplication=True, use_tombstones=True, snapshot_dedup=True
@@ -280,6 +286,7 @@ def test_snapshot_dedup_basic(basic_store_factory):
     assert len(get_data_keys(lib, symbol)) == num_elements
 
 
+@pytest.mark.storage
 def test_snapshot_dedup_multiple1(basic_store_factory):
     lib = basic_store_factory(
         column_group_size=2, segment_row_size=2, de_duplication=True, use_tombstones=True, snapshot_dedup=True
@@ -348,6 +355,7 @@ def test_snapshot_dedup_multiple1(basic_store_factory):
     assert len(get_data_keys(lib, symbol)) == 3 * num_elements / 2
 
 
+@pytest.mark.storage
 def test_snapshot_dedup_multiple2(basic_store_factory):
     lib = basic_store_factory(
         column_group_size=2, segment_row_size=2, de_duplication=True, use_tombstones=True, snapshot_dedup=True
@@ -404,6 +412,7 @@ def test_snapshot_dedup_multiple2(basic_store_factory):
     assert len(get_data_keys(lib, symbol)) == 3 * num_elements / 2
 
 
+@pytest.mark.storage
 def test_dedup_multi_keys(basic_store_factory):
     lib = basic_store_factory(
         column_group_size=2, segment_row_size=2, de_duplication=True, use_tombstones=True, snapshot_dedup=True
@@ -452,6 +461,7 @@ def test_dedup_multi_keys(basic_store_factory):
     comp_dict(data3, lib.read(symbol).data)
 
 
+@pytest.mark.storage
 def test_dedup_multi_keys_snapshot(basic_store_factory):
     lib = basic_store_factory(
         column_group_size=2, segment_row_size=2, de_duplication=True, use_tombstones=True, snapshot_dedup=True

--- a/python/tests/integration/arcticdb/version_store/test_deletion.py
+++ b/python/tests/integration/arcticdb/version_store/test_deletion.py
@@ -33,6 +33,7 @@ MAP_TIMEOUTS = [0, SECOND * 5, SECOND * 10000]
 
 
 @pytest.mark.parametrize("map_timeout", MAP_TIMEOUTS)
+@pytest.mark.storage
 def test_delete_all(map_timeout, object_and_mem_and_lmdb_version_store, sym):
     with config_context("VersionMap.ReloadInterval", map_timeout):
         lib = object_and_mem_and_lmdb_version_store
@@ -55,6 +56,7 @@ def test_delete_all(map_timeout, object_and_mem_and_lmdb_version_store, sym):
         assert_frame_equal(vit.data, df1)
 
 
+@pytest.mark.storage
 def test_version_missing(object_version_store):
     with pytest.raises(NoDataFoundException):
         object_version_store.read("not_there")
@@ -114,6 +116,7 @@ def test_delete_version_basic(s3_version_store, idx, sym):
     assert len(object_version_store.list_versions(symbol)) == 0
 
 
+@pytest.mark.storage
 def test_delete_version_with_batch_write(object_version_store, sym):
     sym_1 = sym
     sym_2 = "another-{}".format(sym)
@@ -150,6 +153,7 @@ def test_delete_version_with_batch_write(object_version_store, sym):
 
 
 @pytest.mark.parametrize("idx", [0, 1])
+@pytest.mark.storage
 def test_delete_version_with_append(object_version_store, idx, sym):
     symbol = sym
     idx1 = np.arange(0, 1000000)
@@ -186,6 +190,7 @@ def test_delete_version_with_append(object_version_store, idx, sym):
         assert vit.version == 2
 
 
+@pytest.mark.storage
 def test_delete_version_with_batch_append(object_version_store, sym):
     sym_1 = sym
     sym_2 = "another-{}".format(sym)
@@ -222,6 +227,7 @@ def test_delete_version_with_batch_append(object_version_store, sym):
     assert_frame_equal(vit[sym_2].data, expected_2)
 
 
+@pytest.mark.storage
 def test_delete_version_with_update(object_version_store, sym):
     symbol = sym
     idx1 = pd.date_range("2000-1-1", periods=5)
@@ -248,6 +254,7 @@ def test_delete_version_with_update(object_version_store, sym):
 
 
 @pytest.mark.parametrize("idx", [2, 3])
+@pytest.mark.storage
 def test_delete_version_with_write_metadata(object_version_store, idx, sym):
     symbol = sym
     idx1 = np.arange(0, 1000000)
@@ -292,6 +299,7 @@ def test_delete_version_with_write_metadata(object_version_store, idx, sym):
 
 
 @pytest.mark.parametrize("idx", [2, 3])
+@pytest.mark.storage
 def test_delete_version_with_batch_write_metadata(object_version_store, idx, sym):
     sym_1 = sym
     sym_2 = "another-{}".format(sym)
@@ -347,6 +355,7 @@ def test_delete_version_with_batch_write_metadata(object_version_store, idx, sym
 
 
 @pytest.mark.parametrize("map_timeout", MAP_TIMEOUTS)
+@pytest.mark.storage
 def test_delete_version_with_snapshot(map_timeout, object_and_mem_and_lmdb_version_store, sym):
     with config_context("VersionMap.ReloadInterval", map_timeout):
         lib = object_and_mem_and_lmdb_version_store
@@ -378,6 +387,7 @@ def test_delete_version_with_snapshot(map_timeout, object_and_mem_and_lmdb_versi
         assert_frame_equal(lib.read(symbol, "delete_version_snap_1").data, df1)
 
 
+@pytest.mark.storage
 def test_delete_mixed(object_version_store, sym):
     symbol = sym
     df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
@@ -392,6 +402,7 @@ def test_delete_mixed(object_version_store, sym):
     assert object_version_store.has_symbol(symbol) is False
 
 
+@pytest.mark.storage
 def tests_with_pruning_and_tombstones(basic_store_tombstone_and_pruning, sym):
     symbol = sym
     lib = basic_store_tombstone_and_pruning
@@ -409,6 +420,7 @@ def tests_with_pruning_and_tombstones(basic_store_tombstone_and_pruning, sym):
 
 
 @pytest.mark.parametrize("map_timeout", MAP_TIMEOUTS)
+@pytest.mark.storage
 def test_with_snapshot_pruning_tombstones(basic_store_tombstone_and_pruning, map_timeout, sym):
     with config_context("VersionMap.ReloadInterval", map_timeout):
         symbol = sym
@@ -442,6 +454,7 @@ def test_with_snapshot_pruning_tombstones(basic_store_tombstone_and_pruning, map
 
 
 @pytest.mark.parametrize("map_timeout", MAP_TIMEOUTS)
+@pytest.mark.storage
 def test_normal_flow_with_snapshot_and_pruning(basic_store_tombstone_and_pruning, map_timeout, sym):
     with config_context("VersionMap.ReloadInterval", map_timeout):
         symbol = sym
@@ -470,6 +483,7 @@ def test_normal_flow_with_snapshot_and_pruning(basic_store_tombstone_and_pruning
         assert len([ver for ver in lib.list_versions() if not ver["deleted"]]) == 2
 
 
+@pytest.mark.storage
 def test_deleting_tombstoned_versions(basic_store_tombstone_and_pruning, sym):
     lib = basic_store_tombstone_and_pruning
     lib.write(sym, 1)
@@ -479,6 +493,7 @@ def test_deleting_tombstoned_versions(basic_store_tombstone_and_pruning, sym):
     # Two versions are tombstoned at this point.
 
 
+@pytest.mark.storage
 def test_delete_multi_keys(object_version_store, sym):
     object_version_store.write(
         sym,
@@ -497,6 +512,7 @@ def test_delete_multi_keys(object_version_store, sym):
 
 
 @pytest.mark.parametrize("map_timeout", MAP_TIMEOUTS)
+@pytest.mark.storage
 def test_delete_multi_keys_snapshot(basic_store, map_timeout, sym):
     data = {"e": np.arange(1000), "f": np.arange(8000), "g": None}
     basic_store.write(sym, data=data, metadata="realyolo2", recursive_normalizers=True)
@@ -624,6 +640,7 @@ def test_delete_date_range_get_info(lmdb_version_store_tiny_segment):
     assert received.index[0] == lib.get_info(sym)["date_range"][0]
 
 
+@pytest.mark.storage
 def test_delete_read_from_timestamp(basic_store):
     sym = "test_from_timestamp_with_delete"
     lib = basic_store

--- a/python/tests/integration/arcticdb/version_store/test_metadata_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_metadata_support.py
@@ -21,6 +21,7 @@ from arcticdb.util.test import assert_frame_equal, distinct_timestamps
 # test_rt_df stands for roundtrip dataframe (implicitly pandas given file name)
 
 
+@pytest.mark.storage
 def test_rt_df_with_small_meta(object_and_mem_and_lmdb_version_store):
     lib = object_and_mem_and_lmdb_version_store
     #  type: (NativeVersionStore)->None
@@ -41,6 +42,7 @@ class A:
         return self.attrib == other.attrib
 
 
+@pytest.mark.storage
 def test_rt_df_with_custom_meta(object_and_mem_and_lmdb_version_store):
     lib = object_and_mem_and_lmdb_version_store
 
@@ -81,6 +83,7 @@ def test_pickled_metadata_warning_bad_config(lmdb_version_store_v1):
     assert_frame_equal(df, vit.metadata)
 
 
+@pytest.mark.storage
 def test_rt_df_with_humonguous_meta(object_and_mem_and_lmdb_version_store):
     with pytest.raises(ArcticDbNotYetImplemented):
         from arcticdb.version_store._normalization import _MAX_USER_DEFINED_META as MAX
@@ -94,6 +97,7 @@ def test_rt_df_with_humonguous_meta(object_and_mem_and_lmdb_version_store):
         assert meta == vit.metadata
 
 
+@pytest.mark.storage
 def test_read_metadata(object_and_mem_and_lmdb_version_store):
     lib = object_and_mem_and_lmdb_version_store
     original_data = [1, 2, 3]
@@ -105,6 +109,7 @@ def test_read_metadata(object_and_mem_and_lmdb_version_store):
     assert lib.read_metadata("test_symbol").metadata == metadata
 
 
+@pytest.mark.storage
 def test_read_metadata_by_version(object_and_mem_and_lmdb_version_store):
     lib = object_and_mem_and_lmdb_version_store
     data_v1 = [1, 2, 3]
@@ -120,6 +125,7 @@ def test_read_metadata_by_version(object_and_mem_and_lmdb_version_store):
     assert lib.read_metadata(symbol, 1).metadata == metadata_v1
 
 
+@pytest.mark.storage
 def test_read_metadata_by_snapshot(basic_store):
     original_data = [1, 2, 3]
     snap_name = "metadata_snap_1"
@@ -131,6 +137,7 @@ def test_read_metadata_by_snapshot(basic_store):
     assert basic_store.read_metadata(symbol, snap_name).metadata == metadata
 
 
+@pytest.mark.storage
 def test_read_metadata_by_timestamp(basic_store):
     symbol = "test_symbol"
 
@@ -173,6 +180,7 @@ def test_read_metadata_by_timestamp(basic_store):
     assert basic_store.read_metadata(symbol, as_of=brexit_almost_over).metadata == metadata_v3
 
 
+@pytest.mark.storage
 def test_write_metadata_first_write(basic_store, sym):
     metadata_v0 = {"something": 1}
     # basic_store.write(symbol, 1, metadata=metadata_v0)  # v0
@@ -183,6 +191,7 @@ def test_write_metadata_first_write(basic_store, sym):
     assert len(basic_store.list_versions(sym)) == 1
 
 
+@pytest.mark.storage
 def test_write_metadata_preexisting_symbol(basic_store, sym):
     lib = basic_store
     metadata_v0 = {"something": 1}
@@ -196,6 +205,7 @@ def test_write_metadata_preexisting_symbol(basic_store, sym):
     assert lib.read(sym).data == 1
 
 
+@pytest.mark.storage
 def test_write_metadata_preexisting_symbol_no_pruning(basic_store, sym):
     lib = basic_store
     metadata_v0 = {"something": 1}

--- a/python/tests/integration/arcticdb/version_store/test_pandas_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_pandas_support.py
@@ -19,6 +19,7 @@ from arcticdb.util.test import assert_frame_equal
 # test_rt_df stands for roundtrip dataframe (implicitly pandas given file name)
 
 
+@pytest.mark.storage
 def test_rt_df_with_datetimeindex_with_timezone(basic_store):
     df = DataFrame(
         data=["A", "BC", "DEF"],
@@ -34,6 +35,7 @@ def test_rt_df_with_datetimeindex_with_timezone(basic_store):
     assert_frame_equal(df, saved_df, check_names=False)
 
 
+@pytest.mark.storage
 def test_rt_df_range_index_with_name(basic_store):
     df = DataFrame(data=["A", "B", "D"])
     df.index.name = "xxx"
@@ -46,6 +48,7 @@ def test_rt_df_range_index_with_name(basic_store):
 
 @pytest.mark.parametrize("has_index", [True, False])
 @pytest.mark.parametrize("N", [1, 5, 10])
+@pytest.mark.storage
 def test_rt_df_small_col_dtidx(basic_store, N, has_index):
     rnd = RandomState(0x42)
 
@@ -79,6 +82,7 @@ def create_params():
     return params
 
 
+@pytest.mark.storage
 @pytest.mark.parametrize("symbol, item", create_params())
 def test_rt_df(basic_store, symbol, item):
     basic_store.write("xxx", item.copy())
@@ -86,6 +90,7 @@ def test_rt_df(basic_store, symbol, item):
     assert_frame_equal(item, df2)
 
 
+@pytest.mark.storage
 def test_empty_df(basic_store):
     item = pd.DataFrame()
     basic_store.write("xxx", item)
@@ -93,6 +98,7 @@ def test_empty_df(basic_store):
     assert df2.empty
 
 
+@pytest.mark.storage
 def test_df_datetime_multi_index_with_timezones(object_and_mem_and_lmdb_version_store):
     zone = "America/Chicago"
     df = DataFrame(

--- a/python/tests/integration/arcticdb/version_store/test_snapshot.py
+++ b/python/tests/integration/arcticdb/version_store/test_snapshot.py
@@ -30,6 +30,7 @@ from tests.util.storage_test import get_s3_storage_config
 from arcticdb_ext.storage import KeyType
 
 
+@pytest.mark.storage
 def test_basic_snapshot_flow(basic_store):
     original_data = [1, 2, 3]
     basic_store.write("a", original_data)
@@ -41,6 +42,7 @@ def test_basic_snapshot_flow(basic_store):
     assert "snap_1" not in basic_store.list_snapshots()
 
 
+@pytest.mark.storage
 def test_re_snapshot_with_same_name(basic_store):
     original_data = [1, 2, 3]
     basic_store.write("a", original_data)
@@ -66,6 +68,7 @@ def test_read_old_snapshot_data(object_version_store):
     assert object_version_store.read("c").data == modified_data
 
 
+@pytest.mark.storage
 def test_snapshot_metadata(object_version_store):
     original_data = [1, 2, 3]
     metadata = {"metadata": "Because why not?"}
@@ -79,6 +82,7 @@ def test_snapshot_metadata(object_version_store):
     assert metadata_for_snap == metadata
 
 
+@pytest.mark.storage
 def test_snapshots_skip_symbol(object_version_store):
     original_data = [1, 2, 3]
     object_version_store.write("f", original_data)
@@ -89,6 +93,7 @@ def test_snapshots_skip_symbol(object_version_store):
         object_version_store.read("f", as_of="snap_5")
 
 
+@pytest.mark.storage
 def test_snapshot_explicit_versions(basic_store):
     lib = basic_store
     original_data = [1, 2, 3]
@@ -105,6 +110,7 @@ def test_snapshot_explicit_versions(basic_store):
     assert lib.read("j", as_of="snap_8").data == modified_data
 
 
+@pytest.mark.storage
 def test_list_symbols_with_snaps(object_version_store):
     original_data = [1, 2, 3]
 
@@ -118,6 +124,7 @@ def test_list_symbols_with_snaps(object_version_store):
     assert "s3" in object_version_store.list_symbols()
 
 
+@pytest.mark.storage
 def test_list_versions(object_version_store):
     lib = object_version_store
     original_data = [1, 2, 3]
@@ -134,6 +141,7 @@ def test_list_versions(object_version_store):
     assert sorted([v["version"] for v in all_versions if v["symbol"] == "t1" and not v["deleted"]]) == sorted([0, 1])
 
 
+@pytest.mark.storage
 def test_snapshots_with_deletes(basic_store):
     original_data = [1, 2, 3]
     v1_data = [1, 2, 3, 4]
@@ -167,6 +175,7 @@ def test_snapshots_with_deletes(basic_store):
     assert basic_store.read("sym3", as_of="sym3_snap").data == original_data
 
 
+@pytest.mark.storage
 def test_delete_symbol_without_snapshot(basic_store):
     original_data = [1, 2, 3]
     v1_data = [1, 2, 3, 4]
@@ -187,6 +196,7 @@ def test_delete_symbol_without_snapshot(basic_store):
     assert not basic_store.has_symbol("sym1")
 
 
+@pytest.mark.storage
 def test_write_to_symbol_in_snapshot_only(basic_store):
     original_data = [1, 2, 3]
     v1_data = [1, 2, 3, 4]
@@ -202,6 +212,7 @@ def test_write_to_symbol_in_snapshot_only(basic_store):
     assert basic_store.read("weird", as_of="store_sym_old").data == original_data
 
 
+@pytest.mark.storage
 def test_read_after_delete_with_snap(basic_store):
     data = np.random.randint(0, 10000, 1024 * 1024).reshape(1024, 1024)
     sym = "2003_australia1"
@@ -218,6 +229,7 @@ def test_read_after_delete_with_snap(basic_store):
         basic_store.read("random")
 
 
+@pytest.mark.storage
 def test_snapshot_with_versions_dict(basic_store):
     original_data = [1, 2, 3]
     basic_store.write("a", original_data)
@@ -231,6 +243,7 @@ def test_snapshot_with_versions_dict(basic_store):
     assert basic_store.read("b", as_of="snap_all").data == original_data
 
 
+@pytest.mark.storage
 def test_has_symbol_with_snapshot(basic_store):
     basic_store.write("a1", 1)
     basic_store.write("a3", 3)
@@ -243,6 +256,7 @@ def test_has_symbol_with_snapshot(basic_store):
     assert basic_store.read("a1", as_of="snap").data == 1
 
 
+@pytest.mark.storage
 def test_pruned_symbol_in_symbol_read_version(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("a", 1)
@@ -287,6 +301,7 @@ def test_read_symbol_with_ts_in_snapshot(store, request, sym):
     assert lib.read(sym, as_of=third_write_timestamps.after).version == 2
 
 
+@pytest.mark.storage
 def test_add_to_snapshot_simple(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -303,6 +318,7 @@ def test_add_to_snapshot_simple(basic_store_tombstone_and_pruning):
     assert lib.read("s3", as_of="snap").data == 3
 
 
+@pytest.mark.storage
 def test_add_to_snapshot_missing_snap(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -313,6 +329,7 @@ def test_add_to_snapshot_missing_snap(basic_store_tombstone_and_pruning):
         lib.add_to_snapshot("snap", ["s3"])
 
 
+@pytest.mark.storage
 def test_add_to_snapshot_specific_version(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -331,6 +348,7 @@ def test_add_to_snapshot_specific_version(basic_store_tombstone_and_pruning):
     assert lib.read("s3", as_of="snap").data == 3
 
 
+@pytest.mark.storage
 def test_add_to_snapshot_replace(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -348,6 +366,7 @@ def test_add_to_snapshot_replace(basic_store_tombstone_and_pruning):
     assert lib.read("s3", as_of="snap").data == 3
 
 
+@pytest.mark.storage
 def test_add_to_snapshot_replace_specific(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -370,6 +389,7 @@ def test_add_to_snapshot_replace_specific(basic_store_tombstone_and_pruning):
     assert lib.read("s3", as_of="saved").data == 1
 
 
+@pytest.mark.storage
 def test_add_to_snapshot_multiple(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -392,6 +412,7 @@ def test_add_to_snapshot_multiple(basic_store_tombstone_and_pruning):
     assert lib.read("s4", as_of="snap").data == 4
 
 
+@pytest.mark.storage
 def test_remove_from_snapshot(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -411,6 +432,7 @@ def test_remove_from_snapshot(basic_store_tombstone_and_pruning):
     assert lib.read("s3", as_of="saved").data == 3
 
 
+@pytest.mark.storage
 def test_remove_from_snapshot_missing_snap(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -421,6 +443,7 @@ def test_remove_from_snapshot_missing_snap(basic_store_tombstone_and_pruning):
         lib.remove_from_snapshot("snap", ["s3"], [0])
 
 
+@pytest.mark.storage
 def test_remove_from_snapshot_multiple(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning
     lib.write("s1", 1)
@@ -441,6 +464,7 @@ def test_remove_from_snapshot_multiple(basic_store_tombstone_and_pruning):
     assert lib.read("s2", as_of="saved").data == 2
 
 
+@pytest.mark.storage
 def test_snapshot_not_accept_tombstoned_key(basic_store_delayed_deletes_v1, sym):
     lib = basic_store_delayed_deletes_v1
     ver = lib.write(sym, 1).version
@@ -449,6 +473,7 @@ def test_snapshot_not_accept_tombstoned_key(basic_store_delayed_deletes_v1, sym)
         lib.snapshot("s", versions={sym: ver})
 
 
+@pytest.mark.storage
 def test_snapshot_partially_valid_version_map(basic_store_delayed_deletes_v1):
     lib = basic_store_delayed_deletes_v1
     symA = "A"
@@ -468,6 +493,7 @@ def test_snapshot_partially_valid_version_map(basic_store_delayed_deletes_v1):
     assert lib.read(symB, as_of="s").data == 3
 
 
+@pytest.mark.storage
 def test_snapshot_tombstoned_but_referenced_in_other_snapshot_version(basic_store_delayed_deletes_v1):
     lib = basic_store_delayed_deletes_v1
     symA = "A"
@@ -508,6 +534,7 @@ def test_add_to_snapshot_atomicity(s3_bucket_versioning_storage, lib_name):
     assert_0_delete_marker(lib, storage)
 
 
+@pytest.mark.storage
 def test_delete_snapshot_basic_flow(basic_store):
     lib = basic_store
     symbol = "sym1"
@@ -542,6 +569,7 @@ def test_delete_snapshot_basic_flow(basic_store):
     assert_frame_equal(df_combined, lib.read(symbol).data)
 
 
+@pytest.mark.storage
 def test_delete_snapshot_basic_flow_with_delete_last_version(basic_store):
     lib = basic_store
     symbol = "sym1"
@@ -585,6 +613,7 @@ def test_delete_snapshot_basic_flow_with_delete_last_version(basic_store):
         data = lib.read(symbol, as_of=snap2).data
 
 
+@pytest.mark.storage
 def test_delete_snapshot_basic_flow_with_delete_prev_version(basic_store):
     lib = basic_store
     symbol = "sym1"
@@ -625,6 +654,7 @@ def test_delete_snapshot_basic_flow_with_delete_prev_version(basic_store):
     reason="""ArcticDB#1863 or other bug. The fail is in the line lib.
                    read(symbol1).data after deleting snapshot 1, read operation throws exception"""
 )
+@pytest.mark.storage
 def test_delete_snapshot_complex_flow_with_delete_multible_symbols(basic_store_tiny_segment_dynamic):
     lib = basic_store_tiny_segment_dynamic
 
@@ -701,6 +731,7 @@ def test_delete_snapshot_complex_flow_with_delete_multible_symbols(basic_store_t
     assert [ver["deleted"] for ver in lib.list_versions(symbol3)] == [False, False]
 
 
+@pytest.mark.storage
 def test_delete_snapshot_multiple_edge_case(basic_store):
     """
     Purpose of test is to examine snapshoting 3 symbols with minimum
@@ -806,6 +837,7 @@ def test_delete_snapshot_multiple_edge_case(basic_store):
     assert_frame_equal(df_1, lib.read(symbol1).data)
 
 
+@pytest.mark.storage
 def test_delete_snapshot_on_updated_and_appended_dataframe(basic_store_tiny_segment):
     lib = basic_store_tiny_segment
     df_1 = create_df_index_datetime(10, 3, 10)

--- a/python/tests/integration/arcticdb/version_store/test_symbol_list.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_list.py
@@ -42,6 +42,7 @@ def make_read_only(lib):
     return NativeVersionStore.create_store_from_lib_config(lib.lib_cfg(), Defaults.ENV, OpenMode.READ)
 
 
+@pytest.mark.storage
 def test_with_symbol_list(basic_store):
     syms = []
     df = sample_dataframe(100)
@@ -78,6 +79,7 @@ def test_with_symbol_list(basic_store):
         assert sym in expected_syms
 
 
+@pytest.mark.storage
 def test_symbol_list_with_rec_norm(basic_store):
     basic_store.write(
         "rec_norm",
@@ -89,6 +91,7 @@ def test_symbol_list_with_rec_norm(basic_store):
     assert basic_store.list_symbols() == ["rec_norm"]
 
 
+@pytest.mark.storage
 def test_interleaved_store_read(version_store_and_real_s3_basic_store_factory):
     basic_store_factory = version_store_and_real_s3_basic_store_factory
     vs1 = basic_store_factory()
@@ -100,6 +103,7 @@ def test_interleaved_store_read(version_store_and_real_s3_basic_store_factory):
     assert vs1.list_symbols() == []
 
 
+@pytest.mark.storage
 def test_symbol_list_regex(basic_store):
     for i in range(15):
         basic_store.write(f"sym_{i}", pd.DataFrame())
@@ -117,6 +121,7 @@ def test_symbol_list_regex(basic_store):
 
 @pytest.mark.parametrize("compact_first", [True, False])
 # Using S3 because LMDB does not allow OpenMode to be changed
+@pytest.mark.storage
 def test_symbol_list_read_only_compaction_needed(small_max_delta, object_version_store, compact_first):
     lib_write = object_version_store
 
@@ -140,6 +145,7 @@ def test_symbol_list_read_only_compaction_needed(small_max_delta, object_version
     assert new_compaction != old_compaction
 
 
+@pytest.mark.storage
 def test_symbol_list_delete(basic_store):
     lib = basic_store
     lib.write("a", 1)
@@ -149,6 +155,7 @@ def test_symbol_list_delete(basic_store):
     assert lib.list_symbols() == ["b"]
 
 
+@pytest.mark.storage
 def test_symbol_list_delete_incremental(basic_store):
     lib = basic_store
     lib.write("a", 1)
@@ -160,6 +167,7 @@ def test_symbol_list_delete_incremental(basic_store):
     assert lib.list_symbols() == ["b"]
 
 
+@pytest.mark.storage
 def test_deleted_symbol_with_tombstones(basic_store_tombstones_no_symbol_list):
     lib = basic_store_tombstones_no_symbol_list
     lib.write("a", 1)
@@ -169,6 +177,7 @@ def test_deleted_symbol_with_tombstones(basic_store_tombstones_no_symbol_list):
     assert lib.list_symbols() == ["b"]
 
 
+@pytest.mark.storage
 def test_empty_lib(basic_store):
     lib = basic_store
     assert lib.list_symbols() == []
@@ -176,6 +185,7 @@ def test_empty_lib(basic_store):
     assert len(lt.find_keys(KeyType.SYMBOL_LIST)) == 1
 
 
+@pytest.mark.storage
 def test_no_active_symbols(basic_store_prune_previous):
     lib = basic_store_prune_previous
     for idx in range(20):
@@ -189,6 +199,7 @@ def test_no_active_symbols(basic_store_prune_previous):
     assert lib.list_symbols() == []
 
 
+@pytest.mark.storage
 def test_only_latest_compaction_key_is_used(basic_store):
     lib: NativeVersionStore = basic_store
     lt = lib.library_tool()
@@ -217,6 +228,7 @@ def test_only_latest_compaction_key_is_used(basic_store):
 
 
 @pytest.mark.parametrize("write_another", [False, True])
+@pytest.mark.storage
 def test_turning_on_symbol_list_after_a_symbol_written(object_store_factory, write_another):
     # The if(!maybe_last_compaction) case
     lib: NativeVersionStore = object_store_factory(symbol_list=False)
@@ -247,6 +259,7 @@ def test_turning_on_symbol_list_after_a_symbol_written(object_store_factory, wri
 
 
 @pytest.mark.parametrize("mode", ["conflict", "normal"])
+@pytest.mark.storage
 def test_lock_contention(small_max_delta, basic_store, mode):
     lib = basic_store
     lt = lib.library_tool()

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -8,6 +8,7 @@ from arcticdb_ext.storage import KeyType
 import arcticdb_ext.cpp_async as adb_async
 
 
+@pytest.mark.storage
 def test_symbol_sizes(basic_store):
     sizes = basic_store.version_store.scan_object_sizes_by_stream()
     assert len(sizes) == 1
@@ -30,6 +31,7 @@ def test_symbol_sizes(basic_store):
     assert sizes["sym_0"][KeyType.TABLE_DATA].compressed_size < 15000
 
 
+@pytest.mark.storage
 def test_symbol_sizes_big(basic_store):
     """
     Manual testing lines up well:
@@ -66,6 +68,7 @@ def test_symbol_sizes_big(basic_store):
     assert sizes["sym"][KeyType.TABLE_DATA].count == 1
 
 
+@pytest.mark.storage
 def test_symbol_sizes_multiple_versions(basic_store):
     basic_store.write("sym", sample_dataframe(1000))
     basic_store.write("sym", sample_dataframe(1000))
@@ -79,6 +82,7 @@ def test_symbol_sizes_multiple_versions(basic_store):
     assert 100_000 < sizes["sym"][KeyType.TABLE_DATA].uncompressed_size < 250_000
 
 
+@pytest.mark.storage
 def test_scan_object_sizes(arctic_client, lib_name):
     lib = arctic_client.create_library(lib_name)
     basic_store = lib._nvs

--- a/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
+++ b/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
@@ -21,6 +21,7 @@ from arcticdb.version_store._custom_normalizers import (
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata
 
 
+@pytest.mark.storage
 def test_update_date_range_dataframe(basic_store):
     """Restrictive update - when date_range is specified ensure that we only touch values in that range."""
     # given
@@ -104,6 +105,7 @@ def basic_store_custom_norm(basic_store_factory):
 
 
 @pytest.mark.parametrize("with_timezone_attr,timezone_", [(True, None), (True, timezone.utc), (False, None)])
+@pytest.mark.storage
 def test_update_date_range_non_pandas_dataframe(basic_store_custom_norm, with_timezone_attr, timezone_):
     """Check that updates with a daterange work for a simple non-Pandas timeseries.
 
@@ -137,6 +139,7 @@ def test_update_date_range_non_pandas_dataframe(basic_store_custom_norm, with_ti
 
 
 @pytest.mark.parametrize("with_timezone_attr,timezone_", [(True, None), (True, timezone.utc), (False, None)])
+@pytest.mark.storage
 def test_append_date_range_non_pandas_dataframe(basic_store_custom_norm, with_timezone_attr, timezone_):
     """Check that updates with a daterange work for a simple non-Pandas timeseries.
 
@@ -169,6 +172,7 @@ def test_append_date_range_non_pandas_dataframe(basic_store_custom_norm, with_ti
     np.testing.assert_array_equal(result["a"].values, pd.concat([df, update_df])["a"].values)
 
 
+@pytest.mark.storage
 def test_update_date_range_dataframe_multiindex(basic_store):
     """Similar to the test_update_date_range_dataframe, but with a multiindex."""
     # given

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -29,6 +29,7 @@ def get_log_types():
     return [KeyType.LOG, KeyType.LOG_COMPACTED]
 
 
+@pytest.mark.storage
 def test_get_types(object_and_mem_and_lmdb_version_store):
     df = sample_dataframe()
     lib = object_and_mem_and_lmdb_version_store
@@ -46,6 +47,7 @@ def test_get_types(object_and_mem_and_lmdb_version_store):
     assert index_df.at[pd.Timestamp(0), "version_id"] == 0
 
 
+@pytest.mark.storage
 def test_read_keys(object_and_mem_and_lmdb_version_store):
     populate_db(object_and_mem_and_lmdb_version_store)
     lib_tool = object_and_mem_and_lmdb_version_store.library_tool()
@@ -105,6 +107,7 @@ def test_empty_excluding_key_types_just_symbol_list(lmdb_version_store_v2):
     assert version_store.version_store.empty()
 
 
+@pytest.mark.storage
 def test_write_keys(object_and_mem_and_lmdb_version_store):
     populate_db(object_and_mem_and_lmdb_version_store)
     lib_tool = object_and_mem_and_lmdb_version_store.library_tool()
@@ -125,6 +128,7 @@ def test_write_keys(object_and_mem_and_lmdb_version_store):
     assert len(new_keys) == len(all_keys)
 
 
+@pytest.mark.storage
 def test_count_keys(object_and_mem_and_lmdb_version_store):
     df = sample_dataframe()
     lib = object_and_mem_and_lmdb_version_store

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -17,6 +17,8 @@ from arcticdb_ext.storage import KeyType
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.util.date import DateRange
 
+
+@pytest.mark.storage
 def test_read_keys(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_update_float_int"
@@ -33,6 +35,7 @@ def test_read_keys(object_and_mem_and_lmdb_version_store_dynamic_schema):
     assert_frame_equal(expected, result)
 
 
+@pytest.mark.storage
 def test_update_int_float(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_update_int_float"
@@ -49,6 +52,7 @@ def test_update_int_float(object_and_mem_and_lmdb_version_store_dynamic_schema):
     assert_frame_equal(expected, result)
 
 
+@pytest.mark.storage
 def test_update_nan_int(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_update_nan_int"
@@ -65,6 +69,7 @@ def test_update_nan_int(object_and_mem_and_lmdb_version_store_dynamic_schema):
     assert_frame_equal(expected, result)
 
 
+@pytest.mark.storage
 def test_update_int_nan(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_update_int_nan"
@@ -82,6 +87,7 @@ def test_update_int_nan(object_and_mem_and_lmdb_version_store_dynamic_schema):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SKIP_WIN Only dynamic strings are supported on Windows")
+@pytest.mark.storage
 def test_append_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_append_dynamic_to_fixed_width_strings"
@@ -105,6 +111,7 @@ def test_append_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_s
     assert_frame_equal(expected_df, read_df)
 
 
+@pytest.mark.storage
 def test_append_fixed_width_to_dynamic_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_append_fixed_width_to_dynamic_strings"
@@ -131,6 +138,7 @@ def test_append_fixed_width_to_dynamic_strings(object_and_mem_and_lmdb_version_s
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SKIP_WIN Only dynamic strings are supported on Windows")
+@pytest.mark.storage
 def test_update_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_update_dynamic_to_fixed_width_strings"
@@ -155,6 +163,7 @@ def test_update_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_s
     assert_frame_equal(expected_df, read_df)
 
 
+@pytest.mark.storage
 def test_update_fixed_width_to_dynamic_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
     symbol = "test_update_fixed_width_to_dynamic_strings"

--- a/python/tests/pytest.ini
+++ b/python/tests/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    storage: marks a test as a test against real storage (deselect with '-m "not storage"')
-    authentication: marks a test for authentication group (deselect with '-m "not authentication"')

--- a/python/tests/pytest.ini
+++ b/python/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    storage: marks a test as a test against real storage (deselect with '-m "not storage"')
+    authentication: marks a test for authentication group (deselect with '-m "not authentication"')

--- a/python/tests/stress/arcticdb/version_store/test_deallocation.py
+++ b/python/tests/stress/arcticdb/version_store/test_deallocation.py
@@ -7,10 +7,12 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 import pandas as pd
 import numpy as np
+import pytest
 
 from arcticdb.util.test import assert_frame_equal
 
 
+@pytest.mark.storage
 def test_many_version_store(basic_store_factory):
     idx2 = np.arange(10, 20)
     d2 = {"x": np.arange(20, 30, dtype=np.int64)}

--- a/python/tests/stress/arcticdb/version_store/test_long_running.py
+++ b/python/tests/stress/arcticdb/version_store/test_long_running.py
@@ -9,6 +9,8 @@ from __future__ import print_function
 import random
 import gc
 
+import pytest
+
 from arcticdb.util.tasks import (
     write_and_append_simple_df,
     write_large_mixed_df,
@@ -40,6 +42,7 @@ SCENARIOS = [
 ]
 
 
+@pytest.mark.storage
 def test_random_scenario(basic_store_small_segment):
     basic_store_small_segment.version_store._set_validate_version_map()
     for iteration in range(ITERATIONS):

--- a/python/tests/stress/arcticdb/version_store/test_stress_delete.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_delete.py
@@ -26,6 +26,7 @@ def check_no_keys(library):
         assert len(lib_tool.find_keys(key_type)) == 0
 
 
+@pytest.mark.storage
 def test_stress_delete(object_store_factory):
     store_factory = object_store_factory
     lib1 = store_factory(name=f"delete_me_{datetime.utcnow().isoformat()}")

--- a/python/tests/stress/arcticdb/version_store/test_stress_dynamic_bucketize.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_dynamic_bucketize.py
@@ -16,6 +16,7 @@ from arcticdb.util.test import assert_frame_equal
     ["colnum", "rownum", "initial_col_width", "max_col_width", "total_rows"],
     [(10, 5, 20, 500, 20), (10, 5, 450, 500, 20), (10, 5, 200, 1000, 20), (128, 100000, 30000, 40000, 4)],
 )
+@pytest.mark.storage
 def test_dynamic_bucketize_append_variable_width(
     get_wide_df, sym, basic_store_factory, colnum, rownum, initial_col_width, max_col_width, total_rows
 ):

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -70,6 +70,7 @@ def test_staging_doesnt_write_append_ref(lmdb_version_store_v1):
     assert not len(lib_tool.find_keys_for_symbol(KeyType.APPEND_REF, sym))
 
 
+@pytest.mark.storage
 def test_remove_incomplete(basic_store):
     lib = basic_store
     lib_tool = lib.library_tool()
@@ -114,6 +115,7 @@ def test_remove_incomplete(basic_store):
     (1, 10, 1),
     (None, None, None)
 ])
+@pytest.mark.storage
 def test_parallel_write(basic_store_tiny_segment, num_segments_live_during_compaction, num_io_threads, num_cpu_threads):
     try:
         with config_context_multi({"VersionStore.NumSegmentsLiveDuringCompaction": num_segments_live_during_compaction,
@@ -273,6 +275,7 @@ def test_floats_to_nans(lmdb_version_store_dynamic_schema):
     "num_segments_live_during_compaction, num_io_threads, num_cpu_threads", [(1, 1, 1), (10, 1, 1), (None, None, None)]
 )
 @pytest.mark.parametrize("prune_previous_versions", (True, False))
+@pytest.mark.storage
 def test_parallel_write_sort_merge(
     basic_store_tiny_segment,
     lib_name,
@@ -326,6 +329,7 @@ def test_parallel_write_sort_merge(
 
 
 @pytest.mark.parametrize("prune_previous_versions", [True, False])
+@pytest.mark.storage
 def test_sort_merge_append(basic_store_dynamic_schema, prune_previous_versions):
     lib = basic_store_dynamic_schema
     num_rows_per_day = 10

--- a/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
+++ b/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
@@ -41,6 +41,7 @@ def assert_vit_equals_except_data(left, right):
     assert left.timestamp == right.timestamp
 
 @pytest.mark.parametrize("read", (lambda lib, sym: lib.batch_read([sym])[sym], lambda lib, sym: lib.read(sym)))
+@pytest.mark.storage
 def test_recursively_written_data(basic_store, read):
     samples = [
         {"a": np.arange(5), "b": np.arange(8)},  # dict of np arrays
@@ -69,6 +70,7 @@ def test_recursively_written_data(basic_store, read):
 
 
 @pytest.mark.parametrize("read", (lambda lib, sym: lib.batch_read([sym])[sym], lambda lib, sym: lib.read(sym)))
+@pytest.mark.storage
 def test_recursively_written_data_with_metadata(basic_store, read):
     samples = [
         {"a": np.arange(5), "b": np.arange(8)},  # dict of np arrays
@@ -89,6 +91,7 @@ def test_recursively_written_data_with_metadata(basic_store, read):
 
 
 @pytest.mark.parametrize("read", (lambda lib, sym: lib.batch_read([sym])[sym], lambda lib, sym: lib.read(sym)))
+@pytest.mark.storage
 def test_recursively_written_data_with_nones(basic_store, read):
     sample = {"a": np.arange(5), "b": np.arange(8), "c": None}
     recursive_sym = "sym_recursive"
@@ -108,6 +111,7 @@ def test_recursively_written_data_with_nones(basic_store, read):
 
 
 @pytest.mark.parametrize("read", (lambda lib, sym: lib.batch_read([sym])[sym], lambda lib, sym: lib.read(sym)))
+@pytest.mark.storage
 def test_recursive_nested_data(basic_store, read):
     sym = "test_recursive_nested_data"
     sample_data = {"a": {"b": {"c": {"d": np.arange(24)}}}}
@@ -124,6 +128,7 @@ def test_recursive_nested_data(basic_store, read):
     assert read_vit.symbol == sym
     assert_vit_equals_except_data(read_vit, write_vit)
 
+@pytest.mark.storage
 def test_recursive_normalizer_with_custom_class():
     list_like_obj = AlmostAList([1, 2, 3])
     fl = Flattener()
@@ -134,6 +139,7 @@ def test_recursive_normalizer_with_custom_class():
     fl = Flattener()
     assert fl.is_normalizable_to_nested_structure(list_like_obj)
 
+@pytest.mark.storage
 def test_nested_custom_types(basic_store):
     data = AlmostAList([1, 2, 3, AlmostAList([5, np.arange(6)])])
     fl = Flattener()
@@ -149,6 +155,7 @@ def test_nested_custom_types(basic_store):
     assert_vit_equals_except_data(write_vit, read_vit)
     assert basic_store.get_info(sym)["type"] != "pickled"
 
+@pytest.mark.storage
 def test_data_directly_msgpackable(basic_store):
     data = {"a": [1, 2, 3], "b": {"c": 5}}
     fl = Flattener()
@@ -163,6 +170,7 @@ def test_data_directly_msgpackable(basic_store):
 
 
 @pytest.mark.parametrize("read", (lambda lib, sym: lib.batch_read([sym])[sym], lambda lib, sym: lib.read(sym)))
+@pytest.mark.storage
 def test_really_large_symbol_for_recursive_data(basic_store, read):
     sym = "s" * 100
     data = {"a" * 100: {"b" * 100: {"c" * 1000: {"d": np.arange(5)}}}}

--- a/python/tests/unit/arcticdb/version_store/test_sort.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+import pytest
 import arcticdb as adb
 from arcticdb.util.test import assert_frame_equal
 from arcticdb_ext.storage import KeyType
@@ -8,6 +9,7 @@ from arcticdb_ext.version_store import SortedValue
 from arcticdb.util.test import random_strings_of_length
 
 
+@pytest.mark.storage
 def test_stage_finalize(arctic_library):
     symbol = "AAPL"
     sort_cols = ["timestamp", "col1"]
@@ -40,6 +42,7 @@ def test_stage_finalize(arctic_library):
     pd.testing.assert_frame_equal(result, expected)
 
 
+@pytest.mark.storage
 def test_stage_finalize_dynamic(arctic_library_dynamic):
     arctic_library = arctic_library_dynamic
     symbol = "AAPL"
@@ -75,6 +78,7 @@ def test_stage_finalize_dynamic(arctic_library_dynamic):
     pd.testing.assert_frame_equal(result, expected)
 
 
+@pytest.mark.storage
 def test_stage_finalize_strings(arctic_library):
     symbol = "AAPL"
     sort_cols = ["timestamp", "col1"]
@@ -109,6 +113,7 @@ def test_stage_finalize_strings(arctic_library):
     pd.testing.assert_frame_equal(result, expected)
 
 
+@pytest.mark.storage
 def test_stage_finalize_strings_dynamic(arctic_library_dynamic):
     arctic_library = arctic_library_dynamic
     symbol = "AAPL"
@@ -145,6 +150,7 @@ def test_stage_finalize_strings_dynamic(arctic_library_dynamic):
     pd.testing.assert_frame_equal(result, expected)
 
 
+@pytest.mark.storage
 def test_stage_finalize_sort_index(arctic_library):
     symbol = "AAPL"
     sort_cols = ["timestamp"]
@@ -239,6 +245,7 @@ def test_stage_with_sort_columns_not_ts(lmdb_version_store_v1):
     assert_frame_equal(df1, actual)
 
 
+@pytest.mark.storage
 def test_stage_finalize_dynamic_with_chunking(arctic_client, lib_name):
     lib_opts = adb.LibraryOptions(dynamic_schema=True, rows_per_segment=2, columns_per_segment=2)
     lib = arctic_client.get_library(lib_name, create_if_missing=True, library_options=lib_opts)
@@ -286,6 +293,7 @@ def test_stage_finalize_dynamic_with_chunking(arctic_client, lib_name):
     pd.testing.assert_frame_equal(result, expected)
 
 
+@pytest.mark.storage
 def test_stage_finalize_index_and_additional(arctic_library):
     symbol = "AAPL"
     sort_cols = ["col1"]

--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -36,6 +36,7 @@ SKIP_CONDA_MARK = pytest.mark.skipif(
 PERSISTENT_STORAGE_TESTS_ENABLED = os.getenv("ARCTICDB_PERSISTENT_STORAGE_TESTS") == "1"
 FAST_TESTS_ONLY = os.getenv("ARCTICDB_FAST_TESTS_ONLY") == "1"
 DISABLE_SLOW_TESTS = os.getenv("ARCTICDB_DISABLE_SLOW_TESTS") == "1"
+# Local storage tests are all LMDB, simulated and a real mongo process/service
 LOCAL_STORAGE_TESTS_ENABLED = os.getenv("ARCTICDB_LOCAL_STORAGE_TESTS_ENABLED", "1") == "1"
 STORAGE_AWS_S3 = os.getenv("ARCTICDB_STORAGE_AWS_S3", "1") == "1"
 STORAGE_GCP = os.getenv("ARCTICDB_STORAGE_GCP") == "1"
@@ -50,9 +51,10 @@ AZURE_TESTS_MARK = pytest.mark.skipif(FAST_TESTS_ONLY or MACOS_CONDA_BUILD or no
                                       reason=_MACOS_CONDA_BUILD_SKIP_REASON)
 """Mark to skip all Azure tests when MACOS_CONDA_BUILD or ARCTICDB_FAST_TESTS_ONLY is set."""
 
+# Mongo tests will run under local storage tests 
 MONGO_TESTS_MARK = pytest.mark.skipif(
     FAST_TESTS_ONLY or sys.platform != "linux" or not LOCAL_STORAGE_TESTS_ENABLED,
-    reason="Skipping mongo tests under ARCTICDB_FAST_TESTS_ONLY",
+    reason="Skipping mongo tests under ARCTICDB_FAST_TESTS_ONLY and if local storage tests are disabled",
 )
 """Mark on tests using the mongo storage fixtures. Currently skips if ARCTICDB_FAST_TESTS_ONLY."""
 

--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -46,11 +46,12 @@ SLOW_TESTS_MARK = pytest.mark.skipif(
     FAST_TESTS_ONLY or DISABLE_SLOW_TESTS, reason="Skipping test as it takes a long time to run"
 )
 
-AZURE_TESTS_MARK = pytest.mark.skipif(FAST_TESTS_ONLY or MACOS_CONDA_BUILD, reason=_MACOS_CONDA_BUILD_SKIP_REASON)
+AZURE_TESTS_MARK = pytest.mark.skipif(FAST_TESTS_ONLY or MACOS_CONDA_BUILD or not LOCAL_STORAGE_TESTS_ENABLED, 
+                                      reason=_MACOS_CONDA_BUILD_SKIP_REASON)
 """Mark to skip all Azure tests when MACOS_CONDA_BUILD or ARCTICDB_FAST_TESTS_ONLY is set."""
 
 MONGO_TESTS_MARK = pytest.mark.skipif(
-    FAST_TESTS_ONLY or sys.platform != "linux",
+    FAST_TESTS_ONLY or sys.platform != "linux" or not LOCAL_STORAGE_TESTS_ENABLED,
     reason="Skipping mongo tests under ARCTICDB_FAST_TESTS_ONLY",
 )
 """Mark on tests using the mongo storage fixtures. Currently skips if ARCTICDB_FAST_TESTS_ONLY."""

--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -36,6 +36,9 @@ SKIP_CONDA_MARK = pytest.mark.skipif(
 PERSISTENT_STORAGE_TESTS_ENABLED = os.getenv("ARCTICDB_PERSISTENT_STORAGE_TESTS") == "1"
 FAST_TESTS_ONLY = os.getenv("ARCTICDB_FAST_TESTS_ONLY") == "1"
 DISABLE_SLOW_TESTS = os.getenv("ARCTICDB_DISABLE_SLOW_TESTS") == "1"
+LOCAL_STORAGE_TESTS_ENABLED = os.getenv("ARCTICDB_LOCAL_STORAGE_TESTS_ENABLED", "1") == "1"
+STORAGE_AWS_S3 = os.getenv("ARCTICDB_STORAGE_AWS_S3", "1") == "1"
+STORAGE_GCP = os.getenv("ARCTICDB_STORAGE_GCP") == "1"
 
 # !!!!!!!!!!!!!!!!!!!!!! Below mark (variable) names should reflect where they will be used, not what they do.
 # This is to avoid the risk of the name becoming out of sync with the actual condition.
@@ -53,11 +56,52 @@ MONGO_TESTS_MARK = pytest.mark.skipif(
 """Mark on tests using the mongo storage fixtures. Currently skips if ARCTICDB_FAST_TESTS_ONLY."""
 
 REAL_S3_TESTS_MARK = pytest.mark.skipif(
-    FAST_TESTS_ONLY or not PERSISTENT_STORAGE_TESTS_ENABLED,
+    FAST_TESTS_ONLY or not PERSISTENT_STORAGE_TESTS_ENABLED or not STORAGE_AWS_S3,
     reason="Can be used only when persistent storage is enabled",
 )
 """Mark on tests using the real (i.e. hosted by AWS as opposed to moto) S3.
 Currently controlled by the ARCTICDB_PERSISTENT_STORAGE_TESTS and ARCTICDB_FAST_TESTS_ONLY env vars."""
+REAL_GCP_TESTS_MARK = pytest.mark.skipif(
+    FAST_TESTS_ONLY or not PERSISTENT_STORAGE_TESTS_ENABLED or not STORAGE_GCP,
+    reason="Can be used only when persistent storage is enabled",
+)
+"""Mark on tests using the real GCP storage.
+"""
+"""Mark on tests using S3 model storage.
+"""
+SIM_S3_TESTS_MARK = pytest.mark.skipif(
+    not LOCAL_STORAGE_TESTS_ENABLED,
+    reason="Ability to disable local storages",
+)
+"""Mark on tests using GCP model storage.
+"""
+SIM_GCP_TESTS_MARK = pytest.mark.skipif(
+    not LOCAL_STORAGE_TESTS_ENABLED,
+    reason="Ability to disable local storages",
+)
+"""Mark on tests using the real GCP storage.
+"""
+"""Mark on tests using the LMDB storage.
+"""
+LMDB_TESTS_MARK = pytest.mark.skipif(
+    not LOCAL_STORAGE_TESTS_ENABLED,
+    reason="Ability to disable local storages",
+)
+"""Mark on tests using the MEM storage.
+"""
+MEM_TESTS_MARK = pytest.mark.skipif(
+    not LOCAL_STORAGE_TESTS_ENABLED,
+    reason="Ability to disable local storages",
+)
+"""Mark on tests using the NFS model storage.
+"""
+SIM_NFS_TESTS_MARK = pytest.mark.skipif(
+    not LOCAL_STORAGE_TESTS_ENABLED,
+    reason="Ability to disable local storages",
+)
+"""Mark on tests using the real GCP storage.
+"""
+
 
 
 """Windows and MacOS have different handling of self-signed CA cert for test. 

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -65,6 +65,22 @@ def real_s3_credentials(shared_path: bool = True):
     return endpoint, bucket, region, access_key, secret_key, path_prefix, clear
 
 
+def real_gcp_credentials(shared_path: bool = True):
+    endpoint = os.getenv("ARCTICDB_REAL_GCP_ENDPOINT")
+    bucket = os.getenv("ARCTICDB_REAL_GCP_BUCKET")
+    region = os.getenv("ARCTICDB_REAL_GCP_REGION")
+    access_key = os.getenv("ARCTICDB_REAL_GCP_ACCESS_KEY")
+    secret_key = os.getenv("ARCTICDB_REAL_GCP_SECRET_KEY")
+    if shared_path:
+        path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX")
+    else:
+        path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX")
+
+    clear = str(os.getenv("ARCTICDB_REAL_GCP_CLEAR")).lower() in ("true", "1")
+
+    return endpoint, bucket, region, access_key, secret_key, path_prefix, clear
+
+
 def get_real_s3_uri(shared_path: bool = True):
     # TODO: Remove this when the latest version that we support
     # contains the s3 fixture code as defined here:

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -69,7 +69,7 @@ def real_s3_credentials(shared_path: bool = True):
 
 def real_gcp_credentials(shared_path: bool = True):
     endpoint = os.getenv("ARCTICDB_REAL_GCP_ENDPOINT")
-    if "://" in endpoint:
+    if endpoint is not None and "://" in endpoint:
        endpoint = endpoint.split("://")[1] 
     bucket = os.getenv("ARCTICDB_REAL_GCP_BUCKET")
     region = os.getenv("ARCTICDB_REAL_GCP_REGION")

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import os
@@ -9,6 +10,7 @@ from datetime import datetime
 
 from arcticdb import Arctic
 from arcticc.pb2.s3_storage_pb2 import Config as S3Config
+from tests.util.mark import PERSISTENT_STORAGE_TESTS_ENABLED
 
 
 # TODO: Remove this when the latest version that we support
@@ -67,6 +69,8 @@ def real_s3_credentials(shared_path: bool = True):
 
 def real_gcp_credentials(shared_path: bool = True):
     endpoint = os.getenv("ARCTICDB_REAL_GCP_ENDPOINT")
+    if "://" in endpoint:
+       endpoint = endpoint.split("://")[1] 
     bucket = os.getenv("ARCTICDB_REAL_GCP_BUCKET")
     region = os.getenv("ARCTICDB_REAL_GCP_REGION")
     access_key = os.getenv("ARCTICDB_REAL_GCP_ACCESS_KEY")
@@ -100,6 +104,50 @@ def get_real_s3_uri(shared_path: bool = True):
     return aws_uri
 
 
+def get_real_gcp_uri(shared_path: bool = True):
+    # TODO: Remove this when the latest version that we support
+    # contains the s3 fixture code as defined here:
+    # https://github.com/man-group/ArcticDB/blob/master/.github/workflows/persistent_storage.yml#L64
+    (
+        endpoint,
+        bucket,
+        region,
+        acs_key,
+        sec_key,
+        path_prefix,
+        _,
+    ) = real_gcp_credentials(shared_path)
+    aws_uri = (
+        f"gcpxml://{endpoint}:{bucket}?access={acs_key}&secret={sec_key}&path_prefix={path_prefix}"
+    )
+    return aws_uri
+
+
+class PersistentTestType(Enum):
+    AWS_S3 = 1,
+    GCP = 2,
+
+
+def persistent_test_type() -> PersistentTestType:
+    """Check which persistent storage type is selected
+    
+    If persistent storage tests are not selected for execution
+    will raise error
+    """
+    if PERSISTENT_STORAGE_TESTS_ENABLED:
+        if os.getenv("ARCTICDB_PERSISTENT_STORAGE_TESTS_TYPE", "").lower() == "gcp":
+            return PersistentTestType.GCP
+        return PersistentTestType.AWS_S3
+    else:
+        raise Exception("Persistence storage tests are not enabled or not configured properly")
+
+
+def get_real_uri(shared_path: bool = True):
+    if persistent_test_type() == PersistentTestType.GCP:
+       return get_real_gcp_uri(shared_path)
+    return get_real_s3_uri(shared_path)
+
+
 def get_s3_storage_config(cfg):
     primary_storage_name = cfg.lib_desc.storage_ids[0]
     primary_any = cfg.storage_by_id[primary_storage_name]
@@ -117,13 +165,13 @@ def normalize_lib_name(lib_name):
 
 def get_seed_libraries(ac=None):
     if ac is None:
-        ac = Arctic(get_real_s3_uri())
+        ac = Arctic(get_real_uri())
     return [lib for lib in ac.list_libraries() if lib.startswith("seed_")]
 
 
 def get_test_libraries(ac=None):
     if ac is None:
-        ac = Arctic(get_real_s3_uri())
+        ac = Arctic(get_real_uri())
     return [lib for lib in ac.list_libraries() if lib.startswith("test_")]
 
 
@@ -314,8 +362,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     job_type = str(args.type).lower()
     # TODO: Add support for other storages
-    uri = get_real_s3_uri()
+    uri = get_real_uri()
     ac = Arctic(uri)
+    print(f"Storage type: {persistent_test_type()}")
 
     if "seed" == job_type:
         seed_library(ac, args.version)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

( AWS S3 tests link - started from actions https://github.com/man-group/ArcticDB/actions/runs/14172795087/job/39700720982 )
(local tests only started from new branch: https://github.com/man-group/ArcticDB/actions/runs/14188770022)

At initial stage of work ...

Introducing 2 markers:
 - storage - for real storage tests (approx 390 out of 1400 tests)
 - authentication - for authentication tests (they are executed againsy real storage, but are different category). Main purpose is to provide quick check for actual state of the authentication only.

The markers now allow more targeted execution of tests - like only storage, authentication tests or all withou a group or more.

Added several new fixtures for GCP type of storage

marked test that use following fixtures as storage tests (potentially they will be executed against all _real_ storages). There will be also need to have exclude mark for certain storage type from some tests TBD)
- basic_store
- basic_store_factory
- version_store_and_real_s3_basic_store_factory
- object_store_factory
- object_version_store
- object_version_store_prune_previous
- real_s3_version_store
- real_s3_version_store_dynamic_schema
- real_s3_sts_store_factory
- basic_arctic_library
- basic_arctic_client
- arctic_library* (many)
- basic_store* (many)
- arctic_client_no_lmdb
- arctic_client_v1
- arctic_client
- version_store_and_real_s3_basic_store_factory

The PR now defines 3 groups of tests which can be locally controlled:
- local storage tests - all tests with local storage (including simulated shared storages)
  - To constorl use env var:   LOCAL_STORAGE_TESTS_ENABLED=(0|1) 
- real AWS S3 tests - tests that are executed agains actual Amazaon storage. 
  - To constorl use env vars:   
    - ARCTICDB_PERSISTENT_STORAGE_TESTS=(0|1) 
    - ARCTICDB_STORAGE_AWS_S3=(0|1) 
- reals GCP tests - tests that are executed against actual Google cloud storage.
  - To constorl use env vars:   
    - ARCTICDB_PERSISTENT_STORAGE_TESTS=(0|1) 
    - ARCTICDB_STORAGE_GCP=(0|1) 

Has a new folder with tests (enduser) which purpose is to be "no wrapping fixture" tests to cover real user experience

There are also 2 new custom marks added to help manage tests:
- @pytest.mark.only_fixture_params([<fixture_param_names_list>], ) - this mark allows limitting the number of of parameters that the fixture will generate for this test only to specified in the parameters list of the mark. Useful for overriding general behavor of a general fixture and producing custom fixture experience for this test
- @pytest.mark.skip_fixture_params([<fixture_param_names_list>], ) - this mark allows skipping generation of specific value(s) of a fixture, Useful when there is a problem with that test and a specific fixture from list. 

Additional useful custom mark is @pytest,mark.bug_ids([<list of bug ids>]) - usful to associate an issue with a test - in case it produced bug or the test is because of specific bugs logged. This mark does not have efect over execution, only helps traceability and provides context, Such marks can and should stay in code unlike xfail marks

With authentication we have potentially unsafe situation to log accidently credential or other sensitive information.
Therefore 2 things need to be introduced:
  - Sanitizing message exception
  - Sanitizing logger
  
 Similar is the problem with pytest parameter - avoiding passing secrets in clear form could be done through masking

Changes to the test execution workflow:

Because tests now can be executed for 3 different types of storages, the checkbox for persistance tests is now a drop down allowing selection of:
  - tests without real storage
  - real AWS S3 storage tests only (no local storage tests)
  - real GCP storage tests (no local test)

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
