### PR TITLE
Add warning when integer types are promoted to float during aggregations with dynamic schema.

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -341,7 +341,7 @@ jobs:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{vars.CMAKE_BUILD_PARALLEL_LEVEL}}
 
       - name: Set persistent storage variables
-        if: ${{ env.real_tests_enabled }} != 'no'
+        if: ${{ env.real_tests_enabled != 'no' }}
         uses: ./.github/actions/set_persistent_storage_env_vars
         with:
           aws_access_key: "${{ secrets.AWS_S3_ACCESS_KEY }}"
@@ -352,7 +352,7 @@ jobs:
           strategy_branch: "${{ env.distinguishing_name }}"
         
       - name: Set s3 sts persistent storage variables for Windows
-        if: ${{ env.real_tests_enabled }} != 'no' && matrix.os == 'windows'
+        if: ${{ env.real_tests_enabled != 'no' && matrix.os == 'windows' }}
         uses: ./.github/actions/set_s3_sts_persistent_storage_env_vars
         with:
           aws_access_key: "${{ secrets.AWS_S3_ACCESS_KEY }}"

--- a/cpp/arcticdb/codec/python_bindings.cpp
+++ b/cpp/arcticdb/codec/python_bindings.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/codec/python_bindings.hpp>
-
 #include <arcticdb/codec/codec.hpp>
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/column_store/column_data.hpp>
@@ -23,6 +22,7 @@
 #include <memory>
 #include <algorithm>
 #include <string>
+
 
 namespace py = pybind11;
 using namespace arcticdb::python_util;

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -22,7 +22,6 @@
 #include <spdlog/async_logger.h>
 #include <spdlog/sinks/stdout_sinks.h>
 
-
 #include <logger.pb.h>
 
 #include <memory>

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -241,22 +241,22 @@ namespace
     };
 
     template <Extremum T>
