### PR TITLE
Support MSVC 19.29

### DIFF
--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -8,7 +8,6 @@
 #include <arcticdb/entity/metrics.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/util/pb_util.hpp>
-#include <folly/gen/Base.h>
 
 #ifdef _WIN32
 #    include <Winsock.h> // for gethostname

--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -107,7 +107,7 @@ struct NativeTensor {
     }
 
     [[nodiscard]] auto nbytes() const { return nbytes_; }
-    [[nodiscard]] auto ndim() const { return ndim_; }
+    [[nodiscard]] int ndim() const { return ndim_; }
     [[nodiscard]] auto strides(size_t pos) const { return strides_[pos]; }
     [[nodiscard]] const auto* strides() const { return strides_.data(); };
     [[nodiscard]] auto shape(size_t pos) const { return shapes_[pos]; }

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -79,7 +79,7 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
 
     util::BitSet output_bitset;
     constexpr auto sparse_missing_value_output = std::is_same_v<std::remove_reference_t<Func>, IsNotInOperator>;
-    details::visit_type(column_with_strings.column_->type().data_type(),[&] (auto col_tag) {
+    details::visit_type(column_with_strings.column_->type().data_type(),[&, sparse_missing_value_output] (auto col_tag) {
         using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
         details::visit_type(value_set.base_type().data_type(), [&] (auto val_set_tag) {
             using val_set_type_info = ScalarTypeInfo<decltype(val_set_tag)>;
@@ -158,7 +158,7 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
     util::BitSet output_bitset;
     constexpr auto sparse_missing_value_output = std::is_same_v<std::remove_reference_t<Func>, NotEqualsOperator>;
 
-    details::visit_type(left.column_->type().data_type(), [&](auto left_tag) {
+    details::visit_type(left.column_->type().data_type(), [&, sparse_missing_value_output](auto left_tag) {
         using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
         details::visit_type(right.column_->type().data_type(), [&](auto right_tag) {
             using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
@@ -212,7 +212,7 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
     util::BitSet output_bitset;
     constexpr auto sparse_missing_value_output = std::is_same_v<std::remove_reference_t<Func>, NotEqualsOperator>;
 
-    details::visit_type(column_with_strings.column_->type().data_type(), [&](auto col_tag) {
+    details::visit_type(column_with_strings.column_->type().data_type(), [&, sparse_missing_value_output](auto col_tag) {
         using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
         details::visit_type(val.type().data_type(), [&](auto val_tag) {
             using val_type_info = ScalarTypeInfo<decltype(val_tag)>;

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -245,10 +245,12 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                 });
             } else if constexpr ((is_numeric_type(col_type_info::data_type) && is_numeric_type(val_type_info::data_type)) ||
                                  (is_bool_type(col_type_info::data_type) && is_bool_type(val_type_info::data_type))) {
+                using ColType = typename col_type_info::RawType;
+                using ValType = typename val_type_info::RawType;
                 using comp = std::conditional_t<arguments_reversed,
-                                                typename arcticdb::Comparable<typename val_type_info::RawType, typename col_type_info::RawType>,
-                                                typename arcticdb::Comparable<typename col_type_info::RawType, typename val_type_info::RawType>>;
-                auto value = static_cast<typename comp::right_type>(*reinterpret_cast<const typename val_type_info::RawType *>(val.data_));
+                                                typename arcticdb::Comparable<ValType, ColType>,
+                                                typename arcticdb::Comparable<ColType, ValType>>;
+                auto value = static_cast<typename comp::right_type>(*reinterpret_cast<const ValType *>(val.data_));
                 Column::transform<typename col_type_info::TDT>(
                         *column_with_strings.column_,
                         output_bitset,

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -125,7 +125,7 @@ VariantData unary_comparator(const ColumnWithStrings& col, Func&& func) {
 
     util::BitSet output_bitset;
     constexpr auto sparse_missing_value_output = std::is_same_v<std::remove_reference_t<Func>, IsNullOperator>;
-    details::visit_type(col.column_->type().data_type(), [&](auto col_tag) {
+    details::visit_type(col.column_->type().data_type(), [&, sparse_missing_value_output](auto col_tag) {
         using type_info = ScalarTypeInfo<decltype(col_tag)>;
         // Non-explicit lambda capture due to a bug in LLVM: https://github.com/llvm/llvm-project/issues/34798
         Column::transform<typename type_info::TDT>(*(col.column_), output_bitset, sparse_missing_value_output, [&](auto input_value) -> bool {

--- a/cpp/arcticdb/stream/merge.hpp
+++ b/cpp/arcticdb/stream/merge.hpp
@@ -90,7 +90,9 @@ void do_merge(
                             const TypeDescriptor& final_type = agg.descriptor().field(field_name_to_index.find(name)->second).type();
                             details::visit_type(final_type.data_type(), [&](auto merged_descriptor_type) {
                                 using merged_type_info = ScalarTypeInfo<decltype(merged_descriptor_type)>;
-                                using row_type_info = ScalarTypeInfo<typename decltype(row_field_descriptor_tag)::DataTypeTag>;
+                                using RowFieldDescriptorTagType = typename std::decay_t<decltype(row_field_descriptor_tag)>;
+                                using RowFieldDescriptorTagDataType = typename RowFieldDescriptorTagType::DataTypeTag;
+                                using row_type_info = ScalarTypeInfo<RowFieldDescriptorTagDataType>;
                                 // At this point all staged descriptors were merged using merge_descritpros and it
                                 // ensured that all staged descriptors are either the same or are convertible to the
                                 // stream descriptor in the aggregator.

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -230,7 +230,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
 
     version.def("write_dataframe_to_file", &write_dataframe_to_file);
     version.def("read_dataframe_from_file",
-        [] (StreamId sid, const std::string(path), std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options){
+        [] (StreamId sid, std::string path, std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options){
             return adapt_read_df(read_dataframe_from_file(sid, path, read_query, read_options));
         });
 


### PR DESCRIPTION
#### Reference Issues/PRs

Extracted from https://github.com/man-group/ArcticDB/pull/2252/.

#### What does this implement or fix?

The compiler for Windows on conda-forge is MSVC 19.29.30158.0.

ArcticDB necessitates (at least) the following changes for this version of MSVC to compile it.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
