### PR TITLE
Move PCRE2_CODE_UNIT_WIDTH to CMake

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -555,6 +555,7 @@ set(arcticdb_srcs
 
 add_library(arcticdb_core_object OBJECT ${arcticdb_srcs})
 
+# Disable default api so both UTF-8 and UTF-32 can be supported
 target_compile_definitions(arcticdb_core_object PUBLIC PCRE2_CODE_UNIT_WIDTH=0)
 
 if(${ARCTICDB_USE_PCH})
@@ -796,6 +797,7 @@ target_include_directories(arcticdb_core_object
 
 add_library(arcticdb_core_static STATIC $<TARGET_OBJECTS:arcticdb_core_object>)
 
+# Disable default api so both UTF-8 and UTF-32 can be supported
 target_compile_definitions(arcticdb_core_static PUBLIC PCRE2_CODE_UNIT_WIDTH=0)
 
 target_include_directories(arcticdb_core_static PUBLIC

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -555,6 +555,8 @@ set(arcticdb_srcs
 
 add_library(arcticdb_core_object OBJECT ${arcticdb_srcs})
 
+target_compile_definitions(arcticdb_core_object PUBLIC PCRE2_CODE_UNIT_WIDTH=0)
+
 if(${ARCTICDB_USE_PCH})
     message(STATUS "Using precompiled headers for target arcticdb_core_object")
     set(BASE_PCH
@@ -794,6 +796,8 @@ target_include_directories(arcticdb_core_object
 
 add_library(arcticdb_core_static STATIC $<TARGET_OBJECTS:arcticdb_core_object>)
 
+target_compile_definitions(arcticdb_core_static PUBLIC PCRE2_CODE_UNIT_WIDTH=0)
+
 target_include_directories(arcticdb_core_static PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
@@ -869,7 +873,6 @@ pybind11_add_module(arcticdb_ext MODULE
         python/arctic_version.cpp
         python/arctic_version.hpp
         )
-
 set (additional_link_flags "")
 if (HIDE_LINKED_SYMBOLS AND (NOT WIN32))
 
@@ -881,7 +884,6 @@ if (HIDE_LINKED_SYMBOLS AND (NOT WIN32))
 endif()
 
 target_link_libraries(arcticdb_ext
-        PUBLIC
         PRIVATE
         arcticdb_python
         ${additional_link_flags}
@@ -1130,6 +1132,7 @@ if(${TEST})
             version/test/rapidcheck_version_map.cpp)
 
     add_executable(arcticdb_rapidcheck_tests ${rapidcheck_srcs})
+
     install(TARGETS arcticdb_rapidcheck_tests RUNTIME
                 DESTINATION .
                 PERMISSIONS ${EXECUTABLE_PERMS}
@@ -1183,7 +1186,6 @@ if(${TEST})
     endif()
 
     gtest_discover_tests(arcticdb_rapidcheck_tests PROPERTIES DISCOVERY_TIMEOUT 60)
-
     if(${ARCTICDB_USE_PCH})
         message(STATUS "Using precompiled headers for target test_unit_arcticdb")
         target_precompile_headers(

--- a/cpp/arcticdb/util/regex_filter.hpp
+++ b/cpp/arcticdb/util/regex_filter.hpp
@@ -7,7 +7,10 @@
 
 #pragma once
 
-#define PCRE2_CODE_UNIT_WIDTH 0 //Disable default api so both UTF-8 and UTF-32 can be supported
+#if !defined(PCRE2_CODE_UNIT_WIDTH) || PCRE2_CODE_UNIT_WIDTH != 0
+#error "ArcticDB requires PCRE2_CODE_UNIT_WIDTH to be 0"
+#endif
+
 #include <pcre2.h>
 #include <boost/locale.hpp>
 #include <arcticdb/util/constructors.hpp>


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 9670303570

#### What does this implement or fix?
This enables the adding pcre2 to the list of PCH files.

After the update of pcre2 there's a requirement to set `PCRE2_CODE_UNIT_WIDTH` prior including the header. This was done in the code using a define, however this breaks the generation of PCH. I moved the definition of the marco to CMake which allows the header to be precomputed. No functional changes.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
