### PR TITLE
Make append_batch and update_batch noop with empty dataframes when there's an existing version

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -612,7 +612,7 @@ VersionedItem LocalVersionedEngine::update_internal(
             ARCTICDB_DEBUG(log::version(), "Updating existing data with an empty item has no effect. \n"
                                            "No new version is being created for symbol='{}', "
                                            "and the last version is returned", stream_id);
-            return VersionedItem(*update_info.previous_index_key_);
+            return VersionedItem{*std::move(update_info.previous_index_key_)};
         }
 
         auto versioned_item = update_impl(store(),
@@ -1458,7 +1458,7 @@ VersionedItem LocalVersionedEngine::append_internal(
             ARCTICDB_DEBUG(log::version(), "Appending an empty item to existing data has no effect. \n"
                                            "No new version has been created for symbol='{}', "
                                            "and the last version is returned", stream_id);
-            return VersionedItem(*update_info.previous_index_key_);
+            return VersionedItem(*std::move(update_info.previous_index_key_));
         }
         auto versioned_item = append_impl(store(),
                                           update_info,
@@ -1513,7 +1513,14 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                 auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                 auto write_options = get_write_options();
                 if (update_info.previous_index_key_.has_value()) {
-                    index_key_fut = async_append_impl(store(), update_info, frame, write_options, validate_index, cfg().write_options().empty_types());
+                    if (frame->empty()) {
+                        ARCTICDB_DEBUG(log::version(), "Appending an empty item to existing data has no effect. \n"
+                               "No new version has been created for symbol='{}', "
+                               "and the last version is returned", stream_id);
+                        return IndexKeyAndUpdateInfo{*update_info.previous_index_key_, update_info};
+                    } else {
+                        index_key_fut = async_append_impl(store(), update_info, frame, write_options, validate_index, cfg().write_options().empty_types());
+                    }
                 } else {
                     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
                     upsert,
@@ -1555,20 +1562,27 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     for (const auto&& [idx, stream_update_info_fut] : enumerate(stream_update_info_futures)) {
         update_versions_futs.push_back(
             std::move(stream_update_info_fut)
-                .thenValue([this, frame = std::move(frames[idx]), stream_id = stream_ids[idx], update_query = update_queries[idx], upsert](auto&& update_info) {
+                .thenValue([this, frame = std::move(frames[idx]), stream_id = stream_ids[idx], update_query = update_queries[idx], upsert](UpdateInfo&& update_info) -> folly::Future<IndexKeyAndUpdateInfo> {
                     auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                     auto write_options = get_write_options();
                     if (update_info.previous_index_key_.has_value()) {
-                        const bool dynamic_schema = cfg().write_options().dynamic_schema();
-                        const bool empty_types = cfg().write_options().empty_types();
-                        index_key_fut = async_update_impl(
-                            store(),
-                            update_info,
-                            update_query,
-                            std::move(frame),
-                            std::move(write_options),
-                            dynamic_schema,
-                            empty_types);
+                        if (frame->empty()) {
+                            ARCTICDB_DEBUG(log::version(), "Updating existing data with an empty item has no effect. \n"
+                               "No new version is being created for symbol='{}', "
+                               "and the last version is returned", stream_id);
+                            return IndexKeyAndUpdateInfo{*update_info.previous_index_key_, update_info};
+                        } else {
+                            const bool dynamic_schema = cfg().write_options().dynamic_schema();
+                            const bool empty_types = cfg().write_options().empty_types();
+                            index_key_fut = async_update_impl(
+                                store(),
+                                update_info,
+                                update_query,
+                                std::move(frame),
+                                std::move(write_options),
+                                dynamic_schema,
+                                empty_types);
+                        }
                     } else {
                         missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
                             upsert,

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -727,6 +727,8 @@ def test_append_batch_empty_dataframe_does_not_increase_version(lmdb_version_sto
         assert(len(lib_tool.find_keys_for_symbol(KeyType.VERSION, symbol)) == 1)
         assert(len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, symbol)) == 1)
         assert(len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, symbol)) == 1)
+    # One symbol list entry for sym1 and one for sym2
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
 
     append_result = lib.batch_append(["sym1", "sym2"], [pd.DataFrame({"a": [5, 6, 7]}), pd.DataFrame({"b": []})])
     assert append_result[0].version == 1
@@ -745,6 +747,11 @@ def test_append_batch_empty_dataframe_does_not_increase_version(lmdb_version_sto
     assert(len(lib_tool.find_keys_for_symbol(KeyType.VERSION, "sym2")) == 1)
     assert(len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym2")) == 1)
     assert(len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "sym2")) == 1)
+
+    # This result is wrong. The correct value is 2. This is due to a bug Monday: 9682041273, append_batch and
+    # update_batch should not create symbol list keys for already existing symbols. Since append_batch is noop when
+    # the input is empty, there is no key for sym_2, but there is a new key for sym_1 and that is wrong.
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 3
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/test_update.py
+++ b/python/tests/integration/arcticdb/test_update.py
@@ -440,8 +440,7 @@ def test_update_batch_types_upgrade(custom_library):
 
 
 
-@pytest.mark.xfail(IS_PANDAS_ONE, 
-                   reason = "update_batch return unexpected exception (9589648728)")
+@pytest.mark.xfail(IS_PANDAS_ONE, reason = "update_batch return unexpected exception (9589648728)")
 def test_update_batch_error_scenario1(arctic_library):   
     lib= arctic_library
     symbol = "experimental 342143"
@@ -458,11 +457,10 @@ def test_update_batch_error_scenario1(arctic_library):
     lib.write_batch([WritePayload(symbol, df)])
     update = UpdatePayload(symbol, df_0col)
     update_result = lib.update_batch([update], prune_previous_versions=True)
-    assert update_result[0].version == 1
+    assert update_result[0].version == 0
 
 
-@pytest.mark.xfail(IS_PANDAS_ONE, 
-                   reason = "update_batch return unexpected exception (9589648728)")
+@pytest.mark.xfail(IS_PANDAS_ONE, reason = "update_batch return unexpected exception (9589648728)")
 def test_update_batch_error_scenario2(arctic_library):   
     lib= arctic_library
     symbol = "experimental 342143"
@@ -475,11 +473,10 @@ def test_update_batch_error_scenario2(arctic_library):
         "2033-12-11 00:00:01",
     ])
     df = pd.DataFrame(data, index=index)
-    df_0col = df[0:0]
     lib.write_batch([WritePayload(symbol, df)])
     update = UpdatePayload(symbol, df[0:1], date_range=(pd.Timestamp("2030-12-11 00:00:00"), pd.Timestamp("2030-12-11 00:00:01")))
     update_result = lib.update_batch([update], prune_previous_versions=True)
-    assert update_result[0].version == 1    
+    assert update_result[0].version == 0
 
 
 def dataframe_simulate_arcticdb_update_dynamic(expected_df: pd.DataFrame, update_df: pd.DataFrame) -> pd.DataFrame:

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -866,7 +866,8 @@ class TestBatchUpdate:
             assert(len(lib_tool.find_keys_for_symbol(KeyType.VERSION, symbol)) == 1)
             assert(len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, symbol)) == 1)
             assert(len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, symbol)) == 1)
-
+        # One symbol list entry for symbol_1 and one for symbol_2
+        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
         update_1 = pd.DataFrame({"a": []}, index=pd.date_range("2024-01-01", periods=0))
         update_2 = pd.DataFrame({"b": [10, 20]}, index=pd.date_range("2023-01-02", periods=2))
         res = lib.update_batch([UpdatePayload("symbol_1", update_1), UpdatePayload("symbol_2", update_2)], upsert=upsert)
@@ -891,6 +892,12 @@ class TestBatchUpdate:
         # update range (values 3, 4). The fourth segment is the original data segment
         assert(len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "symbol_2")) == 4)
         assert(len(lib_tool.read_index("symbol_2")) == 3)
