### PR TITLE
Fix nfs storage tests and bugs in nfs storage

### DIFF
--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -208,7 +208,7 @@ static std::string prefix_handler(const std::string& prefix, const std::string& 
 }
 
 // signature needs to match PrefixHandler in s3_storage.hpp
-static std::string iter_prefix_handler([[maybe_unused]] const std::string& prefix, const std::string& key_type_dir, [[maybe_unused]] const KeyDescriptor& key_descriptor, [[maybe_unused]] KeyType) {
+static std::string iter_prefix_handler(const std::string&, const std::string& key_type_dir, const KeyDescriptor&, KeyType) {
     // The prefix handler is not used for filtering (done in func below)
     // so we just return the key type dir
     return key_type_dir;

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -107,7 +107,6 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
 
         self._ssl = self._query_params.ssl
 
-        print(self._query_params)
         self._test_only_is_nfs_layout = self._query_params._test_only_is_nfs_layout
 
         if "amazonaws" in self._endpoint:

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -62,7 +62,7 @@ class ParsedQuery:
 
     ssl: Optional[bool] = False
 
-    is_nfs_layout: bool = False
+    _test_only_is_nfs_layout: bool = False
 
 
 class S3LibraryAdapter(ArcticLibraryAdapter):
@@ -107,7 +107,8 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
 
         self._ssl = self._query_params.ssl
 
-        self._is_nfs_layout = self._query_params.is_nfs_layout
+        print(self._query_params)
+        self._test_only_is_nfs_layout = self._query_params._test_only_is_nfs_layout
 
         if "amazonaws" in self._endpoint:
             self._configure_aws()
@@ -115,7 +116,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
         super().__init__(uri, self._encoding_version)
 
     def native_config(self):
-        if self._is_nfs_layout:
+        if self._test_only_is_nfs_layout:
             return None
         else:
             return NativeVariantStorage(
@@ -157,12 +158,12 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             ca_cert_path=self._ca_cert_path,
             ca_cert_dir=self._ca_cert_dir,
             ssl=self._ssl,
-            is_nfs_layout=self._is_nfs_layout,
+            is_nfs_layout=self._test_only_is_nfs_layout,
             aws_auth=self._query_params.aws_auth,
             aws_profile=self._query_params.aws_profile,
             native_cfg=self.native_config(),
         )
-        if self._is_nfs_layout:
+        if self._test_only_is_nfs_layout:
             lib = NativeVersionStore.create_store_from_config(
                 (env_cfg), _DEFAULT_ENV, CONFIG_LIBRARY_NAME, encoding_version=self._encoding_version
             )
@@ -247,7 +248,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
 
     def get_storage_override(self) -> StorageOverride:
         storage_override = StorageOverride()
-        if not self._is_nfs_layout:
+        if not self._test_only_is_nfs_layout:
             storage_override.set_s3_override(self._get_s3_override())
         return storage_override
 
@@ -290,7 +291,7 @@ class S3LibraryAdapter(ArcticLibraryAdapter):
             ca_cert_path=self._ca_cert_path,
             ca_cert_dir=self._ca_cert_dir,
             ssl=self._ssl,
-            is_nfs_layout=self._is_nfs_layout,
+            is_nfs_layout=self._test_only_is_nfs_layout,
             aws_auth=self._query_params.aws_auth,
             aws_profile=self._query_params.aws_profile,
             native_cfg=self.native_config(),

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -104,8 +104,8 @@ class S3Bucket(StorageFixture):
             self.arctic_uri += f"&path_prefix={factory.default_prefix}"
         if factory.ssl:
             self.arctic_uri += "&ssl=True"
-        if factory.is_nfs_layout:
-            self.arctic_uri += "&is_nfs_layout=True"
+        if factory._test_only_is_nfs_layout:
+            self.arctic_uri += "&_test_only_is_nfs_layout=True"
         if platform.system() == "Linux":
             if factory.client_cert_file:
                 self.arctic_uri += f"&CA_cert_path={self.factory.client_cert_file}"
@@ -265,7 +265,7 @@ class BaseS3StorageFixtureFactory(StorageFixtureFactory):
     clean_bucket_on_fixture_exit = True
     use_mock_storage_for_testing = None  # If set to true allows error simulation
     use_internal_client_wrapper_for_testing = None  # If set to true uses the internal client wrapper for testing
-    is_nfs_layout: bool = False
+    _test_only_is_nfs_layout: bool = False
 
     def __init__(self, native_config: Optional[dict] = None):
         self.client_cert_file = None
@@ -719,7 +719,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         use_mock_storage_for_testing: bool = False,
         use_internal_client_wrapper_for_testing: bool = False,
         native_config: Optional[NativeVariantStorage] = None,
-        is_nfs_layout: bool = False,
+        _test_only_is_nfs_layout: bool = False,
     ):
         super().__init__(native_config)
         self.http_protocol = "https" if use_ssl else "http"
@@ -729,7 +729,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         self.use_raw_prefix = use_raw_prefix
         self.use_mock_storage_for_testing = use_mock_storage_for_testing
         self.use_internal_client_wrapper_for_testing = use_internal_client_wrapper_for_testing
-        self.is_nfs_layout = is_nfs_layout
+        self._test_only_is_nfs_layout = _test_only_is_nfs_layout
         # This is needed because we might have multiple factory instances in the same test run
         # and we need to make sure the bucket names are unique
         # set the unique_id to the current UNIX timestamp to avoid conflicts

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -265,6 +265,7 @@ class BaseS3StorageFixtureFactory(StorageFixtureFactory):
     clean_bucket_on_fixture_exit = True
     use_mock_storage_for_testing = None  # If set to true allows error simulation
     use_internal_client_wrapper_for_testing = None  # If set to true uses the internal client wrapper for testing
+    is_nfs_layout: bool = False
 
     def __init__(self, native_config: Optional[dict] = None):
         self.client_cert_file = None

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -211,7 +211,7 @@ def s3_ssl_disabled_storage_factory() -> Generator[MotoS3StorageFixtureFactory, 
 @pytest.fixture(scope="session")
 def nfs_backed_s3_storage_factory() -> Generator[MotoNfsBackedS3StorageFixtureFactory, None, None]:
     with MotoNfsBackedS3StorageFixtureFactory(
-        use_ssl=False, ssl_test_support=False, bucket_versioning=False, is_nfs_layout=True
+        use_ssl=False, ssl_test_support=False, bucket_versioning=False, _test_only_is_nfs_layout=True
     ) as f:
         yield f
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -210,7 +210,9 @@ def s3_ssl_disabled_storage_factory() -> Generator[MotoS3StorageFixtureFactory, 
 
 @pytest.fixture(scope="session")
 def nfs_backed_s3_storage_factory() -> Generator[MotoNfsBackedS3StorageFixtureFactory, None, None]:
-    with MotoNfsBackedS3StorageFixtureFactory(use_ssl=False, ssl_test_support=False, bucket_versioning=False) as f:
+    with MotoNfsBackedS3StorageFixtureFactory(
+        use_ssl=False, ssl_test_support=False, bucket_versioning=False, is_nfs_layout=True
+    ) as f:
         yield f
 
 
@@ -310,9 +312,10 @@ def real_gcp_storage_factory() -> BaseGCPStorageFixtureFactory:
     )
 
 
-@pytest.fixture(scope="session",
-                params=[pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),
-                        pytest.param("real_gcp", marks=REAL_GCP_TESTS_MARK)])
+@pytest.fixture(
+    scope="session",
+    params=[pytest.param("real_s3", marks=REAL_S3_TESTS_MARK), pytest.param("real_gcp", marks=REAL_GCP_TESTS_MARK)],
+)
 def real_storage_factory(request) -> Union[BaseGCPStorageFixtureFactory, BaseGCPStorageFixtureFactory]:
     storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage_factory")
     return storage_fixture
@@ -465,29 +468,31 @@ def mem_storage() -> Generator[InMemoryStorageFixture, None, None]:
 # endregion
 # region ==================================== `Arctic` API Fixtures ====================================
 
+
 def filter_out_unwanted_mark(request, current_param):
-    """ Exclude specific fixture parameters or include only certain
+    """Exclude specific fixture parameters or include only certain
 
     Provides ability tp filter out unwanted fixture parameter
     To do that add to test as many of the marks you want to stay using:
-    
+
       @pytest.mark.only_fixture_params([<fixture_param_names_list>], )
 
     Or alternatively you can exclude as many as wanted:
       @pytest.mark.skip_fixture_params([<fixture_param_names_list>], )
     """
     only_fixtures = request.node.get_closest_marker("only_fixture_params")
-    if only_fixtures: 
+    if only_fixtures:
         # Only when defined at least one only_ mark evaluate what should stay
         values_to_include = only_fixtures.args[0]
         if not current_param in values_to_include:
-            pytest.skip(reason = f"Skipping {current_param} param as not included in test 'only_fixture_params' mark.")
+            pytest.skip(reason=f"Skipping {current_param} param as not included in test 'only_fixture_params' mark.")
 
     skip_fixture_value_mark = request.node.get_closest_marker("skip_fixture_params")
     if skip_fixture_value_mark:
         values_to_skip = skip_fixture_value_mark.args[0]
         if current_param in values_to_skip:
-            pytest.skip(reason = f"Skipping param: {current_param} as per 'skip_fixture_params' mark")
+            pytest.skip(reason=f"Skipping param: {current_param} as per 'skip_fixture_params' mark")
+
 
 @pytest.fixture(
     scope="function",
@@ -508,6 +513,7 @@ def arctic_client(request, encoding_version) -> Arctic:
     storage_fixture: StorageFixture = request.getfixturevalue(request.param + "_storage")
     ac = storage_fixture.create_arctic(encoding_version=encoding_version)
     return ac
+
 
 @pytest.fixture(
     scope="function",
@@ -534,6 +540,8 @@ def arctic_client_v1(request) -> Arctic:
     scope="function",
     params=[
         pytest.param("s3", marks=SIM_S3_TESTS_MARK),
+        pytest.param("nfs_backed_s3", marks=SIM_NFS_TESTS_MARK),
+        pytest.param("gcp", marks=SIM_GCP_TESTS_MARK),
         pytest.param("mem", marks=MEM_TESTS_MARK),
         pytest.param("azurite", marks=AZURE_TESTS_MARK),
         pytest.param("mongo", marks=MONGO_TESTS_MARK),
@@ -824,9 +832,13 @@ def local_object_version_store_prune_previous(local_object_store_factory):
     return local_object_store_factory(prune_previous_version=True)
 
 
-@pytest.fixture(params=[pytest.param("version_store_factory", marks=LMDB_TESTS_MARK),
-                        pytest.param("real_gcp_store_factory", marks=REAL_GCP_TESTS_MARK), 
-                        pytest.param("real_s3_store_factory", marks=REAL_S3_TESTS_MARK)])
+@pytest.fixture(
+    params=[
+        pytest.param("version_store_factory", marks=LMDB_TESTS_MARK),
+        pytest.param("real_gcp_store_factory", marks=REAL_GCP_TESTS_MARK),
+        pytest.param("real_s3_store_factory", marks=REAL_S3_TESTS_MARK),
+    ]
+)
 def version_store_and_real_s3_basic_store_factory(request):
     """
     Just the version_store and real_s3 specifically for the test test_interleaved_store_read
@@ -839,7 +851,7 @@ def version_store_and_real_s3_basic_store_factory(request):
 @pytest.fixture(
     params=[
         pytest.param("version_store_factory", marks=LMDB_TESTS_MARK),
-        pytest.param("in_memory_store_factory",marks=MEM_TESTS_MARK),
+        pytest.param("in_memory_store_factory", marks=MEM_TESTS_MARK),
         pytest.param("real_s3_store_factory", marks=REAL_S3_TESTS_MARK),
         pytest.param("real_gcp_store_factory", marks=REAL_GCP_TESTS_MARK),
     ]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes 8873431775

#### What does this implement or fix?
A regression was introduced in https://github.com/man-group/ArcticDB/pull/2176, specifically the change in nfs_backed_storage.cpp, that resulted in the shard directory being calculated incorrectly for NFS-backed storages when deleting objects.
This manifested as failing to delete snapshots, which is particularly noticeable because they then still appear in the output of list_snapshots. This would likely have resulted in no data being deleted correctly from NFS-backed storages, but for other key types this would present as orphaned data rather than errors, as data being logically deleted is represented by a write operation to the version chain.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
