### PR TITLE
Fix permissions for the automatic docs building

### DIFF
--- a/.github/workflows/build_docs_on_release.yml
+++ b/.github/workflows/build_docs_on_release.yml
@@ -9,6 +9,7 @@ jobs:
   check-inputs:
     name: Check inputs
     runs-on: ubuntu-latest
+    environment: TestPypi  # For TAGGING_TOKEN secret
     outputs:
         version: ${{ steps.tag_name.outputs.tag }}
         latest: ${{ github.event.release.tag_name == steps.latest_tag.outputs.tag }}


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Fixes failures when building the docs automatically on release like:
https://github.com/man-group/ArcticDB/actions/runs/14832306883
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
