### PR TITLE
Query Stat framework v3

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -333,6 +333,7 @@ set(arcticdb_srcs
         stream/stream_writer.hpp
         toolbox/library_tool.hpp
         toolbox/storage_mover.hpp
+        toolbox/query_stats.hpp
         util/allocator.hpp
         util/allocation_tracing.hpp
         util/bitset.hpp
@@ -506,6 +507,7 @@ set(arcticdb_srcs
         stream/piloted_clock.cpp
         stream/protobuf_mappings.cpp
         toolbox/library_tool.cpp
+        toolbox/query_stats.cpp
         util/allocator.cpp
         util/allocation_tracing.cpp
         util/buffer_pool.cpp

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -10,9 +10,10 @@
 #include <arcticdb/storage/config_resolvers.hpp>
 #include <arcticdb/storage/library_index.hpp>
 #include <arcticdb/async/async_store.hpp>
-#include <arcticdb/util/test/config_common.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
+#include <arcticdb/util/test/config_common.hpp>
+#include <arcticdb/toolbox/query_stats.hpp>
 
 
 #include <string>
@@ -136,6 +137,59 @@ TEST(Async, CollectWithThrow) {
    }
 
    ARCTICDB_DEBUG(log::version(), "Collect returned");
+}
+
+TEST(Async, QueryStatsDemo) {
+    using namespace arcticdb::query_stats;
+    class EnableQueryStatsRAII {
+    public:
+        EnableQueryStatsRAII() {
+            QueryStats::instance()->enable();
+        }
+        ~EnableQueryStatsRAII() {
+            QueryStats::instance()->disable();
+            QueryStats::instance()->reset_stats();
+        }
+    };
+    EnableQueryStatsRAII enable_query_stats;
+    async::TaskScheduler sched{20, 20};
+    auto work = [&]() {
+        std::vector<folly::Future<folly::Unit>> stuff;
+        {
+            stuff.push_back(sched.submit_cpu_task(MaybeThrowTask(false))
+                .thenValue([](auto) {
+                    auto query_stat_operation_time = query_stats::add_task_count_and_time(KeyType::SYMBOL_LIST, query_stats::TaskType::S3_ListObjectsV2);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1)); // For verifying call duration calculation
+                    query_stats::add(KeyType::SYMBOL_LIST, query_stats::TaskType::S3_ListObjectsV2, 1);
+                    query_stats::add(KeyType::SYMBOL_LIST, query_stats::TaskType::S3_ListObjectsV2, 10);
+                    return folly::Unit{};
+                })
+                .via(&async::io_executor())
+            );
+            stuff.push_back(sched.submit_io_task(MaybeThrowTask(false))
+                .thenValue([](auto) {
+                    auto query_stat_operation_time = query_stats::add_task_count_and_time(KeyType::SYMBOL_LIST, query_stats::TaskType::S3_ListObjectsV2);
+                    query_stats::add(KeyType::SYMBOL_LIST, query_stats::TaskType::S3_ListObjectsV2, 2);
+                    return folly::Unit{};
+                })
+                .thenValue([](auto) {
+                    throw std::runtime_error("Test exception"); // Exception will not affect query stats
+                }).thenValue([](auto) {
+                    // Below won't be logged as preceeding task throws
+                    auto query_stat_operation_time = query_stats::add_task_count_and_time(KeyType::SYMBOL_LIST, query_stats::TaskType::S3_ListObjectsV2);
+                    query_stats::add(KeyType::SYMBOL_LIST, query_stats::TaskType::S3_ListObjectsV2, 3);
+                    return folly::Unit{};
+                })
+            );
+            folly::collectAll(stuff).get();
+        }
+    };
+    std::thread t1(work), t2(work); // mimic multithreading at python level
+    t1.join();
+    t2.join();
+    auto result = QueryStats::instance()->get_stats()["SYMBOL_LIST"]["storage_ops"]["S3_ListObjectsV2"];
+    ASSERT_TRUE(result.stats_["total_time_ms"] > 0);
+    ASSERT_EQ(result.stats_["count"], 15);
 }
 
 using IndexSegmentReader = int;

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -189,7 +189,7 @@ TEST(Async, QueryStatsDemo) {
     t2.join();
     auto result = QueryStats::instance()->get_stats()["SYMBOL_LIST"]["storage_ops"]["S3_ListObjectsV2"];
     ASSERT_TRUE(result.stats_["total_time_ms"] > 0);
-    ASSERT_EQ(result.stats_["count"], 15);
+    ASSERT_EQ(result.stats_["count"], 30);
 }
 
 using IndexSegmentReader = int;

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -10,12 +10,13 @@
 #include <arcticdb/python/adapt_read_dataframe.hpp>
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/s3/s3_storage_tool.hpp>
-#include <arcticdb/toolbox/library_tool.hpp>
-#include <arcticdb/util/memory_tracing.hpp>
 #include <arcticdb/version/symbol_list.hpp>
