### PR TITLE
Fix gcp lib unreachable after making it read only

### DIFF
--- a/.github/actions/set_persistent_storage_env_vars/action.yml
+++ b/.github/actions/set_persistent_storage_env_vars/action.yml
@@ -4,7 +4,7 @@ inputs:
   bucket:            {default: 'arcticdb-ci-test-bucket-02', type: string, description: The name of the S3 bucket that we will test against}
   bucket_gcp:        {default: 'arcticdb-github', type: string, description: The name of the GCP bucket that we will test against}
   endpoint:          {default: 'https://s3.eu-west-1.amazonaws.com', type: string, description: The address of the S3 endpoint}
-  endpoint_gcp:      {default: 'gcpxml://storage.googleapis.com', type: string, description: The address of the GCP endpoint}
+  endpoint_gcp:      {default: 'https://storage.googleapis.com', type: string, description: The address of the GCP endpoint}
   region:            {default: 'eu-west-1', type: string, description: The S3 region of the bucket}
   aws_access_key:    {required: true, type: string, description: The value for the AWS Access key}      
   aws_secret_key:    {required: true, type: string, description: The value for the AWS Secret key}

--- a/cpp/arcticdb/storage/s3/s3_settings.hpp
+++ b/cpp/arcticdb/storage/s3/s3_settings.hpp
@@ -36,7 +36,8 @@ class GCPXMLSettings {
     bool ssl_;
 
 public:
-    GCPXMLSettings() { }
+    GCPXMLSettings():
+        aws_auth_(AWSAuthMethod::DISABLED), https_(false), ssl_(false){ }
 
     explicit GCPXMLSettings(
         AWSAuthMethod aws_auth,
@@ -168,6 +169,14 @@ public:
     explicit S3Settings(AWSAuthMethod aws_auth,
                         const std::string& aws_profile,
                         bool use_internal_client_wrapper_for_testing) :
+        max_connections_(0),
+        connect_timeout_(0),
+        request_timeout_(0),
+        ssl_(false),
+        https_(false),
+        use_virtual_addressing_(false),
+        use_mock_storage_for_testing_(false),
+        use_raw_prefix_(false),
         aws_auth_(aws_auth),
         aws_profile_(aws_profile),
         use_internal_client_wrapper_for_testing_(use_internal_client_wrapper_for_testing) {

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -264,8 +264,8 @@ class NativeVersionStore:
         self._native_cfg = native_cfg
 
     @classmethod
-    def create_store_from_lib_config(cls, lib_cfg, env, open_mode=OpenMode.DELETE):
-        lib = cls.create_lib_from_lib_config(lib_cfg, env, open_mode)
+    def create_store_from_lib_config(cls, lib_cfg, env, open_mode=OpenMode.DELETE, native_cfg=None):
+        lib = cls.create_lib_from_lib_config(lib_cfg, env, open_mode, native_cfg)
         return cls(library=lib, lib_cfg=lib_cfg, env=env, open_mode=open_mode)
 
     @staticmethod
@@ -2789,6 +2789,9 @@ class NativeVersionStore:
 
     def lib_cfg(self):
         return self._lib_cfg
+    
+    def lib_native_cfg(self):
+        return self._native_cfg
 
     def open_mode(self):
         return self._open_mode

--- a/python/tests/integration/arcticdb/version_store/test_symbol_list.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_list.py
@@ -39,7 +39,9 @@ def small_max_delta():
 
 
 def make_read_only(lib):
-    return NativeVersionStore.create_store_from_lib_config(lib.lib_cfg(), Defaults.ENV, OpenMode.READ)
+    return NativeVersionStore.create_store_from_lib_config(
+        lib_cfg=lib.lib_cfg(), env=Defaults.ENV, open_mode=OpenMode.READ, native_cfg=lib.lib_native_cfg()
+    )
 
 
 @pytest.mark.storage


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://man312219.monday.com/boards/7852509418/pulses/8985074856

#### What does this implement or fix?
`create_store_from_lib_config` took protobuf setting only. 
GCP setting is stored natively only, unlike other storages setting.
So when new store is created with the above function, gcp settings have not been passed to the new store. Therefore the SDK will fallback to default but incorrect setting and cause errors.

S3 and GCPXML native settings are given default value to avoid uninitiailzied value being used in the test

#### Any other comments?
Test in the CI: https://github.com/man-group/ArcticDB/actions/runs/15164054821/job/42638155043
```
test_symbol_list.py::test_symbol_list_read_only_compaction_needed[real_gcp_store_factory-True] 
[gw0] [ 95%] PASSED tests/integration/arcticdb/version_store/test_symbol_list.py::test_symbol_list_read_only_compaction_needed[real_gcp_store_factory-True] 
test_symbol_list.py::test_symbol_list_read_only_compaction_needed[real_gcp_store_factory-False] 
[gw0] [ 95%] PASSED tests/integration/arcticdb/version_store/test_symbol_list.py::test_symbol_list_read_only_compaction_needed[real_gcp_store_factory-False] 
```
(Other unrelated tests failed in the flaky real storage CI)
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
