### PR TITLE
Temporarily skip mongo compat tests

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1308,6 +1308,7 @@ def arctic_uri(request):
     """
     storage_fixture = request.getfixturevalue(request.param + "_storage")
     if request.param == "mongo":
+        pytest.skip()
         return storage_fixture.mongo_uri
     else:
         return storage_fixture.arctic_uri


### PR DESCRIPTION
We've been seing `LibraryNotFound` errors on a lot of the mongo compatibility tests. We will temporarily skip them until we figure out what's wrong with them.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
