### PR TITLE
Remove python conda pin

### DIFF
--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -54,8 +54,7 @@ dependencies:
   # Build dependencies for tests
   - libarrow==18.0.0
   # Python dependences
-  # Python 3.13+ is not yet supported
-  - python <3.13
+  - python
   - packaging
   - numpy
   - pandas

--- a/environment_unix.yml
+++ b/environment_unix.yml
@@ -54,7 +54,7 @@ dependencies:
   # Build dependencies for tests
   - libarrow==18.0.0
   # Python dependences
-  - python
+  - python <3.14
   - packaging
   - numpy
   - pandas


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
The support of python 3.13 has left the pin in the upstream repo (here) untouched. It has no effect to downstream feedstock AFAIK but it's better to close the gap

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
