### PR TITLE
Update s3.py moto*.create_fixture - add retry attempts

### DIFF
--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -697,9 +697,10 @@ def create_bucket(s3_client, bucket_name, max_retries=15):
             s3_client.create_bucket(Bucket=bucket_name)
             return
         except botocore.exceptions.EndpointConnectionError as e:
-            time.sleep(1)
-            
-    raise botocore.exceptions.EndpointConnectionError("Failed to create bucket {}".format(bucket_name))    
+            if i >= max_retries - 1:
+                raise
+            logger.warn(f"S3 create bucket failed. Retry {1}/{max_retries}")
+            time.sleep(1)   
 
 
 class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -692,6 +692,16 @@ def run_gcp_server(port, key_file, cert_file):
         ssl_context=(cert_file, key_file) if cert_file and key_file else None,
     )
 
+def create_bucket(s3_client, bucket_name, max_retries=15):
+    for i in range(max_retries):
+        try:
+            s3_client.create_bucket(Bucket=bucket_name)
+            return
+        except botocore.exceptions.EndpointConnectionError as e:
+            time.sleep(1)
+            
+    raise botocore.exceptions.EndpointConnectionError("Failed to create bucket {}".format(bucket_name))    
+
 
 class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
     default_key = Key(id="awd", secret="awd", user_name="dummy")
@@ -830,15 +840,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
 
     def create_fixture(self) -> S3Bucket:
         bucket = self.bucket_name("s3")
-        max_retries = 15
-        for i in range(max_retries):
-            try:
-                self._s3_admin.create_bucket(Bucket=bucket)
-                break
-            except botocore.exceptions.EndpointConnectionError as e:
-                if i >= max_retries-1: 
-                    raise
-            time.sleep(1)
+        create_bucket(self._s3_admin, bucket)
         if self.bucket_versioning:
             self._s3_admin.put_bucket_versioning(Bucket=bucket, VersioningConfiguration={"Status": "Enabled"})
 
@@ -874,15 +876,7 @@ _PermissionCapableFactory = MotoS3StorageFixtureFactory
 class MotoNfsBackedS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
     def create_fixture(self) -> NfsS3Bucket:
         bucket = self.bucket_name("nfs")
-        max_retries = 15
-        for i in range(max_retries):
-            try:
-                self._s3_admin.create_bucket(Bucket=bucket)
-                break
-            except botocore.exceptions.EndpointConnectionError as e:
-                if i >= max_retries-1: 
-                    raise
-            time.sleep(1)
+        create_bucket(self._s3_admin, bucket)
         out = NfsS3Bucket(self, bucket)
         self._live_buckets.append(out)
         return out
@@ -924,14 +918,7 @@ class MotoGcpS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
     def create_fixture(self) -> GcpS3Bucket:
         bucket = self.bucket_name("gcp")
         max_retries = 15
-        for i in range(max_retries):
-            try:
-                self._s3_admin.create_bucket(Bucket=bucket)
-                break
-            except botocore.exceptions.EndpointConnectionError as e:
-                if i >= max_retries-1: 
-                    raise
-            time.sleep(1)
+        create_bucket(self._s3_admin, bucket)
         out = GcpS3Bucket(self, bucket)
         self._live_buckets.append(out)
         return out

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -830,6 +830,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
 
     def create_fixture(self) -> S3Bucket:
         bucket = self.bucket_name("s3")
+        max_retries = 15
         for i in range(max_retries):
             try:
                 self._s3_admin.create_bucket(Bucket=bucket)
@@ -873,6 +874,7 @@ _PermissionCapableFactory = MotoS3StorageFixtureFactory
 class MotoNfsBackedS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
     def create_fixture(self) -> NfsS3Bucket:
         bucket = self.bucket_name("nfs")
+        max_retries = 15
         for i in range(max_retries):
             try:
                 self._s3_admin.create_bucket(Bucket=bucket)