+#include <arcticdb/util/memory_tracing.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
 #include <arcticdb/util/storage_lock.hpp>
 #include <arcticdb/util/reliable_storage_lock.hpp>
+#include <arcticdb/toolbox/library_tool.hpp>
+#include <arcticdb/toolbox/query_stats.hpp>
 #include <arcticdb/toolbox/storage_mover.hpp>
 
 namespace arcticdb::toolbox::apy {
@@ -151,6 +152,27 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
             .def("lock_timeout", &StorageLockWrapper::lock_timeout)
             .def("try_lock", &StorageLockWrapper::try_lock)
             ;
-}
 
+    using namespace arcticdb::query_stats;
+    auto query_stats_module = tools.def_submodule("query_stats", "Query stats functionality");
+    
+    py::class_<QueryStats::OperationStatsOutput>(query_stats_module, "OperationStatsOutput")
+        .def_readonly("stats", &QueryStats::OperationStatsOutput::stats_);
+
+    query_stats_module.def("reset_stats", []() { 
+        QueryStats::instance()->reset_stats(); 
+    });
+    query_stats_module.def("enable", []() { 
+        QueryStats::instance()->enable(); 
+    });
+    query_stats_module.def("disable", []() { 
+        QueryStats::instance()->disable(); 
+    });
+    query_stats_module.def("is_enabled", []() { 
+        return QueryStats::instance()->is_enabled(); 
+    });
+    query_stats_module.def("get_stats", [](){ 
+        return QueryStats::instance()->get_stats(); 
+    });
+}
 } // namespace arcticdb::toolbox::apy

