### PR TITLE
Simple API to remove several staged symbols at once.

### DIFF
--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -463,6 +463,13 @@ void remove_incomplete_segments(
     delete_keys_of_type_for_stream(store, stream_id, KeyType::APPEND_DATA);
 }
 
+void remove_incomplete_segments(
+    const std::shared_ptr<Store>& store, const std::unordered_set<StreamId>& sids, const std::string& common_prefix
+) {
+    auto match_stream_id =  [&sids](const VariantKey & k){ return sids.find(variant_key_id(k)) != sids.end(); };
+    delete_keys_of_type_if(store, match_stream_id, KeyType::APPEND_DATA, common_prefix);
+}
+
 std::vector<AppendMapEntry> load_via_list(
         const std::shared_ptr<Store>& store,
         const StreamId& stream_id,

--- a/cpp/arcticdb/stream/incompletes.hpp
+++ b/cpp/arcticdb/stream/incompletes.hpp
@@ -52,6 +52,9 @@ void remove_incomplete_segments(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id);
 
+void remove_incomplete_segments(
+    const std::shared_ptr<Store>& store, const std::unordered_set<StreamId>& sids, const std::string& common_prefix);
+
 void write_parallel_impl(
     const std::shared_ptr<Store>& store,
     const StreamId& stream_id,

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -989,6 +989,13 @@ void LocalVersionedEngine::remove_incomplete(
     remove_incomplete_segments(store_, stream_id);
 }
 
+void LocalVersionedEngine::remove_incompletes(
+    const std::unordered_set<StreamId>& stream_ids,
+    const std::string& common_prefix
+) {
+    remove_incomplete_segments(store_, stream_ids, common_prefix);
+}
+
 std::set<StreamId> LocalVersionedEngine::get_incomplete_symbols() {
     return ::arcticdb::get_incomplete_symbols(store_);
 }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -24,6 +24,8 @@
 
 namespace arcticdb::version_store {
 
+using VersionedItemOrError = std::variant<VersionedItem, DataError>;
+
 /**
  * Implements the parent interface and provides additional methods not needed/suitable by a RemoteVersionedEngine.
  *
@@ -109,6 +111,10 @@ public:
     void remove_incomplete(
         const StreamId& stream_id
     ) override;
+
+    void remove_incompletes(
+        const std::unordered_set<StreamId>& sids, const std::string& common_prefix
+        );
 
     std::optional<VersionedItem> get_latest_version(
         const StreamId &stream_id);

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -580,6 +580,11 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
          .def("remove_incomplete",
              &PythonVersionStore::remove_incomplete,
              py::call_guard<SingleThreadMutexHolder>(), "Delete incomplete segments")
+         .def("remove_incompletes",
+              [&](PythonVersionStore& v, const std::unordered_set<StreamId>& sids, const std::string& common_prefix) {
+            return v.remove_incompletes(sids, common_prefix);
+         },
+         py::call_guard<SingleThreadMutexHolder>(), "Remove several incomplete segments")
          .def("compact_incomplete",
              &PythonVersionStore::compact_incomplete,
              py::arg("stream_id"),

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -253,7 +253,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const std::optional<bool>& skip_snapshots);
 
     // Batch methods
-    std::vector<std::variant<VersionedItem, DataError>> batch_write(
+    std::vector<VersionedItemOrError> batch_write(
         const std::vector<StreamId> &stream_ids,
         const std::vector<py::tuple> &items,
         const std::vector<py::object> &norms,
@@ -262,13 +262,13 @@ class PythonVersionStore : public LocalVersionedEngine {
         bool validate_index,
         bool throw_on_error);
 
-    std::vector<std::variant<VersionedItem, DataError>> batch_write_metadata(
+    std::vector<VersionedItemOrError> batch_write_metadata(
         const std::vector<StreamId>& stream_ids,
         const std::vector<py::object>& user_meta,
         bool prune_previous_versions,
         bool throw_on_error);
 
-    std::vector<std::variant<VersionedItem, DataError>> batch_append(
+    std::vector<VersionedItemOrError> batch_append(
         const std::vector<StreamId> &stream_ids,
         const std::vector<py::tuple> &items,
         const std::vector<py::object> &norms,
@@ -288,7 +288,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         std::vector<std::shared_ptr<ReadQuery>>& read_queries,
         const ReadOptions& read_options);
 
-    std::vector<std::variant<VersionedItem, DataError>> batch_update(
+    std::vector<VersionedItemOrError> batch_update(
         const std::vector<StreamId>& stream_ids,
         const std::vector<py::tuple>& items,
         const std::vector<py::object>& norms,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2059,6 +2059,26 @@ class NativeVersionStore:
         """
         self.version_store.remove_incomplete(symbol)
 
+    def _remove_incompletes(self, symbols: List[str]):
+        """
+        Removes staged data for several symbols.
+
+        Does not raise if a symbol has no staged data.
+
+        In the worst case this can list over all the staged data in your library, so if you are only touching a small
+        subset of the staged data in your library, it may be better to use the remove_incomplete method above.
+
+        This is a private function for now and its API is not stable.
+
+        Parameters
+        ----------
+        symbols : List[str]
+            Symbols to remove staged data for.
+        """
+        symbols_set = set(symbols)
+        common_prefix = os.path.commonprefix(symbols)
+        self.version_store.remove_incompletes(symbols_set, common_prefix)
+
     def compact_incomplete(
         self,
         symbol: str,

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -13,14 +13,13 @@ from enum import Enum, auto
 from typing import Optional, Any, Tuple, Dict, Union, List, Iterable, NamedTuple
 from numpy import datetime64
 
-from arcticdb.options import \
-    LibraryOptions, EnterpriseLibraryOptions, ModifiableLibraryOption, ModifiableEnterpriseLibraryOption
+from arcticdb.options import LibraryOptions, EnterpriseLibraryOptions
 from arcticdb.preconditions import check
 from arcticdb.supported_types import Timestamp
 from arcticdb.util._versions import IS_PANDAS_TWO
 
 from arcticdb.version_store.processing import ExpressionNode, QueryBuilder
-from arcticdb.version_store._store import NativeVersionStore, VersionedItem, VersionQueryInput
+from arcticdb.version_store._store import NativeVersionStore, VersionedItem
 from arcticdb_ext.exceptions import ArcticException
 from arcticdb_ext.version_store import DataError, OutputFormat
 import pandas as pd


### PR DESCRIPTION
Private in NativeVersionStore for now so we don't need to give API guarantees till we know whether it's useful.

The proper "batch" API where we give back `Union[VersionedItem, DataError]` is nicer - and we'll have to do it if we promote to the Library API - but would need changes to all the storage backends.
