### PR TITLE
Symbol sizes API

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -226,7 +226,7 @@ folly::Future<folly::Unit> visit_object_sizes(
     KeyType type, const std::optional<StreamId>& stream_id_opt, storage::ObjectSizesVisitor visitor) override {
     std::string prefix;
     if (stream_id_opt) {
-        auto stream_id = *stream_id_opt;
+        const auto& stream_id = *stream_id_opt;
         prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
     }
 

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -222,28 +222,49 @@ void iterate_type(
     library_->iterate_type(type, func, prefix);
 }
 
-folly::Future<storage::ObjectSizes> get_object_sizes(KeyType type, const std::string& prefix) override {
+folly::Future<folly::Unit> visit_object_sizes(
+    KeyType type, const std::optional<StreamId>& stream_id_opt, storage::ObjectSizesVisitor visitor) override {
+    std::string prefix;
+    std::optional<std::function<bool(const VariantKey&)>> match_stream_id = std::nullopt;
+    if (stream_id_opt) {
+        auto stream_id = *stream_id_opt;
+        prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
+        match_stream_id = [stream_id](const VariantKey& k) { return variant_key_id(k) == stream_id; };
+    }
+
     if (library_->supports_object_size_calculation()) {
         // The library has native support for some kind of clever size calculation, so let it take over
-        return async::submit_io_task(ObjectSizesTask{type, prefix, library_});
+        return async::submit_io_task(VisitObjectSizesTask{type, prefix, std::move(visitor), library_});
     }
 
     // No native support for a clever size calculation, so just read keys and sum their sizes
-    auto counter = std::make_shared<std::atomic_uint64_t>(0);
-    auto bytes = std::make_shared<std::atomic_uint64_t>(0);
     KeySizeCalculators key_size_calculators;
-    iterate_type(type, [&key_size_calculators, &counter, &bytes](const VariantKey&& k) {
-        key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [counter, bytes] (auto&& ks) {
-            counter->fetch_add(1);
-            auto key_seg = std::forward<decltype(ks)>(ks);
-            auto compressed_size = key_seg.segment().size();
-            bytes->fetch_add(compressed_size);
+    iterate_type(type, [&key_size_calculators, &match_stream_id, &visitor](const VariantKey&& k) {
+        key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [visitor, match_stream_id] (auto&& key_seg) {
+            if (!match_stream_id || match_stream_id.value()(key_seg.variant_key())) {
+                auto compressed_size = key_seg.segment().size();
+                visitor(key_seg.variant_key(), compressed_size);
+            }
             return key_seg.variant_key();
         });
     }, prefix);
 
     read_ignoring_key_not_found(std::move(key_size_calculators));
-    return folly::makeFuture(storage::ObjectSizes{type, *counter, *bytes});
+    return folly::makeFuture();
+}
+
+folly::Future<std::shared_ptr<storage::ObjectSizes>> get_object_sizes(KeyType type, const std::optional<StreamId>& stream_id_opt) override {
+    auto counter = std::make_shared<std::atomic_uint64_t>(0);
+    auto bytes = std::make_shared<std::atomic_uint64_t>(0);
+    storage::ObjectSizesVisitor visitor = [counter, bytes](const VariantKey&, storage::CompressedSize size) {
+        counter->fetch_add(1);
+        bytes->fetch_add(size);
+    };
+
+    return visit_object_sizes(type, stream_id_opt, std::move(visitor))
+    .thenValueInline([counter, bytes, type](folly::Unit&&) {
+        return std::make_shared<storage::ObjectSizes>(type, *counter, *bytes);
+    });
 }
 
 bool scan_for_matching_key(

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -241,9 +241,9 @@ folly::Future<folly::Unit> visit_object_sizes(
         key_size_calculators.emplace_back(std::move(k), [visitor, stream_id_opt] (auto&& key_seg) {
             if (!stream_id_opt || variant_key_id(key_seg.variant_key()) == *stream_id_opt) {
                 auto compressed_size = key_seg.segment().size();
-                visitor(std::forward<decltype(key_seg)>(key_seg).variant_key(), compressed_size);
+                visitor(key_seg.variant_key(), compressed_size);
             }
-            return key_seg.variant_key();
+            return std::forward<decltype(key_seg)>(key_seg).variant_key();
         });
     }, prefix);
 

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -11,6 +11,7 @@
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/storage/store.hpp>
+#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/hash.hpp>
@@ -665,28 +666,31 @@ struct RemoveBatchTask : BaseTask {
     }
 };
 
-struct ObjectSizesTask : BaseTask {
+struct VisitObjectSizesTask : BaseTask {
     KeyType type_;
     std::string prefix_;
+    storage::ObjectSizesVisitor visitor_;
     std::shared_ptr<storage::Library> lib_;
 
-    ObjectSizesTask(
+    VisitObjectSizesTask(
         KeyType type,
         std::string prefix,
+        storage::ObjectSizesVisitor visitor,
         std::shared_ptr<storage::Library> lib
         ) :
         type_(type),
         prefix_(std::move(prefix)),
+        visitor_(std::move(visitor)),
         lib_(std::move(lib)) {
         ARCTICDB_DEBUG(log::storage(), "Creating object sizes task for key type {} prefix {}", type_, prefix_);
     }
 
-    ARCTICDB_MOVE_ONLY_DEFAULT(ObjectSizesTask)
+    ARCTICDB_MOVE_ONLY_DEFAULT(VisitObjectSizesTask)
 
-    folly::Future<storage::ObjectSizes> operator()() {
+    void operator()() {
         util::check(lib_->supports_object_size_calculation(), "ObjectSizesBytesTask should only be used with storages"
                                                               " that natively support size calculation");
-        return lib_->get_object_sizes(type_, prefix_);
+        lib_->visit_object_sizes(type_, prefix_, visitor_);
     }
 };
 }

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -74,9 +74,9 @@ class Library {
         return storages_->supports_object_size_calculation();
     }
 
-    ObjectSizes get_object_sizes(KeyType type, const std::string& prefix) {
-        ARCTICDB_SAMPLE(GetObjectSizes, 0)
-        return storages_->get_object_sizes(type, prefix);
+    void visit_object_sizes(KeyType type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
+        ARCTICDB_SAMPLE(VisitObjectSizes, 0)
+        storages_->visit_object_sizes(type, prefix, visitor);
     }
 
     /**

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -505,14 +505,16 @@ bool do_iterate_type_impl(
 }
 
 template<class KeyBucketizer>
-ObjectSizes do_calculate_sizes_for_type_impl(
+void do_visit_object_sizes_for_type_impl(
     KeyType key_type,
     const std::string& root_folder,
     const std::string& bucket_name,
     const S3ClientInterface& s3_client,
     KeyBucketizer&& bucketizer,
-    const PrefixHandler& prefix_handler = default_prefix_handler(),
-    const std::string& prefix = std::string{}) {
+    const PrefixHandler& prefix_handler,
+    const std::string& prefix,
+    const ObjectSizesVisitor& visitor
+    ) {
     ARCTICDB_SAMPLE(S3StorageCalculateSizesForType, 0)
 
     auto path_info = calculate_path_info(root_folder, key_type, prefix_handler, prefix, std::move(bucketizer));
@@ -528,9 +530,15 @@ ObjectSizes do_calculate_sizes_for_type_impl(
 
             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Received object list");
 
-            for (auto& s3_object_size : output.s3_object_sizes) {
-                res.count_ += 1;
-                res.compressed_size_bytes_ += s3_object_size;
+            auto zipped = folly::gen::from(output.s3_object_sizes) | folly::gen::zip(output.s3_object_names) | folly::gen::as<std::vector>();
+            for (auto& [size, name] : std::move(zipped)) {
+                auto key = name.substr(path_info.path_to_key_size_);
+                auto k = variant_key_from_bytes(
+                    reinterpret_cast<uint8_t *>(key.data()),
+                    key.size(),
+                    key_type);
+
+                visitor(k, size);
             }
             continuation_token = output.next_continuation_token;
         } else {
@@ -542,8 +550,6 @@ ObjectSizes do_calculate_sizes_for_type_impl(
             raise_if_unexpected_error(error, path_info.key_prefix_);
         }
     } while (continuation_token.has_value());
-
-    return res;
 }
 
 template<class KeyBucketizer>

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -517,7 +517,7 @@ void do_visit_object_sizes_for_type_impl(
     ) {
     ARCTICDB_SAMPLE(S3StorageCalculateSizesForType, 0)
 
-    auto path_info = calculate_path_info(root_folder, key_type, prefix_handler, prefix, std::move(bucketizer));
+    auto path_info = calculate_path_info(root_folder, key_type, prefix_handler, prefix, std::forward<KeyBucketizer>(bucketizer));
     ARCTICDB_RUNTIME_DEBUG(log::storage(), "Calculating sizes for objects in bucket {} with prefix {}", bucket_name,
                            path_info.key_prefix_);
 

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -531,7 +531,7 @@ void do_visit_object_sizes_for_type_impl(
             ARCTICDB_RUNTIME_DEBUG(log::storage(), "Received object list");
 
             auto zipped = folly::gen::from(output.s3_object_sizes) | folly::gen::zip(output.s3_object_names) | folly::gen::as<std::vector>();
-            for (auto& [size, name] : std::move(zipped)) {
+            for (const auto& [size, name] : zipped) {
                 auto key = name.substr(path_info.path_to_key_size_);
                 auto k = variant_key_from_bytes(
                     reinterpret_cast<uint8_t *>(key.data()),

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -242,7 +242,7 @@ bool NfsBackedStorage::supports_object_size_calculation() const {
 
 void NfsBackedStorage::do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
     s3::detail::do_visit_object_sizes_for_type_impl(
-        key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, prefix_handler, prefix, std::move(visitor));
+        key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, prefix_handler, prefix, visitor);
 }
 
 } //namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -197,16 +197,6 @@ void NfsBackedStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts)
     s3::detail::do_remove_impl(std::span(enc), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
 }
 
-static std::string prefix_handler(const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor&, KeyType key_type) {
-    std::string new_prefix;
-    if(!prefix.empty()) {
-        uint32_t id = get_id_bucket(encode_item<StreamId, StringId, NumericId>(StringId{prefix}, is_ref_key_class(key_type)));
-        new_prefix = fmt::format("{:03}", id);
-    }
-
-    return !prefix.empty() ? fmt::format("{}/{}", key_type_dir, new_prefix) : key_type_dir;
-}
-
 // signature needs to match PrefixHandler in s3_storage.hpp
 static std::string iter_prefix_handler(const std::string&, const std::string& key_type_dir, const KeyDescriptor&, KeyType) {
     // The prefix handler is not used for filtering (done in func below)
@@ -241,8 +231,17 @@ bool NfsBackedStorage::supports_object_size_calculation() const {
 }
 
 void NfsBackedStorage::do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
+    const ObjectSizesVisitor func = [&v = visitor, prefix=prefix] (const VariantKey& k, CompressedSize size) {
+        auto key = unencode_object_id(k);
+        if (prefix.empty() || variant_key_view(key).find(prefix) != std::string::npos) {
+            v(key, size);
+        } else {
+            return;
+        }
+    };
+
     s3::detail::do_visit_object_sizes_for_type_impl(
-        key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, prefix_handler, prefix, visitor);
+        key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, iter_prefix_handler, prefix, func);
 }
 
 } //namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -240,8 +240,9 @@ bool NfsBackedStorage::supports_object_size_calculation() const {
     return true;
 }
 
-ObjectSizes NfsBackedStorage::do_get_object_sizes(KeyType key_type, const std::string& prefix) {
-    return s3::detail::do_calculate_sizes_for_type_impl(key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, prefix_handler, prefix);
+void NfsBackedStorage::do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
+    s3::detail::do_visit_object_sizes_for_type_impl(
+        key_type, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, prefix_handler, prefix, std::move(visitor));
 }
 
 } //namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -53,7 +53,7 @@ private:
 
     bool do_iterate_type_until_match(KeyType key_type, const IterateTypePredicate& visitor, const std::string &prefix) final;
 
-    ObjectSizes do_get_object_sizes(KeyType key_type, const std::string& prefix) final;
+    void do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) final;
 
     bool do_key_exists(const VariantKey& key) final;
 

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -108,12 +108,13 @@ bool S3Storage::do_iterate_type_until_match(KeyType key_type, const IterateTypeP
     return detail::do_iterate_type_impl(key_type, visitor, root_folder_, bucket_name_, client(), FlatBucketizer{}, prefix_handler, prefix);
 }
 
-ObjectSizes S3Storage::do_get_object_sizes(KeyType key_type, const std::string& prefix) {
+void S3Storage::do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) {
     auto prefix_handler = [] (const std::string& prefix, const std::string& key_type_dir, const KeyDescriptor& key_descriptor, KeyType) {
         return !prefix.empty() ? fmt::format("{}/{}*{}", key_type_dir, key_descriptor, prefix) : key_type_dir;
     };
 
-    return detail::do_calculate_sizes_for_type_impl(key_type, root_folder_, bucket_name_, client(), FlatBucketizer{}, prefix_handler, prefix);
+    detail::do_visit_object_sizes_for_type_impl(key_type, root_folder_, bucket_name_, client(), FlatBucketizer{},
+                                                prefix_handler, prefix, visitor);
 }
 
 bool S3Storage::do_key_exists(const VariantKey& key) {

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -71,7 +71,7 @@ class S3Storage : public Storage, AsyncStorage {
 
     void do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts) override;
 
-    ObjectSizes do_get_object_sizes(KeyType key_type, const std::string& prefix) override final;
+    void do_visit_object_sizes(KeyType key_type, const std::string& prefix, const ObjectSizesVisitor& visitor) final;
 
     bool do_iterate_type_until_match(KeyType key_type, const IterateTypePredicate& visitor, const std::string &prefix) final;
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -23,8 +23,8 @@ using CompressedSize = uint64_t;
 using ObjectSizesVisitor = std::function<void(const VariantKey&, CompressedSize)>;
 
 struct ObjectSizes {
-    ObjectSizes(KeyType key_type, uint64_t count, CompressedSize compressed_size_bytes) :
-        key_type_(key_type), count_(count), compressed_size_bytes_(compressed_size_bytes) {
+    ObjectSizes(KeyType key_type, uint64_t count, CompressedSize compressed_size) :
+        key_type_(key_type), count_(count), compressed_size_(compressed_size) {
 
     }
 
@@ -33,14 +33,14 @@ struct ObjectSizes {
     }
 
     ObjectSizes(const ObjectSizes& other) noexcept : key_type_(other.key_type_), count_(other.count_.load()),
-        compressed_size_bytes_(other.compressed_size_bytes_.load()) {
+                                                     compressed_size_(other.compressed_size_.load()) {
     }
 
     ObjectSizes& operator=(const ObjectSizes& that) noexcept {
         if (this != &that) {
             key_type_ = that.key_type_;
             count_ = that.count_.load();
-            compressed_size_bytes_ = that.compressed_size_bytes_.load();
+            compressed_size_ = that.compressed_size_.load();
         }
 
         return *this;
@@ -48,7 +48,7 @@ struct ObjectSizes {
 
     KeyType key_type_;
     std::atomic_uint64_t count_;
-    std::atomic_uint64_t compressed_size_bytes_;
+    std::atomic_uint64_t compressed_size_;
 };
 
 enum class SupportsAtomicWrites {
@@ -278,8 +278,8 @@ template<> struct formatter<ObjectSizes> {
 
     template<typename FormatContext>
     auto format(const ObjectSizes &sizes, FormatContext &ctx) const {
-        return fmt::format_to(ctx.out(), "ObjectSizes key_type[{}] count[{}] compressed_size_bytes[{}]",
-                              sizes.key_type_, sizes.count_, sizes.compressed_size_bytes_);
+        return fmt::format_to(ctx.out(), "ObjectSizes key_type[{}] count[{}] compressed_size[{}]",
+                              sizes.key_type_, sizes.count_, sizes.compressed_size_);
     }
 };
 }

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -326,8 +326,12 @@ public:
         }
     }
 
-    [[nodiscard]] folly::Future<storage::ObjectSizes> get_object_sizes(KeyType, const std::string&) override {
+    [[nodiscard]] folly::Future<std::shared_ptr<storage::ObjectSizes>> get_object_sizes(KeyType, const std::optional<StreamId>&) override {
         util::raise_rte("get_object_sizes not implemented for InMemoryStore");
+    }
+
+    [[nodiscard]] folly::Future<folly::Unit> visit_object_sizes(KeyType, const std::optional<StreamId>&, storage::ObjectSizesVisitor) override {
+        util::raise_rte("visit_object_sizes not implemented for InMemoryStore");
     }
 
     bool scan_for_matching_key(

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -46,10 +46,13 @@ struct StreamSource {
         const entity::IterateTypeVisitor& func,
         const std::string &prefix = std::string{}) = 0;
 
-    [[nodiscard]] virtual folly::Future<storage::ObjectSizes> get_object_sizes(
+    [[nodiscard]] virtual folly::Future<std::shared_ptr<storage::ObjectSizes>> get_object_sizes(
         KeyType type,
-        const std::string& prefix
+        const std::optional<StreamId>& stream_id
     ) = 0;
+
+    [[nodiscard]] virtual folly::Future<folly::Unit> visit_object_sizes(
+        KeyType type, const std::optional<StreamId>& stream_id_opt, storage::ObjectSizesVisitor visitor) = 0;
 
     virtual bool scan_for_matching_key(
         KeyType key_type, const IterateTypePredicate& predicate) = 0;

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1749,7 +1749,6 @@ static constexpr std::array<KeyType, 5> TYPES_FOR_SIZE_BY_STREAM_CALCULATION = {
 std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes_for_stream(const StreamId& stream_id) {
     using ObjectSizes = storage::ObjectSizes;
     std::vector<folly::Future<std::shared_ptr<ObjectSizes>>> sizes_futs;
-    sizes_futs.reserve(TYPES_FOR_SIZE_BY_STREAM_CALCULATION.size());
 
     for (const auto& key_type : TYPES_FOR_SIZE_BY_STREAM_CALCULATION) {
         sizes_futs.push_back(store()->get_object_sizes(key_type, stream_id));
@@ -1768,7 +1767,6 @@ std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> LocalVer
     std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> sizes;
 
     std::vector<folly::Future<folly::Unit>> futs;
-    futs.reserve(TYPES_FOR_SIZE_BY_STREAM_CALCULATION.size());
     for (const auto& key_type : TYPES_FOR_SIZE_BY_STREAM_CALCULATION) {
         futs.push_back(store()->visit_object_sizes(key_type, std::nullopt, [&mutex, &sizes, key_type](const VariantKey& k, storage::CompressedSize size){
             auto stream_id = variant_key_id(k);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1708,48 +1708,69 @@ timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
     return -1;
 }
 
+// Some key types are historical or very specialized, so restrict to these in size calculations to avoid extra listing
+// operations
+static constexpr std::array<KeyType, 9> TYPES_FOR_SIZE_CALCULATION = {
+    KeyType::VERSION_REF,
+    KeyType::VERSION,
+    KeyType::TABLE_INDEX,
+    KeyType::TABLE_DATA,
+    KeyType::APPEND_DATA,
+    KeyType::SNAPSHOT_REF,
+    KeyType::LOG,
+    KeyType::LOG_COMPACTED,
+    KeyType::SYMBOL_LIST,
+};
+
 std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes() {
     using ObjectSizes = storage::ObjectSizes;
-    std::vector<folly::Future<ObjectSizes>> sizes_futs;
-    foreach_key_type([&store=store(), &sizes=sizes_futs](KeyType key_type) {
-        sizes.push_back(store->get_object_sizes(key_type, ""));
-    });
+    std::vector<folly::Future<std::shared_ptr<ObjectSizes>>> sizes_futs;
 
-    return folly::collect(sizes_futs).via(&async::cpu_executor()).get();
+    for (const auto& key_type : TYPES_FOR_SIZE_CALCULATION) {
+        sizes_futs.push_back(store()->get_object_sizes(key_type, std::nullopt));
+    }
+
+    auto ptrs = folly::collect(sizes_futs).via(&async::cpu_executor()).get();
+    std::vector<storage::ObjectSizes> res;
+    for (const auto& p : ptrs) {
+        res.emplace_back(p->key_type_, p->count_, p->compressed_size_bytes_);
+    }
+    return res;
+}
+
+std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes_for_stream(const StreamId& stream_id) {
+    using ObjectSizes = storage::ObjectSizes;
+    std::vector<folly::Future<std::shared_ptr<ObjectSizes>>> sizes_futs;
+
+    for (const auto& key_type : TYPES_FOR_SIZE_CALCULATION) {
+        sizes_futs.push_back(store()->get_object_sizes(key_type, stream_id));
+    }
+
+    auto ptrs = folly::collect(sizes_futs).via(&async::cpu_executor()).get();
+    std::vector<storage::ObjectSizes> res;
+    for (const auto& p : ptrs) {
+        res.emplace_back(p->key_type_, p->count_, p->compressed_size_bytes_);
+    }
+    return res;
 }
 
 std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> LocalVersionedEngine::scan_object_sizes_by_stream() {
     std::mutex mutex;
     std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> sizes;
-    auto streams = symbol_list().get_symbols(store());
 
-    foreach_key_type([&store=store(), &sizes, &mutex](KeyType key_type) {
-        stream::StreamSource::KeySizeCalculators key_size_calculators;
+    std::vector<folly::Future<folly::Unit>> futs;
+    futs.reserve(TYPES_FOR_SIZE_CALCULATION.size());
+    for (const auto& key_type : TYPES_FOR_SIZE_CALCULATION) {
+        futs.push_back(store()->visit_object_sizes(key_type, std::nullopt, [&mutex, &sizes, key_type](const VariantKey& k, storage::CompressedSize size){
+            auto stream_id = variant_key_id(k);
+            std::lock_guard lock{mutex};
+            auto& sizes_info = sizes[stream_id][key_type];
+            sizes_info.count++;
+            sizes_info.compressed_size += size;
+        }));
+    }
 
-        store->iterate_type(key_type, [&key_size_calculators, &mutex, &sizes, key_type](const VariantKey&& k){
-            key_size_calculators.emplace_back(std::forward<const VariantKey>(k), [key_type, &sizes, &mutex] (auto&& ks) {
-                auto key_seg = std::forward<decltype(ks)>(ks);
-                auto variant_key = key_seg.variant_key();
-                auto stream_id = variant_key_id(variant_key);
-                auto compressed_size = key_seg.segment().size();
-                auto desc = key_seg.segment().descriptor();
-                auto uncompressed_size = desc.uncompressed_bytes();
-
-                {
-                    std::lock_guard lock{mutex};
-                    auto& sizes_info = sizes[stream_id][key_type];
-                    sizes_info.count++;
-                    sizes_info.compressed_size += compressed_size;
-                    sizes_info.uncompressed_size += uncompressed_size;
-                }
-
-                return variant_key;
-            });
-
-        });
-
-        store->read_ignoring_key_not_found(std::move(key_size_calculators));
-    });
+    folly::collectAll(futs).get();
 
     return sizes;
 }

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1710,12 +1710,13 @@ timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
 
 // Some key types are historical or very specialized, so restrict to these in size calculations to avoid extra listing
 // operations
-static constexpr std::array<KeyType, 9> TYPES_FOR_SIZE_CALCULATION = {
+static constexpr std::array<KeyType, 10> TYPES_FOR_SIZE_CALCULATION = {
     KeyType::VERSION_REF,
     KeyType::VERSION,
     KeyType::TABLE_INDEX,
     KeyType::TABLE_DATA,
     KeyType::APPEND_DATA,
+    KeyType::MULTI_KEY,
     KeyType::SNAPSHOT_REF,
     KeyType::LOG,
     KeyType::LOG_COMPACTED,
@@ -1738,12 +1739,13 @@ std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes() {
     return res;
 }
 
-static constexpr std::array<KeyType, 5> TYPES_FOR_SIZE_BY_STREAM_CALCULATION = {
+static constexpr std::array<KeyType, 6> TYPES_FOR_SIZE_BY_STREAM_CALCULATION = {
     KeyType::VERSION_REF,
     KeyType::VERSION,
     KeyType::TABLE_INDEX,
     KeyType::TABLE_DATA,
     KeyType::APPEND_DATA,
+    KeyType::MULTI_KEY
 };
 
 std::vector<storage::ObjectSizes> LocalVersionedEngine::scan_object_sizes_for_stream(const StreamId& stream_id) {

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -47,7 +47,6 @@ struct IndexKeyAndUpdateInfo{
 struct KeySizesInfo {
     size_t count;
     size_t compressed_size; // bytes
-    size_t uncompressed_size; // bytes
 };
 
 folly::Future<folly::Unit> delete_trees_responsibly(
@@ -380,6 +379,8 @@ public:
         const WriteOptions& write_options);
 
     std::vector<storage::ObjectSizes> scan_object_sizes();
+
+    std::vector<storage::ObjectSizes> scan_object_sizes_for_stream(const StreamId& stream_id);
 
     std::unordered_map<StreamId, std::unordered_map<KeyType, KeySizesInfo>> scan_object_sizes_by_stream();
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -514,13 +514,12 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
             .def(py::init())
             .def_readonly("count", &KeySizesInfo::count)
             .def_readonly("compressed_size", &KeySizesInfo::compressed_size)
-            .def_readonly("uncompressed_size", &KeySizesInfo::uncompressed_size)
             .doc() = "Count of keys and their compressed and uncompressed sizes in bytes.";
 
     py::class_<storage::ObjectSizes>(version, "ObjectSizes")
         .def_readonly("key_type", &storage::ObjectSizes::key_type_)
-        .def_readonly("count", &storage::ObjectSizes::count_)
-        .def_readonly("compressed_size_bytes", &storage::ObjectSizes::compressed_size_bytes_)
+        .def_property_readonly("count", [](storage::ObjectSizes& self) {return self.count_.load();})
+        .def_property_readonly("compressed_size_bytes", [](storage::ObjectSizes& self) {return self.compressed_size_bytes_.load();})
         .def("__repr__", [](storage::ObjectSizes object_sizes) {return fmt::format("{}", object_sizes);})
         .doc() = "Count of keys and their uncompressed sizes in bytes for a given key type";
 
@@ -698,13 +697,15 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
          .def("scan_object_sizes",
               &PythonVersionStore::scan_object_sizes,
               py::call_guard<SingleThreadMutexHolder>(),
-              "Scan the compressed sizes of all objects in the library. Sizes are in bytes. Returns a dict "
-              "{KeyType: KeySizesInfo}")
+              "Scan the compressed sizes of all objects in the library.")
         .def("scan_object_sizes_by_stream",
              &PythonVersionStore::scan_object_sizes_by_stream,
              py::call_guard<SingleThreadMutexHolder>(),
-             "Scan the compressed sizes of all objects in the library, grouped by stream ID and KeyType. Sizes are in bytes. "
-             "Returns a dict {symbol_id: {KeyType: KeySizesInfo}}")
+             "Scan the compressed sizes of all objects in the library, grouped by stream ID and KeyType.")
+        .def("scan_object_sizes_for_stream",
+             &PythonVersionStore::scan_object_sizes_for_stream,
+             py::call_guard<SingleThreadMutexHolder>(),
+             "Scan the compressed sizes of the given symbol.")
         .def("find_version",
              &PythonVersionStore::get_version_to_read,
              py::call_guard<SingleThreadMutexHolder>(), "Check if a specific stream has been written to previously")

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -519,7 +519,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
     py::class_<storage::ObjectSizes>(version, "ObjectSizes")
         .def_readonly("key_type", &storage::ObjectSizes::key_type_)
         .def_property_readonly("count", [](storage::ObjectSizes& self) {return self.count_.load();})
-        .def_property_readonly("compressed_size_bytes", [](storage::ObjectSizes& self) {return self.compressed_size_bytes_.load();})
+        .def_property_readonly("compressed_size", [](storage::ObjectSizes& self) {return self.compressed_size_.load();})
         .def("__repr__", [](storage::ObjectSizes object_sizes) {return fmt::format("{}", object_sizes);})
         .doc() = "Count of keys and their uncompressed sizes in bytes for a given key type";
 

--- a/docs/mkdocs/docs/api/admin_tools.md
+++ b/docs/mkdocs/docs/api/admin_tools.md
@@ -1,0 +1,18 @@
+Admin Tools API
+===========
+
+This page documents the ``arcticdb.version_store.admin_tools`` module. This exposes administrative functionality aimed at power users
+and DBAs.
+
+These tools are intended for adhoc use. The API is not currently stable and not governed by the semver version numbers of ArcticDB releases.
+
+To get an ``arcticdb.version_store.admin_tools.AdminTools`` instance, use ``arcticdb.version_store.Library.get_admin_tools``.
+
+::: arcticdb.version_store.admin_tools.Size
+
+::: arcticdb.version_store.admin_tools.KeyType
+
+::: arcticdb.version_store.admin_tools.AdminTools
+    options:
+      # init is not intended to be used directly
+      filters: ["!^__init__$"]

--- a/docs/mkdocs/docs/tutorials/library_sizes.md
+++ b/docs/mkdocs/docs/tutorials/library_sizes.md
@@ -1,0 +1,38 @@
+# Library Sizes
+
+ArcticDB includes some tools to analyze the amount of storage used by your libraries.
+
+The API documentation for these features is [here](../api/admin_tools.md).
+
+We break this down by internal key types, which are documented in `arcticdb.KeyType`. To get the total space used by
+your library, just sum across the key types.
+
+To use these tools, you can run code like,
+
+```py
+from arcticdb import Arctic, KeyType
+from arcticdb.version_store.admin_tools import sum_sizes
+
+lib = Arctic("<your URI>").get_library("<your library>")
+admin_tools = lib.admin_tools()
+
+sizes = admin_tools.get_sizes()  # scan all the sizes in the library, can be slow
+sum_sizes(sizes.values())  # total size of the library
+sizes[KeyType.TABLE_DATA].bytes_compressed  # how much storage is consumed by data segments?
+sizes[KeyType.TABLE_DATA].count  # how many data segments are in your library?
+
+by_symbol = admin_tools.get_sizes_by_symbol()  # scan all the sizes in the library, grouped by symbol
+size_for_sym = by_symbol["sym"]
+sum_sizes(size_for_sym.values())  # total size of the symbol
+size_for_sym[KeyType.TABLE_INDEX].bytes_compressed  # how much storage is consumed by index structures?
+size_for_sym[KeyType.TABLE_INDEX].count  # how many indexes does this symbol have?
+
+for_symbol = admin_tools.get_sizes_for_symbol("<your symbol>")  # scan sizes for one particular symbol, faster than the APIs above
+sum_sizes(for_symbol.values())  # total size of the symbol
+for_symbol[KeyType.VERSION].bytes_compressed  # how much storage is consumed by our versioning metadata layer?
+for_symbol[KeyType.VERSION].count  # how many version keys are in the library?
+```
+
+Most of the space used by a library should be in its `TABLE_DATA` keys since this is where your data is actually kept.
+The other key types are metadata tracked by ArcticDB, primarily to index and version your data. More information about
+our data layout is available [here](../technical/on_disk_storage.md).

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -131,10 +131,11 @@ nav:
   - Arctic: 'api/arctic.md'
   - Arctic URI: 'api/arctic_uri.md'
   - Library: 'api/library.md'
-  - Library related objects: 'api/library_types.md'
+  - Library Related Objects: 'api/library_types.md'
   - DataFrame Processing Operations API: 'api/processing.md'
   - Exceptions: 'api/exceptions.md'
   - Config: 'api/config.md'
+  - Admin Tools: 'api/admin_tools.md'
 
 exclude_docs: |
   *.py

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -100,8 +100,9 @@ nav:
     - Parallel Writes: 'tutorials/parallel_writes.md'
     - Snapshots: 'tutorials/snapshots.md'
     - Metadata: 'tutorials/metadata.md'
-    - In-memory backends: 'tutorials/lmdb_and_in_memory.md'
+    - In-memory Backends: 'tutorials/lmdb_and_in_memory.md'
     - Data Organisation Guide: 'tutorials/data_organisation.md'
+    - Library Sizes: 'tutorials/library_sizes.md'
   - Storage Guides:
     - Getting started with AWS S3: 'aws.md'
     - Library Permissions with AWS S3: 'aws_permissions.md'

--- a/python/arcticdb/__init__.py
+++ b/python/arcticdb/__init__.py
@@ -20,6 +20,7 @@ from arcticdb.version_store.library import (
     StagedDataFinalizeMethod,
     WriteMetadataPayload
 )
+from arcticdb.version_store.admin_tools import KeyType, Size
 
 set_config_from_env_vars(_os.environ)
 

--- a/python/arcticdb/storage_fixtures/azure.py
+++ b/python/arcticdb/storage_fixtures/azure.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 import re
 import shutil
+import uuid
 from typing import TYPE_CHECKING, Optional
 from tempfile import mkdtemp
 
@@ -30,7 +31,6 @@ class AzureContainer(StorageFixture):
         ArcticUriFields.CA_PATH: re.compile("[/;](CA_cert_path=)([^;]*)(;?)"),
         ArcticUriFields.PATH_PREFIX: re.compile("[/;](Path_prefix=)([^;]*)(;?)"),
     }
-    _sequence = 0
 
     container: str
     client: Optional["ContainerClient"]
@@ -54,8 +54,7 @@ class AzureContainer(StorageFixture):
     def __init__(self, factory: "AzuriteStorageFixtureFactory") -> None:
         super().__init__()
         self.factory = factory
-        self.container = f"container{AzureContainer._sequence}"
-        AzureContainer._sequence += 1
+        self.container = f"container{str(uuid.uuid1())[:8]}"
         self._set_uri_and_client(f"AccountName={factory.account_name};AccountKey={factory.account_key}")
 
         # __exit__() assumes this object owns the container, so always create and bail if exists:

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import platform
+import uuid
 from tempfile import mkdtemp
 import boto3
 import time
@@ -705,7 +706,6 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
     _p: multiprocessing.Process
     _s3_admin: Any
     _iam_admin: Any = None
-    _bucket_id = 0
     _live_buckets: List[S3Bucket] = None
 
     def __init__(
@@ -728,20 +728,11 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         self.use_raw_prefix = use_raw_prefix
         self.use_mock_storage_for_testing = use_mock_storage_for_testing
         self.use_internal_client_wrapper_for_testing = use_internal_client_wrapper_for_testing
-        self._test_only_is_nfs_layout = _test_only_is_nfs_layout
-        # This is needed because we might have multiple factory instances in the same test run
-        # and we need to make sure the bucket names are unique
-        # set the unique_id to the current UNIX timestamp to avoid conflicts
-        self.unique_id = str(int(time.time()))
         self._live_buckets = []
 
     def bucket_name(self, bucket_type="s3"):
-        # We need to increment the bucket_id for each new bucket
-        self._bucket_id += 1
-        # We need the unique_id because we have tests that are creating the factory directly
-        # and not using the fixtures
-        # so this guarantees a unique bucket name
-        return f"test_{bucket_type}_bucket_{self.unique_id}_{self._bucket_id}"
+        unique_id = uuid.uuid4()
+        return f"test_{bucket_type}_bucket_{unique_id}"
 
     def _start_server(self):
         port = self.port = get_ephemeral_port(2)

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -718,6 +718,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         use_mock_storage_for_testing: bool = False,
         use_internal_client_wrapper_for_testing: bool = False,
         native_config: Optional[NativeVariantStorage] = None,
+        port: Optional[int] = None,
         _test_only_is_nfs_layout: bool = False,
     ):
         super().__init__(native_config)
@@ -728,6 +729,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         self.use_raw_prefix = use_raw_prefix
         self.use_mock_storage_for_testing = use_mock_storage_for_testing
         self.use_internal_client_wrapper_for_testing = use_internal_client_wrapper_for_testing
+        self.port = port
         self._live_buckets = []
 
     def bucket_name(self, bucket_type="s3"):
@@ -735,7 +737,11 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         return f"test_{bucket_type}_bucket_{unique_id}"
 
     def _start_server(self):
-        port = self.port = get_ephemeral_port(2)
+        if self.port is None:
+            port = get_ephemeral_port(2)
+        else:
+            port = self.port
+
         self.endpoint = f"{self.http_protocol}://{self.host}:{port}"
         self.working_dir = mkdtemp(suffix="MotoS3StorageFixtureFactory")
         self._iam_endpoint = f"{self.http_protocol}://localhost:{port}"
@@ -867,7 +873,10 @@ class MotoNfsBackedS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
 
 class MotoGcpS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
     def _start_server(self):
-        port = self.port = get_ephemeral_port(3)
+        if self.port is None:
+            port = get_ephemeral_port(3)
+        else:
+            port = self.port
         self.endpoint = f"{self.http_protocol}://{self.host}:{port}"
         self.working_dir = mkdtemp(suffix="MotoGcpS3StorageFixtureFactory")
         self._iam_endpoint = f"{self.http_protocol}://localhost:{port}"

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -706,7 +706,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
     _s3_admin: Any
     _iam_admin: Any = None
     _bucket_id = 0
-    _live_buckets: List[S3Bucket] = []
+    _live_buckets: List[S3Bucket] = None
 
     def __init__(
         self,
@@ -733,6 +733,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         # and we need to make sure the bucket names are unique
         # set the unique_id to the current UNIX timestamp to avoid conflicts
         self.unique_id = str(int(time.time()))
+        self._live_buckets = []
 
     def bucket_name(self, bucket_type="s3"):
         # We need to increment the bucket_id for each new bucket

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -42,7 +42,7 @@ def get_ephemeral_port(seed=0):
     while port < 65535:
         try:
             with socketserver.TCPServer(("localhost", port), None):
-                time.sleep(20 if ARCTICDB_USING_CONDA else 10)  # Hold the port open for a while to improve the chance of collision detection
+                time.sleep(20)  # Hold the port open for a while to improve the chance of collision detection
                 return port
         except OSError as e:
             print(repr(e), file=sys.stderr)

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -38,11 +38,11 @@ def get_ephemeral_port(seed=0):
     # https://stackoverflow.com/a/61685162/ and multiple test runners call this function at roughly the same time, they
     # may get the same port! Below more sophisticated implementation uses the PID to avoid that:
     pid = os.getpid()
-    port = (pid // 1000 + pid) % 1000 + seed % 1000 + 10000  # Crude hash
+    port = pid % 1000 + seed % 1000 + 10000  # Crude hash
     while port < 65535:
         try:
             with socketserver.TCPServer(("localhost", port), None):
-                time.sleep(20 if ARCTICDB_USING_CONDA else 10)  # Hold the port open for a while to improve the chance of collision detection
+                time.sleep(20)  # Hold the port open for a while to improve the chance of collision detection
                 return port
         except OSError as e:
             print(repr(e), file=sys.stderr)

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -38,7 +38,7 @@ def get_ephemeral_port(seed=0):
     # https://stackoverflow.com/a/61685162/ and multiple test runners call this function at roughly the same time, they
     # may get the same port! Below more sophisticated implementation uses the PID to avoid that:
     pid = os.getpid()
-    port = (pid // 1000 + pid) % 1000 + seed * 1000 + 10000  # Crude hash
+    port = (pid // 1000 + pid) % 1000 + seed % 1000 + 10000  # Crude hash
     while port < 65535:
         try:
             with socketserver.TCPServer(("localhost", port), None):
@@ -47,7 +47,7 @@ def get_ephemeral_port(seed=0):
         except OSError as e:
             print(repr(e), file=sys.stderr)
             port += 1000
-    raise Exception(f"Cannot find a free port for PID {pid}")
+    raise Exception(f"Cannot find a free port for PID {pid}, last attempted port {port}")
 
 
 ProcessUnion = Union[multiprocessing.Process, subprocess.Popen]

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -38,7 +38,7 @@ def get_ephemeral_port(seed=0):
     # https://stackoverflow.com/a/61685162/ and multiple test runners call this function at roughly the same time, they
     # may get the same port! Below more sophisticated implementation uses the PID to avoid that:
     pid = os.getpid()
-    port = pid % 1000 + seed % 1000 + 10000  # Crude hash
+    port = (pid // 1000 + pid) % 1000 + seed * 1000 + 10000  # Crude hash
     while port < 65535:
         try:
             with socketserver.TCPServer(("localhost", port), None):
@@ -47,7 +47,7 @@ def get_ephemeral_port(seed=0):
         except OSError as e:
             print(repr(e), file=sys.stderr)
             port += 1000
-    raise Exception(f"Cannot find a free port for PID {pid}, last attempted port {port}")
+    raise Exception(f"Cannot find a free port for PID {pid}")
 
 
 ProcessUnion = Union[multiprocessing.Process, subprocess.Popen]

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -42,7 +42,7 @@ def get_ephemeral_port(seed=0):
     while port < 65535:
         try:
             with socketserver.TCPServer(("localhost", port), None):
-                time.sleep(20)  # Hold the port open for a while to improve the chance of collision detection
+                time.sleep(20 if ARCTICDB_USING_CONDA else 10)  # Hold the port open for a while to improve the chance of collision detection
                 return port
         except OSError as e:
             print(repr(e), file=sys.stderr)

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -42,7 +42,7 @@ def get_ephemeral_port(seed=0):
     while port < 65535:
         try:
             with socketserver.TCPServer(("localhost", port), None):
-                time.sleep(20)  # Hold the port open for a while to improve the chance of collision detection
+                time.sleep(30 if ARCTICDB_USING_CONDA else 20)  # Hold the port open for a while to improve the chance of collision detection
                 return port
         except OSError as e:
             print(repr(e), file=sys.stderr)

--- a/python/arcticdb/version_store/admin_tools.py
+++ b/python/arcticdb/version_store/admin_tools.py
@@ -112,12 +112,15 @@ class AdminTools:
         """
         A breakdown of compressed sizes (in bytes) in the library, grouped by symbol and then key type.
 
-        The following key types (and only these) are always included in the output:
-            VERSION_REF
-            VERSION
-            TABLE_INDEX
-            TABLE_DATA
-            APPEND_DATA
+        The following key types (and only these) are always included in the output,
+
+        ```
+        VERSION_REF
+        VERSION
+        TABLE_INDEX
+        TABLE_DATA
+        APPEND_DATA
+        ```
         """
         sizes = self._nvs.version_store.scan_object_sizes_by_stream()
         res = dict()
@@ -131,11 +134,14 @@ class AdminTools:
         A breakdown of compressed sizes (in bytes) used by the given symbol, grouped by key type.
 
         The following key types (and only these) are always included in the output:
-            VERSION_REF
-            VERSION
-            TABLE_INDEX
-            TABLE_DATA
-            APPEND_DATA
+
+        ```
+        VERSION_REF
+        VERSION
+        TABLE_INDEX
+        TABLE_DATA
+        APPEND_DATA
+        ```
 
         Does not raise if the symbol does not exist.
         """

--- a/python/arcticdb/version_store/admin_tools.py
+++ b/python/arcticdb/version_store/admin_tools.py
@@ -1,0 +1,143 @@
+"""
+Copyright 2025 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+from enum import Enum
+from typing import Dict
+
+from arcticdb_ext.exceptions import ArcticException
+from arcticdb_ext.storage import KeyType as NativeKeyType
+from arcticdb.version_store import NativeVersionStore
+from dataclasses import dataclass
+
+
+@dataclass
+class Size:
+    """Information about the size of objects."""
+
+    bytes_compressed: int
+    """Compressed size in bytes."""
+
+    count: int
+    """The number of objects contributing to the size."""
+
+
+class KeyType(Enum):
+    """
+    This is a subset of all the key types that ArcticDB uses, covering the most important types.
+
+    More information about the ArcticDB data layout is available [here](https://docs.arcticdb.io/latest/technical/on_disk_storage/).
+    """
+    TABLE_DATA = 1
+    """Where the contents of data are stored, in a tiled format."""
+
+    TABLE_INDEX = 2
+    """Metadata used by ArcticDB to select the TABLE_DATA blocks to read. One per un-deleted version of the symbol."""
+
+    VERSION = 3
+    """Metadata used by ArcticDB to store the chain of versions associated with a symbol. It is possible to have
+    more VERSION keys than the version number of a symbol, as we also write a VERSION key when we delete data."""
+
+    VERSION_REF = 4
+    """A pointer to the latest version of a symbol. One per symbol."""
+
+    APPEND_DATA = 5
+    """Only used for staged writes. Data that has been staged but not yet finalized."""
+
+    SNAPSHOT_REF = 6
+    """Metadata used by ArcticDB to store the contents of a snapshot (the structure created when you call `lib.snapshot`)."""
+
+    LOG = 7
+    """Only used for enterprise replication. Small objects recording a stream of changes to the library."""
+
+    LOG_COMPACTED = 8
+    """Only used for some enterprise replication installations. A compacted form of the LOG keys."""
+
+    SYMBOL_LIST = 9
+    """A collection of keys that together store the total set of symbols stored in a library. Used for `list_symbols`."""
+
+    @staticmethod
+    def _from_native(native_key_type: NativeKeyType):
+        if native_key_type == NativeKeyType.TABLE_DATA:
+            return KeyType.TABLE_DATA
+        elif native_key_type == NativeKeyType.TABLE_INDEX:
+            return KeyType.TABLE_INDEX
+        elif native_key_type == NativeKeyType.VERSION:
+            return KeyType.VERSION
+        elif native_key_type == NativeKeyType.VERSION_REF:
+            return KeyType.VERSION_REF
+        elif native_key_type == NativeKeyType.SNAPSHOT_REF:
+            return KeyType.SNAPSHOT_REF
+        elif native_key_type == NativeKeyType.APPEND_DATA:
+            return KeyType.APPEND_DATA
+        elif native_key_type == NativeKeyType.LOG:
+            return KeyType.LOG
+        elif native_key_type == NativeKeyType.LOG_COMPACTED:
+            return KeyType.LOG_COMPACTED
+        elif native_key_type == NativeKeyType.SYMBOL_LIST:
+            return KeyType.SYMBOL_LIST
+        else:
+            raise ArcticException(f"Unexpected KeyType {native_key_type} - this indicates a bug in ArcticDB")
+
+
+class AdminTools:
+    """
+    A collection of tools for administrative tasks on an ArcticDB library.
+
+    This API is not currently stable and not governed by the semver version numbers of ArcticDB releases.
+
+    See Also
+    --------
+
+    Library.admin_tools: The API to get a handle on this object from a Library.
+    """
+
+    def __init__(self, nvs: NativeVersionStore):
+        self._nvs = nvs
+
+    def get_sizes(self) -> Dict[KeyType, Size]:
+        """
+        A breakdown of compressed sizes (in bytes) in the library, grouped by key type.
+
+        All the key types in KeyType (and only these) are always included in the output.
+        """
+        sizes = self._nvs.version_store.scan_object_sizes()
+        return {KeyType._from_native(s.key_type) : Size(s.compressed_size, s.count) for s in sizes}
+
+    def get_sizes_by_symbol(self) -> Dict[str, Dict[KeyType, Size]]:
+        """
+        A breakdown of compressed sizes (in bytes) in the library, grouped by symbol and then key type.
+
+        The following key types (and only these) are always included in the output:
+            VERSION_REF
+            VERSION
+            TABLE_INDEX
+            TABLE_DATA
+            APPEND_DATA
+        """
+        sizes = self._nvs.version_store.scan_object_sizes_by_stream()
+        res = dict()
+        for sym, sym_sizes in sizes.items():
+            sizes_as_python = {KeyType._from_native(t): Size(s.compressed_size, s.count) for t, s in sym_sizes.items()}
+            res[sym] = sizes_as_python
+        return res
+
+    def get_sizes_for_symbol(self, symbol: str) -> Dict[KeyType, Size]:
+        """
+        A breakdown of compressed sizes (in bytes) used by the given symbol, grouped by key type.
+
+        The following key types (and only these) are always included in the output:
+            VERSION_REF
+            VERSION
+            TABLE_INDEX
+            TABLE_DATA
+            APPEND_DATA
+
+        Does not raise if the symbol does not exist.
+        """
+        sizes = self._nvs.version_store.scan_object_sizes_for_stream(symbol)
+        return {KeyType._from_native(s.key_type): Size(s.compressed_size, s.count) for s in sizes}

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -29,6 +29,7 @@ import pandas as pd
 import numpy as np
 import logging
 from arcticdb.version_store._normalization import normalize_metadata
+from arcticdb.version_store.admin_tools import AdminTools
 
 logger = logging.getLogger(__name__)
 
@@ -2533,3 +2534,7 @@ class Library:
     def name(self):
         """The name of this library."""
         return self._nvs.name()
+
+    def admin_tools(self):
+        """Administrative utilities that operate on this library."""
+        return AdminTools(self._nvs)

--- a/python/tests/integration/arcticdb/test_admin_tools.py
+++ b/python/tests/integration/arcticdb/test_admin_tools.py
@@ -1,0 +1,193 @@
+"""
+Copyright 2025 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+from arcticdb.util.test import sample_dataframe
+from arcticdb import KeyType, Size
+
+from arcticdb.options import EnterpriseLibraryOptions
+
+
+def test_get_sizes(arctic_client, lib_name):
+    lib_opts = EnterpriseLibraryOptions(replication=True)
+    arctic_library = arctic_client.create_library(lib_name, enterprise_library_options=lib_opts)
+    # Given
+    arctic_library.write_pickle("sym_1", 1)
+    arctic_library.write_pickle("sym_1", 2)
+    df = sample_dataframe(size=250_000)
+    arctic_library.write("sym_1", df)
+    arctic_library.write("sym_2", df)
+    arctic_library.delete("sym_1", versions=[0])
+
+    # When
+    sizes = arctic_library.admin_tools().get_sizes()
+
+    # Then
+    assert len(sizes) == 9
+    assert sizes[KeyType.VERSION_REF].count == 2
+    assert 500 < sizes[KeyType.VERSION_REF].bytes_compressed < 2000
+    assert sizes[KeyType.VERSION].count == 5
+    assert 3000 < sizes[KeyType.VERSION].bytes_compressed < 5000
+    assert sizes[KeyType.TABLE_INDEX].count == 3
+    assert 3000 < sizes[KeyType.TABLE_INDEX].bytes_compressed < 6000
+    assert sizes[KeyType.TABLE_DATA].count == 7
+    assert 20e6 < sizes[KeyType.TABLE_DATA].bytes_compressed < 30e6
+    assert sizes[KeyType.SYMBOL_LIST].count == 4
+    assert 500 < sizes[KeyType.SYMBOL_LIST].bytes_compressed < 3000
+    assert sizes[KeyType.LOG].count == 5
+
+    for t in (KeyType.APPEND_DATA, KeyType.SNAPSHOT_REF, KeyType.LOG_COMPACTED):
+        assert sizes[t].count == 0
+        assert sizes[t].bytes_compressed == 0
+
+    arctic_library.delete("sym_1")
+    sizes = arctic_library.admin_tools().get_sizes()
+    assert sizes[KeyType.VERSION_REF].count == 2
+    assert sizes[KeyType.VERSION].count == 6
+    assert sizes[KeyType.TABLE_INDEX].count == 1
+    assert sizes[KeyType.TABLE_DATA].count == 3
+    assert sizes[KeyType.SYMBOL_LIST].count == 5
+    assert 10e6 < sizes[KeyType.TABLE_DATA].bytes_compressed < 15e6
+
+    # Check the other key types
+    arctic_library.snapshot("snap")
+    arctic_library.write("new_sym", df, staged=True)
+    sizes = arctic_library.admin_tools().get_sizes()
+    assert sizes[KeyType.SNAPSHOT_REF].count == 1
+    assert sizes[KeyType.APPEND_DATA].count == 3
+    assert 10e6 < sizes[KeyType.APPEND_DATA].bytes_compressed < 15e6
+
+
+def test_get_sizes_by_symbol(arctic_client, lib_name):
+    lib_opts = EnterpriseLibraryOptions(replication=True)
+    arctic_library = arctic_client.create_library(lib_name, enterprise_library_options=lib_opts)
+    # Given
+    arctic_library.write_pickle("sym_1", 1)
+    arctic_library.write_pickle("sym_1", 2)
+    df = sample_dataframe(size=250_000)
+    arctic_library.write("sym_1", df)
+    arctic_library.write("sym_2", df)
+    arctic_library.delete("sym_1", versions=[0])
+
+    # When
+    sizes = arctic_library.admin_tools().get_sizes_by_symbol()
+
+    # Then
+    assert len(sizes) == 2
+    assert len(sizes["sym_1"]) == 5
+    assert len(sizes["sym_2"]) == 5
+    assert sizes["sym_1"].keys() == {KeyType.VERSION_REF, KeyType.VERSION, KeyType.TABLE_INDEX, KeyType.TABLE_DATA,
+                                     KeyType.APPEND_DATA}
+
+    assert sizes["sym_1"][KeyType.VERSION_REF].count == 1
+    assert sizes["sym_2"][KeyType.VERSION_REF].count == 1
+    assert 500 < sizes["sym_1"][KeyType.VERSION_REF].bytes_compressed < 2000
+
+    assert sizes["sym_1"][KeyType.VERSION].count == 4
+    assert sizes["sym_2"][KeyType.VERSION].count == 1
+    assert 2000 < sizes["sym_1"][KeyType.VERSION].bytes_compressed < 4000
+    assert 500 < sizes["sym_2"][KeyType.VERSION].bytes_compressed < 1000
+
+    assert sizes["sym_1"][KeyType.TABLE_INDEX].count == 2
+    assert 2000 < sizes["sym_1"][KeyType.TABLE_INDEX].bytes_compressed < 4000
+    assert sizes["sym_1"][KeyType.TABLE_DATA].count == 4
+    assert 10e6 < sizes["sym_1"][KeyType.TABLE_DATA].bytes_compressed < 20e6
+    assert sizes["sym_1"][KeyType.APPEND_DATA].count == 0
+    assert sizes["sym_1"][KeyType.APPEND_DATA].bytes_compressed == 0
+
+    arctic_library.delete("sym_1")
+    sizes = arctic_library.admin_tools().get_sizes_by_symbol()
+    assert sizes["sym_1"][KeyType.VERSION_REF].count == 1
+    assert sizes["sym_1"][KeyType.VERSION].count == 5
+    assert sizes["sym_1"][KeyType.TABLE_INDEX].count == 0
+    assert sizes["sym_1"][KeyType.TABLE_DATA].count == 0
+
+    arctic_library.write("new_sym", df, staged=True)
+    sizes = arctic_library.admin_tools().get_sizes_by_symbol()
+    assert sizes["new_sym"][KeyType.APPEND_DATA].count == 3
+    assert 10e6 < sizes["new_sym"][KeyType.APPEND_DATA].bytes_compressed < 15e6
+
+
+def test_get_sizes_for_symbol(arctic_client, lib_name):
+    lib_opts = EnterpriseLibraryOptions(replication=True)
+    arctic_library = arctic_client.create_library(lib_name, enterprise_library_options=lib_opts)
+    arctic_library.write_pickle("sym_1", 1)
+    arctic_library.write_pickle("sym_1", 2)
+    df = sample_dataframe(size=250_000)
+    arctic_library.write("sym_1", df)
+    arctic_library.delete("sym_1", versions=[0])
+
+    arctic_library.write_pickle("delete_me", 1)
+    arctic_library.delete("delete_me")
+
+    non_existent_sizes = arctic_library.admin_tools().get_sizes_for_symbol("non-existent")
+
+    expected_key_types = {KeyType.VERSION_REF, KeyType.VERSION, KeyType.TABLE_INDEX, KeyType.TABLE_DATA, KeyType.APPEND_DATA}
+    assert non_existent_sizes.keys() == expected_key_types
+    for size in non_existent_sizes.values():
+        assert size == Size(0, 0)
+
+    deleted_sizes = arctic_library.admin_tools().get_sizes_for_symbol("delete_me")
+    assert deleted_sizes.keys() == expected_key_types
+    assert deleted_sizes[KeyType.VERSION_REF].count == 1
+    assert deleted_sizes[KeyType.VERSION].count == 2
+    for t in (KeyType.TABLE_INDEX, KeyType.TABLE_DATA, KeyType.APPEND_DATA):
+        assert deleted_sizes[t] == Size(0, 0)
+
+    sizes = arctic_library.admin_tools().get_sizes_for_symbol("sym_1")
+    assert sizes.keys() == expected_key_types
+
+    assert sizes[KeyType.VERSION_REF].count == 1
+    assert sizes[KeyType.VERSION_REF].count == 1
+    assert 500 < sizes[KeyType.VERSION_REF].bytes_compressed < 2000
+
+    assert sizes[KeyType.VERSION].count == 4
+    assert 1000 < sizes[KeyType.VERSION].bytes_compressed < 4000
+
+    assert sizes[KeyType.TABLE_INDEX].count == 2
+    assert 2000 < sizes[KeyType.TABLE_INDEX].bytes_compressed < 4500
+    assert sizes[KeyType.TABLE_DATA].count == 4
+    assert 10e6 < sizes[KeyType.TABLE_DATA].bytes_compressed < 15e6
+    assert sizes[KeyType.APPEND_DATA].count == 0
+    assert sizes[KeyType.APPEND_DATA].bytes_compressed == 0
+
+    arctic_library.delete("sym_1")
+    sizes = arctic_library.admin_tools().get_sizes_for_symbol("sym_1")
+    assert sizes[KeyType.VERSION_REF].count == 1
+    assert sizes[KeyType.VERSION].count == 5
+    assert sizes[KeyType.TABLE_INDEX].count == 0
+    assert sizes[KeyType.TABLE_INDEX].bytes_compressed == 0
+    assert sizes[KeyType.TABLE_DATA].count == 0
+    assert sizes[KeyType.TABLE_DATA].bytes_compressed == 0
+
+    arctic_library.write("new_sym", df, staged=True)
+    sizes = arctic_library.admin_tools().get_sizes_for_symbol("new_sym")
+    assert sizes[KeyType.APPEND_DATA].count == 3
+    assert 10e6 < sizes[KeyType.APPEND_DATA].bytes_compressed < 15e6
+
+
+def test_size_apis_self_consistent(arctic_library, lib_name):
+    # Given
+    arctic_library.write_pickle("sym_1", 1)
+    arctic_library.write_pickle("sym_1", 2)
+    df = sample_dataframe(size=250_000)
+    arctic_library.write("sym_1", df)
+    arctic_library.write("sym_1", df, staged=True)
+
+    # When
+    sizes = arctic_library.admin_tools().get_sizes()
+    by_symbol = arctic_library.admin_tools().get_sizes_by_symbol()
+    assert len(by_symbol) == 1
+    by_symbol = by_symbol["sym_1"]
+    for_symbol = arctic_library.admin_tools().get_sizes_for_symbol("sym_1")
+
+    # Then
+    for t in (KeyType.VERSION_REF, KeyType.VERSION, KeyType.TABLE_INDEX, KeyType.TABLE_DATA, KeyType.APPEND_DATA):
+        size = sizes[t]
+        assert size == by_symbol[t]
+        assert size == for_symbol[t]
+        assert size.count > 0
+        assert size.bytes_compressed > 0

--- a/python/tests/integration/arcticdb/test_admin_tools.py
+++ b/python/tests/integration/arcticdb/test_admin_tools.py
@@ -5,11 +5,8 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
-import sys
-
 import numpy as np
 import pandas as pd
-import pytest
 from arcticdb.util.test import sample_dataframe
 from arcticdb import KeyType, Size, Arctic
 
@@ -17,7 +14,6 @@ from arcticdb.options import EnterpriseLibraryOptions
 from arcticdb.version_store.admin_tools import sum_sizes
 
 
-@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor < 10, reason="Issue with Azurite on earlier Pythons")
 def test_get_sizes(arctic_client, lib_name):
     lib_opts = EnterpriseLibraryOptions(replication=True)
     arctic_library = arctic_client.create_library(lib_name, enterprise_library_options=lib_opts)

--- a/python/tests/integration/arcticdb/test_admin_tools.py
+++ b/python/tests/integration/arcticdb/test_admin_tools.py
@@ -5,8 +5,11 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+import sys
+
 import numpy as np
 import pandas as pd
+import pytest
 from arcticdb.util.test import sample_dataframe
 from arcticdb import KeyType, Size, Arctic
 
@@ -14,6 +17,7 @@ from arcticdb.options import EnterpriseLibraryOptions
 from arcticdb.version_store.admin_tools import sum_sizes
 
 
+@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor < 10, reason="Issue with Azurite on earlier Pythons")
 def test_get_sizes(arctic_client, lib_name):
     lib_opts = EnterpriseLibraryOptions(replication=True)
     arctic_library = arctic_client.create_library(lib_name, enterprise_library_options=lib_opts)

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -134,7 +134,7 @@ def test_racing_list_and_delete_nfs(nfs_backed_s3_storage, lib_name):
     assert exceptions_in_reader.empty()
 
 
-@pytest.fixture(scope="function", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
+@pytest.fixture(scope="session", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
 def s3_storage_dots_in_path(request):
     prefix = "some_path/.thing_with_a_dot/even.more.dots/end"
 
@@ -198,7 +198,7 @@ def test_prefix():
     return "test_bucket_prefix"
 
 
-@pytest.fixture(scope="function", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
+@pytest.fixture(scope="session", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
 def storage_bucket(test_prefix, request):
     with request.param(
         use_ssl=False, ssl_test_support=False, bucket_versioning=False, default_prefix=test_prefix

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -134,7 +134,7 @@ def test_racing_list_and_delete_nfs(nfs_backed_s3_storage, lib_name):
     assert exceptions_in_reader.empty()
 
 
-@pytest.fixture(scope="session", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
+@pytest.fixture(scope="function", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
 def s3_storage_dots_in_path(request):
     prefix = "some_path/.thing_with_a_dot/even.more.dots/end"
 

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -198,7 +198,7 @@ def test_prefix():
     return "test_bucket_prefix"
 
 
-@pytest.fixture(scope="session", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
+@pytest.fixture(scope="function", params=[MotoNfsBackedS3StorageFixtureFactory, MotoS3StorageFixtureFactory])
 def storage_bucket(test_prefix, request):
     with request.param(
         use_ssl=False, ssl_test_support=False, bucket_versioning=False, default_prefix=test_prefix

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -272,7 +272,8 @@ def test_symbol_sizes_concurrent(reader_store, writer_store):
 def test_symbol_sizes_matches_boto(request, store, lib_name):
     s3_storage = request.getfixturevalue(store)
     bucket = s3_storage.get_boto_bucket()
-    lib = s3_storage.create_version_store_factory(lib_name)()
+    ac = s3_storage.create_arctic(encoding_version=EncodingVersion.V1)
+    lib = ac.create_library(lib_name)._nvs
 
     try:
         df = sample_dataframe(100, 0)
@@ -292,6 +293,7 @@ def test_symbol_sizes_matches_boto(request, store, lib_name):
         assert data_keys[0].size == data_size.compressed_size
     finally:
         lib.version_store.clear()
+        assert lib.version_store.empty()
 
 
 def test_symbol_sizes_matches_azurite(azurite_storage, lib_name):

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -261,7 +261,7 @@ def test_symbol_sizes_concurrent(reader_store, writer_store):
     assert exceptions_in_reader.empty()
 
 
-@pytest.fixture(scope="session", params=[(MotoNfsBackedS3StorageFixtureFactory, 100),
+@pytest.fixture(scope="function", params=[(MotoNfsBackedS3StorageFixtureFactory, 100),
                                          (MotoS3StorageFixtureFactory, 101),
                                          (MotoGcpS3StorageFixtureFactory, 102)])
 def s3_like_storage(request):
@@ -297,7 +297,7 @@ def test_symbol_sizes_matches_boto(s3_like_storage, lib_name):
         assert lib.version_store.empty()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def azure_storage_for_symbol_sizes():
     with AzuriteStorageFixtureFactory(use_ssl=False, ssl_test_support=False, port=get_ephemeral_port(103)) as f:
         with f.create_fixture() as g:

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -261,7 +261,7 @@ def test_symbol_sizes_concurrent(reader_store, writer_store):
     assert exceptions_in_reader.empty()
 
 
-@pytest.fixture(scope="function", params=[(MotoNfsBackedS3StorageFixtureFactory, 100),
+@pytest.fixture(scope="session", params=[(MotoNfsBackedS3StorageFixtureFactory, 100),
                                          (MotoS3StorageFixtureFactory, 101),
                                          (MotoGcpS3StorageFixtureFactory, 102)])
 def s3_like_storage(request):
@@ -297,7 +297,7 @@ def test_symbol_sizes_matches_boto(s3_like_storage, lib_name):
         assert lib.version_store.empty()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def azure_storage_for_symbol_sizes():
     with AzuriteStorageFixtureFactory(use_ssl=False, ssl_test_support=False, port=get_ephemeral_port(103)) as f:
         with f.create_fixture() as g:

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -3,9 +3,6 @@ from multiprocessing import Queue, Process
 import pytest
 from arcticdb import LibraryOptions
 from arcticdb.encoding_version import EncodingVersion
-from arcticdb.storage_fixtures.azure import AzuriteStorageFixtureFactory
-from arcticdb.storage_fixtures.s3 import MotoS3StorageFixtureFactory, MotoNfsBackedS3StorageFixtureFactory, MotoGcpS3StorageFixtureFactory
-from arcticdb.storage_fixtures.utils import get_ephemeral_port
 from arcticdb.util.test import sample_dataframe, config_context_multi
 from arcticdb_ext.storage import KeyType
 import arcticdb_ext.cpp_async as adb_async

--- a/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_sizes.py
@@ -281,10 +281,10 @@ def test_symbol_sizes_matches_boto(request, store, lib_name):
         lib.write("s", df)
 
         sizes = lib.version_store.scan_object_sizes()
-        assert len(sizes) == 9
+        assert len(sizes) == 10
         key_types = {s.key_type for s in sizes}
         assert key_types == {KeyType.TABLE_DATA, KeyType.TABLE_INDEX, KeyType.VERSION, KeyType.VERSION_REF, KeyType.APPEND_DATA,
-                             KeyType.SNAPSHOT_REF, KeyType.LOG, KeyType.LOG_COMPACTED, KeyType.SYMBOL_LIST}
+                             KeyType.MULTI_KEY, KeyType.SNAPSHOT_REF, KeyType.LOG, KeyType.LOG_COMPACTED, KeyType.SYMBOL_LIST}
 
         data_size = [s for s in sizes if s.key_type == KeyType.TABLE_DATA][0]
         data_keys = [o for o in bucket.objects.all() if "test_symbol_sizes_matches_boto" in o.key and "/tdata/" in o.key]


### PR DESCRIPTION
Add Python APIs to get sizes of symbols, in a new `AdminTools` class. Add documentation for this feature to our website.

You can access the new tools with:

```
lib: Library
lib.admin_tools(): AdminTools
```

Refactor the existing symbol scanning APIs to a visitor pattern so they can all share as much of the implementation as possible.

Monday: 8560764974
