### PR TITLE
[Cherry-pick] Fix V2 API created from V1 API when use_norm_failure_handler_known_ty…

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1152,6 +1152,10 @@ class KnownTypeFallbackOnError(Normalizer):
         self._delegate = delegate
         self._failure_handler = nfh
 
+    def set_skip_df_consolidation(self):
+        if isinstance(self._delegate, DataFrameNormalizer):
+            self._delegate.set_skip_df_consolidation()
+
     def normalize(self, item, **kwargs):
         try:
             return self._delegate.normalize(item, **kwargs)
@@ -1179,6 +1183,10 @@ class CompositeNormalizer(Normalizer):
 
         self.msg_pack_denorm = MsgPackNormalizer()  # must exist for deserialization
         self.fallback_normalizer = fallback_normalizer
+
+
+    def set_skip_df_consolidation(self):
+        self.df.set_skip_df_consolidation()
 
     def _normalize(
         self, item, string_max_len=None, dynamic_strings=False, coerce_columns=None, empty_types=False, **kwargs

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -14,6 +14,7 @@ import sys
 from arcticdb import QueryBuilder
 from arcticdb.exceptions import UserInputException
 from arcticdb.util.test import assert_frame_equal, assert_series_equal
+from arcticdb.version_store.library import Library
 from arcticdb_ext import set_config_int
 from arcticdb_ext.storage import KeyType
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
@@ -477,3 +478,8 @@ def test_update_data_key_timestamps(lmdb_version_store_v1, date_range):
     index_df = lib.read_index(sym)
     assert (index_df.index.to_numpy() == np.array([0, 5, 20], dtype="datetime64[ns]")).all()
     assert (index_df["end_index"].to_numpy() == np.array([1, 16, 21], dtype="datetime64[ns]")).all()
+
+
+def test_use_norm_failure_handler_known_types(lmdb_version_store_allows_pickling):
+    nvs = lmdb_version_store_allows_pickling
+    Library("dummy", nvs)


### PR DESCRIPTION
…pes=True (#2421)

#### Reference Issues/PRs

[9429419146](https://man312219.monday.com/boards/7852509418/pulses/9429419146)

#### What does this implement or fix?
Fixes creation of `Library` object from `NativeVersionStore` object when `use_norm_failure_handler_known_types=True`

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
