### PR TITLE
Extend testing for the index names returned by get_info

### DIFF
--- a/cpp/arcticdb/stream/python_bindings.cpp
+++ b/cpp/arcticdb/stream/python_bindings.cpp
@@ -121,6 +121,9 @@ void register_types(py::module &m) {
             return field_collection_to_ref_vector(desc.fields());
         })
         .def("sorted", &StreamDescriptor::sorted)
+        .def_property_readonly("index", [](const StreamDescriptor& self) {
+            return self.index();
+        })
     );
 
     py::class_<TimeseriesDescriptor>(m, "TimeseriesDescriptor")
@@ -139,7 +142,7 @@ void register_types(py::module &m) {
                 return key_from_proto(self.proto().next_key());
             }
             return std::nullopt;
-        });
+        }).def_property_readonly("as_stream_descriptor", &TimeseriesDescriptor::as_stream_descriptor);
 
     py::class_<PyTimestampRange>(m, "TimestampRange")
         .def(py::init<const py::object &, const py::object &>())

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -483,7 +483,7 @@ def _denormalize_columns(item, norm_meta, idx_type, n_indexes):
     return columns, denormed_columns, data
 
 
-def _normalize_columns_names(columns_names, index_names, norm_meta, dynamic_schema=False):
+def _normalize_columns_names(columns_names, norm_meta, dynamic_schema=False):
     counter = Counter(columns_names)
     for idx in range(len(columns_names)):
         col = columns_names[idx]
