### PR TITLE
Fixes to run tests at Man

### DIFF
--- a/python/tests/integration/arcticdb/version_store/test_deletion.py
+++ b/python/tests/integration/arcticdb/version_store/test_deletion.py
@@ -331,6 +331,8 @@ def test_delete_versions_with_update(object_version_store, versions_to_delete, s
             expected = expected.combine_first(d)
             if not expected.empty:
                 expected.loc[d.index] = d
+        # pandas 1.0 patch, otherwise the col will be float64
+        expected['x'] = expected['x'].astype('int64')
         return expected
 
     # Write initial data
@@ -395,6 +397,8 @@ def test_delete_versions_with_update_large_data(object_version_store, versions_t
             expected = expected.combine_first(d)
             if not expected.empty:
                 expected.loc[d.index] = d
+        # pandas 1.0 patch, otherwise the col will be float64
+        expected['x'] = expected['x'].astype('int64')
         return expected
 
     # Write initial data


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

1. A test now accepts several possible errors as different S3 storages might have different errors.
2 A new test is failing because on pandas 1.X which is at pegagus>next the x column will be silently converted to float64

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
