### PR TITLE
Fix segfault during encoding sparse data

### DIFF
--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -641,18 +641,17 @@ void add_bitmagic_compressed_size(
 /// will not improve anything and in fact it might worsen the encoding.
 [[nodiscard]] static size_t encode_bitmap(const util::BitMagic& sparse_map, Buffer& out, std::ptrdiff_t& pos) {
     ARCTICDB_DEBUG(log::version(), "Encoding sparse map of count: {}", sparse_map.count());
-    bm::serializer<bm::bvector<> > bvs;
-    bm::serializer<bm::bvector<> >::buffer sbuf;
-    bvs.serialize(sparse_map, sbuf);
-    auto sz = sbuf.size();
-    auto total_sz = sz + util::combined_bit_magic_delimiters_size();
-    out.assert_size(pos + total_sz);
-
-    uint8_t* target = out.data() + pos;
+    bm::serializer<bm::bvector<> > bvs; // TODO: It is inefficient to create the serializer every time.
+    bm::bvector<>::statistics st;
+    sparse_map.calc_stat(&st);
+    auto total_max_size = st.max_serialize_mem + util::combined_bit_magic_delimiters_size();
+    out.assert_size(pos + total_max_size);
+    uint8_t *target = out.data() + pos;
     util::write_magic<util::BitMagicStart>(target);
-    std::memcpy(target, sbuf.data(), sz);
+    auto sz = bvs.serialize(sparse_map, target, st.max_serialize_mem);
     target += sz;
     util::write_magic<util::BitMagicEnd>(target);
+    auto total_sz = sz + util::combined_bit_magic_delimiters_size();
     pos = pos + static_cast<ptrdiff_t>(total_sz);
     return total_sz;
 }


### PR DESCRIPTION
There was a segfault during desctruction of `bm::buffer` used during encoding of bitmap.

This commit instead doesn't use the bm::buffer at all but directly serializes the bitmap on top of the buffer we're encoding to.

BitMagic documentation is relatively poor but this change follows example shown [here](https://github.com/tlk00/BitMagic/blob/6dfdcbd1222b3919c2a3b71bfde38db5c7862f97/samples/bvsample04/sample4.cpp#L78-L102).

Testing will be done with a man.arcticdb nonreg test.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
