### PR TITLE
Fix compatibility test cleanup

### DIFF
--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -49,7 +49,7 @@ struct IClause {
         // for one ProcessingUnit.
         [[nodiscard]] std::vector<std::vector<size_t>>
         structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys) {
-            return std::move(folly::poly_call<0>(*this, ranges_and_keys));
+            return folly::poly_call<0>(*this, ranges_and_keys);
         }
 
         [[nodiscard]] std::vector<std::vector<EntityId>> structure_for_processing(
@@ -59,7 +59,7 @@ struct IClause {
 
         [[nodiscard]] std::vector<EntityId>
         process(std::vector<EntityId>&& entity_ids) const {
-            return std::move(folly::poly_call<2>(*this, std::move(entity_ids)));
+            return folly::poly_call<2>(*this, std::move(entity_ids));
         }
 
         [[nodiscard]] const ClauseInfo& clause_info() const { return folly::poly_call<3>(*this); };

--- a/python/tests/compat/arcticdb/test_compatibility.py
+++ b/python/tests/compat/arcticdb/test_compatibility.py
@@ -12,7 +12,7 @@ from arcticdb.toolbox.library_tool import LibraryTool
 from tests.util.mark import ARCTICDB_USING_CONDA, ZONE_INFO_MARK
 from arcticdb_ext.tools import StorageMover
 
-from arcticdb.util.venv import CurrentVersion
+from arcticdb.util.venv import CompatLibrary
 
 if ARCTICDB_USING_CONDA:
     pytest.skip("These tests rely on pip based environments", allow_module_level=True)
@@ -20,74 +20,68 @@ if ARCTICDB_USING_CONDA:
 
 def test_compat_write_read(old_venv_and_arctic_uri, lib_name):
     old_venv, arctic_uri = old_venv_and_arctic_uri
-    sym = "sym"
-    df = pd.DataFrame({"col": [1, 2, 3]})
-    df_2 = pd.DataFrame({"col": [4, 5, 6]})
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        sym = "sym"
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        df_2 = pd.DataFrame({"col": [4, 5, 6]})
 
-    # Create library using old version
-    old_ac = old_venv.create_arctic(arctic_uri)
-    old_lib = old_ac.create_library(lib_name)
+        # Write to library using current version
+        with compat.current_version() as curr:
+            curr.lib.write(sym, df)
 
-    # Write to library using current version
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        curr.lib.write(sym, df)
+        # Check that dataframe is readable in old version and is unchanged
+        compat.old_lib.assert_read(sym, df)
 
-    # Check that dataframe is readable in old version and is unchanged
-    old_lib.assert_read(sym, df)
+        # Write new version with old library
+        compat.old_lib.write(sym, df_2)
 
-    # Write new version with old library
-    old_lib.write(sym, df_2)
-
-    # Check that latest version is readable in current version
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        read_df = curr.lib.read(sym).data
-        assert_frame_equal(read_df, df_2)
+        # Check that latest version is readable in current version
+        with compat.current_version() as curr:
+            read_df = curr.lib.read(sym).data
+            assert_frame_equal(read_df, df_2)
 
 
 def test_modify_old_library_option_with_current(old_venv_and_arctic_uri, lib_name):
     old_venv, arctic_uri = old_venv_and_arctic_uri
-    sym = "sym"
-    df = pd.DataFrame({"col": [1, 2, 3]})
-    df_2 = pd.DataFrame({"col": [4, 5, 6]})
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        sym = "sym"
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        df_2 = pd.DataFrame({"col": [4, 5, 6]})
 
-    # Create library using old version and write to it
-    old_ac = old_venv.create_arctic(arctic_uri)
-    old_lib = old_ac.create_library(lib_name)
-    old_lib.write(sym, df)
-    old_lib.assert_read(sym, df)
+        # Create library using old version and write to it
+        compat.old_lib.write(sym, df)
+        compat.old_lib.assert_read(sym, df)
 
-    # Enable replication and background_deletion with current version
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        expected_cfg = LibraryTool.read_unaltered_lib_cfg(curr.ac._library_manager, lib_name)
-        expected_cfg.lib_desc.version.write_options.delayed_deletes = True
-        expected_cfg.lib_desc.version.write_options.sync_passive.enabled = True
+        # Enable replication and background_deletion with current version
+        with compat.current_version() as curr:
+            expected_cfg = LibraryTool.read_unaltered_lib_cfg(curr.ac._library_manager, lib_name)
+            expected_cfg.lib_desc.version.write_options.delayed_deletes = True
+            expected_cfg.lib_desc.version.write_options.sync_passive.enabled = True
 
-        curr.ac.modify_library_option(curr.lib, ModifiableEnterpriseLibraryOption.REPLICATION, True)
-        curr.ac.modify_library_option(curr.lib, ModifiableEnterpriseLibraryOption.BACKGROUND_DELETION, True)
+            curr.ac.modify_library_option(curr.lib, ModifiableEnterpriseLibraryOption.REPLICATION, True)
+            curr.ac.modify_library_option(curr.lib, ModifiableEnterpriseLibraryOption.BACKGROUND_DELETION, True)
 
-        cfg_after_modification = LibraryTool.read_unaltered_lib_cfg(curr.ac._library_manager, lib_name)
-        assert cfg_after_modification == expected_cfg
+            cfg_after_modification = LibraryTool.read_unaltered_lib_cfg(curr.ac._library_manager, lib_name)
+            assert cfg_after_modification == expected_cfg
 
-    # We should still be able to read and write with the old version
-    old_lib.assert_read(sym, df)
-    old_lib.write(sym, df_2)
-    old_lib.assert_read(sym, df_2)
+        # We should still be able to read and write with the old version
+        compat.old_lib.assert_read(sym, df)
+        compat.old_lib.write(sym, df_2)
+        compat.old_lib.assert_read(sym, df_2)
 
-    # We verify that cfg is still what we expect after operations from old_venv
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        cfg_after_use = LibraryTool.read_unaltered_lib_cfg(curr.ac._library_manager, lib_name)
-        assert cfg_after_use == expected_cfg
+        # We verify that cfg is still what we expect after operations from old_venv
+        with compat.current_version() as curr:
+            cfg_after_use = LibraryTool.read_unaltered_lib_cfg(curr.ac._library_manager, lib_name)
+            assert cfg_after_use == expected_cfg
 
 
 def test_pandas_pickling(pandas_v1_venv, s3_ssl_disabled_storage, lib_name):
     arctic_uri = s3_ssl_disabled_storage.arctic_uri
-
-    # Create library using old version and write pickled Pandas 1 metadata
-    old_ac = pandas_v1_venv.create_arctic(arctic_uri)
-    old_ac.create_library(lib_name)
-    old_ac.execute(
-        [
-            f"""
+    with CompatLibrary(pandas_v1_venv, arctic_uri, lib_name) as compat:
+        # Create library using old version and write pickled Pandas 1 metadata
+        compat.old_ac.execute(
+            [
+                f"""
 from packaging import version
 pandas_version = version.parse(pd.__version__)
 assert pandas_version < version.Version("2.0.0")
@@ -97,21 +91,19 @@ df.index = idx
 lib = ac.get_library("{lib_name}")
 lib.write("sym", df, metadata={{"abc": df}})
 """
-        ]
-    )
+            ]
+        )
 
-    pandas_version = version.parse(pd.__version__)
-    assert pandas_version >= version.Version("2.0.0")
-    # Check we can read with Pandas 2
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        sym = "sym"
-        read_df = curr.lib.read(sym).metadata["abc"]
-        expected_df = pd.DataFrame({"a": [1, 2, 3]})
-        idx = pd.Index([1, 2, 3], dtype="int64")
-        expected_df.index = idx
-        assert_frame_equal(read_df, expected_df)
-
-    pandas_v1_venv.create_arctic(arctic_uri).cleanup()
+        pandas_version = version.parse(pd.__version__)
+        assert pandas_version >= version.Version("2.0.0")
+        # Check we can read with Pandas 2
+        with compat.current_version() as curr:
+            sym = "sym"
+            read_df = curr.lib.read(sym).metadata["abc"]
+            expected_df = pd.DataFrame({"a": [1, 2, 3]})
+            idx = pd.Index([1, 2, 3], dtype="int64")
+            expected_df.index = idx
+            assert_frame_equal(read_df, expected_df)
 
 
 def test_compat_snapshot_metadata_read_write(old_venv_and_arctic_uri, lib_name):
@@ -119,44 +111,41 @@ def test_compat_snapshot_metadata_read_write(old_venv_and_arctic_uri, lib_name):
     # sure we can read snapshot metadata written by those versions, and that those versions can read snapshot metadata
     # written by the latest version.
     old_venv, arctic_uri = old_venv_and_arctic_uri
-    old_ac = old_venv.create_arctic(arctic_uri)
 
     adb_version = version.Version(old_venv.version)
     if version.Version("4.5.0") <= adb_version <= version.Version("5.2.1"):
         pytest.skip(
             reason="Versions between 4.5.0 and 5.2.1 store snapshot metadata in timeseries descriptor which is incompatible with any other versions"
         )
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        sym = "sym"
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        snap_meta = {"key": "value"}
+        snap = "snap"
 
-    sym = "sym"
-    df = pd.DataFrame({"col": [1, 2, 3]})
-    snap_meta = {"key": "value"}
-    snap = "snap"
+        # Write snapshot metadata using current version
+        with compat.current_version() as curr:
+            curr.lib.write(sym, df)
+            curr.lib.snapshot(snap, metadata=snap_meta)
 
-    old_lib = old_ac.create_library(lib_name)
-
-    # Write snapshot metadata using current version
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        curr.lib.write(sym, df)
-        curr.lib.snapshot(snap, metadata=snap_meta)
-
-    # Check we can read the snapshot metadata with an old client, and write snapshot metadata with the old client
-    old_lib.execute(
-        [
-            """
+        # Check we can read the snapshot metadata with an old client, and write snapshot metadata with the old client
+        compat.old_lib.execute(
+            [
+                """
 snaps = lib.list_snapshots()
 meta = snaps["snap"]
 assert meta is not None
 assert meta == {"key": "value"}
 lib.snapshot("old_snap", metadata={"old_key": "old_value"})
-        """
-        ]
-    )
+"""
+            ]
+        )
 
-    # Check the modern client can read the snapshot metadata written by the old client
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        snaps = curr.lib.list_snapshots()
-        meta = snaps["old_snap"]
-        assert meta == {"old_key": "old_value"}
+        # Check the modern client can read the snapshot metadata written by the old client
+        with compat.current_version() as curr:
+            snaps = curr.lib.list_snapshots()
+            meta = snaps["old_snap"]
+            assert meta == {"old_key": "old_value"}
 
 
 def test_compat_snapshot_metadata_read(old_venv_and_arctic_uri, lib_name):
@@ -164,52 +153,47 @@ def test_compat_snapshot_metadata_read(old_venv_and_arctic_uri, lib_name):
     # and we need to keep support for reading data serialized like that.
     # It was not possible to add support for those versions reading snapshot metadata written by current versions.
     old_venv, arctic_uri = old_venv_and_arctic_uri
-    sym = "sym"
-    df = pd.DataFrame({"col": [1, 2, 3]})
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        sym = "sym"
+        df = pd.DataFrame({"col": [1, 2, 3]})
 
-    old_ac = old_venv.create_arctic(arctic_uri)
-    old_lib = old_ac.create_library(lib_name)
+        # Write snapshot metadata using current version
+        with compat.current_version() as curr:
+            curr.lib.write(sym, df)
 
-    # Write snapshot metadata using current version
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        curr.lib.write(sym, df)
-
-    # Check we can read the snapshot metadata with an old client, and write snapshot metadata with the old client
-    old_lib.execute(
-        [
-            """
+        # Check we can read the snapshot metadata with an old client, and write snapshot metadata with the old client
+        compat.old_lib.execute(
+            [
+                """
 snaps = lib.list_snapshots()
 lib.snapshot("old_snap", metadata={"old_key": "old_value"})
-        """
-        ]
-    )
+"""
+            ]
+        )
 
-    # Check the modern client can read the snapshot metadata written by the old client
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        snaps = curr.lib.list_snapshots()
-        meta = snaps["old_snap"]
-        assert meta == {"old_key": "old_value"}
+        # Check the modern client can read the snapshot metadata written by the old client
+        with compat.current_version() as curr:
+            snaps = curr.lib.list_snapshots()
+            meta = snaps["old_snap"]
+            assert meta == {"old_key": "old_value"}
 
 
 @ZONE_INFO_MARK
 @pytest.mark.parametrize("zone_name", ["UTC", "America/New_York"])
 def test_compat_timestamp_metadata(old_venv_and_arctic_uri, lib_name, zone_name):
     old_venv, arctic_uri = old_venv_and_arctic_uri
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        sym = "sym"
+        df = pd.DataFrame({"col": [1]})
+        timestamp_no_tz = pd.Timestamp(2025, 1, 1)
+        timestamp_pytz = pd.Timestamp(2025, 1, 1, tz=pytz.timezone(zone_name))
+        timestamp_zoneinfo = pd.Timestamp(2025, 1, 1, tz=zoneinfo.ZoneInfo(zone_name))
 
-    old_ac = old_venv.create_arctic(arctic_uri)
-    old_lib = old_ac.create_library(lib_name)
-
-    sym = "sym"
-    df = pd.DataFrame({"col": [1]})
-    timestamp_no_tz = pd.Timestamp(2025, 1, 1)
-    timestamp_pytz = pd.Timestamp(2025, 1, 1, tz=pytz.timezone(zone_name))
-    timestamp_zoneinfo = pd.Timestamp(2025, 1, 1, tz=zoneinfo.ZoneInfo(zone_name))
-
-    # Write two versions with old arctic:
-    # v0 - no timezone
-    # v1 - pytz
-    old_lib.execute([
-        f"""
+        # Write two versions with old arctic:
+        # v0 - no timezone
+        # v1 - pytz
+        compat.old_lib.execute([
+            f"""
 import pytz
 timestamp_no_tz = pd.Timestamp(year=2025, month=1, day=1)
 timestamp_pytz = pd.Timestamp(year=2025, month=1, day=1, tz=pytz.timezone({repr(zone_name)}))
@@ -217,121 +201,115 @@ lib.write({repr(sym)}, df, metadata=timestamp_no_tz)
 lib.write_metadata({repr(sym)}, timestamp_pytz)
 assert lib.read_metadata({repr(sym)}, as_of=0).metadata == timestamp_no_tz
 assert lib.read_metadata({repr(sym)}, as_of=1).metadata == timestamp_pytz
-        """
-    ], dfs={"df": df})
+"""
+        ], dfs={"df": df})
 
-    # Write 3 more versions with current arctic:
-    # v2 - no timezone
-    # v3 - pytz
-    # v4 - zoneinfo
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        lib = curr.lib
-        assert lib.read_metadata(sym, as_of=0).metadata == timestamp_no_tz
-        assert lib.read_metadata(sym, as_of=1).metadata == timestamp_pytz
-        lib.write_metadata(sym, timestamp_no_tz) # v2
-        lib.write_metadata(sym, timestamp_pytz) # v3
-        lib.write_metadata(sym, timestamp_zoneinfo) # v4
-        assert lib.read_metadata(sym, as_of=2).metadata == timestamp_no_tz
-        assert lib.read_metadata(sym, as_of=3).metadata == timestamp_pytz
-        assert lib.read_metadata(sym, as_of=4).metadata == timestamp_pytz
+        # Write 3 more versions with current arctic:
+        # v2 - no timezone
+        # v3 - pytz
+        # v4 - zoneinfo
+        with compat.current_version() as curr:
+            lib = curr.lib
+            assert lib.read_metadata(sym, as_of=0).metadata == timestamp_no_tz
+            assert lib.read_metadata(sym, as_of=1).metadata == timestamp_pytz
+            lib.write_metadata(sym, timestamp_no_tz) # v2
+            lib.write_metadata(sym, timestamp_pytz) # v3
+            lib.write_metadata(sym, timestamp_zoneinfo) # v4
+            assert lib.read_metadata(sym, as_of=2).metadata == timestamp_no_tz
+            assert lib.read_metadata(sym, as_of=3).metadata == timestamp_pytz
+            assert lib.read_metadata(sym, as_of=4).metadata == timestamp_pytz
 
-    old_lib.execute([
-        f"""
+        compat.old_lib.execute([
+            f"""
 import pytz
 timestamp_no_tz = pd.Timestamp(year=2025, month=1, day=1)
 timestamp_pytz = pd.Timestamp(year=2025, month=1, day=1, tz=pytz.timezone({repr(zone_name)}))
 assert lib.read_metadata({repr(sym)}, as_of=2).metadata == timestamp_no_tz
 assert lib.read_metadata({repr(sym)}, as_of=3).metadata == timestamp_pytz
 assert lib.read_metadata({repr(sym)}, as_of=4).metadata == timestamp_pytz
-        """
-    ])
+"""
+        ])
 
 
 def test_compat_read_incomplete(old_venv_and_arctic_uri, lib_name):
     old_venv, arctic_uri = old_venv_and_arctic_uri
-    sym = "sym"
-    df = pd.DataFrame(
-        {
-            "col": np.arange(10),
-            "float_col": np.arange(10, dtype=np.float64),
-            "str_col": [f"str_{i}" for i in range(10)],
-        },
-        pd.date_range("2024-01-01", periods=10),
-    )
-    df_1 = df.iloc[:8]
-    df_2 = df.iloc[8:]
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        sym = "sym"
+        df = pd.DataFrame(
+            {
+                "col": np.arange(10),
+                "float_col": np.arange(10, dtype=np.float64),
+                "str_col": [f"str_{i}" for i in range(10)],
+            },
+            pd.date_range("2024-01-01", periods=10),
+        )
+        df_1 = df.iloc[:8]
+        df_2 = df.iloc[8:]
 
-    old_ac = old_venv.create_arctic(arctic_uri)
-    old_lib = old_ac.create_library(lib_name)
-
-    if version.Version(old_venv.version) >= version.Version("5.1.0"):
-        # In version 5.1.0 (with commit a3b7545) we moved the streaming incomplete python API to the library tool.
-        old_lib.execute(
-            [
-                """
+        if version.Version(old_venv.version) >= version.Version("5.1.0"):
+            # In version 5.1.0 (with commit a3b7545) we moved the streaming incomplete python API to the library tool.
+            compat.old_lib.execute(
+                [
+                    """
 lib_tool = lib.library_tool()
 lib_tool.append_incomplete("sym", df_1)
 lib_tool.append_incomplete("sym", df_2)
-            """
-            ],
-            dfs={"df_1": df_1, "df_2": df_2},
-        )
-    else:
-        old_lib.execute(
-            [
-                """
+"""
+                ],
+                dfs={"df_1": df_1, "df_2": df_2},
+            )
+        else:
+            compat.old_lib.execute(
+                [
+                    """
 lib._nvs.append("sym", df_1, incomplete=True)
 lib._nvs.append("sym", df_2, incomplete=True)
-            """
-            ],
-            dfs={"df_1": df_1, "df_2": df_2},
-        )
+"""
+                ],
+                dfs={"df_1": df_1, "df_2": df_2},
+            )
 
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        read_df = curr.lib._nvs.read(sym, date_range=(None, None), incomplete=True).data
-        assert_frame_equal(read_df, df)
+        with compat.current_version() as curr:
+            read_df = curr.lib._nvs.read(sym, date_range=(None, None), incomplete=True).data
+            assert_frame_equal(read_df, df)
 
-        read_df = curr.lib._nvs.read(sym, date_range=(None, None), incomplete=True, columns=["float_col"]).data
-        assert_frame_equal(read_df, df[["float_col"]])
+            read_df = curr.lib._nvs.read(sym, date_range=(None, None), incomplete=True, columns=["float_col"]).data
+            assert_frame_equal(read_df, df[["float_col"]])
 
-        read_df = curr.lib._nvs.read(
-            sym, date_range=(None, None), incomplete=True, columns=["float_col", "str_col"]
-        ).data
-        assert_frame_equal(read_df, df[["float_col", "str_col"]])
+            read_df = curr.lib._nvs.read(
+                sym, date_range=(None, None), incomplete=True, columns=["float_col", "str_col"]
+            ).data
+            assert_frame_equal(read_df, df[["float_col", "str_col"]])
 
-        read_df = curr.lib._nvs.read(
-            sym,
-            date_range=(pd.Timestamp(2024, 1, 5), pd.Timestamp(2024, 1, 9)),
-            incomplete=True,
-            columns=["float_col", "str_col"],
-        ).data
-        assert_frame_equal(read_df, df[["float_col", "str_col"]].iloc[4:9])
+            read_df = curr.lib._nvs.read(
+                sym,
+                date_range=(pd.Timestamp(2024, 1, 5), pd.Timestamp(2024, 1, 9)),
+                incomplete=True,
+                columns=["float_col", "str_col"],
+            ).data
+            assert_frame_equal(read_df, df[["float_col", "str_col"]].iloc[4:9])
 
 
 def test_storage_mover_clone_old_library(old_venv_and_arctic_uri, lib_name):
     old_venv, arctic_uri = old_venv_and_arctic_uri
-    df = pd.DataFrame({"col": [1, 2, 3]})
-    df_2 = pd.DataFrame({"col": [4, 5, 6]})
     dst_lib_name = "local.extra"
-    sym = "a"
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as source, CompatLibrary(old_venv, arctic_uri, dst_lib_name, create_with_current_version=True) as dst:
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        df_2 = pd.DataFrame({"col": [4, 5, 6]})
+        sym = "a"
 
-    # Create library using old version
-    old_ac = old_venv.create_arctic(arctic_uri)
-    old_lib = old_ac.create_library(lib_name)
-    old_lib.write(sym, df)
-    old_lib.write(sym, df_2)
+        source.old_lib.write(sym, df)
+        source.old_lib.write(sym, df_2)
 
-    with CurrentVersion(arctic_uri, lib_name) as curr:
-        src_lib = curr.ac.get_library(lib_name)
-        dst_lib = curr.ac.get_library(dst_lib_name, create_if_missing=True)
-        s = StorageMover(src_lib._nvs._library, dst_lib._nvs._library)
-        s.clone_all_keys_for_symbol(sym, 1000)
-        assert_frame_equal(src_lib.read(sym).data, dst_lib.read(sym).data)
+        with source.current_version() as curr:
+            src_lib = curr.ac.get_library(lib_name)
+            dst_lib = curr.ac.get_library(dst_lib_name)
+            s = StorageMover(src_lib._nvs._library, dst_lib._nvs._library)
+            s.clone_all_keys_for_symbol(sym, 1000)
+            assert_frame_equal(src_lib.read(sym).data, dst_lib.read(sym).data)
 
-    if (arctic_uri.startswith("s3") or arctic_uri.startswith("azure")) and "1.6.2" in old_venv.version:
-        pytest.skip("Reading the new library on s3 or azure with 1.6.2 requires some work arounds")
+        if (arctic_uri.startswith("s3") or arctic_uri.startswith("azure")) and "1.6.2" in old_venv.version:
+            pytest.skip("Reading the new library on s3 or azure with 1.6.2 requires some work arounds")
 
-    # Make sure that we can read the new lib with the old version
-    old_ac = old_venv.create_arctic(arctic_uri)
-    old_dst_lib = old_ac.get_library(dst_lib_name)
-    old_dst_lib.assert_read(sym, df_2)
+        # Make sure that we can read the new lib with the old version
+        dst.old_lib.assert_read(sym, df_2)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1323,5 +1323,3 @@ def old_venv_and_arctic_uri(old_venv, arctic_uri):
         pytest.skip("LMDB storage backed has a bug in versions before 5.0.0 which leads to flaky segfaults")
 
     yield old_venv, arctic_uri
-
-    old_venv.create_arctic(arctic_uri).cleanup()

--- a/python/tests/integration/toolbox/test_storage_mover.py
+++ b/python/tests/integration/toolbox/test_storage_mover.py
@@ -14,8 +14,6 @@ from arcticc.pb2.storage_pb2 import EnvironmentConfigsMap
 import hypothesis
 import sys
 
-from arcticdb.util.venv import CurrentVersion
-
 # configure_test_logger("DEBUG")
 
 

--- a/python/tests/unit/arcticdb/version_store/test_incompletes.py
+++ b/python/tests/unit/arcticdb/version_store/test_incompletes.py
@@ -12,8 +12,6 @@ from arcticdb.util.test import assert_frame_equal
 from arcticdb.exceptions import MissingDataException
 from arcticdb_ext.storage import KeyType
 
-from arcticdb.util.venv import CurrentVersion
-
 @pytest.mark.parametrize("batch", (True, False))
 def test_read_incompletes_with_indexed_data(lmdb_version_store_v1, batch):
     lib = lmdb_version_store_v1


### PR DESCRIPTION
Previously in several places we were calling `old_ac.clear()` to clear all arctic/libraries created by an compatibility tests.

This however was producing issues when running pytest with multiprocessing as we do on the CI:
- Each pytest worker sets up its own instance of the session scoped fixtures
- When one process finishes with a fixture it runs the cleanup on an arctic instance which is potentially actively used by another pytest worker. Thus the spurious mongo library not found errors.

To mitigate this we introduce a new context manager `CompatLibrary`. It is responsible for setting up the `Venv`, `VenvArctic` and `VenvLib` and also creates the library on `__enter__` and cleans the library on `__exit__`.

So we rework all compat tests to use the new `CompatLibrary`

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
