### PR TITLE
Remove xfail that's no longer needed

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
+++ b/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
@@ -628,7 +628,6 @@ def test_symbol_concat_non_existent_symbol(lmdb_library):
         concat(lib.read_batch([sym, "non-existent symbol"], lazy=True)).collect()
 
 
-@pytest.mark.xfail(reason="Fatal Python error: Segmentation fault (monday:9539465547)", strict=False)
 def test_symbol_concat_pickled_data(lmdb_library):
     lib = lmdb_library
     df = pd.DataFrame({"bytes": np.arange(10, dtype=np.uint64)})


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
This was fixed by https://github.com/man-group/ArcticDB/pull/2458. This xfail was left out by mistake.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
