### PR TITLE
Enhancement 9402975662: Throw a meaningful exception when trying to read ASCII or fixed-width string columns into Arrow

### DIFF
--- a/cpp/arcticdb/arrow/arrow_handlers.cpp
+++ b/cpp/arcticdb/arrow/arrow_handlers.cpp
@@ -25,6 +25,10 @@ void ArrowStringHandler::handle_type(
     const std::shared_ptr<StringPool>& string_pool) {
     ARCTICDB_SAMPLE(ArrowHandleString, 0)
     util::check(field.has_ndarray(), "String handler expected array");
+    schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
+            m.source_type_desc_.data_type() == DataType::UTF_DYNAMIC64,
+            "Cannot read column '{}' into Arrow output format as it is of unsupported type {} (only {} is supported)",
+            m.frame_field_descriptor_.name(), m.source_type_desc_.data_type(), DataType::UTF_DYNAMIC64);
     ARCTICDB_DEBUG(log::version(), "String handler got encoded field: {}", field.DebugString());
     const auto &ndarray = field.ndarray();
     const auto bytes = encoding_sizes::data_uncompressed_size(ndarray);


### PR DESCRIPTION
#### Reference Issues/PRs
[9402975662](https://man312219.monday.com/boards/7852509418/pulses/9402975662)

#### What does this implement or fix?
Full support for fixed-width (and possibly ASCII) strings will be added later, for now just give a meaningful error if they are read with the output format specified as Arrow.
For context, ASCII strings were only available for writing in Python 2.7 builds of the internal Man Group ArcticDB project. Likewise, fixed-width strings have not been the default for a very long time.