### PR TITLE
Refactor to_atom and to_ref to properly use forwarding references

### DIFF
--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -105,10 +105,10 @@ TEST(Async, DeDupTest) {
 
     //The first key will be de-duped, second key will be fresh because indexes dont match
     ASSERT_EQ(2ULL, keys.size());
-    ASSERT_EQ(k, to_atom(keys[0]));
-    ASSERT_NE(k, to_atom(keys[1]));
-    ASSERT_NE(999, to_atom(keys[1]).creation_ts());
-    ASSERT_EQ(2, to_atom(keys[1]).version_id());
+    ASSERT_EQ(k, keys[0]);
+    ASSERT_NE(k, keys[1]);
+    ASSERT_NE(999, keys[1].creation_ts());
+    ASSERT_EQ(2, keys[1].version_id());
 }
 
 struct MaybeThrowTask : arcticdb::async::BaseTask {

--- a/cpp/arcticdb/entity/variant_key.hpp
+++ b/cpp/arcticdb/entity/variant_key.hpp
@@ -27,24 +27,16 @@ using IterateTypePredicate = std::function<bool(VariantKey &&key)>;
 /** Should be a SNAPSHOT_REF key or the legacy SNAPSHOT AtomKey. */
 using SnapshotVariantKey = VariantKey;
 
-inline AtomKey& to_atom(VariantKey& vk) {
-    return std::get<AtomKey>(vk);
+template<typename KeyType>
+requires std::same_as<std::decay_t<KeyType>, VariantKey>
+decltype(auto) to_atom(KeyType&& vk) {
+    return std::get<AtomKey>(std::forward<KeyType>(vk));
 }
 
-inline const AtomKey& to_atom(const VariantKey& vk) {
-    return std::get<AtomKey>(vk);
-}
-
-inline AtomKey to_atom(VariantKey&& vk) {
-    return std::get<AtomKey>(std::move(vk));
-}
-
-inline RefKey& to_ref(VariantKey& vk) {
-    return std::get<RefKey>(vk);
-}
-
-inline const RefKey& to_ref(const VariantKey& vk) {
-    return std::get<RefKey>(vk);
+template<typename KeyType>
+requires std::same_as<std::decay_t<KeyType>, VariantKey>
+decltype(auto) to_ref(KeyType&& vk) {
+    return std::get<RefKey>(std::forward<KeyType>(vk));
 }
 
 inline std::string_view variant_key_view(const VariantKey &vk) {

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -121,8 +121,8 @@ inline folly::Future<VersionedItem> index_and_version(
         std::move(time_series),
         std::move(slice_and_keys),
         IndexPartialKey{stream_id, version_id},
-        store).thenValue([] (auto&& version_key) {
-            return VersionedItem(to_atom(std::move(version_key)));
+        store).thenValue([] (AtomKey&& version_key) {
+            return VersionedItem(std::move(version_key));
         });
 }
 

--- a/cpp/arcticdb/storage/storage_utils.cpp
+++ b/cpp/arcticdb/storage/storage_utils.cpp
@@ -84,7 +84,7 @@ AtomKey write_table_index_tree_from_source_to_target(
             [](const auto&){});
     }
     // FUTURE: clean up already written keys if exception
-    return to_atom(writer.commit().get());
+    return writer.commit().get();
 }
 
 AtomKey copy_multi_key_from_source_to_target(

--- a/cpp/arcticdb/stream/stream_utils.hpp
+++ b/cpp/arcticdb/stream/stream_utils.hpp
@@ -159,7 +159,7 @@ inline entity::AtomKey read_key_row(const SegmentInMemory &seg, ssize_t i) {
     }
 }
 
-using KeyMemSegmentPair = std::pair<entity::VariantKey, SegmentInMemory>;
+using KeyMemSegmentPair = std::pair<VariantKey, SegmentInMemory>;
 
 class IndexRangeFilter {
   public:

--- a/cpp/arcticdb/util/test/test_key_utils.cpp
+++ b/cpp/arcticdb/util/test/test_key_utils.cpp
@@ -27,8 +27,7 @@ static auto write_version_frame_with_three_segments(
     auto wrapper = get_test_simple_frame(stream_id, 30, 0);  // 30 rows -> 3 segments
     auto& frame = wrapper.frame_;
     auto store = pvs._test_get_store();
-    auto var_key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
-    auto key = to_atom(var_key);
+    AtomKey key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
     pvs.write_version_and_prune_previous(true, key, std::nullopt);
     return key;
 }

--- a/cpp/arcticdb/util/test/test_key_utils.cpp
+++ b/cpp/arcticdb/util/test/test_key_utils.cpp
@@ -27,7 +27,7 @@ static auto write_version_frame_with_three_segments(
     auto wrapper = get_test_simple_frame(stream_id, 30, 0);  // 30 rows -> 3 segments
     auto& frame = wrapper.frame_;
     auto store = pvs._test_get_store();
-    AtomKey key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
+    auto key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
     pvs.write_version_and_prune_previous(true, key, std::nullopt);
     return key;
 }

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -51,7 +51,7 @@ auto write_version_frame(
     auto wrapper = get_test_simple_frame(stream_id, rows, start_val);
     auto& frame = wrapper.frame_;
     auto store = pvs._test_get_store();
-    AtomKey key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
+    auto key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
     if (update_version_map) {
         pvs.write_version_and_prune_previous(prune_previous, key, previous_key);
     }

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -51,8 +51,7 @@ auto write_version_frame(
     auto wrapper = get_test_simple_frame(stream_id, rows, start_val);
     auto& frame = wrapper.frame_;
     auto store = pvs._test_get_store();
-    auto var_key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
-    auto key = to_atom(var_key); // Moves
+    AtomKey key = write_frame(std::move(pk), frame, slicing, store, de_dup_map).get();
     if (update_version_map) {
         pvs.write_version_and_prune_previous(prune_previous, key, previous_key);
     }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -171,8 +171,7 @@ VersionedItem append_impl(
                                              options,
                                              validate_index,
                                              empty_types);
-    auto version_key = std::move(version_key_fut).get();
-    auto versioned_item = VersionedItem(to_atom(std::move(version_key)));
+    auto versioned_item = VersionedItem(std::move(version_key_fut).get());
     ARCTICDB_DEBUG(log::version(), "write_dataframe_impl stream_id: {} , version_id: {}", versioned_item.symbol(), update_info.next_version_id_);
     return versioned_item;
 }
@@ -296,8 +295,7 @@ VersionedItem delete_range_impl(
         using IndexType = decltype(idx);
         return pipelines::index::write_index<IndexType>(index_segment_reader.tsd(), std::move(flattened_slice_and_keys), IndexPartialKey{stream_id, update_info.next_version_id_}, store);
     });
-    auto version_key = std::move(version_key_fut).get();
-    auto versioned_item = VersionedItem(to_atom(std::move(version_key)));
+    auto versioned_item = VersionedItem(std::move(version_key_fut).get());
     ARCTICDB_DEBUG(log::version(), "updated stream_id: {} , version_id: {}", stream_id, update_info.next_version_id_);
     return versioned_item;
 }
@@ -502,8 +500,7 @@ VersionedItem update_impl(
     WriteOptions&& options,
     bool dynamic_schema,
     bool empty_types) {
-    auto version_key = async_update_impl(store, update_info, query, frame, std::move(options), dynamic_schema, empty_types).get();
-    auto versioned_item = VersionedItem(to_atom(std::move(version_key)));
+    auto versioned_item = VersionedItem(async_update_impl(store, update_info, query, frame, std::move(options), dynamic_schema, empty_types).get());
     ARCTICDB_DEBUG(log::version(), "updated stream_id: {} , version_id: {}", frame->desc.id(), update_info.next_version_id_);
     return versioned_item;
 }
@@ -1625,11 +1622,11 @@ VersionedItem collate_and_write(
         for(auto sk = std::begin(pipeline_context->slice_and_keys_); sk < end; ++sk)
             writer.add(sk->key(), sk->slice());
 
-        for (auto key : folly::enumerate(keys)) {
+        for (const auto& key : folly::enumerate(keys)) {
             writer.add(to_atom(*key), slices[key.index]);
         }
-        auto index_key =  writer.commit();
-        return VersionedItem{to_atom(std::move(index_key).get())};
+        folly::Future<AtomKey> index_key_fut =  writer.commit();
+        return VersionedItem{std::move(index_key_fut).get()};
     });
 }
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1625,7 +1625,7 @@ VersionedItem collate_and_write(
         for (const auto& key : folly::enumerate(keys)) {
             writer.add(to_atom(*key), slices[key.index]);
         }
-        folly::Future<AtomKey> index_key_fut =  writer.commit();
+        auto index_key_fut =  writer.commit();
         return VersionedItem{std::move(index_key_fut).get()};
     });
 }

