### PR TITLE
Fix moto teardown rare problem

### DIFF
--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -880,9 +880,13 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
                 if e.response["Error"]["Code"] != "NoSuchBucket" and not is_win_37:
                     raise e
         else:
-            requests.post(
-                self._iam_endpoint + "/moto-api/reset", verify=False
-            )  # If CA cert verify fails, it will take ages for this line to finish
+            try:
+                requests.post(
+                    self._iam_endpoint + "/moto-api/reset", verify=False
+                )  # If CA cert verify fails, it will take ages for this line to finish
+            except Exception:
+                # We clean bucket at session level so failure here does not matter
+                pass            
             self._iam_admin = None
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Address teardown error: https://github.com/man-group/ArcticDB/actions/runs/13861408824/job/38790568264

```
ERROR tests/integration/arcticdb/test_arctic_batch.py::test_write_metadata_batch_with_none[nfs_backed_s3-0] - requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=13635): Max retries exceeded with url: /moto-api/reset (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x14ece9c10>: Failed to establish a new connection: [Errno 61] Connection refused'))
= 7609 passed, 1848 skipped, 82 xfailed, 7 xpassed, 96189 warnings, 1 error in 1210.77s (0:20:10) =
```

the fix is safe - the fixture is at session scope and no test will run after that, moreover this is not real storage but simulated one

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
