### PR TITLE
Fix version calculation based on labels

### DIFF
--- a/.github/workflows/automated_release.calculate_next_version.yml
+++ b/.github/workflows/automated_release.calculate_next_version.yml
@@ -54,7 +54,7 @@ jobs:
           if [ -z "$PULL_REQUESTS" ] || [ ! -f "$PULL_REQUESTS" ]; then
             echo "Error: No PRs found between branches" && exit 1
           fi
-          labels=$(jq -r '.[].labels[].name' "$PULL_REQUESTS")
+          labels=$(jq -r '.[] | select(.pull_request.merged_at) | .labels[].name' "$PULL_REQUESTS")
           echo Labels: $labels
           increment_type="patch"
           case "$labels" in


### PR DESCRIPTION
Add an additional check to prevent errors where a commit is in master but it is a part of a non merged pull request. This pull request should not contribute to the version calculations and thus its labels are ignored

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
