### PR TITLE
fix problem with pandas 1.0.5 and empty dataframe comparison

### DIFF
--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -213,14 +213,6 @@ def maybe_not_check_freq(f):
     def wrapper(*args, **kwargs):
         if PANDAS_VERSION >= CHECK_FREQ_VERSION and "check_freq" not in kwargs:
             kwargs["check_freq"] = False
-        else:
-            # With 1.1.0  this is fixed but until then if both dataframes 
-            # are empty object columns will be translated to float64
-            # therefore best is to check for column names only in that edge case
-            df1 = kwargs["left"]
-            df2 = kwargs["right"]
-            if df1.shape[0] == df2.shape[0] and df1.shape[0] == 0:
-                assert df1.columns.equals(df2.columns)
         try:
             return f(*args, **kwargs)
         except AssertionError as ae:

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -252,6 +252,10 @@ def assert_frame_equal_rebuild_index_first(expected: pd.DataFrame, actual: pd.Da
     First will rebuild index for dataframes to assure we
     have same index in both frames when row range index is used
     """
+    if PANDAS_VERSION < CHECK_FREQ_VERSION:
+        if expected.shape[0] == expected.shape[0] and expected.shape[0] == 0:
+            assert expected.columns.equals(expected.columns)    
+            return
     expected.reset_index(inplace=True, drop=True)
     actual.reset_index(inplace=True, drop=True)
     assert_frame_equal(left=expected, right=actual)

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -213,6 +213,14 @@ def maybe_not_check_freq(f):
     def wrapper(*args, **kwargs):
         if PANDAS_VERSION >= CHECK_FREQ_VERSION and "check_freq" not in kwargs:
             kwargs["check_freq"] = False
+        else:
+            # With 1.1.0  this is fixed but until then if both dataframes 
+            # are empty object columns will be translated to float64
+            # therefore best is to check for column names only in that edge case
+            df1 = kwargs["left"]
+            df2 = kwargs["right"]
+            if df1.shape[0] == df2.shape[0] and df1.shape[0] == 0:
+                assert df1.columns.equals(df2.columns)
         try:
             return f(*args, **kwargs)
         except AssertionError as ae:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

With pandas prior to ver 1.1.0 we have a problem with assert_equals behavior of arcticdb and pandas frames due to mapping of string column to float64.

See log: https://manbuild-ci.res.m/blue/organizations/jenkins/manbuilds%2Fpegasus%2Fnext%2FDATA%2Fman.arcticdb-master/detail/vast_tests/37/tests/

```
Error
AssertionError: Attributes of DataFrame.iloc[:, 3] (column name="short") are different  Attribute "dtype" are different [left]:  object [right]: float64
Stacktrace
arctic_library = Library(Arctic(config=LMDB(path=/tmp/pytest-of-ahldev/pytest-0/test_read_batch_query_and_colu0)), path=test_read_batch_query_and_colu.78_140177544009536_2025-06-24T11_38_34__c090cd38-095c-49ad-9962-4e4c6420ed88, storage=lmdb_storage)
    @pytest.mark.storage
    def test_read_batch_query_and_columns(arctic_library):
    
        def q1(q):
            return q[(q["short"].isin(["A", "B", "C", "Z"])) & (q["bool"] == True)]
    
        def q2(q):
            return q[q["long"] == 'impossible to match']
    
        def q3(q):
            return q[q["uint8"] > 155]
    
        lib = arctic_library
    
        symbol = "sym"
        df1 = generate_mixed_dataframe(num_rows=100)
        df2 = generate_mixed_dataframe(num_rows=50)
        df_all = pd.concat([df1, df2],ignore_index=True)
        df_all.reset_index(inplace = True, drop = True)
        metadata = {"name" : "SomeInterestingName", "info" : [1,3,5,6]}
        columns1 = ['int32', 'float64', 'bool', 'short']
        columns2 = ['bool', 'long']
        columns3 = ["uint8", "strings", "int16", "bool"]
        columns_one_1 = ["long"]
        columns_one_2 = ["bool"]
        columns_one_3 = ["int64"]
        columns_wrong = ["wrong", "uint8", "float32", "int32", "bool", "wrong"]
        columns_mixed = ['int32', 'float64', 'short', 'bool']
    
        lib.write(symbol, df1)
        lib.append(symbol, df2, metadata=metadata)
    
        batch = lib.read_batch(symbols=[ReadRequest(symbol, as_of=0, query_builder=q3(QueryBuilder()), columns=columns3),
                                        ReadRequest(symbol, query_builder=q1(QueryBuilder()), columns=columns1),
                                        ReadRequest(symbol, query_builder=q2(QueryBuilder()), columns=columns2),
                                        ReadRequest(symbol, query_builder=q3(QueryBuilder()), columns=columns_one_1),
                                        ReadRequest(symbol, query_builder=q2(QueryBuilder()), columns=columns_one_2, as_of=0),
                                        ReadRequest(symbol, query_builder=q1(QueryBuilder()), columns=columns_one_3, as_of=0),
                                        ReadRequest(symbol, query_builder=q1(QueryBuilder()), columns=[], as_of=0)
                                        ])
    
        print(q3(df_all)[columns3])
    
        df_filtered = q3(df1)[columns3]
        assert_frame_equal_rebuild_index_first(df_filtered, batch[0].data)
        assert batch[0].metadata is None
        df_filtered = q1(df_all)[columns1]
>       assert_frame_equal_rebuild_index_first(df_filtered, batch[1].data)
python/tests/integration/arcticdb/test_read_batch_more.py:472: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
python/arcticdb/util/test.py:249: in assert_frame_equal_rebuild_index_first
    assert_frame_equal(left=expected, right=actual)
python/arcticdb/util/test.py:230: in wrapper
    raise ae
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
args = ()
kwargs = {'left': Empty DataFrame
Columns: [int32, float64, bool, short]
Index: [], 'right': Empty DataFrame
Columns: [int32, float64, bool, short]
Index: []}
df = Empty DataFrame
Columns: [int32, float64, bool, short]
Index: []
    @wraps(f)
    def wrapper(*args, **kwargs):
        if PANDAS_VERSION >= CHECK_FREQ_VERSION and "check_freq" not in kwargs:
            kwargs["check_freq"] = False
        try:
>           return f(*args, **kwargs)
E           AssertionError: Attributes of DataFrame.iloc[:, 3] (column name="short") are different
E           
E           Attribute "dtype" are different
E           [left]:  object
E           [right]: float64
python/arcticdb/util/test.py:217: AssertionError
Standard Output
uint8     strings  int16   bool
0      172  ÔÞøêâÜ±ä®Ñ    967   True
5      170  IW59U23SY7  31221   True
6      196  ÈïéHÂ¹ËZÌB -10197   True
9      166  8KYO7M3APA   7710   True
11     183  ¬ìĀÏ¯Cú÷þÖ -20998  False
..     ...         ...    ...    ...
139    159  VR36S1VJ0J  -3466   True
143    165  27LL6TSV5D  22702   True
144    242  L4E5NI9QAG   8131  False
145    214  TFQT4QOSKX  31363  False
149    183  Z1T1KI51SW -25153  False
[65 rows x 4 columns]
--------------------------------------------------------------------------------
No full dataframes dumps when shorter logs is activated
--------------------------------------------------------------------------------
No full dataframes dumps when shorter logs is activated
```

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
