### PR TITLE
Add combinatorial testing for column selection in the processing pipeline

### DIFF
--- a/python/arcticdb/util/utils.py
+++ b/python/arcticdb/util/utils.py
@@ -20,6 +20,7 @@ import pandas as pd
 
 from arcticdb.util.test import create_datetime_index, get_sample_dataframe, random_integers, random_string
 from arcticdb.version_store.library import Library
+import itertools
 
 
 # Types supported by arctic

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -43,6 +43,7 @@ from arcticdb.util.test import (
     assert_series_equal,
     config_context,
     distinct_timestamps,
+    subset_permutations
 )
 from tests.util.date import DateRange
 from arcticdb.util.test import equals
@@ -2749,9 +2750,6 @@ def test_dynamic_schema_column_hash(basic_store_column_buckets):
 
     read_df = lib.read("symbol", columns=["a", "c"]).data
     assert_equal(df[["a", "c"]], read_df)
-
-def subset_permutations(input_data):
-    return (p for r in range(1, len(input_data)+1) for p in itertools.permutations(input_data, r))
 
 @pytest.mark.parametrize("bucketize_dynamic", [pytest.param(True, marks=pytest.mark.xfail(reason="Bucketize dynamic is not used in production. There are bugs")), False])
 def test_dynamic_schema_read_columns(version_store_factory, lib_name, bucketize_dynamic):


### PR DESCRIPTION

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

The changes in modify schema affected how column selection works in the processing pipeline. This PR adds testing for column selection in various scenarios for both dynamic and static schema
* Filtering: Working
* Projection: Working except for a known issue: Monday 9492480789
* Perform a projection and then filter on the new column: Working except for a known issue: Monday 9492480789
* Concatenation: Concatenation seems the only one that is genuinely broken. It looks like the bug is that in some cases we don't filter the columns in the output and return all of them.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
