### PR TITLE
Enhancement 9351235967: Support projecting a column of constant values

### DIFF
--- a/cpp/arcticdb/processing/expression_context.hpp
+++ b/cpp/arcticdb/processing/expression_context.hpp
@@ -58,7 +58,7 @@ struct ExpressionContext {
     ConstantMap<ExpressionNode> expression_nodes_;
     ConstantMap<Value> values_;
     ConstantMap<ValueSet> value_sets_;
-    ExpressionName root_node_name_;
+    VariantNode root_node_name_;
     bool dynamic_schema_{false};
 };
 

--- a/cpp/arcticdb/processing/test/test_output_schema_ast_validity.cpp
+++ b/cpp/arcticdb/processing/test/test_output_schema_ast_validity.cpp
@@ -222,6 +222,13 @@ TEST_F(AstParsingOutputTypesTest, FilterComplexExpression) {
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
+TEST_F(AstParsingOutputTypesTest, FilterValue) {
+    auto value = std::make_shared<Value>(construct_value<uint16_t>(2));
+    ec.add_value("2", value);
+    ec.root_node_name_ = ValueName("2");
+    ASSERT_THROW(FilterClause({}, ec, {}), UserInputException);
+}
+
 TEST_F(AstParsingOutputTypesTest, ProjectionAbsNumeric) {
     ec.add_expression_node("root", std::make_shared<ExpressionNode>(ColumnName("int32"), OperationType::ABS));
     ProjectClause project_clause{{"int32"}, "root", ec};
@@ -305,6 +312,17 @@ TEST_F(AstParsingOutputTypesTest, ProjectionComplexExpression) {
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
     stream_desc.add_scalar_field(DataType::INT64, "root");
+    ASSERT_EQ(output_schema.stream_descriptor(), stream_desc);
+}
+
+TEST_F(AstParsingOutputTypesTest, ProjectionValue) {
+    auto value = std::make_shared<Value>(construct_value<uint16_t>(2));
+    ec.add_value("2", value);
+    ec.root_node_name_ = ValueName("2");
+    ProjectClause project_clause{{}, "new_col", ec};
+    auto output_schema = project_clause.modify_schema(initial_schema());
+    auto stream_desc = initial_schema().stream_descriptor();
+    stream_desc.add_scalar_field(DataType::UINT16, "new_col");
     ASSERT_EQ(output_schema.stream_descriptor(), stream_desc);
 }
 

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -1245,6 +1245,13 @@ def visit_expression(expr):
     expression_context = _ExpressionContext()
     input_columns = set()
     valueset_keys = dict()
-    _visit(expr)
-    expression_context.root_node_name = _ExpressionName(expr.get_name())
+    if isinstance(expr, ExpressionNode):
+        _visit(expr)
+        expression_context.root_node_name = _ExpressionName(expr.get_name())
+    elif isinstance(expr, (np.ndarray, list)):
+        raise ArcticNativeException("Query cannot create a new column from a list/set/array of values")
+    else:
+        key = to_string(expr)
+        expression_context.add_value(key, create_value(expr))
+        expression_context.root_node_name = _ValueName(key)
     return input_columns, expression_context

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -148,6 +148,23 @@ def test_lazy_project(lmdb_library):
     assert_frame_equal(expected, received)
 
 
+def test_lazy_project_constant_value(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_project"
+    df = pd.DataFrame(
+        {"col1": np.arange(10, dtype=np.int64), "col2": np.arange(100, 110, dtype=np.int64)}, index=pd.date_range("2000-01-01", periods=10)
+    )
+    lib.write(sym, df)
+
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df["new_col"] = 5
+    received = lazy_df.collect().data
+    expected = df
+    expected["new_col"] = 5
+
+    assert_frame_equal(expected, received, check_dtype=False)
+
+
 def test_lazy_ternary(lmdb_library):
     lib = lmdb_library
     sym = "test_lazy_ternary"


### PR DESCRIPTION
#### Reference Issues/PRs
[9351235967](https://man312219.monday.com/boards/7852509418/pulses/9351235967)

#### What does this implement or fix?
Allow projections with a constant value of the form:
```
lazy_df = lib.read(sym, lazy=True)
lazy_df["new_col"] = 5
```