### PR TITLE
Fix column selection for processing pipeline

### DIFF
--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -930,19 +930,36 @@ static StreamDescriptor generate_initial_output_schema_descriptor(const Pipeline
     return desc;
 }
 
-static OutputSchema create_initial_output_schema(const PipelineContext& pipeline_context) {
+static OutputSchema create_initial_output_schema(PipelineContext& pipeline_context) {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(pipeline_context.norm_meta_,
                                                     "Normalization metadata should not be missing during read_and_process");
     return OutputSchema{generate_initial_output_schema_descriptor(pipeline_context), *pipeline_context.norm_meta_};
 }
 
 static OutputSchema generate_output_schema(
-    const PipelineContext& pipeline_context,
-    const std::span<const std::shared_ptr<Clause>> clauses
+    PipelineContext& pipeline_context,
+    std::shared_ptr<ReadQuery> read_query
 ) {
     OutputSchema output_schema = create_initial_output_schema(pipeline_context);
-    for (const auto& clause: clauses) {
+    for (const auto& clause: read_query->clauses_) {
         output_schema = clause->modify_schema(std::move(output_schema));
+    }
+    if (read_query->columns) {
+        std::unordered_set<std::string_view> selected_columns(read_query->columns->begin(), read_query->columns->end());
+        FieldCollection fields_to_use;
+        if (!pipeline_context.filter_columns_) {
+            pipeline_context.filter_columns_ = std::make_shared<FieldCollection>();
+        }
+        for (const Field& field : output_schema.stream_descriptor().fields()) {
+            if (selected_columns.contains(field.name())) {
+                fields_to_use.add(field.ref());
+                if (!pipeline_context.is_in_filter_columns_set(field.name())) {
+                    pipeline_context.filter_columns_->add(field.ref());
+                }
+            }
+        }
+        pipeline_context.filter_columns_set_ = std::move(selected_columns);
+        output_schema.set_stream_descriptor(StreamDescriptor{output_schema.stream_descriptor().data_ptr(), std::make_shared<FieldCollection>(std::move(fields_to_use))});
     }
     return output_schema;
 }
@@ -1006,7 +1023,7 @@ folly::Future<std::vector<SliceAndKey>> read_process_and_collect(
     auto component_manager = std::make_shared<ComponentManager>();
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
             .thenValue([component_manager, pipeline_context, read_query](std::vector<EntityId>&& processed_entity_ids) {
-                OutputSchema schema = generate_output_schema(*pipeline_context, read_query->clauses_);
+                OutputSchema schema = generate_output_schema(*pipeline_context, std::move(read_query));
                 auto&& [descriptor, norm_meta, default_values] = schema.release();
                 pipeline_context->set_descriptor(std::forward<StreamDescriptor>(descriptor));
                 pipeline_context->norm_meta_ = std::make_shared<proto::descriptors::NormalizationMetadata>(
@@ -2300,7 +2317,7 @@ folly::Future<SymbolProcessingResult> read_and_process(
 
     schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(!pipeline_context->is_pickled(),"Cannot perform multi-symbol join on pickled data");
 
-    OutputSchema output_schema = generate_output_schema(*pipeline_context, read_query->clauses_);
+    OutputSchema output_schema = generate_output_schema(*pipeline_context, read_query);
     ARCTICDB_DEBUG(log::version(), "Fetching data to frame");
 
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, std::move(component_manager))

--- a/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
+++ b/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
@@ -249,7 +249,6 @@ def test_symbol_concat_empty_column_intersection(lmdb_library_factory, dynamic_s
         assert_frame_equal(expected, received)
 
 
-@pytest.mark.xfail(reason="Column selection not working properly with dynamic schema. See Monday issue: 9492480789")
 @pytest.mark.parametrize("dynamic_schema", [True, False])
 @pytest.mark.parametrize("rows_per_segment", [2, 100_000])
 @pytest.mark.parametrize("columns_per_segment", [2, 100_000])
@@ -284,7 +283,6 @@ def test_symbol_concat_column_slicing(lmdb_library_factory, dynamic_schema, rows
     assert_frame_equal(expected, received)
 
 
-@pytest.mark.xfail(reason="Column selection not working properly with dynamic schema. See Monday issue: 9492480789")
 @pytest.mark.parametrize("dynamic_schema", [True, False])
 @pytest.mark.parametrize("join", ["inner", "outer"])
 def test_symbol_concat_filtering_with_column_selection(lmdb_library_factory, dynamic_schema, join):


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 9492480789

#### What does this implement or fix?
The processing pipeline had a known bug that column selection does not work that was made more evident when modify_schema was added. More specifically synthetic columns were not added to the end result.

With this commit everything passing through the processing pipeline now removes filtered columns from the end stream descriptor. This also fixes bug that was introduced with an earlier commit and xfailed concat tests are now working.

#### Any other comments?
I could not evade using the pipeline_context. Things were too tangled to fix in a single PR. There is a ticket in Monday to refactor this portion of the code see: 9654333036


#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