--- a/cpp/arcticdb/version/version_utils.cpp
+++ b/cpp/arcticdb/version/version_utils.cpp
@@ -41,7 +41,7 @@ VariantKey write_multi_index_entry(
                                      std::forward<decltype(segment)>(segment)).wait();
     });
 
-    for (AtomKey& key : keys) {
+    for (const AtomKey& key : keys) {
         multi_index_agg.add_key(key);
     }
     TimeseriesDescriptor timeseries_descriptor;

--- a/cpp/arcticdb/version/version_utils.cpp
+++ b/cpp/arcticdb/version/version_utils.cpp
@@ -41,8 +41,8 @@ VariantKey write_multi_index_entry(
                                      std::forward<decltype(segment)>(segment)).wait();
     });
 
-    for (auto &key : keys) {
-        multi_index_agg.add_key(to_atom(key));
+    for (AtomKey& key : keys) {
+        multi_index_agg.add_key(key);
     }
     TimeseriesDescriptor timeseries_descriptor;
 

--- a/cpp/arcticdb/version/version_utils.cpp
+++ b/cpp/arcticdb/version/version_utils.cpp
@@ -41,7 +41,7 @@ VariantKey write_multi_index_entry(
                                      std::forward<decltype(segment)>(segment)).wait();
     });
 