+
+        # This result is wrong. The correct value is 2. This is due to a bug Monday: 9682041273, append_batch and
+        # update_batch should not create symbol list keys for already existing symbols. Since update_batch is noop when
+        # the input is empty, there is no key for symbol_1, but there is a new key for symbol_2 and that is wrong.
+        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 3
+
 
 
 def test_regular_update_dynamic_schema_named_index(

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -854,6 +854,26 @@ class TestBatchUpdate:
         assert "symbol_1" in str(ex_info.value)
         assert "symbol_2" not in str(ex_info.value)
 
+    @pytest.mark.parametrize("upsert", [True, False])
+    def test_empty_dataframe_does_not_increase_version(self, lmdb_library, upsert):
+        lib = lmdb_library
+        df1 = pd.DataFrame({"a": range(5)}, index=pd.date_range("2024-01-01", periods=5))
+        df2 = pd.DataFrame({"b": range(5)}, index=pd.date_range("2023-01-01", periods=5))
+        lib.write_batch([UpdatePayload("symbol_1", df1), UpdatePayload("symbol_2", df2)])
+
+        update_1 = pd.DataFrame({"a": []}, index=pd.date_range("2024-01-01", periods=0))
+        update_2 = pd.DataFrame({"b": [10, 20]}, index=pd.date_range("2023-01-02", periods=2))
+        res = lib.update_batch([UpdatePayload("symbol_1", update_1), UpdatePayload("symbol_2", update_2)], upsert=upsert)
+        assert res[0].version == 0
+        assert res[1].version == 1
+
+        sym_1_vit, sym_2_vit = lib.read("symbol_1"), lib.read("symbol_2")
+        assert sym_1_vit.version == 0
+        assert_frame_equal(sym_1_vit.data, df1)
+
+        assert sym_2_vit.version == 1
+        assert_frame_equal(sym_2_vit.data, pd.DataFrame({"b": [0, 10, 20, 3, 4]}, index=pd.date_range("2023-01-01", periods=5)))
+
 
 def test_regular_update_dynamic_schema_named_index(
     lmdb_version_store_tiny_segment_dynamic,


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 9663246666

#### What does this implement or fix?
Update and append are noop when there is an existing version and the input is an empty dataframe. They do not create new version, instead of that they return the latest live version's VersionItem.

`update_batch` and `append_batch` do not behave this way, they create new version keeping the same data. This is a bug and they should behave the same way as regular update and append.
#### Any other comments?
`append_batch` and `update_batch` should not create symbol list entries if the symbols exist. There's a new ticket for that Monday: 9682041273
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
