### PR TITLE
Bugfix/9256801170/memory over allocation when reading shorts dfs

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -920,6 +920,7 @@ if(${TEST})
             codec/test/test_encode_field_collection.cpp
             codec/test/test_segment_header.cpp
             codec/test/test_encoded_field.cpp
+            column_store/test/test_chunked_buffer.cpp
             column_store/test/ingestion_stress_test.cpp
             column_store/test/test_column.cpp
             column_store/test/test_column_data_random_accessor.cpp
@@ -1100,7 +1101,6 @@ if(${TEST})
             column_store/test/rapidcheck_column.cpp
             column_store/test/rapidcheck_column_data_random_accessor.cpp
             column_store/test/rapidcheck_column_map.cpp
-            column_store/test/test_chunked_buffer.cpp
             processing/test/rapidcheck_resample.cpp
             stream/test/stream_test_common.cpp
             util/test/rapidcheck_decimal.cpp

--- a/cpp/arcticdb/column_store/chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.cpp
@@ -80,7 +80,7 @@ ChunkedBufferImpl<BlockSize> truncate(const ChunkedBufferImpl<BlockSize>& input,
 
     // This is trivially extendable to use presized_in_blocks, but there is no use case for this right now, and
     // copy_frame_data_to_buffer expects a contiguous buffer
-    auto output = ChunkedBufferImpl<BlockSize>::presized(output_size, entity::AllocationType::PRESIZED);
+    auto output = ChunkedBufferImpl<BlockSize>::presized(output_size);
     auto target_block = *output.blocks().begin();
 
     const auto& input_blocks = input.blocks();

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -92,6 +92,9 @@ class ChunkedBufferImpl {
 
     ChunkedBufferImpl() = default;
 
+    explicit ChunkedBufferImpl(entity::AllocationType allocation_type) :
+            allocation_type_(allocation_type) {}
+
     explicit ChunkedBufferImpl(size_t size) {
         reserve(size);
     }
@@ -145,8 +148,14 @@ class ChunkedBufferImpl {
         *this = std::move(other);
     }
 
-    static auto presized(size_t size, entity::AllocationType allocation_type) {
-        ChunkedBufferImpl output(size, allocation_type);
+    static auto presized(size_t size) {
+        ChunkedBufferImpl output(entity::AllocationType::PRESIZED);
+        if (size > 0) {
+            if (size != DefaultBlockSize) {
+                output.handle_transition_to_irregular();
+            }
+            output.add_block(size, 0UL);
+        }
         output.ensure(size);
         return output;
     }

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -164,7 +164,7 @@ void Column::unsparsify(size_t num_rows) {
         using TagType = decltype(tdt);
         using RawType = typename TagType::DataTypeTag::raw_type;
         const auto dest_bytes = num_rows * sizeof(RawType);
-        auto dest = ChunkedBuffer::presized(dest_bytes, entity::AllocationType::PRESIZED);
+        auto dest = ChunkedBuffer::presized(dest_bytes);
         util::default_initialize<TagType>(dest.data(), dest_bytes);
         util::expand_dense_buffer_using_bitmap<RawType>(sparse_map_.value(), data_.buffer().data(), dest.data());
         std::swap(dest, data_.buffer());

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -84,7 +84,7 @@ RawType* flatten_tensor(
         size_t slice_num,
         size_t regular_slice_size
         ) {
-    flattened_buffer = ChunkedBuffer::presized(rows_to_write * sizeof(RawType), entity::AllocationType::PRESIZED);
+    flattened_buffer = ChunkedBuffer::presized(rows_to_write * sizeof(RawType));
     TypedTensor<RawType> t(tensor, slice_num, regular_slice_size, rows_to_write);
     util::FlattenHelper flattener{t};
     auto dst = reinterpret_cast<RawType*>(flattened_buffer->data());
@@ -220,7 +220,7 @@ void set_bool_object_type(
     util::BitSet bitset = util::scan_object_type_to_sparse(ptr_data, rows_to_write);
 
     const auto num_values = bitset.count();
-    auto bool_buffer = ChunkedBuffer::presized(num_values * sizeof(uint8_t), entity::AllocationType::PRESIZED);
+    auto bool_buffer = ChunkedBuffer::presized(num_values * sizeof(uint8_t));
     auto bool_ptr = bool_buffer.ptr_cast<uint8_t>(0u, num_values);
     for (auto it = bitset.first(); it < bitset.end(); ++it) {
         *bool_ptr = static_cast<uint8_t>(PyObject_IsTrue(ptr_data[*it]));

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -29,7 +29,6 @@ inline void apply_type_handlers(SegmentInMemory seg, std::any& handler_data, Out
         if(auto handler = get_type_handler(output_format, column.type()); handler) {
             ColumnMapping mapping{column.type(), column.type(), seg.field(i), 0, seg.row_count(), 0, 0, 0, i};
             Column dest_column(column.type(), seg.row_count(), AllocationType::PRESIZED, Sparsity::PERMITTED, output_format, DataTypeMode::EXTERNAL);
-            //auto buffer = ChunkedBuffer::presized(seg.row_count() * data_type_size(column.type(), output_format, DataTypeMode::EXTERNAL), AllocationType::PRESIZED);
             handler->convert_type(column, dest_column, mapping, shared_data, handler_data, seg.string_pool_ptr());
             std::swap(column, dest_column);
         }

--- a/cpp/arcticdb/pipeline/string_reducers.hpp
+++ b/cpp/arcticdb/pipeline/string_reducers.hpp
@@ -59,7 +59,7 @@ public:
         frame_(std::move(frame)),
         src_buffer_(column.data().buffer()),
         column_width_(alloc_width),
-        dest_buffer_(ChunkedBuffer::presized(frame_.row_count() * column_width_, entity::AllocationType::PRESIZED)),
+        dest_buffer_(ChunkedBuffer::presized(frame_.row_count() * column_width_)),
         dst_(dest_buffer_.data()) {
         if (dest_buffer_.bytes() > 0) {
             std::memset(dest_buffer_.data(), 0, dest_buffer_.bytes());

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -69,7 +69,7 @@ struct Buffer : public BaseBuffer<Buffer, true> {
         check_invariants();
     }
 
-    static auto presized(size_t size, entity::AllocationType) {
+    static auto presized(size_t size) {
         return Buffer(size);
     };
 

--- a/cpp/arcticdb/util/cursored_buffer.hpp
+++ b/cpp/arcticdb/util/cursored_buffer.hpp
@@ -23,7 +23,7 @@ public:
 
     CursoredBuffer(size_t size, AllocationType allocation_type) :
         cursor_(allocation_type == AllocationType::PRESIZED ? static_cast<int64_t>(size) : 0),
-        buffer_(allocation_type == AllocationType::DYNAMIC ? BufferType{size} : BufferType::presized(size, allocation_type)) { }
+        buffer_(allocation_type == AllocationType::DYNAMIC ? BufferType{size} : BufferType::presized(size)) { }
 
     explicit CursoredBuffer(BufferType&& buffer) :
         cursor_(0),

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -132,7 +132,7 @@ ChunkedBuffer scan_floating_point_to_sparse(
     }
 
     const auto bytes = block_bitset.count() * sizeof(RawType);
-    auto dense_buffer = ChunkedBuffer::presized(bytes, entity::AllocationType::PRESIZED);
+    auto dense_buffer = ChunkedBuffer::presized(bytes);
     auto start = reinterpret_cast<const uint8_t *>(ptr);
     densify_buffer_using_bitmap<RawType>(block_bitset, dense_buffer, start);
     return dense_buffer;

--- a/cpp/arcticdb/util/test/test_bitmagic.cpp
+++ b/cpp/arcticdb/util/test/test_bitmagic.cpp
@@ -46,7 +46,7 @@ TEST(BitMagic, DensifyAndExpand) {
             bv[idx] = true;
         }
     }
-    auto dense_buffer = ChunkedBuffer::presized(sizeof(float) * n_dense, entity::AllocationType::PRESIZED);
+    auto dense_buffer = ChunkedBuffer::presized(sizeof(float) * n_dense);
     auto *ptr = reinterpret_cast<uint8_t *>(&sample_data[0]);
     arcticdb::util::densify_buffer_using_bitmap<float>(bv, dense_buffer, ptr);
     auto *dense_array = reinterpret_cast<float *>(dense_buffer.data());


### PR DESCRIPTION
#### Reference Issues/PRs
[9256801170](https://man312219.monday.com/boards/7852509418/pulses/9256801170)

#### What does this implement or fix?
When presizing a `ChunkedBuffer`, the behaviour was to round this up to the default block size (3968 bytes) if fewer bytes were requested, resulting in a major over-allocation if the buffer would only ever hold a few values.
Inspecting the code makes it clear that this method is only ever used with buffers that will never subsequently be expanded, and so there is no benefit to this overallocation, and we should always create a block that has exactly the correct buffer size.

The test output from the newly added tests (these will be backed out prior to merging):
```
	test_read_short_sym
		pre-fix
			RSS: 849.41 MB
			RSS: 1370.93 MB
			RSS: 2002.95 MB
			RSS: 2525.48 MB
			RSS: 3158.48 MB
			RSS: 3736.20 MB
			RSS: 4258.29 MB
			RSS: 4834.31 MB
			RSS: 5468.00 MB
			RSS: 6100.84 MB
		post-fix
			RSS: 457.21 MB
			RSS: 586.88 MB
			RSS: 826.82 MB
			RSS: 956.86 MB
			RSS: 1197.72 MB
			RSS: 1383.61 MB
			RSS: 1513.94 MB
			RSS: 1697.97 MB
			RSS: 1939.73 MB
			RSS: 2180.68 MB
	test_read_long_sym_date_range
		pre-fix
			RSS: 1105.40 MB
			RSS: 1675.86 MB
			RSS: 2246.67 MB
			RSS: 2821.30 MB
			RSS: 3391.05 MB
			RSS: 3967.81 MB
			RSS: 4542.89 MB
			RSS: 5109.78 MB
			RSS: 5685.29 MB
			RSS: 6254.56 MB
		post-fix
			RSS: 714.96 MB
			RSS: 895.02 MB
			RSS: 1076.36 MB
			RSS: 1258.63 MB
			RSS: 1435.95 MB
			RSS: 1618.65 MB
			RSS: 1801.58 MB
			RSS: 1984.29 MB
			RSS: 2166.22 MB
			RSS: 2344.72 MB
```

#### Any other comments?
Even with this change, we are still holding onto a lot of memory in addition to the raw buffers required to back the numpy arrays. A more thorough fix will come as part of [9106978040](https://man312219.monday.com/boards/7852509418/pulses/9106978040) once the initial Arrow reading PR is merged