### PR TITLE
Implement summming of bools as uint64 instead of bool

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -972,6 +972,7 @@ if(${TEST})
             processing/test/test_set_membership.cpp
             processing/test/test_signed_unsigned_comparison.cpp
             processing/test/test_type_comparison.cpp
+            processing/test/test_unsorted_aggregation.cpp
             storage/test/test_local_storages.cpp
             storage/test/test_memory_storage.cpp
             storage/test/test_s3_storage.cpp

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -191,6 +191,7 @@ constexpr uint8_t combine_val_bits(ValueType v, SizeBits b = SizeBits::UNKNOWN_S
 
 } // namespace anonymous
 
+// When adding DataType here add it to the all_data_types function
 enum class DataType : uint8_t {
     UINT8 = detail::combine_val_bits(ValueType::UINT, SizeBits::S8),
     UINT16 = detail::combine_val_bits(ValueType::UINT, SizeBits::S16),
@@ -214,6 +215,31 @@ enum class DataType : uint8_t {
 #undef DT_COMBINE
     UNKNOWN = 0,
 };
+
+// C++26's reflection will make this obsolete
+consteval auto all_data_types() {
+    return std::array{
+        DataType::UINT8,
+        DataType::UINT16,
+        DataType::UINT32,
+        DataType::UINT64,
+        DataType::INT8,
+        DataType::INT16,
+        DataType::INT32,
+        DataType::INT64,
+        DataType::FLOAT32,
+        DataType::FLOAT64,
+        DataType::BOOL8,
+        DataType::NANOSECONDS_UTC64,
+        DataType::ASCII_FIXED64,
+        DataType::ASCII_DYNAMIC64,
+        DataType::UTF_FIXED64,
+        DataType::UTF_DYNAMIC64,
+        DataType::EMPTYVAL,
+        DataType::BOOL_OBJECT8,
+        DataType::UTF_DYNAMIC32
+    };
+}
 
 std::string_view datatype_to_str(DataType dt);
 

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -216,31 +216,6 @@ enum class DataType : uint8_t {
     UNKNOWN = 0,
 };
 
-// C++26's reflection will make this obsolete
-consteval auto all_data_types() {
-    return std::array{
-        DataType::UINT8,
-        DataType::UINT16,
-        DataType::UINT32,
-        DataType::UINT64,
-        DataType::INT8,
-        DataType::INT16,
-        DataType::INT32,
-        DataType::INT64,
-        DataType::FLOAT32,
-        DataType::FLOAT64,
-        DataType::BOOL8,
-        DataType::NANOSECONDS_UTC64,
-        DataType::ASCII_FIXED64,
-        DataType::ASCII_DYNAMIC64,
-        DataType::UTF_FIXED64,
-        DataType::UTF_DYNAMIC64,
-        DataType::EMPTYVAL,
-        DataType::BOOL_OBJECT8,
-        DataType::UTF_DYNAMIC32
-    };
-}
-
 std::string_view datatype_to_str(DataType dt);
 
 constexpr DataType combine_data_type(ValueType v, SizeBits b = SizeBits::UNKNOWN_SIZE_BITS) {

--- a/cpp/arcticdb/pipeline/test/test_pipeline.cpp
+++ b/cpp/arcticdb/pipeline/test/test_pipeline.cpp
@@ -9,15 +9,12 @@
 
 #include <folly/futures/Future.h>
 #include <arcticdb/column_store/memory_segment.hpp>
-#include <folly/Range.h>
 #include <arcticdb/util/preconditions.hpp>
 #include <unordered_map>
-#include <any>
 #include <string>
 #include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/util/test/generators.hpp>
 #include <variant>
-#include <arcticdb/util/variant.hpp>
 #include <arcticdb/stream/test/stream_test_common.hpp>
 
 

--- a/cpp/arcticdb/pipeline/test/test_value.cpp
+++ b/cpp/arcticdb/pipeline/test/test_value.cpp
@@ -12,7 +12,7 @@ TEST(Value, DefaultConstruct) {
 
 class ValueDataType : public ::testing::TestWithParam<DataType> {};
 
-constexpr auto data_types() {
+consteval auto data_types() {
     return std::array{
         DataType::INT8,
         DataType::INT16,

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -809,13 +809,13 @@ std::vector<EntityId> ResampleClause<closed_boundary>::process(std::vector<Entit
     // Resampling only makes sense for timestamp indexes
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(is_time_type(first_row_slice_index_col.type().data_type()),
                                                     "Cannot resample data with index column of non-timestamp type");
-    const auto first_ts = first_row_slice_index_col.scalar_at<timestamp>(0).value();
+    const auto first_ts = first_row_slice_index_col.template scalar_at<timestamp>(0).value();
     // If there is only one row slice, then the last index value of interest is just the last index value for this row
     // slice. If there is more than one, then the first index value from the second row slice must be used to calculate
     // the buckets of interest, due to an old bug in update. See test_compatibility.py::test_compat_resample_updated_data
     // for details
-    const auto last_ts = row_slices.size() == 1 ? first_row_slice_index_col.scalar_at<timestamp>(first_row_slice_index_col.row_count() - 1).value():
-            row_slices.back().segments_->at(0)->column(0).scalar_at<timestamp>(0).value();
+    const auto last_ts = row_slices.size() == 1 ? first_row_slice_index_col.template scalar_at<timestamp>(first_row_slice_index_col.row_count() - 1).value():
+            row_slices.back().segments_->at(0)->column(0).template scalar_at<timestamp>(0).value();
     auto bucket_boundaries = generate_bucket_boundaries(first_ts, last_ts, responsible_for_first_overlapping_bucket);
     if (bucket_boundaries.size() < 2) {
         return {};

--- a/cpp/arcticdb/processing/test/test_output_schema_aggregator_types.cpp
+++ b/cpp/arcticdb/processing/test/test_output_schema_aggregator_types.cpp
@@ -109,7 +109,7 @@ TEST_F(AggregationClauseOutputTypesTest, Sum) {
     ASSERT_EQ(stream_desc.field(8).type().data_type(), DataType::UINT64); // uint64
     ASSERT_EQ(stream_desc.field(9).type().data_type(), DataType::FLOAT64); // float32
     ASSERT_EQ(stream_desc.field(10).type().data_type(), DataType::FLOAT64); // float64
-    ASSERT_EQ(stream_desc.field(11).type().data_type(), DataType::BOOL8); // bool
+    ASSERT_EQ(stream_desc.field(11).type().data_type(), DataType::UINT64); // bool
 
     aggregation_clause = AggregationClause{"to_group", {{"sum", "timestamp", "timestamp_sum"}}};
     ASSERT_THROW(aggregation_clause.modify_schema(initial_schema()), SchemaException);

--- a/cpp/arcticdb/processing/test/test_unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/test/test_unsorted_aggregation.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <arcticdb/processing/unsorted_aggregation.hpp>
+#include <arcticdb/util/test/test_utils.hpp>
 
 using namespace arcticdb;
 

--- a/cpp/arcticdb/processing/test/test_unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/test/test_unsorted_aggregation.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include <arcticdb/processing/unsorted_aggregation.hpp>
+
+using namespace arcticdb;
+
+class UnsortedAggregationDataTypeParametrizationFixture :public ::testing::TestWithParam<DataType> {};
+
+TEST_P(UnsortedAggregationDataTypeParametrizationFixture, Sum) {
+    SumAggregatorData aggregator_data;
+    const DataType dt = GetParam();
+    aggregator_data.add_data_type(dt);
+    if (is_signed_type(dt)) {
+        constexpr DataType expected_data_type = combine_data_type(ValueType::INT, SizeBits::S64);
+        ASSERT_EQ(aggregator_data.get_output_data_type(), expected_data_type);
+        ASSERT_EQ(aggregator_data.get_default_value(), std::optional{Value(int64_t{0}, expected_data_type)});
+    } else if (is_unsigned_type(dt) || is_bool_type(dt)) {
+        constexpr DataType expected_data_type = combine_data_type(ValueType::UINT, SizeBits::S64);
+        ASSERT_EQ(aggregator_data.get_output_data_type(), expected_data_type);
+        ASSERT_EQ(aggregator_data.get_default_value(), std::optional{Value(uint64_t{0}, expected_data_type)});
+    } else if (is_floating_point_type(dt)) {
+        constexpr DataType expected_data_type = combine_data_type(ValueType::FLOAT, SizeBits::S64);
+        ASSERT_EQ(aggregator_data.get_output_data_type(), expected_data_type);
+        ASSERT_EQ(aggregator_data.get_default_value(), std::optional{Value(double{0}, expected_data_type)});
+    } else if (is_sequence_type(dt) || is_time_type(dt) || is_bool_object_type(dt)) {
+        ASSERT_THROW(aggregator_data.get_output_data_type(), SchemaException);
+    } else {
+        ASSERT_TRUE(is_empty_type(dt));
+        constexpr DataType expected_data_type = combine_data_type(ValueType::FLOAT, SizeBits::S64);
+        ASSERT_EQ(aggregator_data.get_output_data_type(), expected_data_type);
+        ASSERT_EQ(aggregator_data.get_default_value(), std::optional{Value(double{0}, expected_data_type)});
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(Sum, UnsortedAggregationDataTypeParametrizationFixture, ::testing::ValuesIn(all_data_types()));

--- a/cpp/arcticdb/util/test/test_utils.hpp
+++ b/cpp/arcticdb/util/test/test_utils.hpp
@@ -27,6 +27,31 @@
 
 using namespace arcticdb;
 
+consteval auto all_data_types() {
+    return std::array{
+            DataType::UINT8,
+            DataType::UINT16,
+            DataType::UINT32,
+            DataType::UINT64,
+            DataType::INT8,
+            DataType::INT16,
+            DataType::INT32,
+            DataType::INT64,
+            DataType::FLOAT32,
+            DataType::FLOAT64,
+            DataType::BOOL8,
+            DataType::NANOSECONDS_UTC64,
+            DataType::ASCII_FIXED64,
+            DataType::ASCII_DYNAMIC64,
+            DataType::UTF_FIXED64,
+            DataType::UTF_DYNAMIC64,
+            DataType::EMPTYVAL,
+            DataType::BOOL_OBJECT8,
+            DataType::UTF_DYNAMIC32
+    };
+}
+
+
 template<typename DTT, Dimension DIM, NumericId def_tsid = 123, int def_field_count = 4>
 StreamDescriptor create_tsd(StreamId tsid = def_tsid, std::size_t field_count = def_field_count) {
 

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -991,6 +991,8 @@ def common_sum_aggregation_dtype(left, right):
     elif ((pd.api.types.is_signed_integer_dtype(left) and pd.api.types.is_unsigned_integer_dtype(right)) or
           (pd.api.types.is_unsigned_integer_dtype(left) and pd.api.types.is_signed_integer_dtype(right))):
         return np.int64
+    elif pd.api.types.is_bool_dtype(left) and pd.api.types.is_bool_dtype(right):
+        return np.uint64
     else:
         return np.float64
 
@@ -1026,22 +1028,37 @@ def valid_common_type(left, right):
     # Strings are represented via object dtype. Numeric types and strings do not have valid common type
     if (is_numeric_type(left) and not is_numeric_type(right)) or (is_numeric_type(right) and not is_numeric_type(left)):
         return None
+    if pd.api.types.is_bool_dtype(left):
+        if pd.api.types.is_bool_dtype(right):
+            return left
+        elif pd.api.types.is_integer_dtype(right) or pd.api.types.is_float_dtype(right):
+            return None
+        raise Exception(f"Unexpected right dtype: {right}")
     if pd.api.types.is_float_dtype(left):
         if pd.api.types.is_float_dtype(right) or pd.api.types.is_integer_dtype(right):
             return np.promote_types(left, right)
+        elif pd.api.types.is_bool_dtype(right):
+            return None
+        raise Exception(f"Unexpected right dtype: {right}")
     elif pd.api.types.is_signed_integer_dtype(left):
         if pd.api.types.is_float_dtype(right) or pd.api.types.is_signed_integer_dtype(right):
             return np.promote_types(left, right)
         elif pd.api.types.is_unsigned_integer_dtype(right):
             # Numpy promotes int* and uint64 to float64. ArcticDB does not allow such promotion
             return None if right.itemsize >= 8 else np.promote_types(left, right)
+        elif pd.api.types.is_bool_dtype(right):
+            return None
+        raise Exception(f"Unexpected right dtype: {right}")
     elif pd.api.types.is_unsigned_integer_dtype(left):
         if pd.api.types.is_float_dtype(right) or pd.api.types.is_unsigned_integer_dtype(right):
             return np.promote_types(left, right)
         elif pd.api.types.is_signed_integer_dtype(right):
             # Numpy promotes int* and uint64 to float64. ArcticDB does not allow such promotion
             return None if left.itemsize >= 8 else np.promote_types(left, right)
-    return None
+        elif pd.api.types.is_bool_dtype(right):
+            return None
+        raise Exception(f"Unexpected right dtype: {right}")
+    raise Exception(f"Unexpected left dtype: {left}")
 
 def expected_aggregation_type(aggregation, df_list, column_name):
     common_types = compute_common_type_for_columns_in_df_list(df_list)

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -135,7 +135,7 @@ def test_sum_aggregation_bool(lmdb_version_store_v1):
             "grouping_column": ["0", "0", "0", "1", "1", "2", "2", "3", "4"],
             "to_sum": [True, False, True, True, True, False, False, True, False]
         },
-        index=np.arange(7),
+        index=np.arange(9),
     )
     lib.write(symbol, df)
     generic_aggregation_test(lib, symbol, df, "grouping_column", {"to_sum": "sum"})
@@ -548,14 +548,13 @@ def test_sum_aggregation_type(lmdb_version_store_dynamic_schema_v1, first_dtype,
         assert_frame_equal(expected_df, data, check_dtype=True)
 
 @pytest.mark.parametrize("extremum", ["min", "max"])
-@pytest.mark.parametrize("dtype_value", [(np.int32, 0), (np.float32, np.nan), (bool, False)])
-def test_extremum_aggregation_with_missing_aggregation_column(lmdb_version_store_dynamic_schema_v1, extremum, dtype_value):
+@pytest.mark.parametrize("dtype, default_value", [(np.int32, 0), (np.float32, np.nan), (bool, False)])
+def test_extremum_aggregation_with_missing_aggregation_column(lmdb_version_store_dynamic_schema_v1, extremum, dtype, default_value):
     """
     Test that a sparse column will be backfilled with the correct values.
     d1 will be skipped because there is no grouping colum, df2 will form the first row which. The first row is sparse
     because the aggregation column is missing, d2 will be the second row which will be dense and not backfilled.
     """
-    dtype, default_value = dtype_value
     lib = lmdb_version_store_dynamic_schema_v1
     sym = "sym"
     df1 = pd.DataFrame({"agg_column": np.array([0, 0], dtype)})

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -543,6 +543,8 @@ def test_sum_aggregation_type(lmdb_version_store_dynamic_schema_v1, first_dtype,
         else:
             expected_df = pd.DataFrame({"to_sum": np.array([1, 1], expected_type)}, index=["1", "0"])
         expected_df.index.name = "grouping_column"
+        expected_df.sort_index(inplace=True)
+        data.sort_index(inplace=True)
         assert_frame_equal(expected_df, data, check_dtype=True)
 
 @pytest.mark.parametrize("extremum", ["min", "max"])

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -12,7 +12,13 @@ from pandas import DataFrame
 
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb_ext.exceptions import InternalException, SchemaException
-from arcticdb.util.test import assert_frame_equal, generic_aggregation_test, make_dynamic, common_sum_aggregation_dtype
+from arcticdb.util.test import (
+    assert_frame_equal,
+    generic_aggregation_test,
+    make_dynamic,
+    common_sum_aggregation_dtype,
+    valid_common_type
+)
 
 pytestmark = pytest.mark.pipeline
 
@@ -117,6 +123,19 @@ def test_sum_aggregation(lmdb_version_store_v1):
     df = DataFrame(
         {"grouping_column": ["group_1", "group_1", "group_1", "group_2", "group_2"], "to_sum": [1, 1, 2, 2, 2]},
         index=np.arange(5),
+    )
+    lib.write(symbol, df)
+    generic_aggregation_test(lib, symbol, df, "grouping_column", {"to_sum": "sum"})
+
+def test_sum_aggregation_bool(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    symbol = "test_sum_aggregation"
+    df = DataFrame(
+        {
+            "grouping_column": ["0", "0", "0", "1", "1", "2", "2", "3", "4"],
+            "to_sum": [True, False, True, True, True, False, False, True, False]
+        },
+        index=np.arange(7),
     )
     lib.write(symbol, df)
     generic_aggregation_test(lib, symbol, df, "grouping_column", {"to_sum": "sum"})
@@ -391,6 +410,13 @@ def test_sum_aggregation_dynamic(lmdb_version_store_dynamic_schema_v1):
         lib.append(symbol, df_slice, write_if_missing=True)
     generic_aggregation_test(lib, symbol, df, "grouping_column", {"to_sum": "sum"})
 
+def test_sum_aggregation_dynamic_bool_missing_aggregated_column(lmdb_version_store_dynamic_schema_v1):
+    lib = lmdb_version_store_dynamic_schema_v1
+    symbol = "test_sum_aggregation_dynamic"
+    df = DataFrame({"grouping_column": ["group_1", "group_2"], "to_sum": [True, False]}, index=np.arange(2),)
+    lib.write(symbol, df)
+    lib.append(symbol, pd.DataFrame({"grouping_column": ["group_1", "group_2"]}, index=np.arange(2)))
+    generic_aggregation_test(lib, symbol, df, "grouping_column", {"to_sum": "sum"})
 
 def test_sum_aggregation_with_range_index_dynamic(lmdb_version_store_dynamic_schema_v1):
     lib = lmdb_version_store_dynamic_schema_v1
@@ -488,23 +514,22 @@ def test_aggregation_grouping_column_missing_from_row_group(lmdb_version_store_d
     lib.append(symbol, append_df)
     generic_aggregation_test(lib, symbol, pd.concat([write_df, append_df]), "grouping_column", {"to_sum": "sum"})
 
-@pytest.mark.parametrize("first_dtype,", [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float32, np.float64])
-@pytest.mark.parametrize("second_dtype", [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float32, np.float64])
+@pytest.mark.parametrize("first_dtype,", [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float32, np.float64, bool])
+@pytest.mark.parametrize("second_dtype", [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float32, np.float64, bool])
 @pytest.mark.parametrize("first_group", ["0", "1"])
 @pytest.mark.parametrize("second_group", ["0", "1"])
 def test_sum_aggregation_type(lmdb_version_store_dynamic_schema_v1, first_dtype, second_dtype, first_group, second_group):
     """
     Sum aggregation promotes to the largest type of the respective category. int -> int64, uint -> uint64, float -> float64
-    Dynamic schema allows mixin int and uint. In the case of sum aggregation, this will require mixing uint64 and int64
+    Dynamic schema allows mixing int and uint. In the case of sum aggregation, this will require mixing uint64 and int64
     in the end segment, and those do not have a common type. In that case we use int64 (pyarrow does the same). In this
     test we test all configurations of dtypes and grouping options (same group vs different group)
     """
     lib = lmdb_version_store_dynamic_schema_v1
     df1 = pd.DataFrame({"grouping_column": [first_group], "to_sum": np.array([1], first_dtype)})
     df2 = pd.DataFrame({"grouping_column": [second_group], "to_sum": np.array([1], second_dtype)})
-    lib.append("sym", df1)
-    if ((pd.api.types.is_signed_integer_dtype(first_dtype) and second_dtype == np.uint64) or
-        (first_dtype == np.uint64 and pd.api.types.is_signed_integer_dtype(second_dtype))):
+    lib.write("sym", df1)
+    if valid_common_type(first_dtype, second_dtype) is None:
         with pytest.raises(SchemaException):
             lib.append("sym", df2)
     else:
@@ -513,19 +538,25 @@ def test_sum_aggregation_type(lmdb_version_store_dynamic_schema_v1, first_dtype,
         q = q.groupby("grouping_column").agg({"to_sum": "sum"})
         data = lib.read("sym", query_builder=q).data
         expected_type = common_sum_aggregation_dtype(first_dtype, second_dtype)
-        assert np.dtype(data["to_sum"].dtype) == np.dtype(expected_type)
+        if first_group == second_group:
+            expected_df = pd.DataFrame({"to_sum": np.array([2], expected_type)}, index=[first_group])
+        else:
+            expected_df = pd.DataFrame({"to_sum": np.array([1, 1], expected_type)}, index=["1", "0"])
+        expected_df.index.name = "grouping_column"
+        assert_frame_equal(expected_df, data, check_dtype=True)
 
 @pytest.mark.parametrize("extremum", ["min", "max"])
-@pytest.mark.parametrize("dtype", [np.int32, np.float32])
-def test_extremum_aggregation_with_missing_aggregation_column(lmdb_version_store_dynamic_schema_v1, extremum, dtype):
+@pytest.mark.parametrize("dtype_value", [(np.int32, 0), (np.float32, np.nan), (bool, False)])
+def test_extremum_aggregation_with_missing_aggregation_column(lmdb_version_store_dynamic_schema_v1, extremum, dtype_value):
     """
     Test that a sparse column will be backfilled with the correct values.
     d1 will be skipped because there is no grouping colum, df2 will form the first row which. The first row is sparse
     because the aggregation column is missing, d2 will be the second row which will be dense and not backfilled.
     """
+    dtype, default_value = dtype_value
     lib = lmdb_version_store_dynamic_schema_v1
     sym = "sym"
-    df1 = pd.DataFrame({"agg_column": np.array([0.0, 0.0], dtype)})
+    df1 = pd.DataFrame({"agg_column": np.array([0, 0], dtype)})
     df2 = pd.DataFrame({"grouping_column": ["a"]})
     df3 = pd.DataFrame({"grouping_column": ["b"], "agg_column": np.array([0], dtype)})
     for df in [df1, df2, df3]:
@@ -534,7 +565,6 @@ def test_extremum_aggregation_with_missing_aggregation_column(lmdb_version_store
     q = q.groupby("grouping_column").agg({"agg_column": extremum})
     data = lib.read("sym", query_builder=q).data
     data = data.sort_index()
-    default_value = 0 if dtype == np.int32 else np.nan
     expected = pd.DataFrame({"agg_column": np.array([default_value, 0], dtype)}, index=["a", "b"])
     expected.index.name = "grouping_column"
     expected = expected.sort_index()


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

Prior this commit when sum aggregation was performed on bool column the result would be of bool type. The result was computed by applying OR on all values in the group. This not what pandas (and polars) do.

With this new implementation the sum of bools will equal to the number of True values in the group and the dtype will be uint64.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
