### PR TITLE
Add resolve_defaults back in as a static method of NativeVersionStore

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -481,6 +481,10 @@ class NativeVersionStore:
                     timestamp=vit_composite.timestamp
                 )
 
+    @staticmethod
+    def resolve_defaults(param_name, proto_cfg, global_default, existing_value=None, uppercase=True, **kwargs):
+        return resolve_defaults(param_name, proto_cfg, global_default, existing_value=None, uppercase=True, **kwargs)
+
     def _write_options(self):
         return self._lib_cfg.lib_desc.version.write_options
 


### PR DESCRIPTION
#### Reference Issues/PRs
Was removed in #2345 , but is needed at least by some internal tests, and technically constitutes an API break (although we don't expect anybody to be using it)