### PR TITLE
Bugfix 8873431775: Fix NFS-backed storage sharding when deleting objects in 5.3.3

### DIFF
--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -184,7 +184,7 @@ KeySegmentPair NfsBackedStorage::do_read(VariantKey&& variant_key, ReadKeyOpts o
 
 void NfsBackedStorage::do_remove(VariantKey&& variant_key, RemoveOpts) {
     auto enc = encode_object_id(variant_key);
-    std::array<VariantKey, 1> arr{std::move(variant_key)};
+    std::array<VariantKey, 1> arr{std::move(enc)};
     s3::detail::do_remove_impl(std::span(arr), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
 }
 

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -424,3 +424,12 @@ def test_update_index_overlap_corner_cases(lmdb_version_store_tiny_segment, inde
     expected_df = pd.concat(chunks)
     received_df = lib.read(sym).data
     assert_frame_equal(expected_df, received_df)
+
+
+def test_delete_snapshot_regression(nfs_clean_bucket):
+    lib = nfs_clean_bucket.create_version_store_factory("test_delete_snapshot_regression")()
+    lib.write("sym", 1)
+    lib.snapshot("snap")
+    assert "snap" in lib.list_snapshots()
+    lib.delete_snapshot("snap")
+    assert "snap" not in lib.list_snapshots()


### PR DESCRIPTION
Reference Issues/PRs
Fixes 8873431775 on 5.3.3

What does this implement or fix?
A regression was introduced in https://github.com/man-group/ArcticDB/pull/2176, specifically the change in nfs_backed_storage.cpp, that resulted in the shard directory being calculated incorrectly for NFS-backed storages when deleting objects.
This manifested as failing to delete snapshots, which is particularly noticeable because they then still appear in the output of list_snapshots. This would likely have resulted in no data being deleted correctly from NFS-backed storages, but for other key types this would present as orphaned data rather than errors, as data being logically deleted is represented by a write operation to the version chain.