-    for (const AtomKey& key : keys) {
+    for (const auto& key : keys) {
         multi_index_agg.add_key(key);
     }
     TimeseriesDescriptor timeseries_descriptor;

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -100,15 +100,15 @@ std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteratio
     std::vector<AtomKey> read_keys;
     for (auto key_type : key_types) {
         store->iterate_type(key_type,
-            [&predicate, &read_keys, &store, &output, &perform_read_segment_with_keys](VariantKey &&vk) {
-                const auto &key = to_atom(std::move(vk));
+            [&predicate, &read_keys, &store, &output, &perform_read_segment_with_keys](VariantKey&& vk) {
+                const AtomKey& key = to_atom(std::move(vk));
                 if (!predicate(key))
                     return;
 
                 read_keys.push_back(key);
                 ARCTICDB_DEBUG(log::storage(), "Version map iterating key {}", key);
                 if (perform_read_segment_with_keys) {
-                    auto [kv, seg] = store->read_sync(to_atom(key));
+                    auto [kv, seg] = store->read_sync(key);
                     LoadProgress load_progress;
                     (void)read_segment_with_keys(seg, output, load_progress);
                 }

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -101,7 +101,7 @@ std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteratio
     for (auto key_type : key_types) {
         store->iterate_type(key_type,
             [&predicate, &read_keys, &store, &output, &perform_read_segment_with_keys](VariantKey&& vk) {
-                const AtomKey& key = to_atom(std::move(vk));
+                const auto& key = to_atom(std::move(vk));
                 if (!predicate(key))
                     return;
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
This solves two problems
- Code duplication. to_atom had 3 overloads for value/ref/rval ref for the same thing. Forwarding references were invented to solve this problem.
- There were unnecessary copies. `to_atom` had an overload taking `VeriantKey` by value at some point some APIs have changed and started returning `AtomKey` instead of `VariantKey` due to the excessive use of `auto` nobody noticed the difference. Thus we ended up with calling `to_atom` on an atom key, that worked because `VariantKey` can be constructed from an `AtomKey` implicitly thus we ended up constructing `VariantKey` from an `AtomKey` only to extract the `AtomKey` from that. Forwarding references do not allow implicit conversions thus the compiler pointed out all places in the code where the above happens.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
