### PR TITLE
Fix for scheduled workflow build failures to appear in slack

### DIFF
--- a/.github/workflows/failure_notification.yaml
+++ b/.github/workflows/failure_notification.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   on-failure:
     runs-on: ubuntu-latest
+    # This condition aims to include scheduled workflow failures which does not appear on Slack. The reason is that they might not carry head_branch info
     if: |
       (github.event.workflow_run.conclusion == 'failure' || 
        github.event.workflow_run.conclusion == 'timed_out') &&

--- a/.github/workflows/failure_notification.yaml
+++ b/.github/workflows/failure_notification.yaml
@@ -3,12 +3,15 @@ on:
   workflow_run:
     workflows: ["Build and Test", "Build with conda", "Build with analysis tools", "Coverity Static Analysis", "Installation Tests Execution"]
     types: [completed]
-    branches: [master]
 
 jobs:
   on-failure:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+    if: |
+      (github.event.workflow_run.conclusion == 'failure' || 
+       github.event.workflow_run.conclusion == 'timed_out') &&
+      (github.event.workflow_run.head_branch == 'master' || 
+       github.event.workflow_run.head_branch == '')
     steps:
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
         with:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

The fix aims to include scheduled workflow failures which does not appear on Slack. The reason is that they might not carry head_branch info

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