@@ -921,6 +923,7 @@ class MotoGcpS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
 
     def create_fixture(self) -> GcpS3Bucket:
         bucket = self.bucket_name("gcp")
+        max_retries = 15
         for i in range(max_retries):
             try:
                 self._s3_admin.create_bucket(Bucket=bucket)

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -830,7 +830,14 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
 
     def create_fixture(self) -> S3Bucket:
         bucket = self.bucket_name("s3")
-        self._s3_admin.create_bucket(Bucket=bucket)
+        for i in range(max_retries):
+            try:
+                self._s3_admin.create_bucket(Bucket=bucket)
+                break
+            except botocore.exceptions.EndpointConnectionError as e:
+                if i >= max_retries-1: 
+                    raise
+            time.sleep(1)
         if self.bucket_versioning:
             self._s3_admin.put_bucket_versioning(Bucket=bucket, VersioningConfiguration={"Status": "Enabled"})
 
@@ -866,7 +873,14 @@ _PermissionCapableFactory = MotoS3StorageFixtureFactory
 class MotoNfsBackedS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
     def create_fixture(self) -> NfsS3Bucket:
         bucket = self.bucket_name("nfs")
-        self._s3_admin.create_bucket(Bucket=bucket)
+        for i in range(max_retries):
+            try:
+                self._s3_admin.create_bucket(Bucket=bucket)
+                break
+            except botocore.exceptions.EndpointConnectionError as e:
+                if i >= max_retries-1: 
+                    raise
+            time.sleep(1)
         out = NfsS3Bucket(self, bucket)
         self._live_buckets.append(out)
         return out
@@ -907,7 +921,14 @@ class MotoGcpS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
 
     def create_fixture(self) -> GcpS3Bucket:
         bucket = self.bucket_name("gcp")
-        self._s3_admin.create_bucket(Bucket=bucket)
+        for i in range(max_retries):
+            try:
+                self._s3_admin.create_bucket(Bucket=bucket)
+                break
+            except botocore.exceptions.EndpointConnectionError as e:
+                if i >= max_retries-1: 
+                    raise
+            time.sleep(1)
         out = GcpS3Bucket(self, bucket)
         self._live_buckets.append(out)
         return out


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Addresses couple of flaky tests opened due to NFS or S3 problems during fixture setup:

```
Error at: setup of test_add_to_snapshot_atomicity

    @pytest.fixture
    def s3_bucket_versioning_storage(s3_bucket_versioning_storage_factory):
>       with s3_bucket_versioning_storage_factory.create_fixture() as f:

tests/conftest.py:159: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
arcticdb/storage_fixtures/s3.py:400: in create_fixture
    self._s3_admin.create_bucket(Bucket=bucket)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
            urllib_response = conn.urlopen(
                method=request.method,
                url=request_target,
                body=request.body,
                headers=request.headers,
>>>>>>>>>>>>>>> retries=Retry(False),
                assert_same_host=False,
                preload_content=False,
                decode_content=False,
                chunked=self._chunked(request.headers),
            )
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    
        except (NewConnectionError, socket.gaierror) as e:
>           raise EndpointConnectionError(endpoint_url=request.url, error=e)
E           botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://localhost:13167/test_bucket_0"
```

