### PR TITLE
conda-build: Use clang and clang++ 18 for osx

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,8 +6,13 @@ dependencies:
   - sel(win): ninja
   - wheel
   - setuptools
-  - cxx-compiler
-  - c-compiler
+  - sel(linux): cxx-compiler
+  - sel(linux): c-compiler
+  # ArcticDB cannot be compiled with clang++ 19 or higher for now
+  # which is first distributed with cxx-compiler 1.11.
+  # See: https://github.com/conda-forge/compilers-feedstock/pull/73/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR29
+  - sel(osx): cxx-compiler <1.11
+  - sel(osx): c-compiler <1.11
   - cmake
   - gtest
   - gflags


### PR DESCRIPTION
#### Reference Issues/PRs

First observed on the feedstock (see https://github.com/conda-forge/arcticdb-feedstock/commit/19d404fbdae8beadb0e4012a5770943cfb0834b4).

Necessary now due to https://github.com/conda-forge/compilers-feedstock/pull/73 (see the inline comment).

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
