### PR TITLE
Improve error message in case of network error

### DIFF
--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -43,7 +43,7 @@ def test_s3_storage_failures(mock_s3_store_with_error_simulation):
     result_df = lib.read(symbol_success).data
     assert_frame_equal(result_df, df)
 
-    with pytest.raises(StorageException, match="Unexpected network error: S3Error#99"):
+    with pytest.raises(StorageException, match="Network error: S3Error#99"):
         lib.write(symbol_fail_write, df)
 
     with pytest.raises(StorageException, match="Unexpected error: S3Error#17"):
@@ -171,15 +171,15 @@ def test_wrapped_s3_storage(lib_name, wrapped_s3_storage_bucket):
     test_bucket_name = wrapped_s3_storage_bucket.bucket
 
     with config_context("S3ClientTestWrapper.EnableFailures", 1):
-        with pytest.raises(NoDataFoundException, match="Unexpected network error: S3Error#99"):
+        with pytest.raises(NoDataFoundException, match="Network error: S3Error#99"):
             lib.read("s")
 
         with config_context_string("S3ClientTestWrapper.FailureBucket", test_bucket_name):
-            with pytest.raises(StorageException, match="Unexpected network error: S3Error#99"):
+            with pytest.raises(StorageException, match="Network error: S3Error#99"):
                 lib.write("s", data=create_df())
 
         with config_context_string("S3ClientTestWrapper.FailureBucket", f"{test_bucket_name},non_existent_bucket"):
-            with pytest.raises(StorageException, match="Unexpected network error: S3Error#99"):
+            with pytest.raises(StorageException, match="Network error: S3Error#99"):
                 lib.write("s", data=create_df())
 
         # There should be no failures


### PR DESCRIPTION
We had previously short-circuit-ed the [improved error message](https://github.com/man-group/ArcticDB/commit/06a52de976be33b8947189a54f9bcb9763ec7c4a) in case of a network error.

This commit re-adds the improved error message in case of a retry-able s3 error.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
