### PR TITLE
Enhancement 9697077221: Arrow date/row range reads tested with string columns

### DIFF
--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -333,6 +333,9 @@ void decode_or_expand(
             data += decode_field(source_type_desc, encoded_field_info, data, sink, bv, encoding_version);
         }
     }
+    // TODO: This is super inefficient for Arrow string columns. It will first produce the required 3 Arrow buffers
+    // for the entire slice of the column that was just decoded, and then restrict to just the relevant rows of the
+    // "data" column
     handle_truncation(dest_column, mapping);
 }
 


### PR DESCRIPTION
#### Reference Issues/PRs
[9697077221](https://man312219.monday.com/boards/7852509418/pulses/9697077221)

#### What does this implement or fix?
Adds tests for date and row range filtering with string columns (functionality was already working, `version_store_factory` just defaults to `dynamic_strings=False` so it seemed broken)

Current implementation is quite inefficient, see the TODO added in `read_frame.cpp`, we can improve the performance in a future PR.