### PR TITLE
Fix s3 authentication test

### DIFF
--- a/python/tests/enduser/test_authentication.py
+++ b/python/tests/enduser/test_authentication.py
@@ -13,11 +13,19 @@ from tests.util.storage_test import real_gcp_credentials, real_s3_credentials
 logger = get_logger()
 
 
-s3_enpoint, s3_bucket, s3_region, s3_access_key, s3_secret_key, s3_prefix, s3_clear = \
+s3_endpoint, s3_bucket, s3_region, s3_access_key, s3_secret_key, s3_prefix, s3_clear = \
     real_s3_credentials(shared_path=False)
 gcp_enpoint, gcp_bucket, gcp_region, gcp_access_key, gcp_secret_key, gcp_prefix, gcp_clear = \
     real_gcp_credentials(shared_path=False)
 
+
+if "amazonaws.com" in s3_endpoint.lower():
+    web_address = f"s3.{s3_region}.amazonaws.com"
+else:
+    web_address = s3_endpoint
+    if s3_endpoint is not None and "://" in s3_endpoint:
+        web_address = s3_endpoint.split("://")[1] 
+    
 
 access_mark = "*access*"
 secret_mark = "*secret*"
@@ -57,23 +65,23 @@ def execute_uri_test(uri:str, expected: str, access: str, secret: str):
       
 
 @pytest.mark.parametrize("uri,expected", [
-    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&path_prefix=abc", 
+    (f"s3://{web_address}:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
+    (f"s3s://{web_address}:{s3_bucket}?access={access_mark}&secret={secret_mark}", None),
+    (f"s3s://{web_address}:{s3_bucket}?access={access_mark}&secret={secret_mark}&path_prefix=abc", 
      None),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False",
+    (f"s3s://{web_address}:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=False",
       None),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", 
+    (f"s3s://{web_address}:{s3_bucket}?access={access_mark}&secret={secret_mark}&aws_auth=True", 
      "E_PERMISSION Permission error"),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secrets={secret_mark}", 
+    (f"s3s://{web_address}:{s3_bucket}?access={access_mark}&secrets={secret_mark}", 
      "Invalid S3 URI. Invalid query parameter"),
-    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}&secret={secret_mark}1", 
+    (f"s3://{web_address}:{s3_bucket}?access={access_mark}&secret={secret_mark}1", 
      "SignatureDoesNotMatch"),
-    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}1&secret={secret_mark}", 
+    (f"s3://{web_address}:{s3_bucket}?access={access_mark}1&secret={secret_mark}", 
      "InvalidAccessKeyId"),
-    (f"s3s://s3.{s3_region}.amazonaws.com:{s3_bucket}?access={access_mark}", 
+    (f"s3s://{web_address}:{s3_bucket}?access={access_mark}", 
      "AccessDenied: Access Denied for object"),
-    (f"s3://s3.{s3_region}.amazonaws.com:{s3_bucket}?secret={secret_mark}", 
+    (f"s3://{web_address}:{s3_bucket}?secret={secret_mark}", 
      "E_PERMISSION Permission error"),
 ])
 @REAL_S3_TESTS_MARK


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

This test assumes S3 URLs are always AWS. They can be VAST, Pure etc, The fix not does not make this assumption and makes a distinction

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