--- a/cpp/arcticdb/toolbox/query_stats.cpp
+++ b/cpp/arcticdb/toolbox/query_stats.cpp
@@ -1,0 +1,152 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+*/
+
+#include <arcticdb/toolbox/query_stats.hpp>
+#include <arcticdb/async/task_scheduler.hpp>
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/log/log.hpp>
+
+namespace arcticdb::query_stats {
+
+std::shared_ptr<QueryStats> QueryStats::instance_;
+std::once_flag QueryStats::init_flag_;
+
+std::shared_ptr<QueryStats> QueryStats::instance() {
+    std::call_once(init_flag_, [] () {
+        instance_ = std::make_shared<QueryStats>();
+    });
+    return instance_;
+}
+
+QueryStats::QueryStats(){
+    reset_stats();
+}
+
+void QueryStats::reset_stats() {
+    for (auto& op_stats : stats_by_key_type_) {
+        for (auto& op_stat : op_stats) {
+            op_stat.reset_stats();
+        }
+    }
+}
+
+void QueryStats::enable() {
+    is_enabled_ = true;
+}
+
+void QueryStats::disable() {
+    is_enabled_ = false;
+}
+
+bool QueryStats::is_enabled() const {
+    return is_enabled_;
+}
+
+
+std::string task_type_to_string(TaskType task_type) {
+    switch (task_type) {
+    case TaskType::S3_ListObjectsV2:
+        return "S3_ListObjectsV2";
+    default:
+        log::version().warn("Unknown task type {}", static_cast<int>(task_type));
+        return "Unknown";
+    }
+}
+
+std::string stat_type_to_string(StatType stat_type) {
+    switch (stat_type) {
+        case StatType::TOTAL_TIME_MS:
+            return "total_time_ms";
+        case StatType::COUNT:
+            return "count";
+        default:
+            log::version().warn("Unknown stat type {}", static_cast<int>(stat_type));
+            return "unknown";
+    }
+}
+
+QueryStats::QueryStatsOutput QueryStats::get_stats() const {
+    QueryStatsOutput result;
+    
+    for (size_t key_idx = 0; key_idx < static_cast<size_t>(entity::KeyType::UNDEFINED); ++key_idx) {
+        entity::KeyType key_type = static_cast<entity::KeyType>(key_idx);
+        std::string key_type_str = entity::get_key_description(key_type);
+        std::string token = "::";
+        auto token_pos = key_type_str.find(token); //KeyType::SYMBOL_LIST -> SYMBOL_LIST
+        key_type_str = token_pos == std::string::npos ? key_type_str : key_type_str.substr(token_pos + token.size());
+        
+        for (size_t task_idx = 0; task_idx < static_cast<size_t>(TaskType::END); ++task_idx) {
+            TaskType task_type = static_cast<TaskType>(task_idx);
+            std::string task_type_str = task_type_to_string(task_type);
+            
+            const auto& op_stats = stats_by_key_type_[key_idx][task_idx];
+            
+            OperationStatsOutput op_output;
+            
+            for (size_t stat_idx = 0; stat_idx < static_cast<size_t>(StatType::END); ++stat_idx) {
+                StatType stat_type = static_cast<StatType>(stat_idx);
+                uint32_t value = 0;
+                switch (stat_type) {
+                    case StatType::TOTAL_TIME_MS:
+                        value = op_stats.total_time_ns_.readFull() / 1e6;
+                        break;
+                    case StatType::COUNT:
+                        value = op_stats.count_.readFull();
+                        break;
+                    default:
+                        continue;
+                }
+                if (value > 0) {
+                    std::string stat_name = stat_type_to_string(stat_type);
+                    op_output.stats_[stat_name] = value;
+                }
+            }
+            
+            // Only non-zero stats will be added to the output
+            if (!op_output.stats_.empty()) {
+                result[key_type_str]["storage_ops"][task_type_str] = std::move(op_output);
+            }
+        }
+    }
+    
+    return result;
+}
+
+void QueryStats::add(entity::KeyType key_type, TaskType task_type, uint32_t value) {
+    if (is_enabled()) {
+        stats_by_key_type_[static_cast<size_t>(key_type)][static_cast<size_t>(task_type)].count_.increment(value);
+    }
+}
+
+[[nodiscard]] std::optional<RAIIAddTime> QueryStats::add_task_count_and_time(entity::KeyType key_type, TaskType task_type) {
+    if (is_enabled()) {
+        auto& stats = stats_by_key_type_[static_cast<size_t>(key_type)][static_cast<size_t>(task_type)];
+        stats.count_.increment(1);
+        return std::make_optional<RAIIAddTime>(stats.total_time_ns_);
+    }
+    return std::nullopt;
+}
+
+RAIIAddTime::RAIIAddTime(folly::ThreadCachedInt<timestamp>& time_var) :
+    time_var_(time_var),
+    start_(std::chrono::steady_clock::now()) {
+
+}
+
+RAIIAddTime::~RAIIAddTime() {
+    time_var_.increment(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start_).count());
+}
+
+void add(entity::KeyType key_type, TaskType task_type, uint32_t value) {
+    QueryStats::instance()->add(key_type, task_type, value);
+}
+
+[[nodiscard]] std::optional<RAIIAddTime> add_task_count_and_time(entity::KeyType key_type, TaskType task_type) {
+    return QueryStats::instance()->add_task_count_and_time(key_type, task_type);
+}
+
+}

