### PR TITLE
Release the GIL when logging from the Python API

### DIFF
--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -111,6 +111,7 @@ void register_log(py::module && log) {
 
     log.def("log",[&](LoggerId log_id, spdlog::level::level_enum level, const std::string & msg){
         //assuming formatting done in python
+        py::gil_scoped_release gil_release;
         auto & logger = choose_logger(log_id);
         switch(level){
             case spdlog::level::level_enum::debug:
@@ -136,6 +137,7 @@ void register_log(py::module && log) {
     });
 
     log.def("flush_all", [](){
+        py::gil_scoped_release gil_release;
         arcticdb::log::Loggers::instance().flush_all();
     });
 }


### PR DESCRIPTION
This one is a long story.

[Link ](https://chat-man.slack.com/archives/CKD4V6N0H/p1753113852422909) to internal issue report.

A user reported hangs when writing large dictionaries of data - but only in Jupyter. This logged many lines of the form,

```
Pickling metadata - may not be readable by other clients
```

using the `arcticdb.log` APIs, which actually call down to the native layer.

I reduced the hangs to a minimal repro,

```
from arcticdb.log import root

for i in range(1250):
    root.warn(f"hi-{i}")
```

1250 seemed to be a tipping point here - writing less did not trigger the issue.

I then ran `jupyterlab` again, logged the kernel PID with `os.getpid()` and attached a debugger to it while it was frozen. Then you could see it's just stuck here,

```
template <typename ConsoleMutex>
SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::log(const details::log_msg &msg) {
#ifdef _WIN32
    if (handle_ == INVALID_HANDLE_VALUE) {
        return;
    }
    std::lock_guard<mutex_t> lock(mutex_);
    memory_buf_t formatted;
    formatter_->format(msg, formatted);
    auto size = static_cast<DWORD>(formatted.size());
    DWORD bytes_written = 0;
    bool ok = ::WriteFile(handle_, formatted.data(), size, &bytes_written, nullptr) != 0;
    if (!ok) {
        throw_spdlog_ex("stdout_sink_base: WriteFile() failed. GetLastError(): " +
                        std::to_string(::GetLastError()));
    }
#else
    std::lock_guard<mutex_t> lock(mutex_);
    memory_buf_t formatted;
    formatter_->format(msg, formatted);
    ::fwrite(formatted.data(), sizeof(char), formatted.size(), file_);
#endif                // WIN32
    ::fflush(file_);  // flush every line to terminal
}
```

on the `fwrite` call.

I found this Jupyterlab issue https://github.com/jupyterlab/jupyterlab/issues/12845 which linked to https://github.com/ipython/ipykernel/pull/752

whose description stated that,

```
Be aware that doing this can cause hangs if GIL-holding code tries to write more than pipe-max-size bytes (usually 64k by default). Running this code will hang most IPython kernels in a non-interruptible state after #630:
```

and linked to further explanation here https://github.com/minrk/wurlitzer/issues/48 which suggests that, since the ipython kernel is capturing stderr now, after https://github.com/ipython/ipykernel/pull/630 , there is a pipe reading from stderr that is not reliably being drained because the ArcticDB log call is holding the GIL. This is a deadlock - the `log` call needs room in the pipe to continue, but room cannot be made in the pipe until the log call returns.

Since we have no reason to hold the GIL while logging, I tried releasing it and this fixed the problem.

Similar problems may continue to be present anywhere that we log a lot while holding the GIL - this PR does not fix them all.

Incidentally https://github.com/ipython/ipykernel/pull/752 has fixed our long standing issue #541 so I've resolved that ticket.

Also see docs on pipes https://man7.org/linux/man-pages/man7/pipe.7.html .

We can actually see the pipes, 8150 is the PID of my ipython kernel,

````
➜  ~ lsof +E -p 8150 | grep pipe
lsof: WARNING: can't stat() overlay file system /var/lib/docker/overlay2/f7a9ccd154dff58cb878e96df7a9088c6c9ed524fa378ac959daef405ec65ad5/merged
      Output information may be incomplete.
lsof: WARNING: can't stat() nsfs file system /run/docker/netns/86ec80b706d2
      Output information may be incomplete.
python3 8150 alex    0r     FIFO               0,14       0t0   204707 pipe
python3 8150 alex    1w     FIFO               0,14       0t0   233700 pipe 8150,python3,36r 8150,python3,37w
python3 8150 alex    2w     FIFO               0,14       0t0   233701 pipe 8150,python3,39r 8150,python3,40w
python3 8150 alex   36r     FIFO               0,14       0t0   233700 pipe 8150,python3,1w 8150,python3,37w
python3 8150 alex   37w     FIFO               0,14       0t0   233700 pipe 8150,python3,1w 8150,python3,36r
python3 8150 alex   39r     FIFO               0,14       0t0   233701 pipe 8150,python3,2w 8150,python3,40w <--- 40 is stderr in Jupyter, 2w is normal stderr
python3 8150 alex   40w     FIFO               0,14       0t0   233701 pipe 8150,python3,2w 8150,python3,39r
```