-    inline void aggregate_impl(
+    void aggregate_impl(
         const std::optional<ColumnWithStrings>& input_column,
         const std::vector<size_t>& groups,
         size_t unique_values,
-        std::vector<uint8_t>& aggregated_,
-        std::optional<DataType>& data_type_
+        std::vector<uint8_t>& aggregated,
+        std::optional<DataType>& data_type
     ) {
-        if(data_type_.has_value() && *data_type_ != DataType::EMPTYVAL && input_column.has_value()) {
-            details::visit_type(*data_type_, [&aggregated_, &input_column, unique_values, &groups] (auto global_tag) {
+        if(data_type.has_value() && *data_type != DataType::EMPTYVAL && input_column.has_value()) {
+            details::visit_type(*data_type, [&aggregated, &input_column, unique_values, &groups] (auto global_tag) {
                 using global_type_info = ScalarTypeInfo<decltype(global_tag)>;
                 using GlobalRawType = typename global_type_info::RawType;
                 if constexpr(!is_sequence_type(global_type_info::data_type)) {
                     using MaybeValueType = MaybeValue<GlobalRawType, T>;
-                    auto prev_size = aggregated_.size() / sizeof(MaybeValueType);
-                    aggregated_.resize(sizeof(MaybeValueType) * unique_values);
-                    auto out_ptr = reinterpret_cast<MaybeValueType*>(aggregated_.data());
+                    auto prev_size = aggregated.size() / sizeof(MaybeValueType);
+                    aggregated.resize(sizeof(MaybeValueType) * unique_values);
+                    auto out_ptr = reinterpret_cast<MaybeValueType*>(aggregated.data());
                     std::fill(out_ptr + prev_size, out_ptr + unique_values, MaybeValueType{});
                     details::visit_type(input_column->column_->type().data_type(), [&input_column, &groups, &out_ptr] (auto col_tag) {
                         using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
@@ -294,37 +294,59 @@ namespace
         }
     }
 
+    template<Extremum extremum>
+    consteval const char* extremum_name() {
+        if constexpr (extremum == Extremum::MAX) {
+            return "MAX";
+        } else if constexpr (extremum == Extremum::MIN) {
+            return "MIN";
+        } else {
+            static_assert(sizeof(extremum) == 0, "Unknown extremum value");
+        }
+    }
+
     template <Extremum T>
-    inline SegmentInMemory finalize_impl(
+    SegmentInMemory finalize_impl(
             const ColumnName& output_column_name,
             bool dynamic_schema,
             size_t unique_values,
-            std::vector<uint8_t>& aggregated_,
-            std::optional<DataType>& data_type_
+            std::vector<uint8_t>& aggregated,
+            std::optional<DataType>& data_type
     ) {
         SegmentInMemory res;
-        if(!aggregated_.empty()) {
+        if(!aggregated.empty()) {
             constexpr auto dynamic_schema_data_type = DataType::FLOAT64;
             using DynamicSchemaTDT = ScalarTagType<DataTypeTag<dynamic_schema_data_type>>;
-            auto col = std::make_shared<Column>(make_scalar_type(dynamic_schema ? dynamic_schema_data_type: data_type_.value()), unique_values, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED);
+            const TypeDescriptor column_type = make_scalar_type(dynamic_schema ? dynamic_schema_data_type: data_type.value());
+            auto col = std::make_shared<Column>(column_type, unique_values, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED);
             auto column_data = col->data();
             col->set_row_data(unique_values - 1);
-            res.add_column(scalar_field(dynamic_schema ? dynamic_schema_data_type : data_type_.value(), output_column_name.value), col);
-            details::visit_type(*data_type_, [&aggregated_, &column_data, unique_values, dynamic_schema] (auto col_tag) {
+            res.add_column(scalar_field(col->type().data_type(), output_column_name.value), std::move(col));
+            details::visit_type(*data_type, [&] (auto col_tag) {
                 using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
                 using MaybeValueType = MaybeValue<typename col_type_info::RawType, T>;
                 if(dynamic_schema) {
-                    auto prev_size = aggregated_.size() / sizeof(MaybeValueType);
+                    if constexpr (dynamic_schema_data_type != col_type_info::data_type && is_integer_type(col_type_info::data_type)) {
+                        log::message().warn(
+                            "The column \"{}\" of type {} is a result of a {} aggregation, and the library is using a"
+                            "dynamic schema. ArcticDB will promote the type to {} so that if a grouping bucket is empty,"
+                            " it will be assigned a value of NaN. This behavior will be deprecated with the release of "
+                            "ArcticDB v6.0.0 and will change as follows. If Arrow is used as a backend, empty grouping"
+                            " buckets will be use Arrow's missing value. If numpy is used as a backend all missing data"
+                            "will be backfilled with 0.",
+                            output_column_name.value, col_type_info::data_type, extremum_name<T>(), dynamic_schema_data_type);
+                    }
+                    auto prev_size = aggregated.size() / sizeof(MaybeValueType);
                     auto new_size = sizeof(MaybeValueType) * unique_values;
-                    aggregated_.resize(new_size);
-                    auto in_ptr = reinterpret_cast<MaybeValueType *>(aggregated_.data());
+                    aggregated.resize(new_size);
+                    auto in_ptr = reinterpret_cast<MaybeValueType *>(aggregated.data());
                     std::fill(in_ptr + prev_size, in_ptr + unique_values, MaybeValueType{});
                     for (auto it = column_data.begin<DynamicSchemaTDT>(); it != column_data.end<DynamicSchemaTDT>(); ++it, ++in_ptr) {
                         *it = in_ptr->written_ ? static_cast<double>(in_ptr->value_)
                                                : std::numeric_limits<double>::quiet_NaN();
                     }
                 } else {
-                    auto in_ptr = reinterpret_cast<MaybeValueType*>(aggregated_.data());
+                    auto in_ptr = reinterpret_cast<MaybeValueType*>(aggregated.data());
                     for (auto it = column_data.begin<typename col_type_info::TDT>(); it != column_data.end<typename col_type_info::TDT>(); ++it, ++in_ptr) {
                         if constexpr (is_floating_point_type(col_type_info::data_type)) {
                             *it = in_ptr->written_ ? in_ptr->value_ : std::numeric_limits<typename col_type_info::RawType>::quiet_NaN();

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -317,12 +317,12 @@ namespace
                 if(dynamic_schema) {
                     if constexpr (dynamic_schema_data_type != col_type_info::data_type && is_integer_type(col_type_info::data_type)) {
                         log::message().warn(
-                            "The column \"{}\" of type {} is a result of a {} aggregation, and the library is using a"
-                            "dynamic schema. ArcticDB will promote the type to {} so that if a grouping bucket is empty,"
-                            " it will be assigned a value of NaN. This behavior will be deprecated with the release of "
-                            "ArcticDB v6.0.0 and will change as follows. If Arrow is used as a backend, empty grouping"
-                            " buckets will be use Arrow's missing value. If numpy is used as a backend all missing data"
-                            "will be backfilled with 0.",
+                            "The column \"{}\" of type {} is a result of a {} aggregation and the library is configured"
+                            " to use dynamic schema. ArcticDB will promote the type to {} so that if a grouping bucket "
+                            "is empty, it will be assigned a value of NaN. This behavior will be deprecated with the "
+                            "release of ArcticDB v6.0.0 and will change as follows. If Arrow output format is used, "
+                            "empty grouping buckets will be use Arrow's missing value. If numpy output format is used "
+                            "all missing data will be backfilled with 0.",
                             output_column_name.value, col_type_info::data_type, T == Extremum::MIN ? "MIN" : "MAX", dynamic_schema_data_type);
                     }
                     auto prev_size = aggregated.size() / sizeof(MaybeValueType);

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -294,16 +294,6 @@ namespace
         }
     }
 
-    template<Extremum extremum>
-    requires (extremum == Extremum::MAX || extremum == Extremum::MIN)
-    consteval const char* extremum_name() {
-        if constexpr (extremum == Extremum::MAX) {
-            return "MAX";
-        } else if constexpr (extremum == Extremum::MIN) {
-            return "MIN";
-        }
-    }
-
     template <Extremum T>
     SegmentInMemory finalize_impl(
             const ColumnName& output_column_name,
@@ -333,7 +323,7 @@ namespace
                             "ArcticDB v6.0.0 and will change as follows. If Arrow is used as a backend, empty grouping"
                             " buckets will be use Arrow's missing value. If numpy is used as a backend all missing data"
                             "will be backfilled with 0.",
-                            output_column_name.value, col_type_info::data_type, extremum_name<T>(), dynamic_schema_data_type);
+                            output_column_name.value, col_type_info::data_type, T == Extremum::MIN ? "MIN" : "MAX", dynamic_schema_data_type);
                     }
                     auto prev_size = aggregated.size() / sizeof(MaybeValueType);
                     auto new_size = sizeof(MaybeValueType) * unique_values;

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -295,13 +295,12 @@ namespace
     }
 
     template<Extremum extremum>
+    requires (extremum == Extremum::MAX || extremum == Extremum::MIN)
     consteval const char* extremum_name() {
         if constexpr (extremum == Extremum::MAX) {
             return "MAX";
         } else if constexpr (extremum == Extremum::MIN) {
             return "MIN";
-        } else {
-            static_assert(sizeof(extremum) == 0, "Unknown extremum value");
         }
     }
 

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -505,7 +505,6 @@ class TestDynamicSchemaLogsWarningWhenPromotingIntToFloat:
         qb = QueryBuilder().groupby("group").agg({agg: ("col", agg)})
         lib.read("sym", query_builder=qb)
         stdout, stderr = capfd.readouterr()
-        print(stderr)
         assert all([w in stderr for w in ["W arcticdb", agg, "ArcticDB v6.0.0", "FLOAT64", dtype.upper(), agg.upper()]])
 
     @pytest.mark.parametrize("agg", ["min", "max"])

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -13,8 +13,6 @@ from pandas import DataFrame
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb_ext.exceptions import InternalException, SchemaException
 from arcticdb.util.test import assert_frame_equal, generic_aggregation_test, make_dynamic
-from arcticdb.config import set_log_level
-from arcticdb_ext.log import flush_all
 
 pytestmark = pytest.mark.pipeline
 
@@ -488,16 +486,6 @@ def test_aggregation_grouping_column_missing_from_row_group(lmdb_version_store_d
     lib.append(symbol, append_df)
     generic_aggregation_test(lib, symbol, pd.concat([write_df, append_df]), "grouping_column", {"to_sum": "sum"})
 
-@pytest.fixture(scope='class')
-def class_log_file(tmpdir_factory):
-    file = tmpdir_factory.mktemp('logs').join('log.txt')
-    yield file
-
-@pytest.fixture(scope='function')
-def clean_class_log_file(class_log_file):
-    class_log_file.write_text("", encoding="utf-8")
-    yield class_log_file
-
 class TestDynamicSchemaLogsWarningWhenPromotingIntToFloat:
     """
     Dynamic schema promotes int typed columns to float for min and max so that if that a column is missing from a
@@ -510,25 +498,21 @@ class TestDynamicSchemaLogsWarningWhenPromotingIntToFloat:
 
     @pytest.mark.parametrize("agg", ["min", "max"])
     @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"])
-    def test_warn_int_types(self, lmdb_library_dynamic_schema, agg, dtype, clean_class_log_file):
-        set_log_level(console_output=False, file_output_path=str(clean_class_log_file))
+    def test_warn_int_types(self, lmdb_library_dynamic_schema, agg, dtype, get_stderr):
         lib = lmdb_library_dynamic_schema
         lib.write("sym", pd.DataFrame({"group": [0], "col": np.array([1], dtype=dtype)}))
         lib.append("sym", pd.DataFrame({"group": [1]}))
         qb = QueryBuilder().groupby("group").agg({agg: ("col", agg)})
         lib.read("sym", query_builder=qb)
-        flush_all()
-        logs = clean_class_log_file.read_text(encoding="utf-8")
+        logs = get_stderr()
         assert all([w in logs for w in ["W arcticdb", agg, "ArcticDB v6.0.0", "FLOAT64", dtype.upper(), agg.upper()]])
     @pytest.mark.parametrize("agg", ["min", "max"])
     @pytest.mark.parametrize("dtype", ["datetime64[ns]", "float32", "float64"])
-    def test_dont_warn_non_int_types(self, lmdb_library_dynamic_schema, agg, dtype, clean_class_log_file):
-        set_log_level(file_output_path=str(clean_class_log_file))
+    def test_dont_warn_non_int_types(self, lmdb_library_dynamic_schema, agg, dtype, get_stderr):
         lib = lmdb_library_dynamic_schema
         lib.write("sym", pd.DataFrame({"group": [0], "col": np.array([1], dtype=dtype)}))
         lib.append("sym", pd.DataFrame({"group": [1]}))
         qb = QueryBuilder().groupby("group").agg({agg: ("col", agg)})
         lib.read("sym", query_builder=qb)
-        flush_all()
-        logs = clean_class_log_file.read_text(encoding="utf-8")
+        logs = get_stderr()
         assert logs == ""

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -13,6 +13,8 @@ from pandas import DataFrame
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb_ext.exceptions import InternalException, SchemaException
 from arcticdb.util.test import assert_frame_equal, generic_aggregation_test, make_dynamic
+from arcticdb.config import set_log_level
+from arcticdb_ext.log import flush_all
 
 pytestmark = pytest.mark.pipeline
 
@@ -486,6 +488,21 @@ def test_aggregation_grouping_column_missing_from_row_group(lmdb_version_store_d
     lib.append(symbol, append_df)
     generic_aggregation_test(lib, symbol, pd.concat([write_df, append_df]), "grouping_column", {"to_sum": "sum"})
 
+@pytest.fixture(scope='session')
+def log_file(tmpdir_factory):
+    file = tmpdir_factory.mktemp('logs').join('log.txt')
+    yield file
+
+@pytest.fixture(scope='function')
+def clean_log_file(log_file):
+    """
+    Current implementation of set_log_level allows setting the output file only once, next calls are ignored. Thus we
+    need to create a session scoped file and erase its contents in a funciton scoped fixture. It's safe to do this for
+    parallel tests as tmpdir_factory will be different for the different workers
+    """
+    log_file.write_text("", encoding="utf-8")
+    yield log_file
+
 class TestDynamicSchemaLogsWarningWhenPromotingIntToFloat:
     """
     Dynamic schema promotes int typed columns to float for min and max so that if that a column is missing from a
@@ -495,24 +512,27 @@ class TestDynamicSchemaLogsWarningWhenPromotingIntToFloat:
     valid.
     """
 
-
     @pytest.mark.parametrize("agg", ["min", "max"])
     @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"])
-    def test_warn_int_types(self, lmdb_library_dynamic_schema, agg, dtype, get_stderr):
+    def test_warn_int_types(self, lmdb_library_dynamic_schema, agg, dtype, clean_log_file):
+        set_log_level(console_output=False, file_output_path=str(clean_log_file))
         lib = lmdb_library_dynamic_schema
         lib.write("sym", pd.DataFrame({"group": [0], "col": np.array([1], dtype=dtype)}))
         lib.append("sym", pd.DataFrame({"group": [1]}))
         qb = QueryBuilder().groupby("group").agg({agg: ("col", agg)})
         lib.read("sym", query_builder=qb)
-        logs = get_stderr()
+        flush_all()
+        logs = clean_log_file.read_text(encoding="utf-8")
         assert all([w in logs for w in ["W arcticdb", agg, "ArcticDB v6.0.0", "FLOAT64", dtype.upper(), agg.upper()]])
     @pytest.mark.parametrize("agg", ["min", "max"])
     @pytest.mark.parametrize("dtype", ["datetime64[ns]", "float32", "float64"])
-    def test_dont_warn_non_int_types(self, lmdb_library_dynamic_schema, agg, dtype, get_stderr):
+    def test_dont_warn_non_int_types(self, lmdb_library_dynamic_schema, agg, dtype, clean_log_file):
+        set_log_level(console_output=False, file_output_path=str(clean_log_file))
         lib = lmdb_library_dynamic_schema
         lib.write("sym", pd.DataFrame({"group": [0], "col": np.array([1], dtype=dtype)}))
         lib.append("sym", pd.DataFrame({"group": [1]}))
         qb = QueryBuilder().groupby("group").agg({agg: ("col", agg)})
         lib.read("sym", query_builder=qb)
-        logs = get_stderr()
+        flush_all()
+        logs = clean_log_file.read_text(encoding="utf-8")
         assert logs == ""

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -505,6 +505,7 @@ class TestDynamicSchemaLogsWarningWhenPromotingIntToFloat:
         qb = QueryBuilder().groupby("group").agg({agg: ("col", agg)})
         lib.read("sym", query_builder=qb)
         stdout, stderr = capfd.readouterr()
+        print(stderr)
         assert all([w in stderr for w in ["W arcticdb", agg, "ArcticDB v6.0.0", "FLOAT64", dtype.upper(), agg.upper()]])
 
     @pytest.mark.parametrize("agg", ["min", "max"])


### PR DESCRIPTION
This behavior will change in future ArcticDB versions. When dynamic schema is used in combination with min/max groupby aggregation int columns won't be promoted to float. If Arrow is used as a backend it will use Arrow's missing value funcitonality, for numpy data will be backfilled with 0.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
