### PR TITLE
Implemented conversion from dataframe to SegmentInMemory

### DIFF
--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -77,11 +77,22 @@ void LibraryTool::overwrite_segment_in_memory(VariantKey key, SegmentInMemory& s
     write(key, segment);
 }
 
+SegmentInMemory LibraryTool::item_to_segment_in_memory(
+        StreamId stream_id,
+        const py::tuple &item,
+        const py::object &norm,
+        const py::object &user_meta,
+        std::optional<AtomKey> next_key) {
+    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, engine_.cfg().write_options().empty_types());
+    auto segment_in_memory = incomplete_segment_from_frame(frame, 0, std::move(next_key), engine_.cfg().write_options().allow_sparse());
+    return segment_in_memory;
+}
+
 SegmentInMemory LibraryTool::overwrite_append_data(
         VariantKey key,
         const py::tuple &item,
         const py::object &norm,
-        const py::object & user_meta) {
+        const py::object &user_meta) {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
         std::holds_alternative<AtomKey>(key) && std::get<AtomKey>(key).type() == KeyType::APPEND_DATA,
         "Can only override APPEND_DATA keys. Received: {}", key);
@@ -94,8 +105,7 @@ SegmentInMemory LibraryTool::overwrite_append_data(
     }
 
     auto stream_id = util::variant_match(key, [](const auto& key){return key.id();});
-    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, engine_.cfg().write_options().empty_types());
-    auto segment_in_memory = incomplete_segment_from_frame(frame, 0, std::move(next_key), engine_.cfg().write_options().allow_sparse());
+    auto segment_in_memory = item_to_segment_in_memory(stream_id, item, norm, user_meta, next_key);
     overwrite_segment_in_memory(key, segment_in_memory);
     return old_segment_in_memory;
 }

--- a/cpp/arcticdb/toolbox/library_tool.hpp
+++ b/cpp/arcticdb/toolbox/library_tool.hpp
@@ -48,6 +48,8 @@ public:
 
     void overwrite_segment_in_memory(VariantKey key, SegmentInMemory& segment_in_memory);
 
+    SegmentInMemory item_to_segment_in_memory(StreamId stream_id, const py::tuple &item, const py::object &norm, const py::object & user_meta, std::optional<AtomKey> next_key);
+
     SegmentInMemory overwrite_append_data(VariantKey key, const py::tuple &item, const py::object &norm, const py::object & user_meta);
 
     void remove(VariantKey key);

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -54,6 +54,7 @@ void register_bindings(py::module &m, py::exception<arcticdb::ArcticException>& 
             )pbdoc")
             .def("write", &LibraryTool::write)
             .def("overwrite_segment_in_memory", &LibraryTool::overwrite_segment_in_memory)
+            .def("item_to_segment_in_memory", &LibraryTool::item_to_segment_in_memory)
             .def("overwrite_append_data", &LibraryTool::overwrite_append_data)
             .def("remove", &LibraryTool::remove)
             .def("find_keys", &LibraryTool::find_keys)

--- a/python/arcticdb/toolbox/library_tool.py
+++ b/python/arcticdb/toolbox/library_tool.py
@@ -174,7 +174,7 @@ class LibraryTool(LibraryToolImpl):
 
     def dataframe_to_segment_in_memory(self, df : pd.DataFrame, stream_id):
         item, norm_meta = self.normalize_dataframe_with_nvs_defaults(df)
-        return item_to_segment_in_memory(stream_id, item, norm_meta, None)
+        return self.item_to_segment_in_memory(stream_id, item, norm_meta, None)
     
     def overwrite_append_data_with_dataframe(self, key : VariantKey, df : pd.DataFrame) -> SegmentInMemory:
         """

--- a/python/arcticdb/toolbox/library_tool.py
+++ b/python/arcticdb/toolbox/library_tool.py
@@ -172,6 +172,10 @@ class LibraryTool(LibraryToolImpl):
         dynamic_strings = self._nvs._resolve_dynamic_strings({})
         return normalize_dataframe(df, dynamic_schema=dynamic_schema, empty_types=empty_types, dynamic_strings=dynamic_strings)
 
+    def dataframe_to_segment_in_memory(self, df : pd.DataFrame, stream_id):
+        item, norm_meta = self.normalize_dataframe_with_nvs_defaults(df)
+        return item_to_segment_in_memory(stream_id, item, norm_meta, None)
+    
     def overwrite_append_data_with_dataframe(self, key : VariantKey, df : pd.DataFrame) -> SegmentInMemory:
         """
         Overwrites the append data key with the provided dataframe. Use with extreme caution as overwriting with


### PR DESCRIPTION


#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Conversion from dataframe to SegmentInMemory on the python layer, helper function on the C++ layer that converts normalized dataframe to segment in memory.


#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
