### PR TITLE
Enhancement/9288960436/arrow support for reading sparse float columns

### DIFF
--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -15,7 +15,6 @@
 #include <arcticdb/pipeline/frame_utils.hpp>
 #include <arcticdb/pipeline/frame_slice_map.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
-#include <arcticdb/util/encoding_conversion.hpp>
 #include <arcticdb/util/type_handler.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/codec/slice_data_sink.hpp>
@@ -263,6 +262,15 @@ void handle_truncation(
     handle_truncation(dest_column, mapping.truncate_);
 }
 
+void handle_truncation(util::BitSet& bv, const ColumnTruncation& truncate) {
+    if (truncate.start_) {
+        bv = util::truncate_sparse_map(bv, *truncate.start_, truncate.end_.value_or(bv.size()));
+    } else if (truncate.end_) {
+        // More efficient than util::truncate_sparse_map as it avoids a copy
+        bv.resize(*truncate.end_);
+    }
+}
+
 void create_dense_bitmap(size_t offset, const util::BitSet& sparse_map, Column& dest_column, AllocationType allocation_type) {
     auto& sparse_buffer = dest_column.create_extra_buffer(
         offset,
@@ -309,17 +317,23 @@ void decode_or_expand(
             ChunkedBuffer sparse = ChunkedBuffer::presized(bytes);
             SliceDataSink sparse_sink{sparse.data(), bytes};
             data += decode_field(source_type_desc, encoded_field_info, data, sparse_sink, bv, encoding_version);
-            source_type_desc.visit_tag([dest, dest_bytes, &bv, &sparse](auto tdt) {
+            source_type_desc.visit_tag([dest, dest_bytes, &bv, &sparse, output_format](auto tdt) {
                 using TagType = decltype(tdt);
                 using RawType = typename TagType::DataTypeTag::raw_type;
-                util::default_initialize<TagType>(dest, dest_bytes);
+                if (output_format != OutputFormat::ARROW) {
+                    // Arrow doesn't care what values are at indices where the validity bitmap is zero
+                    util::default_initialize<TagType>(dest, dest_bytes);
+                }
                 util::expand_dense_buffer_using_bitmap<RawType>(bv.value(), sparse.data(), dest);
             });
 
             // TODO We must handle sparse columns in ArrowStringHandler and deduplicate logic between the two.
             // Consider registering a sparse handler on the TypeHandlerRegistry.
-            if(output_format == OutputFormat::ARROW)
+            if(output_format == OutputFormat::ARROW) {
+                bv->resize(dest_bytes / dest_type_desc.get_type_bytes());
+                handle_truncation(*bv, mapping.truncate_);
                 create_dense_bitmap(mapping.offset_bytes_, *bv, dest_column, AllocationType::DETACHABLE);
+            }
         } else {
             SliceDataSink sink(dest, dest_bytes);
             const auto &ndarray = encoded_field_info.ndarray();

--- a/cpp/arcticdb/util/sparse_utils.cpp
+++ b/cpp/arcticdb/util/sparse_utils.cpp
@@ -27,4 +27,42 @@ util::BitSet scan_object_type_to_sparse(
     return bitset;
 }
 
+util::BitMagic truncate_sparse_map(
+        const util::BitMagic& input_sparse_map,
+        size_t start_row,
+        size_t end_row
+) {
+    // The output sparse map is the slice [start_row, end_row) of the input sparse map
+    // BitMagic doesn't have a method for this, so hand-roll it here
+    // Ctor parameter is the size
+    util::BitMagic output_sparse_map(end_row - start_row);
+    util::BitSetSizeType set_input_bit;
+    // find returns false if there are no set bits after (inclusive) start_row
+    if (input_sparse_map.find(start_row, set_input_bit)) {
+        util::BitSet::bulk_insert_iterator inserter(output_sparse_map);
+        while (set_input_bit < end_row) {
+            inserter = set_input_bit - start_row;
+            set_input_bit = input_sparse_map.get_next(set_input_bit);
+            // get_next returns 0 if there are no more set bits
+            if (set_input_bit == 0) {
+                break;
+            }
+        }
+        inserter.flush();
+    } // else no set bits after (inclusive) start_row. Ctor for output_sparse_map used initialises all bits to zero
+    return output_sparse_map;
+
+    // The above code is equivalent to the (easier to read) implementation:
+    //    for (auto en = input_sparse_map.first(); en != input_sparse_map.end(); ++en) {
+    //        if (*en < start_row) {
+    //            continue;
+    //        } else if (*en < end_row) {
+    //            inserter = *en - start_row;
+    //        } else {
+    //            break;
+    //        }
+    //    }
+    // but is more efficient in the case that the first set bit is deep into input_sparse_map
+}
+
 } //namespace arcticdb::util

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -165,6 +165,12 @@ inline util::BitMagic deserialize_bytes_to_bitmap(const std::uint8_t*& input, si
     return bv;
 }
 
+util::BitMagic truncate_sparse_map(
+        const util::BitMagic& input_sparse_map,
+        size_t start_row,
+        size_t end_row
+);
+
 inline void dump_bitvector(const util::BitMagic& bv) {
     auto en = bv.first();
     auto en_end = bv.end();


### PR DESCRIPTION
#### Reference Issues/PRs
[9288960436](https://man312219.monday.com/boards/7852509418/pulses/9288960436)

#### What does this implement or fix?
Adds support for Arrow reading sparse float data. Currently limited to floats only because it is difficult to end-to-end test sparse data of other types. Will probably also work out of the box for other numeric types, strings will probably require more effort.