### PR TITLE
Patch for Real S3 library names

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -102,7 +102,8 @@ def lib_name(request: "pytest.FixtureRequest") -> str:
     name = re.sub(r"[^\w]", "_", request.node.name)[:30]
     pid = os.getpid()
     thread_id = threading.get_ident()
-    return f"{name}.{random.randint(0, 9999999)}_{pid}_{thread_id}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_%f')}_{uuid.uuid4()}"
+    # There is limit to the name length
+    return f"{name}_{pid}_{thread_id}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_')}_{uuid.uuid4()}"
 
 
 @pytest.fixture

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -102,8 +102,9 @@ def lib_name(request: "pytest.FixtureRequest") -> str:
     name = re.sub(r"[^\w]", "_", request.node.name)[:30]
     pid = os.getpid()
     thread_id = threading.get_ident()
-    # There is limit to the name length
-    return f"{name}_{pid}_{thread_id}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_')}_{uuid.uuid4()}"
+    # There is limit to the name length, and note that without 
+    # the dot (.) in the name mongo will not work!
+    return f"{name}.{pid}_{thread_id}_{datetime.utcnow().strftime('%Y-%m-%dT%H_%M_%S_')}_{uuid.uuid4()}"
 
 
 @pytest.fixture

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -84,7 +84,7 @@ def test_get_library(arctic_client, lib_name):
     with pytest.raises(LibraryNotFound):
         _ = ac.get_library(lib_name)
     # Creates library with default options if just create_if_missing set to True
-    lib = ac.get_library(f"{lib_name}_default_options", create_if_missing=True)
+    lib = ac.get_library(f"{lib_name}_do", create_if_missing=True)
 
     assert lib.options() == LibraryOptions(encoding_version=ac._encoding_version)
     # Creates library with the specified options if create_if_missing set to True and options provided
@@ -96,7 +96,7 @@ def test_get_library(arctic_client, lib_name):
         encoding_version=EncodingVersion.V1 if ac._encoding_version == EncodingVersion.V2 else EncodingVersion.V2,
     )
     lib = ac.get_library(
-        f"{lib_name}_specified_options",
+        f"{lib_name}_so", # specific options
         create_if_missing=True,
         library_options=library_options,
     )
@@ -106,7 +106,7 @@ def test_get_library(arctic_client, lib_name):
     library_options.dynamic_schema = False
     with pytest.raises(MismatchingLibraryOptions):
         _ = ac.get_library(
-            f"{lib_name}_specified_options",
+            f"{lib_name}_so", # specific options
             create_if_missing=True,
             library_options=library_options,
         )
@@ -338,8 +338,9 @@ def test_do_not_persist_s3_details(s3_storage):
 @pytest.mark.storage
 def test_library_options(arctic_client, lib_name):
     ac = arctic_client
-    ac.create_library(f"{lib_name}_default_options")
-    lib = ac[f"{lib_name}_default_options"]
+    lib_name_do = lib_name_do # default options
+    ac.create_library(lib_name_do)
+    lib = ac[lib_name_do]
     assert lib.options() == LibraryOptions(encoding_version=ac._encoding_version)
     write_options = lib._nvs._lib_cfg.lib_desc.version.write_options
     assert not write_options.dynamic_schema
@@ -355,11 +356,12 @@ def test_library_options(arctic_client, lib_name):
         columns_per_segment=3,
         encoding_version=EncodingVersion.V2,
     )
+    lib_name_eo = f"{lib_name}_explicit_options" # explicit options
     ac.create_library(
-        f"{lib_name}_explicit_options",
+        lib_name_eo,
         library_options,
     )
-    lib = ac[f"{lib_name}_explicit_options"]
+    lib = ac[lib_name_eo]
     assert lib.options() == library_options
     write_options = lib._nvs._lib_cfg.lib_desc.version.write_options
     assert write_options.dynamic_schema

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -338,7 +338,7 @@ def test_do_not_persist_s3_details(s3_storage):
 @pytest.mark.storage
 def test_library_options(arctic_client, lib_name):
     ac = arctic_client
-    lib_name_do = lib_name_do # default options
+    lib_name_do = f"{lib_name}_do" # default options
     ac.create_library(lib_name_do)
     lib = ac[lib_name_do]
     assert lib.options() == LibraryOptions(encoding_version=ac._encoding_version)
@@ -356,7 +356,7 @@ def test_library_options(arctic_client, lib_name):
         columns_per_segment=3,
         encoding_version=EncodingVersion.V2,
     )
-    lib_name_eo = f"{lib_name}_explicit_options" # explicit options
+    lib_name_eo = f"{lib_name}_eo" # explicit options
     ac.create_library(
         lib_name_eo,
         library_options,


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Currently we create library names which are too long for real S3, this is a patch for the tests until the real bug is addressed

Manually triggered run: https://github.com/man-group/ArcticDB/actions/runs/15013824867

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
