### PR TITLE
Fix link to the SL caching docs in warning

### DIFF
--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -74,7 +74,7 @@ std::vector<SymbolListEntry> load_previous_from_version_keys(
             log::symbol().warn(
                 "No compacted symbol list cache found. "
                 "`list_symbols` may take longer than expected. \n\n"
-                "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
+                "See here for more information: https://docs.arcticdb.io/latest/technical/on_disk_storage/#symbol-list-caching\n\n"
                 "To resolve, run `list_symbols` through to completion to compact the symbol list cache.\n"
                 "Note: This warning will only appear once.\n");
 
@@ -110,7 +110,7 @@ std::vector<AtomKey> get_all_symbol_list_keys(
         if (uncompacted_keys_found == warning_threshold() && !data.warned_expected_slowdown_) {
             log::symbol().warn(
                 "`list_symbols` may take longer than expected as there have been many modifications since `list_symbols` was last called. \n\n"
-                "See here for more information: https://docs.arcticdb.io/technical/on_disk_storage/#symbol-list-caching\n\n"
+                "See here for more information: https://docs.arcticdb.io/latest/technical/on_disk_storage/#symbol-list-caching\n\n"
                 "To resolve, run `list_symbols` through to completion frequently.\n"
                 "Note: This warning will only appear once.\n");
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Fixes the link in the SL caching warning to point to the correct page.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
