### PR TITLE
9220057136: Allow block manager consolidation in Pandas < 2

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -738,6 +738,13 @@ class DataFrameNormalizer(_PandasNormalizer):
         super(DataFrameNormalizer, self).__init__(*args, **kwargs)
         self._skip_df_consolidation = IS_PANDAS_TWO and os.getenv("SKIP_DF_CONSOLIDATION") is not None
 
+    def set_skip_df_consolidation(self):
+        if IS_PANDAS_TWO:
+            self._skip_df_consolidation = True
+        else:
+            self._skip_df_consolidation = False
+
+
     def df_without_consolidation(self, columns, index, item, n_indexes, data):
         """
         This is a hack that allows us to monkey-patch the DataFrame Block Manager so it doesn't do any

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -736,7 +736,7 @@ class DataFrameNormalizer(_PandasNormalizer):
 
     def __init__(self, *args, **kwargs):
         super(DataFrameNormalizer, self).__init__(*args, **kwargs)
-        self._skip_df_consolidation = os.getenv("SKIP_DF_CONSOLIDATION") is not None
+        self._skip_df_consolidation = IS_PANDAS_TWO and os.getenv("SKIP_DF_CONSOLIDATION") is not None
 
     def df_without_consolidation(self, columns, index, item, n_indexes, data):
         """

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -750,8 +750,7 @@ class Library:
         """
         self.arctic_instance_desc = arctic_instance_description
         self._nvs = nvs
-        if IS_PANDAS_TWO:
-            self._nvs._normalizer.df._skip_df_consolidation = True
+        self._nvs._normalizer.df.set_skip_df_consolidation()
         self._dev_tools = DevTools(nvs)
 
     def __repr__(self):

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -750,7 +750,8 @@ class Library:
         """
         self.arctic_instance_desc = arctic_instance_description
         self._nvs = nvs
-        self._nvs._normalizer.df._skip_df_consolidation = True
+        if IS_PANDAS_TWO:
+            self._nvs._normalizer.df._skip_df_consolidation = True
         self._dev_tools = DevTools(nvs)
 
     def __repr__(self):

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -1066,7 +1066,7 @@ def test_required_field_inclusion(version_store_factory, dynamic_schema, segment
 def test_pandas_consolidation(lmdb_version_store_v1, skip_df_consolidation):
     lib = lmdb_version_store_v1
     sym = "test_pandas_consolidation"
-    lib._normalizer.df._skip_df_consolidation = skip_df_consolidation
+    lib._normalizer.df._skip_df_consolidation = IS_PANDAS_TWO and skip_df_consolidation
     # Two columns of the same type can be consolidated
     df = pd.DataFrame({"col1": np.arange(5), "col2": np.arange(5, 10)})
     lib.write(sym, df)

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -1066,7 +1066,8 @@ def test_required_field_inclusion(version_store_factory, dynamic_schema, segment
 def test_pandas_consolidation(lmdb_version_store_v1, skip_df_consolidation):
     lib = lmdb_version_store_v1
     sym = "test_pandas_consolidation"
-    lib._normalizer.df._skip_df_consolidation = IS_PANDAS_TWO and skip_df_consolidation
+    if skip_df_consolidation:
+        lib._normalizer.df.set_skip_df_consolidation()
     # Two columns of the same type can be consolidated
     df = pd.DataFrame({"col1": np.arange(5), "col2": np.arange(5, 10)})
     lib.write(sym, df)


### PR DESCRIPTION
#### Reference Issues/PRs
[9220057136](https://man312219.monday.com/boards/7852509418/pulses/9220057136)

#### What does this implement or fix?
Pandas < 2 has a bug for which some operations do not work or produce results with the wrong dtype if the block manager has not been allowed to consolidate. This change makes it so that dataframe consolidation is only ever skipped in Pandas 2.X