```
2024-11-06T13:33:21.5447865Z During handling of the above exception, another exception occurred:
2024-11-06T13:33:21.5448377Z 
2024-11-06T13:33:21.5449236Z nfs_backed_s3_storage_factory = <arcticdb.storage_fixtures.s3.MotoNfsBackedS3StorageFixtureFactory object at 0x7fa50cef3a20>
2024-11-06T13:33:21.5450123Z 
2024-11-06T13:33:21.5450258Z     @pytest.fixture
2024-11-06T13:33:21.5451004Z     def nfs_backed_s3_storage(nfs_backed_s3_storage_factory) -> Iterator[NfsS3Bucket]:
2024-11-06T13:33:21.5451934Z >       with nfs_backed_s3_storage_factory.create_fixture() as f:

....................................................................................................................................
2024-11-06T13:33:21.5490425Z     def send(self, request):
2024-11-06T13:33:21.5490690Z         try:
2024-11-06T13:33:21.5491041Z             proxy_url = self._proxy_config.proxy_url_for(request.url)
2024-11-06T13:33:21.5491603Z             manager = self._get_connection_manager(request.url, proxy_url)
2024-11-06T13:33:21.5492114Z             conn = manager.connection_from_url(request.url)
2024-11-06T13:33:21.5492595Z             self._setup_ssl_cert(conn, request.url, self._verify)
2024-11-06T13:33:21.5492999Z             if ensure_boolean(
2024-11-06T13:33:21.5493489Z                 os.environ.get('BOTO_EXPERIMENTAL__ADD_PROXY_HOST_HEADER', '')
2024-11-06T13:33:21.5493911Z             ):
2024-11-06T13:33:21.5494284Z                 # This is currently an "experimental" feature which provides
2024-11-06T13:33:21.5494852Z                 # no guarantees of backwards compatibility. It may be subject
2024-11-06T13:33:21.5495424Z                 # to change or removal in any patch version. Anyone opting in
2024-11-06T13:33:21.5495939Z                 # to this feature should strictly pin botocore.
2024-11-06T13:33:21.5496381Z                 host = urlparse(request.url).hostname
2024-11-06T13:33:21.5496831Z                 conn.proxy_headers['host'] = host
2024-11-06T13:33:21.5497162Z     
2024-11-06T13:33:21.5497513Z             request_target = self._get_request_target(request.url, proxy_url)
2024-11-06T13:33:21.5497994Z             urllib_response = conn.urlopen(
2024-11-06T13:33:21.5498355Z                 method=request.method,
2024-11-06T13:33:21.5498688Z                 url=request_target,
2024-11-06T13:33:21.5499006Z                 body=request.body,
2024-11-06T13:33:21.5499345Z                 headers=request.headers,
2024-11-06T13:33:21.5499683Z                 retries=Retry(False),                     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2024-11-06T13:33:21.5500013Z                 assert_same_host=False,
2024-11-06T13:33:21.5500351Z                 preload_content=False,
2024-11-06T13:33:21.5500680Z                 decode_content=False,
2024-11-06T13:33:21.5501055Z                 chunked=self._chunked(request.headers),
2024-11-06T13:33:21.5501398Z             )
2024-11-06T13:33:21.5501595Z     
2024-11-06T13:33:21.5501904Z             http_response = botocore.awsrequest.AWSResponse(
2024-11-06T13:33:21.5502444Z                 request.url,
2024-11-06T13:33:21.5502744Z                 urllib_response.status,
2024-11-06T13:33:21.5503091Z                 urllib_response.headers,
2024-11-06T13:33:21.5503416Z                 urllib_response,
2024-11-06T13:33:21.5503687Z             )
2024-11-06T13:33:21.5503884Z     
2024-11-06T13:33:21.5504122Z             if not request.stream_output:
2024-11-06T13:33:21.5504588Z                 # Cause the raw stream to be exhausted immediately. We do it
2024-11-06T13:33:21.5505259Z                 # this way instead of using preload_content because
2024-11-06T13:33:21.5505757Z                 # preload_content will never buffer chunked responses
2024-11-06T13:33:21.5506178Z                 http_response.content
2024-11-06T13:33:21.5506463Z     
2024-11-06T13:33:21.5506678Z             return http_response
2024-11-06T13:33:21.5506994Z         except URLLib3SSLError as e:
2024-11-06T13:33:21.5507411Z             raise SSLError(endpoint_url=request.url, error=e)
2024-11-06T13:33:21.5507899Z         except (NewConnectionError, socket.gaierror) as e:
2024-11-06T13:33:21.5508491Z >           raise EndpointConnectionError(endpoint_url=request.url, error=e)
2024-11-06T13:33:21.5509461Z E           botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://localhost:14255/test_bucket_0"
```

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
