### PR TITLE
maint: Add support for libprotobuf 6

### DIFF
--- a/cpp/arcticdb/codec/segment.cpp
+++ b/cpp/arcticdb/codec/segment.cpp
@@ -97,7 +97,7 @@ SegmentHeaderProtoWrapper decode_protobuf_header(const uint8_t* data, size_t hea
     google::protobuf::io::ArrayInputStream ais(data, static_cast<int>(header_bytes_size));
 
     auto arena = std::make_unique<google::protobuf::Arena>();
-    auto seg_hdr = google::protobuf::Arena::CreateMessage<arcticdb::proto::encoding::SegmentHeader>(arena.get());
+    auto seg_hdr = google::protobuf::Arena::Create<arcticdb::proto::encoding::SegmentHeader>(arena.get());
     seg_hdr->ParseFromZeroCopyStream(&ais);
     ARCTICDB_TRACE(log::codec(), "Decoded protobuf header: {}", seg_hdr->DebugString());
     return {seg_hdr, std::move(arena)};

--- a/cpp/arcticdb/python/python_utils.hpp
+++ b/cpp/arcticdb/python/python_utils.hpp
@@ -115,7 +115,7 @@ PyObject** fill_with_none(PyObject** ptr_dest, size_t count, PythonHandlerData& 
 template<typename Msg>
 py::object pb_to_python(const Msg & out){
     std::string_view full_name = out.descriptor()->full_name();
-    auto & name = out.descriptor()->name();
+    const auto & name = out.descriptor()->name();
     std::string_view pkg_name = full_name.substr(0, full_name.size() - name.size());
     if(pkg_name[pkg_name.size()-1] == '.'){
         pkg_name = pkg_name.substr(0, pkg_name.size()-1);

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,7 +31,7 @@ dependencies:
   - cyrus-sasl
   - aws-sdk-cpp >=1.11.405
   - prometheus-cpp
-  - libprotobuf <6
+  - libprotobuf <7
   - openssl
   - libcurl
   - bitmagic

--- a/python/arcticc/pb2/__init__.py
+++ b/python/arcticc/pb2/__init__.py
@@ -3,7 +3,7 @@ import sys as _sys
 import google.protobuf as _protobuf
 
 _proto_ver = _protobuf.__version__.split(".")[0]
-if _proto_ver in "345":
+if _proto_ver in "3456":
 
     _python = _sys.version_info[:2]
     if _python >= (3, 11) and _proto_ver == "3":
@@ -25,6 +25,12 @@ if _proto_ver in "345":
             "We recommend updating your environment to use the minimum supported version of Python.\n"
             "For more information, see: https://devguide.python.org/versions/#supported-versions"
         )
+    elif _python <= (3, 8) and _proto_ver >= "6":
+        raise RuntimeError(
+            "Your environment uses protobuf 6 which does not support Python<=3.8.\n"
+            "We recommend updating your environment to use the minimum supported version of Python.\n"
+            "For more information, see: https://devguide.python.org/versions/#supported-versions"
+        )
 
     # Use the namespace package (https://peps.python.org/pep-0420) feature to select the pb2 files matching the protobuf
     _protos_path = _os.path.abspath(
@@ -32,4 +38,4 @@ if _proto_ver in "345":
     )
     __path__.append(_protos_path)
 else:
-    raise NotImplementedError(f"We only support protobuf versions 3, 4 & 5. You have {_protobuf.__version__}")
+    raise NotImplementedError(f"We only support protobuf versions 3, 4, 5 & 6. You have {_protobuf.__version__}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     pandas
     numpy
     attrs
-    protobuf >=3.5.0.post1, < 6 # Per https://github.com/grpc/grpc/blob/v1.45.3/requirements.txt
+    protobuf >=3.5.0.post1, < 7 # Per https://github.com/grpc/grpc/blob/v1.45.3/requirements.txt
     msgpack >=0.5.0 # msgpack 0.5.0 is required for strict_types argument, needed for correct pickling fallback
     pyyaml
     packaging

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def _log_and_run(*cmd, **kwargs):
 
 class CompileProto(Command):
     # When adding new protobuf versions, also update: setup.cfg, python/arcticdb/__init__.py
-    _PROTOBUF_TO_GRPC_VERSION = {"3": "<1.31", "4": ">=1.49", "5": ">=1.68.1"}
+    _PROTOBUF_TO_GRPC_VERSION = {"3": "<1.31", "4": ">=1.49", "5": ">=1.68.1", "6": ">=1.73.0"}
 
     description = '"protoc" generate code _pb2.py from .proto files'
     user_options = [
@@ -68,6 +68,9 @@ class CompileProto(Command):
             elif not ARCTICDB_USING_CONDA and python >= (3, 13) and proto_ver < "5":
                 # Not compatible with protobuf<5.26.1 as
                 # Python 3.13 requires GRPCIO >= 1.66.2, which requires protobuf >=5.26.1 https://github.com/grpc/grpc/blob/6fa8043bf9befb070b846993b59a3348248e6566/requirements.txt#L4
+                print(f"Python protobuf {proto_ver} does not run on Python {python}. Skipping...")
+            elif not ARCTICDB_USING_CONDA and python <= (3, 8) and proto_ver == "6":
+                # Python 3.8 is not compatible with protobuf 6
                 print(f"Python protobuf {proto_ver} does not run on Python {python}. Skipping...")
             else:
                 self._compile_one_version(proto_ver, os.path.join(output_dir, proto_ver))


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

Motivated by https://github.com/conda-forge/arcticdb-feedstock/pull/476.

#### What does this implement or fix?

Add support for libprotobuf 6 which is going to be used globally in conda-forge.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