--- a/cpp/arcticdb/toolbox/query_stats.hpp
+++ b/cpp/arcticdb/toolbox/query_stats.hpp
@@ -1,0 +1,98 @@
+/* Copyright 2023 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <type_traits>
+#include <string>
+#include <chrono>
+#include <array>
+#include <memory>
+#include <folly/ThreadCachedInt.h>
+
+#include <arcticdb/entity/key.hpp>
+#include <arcticdb/util/constants.hpp>
+
+namespace arcticdb::query_stats{
+enum class TaskType : size_t {
+    S3_ListObjectsV2 = 0,
+    END
+};
+
+enum class StatType : size_t {
+    TOTAL_TIME_MS = 0,
+    COUNT,
+    END
+};
+
+class RAIIAddTime {
+public:
+    RAIIAddTime(folly::ThreadCachedInt<timestamp>& time_var);
+    ~RAIIAddTime();
+private:
+    folly::ThreadCachedInt<timestamp>& time_var_;
+    std::chrono::time_point<std::chrono::steady_clock> start_;
+};
+
+// Example output:
+// {
+//     "SYMBOL_LIST": { <- STATS_BY_KEY_TYPE
+//         "storage_ops": { <- STATS_BY_OP_TYPE
+//             "S3_ListObjectsV2": { <- OperationStats::stats_
+//                 "total_time_ms": 83,
+//                 "count": 3
+//             }
+//         }
+//     }
+// }
+
+
+
+
+
+class QueryStats {
+public:
+    struct OperationStats{
+        folly::ThreadCachedInt<timestamp> total_time_ns_;
+        folly::ThreadCachedInt<uint32_t> count_;
+        void reset_stats(){
+            total_time_ns_.set(0);
+            count_.set(0);
+        }
+        OperationStats(){
+            reset_stats(); 
+        } 
+    };
+    struct OperationStatsOutput {
+        std::map<std::string, uint32_t> stats_;
+    };
+    using QueryStatsOutput = std::map<std::string, std::map<std::string, std::map<std::string, OperationStatsOutput>>>;
+    using STATS_BY_OP_TYPE = std::array<OperationStats, static_cast<size_t>(TaskType::END)>;
+    using STATS_BY_KEY_TYPE = std::array<STATS_BY_OP_TYPE, static_cast<size_t>(entity::KeyType::UNDEFINED)>;
+
+    ARCTICDB_NO_MOVE_OR_COPY(QueryStats);
+    void reset_stats();
+    static std::shared_ptr<QueryStats> instance();
+    void enable();
+    void disable();
+    bool is_enabled() const;
+    void add(entity::KeyType key_type, TaskType task_type, uint32_t value);
+    [[nodiscard]] std::optional<RAIIAddTime> add_task_count_and_time(entity::KeyType key_type, TaskType task_type);
+    QueryStatsOutput get_stats() const;
+    QueryStats();
+
+    STATS_BY_KEY_TYPE stats_by_key_type_;
+private:
+    static std::once_flag init_flag_;
+    static std::shared_ptr<QueryStats> instance_;
+    std::atomic<bool> is_enabled_ = false;
+};
+
+void add(entity::KeyType key_type, TaskType task_type, uint32_t value);
+[[nodiscard]] std::optional<RAIIAddTime> add_task_count_and_time(entity::KeyType key_type, TaskType task_type);
+}

--- a/python/arcticdb/toolbox/query_stats.py
+++ b/python/arcticdb/toolbox/query_stats.py
@@ -1,0 +1,124 @@
+"""
+Query Statistics API for ArcticDB.
+
+This module provides utilities for collecting query statistics.
+
+.. warning::
+    This API is unstable and not governed by ArcticDB's semantic versioning.
+    It may change or be removed in future versions without notice.
+"""
+
+from contextlib import contextmanager
+from typing import Dict, Any, Iterator
+import arcticdb_ext.tools.query_stats as qs
+from arcticdb_ext.exceptions import UserInputException
+
+
+@contextmanager
+def query_stats() -> Iterator[None]:
+    """
+    Context manager for enabling query statistics collection within a specific scope.
+    
+    When entering the context, query statistics collection is enabled.
+    When exiting the context, it is automatically disabled.
+    
+    Raises:
+        UserInputException: If query stats is already enabled.
+        
+    Example:
+        >>> with query_stats():
+        ...     store.list_symbols()
+    
+    .. warning::
+        This API is unstable and not governed by semantic versioning.
+    """
+    if qs.is_enabled():
+        raise UserInputException("Query Stats is already enabled")
+    enable()
+    yield
+    disable()
+    
+
+def get_query_stats() -> Dict[str, Any]:
+    """
+    Get collected query statistics.
+    
+    Returns:
+        Dict[str, Any]: A dictionary containing statistics organized by key type,
+            operation group, and task type. Each task contains timing and count information.
+            
+    Example output:
+    {
+        "SYMBOL_LIST": {
+            "storage_ops": {
+                "S3_ListObjectsV2": {
+                    "total_time_ms": 83,
+                    "count": 3
+                }
+            }
+        },
+        "VERSION_REF": {
+            "storage_ops": {
+                "S3_ListObjectsV2": {
+                    "total_time_ms": 21,
+                    "count": 1
+                }
+            }
+        }
+    }
+    
+    .. warning::
+        This API is unstable and not governed by semantic versioning.
+    """
+    raw_stats = qs.get_stats()
+    result = {}
+    
+    for key_type, key_type_data in raw_stats.items():
+        result[key_type] = {}
+            
+        for op_group, op_group_data in key_type_data.items():
+            result[key_type][op_group] = {}
+            for task_type, task_data in op_group_data.items():                
+                result[key_type][op_group][task_type] = task_data.stats
+                
+    return result
+
+
+def reset_stats() -> None:
+    """
+    Reset all collected query statistics.
+    
+    This clears all statistics that have been collected since enabling
+    the query statistics collection.
+    
+    .. warning::
+        This API is unstable and not governed by semantic versioning.
+    """
+    qs.reset_stats()
+
+
+def enable() -> None:
+    """
+    Enable query statistics collection.
+    
+    Once enabled, statistics will be collected for operations performed
+    until disable() is called or the context manager exits.
+    
+    .. warning::
+        This API is unstable and not governed by semantic versioning.
+    """
+    qs.enable()
+
+
+def disable() -> None:
+    """
+    Disable query statistics collection.
+    
+    Stops collecting statistics for subsequent operations.
+    Previously collected statistics remain available via get_query_stats().
+    
+    .. warning::
+        This API is unstable and not governed by semantic versioning.
+    """
+    qs.disable()
+

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -70,6 +70,7 @@ from .util.mark import (
 from arcticdb.storage_fixtures.utils import safer_rmtree
 from packaging.version import Version
 from arcticdb.util.venv import Venv
+import arcticdb.toolbox.query_stats as query_stats
 
 
 # region =================================== Misc. Constants & Setup ====================================
@@ -1335,3 +1336,10 @@ def old_venv_and_arctic_uri(old_venv, arctic_uri):
         pytest.skip("LMDB storage backed has a bug in versions before 5.0.0 which leads to flaky segfaults")
 
     yield old_venv, arctic_uri
+
+    
+@pytest.fixture
+def clear_query_stats():
+    yield
+    query_stats.disable()
+    query_stats.reset_stats()

--- a/python/tests/integration/toolbox/test_query_stats.py
+++ b/python/tests/integration/toolbox/test_query_stats.py
@@ -1,0 +1,66 @@
+import arcticdb.toolbox.query_stats as qs
+
+def verify_list_symbol_stats(list_symbol_call_counts):
+    stats = qs.get_query_stats()
+    # """
+    # Sample output:
+    # {
+    #     "SYMBOL_LIST": {
+    #         "storage_ops": {
+    #             "S3_ListObjectsV2": {
+    #                 "total_time_ms": 83,
+    #                 "count": 3
+    #             }
+    #         }
+    #     },
+    #     "VERSION_REF": {
+    #         "storage_ops": {
+    #             "S3_ListObjectsV2": {
+    #                 "total_time_ms": 21,
+    #                 "count": 1
+    #             }
+    #         }
+    #     }
+    # }
+    # """    
+    assert "SYMBOL_LIST" in stats
+    for key, key_type_map in stats.items():
+        assert "storage_ops" in key_type_map
+        assert "S3_ListObjectsV2" in key_type_map["storage_ops"]
+        assert "count" in key_type_map["storage_ops"]["S3_ListObjectsV2"]
+        list_object_ststs = key_type_map["storage_ops"]["S3_ListObjectsV2"]
+        assert list_object_ststs["count"] == 1 if key == "VERSION_REF" else list_symbol_call_counts
+        assert list_object_ststs["total_time_ms"] > 1
+        assert list_object_ststs["total_time_ms"] < 200
+
+
+def test_query_stats(s3_version_store_v1, clear_query_stats):
+    s3_version_store_v1.write("a", 1)
+    qs.enable()
+    
+    s3_version_store_v1.list_symbols()
+    verify_list_symbol_stats(1)
+    s3_version_store_v1.list_symbols()
+    verify_list_symbol_stats(2)
+    
+
+def test_query_stats_context(s3_version_store_v1, clear_query_stats):
+    s3_version_store_v1.write("a", 1)
+    with qs.query_stats():
+        s3_version_store_v1.list_symbols()
+    verify_list_symbol_stats(1)
+    
+    with qs.query_stats():
+        s3_version_store_v1.list_symbols()
+    verify_list_symbol_stats(2)
+
+
+def test_query_stats_clear(s3_version_store_v1, clear_query_stats):
+    s3_version_store_v1.write("a", 1)
+    qs.enable()
+    s3_version_store_v1.list_symbols()
+    qs.reset_stats()
+    assert not qs.get_query_stats()
+
+    s3_version_store_v1.list_symbols()
+    verify_list_symbol_stats(1)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
New query stat implemenation which its schema is static
The feature of linking arcticdb API calls to storage operations has been dropped. Now only storage operation stats will be logged. Therefore the schema of the stats is hardcoded and allow the summation of stats is logged, one statical object with numerous atomic ints is enough to do the job.
No fancy map nor modification of folly executor.

#### Any other comments?
Sample output:
```
{ // Stats
        "SYMBOL_LIST":  // std::array<std::array<OpStats, NUMBER_OF_TASK_TYPES>, NUMBER_OF_KEYS>
         { 
            "storage_ops": {
                "S3_ListObjectsV2": 
                { // OpStats
                    "result_count": 1,
                    "total_time_ms": 34
                }
            }
        }
    }
```


#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
