### PR TITLE
Remove matrix from macos flow as it is not needed

### DIFF
--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -134,7 +134,6 @@ jobs:
       always() &&
       !cancelled()
     runs-on: macos-14
-    fail-fast: false
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -130,13 +130,11 @@ jobs:
 
 
   macos:
-    strategy:
-      matrix:
-        include:
-          - os: macos-14
-
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+    if: |
+      always() &&
+      !cancelled()
+    runs-on: macos-14
+    fail-fast: false
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Remove the macos matrix because it is not needed and it makes it hard to create a rule for merge checks as the name of the job can shift based on the `os` parameter

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
