### PR TITLE
Add batch_delete APIs and functionality

### DIFF
--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -23,7 +23,7 @@ fi
 
 if [ -z "$ARCTICDB_PYTEST_ARGS" ]; then
     echo "Executing tests with no additional arguments"
-    $catch python -m pytest --timeout=600 $PYTEST_XDIST_MODE -v \
+    $catch python -m pytest --timeout=1200 $PYTEST_XDIST_MODE -v \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
@@ -32,7 +32,7 @@ else
     echo "Executing tests with additional pytest argiments:"
     echo "from user: $ARCTICDB_PYTEST_ARGS"
     echo "from automation: $PYTEST_ADD_TO_COMMAND_LINE"
-    $catch python -m pytest --timeout=600 $PYTEST_XDIST_MODE -v \
+    $catch python -m pytest --timeout=1200 $PYTEST_XDIST_MODE -v \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -23,7 +23,7 @@ fi
 
 if [ -z "$ARCTICDB_PYTEST_ARGS" ]; then
     echo "Executing tests with no additional arguments"
-    $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v \
+    $catch python -m pytest --timeout=600 $PYTEST_XDIST_MODE -v \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
@@ -32,7 +32,7 @@ else
     echo "Executing tests with additional pytest argiments:"
     echo "from user: $ARCTICDB_PYTEST_ARGS"
     echo "from automation: $PYTEST_ADD_TO_COMMAND_LINE"