@@ -512,7 +512,7 @@ def _normalize_columns_names(columns_names, index_names, norm_meta, dynamic_sche
             if dynamic_schema and (counter[col] > 1):
                 raise ArcticNativeException("Same column names not allowed in dynamic_schema")
             new_name = col_str
-            if counter[col] > 1 or col in index_names:
+            if counter[col] > 1:
                 new_name = "__col_{}__{}".format(col, 0 if dynamic_schema else idx)
             if isinstance(col, int):
                 norm_meta.common.col_names[new_name].is_int = True
@@ -537,7 +537,7 @@ def _normalize_columns(
     if not isinstance(columns_names, RangeIndex):
         if coerce_columns is not None and (set(columns_names_norm) != set(coerce_columns.keys())):
             raise ArcticNativeException("Keys in coerce column dictionary must match columns in dataframes")
-        columns_names_norm = _normalize_columns_names(list(columns_names), index_names, norm_meta, dynamic_schema)
+        columns_names_norm = _normalize_columns_names(list(columns_names), norm_meta, dynamic_schema)
 
         if columns_names_norm != list(columns_names):
             log.debug("Dataframe column names normalized")

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2981,9 +2981,7 @@ class NativeVersionStore:
 
     def _process_info(
         self,
-        symbol: str,
         dit,
-        as_of: VersionQueryInput,
         date_range_ns_precision: bool,
     ) -> Dict[str, Any]:
         timeseries_descriptor = dit.timeseries_descriptor
@@ -3080,7 +3078,7 @@ class NativeVersionStore:
         date_range_ns_precision = kwargs.get("date_range_ns_precision", False)
         version_query = self._get_version_query(version, **kwargs)
         dit = self.version_store.read_descriptor(symbol, version_query)
-        return self._process_info(symbol, dit, version, date_range_ns_precision)
+        return self._process_info(dit, date_range_ns_precision)
 
     def batch_get_info(
         self, symbols: List[str], as_ofs: Optional[List[VersionQueryInput]] = None
@@ -3137,7 +3135,7 @@ class NativeVersionStore:
             if isinstance(dit, DataError):
                 description_results.append(dit)
             else:
-                description_results.append(self._process_info(symbol, dit, as_of, date_range_ns_precision))
+                description_results.append(self._process_info(dit, date_range_ns_precision))
         return description_results
 
     def write_metadata(

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -76,7 +76,7 @@ from arcticdb.version_store._normalization import (
     _from_tz_timestamp,
     restrict_data_to_date_range_only,
     normalize_dt_range_to_ts,
-    _denormalize_single_index,
+    _denormalize_columns_names,
 )
 
 TimeSeriesType = Union[pd.DataFrame, pd.Series]
@@ -2991,7 +2991,12 @@ class NativeVersionStore:
         index_dtype = []
         input_type = timeseries_descriptor.normalization.WhichOneof("input_type")
         index_type = "NA"
-        if input_type == "df":
+        if input_type == "series":
+            _denormalize_columns_names(columns, timeseries_descriptor.normalization.series)
+        elif input_type == "ts":
+            _denormalize_columns_names(columns, timeseries_descriptor.normalization.ts)
+        elif input_type == "df":
+            _denormalize_columns_names(columns, timeseries_descriptor.normalization.df)
             index_type = timeseries_descriptor.normalization.df.common.WhichOneof("index_type")
             if index_type == "index":
                 index_metadata = timeseries_descriptor.normalization.df.common.index

--- a/python/tests/compat/arcticdb/test_compatibility.py
+++ b/python/tests/compat/arcticdb/test_compatibility.py
@@ -468,3 +468,59 @@ def test_compat_arrow_range_old_updated_data(pandas_v1_venv, s3_ssl_disabled_sto
             expected_df.index.name = "index"
             assert_frame_equal(df, expected_df)
 
+
+def test_norm_meta_column_and_index_names_write_old_read_new(old_venv_and_arctic_uri, lib_name):
+    """Can a new venv read column and index names serialized by an old client?"""
+    old_venv, arctic_uri = old_venv_and_arctic_uri
+
+    sym = "sym"
+
+    df = pd.DataFrame(
+        index=[pd.Timestamp("2018-01-02 00:01:00"), pd.Timestamp("2018-01-02 00:02:00")],
+        data={"col_one": ["a", "b"], "col_two": ["c", "d"]},
+    )
+    df.index.set_names(["col_one"], inplace=True)  # specifically testing an odd behaviour when an index name matches a column name
+
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        compat.old_lib.execute([
+            'df = pd.DataFrame(index=[pd.Timestamp("2018-01-02 00:01:00"), pd.Timestamp("2018-01-02 00:02:00")], data={"col_one": ["a", "b"], "col_two": ["c", "d"]})',
+            'df.index.set_names(["col_one"], inplace=True)',
+            'lib.write("sym", df)',
+        ])
+
+        with compat.current_version() as curr:
+            res = curr.lib.get_description(sym)
+            assert ["col_one", "col_two"] == [c.name for c in res.columns]
+            assert res.index[0][0] == "col_one"
+            assert_frame_equal(curr.lib.read(sym).data, df)
+
+
+def test_norm_meta_column_and_index_names_write_new_read_old(old_venv_and_arctic_uri, lib_name):
+    """Can an old venv read column and index names serialized by a new client?"""
+    old_venv, arctic_uri = old_venv_and_arctic_uri
+
+    start = pd.Timestamp("2018-01-02")
+    index = pd.date_range(start=start, periods=4)
+
+    df = pd.DataFrame(
+        index=index,
+        data={"col_one": [1, 2, 3, 4], "col_two": [1, 2, 3, 4]},
+        dtype=np.uint64
+    )
+    df.index.set_names(["col_one"], inplace=True)  # specifically testing an odd behaviour when an index name matches a column name
+
+    with CompatLibrary(old_venv, arctic_uri, lib_name) as compat:
+        with compat.current_version() as curr:
+            curr.lib.write("sym", df)
+
+        compat.old_lib.execute([
+            f"desc = lib.get_description('sym')",
+            "actual_desc_cols = [c.name for c in desc.columns]",
+            "assert ['__col_col_one__0', 'col_two'] == actual_desc_cols, f'Actual columns were {actual_desc_cols}'",
+            "actual_desc_index_name = desc.index[0][0]",
+            "assert actual_desc_index_name == 'col_one', f'Actual index name was {actual_desc_index_name}'",
+            "actual_df = lib.read('sym').data",
+            "assert actual_df.index.name == 'col_one', f'Actual index name was {actual_df.index.name}'",
+            "actual_col_names = list(actual_df.columns.values)",
+            "assert actual_col_names == ['col_one', 'col_two'], f'Actual col names were {actual_col_names}'"
+        ])

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -934,18 +934,57 @@ def test_date_range_row_sliced(basic_store_tiny_segment, use_date_range_clause):
     assert_equal(expected, received)
 
 
+@pytest.mark.parametrize("index_name", ["blah", None, "col1"])
 @pytest.mark.storage
-def test_get_info(basic_store):
+def test_get_info(basic_store, index_name):
     sym = "get_info_test"
     df = pd.DataFrame(data={"col1": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))
-    df.index.name = "dt_index"
+    df.index.name = index_name
     basic_store.write(sym, df)
     info = basic_store.get_info(sym)
     assert int(info["rows"]) == 10
     assert info["type"] == "pandasdf"
     assert info["col_names"]["columns"] == ["col1"]
-    assert info["col_names"]["index"] == ["dt_index"]
+    assert info["col_names"]["index"] == [index_name]
     assert info["index_type"] == "index"
+
+
+@pytest.mark.parametrize("index_name", ["blah", None, "col1"])
+@pytest.mark.storage
+def test_get_info_series(basic_store, index_name):
+    """Index names are not handled very well at the moment for series. Since the normalization metadata is complex,
+    and any changes need to be backwards compatible with old readers, it does not seem worthwhile changing these
+    odd behaviours now."""
+    sym = "get_info_series_test"
+    series = pd.Series(np.arange(10), name="col1", index=pd.date_range(pd.Timestamp(0), periods=10))
+    series.index.name = index_name
+    basic_store.write(sym, series)
+    info = basic_store.get_info(sym)
+    assert int(info["rows"]) == 10
+    assert info["type"] == "pandasseries"
+    assert info["col_names"]["columns"] == [index_name, "col1"] if index_name else ["col1"]
+    assert info["col_names"]["index"] == []
+    assert info["index_type"] == "NA"
+
+
+@pytest.mark.storage
+@pytest.mark.parametrize("index_name", ["blah", None])
+def test_get_info_series_multiindex(basic_store, index_name):
+    """Index names are not handled very well at the moment for series. Since the normalization metadata is complex,
+    and any changes need to be backwards compatible with old readers, it does not seem worthwhile changing these
+    odd behaviours now."""
+    sym = "get_info_series_test"
+    dtidx = pd.date_range(pd.Timestamp("2016-01-01"), periods=10)
+    vals = np.arange(10, dtype=np.uint32)
+    series = pd.Series(np.arange(10), name="col1", index=pd.MultiIndex.from_arrays([dtidx, vals]))
+    series.index.name = index_name
+    basic_store.write(sym, series)
+    info = basic_store.get_info(sym)
+    assert int(info["rows"]) == 10
+    assert info["type"] == "pandasseries"
+    assert info["col_names"]["columns"] == ['index', '__fkidx__1', 'col1'] if index_name else ["col1"]
+    assert info["col_names"]["index"] == []
+    assert info["index_type"] == "NA"
 
 
 @pytest.mark.storage
@@ -1091,10 +1130,12 @@ def test_update_times(basic_store):
 
 
 @pytest.mark.storage
-def test_get_info_multi_index(basic_store):
+@pytest.mark.parametrize("index_names", [("blah", None), (None, None), (None, "blah"), ("blah1", "blah2")])
+def test_get_info_multi_index(basic_store, index_names):
     dtidx = pd.date_range(pd.Timestamp("2016-01-01"), periods=3)
     vals = np.arange(3, dtype=np.uint32)
     multi_df = pd.DataFrame({"col1": [1, 4, 9]}, index=pd.MultiIndex.from_arrays([dtidx, vals]))
+    multi_df.index.set_names(index_names, inplace=True)
     sym = "multi_info_test"
     basic_store.write(sym, multi_df)
     info = basic_store.get_info(sym)

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1130,7 +1130,7 @@ def test_update_times(basic_store):
 
 
 @pytest.mark.storage
-@pytest.mark.parametrize("index_names", [("blah", None), (None, None), (None, "blah"), ("blah1", "blah2")])
+@pytest.mark.parametrize("index_names", [("blah", None), (None, None), (None, "blah"), ("blah1", "blah2"), ("col1", "col2"), ("col1", "col1")])
 def test_get_info_multi_index(basic_store, index_names):
     dtidx = pd.date_range(pd.Timestamp("2016-01-01"), periods=3)
     vals = np.arange(3, dtype=np.uint32)
@@ -1142,7 +1142,9 @@ def test_get_info_multi_index(basic_store, index_names):
     assert int(info["rows"]) == 3
     assert info["type"] == "pandasdf"
     assert info["col_names"]["columns"] == ["col1"]
-    assert len(info["col_names"]["index"]) == 2
+    actual_index_names = info["col_names"]["index"]
+    assert len(actual_index_names) == 2
+    assert actual_index_names == list(index_names)
     assert info["index_type"] == "multi_index"
 
 

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -18,6 +18,8 @@ import pandas as pd
 import dateutil as du
 import pytest
 import pytz
+from arcticdb_ext.types import IndexKind
+
 if sys.version_info >= (3, 9):
     import zoneinfo
 from numpy.testing import assert_equal, assert_array_equal
@@ -45,8 +47,6 @@ from arcticdb.version_store._normalization import (
     NPDDataFrame,
 )
 from arcticdb.version_store._common import TimeFrame
-from arcticdb.version_store._store import NativeVersionStore
-from arcticdb.version_store.library import Library
 from arcticdb.util.test import (
     CustomThing,
     TestCustomNormalizer,
@@ -55,6 +55,7 @@ from arcticdb.util.test import (
 )
 from arcticdb.util._versions import IS_PANDAS_ZERO, IS_PANDAS_TWO
 from arcticdb.exceptions import ArcticNativeException
+import arcticc.pb2.descriptors_pb2 as descriptors_pb2
 
 from tests.util.mark import param_dict, ZONE_INFO_MARK
 
@@ -1091,3 +1092,180 @@ def test_pandas_consolidation_v2(lmdb_library_factory, monkeypatch, env_var_set)
         assert isinstance(df._mgr, BlockManagerUnconsolidated)
     else:
         assert isinstance(df._mgr, pd.core.internals.managers.BlockManager)
+
+
+@pytest.mark.parametrize("use_col_name_for_index", (True, False))
+def test_norm_meta_column_and_index_names_df(lmdb_version_store, use_col_name_for_index):
+    lib = lmdb_version_store
+
+    start = pd.Timestamp("2018-01-02")
+    index = pd.date_range(start=start, periods=2)
+
+    df = pd.DataFrame(
+        index=index,
+        data=[[1, 2, 3, 4, 5]],
+        columns=["col_one", "col_two", "col_two", "col_one", "col_three"]
+    )
+
+    if use_col_name_for_index:
+        index_name = "col_one"
+        df.index.set_names([index_name], inplace=True)
+    else:
+        index_name = "index_name"
+        df.index.set_names([index_name], inplace=True)
+
+    lib.write("sym", df)
+
+    res = lib.get_info("sym")
+    assert list(df.columns) == res["col_names"]["columns"]
+    assert res["col_names"]["index"] == [index_name]
+
+    version_query = lib._get_version_query(None)
+    descriptor = lib.version_store.read_descriptor("sym", version_query)
+
+    norm_meta = descriptor.timeseries_descriptor.normalization
+    assert norm_meta.df.common.index.name == index_name
+    assert norm_meta.df.common.index.is_physically_stored
+    assert dict(norm_meta.df.common.col_names) == {
+        "__col_col_one__0": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_one"),
+        "__col_col_two__1": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_two"),
+        "__col_col_two__2": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_two"),
+        "__col_col_one__3": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_one"),
+        "col_three": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_three"),
+    }
+
+    assert_frame_equal(lib.read("sym").data, df)
+
+
+@pytest.mark.parametrize("use_col_name_for_index", (True, False))
+def test_norm_meta_column_and_index_names_series(lmdb_version_store_static_and_dynamic, use_col_name_for_index):
+    lib = lmdb_version_store_static_and_dynamic
+
+    start = pd.Timestamp("2018-01-02")
+    index = pd.date_range(start=start, periods=2)
+
+    series = pd.Series(
+        index=index,
+        data=[1, 2],
+        name="col_one"
+    )
+
+    if use_col_name_for_index:
+        index_name = "col_one"
+        series.index.set_names([index_name], inplace=True)
+    else:
+        index_name = "index_name"
+        series.index.set_names([index_name], inplace=True)
+
+    lib.write("sym", series)
+
+    res = lib.get_info("sym")
+
+    # For some reason the index name appears only under col_names
+    assert [index_name, "col_one"] == res["col_names"]["columns"]
+    assert res["col_names"]["index"] == []
+
+    version_query = lib._get_version_query(None)
+    descriptor = lib.version_store.read_descriptor("sym", version_query)
+
+    norm_meta = descriptor.timeseries_descriptor.normalization
+    assert norm_meta.series.common.index.name == index_name
+    assert norm_meta.series.common.index.is_physically_stored
+    if use_col_name_for_index:
+        assert dict(norm_meta.series.common.col_names) == {
+            "__col_col_one__0": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_one"),
+        }
+    else:
+        assert dict(norm_meta.series.common.col_names) == {
+            "col_one": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_one"),
+        }
+
+    assert_series_equal(lib.read("sym").data, series)
+
+
+@pytest.mark.parametrize("use_col_name_for_index", (True, False))
+def test_norm_meta_column_and_index_names_df_dynamic_schema(lmdb_version_store_dynamic_schema, use_col_name_for_index):
+    lib = lmdb_version_store_dynamic_schema
+
+    start = pd.Timestamp("2018-01-02")
+    index = pd.date_range(start=start, periods=2)
+
+    df = pd.DataFrame(
+        index=index,
+        data=[[1, 2]],
+        columns=["col_one", "col_two"]
+    )
+
+    if use_col_name_for_index:
+        index_name = "col_one"
+        df.index.set_names([index_name], inplace=True)
+    else:
+        index_name = "index_name"
+        df.index.set_names([index_name], inplace=True)
+
+    lib.write("sym", df)
+
+    res = lib.get_info("sym")
+    assert list(df.columns) == res["col_names"]["columns"]
+    assert res["col_names"]["index"] == [index_name]
+
+    version_query = lib._get_version_query(None)
+    descriptor = lib.version_store.read_descriptor("sym", version_query)
+
+    norm_meta = descriptor.timeseries_descriptor.normalization
+    assert norm_meta.df.common.index.name == index_name
+    assert norm_meta.df.common.index.is_physically_stored
+
+    if use_col_name_for_index:
+        assert dict(norm_meta.df.common.col_names) == {
+            "__col_col_one__0": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_one"),
+            "col_two": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_two"),
+        }
+    else:
+        assert dict(norm_meta.df.common.col_names) == {
+            "col_one": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_one"),
+            "col_two": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_two"),
+        }
+
+    assert_frame_equal(lib.read("sym").data, df)
+
+
+def test_norm_meta_column_and_index_names_df_multi_index(lmdb_version_store_static_and_dynamic):
+    lib = lmdb_version_store_static_and_dynamic
+    is_dynamic_schema = lib.lib_cfg().lib_desc.version.write_options.dynamic_schema
+
+    start = pd.Timestamp("2018-01-02")
+    num_rows = 4
+    index = pd.MultiIndex.from_arrays([[start + datetime.timedelta(days=i) for i in range(num_rows)], ["a", "b", "c", "d"]])
+
+    df = pd.DataFrame(
+        index=index,
+        data={"col_one": [1, 2, 3, 4], "col_two": [1, 2, 3, 4], "col_three": [5, 6, 7, 8]}
+    )
+    df.index.set_names(["col_one", "col_two"], inplace=True)
+    lib.write("sym", df)
+
+    res = lib.get_info("sym")
+    assert list(df.columns) == res["col_names"]["columns"]
+    assert res["col_names"]["index"] == ["col_one", "col_two"]
+
+    version_query = lib._get_version_query(None)
+    descriptor = lib.version_store.read_descriptor("sym", version_query)
+
+    norm_meta = descriptor.timeseries_descriptor.normalization
+    index_meta = norm_meta.df.common.multi_index
+    assert index_meta.name == "col_one"
+
+    expected_col_one_name = "__col_col_one__0" if is_dynamic_schema else "__col_col_one__1"
+    assert dict(norm_meta.df.common.col_names) == {
+        "__idx__col_two": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="__idx__col_two"),
+        expected_col_one_name: descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_one"),
+        "col_two": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_two"),
+        "col_three": descriptors_pb2.NormalizationMetadata.Pandas.ColumnName(original_name="col_three"),
+    }
+
+    stream_descriptor = descriptor.timeseries_descriptor.as_stream_descriptor
+    field_names = [f.name for f in stream_descriptor.fields()]
+    assert field_names == ["col_one", "__idx__col_two", expected_col_one_name, "col_two", "col_three"]
+    assert stream_descriptor.index.field_count() == 1
+    assert stream_descriptor.index.kind() == IndexKind.TIMESTAMP

--- a/python/tests/unit/arcticdb/version_store/test_unicode.py
+++ b/python/tests/unit/arcticdb/version_store/test_unicode.py
@@ -277,19 +277,20 @@ def test_snapshots(lmdb_version_store):
 def test_get_info(lmdb_version_store, batch):
     start = pd.Timestamp("2018-01-02")
     index = pd.date_range(start=start, periods=4)
-    unicode_str = "ab"
 
     df_1 = pd.DataFrame(
         index=index,
         data={"a": ["123", unicode_str, copyright, trademark], trademark: [1, 2, 3, 4], copyright: [unicode_str] * 4},
     )
-    df_1.index.set_names([unicode_str])
+    df_1.index.set_names([unicode_str], inplace=True)
 
+    # This one has an index with the same name as a column, which used to incorrectly obfuscate that column name
+    # in the get_info output.
     df_2 = pd.DataFrame(
         index=index,
         data={unicode_str: [1, 2, 3, 4], trademark: [1, 2, 3, 4], copyright: [unicode_str] * 4},
     )
-    df_2.index.set_names([unicode_str])
+    df_2.index.set_names([unicode_str], inplace=True)
     lmdb_version_store.write("sym_1", df_1, metadata=metadata)
     lmdb_version_store.write("sym_2", df_2, metadata=metadata)
 
@@ -298,11 +299,13 @@ def test_get_info(lmdb_version_store, batch):
         assert len(res) == 2
         assert list(df_1.columns) == res[0]["col_names"]["columns"]
         assert list(df_2.columns) == res[1]["col_names"]["columns"]
+        assert res[0]["col_names"]["index"] == [unicode_str]
+        assert res[1]["col_names"]["index"] == [unicode_str]
     else:
         for sym, df in [("sym_1", df_1), ("sym_2", df_2)]:
             res = lmdb_version_store.get_info(sym)
             assert list(df.columns) == res["col_names"]["columns"]
-            # assert res["col_names"]["index"] == [unicode_str]  # index names are not exposed by get_info, seems to be a bug 8667920777
+            assert res["col_names"]["index"] == [unicode_str]  # index names are not exposed by get_info, seems to be a bug 8667920777
 
 
 def sample_nested_structures():

--- a/python/tests/unit/arcticdb/version_store/test_unicode.py
+++ b/python/tests/unit/arcticdb/version_store/test_unicode.py
@@ -305,7 +305,7 @@ def test_get_info(lmdb_version_store, batch):
         for sym, df in [("sym_1", df_1), ("sym_2", df_2)]:
             res = lmdb_version_store.get_info(sym)
             assert list(df.columns) == res["col_names"]["columns"]
-            assert res["col_names"]["index"] == [unicode_str]  # index names are not exposed by get_info, seems to be a bug 8667920777
+            assert res["col_names"]["index"] == [unicode_str]
 
 
 def sample_nested_structures():


### PR DESCRIPTION
This is to fix https://man312219.monday.com/boards/7852509418/views/168855452/pulses/8667920777 which was actually working correctly - the test case was incorrect (it was not actually setting names on the index being written).

Also fix some obfuscation that shouldn't happen when an index and a column share the same name.

The testing exposes several rough edges with the index names exposed by `get_info` on `Series` - but it does not seem particularly worthwhile changing their behaviour now.
