### PR TITLE
Bugfix/9123099670/fix resampling of old updated data

### DIFF
--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -739,9 +739,12 @@ std::vector<EntityId> ResampleClause<closed_boundary>::process(std::vector<Entit
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(is_time_type(first_row_slice_index_col.type().data_type()),
                                                     "Cannot resample data with index column of non-timestamp type");
     auto first_ts = first_row_slice_index_col.scalar_at<timestamp>(0).value();
-    // We can use the last timestamp from the first row-slice's index column, as by construction (structure_for_processing) the bucket covering
-    // this value will cover the remaining index values this call is responsible for
-    auto last_ts = first_row_slice_index_col.scalar_at<timestamp>(first_row_slice_index_col.row_count() - 1).value();
+    // If there is only one row slice, then the last index value of interest is just the last index value for this row
+    // slice. If there is more than one, then the first index value from the second row slice must be used to calculate
+    // the buckets of interest, due to an old bug in update. See test_compatibility.py::test_compat_resample_updated_data
+    // for details
+    auto last_ts = row_slices.size() == 1 ? first_row_slice_index_col.scalar_at<timestamp>(first_row_slice_index_col.row_count() - 1).value():
+            row_slices.back().segments_->at(0)->column(0).scalar_at<timestamp>(0).value();
     auto bucket_boundaries = generate_bucket_boundaries(first_ts, last_ts, responsible_for_first_overlapping_bucket);
     if (bucket_boundaries.size() < 2) {
         return {};

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -727,6 +727,7 @@ struct DateRangeClause {
 
     ClauseInfo clause_info_;
     std::shared_ptr<ComponentManager> component_manager_;
+    ProcessingConfig processing_config_;
     // Time range to keep, inclusive of start and end
     timestamp start_;
     timestamp end_;
@@ -752,8 +753,7 @@ struct DateRangeClause {
         return clause_info_;
     }
 
-    void set_processing_config(ARCTICDB_UNUSED const ProcessingConfig& processing_config) {
-    }
+    void set_processing_config(const ProcessingConfig& processing_config);
 
     void set_component_manager(std::shared_ptr<ComponentManager> component_manager) {
         component_manager_ = component_manager;

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -61,7 +61,8 @@ struct ClauseInfo {
 // Changes how the clause behaves based on information only available after it is constructed
 struct ProcessingConfig {
     bool dynamic_schema_{false};
-    uint64_t total_rows_ = 0;
+    uint64_t total_rows_{0};
+    IndexDescriptor::Type index_type_{IndexDescriptor::Type::UNKNOWN};
 };
 
 // Used when restructuring segments inbetween clauses with differing ProcessingStructures

--- a/cpp/arcticdb/processing/sorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.cpp
@@ -44,6 +44,7 @@ Column SortedAggregator<aggregation_operator, closed_boundary>::aggregate(const 
                 auto bucket_start_it = bucket_boundaries.cbegin();
                 auto bucket_end_it = std::next(bucket_start_it);
                 Bucket<closed_boundary> current_bucket(*bucket_start_it, *bucket_end_it);
+                bool bucket_has_values{false};
                 const auto bucket_boundaries_end = bucket_boundaries.cend();
                 for (auto [idx, input_agg_column]: folly::enumerate(input_agg_columns)) {
                     // Always true right now due to earlier check
@@ -61,6 +62,7 @@ Column SortedAggregator<aggregation_operator, closed_boundary>::aggregate(const 
                             &bucket_start_it,
                             &bucket_end_it,
                             &current_bucket,
+                            &bucket_has_values,
                             &reached_end_of_buckets](auto input_type_desc_tag) {
                                 using input_type_info = ScalarTypeInfo<decltype(input_type_desc_tag)>;
                                 // Again, only needed to generate valid code below, exception will have been thrown earlier at runtime
@@ -75,7 +77,6 @@ Column SortedAggregator<aggregation_operator, closed_boundary>::aggregate(const 
                                     const auto index_cend = index_data.template cend<IndexTDT>();
                                     auto agg_data = agg_column.column_->data();
                                     auto agg_it = agg_data.template cbegin<typename input_type_info::TDT>();
-                                    bool bucket_has_values = false;
                                     for (auto index_it = index_data.template cbegin<IndexTDT>(); index_it != index_cend && !reached_end_of_buckets; ++index_it, ++agg_it) {
                                         if (ARCTICDB_LIKELY(current_bucket.contains(*index_it))) {
                                             push_to_aggregator<input_type_info::data_type>(bucket_aggregator, *agg_it, agg_column);

--- a/cpp/arcticdb/processing/test/rapidcheck_resample.cpp
+++ b/cpp/arcticdb/processing/test/rapidcheck_resample.cpp
@@ -112,12 +112,15 @@ RC_GTEST_PROP(Resample, StructureForProcessing, ()) {
         }
     }
 
+    ProcessingConfig processing_config{false, index_values.size(), IndexDescriptor::Type::TIMESTAMP};
     if (left_boundary_closed) {
         ResampleClause<ResampleBoundary::LEFT> resample_clause{"dummy", ResampleBoundary::LEFT, generate_bucket_boundaries(std::move(bucket_boundaries)), 0, 0};
+        resample_clause.set_processing_config(processing_config);
         auto result = resample_clause.structure_for_processing(ranges_and_keys);
         RC_ASSERT(expected_result == result);
     } else {
         ResampleClause<ResampleBoundary::RIGHT> resample_clause{"dummy", ResampleBoundary::RIGHT, generate_bucket_boundaries(std::move(bucket_boundaries)), 0, 0};
+        resample_clause.set_processing_config(processing_config);
         auto result = resample_clause.structure_for_processing(ranges_and_keys);
         RC_ASSERT(expected_result == result);
     }

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -110,6 +110,10 @@ std::vector<timestamp> generate_buckets(
     timestamp offset,
     const ResampleOrigin& origin
 ) {
+    // e.g. Can happen if date range specified does not overlap with the time range covered by the symbol
+    if (end < start) {
+        return {};
+    }
     const timestamp rule_ns = [](std::string_view rule) {
         py::gil_scoped_acquire acquire_gil;
         return python_util::pd_to_offset(rule);

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -908,7 +908,11 @@ folly::Future<std::vector<EntityId>> read_and_schedule_processing(
     const ReadOptions& read_options,
     std::shared_ptr<ComponentManager> component_manager
     ) {
-    ProcessingConfig processing_config{opt_false(read_options.dynamic_schema()), pipeline_context->rows_};
+    ProcessingConfig processing_config{
+        opt_false(read_options.dynamic_schema()),
+        pipeline_context->rows_,
+        pipeline_context->descriptor().index().type()
+    };
     for (auto& clause: read_query->clauses_) {
         clause->set_processing_config(processing_config);
         clause->set_component_manager(component_manager);

--- a/python/arcticdb/util/venv.py
+++ b/python/arcticdb/util/venv.py
@@ -182,6 +182,9 @@ class VenvLib:
     def write(self, sym: str, df) -> None:
         return self.execute([f"lib.write('{sym}', df)"], {"df": df})
 
+    def update(self, sym: str, df, date_range: str):
+        return self.execute([f"lib.update('{sym}', df, date_range={date_range})"], {"df": df})
+
     def assert_read(self, sym: str, df) -> None:
         python_commands = [
             f"read_df = lib.read('{sym}').data",

--- a/python/tests/compat/arcticdb/test_compatibility.py
+++ b/python/tests/compat/arcticdb/test_compatibility.py
@@ -337,5 +337,6 @@ def test_compat_resample_updated_data(old_venv_and_arctic_uri, lib_name):
         # Resample using current version
         with compat.current_version() as curr:
             q = QueryBuilder().date_range((pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-04 23:59"))).resample("1D").agg({"col": "sum"})
-            curr.lib.read(sym, query_builder=q)
-            # TODO: Check that result is correct
+            received_df = curr.lib.read(sym, query_builder=q).data
+            expected_df = curr.lib.read(sym, date_range=(pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-04 23:59"))).data.resample("1D").agg({"col": "sum"})
+            assert_frame_equal(expected_df, received_df)

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -11,6 +11,8 @@ import datetime
 import pytest
 import sys
 
+from arcticdb import QueryBuilder
+from arcticdb.exceptions import UserInputException
 from arcticdb.util.test import assert_frame_equal, assert_series_equal
 from arcticdb_ext import set_config_int
 from arcticdb_ext.storage import KeyType
@@ -442,3 +444,18 @@ def test_delete_snapshot_regression(nfs_clean_bucket):
     assert "snap" in lib.list_snapshots()
     lib.delete_snapshot("snap")
     assert "snap" not in lib.list_snapshots()
+
+
+def test_resampling_non_timeseries(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_resampling_non_timeseries"
+
+    df = pd.DataFrame({"col": np.arange(10)})
+    lib.write(sym, df)
+    q = QueryBuilder().resample('1min').agg({"col": "sum"})
+    with pytest.raises(UserInputException):
+        lib.read(sym, query_builder=q)
+    q = QueryBuilder().date_range((pd.Timestamp("2025-01-01"), pd.Timestamp("2025-02-01"))).resample('1min').agg({"col": "sum"})
+    with pytest.raises(UserInputException) as e:
+        lib.read(sym, query_builder=q)
+    assert "std::length_error(vector::reserve)" not in str(e.value)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes [9123099670](https://man312219.monday.com/boards/7852509418/views/168855452/pulses/9123099670)

#### What does this implement or fix?
Fixes three separate resampling bugs:

1. Old versions of `update` (changed sometime between `4.1.0` and `4.4.0`, I haven't pinned down exactly where) had a behaviour in which the `end_index` value in the data key of the segment overlapping with the start of the date range provided to the `update` call was set to the first value of the date range in the `update` call. For all other modification methods, this is set to 1 nanosecond larger than the last index value in the contained segment. Resampling assumed this to be the case, and had an assertion verifying it. Relaxing this assertion is sufficient to fix the issue.
2. Providing a `date_range` argument with a resample where the provided date range did not overlap with the timerange covered by the index of the symbol led to trying to reserve a vector with a negative size. This now correctly returns an empty result.
3. Previously, checks that a symbol being resampled had a timestamp index occurred after some operations which also require this to be true, which could lead to the same vector reserve issue above. It is now checked in advance, and a suitable exception raised.