### PR TITLE
Workaround folly issue with clang 19

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -364,6 +364,7 @@ set(arcticdb_srcs
         util/flatten_utils.hpp
         util/format_bytes.hpp
         util/format_date.hpp
+        util/folly_ranges.hpp
         util/hash.hpp
         util/spinlock.hpp
         util/key_utils.hpp

--- a/cpp/arcticdb/entity/test/test_atom_key.cpp
+++ b/cpp/arcticdb/entity/test/test_atom_key.cpp
@@ -12,8 +12,7 @@
 
 #include <arcticdb/entity/serialized_key.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
-
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 
 using namespace arcticdb;
 using namespace arcticdb::entity;

--- a/cpp/arcticdb/entity/variant_key.hpp
+++ b/cpp/arcticdb/entity/variant_key.hpp
@@ -10,7 +10,7 @@
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/ref_key.hpp>
 #include <variant>
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 
 namespace arcticdb::entity {
 

--- a/cpp/arcticdb/pipeline/test/test_pipeline.cpp
+++ b/cpp/arcticdb/pipeline/test/test_pipeline.cpp
@@ -9,7 +9,7 @@
 
 #include <folly/futures/Future.h>
 #include <arcticdb/column_store/memory_segment.hpp>
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <unordered_map>
 #include <any>

--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <variant>
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 #include <arcticdb/util/string_wrapping_value.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/variant_key.hpp>

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -19,8 +19,8 @@
 #include <arcticdb/storage/single_file_storage.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/composite.hpp>
+#include <arcticdb/util/folly_ranges.hpp>
 
-#include <folly/Range.h>
 #include <folly/concurrency/ConcurrentHashMap.h>
 #include <boost/core/noncopyable.hpp>
 #include <filesystem>

--- a/cpp/arcticdb/storage/library_manager.cpp
+++ b/cpp/arcticdb/storage/library_manager.cpp
@@ -13,7 +13,7 @@
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/codec/default_codecs.hpp>
 
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 #include <filesystem>
 
 namespace arcticdb::storage {

--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -9,9 +9,9 @@
 
 #include <arcticdb/util/hash.hpp>
 #include <arcticdb/util/name_validation.hpp>
+#include <arcticdb/util/folly_ranges.hpp>
 
 #include <boost/container/small_vector.hpp>
-#include <folly/Range.h>
 #include <fmt/format.h>
 #include <memory>
 #include <string>

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -11,7 +11,7 @@
 #include <arcticdb/storage/storage_factory.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/composite.hpp>
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 #include <folly/concurrency/ConcurrentHashMap.h>
 #include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/util/pb_util.hpp>

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -13,7 +13,7 @@
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/composite.hpp>
 #include <arcticdb/util/pb_util.hpp>
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 
 namespace arcticdb::storage::mongo {
 

--- a/cpp/arcticdb/storage/test/test_storage_factory.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_factory.cpp
@@ -14,7 +14,7 @@
 #include <arcticdb/storage/config_resolvers.hpp>
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/util/test/config_common.hpp>
-#include "folly/Range.h"
+#include <arcticdb/util/folly_ranges.hpp>
 
 #include <unordered_map>
 #include <vector>

--- a/cpp/arcticdb/stream/index.cpp
+++ b/cpp/arcticdb/stream/index.cpp
@@ -11,7 +11,7 @@
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 
 namespace arcticdb::stream {
 

--- a/cpp/arcticdb/stream/row_builder.hpp
+++ b/cpp/arcticdb/stream/row_builder.hpp
@@ -19,7 +19,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h> // for auto return type conversion
 
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 #include <folly/Function.h>
 #include <folly/ScopeGuard.h>
 

--- a/cpp/arcticdb/stream/stream_utils.hpp
+++ b/cpp/arcticdb/stream/stream_utils.hpp
@@ -19,10 +19,10 @@
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
+#include <arcticdb/util/folly_ranges.hpp>
 
 #include <folly/gen/Base.h>
 #include <folly/Function.h>
-#include <folly/Range.h>
 #include <folly/futures/Future.h>
 #include <boost/circular_buffer.hpp>
 

--- a/cpp/arcticdb/util/composite.hpp
+++ b/cpp/arcticdb/util/composite.hpp
@@ -10,8 +10,8 @@
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/variant.hpp>
+#include <arcticdb/util/folly_ranges.hpp>
 
-#include <folly/Range.h>
 #include <folly/container/Enumerate.h>
 #include <boost/iterator/iterator_facade.hpp>
 

--- a/cpp/arcticdb/util/folly_ranges.hpp
+++ b/cpp/arcticdb/util/folly_ranges.hpp
@@ -5,6 +5,13 @@
 // are provided. folly::Ranges triggers the instantiation of
 // std::char_traits<unsigned char>, resulting in a compilation error.
 
+#if defined(__clang__)
+#pragma message("========== CLANG DETECTED ==========")
+#if (__clang_major__ == 19)
+#pragma message("========== CLANG 19 ============")
+#endif
+#endif
+
 #if defined(__clang__) && (__clang_major__ == 19)
 
 #include <string>

--- a/cpp/arcticdb/util/folly_ranges.hpp
+++ b/cpp/arcticdb/util/folly_ranges.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+// The base template for std::char_traits has been removed in LLVM 19,
+// only the specializations for char, wchar_t, char8_t, char16_t char32_t
+// are provided. folly::Ranges triggers the instantiation of
+// std::char_traits<unsigned char>, resulting in a compilation error.
+
+#if defined(__clang__) && (__clang_major__ == 19)
+
+#include <string>
+
+namespace arcticdb::workaround
+{
+    template<class CharT, class BaseT>
+    class traits_cloner
+    {
+    public:
+        using char_type = CharT;
+
+        using base_type = BaseT;
+        using base_traits = std::char_traits<base_type>;
+
+        static std::size_t length(char_type const* s)
+        {
+            return base_traits::length(reinterpret_cast<base_type const*>(s));
+        }
+
+        static int compare(char_type const* s1, char_type const* s2, std::size_t count)
+        {
+            return base_traits::compare(
+                reinterpret_cast<base_type const*>(s1),
+                reinterpret_cast<base_type const*>(s2), count
+            );
+        }
+        
+        static char_type* copy(char_type* dest, char_type const* src, std::size_t count)
+        {
+            return reinterpret_cast<char_type*>(
+                base_traits::copy(reinterpret_cast<base_type*>(dest),
+                reinterpret_cast<base_type const*>(src), count)
+            );
+        }
+
+        static void assign(char_type& c1, char_type const& c2) noexcept
+        {
+            c1 = c2;
+        }
+        
+        static char_type const* find(char_type const* ptr, std::size_t count, char_type const& ch)
+        {
+            return reinterpret_cast<char_type const*>(
+                base_traits::find(reinterpret_cast<base_type const*>(ptr),
+                count,
+                reinterpret_cast<base_type const&>(ch))
+           );
+        }
+    };
+}
+
+template <>
+class std::char_traits<unsigned char>
+    : public arcticdb::workaround::traits_cloner<unsigned char, char>
+{
+};
+
+#endif
+
+#include <folly/Range.h>
+

--- a/cpp/arcticdb/util/pb_util.hpp
+++ b/cpp/arcticdb/util/pb_util.hpp
@@ -13,7 +13,7 @@
 #include <google/protobuf/any.pb.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <arcticdb/util/preconditions.hpp>
-#include <folly/Range.h>
+#include <arcticdb/util/folly_ranges.hpp>
 
 #include <exception>
 #include <optional>

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,13 +6,8 @@ dependencies:
   - sel(win): ninja
   - wheel
   - setuptools
-  - sel(linux): cxx-compiler
-  - sel(linux): c-compiler
-  # ArcticDB cannot be compiled with clang++ 19 or higher for now
-  # which is first distributed with cxx-compiler 1.11.
-  # See: https://github.com/conda-forge/compilers-feedstock/pull/73/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR29
-  - sel(osx): cxx-compiler <1.11
-  - sel(osx): c-compiler <1.11
+  - cxx-compiler
+  - c-compiler
   - cmake
   - gtest
   - gflags


### PR DESCRIPTION
This workaround allows to build ArcticDB with clang 19 and revert the pinning done in #2476 
