### PR TITLE
Use new name for rc's and fix docs building

### DIFF
--- a/.github/workflows/automated_release.calculate_next_version.yml
+++ b/.github/workflows/automated_release.calculate_next_version.yml
@@ -67,7 +67,7 @@ jobs:
           esac
           echo "increment_type=$increment_type" >> $GITHUB_OUTPUT
           TAG=${{ steps.latest_tag.outputs.tag }}
-          echo "tag=${TAG%rc*}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG%${{ vars.RC_SUFFIX }}*}" >> $GITHUB_OUTPUT
 
       - name: Calculate next version. Increment type - ${{ steps.get_increment_type.outputs.increment_type }}
         id: get-next-version

--- a/.github/workflows/automated_release.calculate_next_version.yml
+++ b/.github/workflows/automated_release.calculate_next_version.yml
@@ -49,9 +49,9 @@ jobs:
         id: get_increment_type
         env:
           PULL_REQUESTS: ${{ steps.pull_requests.outputs.pull_requests }}
-          MAJOR_LABEL: "api break"
-          MINOR_LABEL: "enhancement"
-          PATCH_LABEL: "bug"
+          MAJOR_LABEL: "major"
+          MINOR_LABEL: "minor"
+          PATCH_LABEL: "patch"
         run: |
           if [ -z "$PULL_REQUESTS" ]; then
             echo "Error: No PRs found between branches" && exit 1

--- a/.github/workflows/automated_release.create_developmental_release.yml
+++ b/.github/workflows/automated_release.create_developmental_release.yml
@@ -25,7 +25,7 @@ jobs:
     needs: get-master-sha
     uses: ./.github/workflows/automated_release.calculate_next_version.yml
     with:
-      regex: ^v\d+\.\d+\.\d+rc\d+$
+      regex: ^v\d+\.\d+\.\d+\${{ vars.RC_SUFFIX }}\d+$
       from_branch: ${{ needs.get-master-sha.outputs.sha }}
       
   get-dev-number:

--- a/.github/workflows/automated_release.create_release_branch.yml
+++ b/.github/workflows/automated_release.create_release_branch.yml
@@ -1,9 +1,8 @@
 name: "Automated Release: Create next release branch"
 
 on:
-  release:
-    types: [released]
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   get-master-sha:
@@ -27,7 +26,7 @@ jobs:
     needs: get-master-sha
     uses: ./.github/workflows/automated_release.calculate_next_version.yml
     with:
-      regex: ^v\d+\.\d+\.\d+$
+      regex: ^v\d+\.\d+\.\d+\${{ vars.RC_SUFFIX }}\d+$
       from_branch: ${{ needs.get-master-sha.outputs.sha }}
     
   create-next-release-branch:

--- a/.github/workflows/automated_release.create_release_branch.yml
+++ b/.github/workflows/automated_release.create_release_branch.yml
@@ -46,15 +46,4 @@ jobs:
       with:
         branch: ${{ needs.calculate-next-version.outputs.version }}
         sha: ${{ needs.get-master-sha.outputs.sha }}
-    
-  rc_release:
-    name: Tag and Release version ${{ needs.create-next-release-branch.outputs.new_branch }}rc0 from branch ${{ needs.create-next-release-branch.outputs.new_branch }} 
-    secrets: inherit
-    permissions:
-      checks: read
-      contents: write
-    uses: ./.github/workflows/tag.yml
-    needs: create-next-release-branch
-    with:
-      version: ${{ needs.create-next-release-branch.outputs.new_branch }}rc0
-      from_branch: ${{ needs.create-next-release-branch.outputs.new_branch }}
+  

--- a/.github/workflows/automated_release.full_version_cron.yml
+++ b/.github/workflows/automated_release.full_version_cron.yml
@@ -40,3 +40,11 @@ jobs:
     with:
       version: ${{ needs.get_tag_name.outputs.next_version }}  
       from_branch: ${{ needs.get_tag_name.outputs.next_version }}
+
+  create_next_release_branch:
+    name: Create next release branch
+    permissions:
+      checks: read
+      contents: write
+    secrets: inherit
+    uses: ./.github/workflows/automated_release.create_release_branch.yml

--- a/.github/workflows/automated_release.full_version_cron.yml
+++ b/.github/workflows/automated_release.full_version_cron.yml
@@ -19,14 +19,14 @@ jobs:
         uses: oprypin/find-latest-tag@v1
         with:
           repository: ${{ github.repository }}
-          regex: ^v\d+\.\d+\.\d+rc\d+$
+          regex: ^v\d+\.\d+\.\d+\${{ vars.RC_SUFFIX }}\d+$
       
       - name: Calculate next version
         id: calculate-next-version
         run: |
           LATEST_TAG="${{ steps.latest_rc_tag.outputs.tag }}"
           LATEST_TAG="${LATEST_TAG#v}"
