### PR TITLE
Update recursive normalizers layout assertions

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
+++ b/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
@@ -577,7 +577,7 @@ def test_data_layout(lmdb_version_store_v1):
     # Check that keys are cleaned up when we prune
     lib.write("sym", data, recursive_normalizers=True, prune_previous_version=True)
     assert len(lt.find_keys(KeyType.VERSION_REF)) == 1
-    assert len(lt.find_keys(KeyType.VERSION)) == 4
+    assert len(lt.find_keys(KeyType.VERSION)) == 3
     assert len(lt.find_keys(KeyType.MULTI_KEY)) == 1
     assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 3
     assert len(lt.find_keys(KeyType.TABLE_DATA)) == 3
@@ -585,7 +585,7 @@ def test_data_layout(lmdb_version_store_v1):
     # Check that keys are cleaned up when we delete
     lib.delete("sym")
     assert len(lt.find_keys(KeyType.VERSION_REF)) == 1
-    assert len(lt.find_keys(KeyType.VERSION)) == 5
+    assert len(lt.find_keys(KeyType.VERSION)) == 4
     assert len(lt.find_keys(KeyType.MULTI_KEY)) == 0
     assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 0
     assert len(lt.find_keys(KeyType.TABLE_DATA)) == 0


### PR DESCRIPTION
This is to reflect PR #2352. Looking at its `version_map.hpp` change, we change from writing two version keys when we write and tombstone_all (one for the tombstone, one for the write) to folding them together in to a single version key. This has reduced the number of version keys we write by one.