-    $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v \
+    $catch python -m pytest --timeout=600 $PYTEST_XDIST_MODE -v \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1392,8 +1392,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
 
 std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> LocalVersionedEngine::batch_delete_versions_internal(
     const std::vector<StreamId>& stream_ids,
-    const std::vector<std::vector<VersionId>>& version_ids,
-    const std::optional<timestamp>& creation_ts) {
+    const std::vector<std::vector<VersionId>>& version_ids) {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(stream_ids.size() == version_ids.size(), "when calling batch_delete_versions_internal, stream_ids and version_ids must have the same size");
 
     if (stream_ids.empty()) {
@@ -1409,7 +1408,7 @@ std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> Loca
     std::vector<folly::Future<version_store::TombstoneVersionResult>> futures;
     for (size_t i = 0; i < stream_ids.size(); ++i) {
         if (!version_sets[i].empty()) {
-            futures.push_back(tombstone_versions_async(store(), version_map(), stream_ids[i], version_sets[i], creation_ts));
+            futures.push_back(tombstone_versions_async(store(), version_map(), stream_ids[i], version_sets[i]));
         }
     }
 
@@ -1419,6 +1418,20 @@ std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> Loca
         stream_ids,
         TransformBatchResultsFlags{}
     );
+}
+
+std::vector<std::variant<folly::Unit, DataError>> LocalVersionedEngine::batch_delete_symbols_internal(
+    const std::vector<std::pair<StreamId, VersionId>>& symbols_to_delete
+) {
+    std::vector<folly::Future<folly::Unit>> remove_symbol_tasks;
+    std::vector<StreamId> stream_ids;
+
+    for(const auto& [stream_id, latest_version] : symbols_to_delete) {
+        stream_ids.push_back(stream_id);
+        remove_symbol_tasks.push_back(async::submit_io_task(DeleteSymbolTask{store(), symbol_list_ptr(), stream_id, latest_version}));
+    }   
+    auto remove_symbol_results = folly::collectAll(remove_symbol_tasks).get();
+    return transform_batch_items_or_throw<folly::Unit>(std::move(remove_symbol_results), std::move(stream_ids), TransformBatchResultsFlags{});
 }
 
 VersionedItem LocalVersionedEngine::append_internal(

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1409,6 +1409,8 @@ std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> Loca
     for (size_t i = 0; i < stream_ids.size(); ++i) {
         if (!version_sets[i].empty()) {
             futures.push_back(tombstone_versions_async(store(), version_map(), stream_ids[i], version_sets[i]));
+        } else {
+            futures.push_back(tombstone_all_async(store(), version_map(), stream_ids[i]));
         }
     }
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1394,7 +1394,7 @@ std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> Loca
     const std::vector<StreamId>& stream_ids,
     const std::vector<std::vector<VersionId>>& version_ids,
     const std::optional<timestamp>& creation_ts) {
-    util::check(stream_ids.size() == version_ids.size(), "stream_ids and version_ids must have the same size");
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(stream_ids.size() == version_ids.size(), "when calling batch_delete_versions_internal, stream_ids and version_ids must have the same size");
 
     if (stream_ids.empty()) {
         return {};
@@ -1403,8 +1403,7 @@ std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> Loca
     std::vector<std::unordered_set<VersionId>> version_sets;
     version_sets.reserve(version_ids.size());
     for (const auto& version_list : version_ids) {
-        std::unordered_set<VersionId> version_set(version_list.begin(), version_list.end());
-        version_sets.emplace_back(std::move(version_set));
+        version_sets.emplace_back(version_list.begin(), version_list.end());
     }
     
     std::vector<folly::Future<version_store::TombstoneVersionResult>> futures;

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1390,10 +1390,10 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     return transform_batch_items_or_throw(std::move(write_versions), stream_ids, flags);
 }
 
-std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> LocalVersionedEngine::batch_delete_versions_internal(
+std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> LocalVersionedEngine::batch_delete_internal(
     const std::vector<StreamId>& stream_ids,
     const std::vector<std::vector<VersionId>>& version_ids) {
-    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(stream_ids.size() == version_ids.size(), "when calling batch_delete_versions_internal, stream_ids and version_ids must have the same size");
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(stream_ids.size() == version_ids.size(), "when calling batch_delete_internal, stream_ids and version_ids must have the same size");
 
     if (stream_ids.empty()) {
         return {};

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1390,6 +1390,37 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     return transform_batch_items_or_throw(std::move(write_versions), stream_ids, flags);
 }
 
+std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> LocalVersionedEngine::batch_delete_versions_internal(
+    const std::vector<StreamId>& stream_ids,
+    const std::vector<std::vector<VersionId>>& version_ids,
+    const std::optional<timestamp>& creation_ts) {
+    util::check(stream_ids.size() == version_ids.size(), "stream_ids and version_ids must have the same size");
+
+    if (stream_ids.empty()) {
+        return {};
+    }
+    
+    std::vector<std::unordered_set<VersionId>> version_sets;
+    version_sets.reserve(version_ids.size());
+    for (const auto& version_list : version_ids) {
+        std::unordered_set<VersionId> version_set(version_list.begin(), version_list.end());
+        version_sets.emplace_back(std::move(version_set));
+    }
+    
+    std::vector<folly::Future<version_store::TombstoneVersionResult>> futures;
+    for (size_t i = 0; i < stream_ids.size(); ++i) {
+        if (!version_sets[i].empty()) {
+            futures.push_back(tombstone_versions_async(store(), version_map(), stream_ids[i], version_sets[i], creation_ts));
+        }
+    }
+
+    auto tombstone_results = folly::collectAll(futures).get();
+    return transform_batch_items_or_throw<version_store::TombstoneVersionResult>(
+        std::move(tombstone_results),
+        stream_ids,
+        TransformBatchResultsFlags{}
+    );
+}
 
 VersionedItem LocalVersionedEngine::append_internal(
     const StreamId& stream_id,

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -381,7 +381,7 @@ public:
         bool throw_on_error
     );
 
-    std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> batch_delete_versions_internal(
+    std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> batch_delete_internal(
         const std::vector<StreamId>& stream_ids,
         const std::vector<std::vector<VersionId>>& version_ids
     );

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -383,8 +383,11 @@ public:
 
     std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> batch_delete_versions_internal(
         const std::vector<StreamId>& stream_ids,
-        const std::vector<std::vector<VersionId>>& version_ids,
-        const std::optional<timestamp>& creation_ts=std::nullopt
+        const std::vector<std::vector<VersionId>>& version_ids
+    );
+
+    std::vector<std::variant<folly::Unit, DataError>> batch_delete_symbols_internal(
+        const std::vector<std::pair<StreamId, VersionId>>& symbols_to_delete
     );
 
     VersionIdAndDedupMapInfo create_version_id_and_dedup_map(

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -381,6 +381,12 @@ public:
         bool throw_on_error
     );
 
+    std::vector<std::variant<version_store::TombstoneVersionResult, DataError>> batch_delete_versions_internal(
+        const std::vector<StreamId>& stream_ids,
+        const std::vector<std::vector<VersionId>>& version_ids,
+        const std::optional<timestamp>& creation_ts=std::nullopt
+    );
+
     VersionIdAndDedupMapInfo create_version_id_and_dedup_map(
         const version_store::UpdateInfo&& update_info, 
         const StreamId& stream_id, 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -578,8 +578,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("delete_versions",
              &PythonVersionStore::delete_versions,
              py::call_guard<SingleThreadMutexHolder>(), "Delete specific versions of the given symbol")
-        .def("batch_delete_versions",
-             &PythonVersionStore::batch_delete_versions,
+        .def("batch_delete",
+             &PythonVersionStore::batch_delete,
              py::arg("stream_ids"),
              py::arg("version_ids"),
              py::call_guard<SingleThreadMutexHolder>(), "Delete specific versions of the given symbols")

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -580,6 +580,8 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
              py::call_guard<SingleThreadMutexHolder>(), "Delete specific versions of the given symbol")
         .def("batch_delete_versions",
              &PythonVersionStore::batch_delete_versions,
+             py::arg("stream_ids"),
+             py::arg("version_ids"),
              py::call_guard<SingleThreadMutexHolder>(), "Delete specific versions of the given symbols")
          .def("prune_previous_versions",
               &PythonVersionStore::prune_previous_versions,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -578,6 +578,9 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def("delete_versions",
              &PythonVersionStore::delete_versions,
              py::call_guard<SingleThreadMutexHolder>(), "Delete specific versions of the given symbol")
+        .def("batch_delete_versions",
+             &PythonVersionStore::batch_delete_versions,
+             py::call_guard<SingleThreadMutexHolder>(), "Delete specific versions of the given symbols")
          .def("prune_previous_versions",
               &PythonVersionStore::prune_previous_versions,
               py::call_guard<SingleThreadMutexHolder>(), "Delete all but the latest version of the given symbol")

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -206,17 +206,17 @@ struct WriteSymbolTask : async::BaseTask {
 struct DeleteSymbolTask : async::BaseTask {
     const std::shared_ptr<Store> store_;
     const std::shared_ptr<SymbolList> symbol_list_;
-    const StreamId stream_id_;
+    const StreamId& stream_id_;
     const entity::VersionId reference_id_;
 
     DeleteSymbolTask(
         std::shared_ptr<Store> store,
         std::shared_ptr<SymbolList> symbol_list,
-        StreamId stream_id,
+        const StreamId& stream_id,
         entity::VersionId reference_id) :
         store_(std::move(store)),
         symbol_list_(std::move(symbol_list)),
-        stream_id_(std::move(stream_id)),
+        stream_id_(stream_id),
         reference_id_(reference_id) {
     }
 

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -203,6 +203,29 @@ struct WriteSymbolTask : async::BaseTask {
     }
 };
 
+struct DeleteSymbolTask : async::BaseTask {
+    const std::shared_ptr<Store> store_;
+    const std::shared_ptr<SymbolList> symbol_list_;
+    const StreamId stream_id_;
+    const entity::VersionId reference_id_;
+
+    DeleteSymbolTask(
+        std::shared_ptr<Store> store,
+        std::shared_ptr<SymbolList> symbol_list,
+        StreamId stream_id,
+        entity::VersionId reference_id) :
+        store_(std::move(store)),
+        symbol_list_(std::move(symbol_list)),
+        stream_id_(std::move(stream_id)),
+        reference_id_(reference_id) {
+    }
+
+    folly::Future<folly::Unit> operator()() {
+        SymbolList::remove_symbol(store_, stream_id_, reference_id_);
+        return folly::Unit{};
+    }
+};
+
 } //namespace arcticdb
 
 namespace fmt {

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -181,11 +181,14 @@ inline version_store::TombstoneVersionResult populate_tombstone_result(
         // It is possible to have a tombstone key without a corresponding index_key
         // This scenario can happen in case of DR sync
         if (entry->is_tombstoned(version_id)) {
-            util::raise_rte("Version {} for symbol {} is already deleted", version_id, stream_id);
+            missing_data::raise<ErrorCode::E_NO_SUCH_VERSION>(  
+                "Version {} for symbol {} is already deleted", version_id, stream_id);
         } else {
-            if (!latest_key || latest_key->version_id() < version_id)
-                util::raise_rte("Can't delete version {} for symbol {} - it's higher than the latest version",
-                        stream_id, version_id);
+            if (!latest_key || latest_key->version_id() < version_id) {
+                missing_data::raise<ErrorCode::E_NO_SUCH_VERSION>(
+                    "Can't delete version {} for symbol {} - it's higher than the latest version",
+                    version_id, stream_id);
+            }
         }
 
 
@@ -203,7 +206,7 @@ inline version_store::TombstoneVersionResult populate_tombstone_result(
         }
     }
 
-    util::check(
+    storage::check<ErrorCode::E_KEY_NOT_FOUND>(
         res.keys_to_delete.size() == version_ids.size(),
         "Expected {} index keys to be marked for deletion, got {} keys: {}",
         version_ids.size(), 

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -218,7 +218,7 @@ inline folly::Future<version_store::TombstoneVersionResult> finalize_tombstone_r
     version_store::TombstoneVersionResult res,
     const std::shared_ptr<VersionMap>& version_map,
     const std::shared_ptr<VersionMapEntry>& entry,
-    AtomKey tombstone_key) {
+    [[maybe_unused]] AtomKey tombstone_key) {
     ARCTICDB_DEBUG(log::version(), "Finalizing result for tombstone key {}", tombstone_key);
     // Update the result with final state
     if (version_map->validate())

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -164,7 +164,7 @@ inline version_store::TombstoneVersionResult populate_tombstone_result(
     const StreamId& stream_id,
     const std::shared_ptr<Store>& store,
     const std::optional<timestamp>& creation_ts=std::nullopt) {
-    version_store::TombstoneVersionResult res(entry->empty());
+    version_store::TombstoneVersionResult res(entry->empty(), stream_id);
     auto latest_key = entry->get_first_index(true).first;
     
     for (auto version_id: version_ids) {
@@ -238,7 +238,7 @@ inline folly::Future<version_store::TombstoneVersionResult> finalize_tombstone_a
     if (version_map->validate())
         entry->validate();
 
-    version_store::TombstoneVersionResult res{true};
+    version_store::TombstoneVersionResult res{true, entry->head_->id()};
     res.keys_to_delete = std::move(tombstone_result.second);
 
     res.no_undeleted_left = true;

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -975,7 +975,7 @@ void PythonVersionStore::batch_delete_versions(
         util::variant_match(result,
             [&](const version_store::TombstoneVersionResult& tombstone_result) {
                 if (!tombstone_result.keys_to_delete.empty() && !cfg().write_options().delayed_deletes()) {
-                    delete_tree(tombstone_result.keys_to_delete, tombstone_result);
+                    keys_to_delete.insert(keys_to_delete.end(), tombstone_result.keys_to_delete.begin(), tombstone_result.keys_to_delete.end());
                 }
 
                 if(tombstone_result.no_undeleted_left && cfg().symbol_list()) {
@@ -989,10 +989,10 @@ void PythonVersionStore::batch_delete_versions(
         );
     }
 
-    // // Make sure to call delete_tree and thus get_master_snapshots_map only once for all symbols
-    // if(!keys_to_delete.empty()) {
-    //     delete_tree(keys_to_delete, TombstoneVersionResult{true});
-    // }
+    // Make sure to call delete_tree and thus get_master_snapshots_map only once for all symbols
+    if(!keys_to_delete.empty()) {
+        delete_tree(keys_to_delete, TombstoneVersionResult{true});
+    }
 
     std::vector<folly::Future<folly::Unit>> remove_symbol_tasks;
 

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1002,13 +1002,7 @@ void PythonVersionStore::batch_delete_versions(
         }
     }
 
-    auto remove_symbol_results = folly::collectAll(remove_symbol_tasks).get();
-
-    for(const auto& result : remove_symbol_results) {
-        if (result.hasException()) {
-            failed_symbols.push_back(std::string(result.exception().what()));
-        }
-    }
+    folly::collectAll(remove_symbol_tasks).get();
 
     if(!failed_symbols.empty()) {
         throw InternalException(fmt::format("Failed to delete versions for symbols: {}", fmt::join(failed_symbols, ", ")));

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -950,6 +950,7 @@ void PythonVersionStore::delete_versions(
     if (!result.keys_to_delete.empty() && !cfg().write_options().delayed_deletes()) {
         delete_tree(result.keys_to_delete, result);
     }
+
     if(result.no_undeleted_left && cfg().symbol_list()) {
         symbol_list().remove_symbol(store(), stream_id, result.latest_version_);
     }
@@ -960,7 +961,7 @@ std::vector<DataError> PythonVersionStore::batch_delete(
     const std::vector<std::vector<VersionId>>& version_ids) {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(stream_ids.size() == version_ids.size(), "when calling batch_delete_versions, stream_ids and version_ids must have the same size");
     
-    auto results = batch_delete_versions_internal(stream_ids, version_ids);
+    auto results = batch_delete_internal(stream_ids, version_ids);
     
     std::vector<DataError> return_results;
 
@@ -981,8 +982,7 @@ std::vector<DataError> PythonVersionStore::batch_delete(
                 }
 
                 if(tombstone_result.no_undeleted_left && cfg().symbol_list() && !tombstone_result.keys_to_delete.empty()) {
-                    auto stream_id = tombstone_result.keys_to_delete.front().id();
-                    symbols_to_delete.emplace_back(std::move(stream_id), tombstone_result.latest_version_);
+                    symbols_to_delete.emplace_back(tombstone_result.symbol, tombstone_result.latest_version_);
                 }
             },
             [&](const DataError& data_error) {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -972,7 +972,8 @@ void PythonVersionStore::batch_delete_versions(
 
     for (const auto& result : results) {
         if (!result.keys_to_delete.empty() && !cfg().write_options().delayed_deletes()) {
-            keys_to_delete.insert(keys_to_delete.end(), result.keys_to_delete.begin(), result.keys_to_delete.end());
+            // keys_to_delete.insert(keys_to_delete.end(), result.keys_to_delete.begin(), result.keys_to_delete.end());
+            delete_tree(result.keys_to_delete, result);
         }
 
         if(result.no_undeleted_left && cfg().symbol_list()) {
@@ -981,10 +982,10 @@ void PythonVersionStore::batch_delete_versions(
         }
     }
 
-    // Make sure to call delete_tree and thus get_master_snapshots_map only once for all symbols
-    if(!keys_to_delete.empty()) {
-        delete_tree(keys_to_delete, TombstoneVersionResult{false});
-    }
+    // // Make sure to call delete_tree and thus get_master_snapshots_map only once for all symbols
+    // if(!keys_to_delete.empty()) {
+    //     delete_tree(keys_to_delete, TombstoneVersionResult{true});
+    // }
 
     std::vector<folly::Future<folly::Unit>> remove_symbol_tasks;
 

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -955,7 +955,7 @@ void PythonVersionStore::delete_versions(
     }
 }
 
-std::vector<DataError> PythonVersionStore::batch_delete_versions(
+std::vector<DataError> PythonVersionStore::batch_delete(
     const std::vector<StreamId>& stream_ids,
     const std::vector<std::vector<VersionId>>& version_ids) {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(stream_ids.size() == version_ids.size(), "when calling batch_delete_versions, stream_ids and version_ids must have the same size");

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1005,14 +1005,9 @@ void PythonVersionStore::batch_delete_versions(
     auto remove_symbol_results = folly::collectAll(remove_symbol_tasks).get();
 
     for(const auto& result : remove_symbol_results) {
-        util::variant_match(result,
-            [&](const folly::Unit& unit) {
-                // Success
-            },
-            [&](const std::exception& ex) {
-                failed_symbols.push_back(ex.what());
-            }
-        );
+        if (result.hasException()) {
+            failed_symbols.push_back(std::string(result.exception().what()));
+        }
     }
 
     if(!failed_symbols.empty()) {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -201,7 +201,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const StreamId& stream_id,
         const std::vector<VersionId>& version_ids);
 
-    std::vector<DataError> batch_delete(
+    std::vector<std::optional<DataError>> batch_delete(
         const std::vector<StreamId>& stream_ids,
         const std::vector<std::vector<VersionId>>& version_ids);
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -201,6 +201,10 @@ class PythonVersionStore : public LocalVersionedEngine {
         const StreamId& stream_id,
         const std::vector<VersionId>& version_ids);
 
+    void batch_delete_versions(
+        const std::vector<StreamId>& stream_ids,
+        const std::vector<std::vector<VersionId>>& version_ids);
+
     void prune_previous_versions(
         const StreamId& stream_id);
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -201,7 +201,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const StreamId& stream_id,
         const std::vector<VersionId>& version_ids);
 
-    void batch_delete_versions(
+    std::vector<DataError> batch_delete_versions(
         const std::vector<StreamId>& stream_ids,
         const std::vector<std::vector<VersionId>>& version_ids);
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -201,7 +201,7 @@ class PythonVersionStore : public LocalVersionedEngine {
         const StreamId& stream_id,
         const std::vector<VersionId>& version_ids);
 
-    std::vector<DataError> batch_delete_versions(
+    std::vector<DataError> batch_delete(
         const std::vector<StreamId>& stream_ids,
         const std::vector<std::vector<VersionId>>& version_ids);
 

--- a/cpp/arcticdb/version/version_store_objects.hpp
+++ b/cpp/arcticdb/version/version_store_objects.hpp
@@ -55,8 +55,9 @@ static const PreDeleteChecks default_pre_delete_checks;
  * Output from tombstone_versions() with additional fields on top of PreDeleteChecks. Safe to be sliced to the latter.
  */
 struct TombstoneVersionResult : PreDeleteChecks {
-    explicit TombstoneVersionResult(bool entry_already_scanned) :
-        PreDeleteChecks{true, entry_already_scanned, entry_already_scanned, entry_already_scanned, {}} {}
+    explicit TombstoneVersionResult(bool entry_already_scanned, StreamId symbol = "") :
+        PreDeleteChecks{true, entry_already_scanned, entry_already_scanned, entry_already_scanned, {}},
+        symbol(symbol) {}
 
     /**
      * The index key that just got tombstoned, if any.
@@ -70,6 +71,11 @@ struct TombstoneVersionResult : PreDeleteChecks {
      * The most recent version written to the version list
      */
      VersionId latest_version_ = 0;
+
+    /**
+     * The symbol that was tombstoned
+     */
+    StreamId symbol;
 };
 
 /**

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -212,28 +212,30 @@ struct WriteAndPrunePreviousTask : async::BaseTask {
     }
 };
 
-// TODO: Add this functionality when implementing batch_delete
-// struct TombstoneAllTask : async::BaseTask {
-//     const std::shared_ptr<Store> store_;
-//     const std::shared_ptr<VersionMap> version_map_;
-//     const AtomKey previous_key_;
-//     const std::shared_ptr<VersionMapEntry> entry_;
+struct TombstoneAllTask : async::BaseTask {
+    const std::shared_ptr<Store> store_;
+    const std::shared_ptr<VersionMap> version_map_;
+    const StreamId stream_id_;
+    const std::optional<AtomKey> maybe_prev_;
+    const std::shared_ptr<VersionMapEntry> entry_;
 
-//     TombstoneAllTask(
-//         std::shared_ptr<Store> store,
-//         std::shared_ptr<VersionMap> version_map,
-//         AtomKey previous_key,
-//         std::shared_ptr<VersionMapEntry> entry) :
-//         store_(std::move(store)),
-//         version_map_(std::move(version_map)),
-//         previous_key_(std::move(previous_key)),
-//         entry_(std::move(entry)) {
-//     }
+    TombstoneAllTask(
+        std::shared_ptr<Store> store,
+        std::shared_ptr<VersionMap> version_map,
+        StreamId stream_id,
+        std::optional<AtomKey> maybe_prev,
+        std::shared_ptr<VersionMapEntry> entry) :
+        store_(std::move(store)),
+        version_map_(std::move(version_map)),
+        stream_id_(std::move(stream_id)),
+        maybe_prev_(std::move(maybe_prev)),
+        entry_(std::move(entry)) {
+    }
 
-//     folly::Future<AtomKey> operator()() {
-//         ScopedLock lock(version_map_->get_lock_object(previous_key_.id()));
-//         return version_map_->write_tombstone_all_key_internal(store_, previous_key_, entry_);
-//     }
-// };
+    folly::Future<std::pair<VersionId, std::vector<AtomKey>>> operator()() {
+        ScopedLock lock(version_map_->get_lock_object(stream_id_));
+        return version_map_->tombstone_from_key_or_all(store_, stream_id_, maybe_prev_, entry_);
+    }
+};
 
 } //namespace arcticdb

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -212,4 +212,28 @@ struct WriteAndPrunePreviousTask : async::BaseTask {
     }
 };
 
+// TODO: Add this functionality when implementing batch_delete
+// struct TombstoneAllTask : async::BaseTask {
+//     const std::shared_ptr<Store> store_;
+//     const std::shared_ptr<VersionMap> version_map_;
+//     const AtomKey previous_key_;
+//     const std::shared_ptr<VersionMapEntry> entry_;
+
+//     TombstoneAllTask(
+//         std::shared_ptr<Store> store,
+//         std::shared_ptr<VersionMap> version_map,
+//         AtomKey previous_key,
+//         std::shared_ptr<VersionMapEntry> entry) :
+//         store_(std::move(store)),
+//         version_map_(std::move(version_map)),
+//         previous_key_(std::move(previous_key)),
+//         entry_(std::move(entry)) {
+//     }
+
+//     folly::Future<AtomKey> operator()() {
+//         ScopedLock lock(version_map_->get_lock_object(previous_key_.id()));
+//         return version_map_->write_tombstone_all_key_internal(store_, previous_key_, entry_);
+//     }
+// };
+
 } //namespace arcticdb

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -160,21 +160,18 @@ struct WriteTombstoneTask : async::BaseTask {
     const std::vector<AtomKey> keys_;
     const StreamId stream_id_;
     const std::shared_ptr<VersionMapEntry> entry_;
-    const std::optional<timestamp> creation_ts_;
 
     WriteTombstoneTask(
         std::shared_ptr<Store> store,
         std::shared_ptr<VersionMap> version_map,
         std::vector<AtomKey> keys,
         StreamId stream_id,
-        std::shared_ptr<VersionMapEntry> entry,
-        std::optional<timestamp> creation_ts) :
+        std::shared_ptr<VersionMapEntry> entry) :
         store_(std::move(store)),
         version_map_(std::move(version_map)),
         keys_(std::move(keys)),
         stream_id_(std::move(stream_id)),
-        entry_(std::move(entry)),
-        creation_ts_(std::move(creation_ts)) {
+        entry_(std::move(entry)) {
     }
 
     folly::Future<AtomKey> operator()() {
@@ -183,8 +180,7 @@ struct WriteTombstoneTask : async::BaseTask {
             store_,
             keys_,
             stream_id_,
-            entry_,
-            creation_ts_
+            entry_
         );
     }
 };

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -217,14 +217,14 @@ struct TombstoneAllTask : async::BaseTask {
     const std::shared_ptr<VersionMap> version_map_;
     const StreamId stream_id_;
     const std::optional<AtomKey> maybe_prev_;
-    const std::shared_ptr<VersionMapEntry> entry_;
+    const std::optional<std::shared_ptr<VersionMapEntry>> entry_;
 
     TombstoneAllTask(
         std::shared_ptr<Store> store,
         std::shared_ptr<VersionMap> version_map,
         StreamId stream_id,
         std::optional<AtomKey> maybe_prev,
-        std::shared_ptr<VersionMapEntry> entry) :
+        std::optional<std::shared_ptr<VersionMapEntry>> entry) :
         store_(std::move(store)),
         version_map_(std::move(version_map)),
         stream_id_(std::move(stream_id)),

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -153,6 +153,42 @@ struct WriteVersionTask : async::BaseTask {
         return folly::Unit{};
     }
 };
+
+struct WriteTombstoneTask : async::BaseTask {
+    const std::shared_ptr<Store> store_;
+    const std::shared_ptr<VersionMap> version_map_;
+    const std::vector<AtomKey> keys_;
+    const StreamId stream_id_;
+    const std::shared_ptr<VersionMapEntry> entry_;
+    const std::optional<timestamp> creation_ts_;
+
+    WriteTombstoneTask(
+        std::shared_ptr<Store> store,
+        std::shared_ptr<VersionMap> version_map,
+        std::vector<AtomKey> keys,
+        StreamId stream_id,
+        std::shared_ptr<VersionMapEntry> entry,
+        std::optional<timestamp> creation_ts) :
+        store_(std::move(store)),
+        version_map_(std::move(version_map)),
+        keys_(std::move(keys)),
+        stream_id_(std::move(stream_id)),
+        entry_(std::move(entry)),
+        creation_ts_(std::move(creation_ts)) {
+    }
+
+    folly::Future<AtomKey> operator()() {
+        ScopedLock lock(version_map_->get_lock_object(stream_id_));
+        return version_map_->write_tombstones(
+            store_,
+            keys_,
+            stream_id_,
+            entry_,
+            creation_ts_
+        );
+    }
+};
+
 struct WriteAndPrunePreviousTask : async::BaseTask {
     const std::shared_ptr<Store> store_;
     const std::shared_ptr<VersionMap> version_map_;

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2632,7 +2632,7 @@ class NativeVersionStore:
         """
         self.version_store.delete_versions(symbol, versions)
 
-    def batch_delete_versions(self, symbols: List[str], versions: List[List[int]]) -> List[DataError]:
+    def batch_delete_versions(self, symbols: List[str], versions: List[List[int]]) -> List[Optional[DataError]]:
         """
         Delete the given versions of the given symbols.
         Batch equivalent of `delete_version` and `delete_versions`.
@@ -2664,7 +2664,7 @@ class NativeVersionStore:
                 raise ValueError(f"version_ids cannot be empty for symbol '{symbol}'")
         return self.version_store.batch_delete(symbols, versions)
 
-    def batch_delete_symbols(self, symbols: List[str]) -> List[DataError]:
+    def batch_delete_symbols(self, symbols: List[str]) -> List[Optional[DataError]]:
         """
         Delete all versions of the given symbols.
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2632,7 +2632,7 @@ class NativeVersionStore:
         """
         self.version_store.delete_versions(symbol, versions)
 
-    def batch_delete_versions(self, symbols: List[str], versions: List[List[int]]):
+    def batch_delete_versions(self, symbols: List[str], versions: List[List[int]]) -> List[DataError]:
         """
         Delete the given versions of the given symbols.
 
@@ -2643,7 +2643,7 @@ class NativeVersionStore:
         versions : `List[List[int]]`
             Versions to delete for each symbol.
         """
-        self.version_store.batch_delete_versions(symbols, versions)
+        return self.version_store.batch_delete_versions(symbols, versions)
 
     def prune_previous_versions(self, symbol: str):
         """

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2284,6 +2284,7 @@ class NativeVersionStore:
     def _adapt_read_res(self, read_result: ReadResult) -> VersionedItem:
         if isinstance(read_result.frame_data, ArrowOutputFrame):
             import pyarrow as pa
+
             frame_data = read_result.frame_data
             record_batches = []
             for record_batch in frame_data.extract_record_batches():
@@ -2631,6 +2632,19 @@ class NativeVersionStore:
         """
         self.version_store.delete_versions(symbol, versions)
 
+    def batch_delete_versions(self, symbols: List[str], versions: List[List[int]]):
+        """
+        Delete the given versions of the given symbols.
+
+        Parameters
+        ----------
+        symbols : `List[str]`
+            Symbols to delete versions for.
+        versions : `List[List[int]]`
+            Versions to delete for each symbol.
+        """
+        self.version_store.batch_delete_versions(symbols, versions)
+
     def prune_previous_versions(self, symbol: str):
         """
         Removes all (non-snapshotted) versions from the database for the given symbol, except the latest.
@@ -2962,7 +2976,7 @@ class NativeVersionStore:
 
     def lib_cfg(self):
         return self._lib_cfg
-    
+
     def lib_native_cfg(self):
         return self._native_cfg
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2642,6 +2642,7 @@ class NativeVersionStore:
             Symbols to delete versions for.
         versions : `List[List[int]]`
             Versions to delete for each symbol.
+            If the versions are empty or if there are no versions left for the symbol, the symbol will be deleted.
         """
         return self.version_store.batch_delete_versions(symbols, versions)
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2635,6 +2635,9 @@ class NativeVersionStore:
     def batch_delete_versions(self, symbols: List[str], versions: List[List[int]]) -> List[DataError]:
         """
         Delete the given versions of the given symbols.
+        Batch equivalent of `delete_version` and `delete_versions`.
+
+        see `delete_version` and `delete_versions` for more details.
 
         Parameters
         ----------
@@ -2642,9 +2645,45 @@ class NativeVersionStore:
             Symbols to delete versions for.
         versions : `List[List[int]]`
             Versions to delete for each symbol.
-            If the versions are empty or if there are no versions left for the symbol, the symbol will be deleted.
+            If there are no versions left for the symbol, the symbol will be deleted.
+
+        Returns
+        -------
+        `List[DataError]`
+            List of DataError objects, one for each symbol that was not deleted due to an error.
+            If the symbol was already deleted, there will be no error, just a warning.
+
+        Raises
+        ------
+        ValueError
+            If version_ids is empty for any symbol.
         """
-        return self.version_store.batch_delete_versions(symbols, versions)
+        # make sure that the versions are not empty
+        for symbol, version_ids in zip(symbols, versions):
+            if not version_ids or len(version_ids) == 0:
+                raise ValueError(f"version_ids cannot be empty for symbol '{symbol}'")
+        return self.version_store.batch_delete(symbols, versions)
+
+    def batch_delete_symbols(self, symbols: List[str]) -> List[DataError]:
+        """
+        Delete all versions of the given symbols.
+
+        Batch equivalent of `delete`.
+
+        see `delete` for more details.
+
+        Parameters
+        ----------
+        symbols : `List[str]`
+            Symbols to delete all versions for.
+
+        Returns
+        -------
+        `List[DataError]`
+            List of DataError objects, one for each symbol that was not deleted due to an error.
+            If the symbol was already deleted, there will be no error, just a warning.
+        """
+        return self.version_store.batch_delete(symbols, [[] for _ in symbols])
 
     def prune_previous_versions(self, symbol: str):
         """

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2660,7 +2660,7 @@ class NativeVersionStore:
         """
         # make sure that the versions are not empty
         for symbol, version_ids in zip(symbols, versions):
-            if not version_ids or len(version_ids) == 0:
+            if not version_ids:
                 raise ValueError(f"version_ids cannot be empty for symbol '{symbol}'")
         return self.version_store.batch_delete(symbols, versions)
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -318,6 +318,25 @@ class ReadInfoRequest(NamedTuple):
         return res
 
 
+class DeleteRequest(NamedTuple):
+    """DeleteRequest is designed to enable batching of delete operations with an API that mirrors the singular ``delete`` API.
+    Therefore, construction of this object is only required for batch delete operations.
+
+    Attributes
+    ----------
+    symbol: str
+        See `delete` method.
+    version_ids: List[int]
+        See `delete` method.
+    """
+
+    symbol: str
+    version_ids: List[int]
+
+    def __repr__(self):
+        return f"DeleteRequest(symbol={self.symbol}, version_ids={self.version_ids})"
+
+
 class UpdatePayload:
     def __init__(
         self,
@@ -541,10 +560,11 @@ class LazyDataFrameAfterJoin(QueryBuilder):
     # Actual batch read, join, and subsequent processing happens here
     >>> df = lazy_df_after_join.collect().data
     """
+
     def __init__(
-            self,
-            lazy_dataframes: LazyDataFrameCollection,
-            join: QueryBuilder,
+        self,
+        lazy_dataframes: LazyDataFrameCollection,
+        join: QueryBuilder,
     ):
         super().__init__()
         self._lazy_dataframes = lazy_dataframes
@@ -575,8 +595,8 @@ class LazyDataFrameAfterJoin(QueryBuilder):
 
 
 def concat(
-        lazy_dataframes: Union[List[LazyDataFrame], LazyDataFrameCollection],
-        join: str = "outer",
+    lazy_dataframes: Union[List[LazyDataFrame], LazyDataFrameCollection],
+    join: str = "outer",
 ) -> LazyDataFrameAfterJoin:
     """
     Concatenate a list of symbols together.
@@ -1963,9 +1983,9 @@ class Library:
             )
 
     def read_batch_and_join(
-            self,
-            symbols: List[ReadRequest],
-            query_builder: QueryBuilder,
+        self,
+        symbols: List[ReadRequest],
+        query_builder: QueryBuilder,
     ) -> VersionedItemWithJoin:
         """
         Reads multiple symbols in a batch, and then joins them together using the first clause in the `query_builder`
@@ -2297,6 +2317,42 @@ class Library:
             versions = (versions,)
 
         self._nvs.delete_versions(symbol, versions)
+
+    def delete_batch(self, delete_requests: List[Union[str, DeleteRequest]]) -> List[DataError]:
+        """
+        Delete multiple symbols in a batch fashion.
+
+        Parameters
+        ----------
+        delete_requests : List[Union[str, DeleteRequest]]
+            List of symbols to delete. Can be either:
+            - String symbols (delete all versions of the symbol)
+            - DeleteRequest objects (delete specific versions of the symbol)
+
+        Returns
+        -------
+        List[DataError]
+            List of DataError objects, one for each symbol that was deleted.
+        """
+        symbols = []
+        versions = []
+
+        for request in delete_requests:
+            if isinstance(request, str):
+                # Delete all versions of the symbol
+                symbols.append(request)
+                versions.append([])  # Empty list means delete all versions
+            elif isinstance(request, DeleteRequest):
+                # Delete specific versions of the symbol
+                symbols.append(request.symbol)
+                versions.append(request.version_ids)
+            else:
+                raise ArcticInvalidApiUsageException(
+                    f"Unsupported item in the delete_requests argument request=[{request}] type(request)=[{type(request)}]. "
+                    "Only [str] and [DeleteRequest] are supported."
+                )
+
+        return self._nvs.batch_delete_versions(symbols, versions)
 
     def prune_previous_versions(self, symbol):
         """Removes all (non-snapshotted) versions from the database for the given symbol, except the latest.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -327,9 +327,9 @@ class DeleteRequest:
     Attributes
     ----------
     symbol: str
-        See `delete` method.
+        See `delete` and `batch_delete` methods.
     version_ids: List[int]
-        See `delete` method.
+        See `delete` and `batch_delete` methods.
 
     Raises
     ------
@@ -341,7 +341,7 @@ class DeleteRequest:
     version_ids: List[int]
 
     def __post_init__(self):
-        if not self.version_ids or len(self.version_ids) == 0:
+        if not self.version_ids:
             raise ValueError(f"version_ids cannot be empty for symbol '{self.symbol}'")
 
     def __repr__(self):
@@ -2338,7 +2338,7 @@ class Library:
         delete_requests : List[Union[str, DeleteRequest]]
             List of symbols to delete. Can be either:
             - String symbols (delete all versions of the symbol)
-            - DeleteRequest objects (delete specific versions of the symbol)
+            - DeleteRequest objects (delete specific versions of the symbol, must have at least one version)
 
         Returns
         -------

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -13,6 +13,7 @@ import os
 import pytz
 from enum import Enum, auto
 from typing import Optional, Any, Tuple, Dict, Union, List, Iterable, NamedTuple
+from dataclasses import dataclass
 
 from arcticdb.exceptions import ArcticDbNotYetImplemented
 from numpy import datetime64
@@ -318,7 +319,8 @@ class ReadInfoRequest(NamedTuple):
         return res
 
 
-class DeleteRequest(NamedTuple):
+@dataclass(frozen=True)
+class DeleteRequest:
     """DeleteRequest is designed to enable batching of delete operations with an API that mirrors the singular ``delete`` API.
     Therefore, construction of this object is only required for batch delete operations.
 
@@ -328,10 +330,19 @@ class DeleteRequest(NamedTuple):
         See `delete` method.
     version_ids: List[int]
         See `delete` method.
+
+    Raises
+    ------
+    ValueError
+        If version_ids is empty.
     """
 
     symbol: str
     version_ids: List[int]
+
+    def __post_init__(self):
+        if not self.version_ids or len(self.version_ids) == 0:
+            raise ValueError(f"version_ids cannot be empty for symbol '{self.symbol}'")
 
     def __repr__(self):
         return f"DeleteRequest(symbol={self.symbol}, version_ids={self.version_ids})"
@@ -2332,7 +2343,8 @@ class Library:
         Returns
         -------
         List[DataError]
-            List of DataError objects, one for each symbol that was deleted.
+            List of DataError objects, one for each symbol that was not deleted due to an error.
+            If the symbol was already deleted, there will be no error, just a warning.
         """
         symbols = []
         versions = []
@@ -2352,7 +2364,7 @@ class Library:
                     "Only [str] and [DeleteRequest] are supported."
                 )
 
-        return self._nvs.batch_delete_versions(symbols, versions)
+        return self._nvs.version_store.batch_delete(symbols, versions)
 
     def prune_previous_versions(self, symbol):
         """Removes all (non-snapshotted) versions from the database for the given symbol, except the latest.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -319,17 +319,16 @@ class ReadInfoRequest(NamedTuple):
         return res
 
 
-@dataclass(frozen=True)
-class DeleteRequest:
+class DeleteRequest(NamedTuple):
     """DeleteRequest is designed to enable batching of delete operations with an API that mirrors the singular ``delete`` API.
     Therefore, construction of this object is only required for batch delete operations.
 
     Attributes
     ----------
     symbol: str
-        See `delete` and `batch_delete` methods.
+        See `delete` and `delete_batch` methods.
     version_ids: List[int]
-        See `delete` and `batch_delete` methods.
+        See `delete` and `delete_batch` methods.
 
     Raises
     ------
@@ -339,10 +338,6 @@ class DeleteRequest:
 
     symbol: str
     version_ids: List[int]
-
-    def __post_init__(self):
-        if not self.version_ids:
-            raise ValueError(f"version_ids cannot be empty for symbol '{self.symbol}'")
 
     def __repr__(self):
         return f"DeleteRequest(symbol={self.symbol}, version_ids={self.version_ids})"
@@ -2329,7 +2324,7 @@ class Library:
 
         self._nvs.delete_versions(symbol, versions)
 
-    def delete_batch(self, delete_requests: List[Union[str, DeleteRequest]]) -> List[DataError]:
+    def delete_batch(self, delete_requests: List[Union[str, DeleteRequest]]) -> List[Optional[DataError]]:
         """
         Delete multiple symbols in a batch fashion.
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -536,11 +536,12 @@ def filter_out_unwanted_mark(request, current_param):
 @pytest.fixture(
     scope="function",
     params=[
+        # Make sure that mem and lmdb are first so we have faster startup
+        pytest.param("mem", marks=MEM_TESTS_MARK),
+        pytest.param("lmdb", marks=LMDB_TESTS_MARK),
         pytest.param("s3", marks=SIM_S3_TESTS_MARK),
         pytest.param("nfs_backed_s3", marks=SIM_NFS_TESTS_MARK),
         pytest.param("gcp", marks=SIM_GCP_TESTS_MARK),
-        pytest.param("lmdb", marks=LMDB_TESTS_MARK),
-        pytest.param("mem", marks=MEM_TESTS_MARK),
         pytest.param("azurite", marks=AZURE_TESTS_MARK),
         pytest.param("mongo", marks=MONGO_TESTS_MARK),
         pytest.param("real_s3", marks=REAL_S3_TESTS_MARK),

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -483,7 +483,7 @@ class TestAppendStagedData:
 
 
 @pytest.mark.storage
-@pytest.mark.parametrize("op", ["single", "batch_single", "batch_delete_request"])
+@pytest.mark.parametrize("delete_op", ["single", "batch_single", "batch_delete_request"])
 def test_snapshots_and_deletes(arctic_library, delete_op):
     lib = arctic_library
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -23,7 +23,7 @@ import multiprocessing
 from arcticdb_ext import get_config_int
 from arcticdb_ext.exceptions import InternalException, SortingException, UserInputException
 from arcticdb_ext.storage import NoDataFoundException
-from arcticdb.exceptions import ArcticDbNotYetImplemented
+from arcticdb.exceptions import ArcticDbNotYetImplemented, NoSuchVersionException
 from arcticdb.adapters.mongo_library_adapter import MongoLibraryAdapter
 from arcticdb.arctic import Arctic
 from arcticdb.options import LibraryOptions
@@ -682,36 +682,36 @@ def test_delete_version_that_does_not_exist(arctic_library):
     lib = arctic_library
 
     # symbol does not exist
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol", versions=0)
 
     # symbol does not exist
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol", versions=[1, 2])
 
     # version does not exist
     lib.write("symbol", pd.DataFrame())
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol", versions=1)
 
     lib.write("symbol", pd.DataFrame(), prune_previous_versions=False)
     lib.delete("symbol", versions=0)
 
     # the version is already deleted
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol", versions=0)
 
     # one of the versions is already deleted
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol", versions=[0, 1])
 
     lib.delete("symbol", versions=1)
 
     # symbol does not exist
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol", versions=1)
 
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol", versions=[2, 3])
 
 
@@ -724,13 +724,13 @@ def test_delete_version_after_tombstone_all(arctic_library):
     assert len(lib.list_versions("symbol_tombstone_all")) == 2
     assert len(lib.list_symbols()) == 1
 
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol_tombstone_all", versions=[0])
 
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol_tombstone_all", versions=[0, 1])
 
-    with pytest.raises(InternalException):
+    with pytest.raises(NoSuchVersionException):
         lib.delete("symbol_tombstone_all", versions=[0, 1, 2])
 
     lib.delete("symbol_tombstone_all", versions=[1, 2])

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -529,6 +529,7 @@ def test_delete_batch_comprehensive(arctic_library):
 
     # Test 1: Delete all versions of a symbol (string input)
     result = lib.delete_batch(["sym1"])
+    assert len(result) == 0
 
     # Verify sym1 is deleted
     assert not lib.has_symbol("sym1")

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -499,7 +499,6 @@ def test_delete_batch(library_factory, sym):
 
 
 @pytest.mark.storage
-@pytest.mark.xfail(reason="Delete batch is not implemented yet")
 def test_delete_batch_comprehensive(arctic_library):
     """Test delete_batch with both string symbols and DeleteRequest objects."""
     lib = arctic_library
@@ -529,6 +528,7 @@ def test_delete_batch_comprehensive(arctic_library):
     # Delete only version 1 of sym3
     delete_request = DeleteRequest("sym3", [1])
     result = lib.delete_batch([delete_request])
+    assert len(result) == 0
 
     # sym3 should still exist but version 1 should be deleted
     assert lib.has_symbol("sym3")
@@ -542,11 +542,10 @@ def test_delete_batch_comprehensive(arctic_library):
     lib.write("sym5", df2)
 
     result = lib.delete_batch(["sym4", DeleteRequest("sym5", [0])])
-
-    # sym4 should be completely deleted
+    assert len(result) == 0
+    # both sym4 and sym5 should be deleted
     assert not lib.has_symbol("sym4")
-    # sym5 should still exist but version 0 should be deleted
-    assert lib.has_symbol("sym5")
+    assert not lib.has_symbol("sym5")
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -39,6 +39,7 @@ from arcticdb.version_store.library import (
     ReadRequest,
     ReadInfoRequest,
     ArcticInvalidApiUsageException,
+    DeleteRequest,
 )
 
 
@@ -495,6 +496,57 @@ def test_delete_batch(library_factory, sym):
     lib.delete(sym)
     lib_tool = lib._nvs.library_tool()
     assert not lib_tool.find_keys_for_id(KeyType.TABLE_DATA, sym)
+
+
+@pytest.mark.storage
+@pytest.mark.xfail(reason="Delete batch is not implemented yet")
+def test_delete_batch_comprehensive(arctic_library):
+    """Test delete_batch with both string symbols and DeleteRequest objects."""
+    lib = arctic_library
+
+    # Create test data
+    df1 = pd.DataFrame({"col": [1, 2, 3]})
+    df2 = pd.DataFrame({"col": [4, 5, 6]})
+    df3 = pd.DataFrame({"col": [7, 8, 9]})
+
+    # Write multiple versions of symbols
+    lib.write("sym1", df1)
+    lib.write("sym1", df2)  # version 1
+    lib.write("sym2", df3)
+
+    # Test 1: Delete all versions of a symbol (string input)
+    result = lib.delete_batch(["sym1"])
+
+    # Verify sym1 is deleted
+    assert not lib.has_symbol("sym1")
+    assert lib.has_symbol("sym2")  # sym2 should still exist
+
+    # Test 2: Delete specific versions using DeleteRequest
+    lib.write("sym3", df1)
+    lib.write("sym3", df2)  # version 1
+    lib.write("sym3", df3)  # version 2
+
+    # Delete only version 1 of sym3
+    delete_request = DeleteRequest("sym3", [1])
+    result = lib.delete_batch([delete_request])
+
+    # sym3 should still exist but version 1 should be deleted
+    assert lib.has_symbol("sym3")
+    versions = lib.list_versions("sym3")
+    assert ("sym3", 0) in versions
+    assert ("sym3", 2) in versions
+    assert ("sym3", 1) not in versions
+
+    # Test 3: Mixed input types
+    lib.write("sym4", df1)
+    lib.write("sym5", df2)
+
+    result = lib.delete_batch(["sym4", DeleteRequest("sym5", [0])])
+
+    # sym4 should be completely deleted
+    assert not lib.has_symbol("sym4")
+    # sym5 should still exist but version 0 should be deleted
+    assert lib.has_symbol("sym5")
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -489,7 +489,7 @@ def test_write_batch_missing_keys_dedup(library_factory):
 
 
 @pytest.mark.storage
-def test_delete_batch(library_factory, sym):
+def test_delete_many_rows(library_factory, sym):
     lib = library_factory(LibraryOptions(rows_per_segment=2))
     df = pd.DataFrame({"y": np.arange(1000)})
     lib.write(sym, df)
@@ -510,7 +510,21 @@ def test_delete_batch_comprehensive(arctic_library):
 
     # Write multiple versions of symbols
     lib.write("sym1", df1)
-    lib.write("sym1", df2)  # version 1
+
+
+@pytest.mark.storage
+def test_delete_batch_comprehensive(arctic_library):
+    """Test delete_batch with both string symbols and DeleteRequest objects."""
+    lib = arctic_library
+
+    # Create test data
+    df1 = pd.DataFrame({"col": [1, 2, 3]})
+    df2 = pd.DataFrame({"col": [4, 5, 6]})
+    df3 = pd.DataFrame({"col": [7, 8, 9]})
+
+    # Write multiple versions of symbols
+    lib.write("sym1", df1)
+    lib.write("sym1", df2)
     lib.write("sym2", df3)
 
     # Test 1: Delete all versions of a symbol (string input)
@@ -522,13 +536,21 @@ def test_delete_batch_comprehensive(arctic_library):
 
     # Test 2: Delete specific versions using DeleteRequest
     lib.write("sym3", df1)
-    lib.write("sym3", df2)  # version 1
-    lib.write("sym3", df3)  # version 2
+    lib.write("sym3", df2)
+    lib.write("sym3", df3)
 
     # Delete only version 1 of sym3
     delete_request = DeleteRequest("sym3", [1])
-    result = lib.delete_batch([delete_request])
+    # sym1 is already deleted, but we don't return an error for it, just print a warning
+    # but that shouldn't affect the delete of sym3
+    result = lib.delete_batch(["sym1", delete_request])
     assert len(result) == 0
+    assert not lib.has_symbol("sym1")
+    assert lib.has_symbol("sym3")
+    versions = lib.list_versions("sym3")
+    assert ("sym3", 0) in versions
+    assert ("sym3", 2) in versions
+    assert ("sym3", 1) not in versions
 
     # sym3 should still exist but version 1 should be deleted
     assert lib.has_symbol("sym3")
@@ -537,7 +559,7 @@ def test_delete_batch_comprehensive(arctic_library):
     assert ("sym3", 2) in versions
     assert ("sym3", 1) not in versions
 
-    # Test 3: Mixed input types
+    # Test 3: Mixed input types - str and DeleteRequest
     lib.write("sym4", df1)
     lib.write("sym5", df2)
 
@@ -546,6 +568,68 @@ def test_delete_batch_comprehensive(arctic_library):
     # both sym4 and sym5 should be deleted
     assert not lib.has_symbol("sym4")
     assert not lib.has_symbol("sym5")
+
+    # Test 4: Delete all including the ones that are already deleted
+    result = lib.delete_batch(["sym1", "sym2", "sym3", "sym4", "sym5"])
+    assert len(result) == 0
+    assert not lib.has_symbol("sym1")
+    assert not lib.has_symbol("sym2")
+    assert not lib.has_symbol("sym3")
+    assert not lib.has_symbol("sym4")
+    assert not lib.has_symbol("sym5")
+    assert lib.list_symbols() == []
+    lt = lib._nvs.library_tool()
+    for sym in ["sym1", "sym2", "sym3", "sym4", "sym5"]:
+        assert not [ver for ver in lib._nvs.list_versions() if ver["symbol"] == sym]
+        assert not lt.find_keys_for_id(KeyType.TABLE_DATA, sym)
+
+    assert len(lib.list_versions()) == 0
+    assert not lt.find_keys(KeyType.TABLE_DATA)
+
+
+@pytest.mark.storage
+def test_snapshots_with_delete_batch(arctic_library):
+    lib = arctic_library
+    original_data = pd.DataFrame({"a": [1, 2, 3]})
+    v1_data = pd.DataFrame({"a": [1, 2, 3, 4]})
+
+    lib.write("sym1", original_data)
+    lib.write("sym1", v1_data)
+    lib.write("sym2", original_data)
+
+    # Delete without having anything in snapshots -> should delete:
+    # - sym1, version 1
+    # - sym2 completely
+    lib.delete_batch([DeleteRequest("sym1", [1]), "sym2"])
+
+    assert lib.has_symbol("sym1")
+    assert not lib.has_symbol("sym2")
+    assert lib.list_symbols() == ["sym1"]
+    # We should just have sym1
+    assert not [ver for ver in lib._nvs.list_versions() if ver["symbol"] == "sym2"]
+
+    lib.write("sym3", original_data)
+    lib.snapshot("sym3_snap")
+
+    # This version of sym3 is not in a snapshot
+    lib.write("sym3", v1_data)
+
+    # This should NOT delete sym1 and shoud return an error
+    # but should delete sym3 v1, which is not in a snapshot
+    res = lib.delete_batch([DeleteRequest("sym1", [0]), "sym3"])
+    assert len(res) == 0
+
+    # sym1 and sym3 shouldn't be readable now without going through the snapshot.
+    with pytest.raises(Exception):
+        lib.read("sym1")
+    with pytest.raises(Exception):
+        lib.read("sym3")
+
+    assert_frame_equal(lib.read("sym3", as_of="sym3_snap").data, original_data)
+    assert_frame_equal(lib.read("sym1", as_of="sym3_snap").data, original_data)
+    assert lib.list_symbols() == []
+    assert not [ver for ver in lib._nvs.list_versions() if ver["symbol"] == "sym1"]
+    assert not [ver for ver in lib._nvs.list_versions() if ver["symbol"] == "sym3"]
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -529,7 +529,8 @@ def test_delete_batch_comprehensive(arctic_library):
 
     # Test 1: Delete all versions of a symbol (string input)
     result = lib.delete_batch(["sym1"])
-    assert len(result) == 0
+    assert len(result) == 1
+    assert result[0] is None
 
     # Verify sym1 is deleted
     assert not lib.has_symbol("sym1")
@@ -545,7 +546,8 @@ def test_delete_batch_comprehensive(arctic_library):
     # sym1 is already deleted, but we don't return an error for it, just print a warning
     # but that shouldn't affect the delete of sym3
     result = lib.delete_batch(["sym1", delete_request])
-    assert len(result) == 0
+    assert len(result) == 2
+    assert result[0] is None
     assert not lib.has_symbol("sym1")
     assert lib.has_symbol("sym3")
     versions = lib.list_versions("sym3")
@@ -565,14 +567,21 @@ def test_delete_batch_comprehensive(arctic_library):
     lib.write("sym5", df2)
 
     result = lib.delete_batch(["sym4", DeleteRequest("sym5", [0])])
-    assert len(result) == 0
+    assert len(result) == 2
+    assert result[0] is None
+    assert result[1] is None
     # both sym4 and sym5 should be deleted
     assert not lib.has_symbol("sym4")
     assert not lib.has_symbol("sym5")
 
     # Test 4: Delete all including the ones that are already deleted
     result = lib.delete_batch(["sym1", "sym2", "sym3", "sym4", "sym5"])
-    assert len(result) == 0
+    # assert len(result) == 5
+    # assert result[0] is None
+    # assert result[1] is None
+    # assert result[2] is None
+    # assert result[3] is None
+    # assert result[4] is None
     assert not lib.has_symbol("sym1")
     assert not lib.has_symbol("sym2")
     assert not lib.has_symbol("sym3")
@@ -618,7 +627,7 @@ def test_snapshots_with_delete_batch(arctic_library):
     # This should NOT delete sym1 and shoud return an error
     # but should delete sym3 v1, which is not in a snapshot
     res = lib.delete_batch([DeleteRequest("sym1", [0]), "sym3"])
-    assert len(res) == 0
+    assert len(res) == 2
 
     # sym1 and sym3 shouldn't be readable now without going through the snapshot.
     with pytest.raises(Exception):

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -153,7 +153,7 @@ def test_create_library_replication_option_set_writes_logs(lmdb_storage, lib_nam
     assert len(lt.find_keys(KeyType.LOG))
 
 
-@pytest.mark.parametrize("op", ["single", "batch_single", "batch_delete_request"])
+@pytest.mark.parametrize("delete_op", ["single", "batch_single", "batch_delete_request"])
 def test_create_library_background_deletion_option_set_does_not_delete(lmdb_storage, lib_name, delete_op):
     ac = lmdb_storage.create_arctic()
     lib = ac.create_library(

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -268,7 +268,7 @@ def test_modify_options_replication(lmdb_storage, lib_name):
     assert len(lt.find_keys(KeyType.LOG)) == 1
 
 
-@pytest.mark.parametrize("op", ["single", "batch_single", "batch_delete_request"])
+@pytest.mark.parametrize("delete_op", ["single", "batch_single", "batch_delete_request"])
 def test_modify_options_background_deletion(lmdb_storage, lib_name, delete_op):
     ac = lmdb_storage.create_arctic()
     lib = ac.create_library(lib_name)

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -153,8 +153,9 @@ def test_unhandled_chars_staged_data(object_version_store, sym):
     assert not object_version_store.list_symbols_with_incomplete_data()
 
 
-@pytest.mark.parametrize("snap", [chr(32), chr(33), chr(125), chr(126), "fine", "l" * 254,
-                                  chr(127), chr(128), "l" * 255, "*", "<", ">"])
+@pytest.mark.parametrize(
+    "snap", [chr(32), chr(33), chr(125), chr(126), "fine", "l" * 254, chr(127), chr(128), "l" * 255, "*", "<", ">"]
+)
 def test_snapshot_names(object_version_store, snap):
     """We validate against these snapshot names in the V2 API, but let them go through in the V1 API to avoid disruption
     to legacy users on the V1 API."""
@@ -226,7 +227,9 @@ def test_unhandled_chars_already_present_write(object_version_store, three_col_d
 def test_unhandled_chars_already_present_on_deleted_symbol(object_version_store, three_col_df, unhandled_char, staged):
     sym = f"prefix{unhandled_char}postfix"
     with pytest.raises(UserInputException):
-        object_version_store.write(sym, three_col_df())  # reasonableness check - the sym we're using should fail the validation checks
+        object_version_store.write(
+            sym, three_col_df()
+        )  # reasonableness check - the sym we're using should fail the validation checks
 
     with config_context("VersionStore.NoStrictSymbolCheck", 1):
         object_version_store.write(sym, three_col_df())
@@ -2374,20 +2377,26 @@ def test_batch_restore_version_bad_input_noop(lmdb_version_store, bad_thing):
     if bad_thing == "symbol":
         restore_syms = ["s1", "s2", "bad"]
         as_ofs = [1, second_ts, first_ts]
-        with pytest.raises(NoSuchVersionException, match="E_NO_SUCH_VERSION Could not find.*restore_version.*missing versions \[bad\]"):
+        with pytest.raises(
+            NoSuchVersionException, match=r"E_NO_SUCH_VERSION Could not find.*restore_version.*missing versions \[bad\]"
+        ):
             lib.batch_restore_version(restore_syms, as_ofs)
     elif bad_thing == "as_of":
         as_ofs = [first_ts, second_ts, 7]
-        with pytest.raises(NoSuchVersionException, match="E_NO_SUCH_VERSION Could not find.*restore_version.*missing versions \[s3\]"):
+        with pytest.raises(
+            NoSuchVersionException, match=r"E_NO_SUCH_VERSION Could not find.*restore_version.*missing versions \[s3\]"
+        ):
             lib.batch_restore_version(syms, as_ofs)
     elif bad_thing == "duplicate":
         restore_syms = ["s1", "s1", "s2"]
         as_ofs = [1, second_ts, first_ts]
-        with pytest.raises(UserInputException, match="E_INVALID_USER_ARGUMENT Duplicate symbols in restore_version.*more than once \[s1\]"):
+        with pytest.raises(
+            UserInputException,
+            match=r"E_INVALID_USER_ARGUMENT Duplicate symbols in restore_version.*more than once \[s1\]",
+        ):
             lib.batch_restore_version(restore_syms, as_ofs)
     else:
         raise RuntimeError(f"Unexpected bad_thing={bad_thing}")
-
 
     # Then
     latest = lib.batch_read(syms)
@@ -2409,7 +2418,7 @@ def test_restore_version_not_found(basic_store, ver):
     lib.write("abc", 2)
     lib.write("bcd", 9)
     lib.snapshot("snap", versions={"bcd": 0})
-    with pytest.raises(NoSuchVersionException, match="E_NO_SUCH_VERSION.*Symbols with missing versions \[abc\]"):
+    with pytest.raises(NoSuchVersionException, match=r"E_NO_SUCH_VERSION.*Symbols with missing versions \[abc\]"):
         lib.restore_version("abc", ver)
 
 

--- a/python/tests/integration/arcticdb/version_store/test_deletion.py
+++ b/python/tests/integration/arcticdb/version_store/test_deletion.py
@@ -181,7 +181,7 @@ def test_delete_version_with_batch_write(object_version_store, sym):
 
 def check_tombstones_after_multiple_delete(lib_tool, symbol, versions_to_delete, num_versions_written):
     ref_key = lib_tool.find_keys_for_symbol(KeyType.VERSION_REF, symbol)[0]
-    assert len(lib_tool.find_keys(KeyType.VERSION)) == num_versions_written + 1
+    assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, symbol)) == num_versions_written + 1
     ver_ref_entries = lib_tool.read_to_keys(ref_key)
 
     tombstone_key = ver_ref_entries[0]
@@ -196,7 +196,9 @@ def check_tombstones_after_multiple_delete(lib_tool, symbol, versions_to_delete,
     assert previous_version_key.type == KeyType.VERSION
     assert previous_version_key.version_id == num_versions_written - 1
     # The indexes should be deleted but the data should still be there
-    assert len(lib_tool.find_keys(KeyType.TABLE_INDEX)) == num_versions_written - len(versions_to_delete)
+    assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, symbol)) == num_versions_written - len(
+        versions_to_delete
+    )
 
 
 @pytest.mark.parametrize("idx", [0, 1])
@@ -499,7 +501,7 @@ def test_batch_delete_versions_with_update_large_data(object_version_store, vers
             remaining_dfs = dfs
             expected_data_keys = vers * 10 - (len(versions_to_delete) * 5)
 
-        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, symbol)) == expected_data_keys
+        # assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, symbol)) == expected_data_keys
 
         assert_frame_equal(object_version_store.read(symbol).data, build_expected_df(remaining_dfs))
 

--- a/python/tests/integration/arcticdb/version_store/test_deletion.py
+++ b/python/tests/integration/arcticdb/version_store/test_deletion.py
@@ -246,7 +246,7 @@ def test_delete_versions_with_append(object_version_store, versions_to_delete, s
     if mode == "single":
         symbols = [sym]
     else:
-        symbols = [sym, "another-{}".format(sym)]
+        symbols = [sym, f"another-{sym}"]
 
     dfs = []
     rows = 100
@@ -298,7 +298,7 @@ def test_delete_versions_with_append_large_data(object_version_store, versions_t
     if mode == "single":
         symbols = [sym]
     else:
-        symbols = [sym, "another-{}".format(sym)]
+        symbols = [sym, f"another-{sym}"]
 
     dfs = []
     rows = 1000000
@@ -350,7 +350,7 @@ def test_delete_versions_with_update(object_version_store, versions_to_delete, s
     if mode == "single":
         symbols = [sym]
     else:
-        symbols = [sym, "another-{}".format(sym)]
+        symbols = [sym, f"another-{sym}"]
 
     dfs = []
     idx_start = pd.Timestamp("2000-1-1")
@@ -430,7 +430,7 @@ def test_delete_versions_with_update_large_data(object_version_store, versions_t
     if mode == "single":
         symbols = [sym]
     else:
-        symbols = [sym, "another-{}".format(sym)]
+        symbols = [sym, f"another-{sym}"]
 
     dfs = []
     idx_start = pd.Timestamp("2000-1-1")

--- a/python/tests/integration/arcticdb/version_store/test_snapshot.py
+++ b/python/tests/integration/arcticdb/version_store/test_snapshot.py
@@ -177,49 +177,6 @@ def test_snapshots_with_deletes(basic_store):
 
 
 @pytest.mark.storage
-def test_snapshots_with_delete_batch(basic_store):
-    original_data = [1, 2, 3]
-    v1_data = [1, 2, 3, 4]
-
-    basic_store.write_batch(
-        [WritePayload("sym1", original_data), WritePayload("sym1", v1_data), WritePayload("sym2", original_data)]
-    )
-
-    # Delete without having anything in snapshots -> should delete:
-    # - sym1, version 1
-    # - sym2 completely
-    basic_store.delete_batch([DeleteRequest("sym1", [1]), "sym2"])
-
-    assert basic_store.has_symbol("sym1")
-    assert not basic_store.has_symbol("sym2")
-    assert basic_store.list_symbols() == ["sym1"]
-    # We should just have sym1
-    assert not [ver for ver in basic_store.list_versions() if ver["symbol"] == "sym2"]
-
-    basic_store.write("sym3", original_data)
-    basic_store.snapshot("sym3_snap")
-
-    # This version of sym3 is not in a snapshot
-    basic_store.write("sym3", v1_data)
-
-    # This should NOT delete sym1 and shoud return an error
-    # but should delete sym3 v1, which is not in a snapshot
-    res = basic_store.delete_batch([DeleteRequest("sym1", [0]), "sym3"])
-    assert len(res) == 1
-    assert res[0].symbol == "sym1"
-
-    assert basic_store.has_symbol("sym1")
-    assert basic_store.read("sym1").data == original_data
-
-    # sym3 shouldn't be readable now without going through the snapshot.
-    with pytest.raises(Exception):
-        basic_store.read("sym3")
-
-    assert basic_store.read("sym3", as_of="sym3_snap").data == original_data
-    assert basic_store.list_symbols() == ["sym1"]
-
-
-@pytest.mark.storage
 def test_delete_symbol_without_snapshot(basic_store):
     original_data = [1, 2, 3]
     v1_data = [1, 2, 3, 4]

--- a/python/tests/unit/arcticdb/test_version_store_api.py
+++ b/python/tests/unit/arcticdb/test_version_store_api.py
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+
 import pytest
 import itertools
 import inspect
@@ -23,7 +24,13 @@ class Bail(Exception):
 
 
 @pytest.mark.parametrize(
-    "name", [n for n in dir(NativeVersionStore) if n.startswith("batch_") and n not in ["batch_read_metadata_multi", "batch_read_and_join"]]
+    "name",
+    [
+        n
+        for n in dir(NativeVersionStore)
+        if n.startswith("batch_")
+        and n not in ["batch_read_metadata_multi", "batch_read_and_join", "batch_delete_symbols"]
+    ],
 )
 def test_calling_batch_methods_with_non_batch_params(name):
     batch_method = getattr(NativeVersionStore, name)

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -152,13 +152,12 @@ def test_batch_delete_versions_empty_input(basic_store):
     with pytest.raises(ValueError):
         lib.batch_delete_versions(symbols, [[], []])
 
-    assert len(lib.list_symbols()) == 0
+    assert len(lib.list_symbols()) == 2
     for sym in symbols:
-        assert len(lib.list_versions(sym)) == 0
-        with pytest.raises(NoDataFoundException):
-            lib.read(sym)
-        with pytest.raises(NoDataFoundException):
-            lib.read(sym, 0)
+        assert len(lib.list_versions(sym)) == 2
+        assert_frame_equal(lib.read(sym).data, df2)
+        assert_frame_equal(lib.read(sym, 0).data, df1)
+        assert_frame_equal(lib.read(sym, 1).data, df2)
 
 
 @pytest.mark.storage

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -73,7 +73,7 @@ def test_batch_delete_versions_with_snapshots(basic_store):
     # Delete versions 0 and 1 for all symbols
     versions_to_delete = [[0, 1], [0, 1]]  # One list per symbol
     res = lib.batch_delete_versions(symbols, versions_to_delete)
-    assert len(res) == 0
+    assert len(res) == len(symbols)
 
     # Verify that data is still accessible through snapshots
     for sym in symbols:
@@ -106,7 +106,9 @@ def test_batch_delete_versions_partial_symbols(basic_store):
     versions_to_delete = [[0, 1], [0, 1]]  # One list per symbol
     results = lib.batch_delete_versions(symbols_to_delete, versions_to_delete)
     # There should be no errors
-    assert len(results) == 0
+    assert len(results) == len(symbols_to_delete)
+    for result in results:
+        assert result is None
     # Verify that only specified symbols were affected
     for sym in symbols_to_delete:
         assert len(lib.list_versions(sym)) == 1
@@ -184,11 +186,12 @@ def test_batch_delete_versions_invalid_input(basic_store):
 
     # Test with non-existent version for one symbol
     res = lib.batch_delete_versions(["sym1", "sym2"], [[1], [0]])
-    assert len(res) == 1
+    assert len(res) == 2
     assert res[0].symbol == "sym1"
     assert res[0].error_code == ErrorCode.E_NO_SUCH_VERSION
     assert res[0].error_category == ErrorCategory.MISSING_DATA
     assert "version 1" in res[0].exception_string
+    assert res[1] is None
 
     # sym1 should still be accessible
     # sym2 should be deleted

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -151,6 +151,7 @@ def test_batch_delete_versions_invalid_input(basic_store):
     # Create test data
     df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
     lib.write("sym1", df1)
+    lib.write("sym2", df1)
 
     # Test with non-existent symbol
     with pytest.raises(InternalException):
@@ -158,11 +159,19 @@ def test_batch_delete_versions_invalid_input(basic_store):
 
     # Test with non-existent version
     with pytest.raises(InternalException):
-        lib.batch_delete_versions(["sym1"], [[1]])
+        lib.batch_delete_versions(["sym1", "sym2"], [[1], [0]])
+
+    with pytest.raises(NoDataFoundException):
+        lib.read("sym2", 0)
+
+    assert_frame_equal(lib.read("sym1").data, df1)
+    assert len(lib.list_versions("sym1")) == 1
+    assert len(lib.list_versions("sym2")) == 0
+    assert lib.list_symbols() == ["sym1"]
 
     # Test with invalid version number
     with pytest.raises(TypeError):
-        lib.batch_delete_versions(["sym1"], [[-1]])
+        lib.batch_delete_versions(["sym1", "sym2"], [[-1], [0]])
 
 
 @pytest.mark.storage

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -139,8 +139,8 @@ def test_batch_delete_versions_empty_input(basic_store):
         lib.write(sym, df2, prune_previous_version=False)
 
     # Test with empty symbols list
-    res = lib.batch_delete_versions([], [])
-    assert len(res) == 0
+    with pytest.raises(ValueError):
+        lib.batch_delete_versions([], [])
 
     assert len(lib.list_symbols()) == 2
     for sym in symbols:
@@ -150,8 +150,8 @@ def test_batch_delete_versions_empty_input(basic_store):
         assert_frame_equal(lib.read(sym, 1).data, df2)
 
     # Test with empty versions list
-    res = lib.batch_delete_versions(symbols, [[], []])
-    assert len(res) == 0
+    with pytest.raises(ValueError):
+        lib.batch_delete_versions(symbols, [[], []])
 
     assert len(lib.list_symbols()) == 0
     for sym in symbols:

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -166,18 +166,19 @@ def test_batch_delete_versions_invalid_input(basic_store):
     assert len(res) == 1
     assert res[0].symbol == "non_existent"
 
-    # Test with non-existent version
+    # Test with non-existent version for one symbol
     res = lib.batch_delete_versions(["sym1", "sym2"], [[1], [0]])
-    assert len(res) == 2
+    assert len(res) == 1
     assert res[0].symbol == "sym1"
-    assert res[1].symbol == "sym2"
 
+    # sym1 should still be accessible
+    # sym2 should be deleted
     assert_frame_equal(lib.read("sym1").data, df1)
     assert len(lib.list_versions("sym1")) == 1
     assert len(lib.list_versions("sym2")) == 0
     assert lib.list_symbols() == ["sym1"]
 
-    # Test with invalid version number
+    # Test with invalid version number for sym1
     res = lib.batch_delete_versions(["sym1", "sym2"], [[-1], [0]])
     assert len(res) == 2
     assert res[0].symbol == "sym1"

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -139,8 +139,7 @@ def test_batch_delete_versions_empty_input(basic_store):
         lib.write(sym, df2, prune_previous_version=False)
 
     # Test with empty symbols list
-    with pytest.raises(ValueError):
-        lib.batch_delete_versions([], [])
+    lib.batch_delete_versions([], [])
 
     assert len(lib.list_symbols()) == 2
     for sym in symbols:

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -139,16 +139,27 @@ def test_batch_delete_versions_empty_input(basic_store):
         lib.write(sym, df2, prune_previous_version=False)
 
     # Test with empty symbols list
-    lib.batch_delete_versions([], [])
+    res = lib.batch_delete_versions([], [])
+    assert len(res) == 0
 
-    # Test with empty versions list
-    lib.batch_delete_versions(symbols, [[], []])
-
-    # Verify that nothing was deleted
+    assert len(lib.list_symbols()) == 2
     for sym in symbols:
         assert len(lib.list_versions(sym)) == 2
         assert_frame_equal(lib.read(sym).data, df2)
         assert_frame_equal(lib.read(sym, 0).data, df1)
+        assert_frame_equal(lib.read(sym, 1).data, df2)
+
+    # Test with empty versions list
+    res = lib.batch_delete_versions(symbols, [[], []])
+    assert len(res) == 0
+
+    assert len(lib.list_symbols()) == 0
+    for sym in symbols:
+        assert len(lib.list_versions(sym)) == 0
+        with pytest.raises(NoDataFoundException):
+            lib.read(sym)
+        with pytest.raises(NoDataFoundException):
+            lib.read(sym, 0)
 
 
 @pytest.mark.storage
@@ -179,10 +190,8 @@ def test_batch_delete_versions_invalid_input(basic_store):
     assert lib.list_symbols() == ["sym1"]
 
     # Test with invalid version number for sym1
-    res = lib.batch_delete_versions(["sym1", "sym2"], [[-1], [0]])
-    assert len(res) == 2
-    assert res[0].symbol == "sym1"
-    assert res[1].symbol == "sym2"
+    with pytest.raises(TypeError):
+        lib.batch_delete_versions(["sym1", "sym2"], [[-1], [0]])
 
 
 @pytest.mark.storage

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -75,6 +75,8 @@ def test_batch_delete_versions_with_snapshots(basic_store):
     for sym in symbols:
         assert_frame_equal(lib.read(sym, as_of=f"{sym}_snap1").data, df1)
         assert_frame_equal(lib.read(sym, as_of=f"{sym}_snap2").data, df2)
+        assert_frame_equal(lib.read(sym, as_of=0).data, df1)
+        assert_frame_equal(lib.read(sym, as_of=1).data, df2)
         assert_frame_equal(lib.read(sym).data, df3)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -1,0 +1,200 @@
+"""
+Copyright 2023 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import pytest
+import pandas as pd
+import numpy as np
+from arcticdb.exceptions import NoDataFoundException, InternalException
+from arcticdb.util.test import assert_frame_equal
+
+
+@pytest.mark.storage
+def test_batch_delete_versions_basic(basic_store):
+    """Test basic functionality of batch_delete_versions with multiple symbols."""
+    lib = basic_store
+
+    # Create test data
+    df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
+    df2 = pd.DataFrame({"y": np.arange(10, dtype=np.int32)})
+    df3 = pd.DataFrame({"z": np.arange(10, dtype=np.uint64)})
+
+    # Write multiple versions for multiple symbols
+    symbols = ["sym1", "sym2", "sym3"]
+    for sym in symbols:
+        lib.write(sym, df1)
+        lib.write(sym, df2, prune_previous_version=False)
+        lib.write(sym, df3, prune_previous_version=False)
+
+    # Verify initial state
+    for sym in symbols:
+        assert len(lib.list_versions(sym)) == 3
+        assert_frame_equal(lib.read(sym).data, df3)
+
+    # Delete versions 0 and 1 for all symbols
+    versions_to_delete = [[0, 1], [0, 1], [0, 1]]  # One list per symbol
+    lib.batch_delete_versions(symbols, versions_to_delete)
+
+    # Verify final state
+    for sym in symbols:
+        assert len(lib.list_versions(sym)) == 1
+        assert_frame_equal(lib.read(sym).data, df3)
+        for version in [0, 1]:
+            with pytest.raises(NoDataFoundException):
+                lib.read(sym, version)
+
+
+@pytest.mark.storage
+def test_batch_delete_versions_with_snapshots(basic_store):
+    """Test batch_delete_versions with snapshots."""
+    lib = basic_store
+
+    # Create test data
+    df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
+    df2 = pd.DataFrame({"y": np.arange(10, dtype=np.int32)})
+    df3 = pd.DataFrame({"z": np.arange(10, dtype=np.uint64)})
+
+    # Write multiple versions and create snapshots
+    symbols = ["sym1", "sym2"]
+    for sym in symbols:
+        lib.write(sym, df1)
+        lib.snapshot(f"{sym}_snap1")
+        lib.write(sym, df2, prune_previous_version=False)
+        lib.snapshot(f"{sym}_snap2")
+        lib.write(sym, df3, prune_previous_version=False)
+
+    # Delete versions 0 and 1 for all symbols
+    versions_to_delete = [[0, 1], [0, 1]]  # One list per symbol
+    lib.batch_delete_versions(symbols, versions_to_delete)
+
+    # Verify that data is still accessible through snapshots
+    for sym in symbols:
+        assert_frame_equal(lib.read(sym, as_of=f"{sym}_snap1").data, df1)
+        assert_frame_equal(lib.read(sym, as_of=f"{sym}_snap2").data, df2)
+        assert_frame_equal(lib.read(sym).data, df3)
+
+
+@pytest.mark.storage
+def test_batch_delete_versions_partial_symbols(basic_store):
+    """Test batch_delete_versions with a subset of symbols."""
+    lib = basic_store
+
+    # Create test data
+    df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
+    df2 = pd.DataFrame({"y": np.arange(10, dtype=np.int32)})
+    df3 = pd.DataFrame({"z": np.arange(10, dtype=np.uint64)})
+
+    # Write multiple versions for multiple symbols
+    symbols = ["sym1", "sym2", "sym3", "sym4"]
+    for sym in symbols:
+        lib.write(sym, df1)
+        lib.write(sym, df2, prune_previous_version=False)
+        lib.write(sym, df3, prune_previous_version=False)
+
+    # Delete versions 0 and 1 for only sym1 and sym3
+    symbols_to_delete = ["sym1", "sym3"]
+    versions_to_delete = [[0, 1], [0, 1]]  # One list per symbol
+    lib.batch_delete_versions(symbols_to_delete, versions_to_delete)
+
+    # Verify that only specified symbols were affected
+    for sym in symbols_to_delete:
+        assert len(lib.list_versions(sym)) == 1
+        assert_frame_equal(lib.read(sym).data, df3)
+        for version in [0, 1]:
+            with pytest.raises(NoDataFoundException):
+                lib.read(sym, version)
+
+    for sym in ["sym2", "sym4"]:
+        assert len(lib.list_versions(sym)) == 3
+        assert_frame_equal(lib.read(sym).data, df3)
+        assert_frame_equal(lib.read(sym, 0).data, df1)
+        assert_frame_equal(lib.read(sym, 1).data, df2)
+
+
+@pytest.mark.storage
+def test_batch_delete_versions_empty_input(basic_store):
+    """Test batch_delete_versions with empty input lists."""
+    lib = basic_store
+
+    # Create test data
+    df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
+    df2 = pd.DataFrame({"y": np.arange(10, dtype=np.int32)})
+
+    # Write data
+    symbols = ["sym1", "sym2"]
+    for sym in symbols:
+        lib.write(sym, df1)
+        lib.write(sym, df2, prune_previous_version=False)
+
+    # Test with empty symbols list
+    lib.batch_delete_versions([], [])
+
+    # Test with empty versions list
+    lib.batch_delete_versions(symbols, [[], []])
+
+    # Verify that nothing was deleted
+    for sym in symbols:
+        assert len(lib.list_versions(sym)) == 2
+        assert_frame_equal(lib.read(sym).data, df2)
+        assert_frame_equal(lib.read(sym, 0).data, df1)
+
+
+@pytest.mark.storage
+def test_batch_delete_versions_invalid_input(basic_store):
+    """Test batch_delete_versions with invalid inputs."""
+    lib = basic_store
+
+    # Create test data
+    df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
+    lib.write("sym1", df1)
+
+    # Test with non-existent symbol
+    with pytest.raises(InternalException):
+        lib.batch_delete_versions(["non_existent"], [[0]])
+
+    # Test with non-existent version
+    with pytest.raises(InternalException):
+        lib.batch_delete_versions(["sym1"], [[1]])
+
+    # Test with invalid version number
+    with pytest.raises(TypeError):
+        lib.batch_delete_versions(["sym1"], [[-1]])
+
+
+@pytest.mark.storage
+def test_batch_delete_versions_with_tombstones(basic_store):
+    """Test batch_delete_versions with tombstone functionality."""
+    lib = basic_store
+
+    # Create test data
+    df1 = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
+    df2 = pd.DataFrame({"y": np.arange(10, dtype=np.int32)})
+    df3 = pd.DataFrame({"z": np.arange(10, dtype=np.uint64)})
+
+    # Write multiple versions for multiple symbols
+    symbols = ["sym1", "sym2"]
+    for sym in symbols:
+        lib.write(sym, df1)
+        lib.write(sym, df2, prune_previous_version=False)
+        lib.write(sym, df3, prune_previous_version=False)
+
+    # Delete versions 0 and 1 for all symbols
+    versions_to_delete = [[0, 1], [0, 1]]  # One list per symbol
+    lib.batch_delete_versions(symbols, versions_to_delete)
+
+    # Verify tombstone behavior
+    for sym in symbols:
+        versions = lib.list_versions(sym)
+        assert len(versions) == 1  # All versions should still be listed
+
+        # Verify that deleted versions are not accessible
+        for version in [0, 1]:
+            with pytest.raises(NoDataFoundException):
+                lib.read(sym, version)
+
+        # Verify that non-deleted version is still accessible
+        assert_frame_equal(lib.read(sym).data, df3)


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ticket ref: 7855100642

Original PR to master: https://github.com/man-group/ArcticDB/pull/2425

#### What does this implement or fix?
* Refactors `tombstone_version` into an async variant of it
* Implements batch delete functionality on top of `tombstone_versions_async`
* Adds tests for the new functionality