### PR TITLE
Library tool/read segment to dataframe

### DIFF
--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -47,6 +47,18 @@ ReadResult LibraryTool::read(const VariantKey& key, std::any& handler_data, Outp
     return pipelines::read_result_from_single_frame(frame_and_descriptor, atom_key, handler_data, output_format);
 }
 
+py::tuple LibraryTool::segment_to_read_result(arcticdb::SegmentInMemory& segment) {
+    constexpr OutputFormat output_format = OutputFormat::PANDAS;
+
+    auto handler_data = TypeHandlerRegistry::instance()->get_handler_data(output_format);
+    std::pair<std::any &, OutputFormat> handler{handler_data, output_format};
+    const auto &atom_key = AtomKeyBuilder().build<KeyType::VERSION_REF>(segment.descriptor().id());
+    auto frame_and_descriptor = frame_and_descriptor_from_segment(std::move(segment));
+
+    auto interm = pipelines::read_result_from_single_frame(frame_and_descriptor, atom_key, handler_data, output_format);
+    return arcticdb::adapt_read_df(std::move(interm), &handler_data);
+}
+
 Segment LibraryTool::read_to_segment(const VariantKey& key) {
     auto kv = store()->read_compressed_sync(key);
     util::check(kv.has_segment(), "Failed to read key: {}", key);

--- a/cpp/arcticdb/toolbox/library_tool.hpp
+++ b/cpp/arcticdb/toolbox/library_tool.hpp
@@ -16,6 +16,7 @@
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/entity/read_result.hpp>
 #include <arcticdb/version/local_versioned_engine.hpp>
+#include <arcticdb/python/adapt_read_dataframe.hpp>
 
 #include <memory>
 
@@ -35,6 +36,8 @@ public:
     explicit LibraryTool(std::shared_ptr<storage::Library> lib);
 
     ReadResult read(const VariantKey& key, std::any& handler_data, OutputFormat output_format);
+
+    py::tuple segment_to_read_result(arcticdb::SegmentInMemory& segment);
 
     Segment read_to_segment(const VariantKey& key);
 

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -62,13 +62,6 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
             .def("find_keys_for_id", &LibraryTool::find_keys_for_id)
             .def("clear_ref_keys", &LibraryTool::clear_ref_keys)
             .def("batch_key_exists", &LibraryTool::batch_key_exists, py::call_guard<SingleThreadMutexHolder>())
-            .def("_read_to_read_result",
-             [&](LibraryTool& lt, const VariantKey& key){
-                 constexpr OutputFormat output_format = OutputFormat::PANDAS;
-                 auto handler_data = TypeHandlerRegistry::instance()->get_handler_data(output_format);
-                 return adapt_read_df(lt.read(key, handler_data, output_format), &handler_data);
-             },
-             "Read the most recent dataframe from the store")
              .def("inspect_env_variable", &LibraryTool::inspect_env_variable)
              .def_static("read_unaltered_lib_cfg", &LibraryTool::read_unaltered_lib_cfg)
              .def("segment_to_read_result", &LibraryTool::segment_to_read_result);

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -70,7 +70,8 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
              },
              "Read the most recent dataframe from the store")
              .def("inspect_env_variable", &LibraryTool::inspect_env_variable)
-             .def_static("read_unaltered_lib_cfg", &LibraryTool::read_unaltered_lib_cfg);
+             .def_static("read_unaltered_lib_cfg", &LibraryTool::read_unaltered_lib_cfg)
+             .def("segment_to_read_result", &LibraryTool::segment_to_read_result);
 
     // Reliable storage lock exposed for integration testing. It is intended for use in C++
     using namespace arcticdb::lock;

--- a/python/arcticdb/toolbox/library_tool.py
+++ b/python/arcticdb/toolbox/library_tool.py
@@ -69,6 +69,9 @@ class LibraryTool(LibraryToolImpl):
     def read_to_segment_in_memory(self, key: VariantKey) -> SegmentInMemory:
         return decode_segment(self.read_to_segment(key))
 
+    def segment_in_memory_to_dataframe(self, segment: SegmentInMemory) -> pd.DataFrame:
+        return denormalize_dataframe(self.segment_to_read_result(segment))
+
     def read_to_dataframe(self, key: VariantKey) -> pd.DataFrame:
         """
         Reads the segment associated with the provided key into a Pandas DataFrame format. Any strings in the segment
@@ -92,7 +95,7 @@ class LibraryTool(LibraryToolImpl):
           start_index                     end_index  version_id stream_id          creation_ts         content_hash  index_type  key_type
         0  2023-01-01 2023-01-02 00:00:00.000000001           0      None  1681399019580103187  3563433649738173789          84         3
         """
-        return denormalize_dataframe(self._read_to_read_result(key))
+        return self.segment_in_memory_to_dataframe(self.read_to_segment_in_memory(key))
 
     def read_to_keys(
         self, key: VariantKey, id: Optional[Union[str, int]] = None, filter_key_type: Optional[KeyType] = None

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -12,6 +12,7 @@ from arcticdb.util.test import sample_dataframe, populate_db, assert_frame_equal
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.types import DataType
 from arcticdb_ext.exceptions import SchemaException, InternalException
+from arcticdb.version_store._normalization import denormalize_dataframe
 
 
 def get_ref_key_types():
@@ -361,3 +362,15 @@ def test_overwrite_append_data(lmdb_version_store_v1):
     lib.compact_incomplete(sym, append=True, convert_int_to_float=False, via_iteration=False)
     assert read_append_data_keys_from_ref(sym) == []
     assert_frame_equal(lib.read(sym).data, get_df(18, 0, np.int64))
+
+def test_read_segment_to_dataframe(lmdb_version_store_v1):
+    df = sample_dataframe()
+    lib = lmdb_version_store_v1
+    lib_tool = lib.library_tool()
+    sym = "sym"
+    lib.write(sym, sample_dataframe)
+
+    segment_in_memory = lib_tool.read_to_segment_in_memory(lib_tool.find_keys(KeyType.TABLE_DATA)[0])
+    dataframe = lib_tool.segment_in_memory_to_dataframe(segment_in_memory)
+
+    assert isinstance(dataframe, pd.DataFrame)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Implementation of methods "segment_to_read_result" and "segment_in_memory_to_dataframe" which take SegmentInMemory as argument. This enables the already implemented "read_to_dataframe" to just be a combination of "read_to_segment_in_memory" and "segment_in_memory_to_dataframe". With this refactor, "read_to_read_result" is not needed.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