-          base="${LATEST_TAG%rc*}"
+          base="${LATEST_TAG%${{ vars.RC_SUFFIX }}*}"
           echo "next_version=$base" >> $GITHUB_OUTPUT
 
   tag_and_release:

--- a/.github/workflows/automated_release.rc_version.yml
+++ b/.github/workflows/automated_release.rc_version.yml
@@ -15,24 +15,29 @@ jobs:
     outputs:
       next_version: ${{ steps.calculate-next-version.outputs.next_version }}
     steps:
-      - name: Get latest RC tag.
+      - name: Get latest RC tag
         id: latest_rc_tag
         uses: oprypin/find-latest-tag@v1
         with:
           repository: ${{ github.repository }}
-          prefix: v${{ env.CURRENT_BRANCH }}rc
-      
+          prefix: v${{ env.CURRENT_BRANCH }}${{ vars.RC_SUFFIX }}
+        continue-on-error: true
+
       - name: Calculate next_version
         id: calculate-next-version
         run: |
-          CURRENT_BRANCH="${{ github.ref_name }}"
           LATEST_TAG="${{ steps.latest_rc_tag.outputs.tag }}"
-          LATEST_TAG="${LATEST_TAG#v}"
-          # Split version by 'rc' and increment the last number
-          base="${LATEST_TAG%rc*}"
-          rc_number="${LATEST_TAG##*rc}"
-          next_rc_number=$((rc_number + 1))
-          next_version="${base}rc${next_rc_number}"
+          
+          if [[ -z "$LATEST_TAG" ]]; then
+            next_version="${CURRENT_BRANCH}${{ vars.RC_SUFFIX }}0"
+          else
+            LATEST_TAG="${LATEST_TAG#v}"
+            base="${LATEST_TAG%${{ vars.RC_SUFFIX }}*}"
+            rc_number="${LATEST_TAG##*${{ vars.RC_SUFFIX }}}"
+            next_rc_number=$((rc_number + 1))
+            next_version="${base}rc${next_rc_number}"
+          fi
+          
           echo "next_version=$next_version" >> $GITHUB_OUTPUT
 
   tag_and_release:

--- a/.github/workflows/automated_release.rc_version.yml
+++ b/.github/workflows/automated_release.rc_version.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
 run-name: Release next RC from '${{ github.ref_name }}' 
 jobs:
@@ -35,7 +36,7 @@ jobs:
             base="${LATEST_TAG%${{ vars.RC_SUFFIX }}*}"
             rc_number="${LATEST_TAG##*${{ vars.RC_SUFFIX }}}"
             next_rc_number=$((rc_number + 1))
-            next_version="${base}rc${next_rc_number}"
+            next_version="${base}${{ vars.RC_SUFFIX }}${next_rc_number}"
           fi
           
           echo "next_version=$next_version" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,8 @@ jobs:
                 container: null
     steps:
       - run: |
-          if ${{startsWith(github.ref, 'refs/tags/v')}}; then
-            # Can only upload to Pypi once per version, so only auto upload on tag builds:
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            # Can only upload to Pypi once per version, so only publish stable (non-rc) tags:
             echo -e "PUBLISH_ENV=ProdPypi\nCMAKE_PRESET_TYPE=release\nPYPI_PUBLISH=1" | tee -a $GITHUB_ENV
           elif $GITHUB_REF_PROTECTED || ${{github.ref == 'refs/heads/master'}} ; then
             echo -e "PUBLISH_ENV=TestPypi\nCMAKE_PRESET_TYPE=release" | tee -a $GITHUB_ENV

--- a/.github/workflows/build_docs_on_release.yml
+++ b/.github/workflows/build_docs_on_release.yml
@@ -49,6 +49,9 @@ jobs:
     needs: check-inputs
     name: "Build docs with version: ${{ needs.check-inputs.outputs.version }}, latest: ${{ needs.check-inputs.outputs.latest }}"
     uses: ./.github/workflows/docs_build.yml
+    secrets: inherit
+    permissions:
+       contents: write
     with:
       version: ${{ needs.check-inputs.outputs.version }}
       latest: ${{ needs.check-inputs.outputs.latest }}

--- a/build_tooling/change_log.json
+++ b/build_tooling/change_log.json
@@ -14,7 +14,7 @@
     }
 ],
 "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
-"template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
+"template": "${{CHANGELOG}}\n\n\n${{UNCATEGORIZED}}",
 "ignore_labels": [
     "no-release-notes"
 ]


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
* `rc` suffix is replaced by the `RC_SUFFIX` Github variable (which as of today is set to `+man`)
* Permissions' issue on the automated docs building on release is fixed
* Release Labels fix
* Reduce clutter from changelog template
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
