### PR TITLE
Fix ASV Real test

### DIFF
--- a/python/benchmarks/real_modification_functions.py
+++ b/python/benchmarks/real_modification_functions.py
@@ -295,6 +295,7 @@ class AWSDeleteTestsFewLarge(AsvBase):
         self.setup_symbol(self.lib, writes_list)
         self.get_logger().info(f"Library {self.lib}")
         assert self.lib.has_symbol(self.symbol)
+        self.symbol_deleted = False
 
     def setup_symbol(self, lib: Library, writes_list: List[pd.DataFrame]):
         logger = self.get_logger()
@@ -307,11 +308,14 @@ class AWSDeleteTestsFewLarge(AsvBase):
             logger.info(f"Appended frame {frame.shape[0]}")
 
     def teardown(self, cache, num_rows):
-        assert not self.lib.has_symbol(self.symbol)
+        ## This is check only for standard delete operation
+        if self.symbol_deleted:
+            assert not self.lib.has_symbol(self.symbol)
         self.get_library_manager().clear_all_modifiable_libs_from_this_process()
 
     def time_delete(self, cache, num_rows):
         self.lib.delete(self.symbol)
+        self.symbol_deleted = True
 
     def time_delete_over_time(self, cache, num_rows):
         with config_context("VersionMap.ReloadInterval", 0):


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

The time_delete tests has a verification which should be triggered only when it has been really executed.


#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
