### PR TITLE
Bugfix 9209057536: Allow concatenation of uint64 columns with int* columns

### DIFF
--- a/cpp/arcticdb/entity/type_utils.cpp
+++ b/cpp/arcticdb/entity/type_utils.cpp
@@ -198,4 +198,16 @@ namespace arcticdb {
         }
     }
 
+    // The above method requires that both types are exactly representable by one type
+    // This is more permissive, allowing (for example) a uint64_t to be combined with an int* with the result being a double
+    std::optional<entity::TypeDescriptor> promotable_type(const entity::TypeDescriptor& left, const entity::TypeDescriptor& right) {
+        auto res = has_valid_common_type(left, right);
+        if (!res.has_value() &&
+            is_valid_type_promotion_to_target(left, make_scalar_type(entity::DataType::FLOAT64)) &&
+            is_valid_type_promotion_to_target(right, make_scalar_type(entity::DataType::FLOAT64))) {
+            res = make_scalar_type(entity::DataType::FLOAT64);
+        }
+        return res;
+    }
+
 }

--- a/cpp/arcticdb/entity/type_utils.hpp
+++ b/cpp/arcticdb/entity/type_utils.hpp
@@ -31,6 +31,11 @@ namespace entity {
     const entity::TypeDescriptor& right
 );
 
+[[nodiscard]] std::optional<entity::TypeDescriptor> promotable_type(
+        const entity::TypeDescriptor& left,
+        const entity::TypeDescriptor& right
+);
+
 inline std::string get_user_friendly_type_string(const entity::TypeDescriptor& type) {
     return is_sequence_type(type.data_type()) ? fmt::format("TD<type=STRING, dim={}>", type.dimension_) : fmt::format("{}", type);
 }

--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -408,10 +408,10 @@ void inner_join(StreamDescriptor& stream_desc, std::vector<OutputSchema>& input_
                     // and if necessary modify the columns_to_keep value to a type capable of representing all
                     auto& current_data_type = columns_to_keep_it->second;
                     if (current_data_type.has_value()) {
-                        auto opt_common_type = has_valid_common_type(make_scalar_type(*current_data_type),
-                                                                     make_scalar_type(it->second));
-                        if (opt_common_type.has_value()) {
-                            current_data_type = opt_common_type->data_type();
+                        auto opt_promotable_type = promotable_type(make_scalar_type(*current_data_type),
+                                                                   make_scalar_type(it->second));
+                        if (opt_promotable_type.has_value()) {
+                            current_data_type = opt_promotable_type->data_type();
                         } else {
                             current_data_type.reset();
                         }
@@ -466,10 +466,10 @@ void outer_join(StreamDescriptor& stream_desc, std::vector<OutputSchema>& input_
                         // Current set of columns under consideration contains column_name, so ensure types are compatible
                         // and if necessary modify the columns_to_keep value to a type capable of representing all
                         auto& current_data_type = columns_to_keep_it->second;
-                        auto opt_common_type = has_valid_common_type(make_scalar_type(current_data_type),
-                                                                     make_scalar_type(data_type));
-                        if (opt_common_type.has_value()) {
-                            current_data_type = opt_common_type->data_type();
+                        auto opt_promotable_type = promotable_type(make_scalar_type(current_data_type),
+                                                                   make_scalar_type(data_type));
+                        if (opt_promotable_type.has_value()) {
+                            current_data_type = opt_promotable_type->data_type();
                         } else {
                             schema::raise<ErrorCode::E_DESCRIPTOR_MISMATCH>(
                                     "No common type between {} and {} when joining schemas", current_data_type,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes [9209057536](https://man312219.monday.com/boards/7852509418/pulses/9209057536)

#### What does this implement or fix?
Allows concatenating columns of type uint64 with columns of type int*