### PR TITLE
API to get sizes for a particular stream

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -223,28 +223,49 @@ void iterate_type(
     library_->iterate_type(type, func, prefix);
 }
 
-folly::Future<storage::ObjectSizes> get_object_sizes(KeyType type, const std::string& prefix) override {
+folly::Future<folly::Unit> visit_object_sizes(
+    KeyType type, const std::optional<StreamId>& stream_id_opt, storage::ObjectSizesVisitor visitor) override {
+    std::string prefix;
+    std::optional<std::function<bool(const VariantKey&)>> match_stream_id = std::nullopt;
+    if (stream_id_opt) {
+        auto stream_id = *stream_id_opt;
+        prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
+        match_stream_id = [stream_id](const VariantKey& k) { return variant_key_id(k) == stream_id; };
+    }
+
     if (library_->supports_object_size_calculation()) {
         // The library has native support for some kind of clever size calculation, so let it take over
-        return async::submit_io_task(ObjectSizesTask{type, prefix, library_});
+        return async::submit_io_task(VisitObjectSizesTask{type, prefix, std::move(visitor), library_});
     }
 
     // No native support for a clever size calculation, so just read keys and sum their sizes
-    auto counter = std::make_shared<std::atomic_uint64_t>(0);
-    auto bytes = std::make_shared<std::atomic_uint64_t>(0);
     KeySizeCalculators key_size_calculators;
-    iterate_type(type, [&key_size_calculators, &counter, &bytes](const VariantKey&& k) {
-        key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [counter, bytes] (auto&& ks) {
-            counter->fetch_add(1);
-            auto key_seg = std::forward<decltype(ks)>(ks);
-            auto compressed_size = key_seg.segment().size();
-            bytes->fetch_add(compressed_size);
+    iterate_type(type, [&key_size_calculators, &match_stream_id, &visitor](const VariantKey&& k) {
+        key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [visitor, match_stream_id] (auto&& key_seg) {
+            if (!match_stream_id || match_stream_id.value()(key_seg.variant_key())) {
+                auto compressed_size = key_seg.segment().size();
+                visitor(key_seg.variant_key(), compressed_size);
+            }
             return key_seg.variant_key();
         });
     }, prefix);
 
     read_ignoring_key_not_found(std::move(key_size_calculators));
-    return folly::makeFuture(storage::ObjectSizes{type, *counter, *bytes});
+    return folly::makeFuture();
+}
+
+folly::Future<std::shared_ptr<storage::ObjectSizes>> get_object_sizes(KeyType type, const std::optional<StreamId>& stream_id_opt) override {
+    auto counter = std::make_shared<std::atomic_uint64_t>(0);
+    auto bytes = std::make_shared<std::atomic_uint64_t>(0);
+    storage::ObjectSizesVisitor visitor = [counter, bytes](const VariantKey&, storage::CompressedSize size) {
+        counter->fetch_add(1);
+        bytes->fetch_add(size);
+    };
+
+    return visit_object_sizes(type, stream_id_opt, std::move(visitor))
+    .thenValueInline([counter, bytes, type](folly::Unit&&) {
+        return std::make_shared<storage::ObjectSizes>(type, *counter, *bytes);
+    });
 }
 
 bool scan_for_matching_key(

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -11,6 +11,7 @@
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/storage/store.hpp>
+#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/hash.hpp>
@@ -665,28 +666,31 @@ struct RemoveBatchTask : BaseTask {
     }
 };
 
-struct ObjectSizesTask : BaseTask {
+struct VisitObjectSizesTask : BaseTask {
     KeyType type_;
     std::string prefix_;
+    storage::ObjectSizesVisitor visitor_;
     std::shared_ptr<storage::Library> lib_;
 
-    ObjectSizesTask(
+    VisitObjectSizesTask(
         KeyType type,
         std::string prefix,
+        storage::ObjectSizesVisitor visitor,
         std::shared_ptr<storage::Library> lib
         ) :
         type_(type),
         prefix_(std::move(prefix)),
+        visitor_(std::move(visitor)),
         lib_(std::move(lib)) {
         ARCTICDB_DEBUG(log::storage(), "Creating object sizes task for key type {} prefix {}", type_, prefix_);
     }
 
-    ARCTICDB_MOVE_ONLY_DEFAULT(ObjectSizesTask)
+    ARCTICDB_MOVE_ONLY_DEFAULT(VisitObjectSizesTask)
 
-    folly::Future<storage::ObjectSizes> operator()() {
+    void operator()() {
         util::check(lib_->supports_object_size_calculation(), "ObjectSizesBytesTask should only be used with storages"
                                                               " that natively support size calculation");
-        return lib_->get_object_sizes(type_, prefix_);
+        lib_->visit_object_sizes(type_, prefix_, visitor_);
     }
 };
 }

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -74,9 +74,9 @@ class Library {
         return storages_->supports_object_size_calculation();
     }
 
-    ObjectSizes get_object_sizes(KeyType type, const std::string& prefix) {
-        ARCTICDB_SAMPLE(GetObjectSizes, 0)
-        return storages_->get_object_sizes(type, prefix);
+    void visit_object_sizes(KeyType type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
+        ARCTICDB_SAMPLE(VisitObjectSizes, 0)
+        storages_->visit_object_sizes(type, prefix, visitor);
     }
 
     /**

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -506,14 +506,16 @@ bool do_iterate_type_impl(
 }
 
 template<class KeyBucketizer>
-ObjectSizes do_calculate_sizes_for_type_impl(
+void do_visit_object_sizes_for_type_impl(
     KeyType key_type,
     const std::string& root_folder,
     const std::string& bucket_name,
     const S3ClientInterface& s3_client,
     KeyBucketizer&& bucketizer,
-    const PrefixHandler& prefix_handler = default_prefix_handler(),
-    const std::string& prefix = std::string{}) {
+    const PrefixHandler& prefix_handler,
+    const std::string& prefix,
+    const ObjectSizesVisitor& visitor
+    ) {
     ARCTICDB_SAMPLE(S3StorageCalculateSizesForType, 0)
 
     auto path_info = calculate_path_info(root_folder, key_type, prefix_handler, prefix, std::move(bucketizer));
@@ -529,9 +531,15 @@ ObjectSizes do_calculate_sizes_for_type_impl(
 
             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Received object list");
 
-            for (auto& s3_object_size : output.s3_object_sizes) {
-                res.count_ += 1;
-                res.compressed_size_bytes_ += s3_object_size;
+            auto zipped = folly::gen::from(output.s3_object_sizes) | folly::gen::zip(output.s3_object_names) | folly::gen::as<std::vector>();
+            for (auto& [size, name] : std::move(zipped)) {
+                auto key = name.substr(path_info.path_to_key_size_);
+                auto k = variant_key_from_bytes(
+                    reinterpret_cast<uint8_t *>(key.data()),
+                    key.size(),
+                    key_type);
+
+                visitor(k, size);
             }
             continuation_token = output.next_continuation_token;
         } else {
@@ -543,8 +551,6 @@ ObjectSizes do_calculate_sizes_for_type_impl(
             raise_if_unexpected_error(error, path_info.key_prefix_);
         }
     } while (continuation_token.has_value());
-
-    return res;
 }
 
 template<class KeyBucketizer>

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -229,8 +229,9 @@ bool NfsBackedStorage::supports_object_size_calculation() const {
     return true;
 }
 
-ObjectSizes NfsBackedStorage::do_get_object_sizes(KeyType key_type, const std::string& prefix) {
-    return s3::detail::do_calculate_sizes_for_type_impl(key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, prefix_handler, prefix);
+void NfsBackedStorage::do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
+    s3::detail::do_visit_object_sizes_for_type_impl(
+        key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, prefix_handler, prefix, std::move(visitor));
 }
 
 } //namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -53,7 +53,7 @@ private:
 
     bool do_iterate_type_until_match(KeyType key_type, const IterateTypePredicate& visitor, const std::string &prefix) final;
 
-    ObjectSizes do_get_object_sizes(KeyType key_type, const std::string& prefix) final;
+    void do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) final;
 
     bool do_key_exists(const VariantKey& key) final;
 

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -108,12 +108,13 @@ bool S3Storage::do_iterate_type_until_match(KeyType key_type, const IterateTypeP
     return detail::do_iterate_type_impl(key_type, visitor, root_folder_, bucket_name_, client(), FlatBucketizer{}, prefix_handler, prefix);
 }
 
-ObjectSizes S3Storage::do_get_object_sizes(KeyType key_type, const std::string& prefix) {
+void S3Storage::do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
     auto prefix_handler = [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
         return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
     };
 
-    return detail::do_calculate_sizes_for_type_impl(key_type, root_folder_, bucket_name_, client(), FlatBucketizer{}, prefix_handler, prefix);
+    detail::do_visit_object_sizes_for_type_impl(key_type, root_folder_, bucket_name_, client(), FlatBucketizer{},
+                                                prefix_handler, prefix, visitor);
 }
 
 bool S3Storage::do_key_exists(const VariantKey& key) {

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -71,7 +71,7 @@ class S3Storage : public Storage, AsyncStorage {
 
     void do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts);
 
-    ObjectSizes do_get_object_sizes(KeyType key_type, const std::string& prefix) override final;
+    void do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) final;
 
     bool do_iterate_type_until_match(KeyType key_type, const IterateTypePredicate& visitor, const std::string &prefix) final;
 

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -326,8 +326,12 @@ public:
         }
     }
 
-    [[nodiscard]] folly::Future<storage::ObjectSizes> get_object_sizes(KeyType, const std::string&) override {
+    [[nodiscard]] folly::Future<std::shared_ptr<storage::ObjectSizes>> get_object_sizes(KeyType, const std::optional<StreamId>&) override {
         util::raise_rte("get_object_sizes not implemented for InMemoryStore");
+    }
+
+    [[nodiscard]] folly::Future<folly::Unit> visit_object_sizes(KeyType, const std::optional<StreamId>&, storage::ObjectSizesVisitor) override {
+        util::raise_rte("visit_object_sizes not implemented for InMemoryStore");
     }
 
     bool scan_for_matching_key(

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -46,10 +46,13 @@ struct StreamSource {
         const entity::IterateTypeVisitor& func,
         const std::string &prefix = std::string{}) = 0;
 
-    [[nodiscard]] virtual folly::Future<storage::ObjectSizes> get_object_sizes(
+    [[nodiscard]] virtual folly::Future<std::shared_ptr<storage::ObjectSizes>> get_object_sizes(
         KeyType type,
-        const std::string& prefix
+        const std::optional<StreamId>& stream_id
     ) = 0;
+
+    [[nodiscard]] virtual folly::Future<folly::Unit> visit_object_sizes(
+        KeyType type, const std::optional<StreamId>& stream_id_opt, storage::ObjectSizesVisitor visitor) = 0;
 
     virtual bool scan_for_matching_key(
         KeyType key_type, const IterateTypePredicate& predicate) = 0;

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1701,48 +1701,69 @@ timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
     return -1;
 }
 
+// Some key types are historical or very specialized, so restrict to these in size calculations to avoid extra listing
+// operations
+static constexpr std::array<KeyType, 9> TYPES_FOR_SIZE_CALCULATION = {
+    KeyType::VERSION_REF,
+    KeyType::VERSION,
+    KeyType::TABLE_INDEX,
+    KeyType::TABLE_DATA,
+    KeyType::APPEND_DATA,
+    KeyType::SNAPSHOT_REF,
+    KeyType::LOG,
+    KeyType::LOG_COMPACTED,
+    KeyType::SYMBOL_LIST,
+};
+
 std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes() {
     using ObjectSizes = storage::ObjectSizes;
-    std::vector<folly::Future<ObjectSizes>> sizes_futs;
-    foreach_key_type([&store=store(), &sizes=sizes_futs](KeyType key_type) {
-        sizes.push_back(store->get_object_sizes(key_type, ""));
-    });
+    std::vector<folly::Future<std::shared_ptr<ObjectSizes>>> sizes_futs;
 
-    return folly::collect(sizes_futs).via(&async::cpu_executor()).get();
+    for (const auto& key_type : TYPES_FOR_SIZE_CALCULATION) {
+        sizes_futs.push_back(store()->get_object_sizes(key_type, std::nullopt));
+    }
+
+    auto ptrs = folly::collect(sizes_futs).via(&async::cpu_executor()).get();
+    std::vector<storage::ObjectSizes> res;
+    for (const auto& p : ptrs) {
+        res.emplace_back(p->key_type_, p->count_, p->compressed_size_bytes_);
+    }
+    return res;
+}
+
+std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes_for_stream(const StreamId& stream_id) {
+    using ObjectSizes = storage::ObjectSizes;
+    std::vector<folly::Future<std::shared_ptr<ObjectSizes>>> sizes_futs;
+
+    for (const auto& key_type : TYPES_FOR_SIZE_CALCULATION) {
+        sizes_futs.push_back(store()->get_object_sizes(key_type, stream_id));
+    }
+
+    auto ptrs = folly::collect(sizes_futs).via(&async::cpu_executor()).get();
+    std::vector<storage::ObjectSizes> res;
+    for (const auto& p : ptrs) {
+        res.emplace_back(p->key_type_, p->count_, p->compressed_size_bytes_);
+    }
+    return res;
 }
 
 std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> LocalVersionedEngine::scan_object_sizes_by_stream() {
     std::mutex mutex;
     std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> sizes;
-    auto streams = symbol_list().get_symbols(store());
 
-    foreach_key_type([&store=store(), &sizes, &mutex](KeyType key_type) {
-        stream::StreamSource::KeySizeCalculators key_size_calculators;
+    std::vector<folly::Future<folly::Unit>> futs;
+    futs.reserve(TYPES_FOR_SIZE_CALCULATION.size());
+    for (const auto& key_type : TYPES_FOR_SIZE_CALCULATION) {
+        futs.push_back(store()->visit_object_sizes(key_type, std::nullopt, [&mutex, &sizes, key_type](const VariantKey& k, storage::CompressedSize size){
+            auto stream_id = variant_key_id(k);
+            std::lock_guard lock{mutex};
+            auto& sizes_info = sizes[stream_id][key_type];
+            sizes_info.count++;
+            sizes_info.compressed_size += size;
+        }));
+    }
 
-        store->iterate_type(key_type, [&key_size_calculators, &mutex, &sizes, key_type](const VariantKey&& k){
-            key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [key_type, &sizes, &mutex] (auto&& ks) {
-                auto key_seg = std::forward<decltype(ks)>(ks);
-                auto variant_key = key_seg.variant_key();
-                auto stream_id = variant_key_id(variant_key);
-                auto compressed_size = key_seg.segment().size();
-                auto desc = key_seg.segment().descriptor();
-                auto uncompressed_size = desc.uncompressed_bytes();
-
-                {
-                    std::lock_guard lock{mutex};
-                    auto& sizes_info = sizes[stream_id][key_type];
-                    sizes_info.count++;
-                    sizes_info.compressed_size += compressed_size;
-                    sizes_info.uncompressed_size += uncompressed_size;
-                }
-
-                return variant_key;
-            });
-
-        });
-
-        store->read_ignoring_key_not_found(std::move(key_size_calculators));
-    });
+    folly::collectAll(futs).get();
 
     return sizes;
 }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -45,7 +45,6 @@ struct IndexKeyAndUpdateInfo{
 struct KeySizesInfo {
     size_t count;
     size_t compressed_size; // bytes
-    size_t uncompressed_size; // bytes
 };
 
 folly::Future<folly::Unit> delete_trees_responsibly(
@@ -374,6 +373,8 @@ public:
         const WriteOptions& write_options);
 
     std::vector<storage::ObjectSizes> scan_object_sizes();
+
+    std::vector<storage::ObjectSizes> scan_object_sizes_for_stream(const StreamId& stream_id);
 
     std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> scan_object_sizes_by_stream();
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -514,13 +514,12 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def(py::init())
             .def_readonly("count", &KeySizesInfo::count)
             .def_readonly("compressed_size", &KeySizesInfo::compressed_size)
-            .def_readonly("uncompressed_size", &KeySizesInfo::uncompressed_size)
             .doc() = "Count of keys and their compressed and uncompressed sizes in bytes.";
 
     py::class_<storage::ObjectSizes>(version, "ObjectSizes")
         .def_readonly("key_type", &storage::ObjectSizes::key_type_)
-        .def_readonly("count", &storage::ObjectSizes::count_)
-        .def_readonly("compressed_size_bytes", &storage::ObjectSizes::compressed_size_bytes_)
+        .def_property_readonly("count", [](storage::ObjectSizes& self) {return self.count_.load();})
+        .def_property_readonly("compressed_size_bytes", [](storage::ObjectSizes& self) {return self.compressed_size_bytes_.load();})
         .def("__repr__", [](storage::ObjectSizes object_sizes) {return fmt::format("{}", object_sizes);})
         .doc() = "Count of keys and their uncompressed sizes in bytes for a given key type";
 
@@ -693,13 +692,15 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
          .def("scan_object_sizes",
               &PythonVersionStore::scan_object_sizes,
               py::call_guard<SingleThreadMutexHolder>(),
-              "Scan the compressed sizes of all objects in the library. Sizes are in bytes. Returns a dict "
-              "{KeyType: KeySizesInfo}")
+              "Scan the compressed sizes of all objects in the library.")
         .def("scan_object_sizes_by_stream",
              &PythonVersionStore::scan_object_sizes_by_stream,
              py::call_guard<SingleThreadMutexHolder>(),
-             "Scan the compressed sizes of all objects in the library, grouped by stream ID and KeyType. Sizes are in bytes. "
-             "Returns a dict {symbol_id: {KeyType: KeySizesInfo}}")
+             "Scan the compressed sizes of all objects in the library, grouped by stream ID and KeyType.")
+        .def("scan_object_sizes_for_stream",
+             &PythonVersionStore::scan_object_sizes_for_stream,
+             py::call_guard<SingleThreadMutexHolder>(),
+             "Scan the compressed sizes of the given symbol.")
         .def("find_version",
              &PythonVersionStore::get_version_to_read,
              py::call_guard<SingleThreadMutexHolder>(), "Check if a specific stream has been written to previously")

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -8,19 +8,19 @@ from arcticdb_ext.storage import KeyType
 import arcticdb_ext.cpp_async as adb_async
 
 
-def test_symbol_sizes(basic_store):
-    sizes = basic_store.version_store.scan_object_sizes_by_stream()
-    assert len(sizes) == 1
-    assert "__symbols__" in sizes
+def test_symbol_sizes(arctic_library):
+    nvs = arctic_library._nvs
+    sizes = nvs.version_store.scan_object_sizes_by_stream()
+    assert len(sizes) == 0
 
     sym_names = []
     for i in range(5):
         df = sample_dataframe(100, i)
         sym = "sym_{}".format(i)
         sym_names.append(sym)
-        basic_store.write(sym, df)
+        nvs.write(sym, df)
 
-    sizes = basic_store.version_store.scan_object_sizes_by_stream()
+    sizes = nvs.version_store.scan_object_sizes_by_stream()
 
     for s in sym_names:
         assert s in sizes
@@ -28,6 +28,40 @@ def test_symbol_sizes(basic_store):
     assert sizes["sym_0"][KeyType.VERSION].compressed_size < 1000
     assert sizes["sym_0"][KeyType.TABLE_INDEX].compressed_size < 5000
     assert sizes["sym_0"][KeyType.TABLE_DATA].compressed_size < 15000
+
+
+def test_symbol_sizes_for_stream(arctic_library):
+    nvs = arctic_library._nvs
+    sym_names = []
+    for i in range(5):
+        df = sample_dataframe(100, i)
+        sym = "sym_{}".format(i)
+        sym_names.append(sym)
+        nvs.write(sym, df)
+
+    last_data_size = -1
+    for s in sym_names:
+        sizes = nvs.version_store.scan_object_sizes_for_stream(s)
+        res = dict()
+        for size in sizes:
+            res[size.key_type] = (size.count, size.compressed_size_bytes)
+
+        assert res[KeyType.VERSION][0] == 1
+        assert res[KeyType.VERSION][1] < 1000
+        assert res[KeyType.TABLE_INDEX][1] < 5000
+        last_data_size = res[KeyType.TABLE_DATA][1]
+        assert last_data_size < 15000
+
+    # Write a symbol 10 times bigger than the ones above. Check that the size of its data key is plausible: roughly
+    # 10x larger than those of the smaller writes.
+    big_sym = "big_sym"
+    df = sample_dataframe(1000, 4)
+    nvs.write(big_sym, df)
+    sizes = nvs.version_store.scan_object_sizes_for_stream(big_sym)
+    big_data_sizes = [s.compressed_size_bytes for s in sizes if s.key_type == KeyType.TABLE_DATA]
+    assert len(big_data_sizes) == 1
+    big_data_size = big_data_sizes[0]
+    assert 0.8 * 10 * last_data_size < big_data_size < 1.2 * 10 * last_data_size
 
 
 def test_symbol_sizes_big(basic_store):
@@ -54,15 +88,12 @@ def test_symbol_sizes_big(basic_store):
     sizes = basic_store.version_store.scan_object_sizes_by_stream()
 
     assert sizes["sym"][KeyType.VERSION].compressed_size < 1000
-    assert sizes["sym"][KeyType.VERSION].uncompressed_size < 200
     assert sizes["sym"][KeyType.VERSION].count == 1
 
     assert sizes["sym"][KeyType.TABLE_INDEX].compressed_size < 5000
-    assert sizes["sym"][KeyType.TABLE_INDEX].uncompressed_size < 2500
     assert sizes["sym"][KeyType.TABLE_INDEX].count == 1
 
     assert 50_000 < sizes["sym"][KeyType.TABLE_DATA].compressed_size < 85_000
-    assert 60_000 < sizes["sym"][KeyType.TABLE_DATA].uncompressed_size < 150_000
     assert sizes["sym"][KeyType.TABLE_DATA].count == 1
 
 
@@ -76,18 +107,16 @@ def test_symbol_sizes_multiple_versions(basic_store):
     assert sizes["sym"][KeyType.VERSION].count == 2
     assert sizes["sym"][KeyType.TABLE_INDEX].count == 2
     assert sizes["sym"][KeyType.TABLE_DATA].count == 2
-    assert 100_000 < sizes["sym"][KeyType.TABLE_DATA].uncompressed_size < 250_000
 
 
-def test_scan_object_sizes(arctic_client, lib_name):
-    lib = arctic_client.create_library(lib_name)
-    basic_store = lib._nvs
+def test_scan_object_sizes(arctic_library):
+    nvs = arctic_library._nvs
 
     df = sample_dataframe(1000)
-    basic_store.write("sym", df)
-    basic_store.write("sym", df)
+    nvs.write("sym", df)
+    nvs.write("sym", df)
 
-    sizes = basic_store.version_store.scan_object_sizes()
+    sizes = nvs.version_store.scan_object_sizes()
 
     res = dict()
     for s in sizes:
@@ -224,3 +253,26 @@ def test_symbol_sizes_concurrent(reader_store, writer_store):
         reader.terminate()
 
     assert exceptions_in_reader.empty()
+
+
+def test_symbol_sizes_matches_boto(s3_storage, lib_name):
+    lib = s3_storage.create_version_store_factory(lib_name)()
+    df = sample_dataframe(100, 0)
+    lib.write("s", df)
+
+    sizes = lib.version_store.scan_object_sizes()
+    assert len(sizes) == 9
+    key_types = {s.key_type for s in sizes}
+    assert key_types == {KeyType.TABLE_DATA, KeyType.TABLE_INDEX, KeyType.VERSION, KeyType.VERSION_REF, KeyType.APPEND_DATA,
+                         KeyType.SNAPSHOT_REF, KeyType.LOG, KeyType.LOG_COMPACTED, KeyType.SYMBOL_LIST}
+
+    as_dict = dict()
+    for s in sizes:
+        as_dict[s.key_type] = s.compressed_size_bytes
+
+    data_size = as_dict[KeyType.TABLE_DATA]
+
+    bucket = s3_storage.get_boto_bucket()
+    data_keys = [o for o in bucket.objects.all() if "test_symbol_sizes_matches_boto" in o.key and "/tdata/" in o.key]
+    assert len(data_keys) == 1
+    assert data_keys[0].size == data_size


### PR DESCRIPTION
Add `version_store.scan_object_sizes_for_stream` to get the compressed sizes of a particular stream.

Refactor the existing symbol scanning APIs to a visitor pattern so they can all share as much of the implementation as possible.

Monday: 8560764974
