### PR TITLE
Respect legacy env vars

### DIFF
--- a/python/arcticdb/tools.py
+++ b/python/arcticdb/tools.py
@@ -14,6 +14,7 @@ from arcticdb_ext import set_config_int, set_config_string, set_config_double
 
 # Setting config from environment variables. This code is used in the package __init__.py
 _ARCTICDB_ENV_VAR_PREFIX = "ARCTICDB_"
+_ARCTIC_NATIVE_ENV_VAR_PREFIX = "ARCTIC_NATIVE_"
 _TYPE_INT = "INT"
 _TYPE_FLOAT = "FLOAT"
 _TYPE_STR = "STR"
@@ -38,7 +39,9 @@ def set_config_from_env_vars(env_vars: Dict[str, str]):
     for k, v in env_vars.items():
         k = k.upper()
         start_index = None
-        if k.startswith(_ARCTICDB_ENV_VAR_PREFIX):  # 1 underscore in prefix
+        if k.startswith(_ARCTIC_NATIVE_ENV_VAR_PREFIX):  # 2 underscores in prefix
+            start_index = 2
+        elif k.startswith(_ARCTICDB_ENV_VAR_PREFIX):  # 1 underscore in prefix
             start_index = 1
 
         if start_index is not None:

--- a/python/tests/unit/arcticdb/test_env_vars.py
+++ b/python/tests/unit/arcticdb/test_env_vars.py
@@ -8,7 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import pytest
 
 from unittest.mock import patch
-from arcticdb.tools import set_config_from_env_vars, _ARCTICDB_ENV_VAR_PREFIX
+from arcticdb.tools import set_config_from_env_vars, _ARCTICDB_ENV_VAR_PREFIX, _ARCTIC_NATIVE_ENV_VAR_PREFIX
 
 _MODULE = set_config_from_env_vars.__module__  # Insulate the tests from any move of the function
 
@@ -21,9 +21,10 @@ def mocks():
             yield {int: s_int, float: s_double, str: s_str}
 
 
+@pytest.mark.parametrize("prefix", [_ARCTICDB_ENV_VAR_PREFIX, _ARCTIC_NATIVE_ENV_VAR_PREFIX])
 @pytest.mark.parametrize("key, value", [("a_int", 42), ("a_float", 3.14), ("a_str", "text"), ("without_suffix", "xx")])
-def test_get_normal(key, value, mocks):
-    set_config_from_env_vars({_ARCTICDB_ENV_VAR_PREFIX + key: str(value)})
+def test_get_normal(prefix, key, value, mocks):
+    set_config_from_env_vars({prefix + key: str(value)})
     for typ, setter in mocks.items():
         if typ is type(value):
             setter.assert_called_with("a".upper() if key.startswith("a_") else "without.suffix".upper(), value)


### PR DESCRIPTION
#### What does this implement or fix?
The legacy Man-internal version of Arctic respected environment variables prefixed with both `ARCTICDB_` and `ARCTIC_NATIVE_`, enable the same here to ease migration.