### PR TITLE
Fix the perfect forwarding in variant_match

### DIFF
--- a/cpp/arcticdb/entity/key.hpp
+++ b/cpp/arcticdb/entity/key.hpp
@@ -10,8 +10,6 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/hash.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/preprocess.hpp>
-#include <type_traits>
 #include <string_view>
 #include <memory>
 #include <algorithm>

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -9,10 +9,7 @@
 
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/constructors.hpp>
-#include <arcticdb/util/variant.hpp>
 #include <arcticdb/entity/output_format.hpp>
-#include <arcticdb/log/log.hpp>
-#include <google/protobuf/util/message_differencer.h>
 #include "arcticdb/storage/memory_layout.hpp"
 
 #include <cstdint>

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -46,8 +46,8 @@ class S3Storage : public Storage, AsyncStorage {
         return ConfigsMap::instance()->get_int("S3.Async", 0) == 1;
     }
 
-    AsyncStorage* async_api() {
-        return dynamic_cast<AsyncStorage*>(this);
+    AsyncStorage* async_api() override {
+        return this;
     }
 
     bool supports_object_size_calculation() const final override;
@@ -67,9 +67,9 @@ class S3Storage : public Storage, AsyncStorage {
 
     folly::Future<KeySegmentPair> do_async_read(entity::VariantKey&& variant_key, ReadKeyOpts opts) final;
 
-    void do_remove(VariantKey&& variant_key, RemoveOpts opts);
+    void do_remove(VariantKey&& variant_key, RemoveOpts opts) override;
 
-    void do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts);
+    void do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts) override;
 
     ObjectSizes do_get_object_sizes(KeyType key_type, const std::string& prefix) override final;
 

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <util/allocator.hpp>
-#include <util/constructors.hpp>
-
+#include <arcticdb/util/allocator.hpp>
+#include <arcticdb/util/constructors.hpp>
+#include <arcticdb/util/variant.hpp>
 #include <cstdint>
 #include <memory>
 #include <variant>

--- a/cpp/arcticdb/util/variant.hpp
+++ b/cpp/arcticdb/util/variant.hpp
@@ -9,6 +9,7 @@
 
 #include <cstddef> // for std::size_t
 #include <variant>
+#include <tuple>
 
 namespace arcticdb::util {
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1885,7 +1885,7 @@ VersionedItem compact_incomplete_impl(
     });
 
     return util::variant_match(std::move(result),
-                        [&slices, &pipeline_context, &store, &user_meta](CompactionWrittenKeys& written_keys) -> VersionedItem {
+                        [&slices, &pipeline_context, &store, &user_meta](CompactionWrittenKeys&& written_keys) -> VersionedItem {
                             auto vit = collate_and_write(
                                 store,
                                 pipeline_context,
@@ -1895,7 +1895,7 @@ VersionedItem compact_incomplete_impl(
                                 user_meta);
                             return vit;
                         },
-                        [](Error& error) -> VersionedItem {
+                        [](Error&& error) -> VersionedItem {
                             error.throw_error();
                             return VersionedItem{}; // unreachable
                         }
@@ -1995,7 +1995,7 @@ VersionedItem defragment_symbol_data_impl(
     });
 
     return util::variant_match(std::move(result),
-                               [&slices, &pre_defragmentation_info, &store](CompactionWrittenKeys& written_keys) -> VersionedItem {
+                               [&slices, &pre_defragmentation_info, &store](CompactionWrittenKeys&& written_keys) -> VersionedItem {
                                 return collate_and_write(
                                         store,
                                         pre_defragmentation_info.pipeline_context,
@@ -2004,7 +2004,7 @@ VersionedItem defragment_symbol_data_impl(
                                         pre_defragmentation_info.append_after.value(),
                                         std::nullopt);
                                },
-                               [](Error& error) -> VersionedItem {
+                               [](Error&& error) -> VersionedItem {
                                    error.throw_error();
                                    return VersionedItem{}; // unreachable
                                }


### PR DESCRIPTION
Variant match has unnecessary overload for const rvalue ref. The tuple is not a universal referance.
Neither std::forward nor std::move were called on arguments so we ended up copying.
The old implementation allowed something which looks like a reference to a moved object. What happened in fact was that a object was moved then copied and the reference was to the copy. In general the code does not produce bugs but is sub-optimal as it can copy instead of move in particular cases.
Fix clang compilation warnings turned into errors (related to missing override qualifier for virtual functions)

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
