### PR TITLE
Enhancement 9360445961: Support for reading dynamic schema with changing column types and missing columns with Arrow

### DIFF
--- a/cpp/arcticdb/arrow/array_from_block.hpp
+++ b/cpp/arcticdb/arrow/array_from_block.hpp
@@ -13,11 +13,10 @@
 
 namespace arcticdb {
 
-inline std::optional<sparrow::validity_bitmap> create_validity_bitmap(size_t offset, const Column& column) {
+inline std::optional<sparrow::validity_bitmap> create_validity_bitmap(size_t offset, const Column& column, size_t bitmap_size) {
     if(column.has_extra_buffer(offset, ExtraBufferType::BITMAP)) {
         auto &bitmap_buffer = column.get_extra_buffer(offset, ExtraBufferType::BITMAP);
-        const auto bitmap_size = bitmap_buffer.block(0)->bytes() / sizeof(uint32_t);
-        return sparrow::validity_bitmap{reinterpret_cast<uint8_t *>(bitmap_buffer.block(0)->release()), bitmap_size };
+        return sparrow::validity_bitmap{reinterpret_cast<uint8_t *>(bitmap_buffer.block(0)->release()), bitmap_size};
     } else {
         return std::nullopt;
     }
@@ -72,6 +71,20 @@ sparrow::dictionary_encoded_array<T> create_dict_array(
     }
 }
 
+// TODO: This is super hacky. Our string column return type is dictionary encoded, and this should be
+//  consistent when there are zero rows or the validity bitmap is all zeros. But sparrow (or possibly Arrow) requires at
+//  least one key-value pair in the dictionary, even if there are zero rows
+std::pair<sparrow::u8_buffer<int64_t>, sparrow::u8_buffer<char>> minimal_strings_dict() {
+    std::unique_ptr<int64_t[]> offset_ptr(new int64_t[2]);
+    offset_ptr[0] = 0;
+    offset_ptr[1] = 1;
+    sparrow::u8_buffer<int64_t> offsets_buffer(offset_ptr.release(), 2);
+    std::unique_ptr<char[]> strings_ptr(new char[1]);
+    strings_ptr[0] = 'a';
+    sparrow::u8_buffer<char> strings_buffer(strings_ptr.release(), 1);
+    return std::make_pair(std::move(offsets_buffer), std::move(strings_buffer));
+}
+
 template <typename TagType>
 sparrow::array string_dict_from_block(
         TypedBlockData<TagType>& block,
@@ -86,13 +99,23 @@ sparrow::array string_dict_from_block(
 
     // String offsets must be signed `int64_t` even though they are unsigned indices due to arrow spec.
     // https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-layout
-    auto &string_offsets = column.get_extra_buffer(offset, ExtraBufferType::OFFSET);
-    const auto offset_buffer_value_count = string_offsets.block(0)->bytes() / sizeof(int64_t);
-    sparrow::u8_buffer<int64_t> offset_buffer(reinterpret_cast<int64_t *>(string_offsets.block(0)->release()), offset_buffer_value_count);
-
-    auto &strings = column.get_extra_buffer(offset, ExtraBufferType::STRING);
-    const auto strings_buffer_size = strings.block(0)->bytes();
-    sparrow::u8_buffer<char> strings_buffer(reinterpret_cast<char *>(strings.block(0)->release()), strings_buffer_size);
+    const bool has_offset_buffer = column.has_extra_buffer(offset, ExtraBufferType::OFFSET);
+    const bool has_string_buffer = column.has_extra_buffer(offset, ExtraBufferType::STRING);
+    auto [offset_buffer, strings_buffer] = [&]() -> std::pair<sparrow::u8_buffer<int64_t>, sparrow::u8_buffer<char>> {
+        if (has_offset_buffer && has_string_buffer) {
+            auto& string_offsets = column.get_extra_buffer(offset, ExtraBufferType::OFFSET);
+            const auto offset_buffer_value_count = string_offsets.block(0)->bytes() / sizeof(int64_t);
+            sparrow::u8_buffer<int64_t> _offsets_buffer(reinterpret_cast<int64_t *>(string_offsets.block(0)->release()), offset_buffer_value_count);
+            auto& strings = column.get_extra_buffer(offset, ExtraBufferType::STRING);
+            const auto strings_buffer_size = strings.block(0)->bytes();
+            sparrow::u8_buffer<char> _strings_buffer(reinterpret_cast<char *>(strings.block(0)->release()), strings_buffer_size);
+            return std::make_pair(std::move(_offsets_buffer), std::move(_strings_buffer));
+        } else if (!has_offset_buffer && !has_string_buffer) {
+            return minimal_strings_dict();
+        } else {
+            util::raise_rte("Arrow output string creation expected either both or neither of OFFSET and STRING buffers to be present");
+        }
+    }();
 
     // We use `int32_t` dictionary keys because pyarrow doesn't work with unsigned dictionary keys:
     // https://github.com/pola-rs/polars/issues/10977

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -184,6 +184,8 @@ class ChunkedBufferImpl {
 
     [[nodiscard]] const auto &blocks() const { return blocks_; }
 
+    [[nodiscard]] const auto &block_offsets() const { return block_offsets_; }
+
     BlockType* block(size_t pos) {
         util::check(pos < blocks_.size(), "Requested block {} out of range {}", pos, blocks_.size());
         return blocks_[pos];

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -623,6 +623,10 @@ public:
         return data_.buffer().blocks();
     }
 
+    const auto& block_offsets() const {
+        return data_.buffer().block_offsets();
+    }
+
     inline shape_t *allocate_shapes(std::size_t bytes) {
         shapes_.ensure_bytes(bytes);
         return reinterpret_cast<shape_t *>(shapes_.cursor());

--- a/cpp/arcticdb/util/bitset.hpp
+++ b/cpp/arcticdb/util/bitset.hpp
@@ -33,22 +33,19 @@ constexpr bm::bvector<>::size_type bv_size(uint64_t val) {
     return static_cast<bm::bvector<>::size_type>(val);
 }
 
-constexpr size_t bitset_unpacked_size(size_t size) {
-    return (size + 63) / 64 * sizeof(uint64_t);
+// The number of bytes needed to hold num_bits in a packed bitset
+constexpr size_t bitset_packed_size_bytes(size_t num_bits) {
+    return (num_bits + 7) / 8;
 }
 
-inline void bitset_to_packed_bits(const bm::bvector<>& bv, uint64_t* dest_ptr) {
-    std::memset(dest_ptr, 0, bitset_unpacked_size(bv.size()));
-
-    auto en = bv.first();
+inline void bitset_to_packed_bits(const bm::bvector<>& bv, uint8_t* dest_ptr) {
+    std::memset(dest_ptr, 0, bitset_packed_size_bytes(bv.size()));
     auto last = bv.end();
-    for (; en != last; ++en) {
+    for (auto en = bv.first(); en != last; ++en) {
         size_t bit_pos = *en;
-
-        size_t word_idx = bit_pos / 64;
-        size_t bit_idx = bit_pos % 64;
-
-        dest_ptr[word_idx] |= (1ULL << bit_idx);
+        size_t byte_idx = bit_pos / 8;
+        size_t bit_idx = bit_pos % 8;
+        dest_ptr[byte_idx] |= (uint8_t(1) << bit_idx);
     }
 }
 

--- a/python/tests/unit/arcticdb/version_store/test_arrow.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow.py
@@ -1,4 +1,6 @@
 from arcticdb_ext.version_store import OutputFormat
+from hypothesis import assume, given, settings, strategies as st
+from hypothesis.extra.numpy import unsigned_integer_dtypes, integer_dtypes, floating_dtypes
 import pandas as pd
 import numpy as np
 import pytest
@@ -6,9 +8,23 @@ import pytest
 from pandas.testing import assert_frame_equal
 from arcticdb.version_store.processing import QueryBuilder
 import pyarrow as pa
+from arcticdb.util.hypothesis import (
+    use_of_function_scoped_fixtures_in_hypothesis_checked,
+    ENDIANNESS,
+    supported_string_dtypes,
+    dataframe_strategy,
+    column_strategy,
+)
 from arcticdb.util.test import get_sample_dataframe
 from arcticdb_ext.storage import KeyType
 from tests.util.mark import WINDOWS
+
+
+def stringify_dictionary_encoded_columns(table: pa.Table) -> pa.Table:
+    for i, name in enumerate(table.column_names):
+        if pa.types.is_dictionary(table.column(i).type):
+            table = table.set_column(i, name, table.column(name).cast(pa.string()))
+    return table
 
 
 def test_basic(lmdb_version_store_v1):
@@ -306,39 +322,6 @@ def test_with_querybuilder(lmdb_version_store_v1):
     assert_frame_equal(result, expected)
 
 
-def test_dynamic_schema(lmdb_version_store_dynamic_schema):
-    lib = lmdb_version_store_dynamic_schema
-    df1 = pd.DataFrame({"x": np.arange(10), "y": np.arange(10.0, 20.0)})
-
-    lib.write("arrow", df1)
-    df2 = pd.DataFrame({"y": np.arange(20.0, 30.0), "z": np.arange(10.0, 20.0)})
-    lib.append("arrow", df2)
-    vit = lib.read("arrow", _output_format=OutputFormat.ARROW)
-    result = vit.data.to_pandas()
-    expected = pd.concat([df1, df2])
-    expected.reset_index(drop=True, inplace=True)
-    assert_frame_equal(result.astype(float).fillna(0), expected.fillna(0))
-
-
-def test_dynamic_schema_column_change(lmdb_version_store_dynamic_schema):
-    lib = lmdb_version_store_dynamic_schema
-    df1 = pd.DataFrame({"x": np.arange(10)})
-
-    lib.write("arrow", df1)
-    df2 = pd.DataFrame({"x": np.arange(20.0, 30.0, dtype=np.float64)})
-    lib.append("arrow", df2)
-    arrow_table = lib.read("arrow", _output_format=OutputFormat.ARROW).data
-    batches = arrow_table.to_batches()
-    assert len(batches) == 2
-    for record_batch in batches:
-        x_arr = record_batch.columns[0]
-        assert x_arr.type == pa.float64()
-    result = arrow_table.to_pandas()
-    expected = pd.concat([df1, df2])
-    expected.reset_index(drop=True, inplace=True)
-    assert_frame_equal(result.astype(float).fillna(0), expected.fillna(0))
-
-
 def test_arrow_layout(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
     lib_tool = lib.library_tool()
@@ -357,3 +340,121 @@ def test_arrow_layout(lmdb_version_store_tiny_segment):
         assert index_arr.type == pa.int64()
         assert int_arr.type == pa.int64()
         assert str_arr.type == pa.dictionary(pa.int32(), pa.large_string())
+
+
+@pytest.mark.parametrize(
+    "first_type",
+    [pa.uint8(), pa.uint16(), pa.uint32(), pa.uint64(), pa.int8(), pa.int16(), pa.int32(), pa.int64(), pa.float32(), pa.float64()]
+)
+@pytest.mark.parametrize(
+    "second_type",
+    [pa.uint8(), pa.uint16(), pa.uint32(), pa.uint64(), pa.int8(), pa.int16(), pa.int32(), pa.int64(), pa.float32(), pa.float64()]
+)
+def test_arrow_dynamic_schema_changing_types(lmdb_version_store_dynamic_schema_v1, first_type, second_type):
+    if ((pa.types.is_uint64(first_type) and pa.types.is_signed_integer(second_type)) or
+            (pa.types.is_uint64(second_type) and pa.types.is_signed_integer(first_type))):
+        pytest.skip("Unsupported ArcticDB type combination")
+    lib = lmdb_version_store_dynamic_schema_v1
+    sym = "test_arrow_dynamic_schema_changing_types"
+    write_table = pa.table({"col": pa.array([0], first_type)})
+    append_table = pa.table({"col": pa.array([1], second_type)})
+    # TODO: Remove to_pandas() when we support writing Arrow structures directly
+    lib.write(sym, write_table.to_pandas())
+    lib.append(sym, append_table.to_pandas())
+    expected = pa.concat_tables([write_table, append_table], promote_options="permissive")
+    received = lib.read(sym, _output_format=OutputFormat.ARROW).data
+    assert expected.equals(received)
+
+
+@pytest.mark.parametrize("rows_per_row_slice", [1, 7, 8, 9, 100_000])
+def test_arrow_dynamic_schema_missing_columns_numeric(lmdb_version_store_dynamic_schema_v1, rows_per_row_slice):
+    lib = lmdb_version_store_dynamic_schema_v1
+    sym = "test_arrow_dynamic_schema_missing_columns_numeric"
+    write_table = pa.table({"col1": pa.array([1] * rows_per_row_slice, pa.int64())})
+    append_table = pa.table({"col2": pa.array([2] * rows_per_row_slice, pa.int32())})
+    # TODO: Remove to_pandas() when we support writing Arrow structures directly
+    lib.write(sym, write_table.to_pandas())
+    lib.append(sym, append_table.to_pandas())
+    expected = pa.concat_tables([write_table, append_table], promote_options="permissive")
+    received = lib.read(sym, _output_format=OutputFormat.ARROW).data
+    assert expected.equals(received)
+
+
+@pytest.mark.parametrize("rows_per_row_slice", [1, 7, 8, 9, 100_000])
+def test_arrow_dynamic_schema_missing_columns_strings(lmdb_version_store_dynamic_schema_v1, rows_per_row_slice):
+    lib = lmdb_version_store_dynamic_schema_v1
+    sym = "test_arrow_dynamic_schema_missing_columns_strings"
+    write_table = pa.table({"col1": pa.array(["hello"] * rows_per_row_slice, pa.string())})
+    append_table = pa.table({"col2": pa.array(["goodbye"] * rows_per_row_slice, pa.string())})
+    # TODO: Remove to_pandas() when we support writing Arrow structures directly
+    lib.write(sym, write_table.to_pandas())
+    lib.append(sym, append_table.to_pandas())
+    expected = pa.concat_tables([write_table, append_table], promote_options="permissive")
+    received = lib.read(sym, _output_format=OutputFormat.ARROW).data
+    received = stringify_dictionary_encoded_columns(received)
+    assert expected.equals(received)
+
+
+# Omit uint64 as it cannot be combined with signed int types in calls to append
+# Omit int64 as pyarrow refuses to concatenate arrays together if an int is greater than 2^53
+@st.composite
+def combinable_numeric_dtypes(draw):
+    return draw(
+        st.one_of(
+            st.one_of(
+                unsigned_integer_dtypes(endianness=ENDIANNESS, sizes=[8, 16, 32]),
+                integer_dtypes(endianness=ENDIANNESS, sizes=[8, 16, 32]),
+                floating_dtypes(endianness=ENDIANNESS, sizes=[32, 64]),
+            )
+        )
+    )
+
+
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(deadline=None)
+@given(
+    df_0=dataframe_strategy(
+        [
+            column_strategy("numeric_1", combinable_numeric_dtypes()),
+            column_strategy("numeric_2", combinable_numeric_dtypes()),
+            column_strategy("string_1", supported_string_dtypes()),
+            column_strategy("string_2", supported_string_dtypes()),
+        ]
+    ),
+    df_1=dataframe_strategy(
+        [
+            column_strategy("numeric_1", combinable_numeric_dtypes()),
+            column_strategy("numeric_2", combinable_numeric_dtypes()),
+            column_strategy("string_1", supported_string_dtypes()),
+            column_strategy("string_2", supported_string_dtypes()),
+        ]
+    ),
+    df_2=dataframe_strategy(
+        [
+            column_strategy("numeric_1", combinable_numeric_dtypes()),
+            column_strategy("numeric_2", combinable_numeric_dtypes()),
+            column_strategy("string_1", supported_string_dtypes()),
+            column_strategy("string_2", supported_string_dtypes()),
+        ]
+    ),
+    columns_0=st.lists(st.sampled_from(["numeric_1", "numeric_2", "string_1", "string_2"]), min_size=1, max_size=4, unique=True),
+    columns_1=st.lists(st.sampled_from(["numeric_1", "numeric_2", "string_1", "string_2"]), min_size=1, max_size=4, unique=True),
+    columns_2=st.lists(st.sampled_from(["numeric_1", "numeric_2", "string_1", "string_2"]), min_size=1, max_size=4, unique=True),
+)
+def test_arrow_dynamic_schema_missing_columns_hypothesis(lmdb_version_store_dynamic_schema_v1, df_0, df_1, df_2, columns_0, columns_1, columns_2):
+    assume(len(df_0) and len(df_1) and len(df_2))
+    lib = lmdb_version_store_dynamic_schema_v1
+    sym = "test_arrow_dynamic_schema_missing_columns_hypothesis"
+    df_0 = df_0[columns_0]
+    df_1 = df_1[columns_1]
+    df_2 = df_2[columns_2]
+    lib.write(sym, df_0)
+    lib.append(sym, df_1)
+    lib.append(sym, df_2)
+    expected = pa.concat_tables(
+        [pa.Table.from_pandas(df_0), pa.Table.from_pandas(df_1), pa.Table.from_pandas(df_2)],
+        promote_options="permissive",
+    )
+    received = lib.read(sym, _output_format=OutputFormat.ARROW).data
+    received = stringify_dictionary_encoded_columns(received)
+    assert expected.equals(received)


### PR DESCRIPTION
#### Reference Issues/PRs
[9360445961](https://man312219.monday.com/boards/7852509418/pulses/9360445961)

#### What does this implement or fix?
Support reading into Arrow format symbols with dynamic schema where column types are changing (this was already working, just added a test) and where columns are missing from some row slices.