### PR TITLE
Fix get_backing_store could check non-primary storage

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -408,7 +408,8 @@ class NativeVersionStore:
     def get_backing_store(self):
         backing_store = ""
         try:
-            primary_backing_url = list(self._lib_cfg.storage_by_id.values())[0].config.type_url
+            primary_storage_id = self._lib_cfg.lib_desc.storage_ids[0]
+            primary_backing_url = self._lib_cfg.storage_by_id[primary_storage_id].config.type_url
             storage_val = re.search("cxx.arctic.org/arcticc.pb2.(.*)_pb2.Config", primary_backing_url)
             backing_store = storage_val.group(1)
         except Exception as e:

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1526,8 +1526,8 @@ def test_ok_chars_snapshots(arctic_library_v1, snap):
     assert arctic_library.list_snapshots() == {snap: None}
 
 
-def test_backing_store(mongo_storage, s3_version_store_v1):
-    ac = mongo_storage.create_arctic()
+def test_backing_store(lmdb_storage, s3_version_store_v1):
+    ac = lmdb_storage.create_arctic()
     lib = ac.create_library("abc")
     lib_cfg = lib._nvs.lib_cfg()
     primary_storage_id = list(lib_cfg.storage_by_id.keys())[0]
@@ -1549,6 +1549,7 @@ def test_backing_store(mongo_storage, s3_version_store_v1):
         
         def __getattr__(self, name):
             return getattr(self._original, name)
+            
     new_lib_cfg = LibraryConfigWrapper(lib_cfg, new_storage_by_id)
     # get_backing_store() was only returning backed storage at the beginning of the list
     # so we need to recreate the situation so confirm now it returns primary storage
@@ -1556,5 +1557,5 @@ def test_backing_store(mongo_storage, s3_version_store_v1):
     lib_with_s3 = NativeVersionStore.create_store_from_lib_config(
         new_lib_cfg, env=Defaults.ENV, open_mode=OpenMode.DELETE
     )
-    assert lib_with_s3.get_backing_store() == "mongo_storage"
+    assert lib_with_s3.get_backing_store() == "lmdb_storage"
 

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -32,6 +32,7 @@ from arcticdb.storage_fixtures.api import StorageFixture, ArcticUriFields, Stora
 from arcticdb.storage_fixtures.mongo import MongoDatabase
 from arcticdb.util.test import assert_frame_equal, sample_dataframe, config_context
 from arcticdb.storage_fixtures.s3 import S3Bucket
+from arcticdb.config import Defaults
 from arcticdb.version_store.library import (
     WritePayload,
     ArcticUnsupportedDataTypeException,
@@ -39,6 +40,8 @@ from arcticdb.version_store.library import (
     StagedDataFinalizeMethod,
     DeleteRequest,
 )
+from arcticdb.authorization.permissions import OpenMode
+from arcticdb.version_store._store import NativeVersionStore
 
 from arcticdb.version_store.library import ArcticInvalidApiUsageException
 from ...util.mark import (
@@ -1521,3 +1524,37 @@ def test_ok_chars_snapshots(arctic_library_v1, snap):
 
     assert_frame_equal(arctic_library.read("sym", as_of=snap).data, df)
     assert arctic_library.list_snapshots() == {snap: None}
+
+
+def test_backing_store(mongo_storage, s3_version_store_v1):
+    ac = mongo_storage.create_arctic()
+    lib = ac.create_library("abc")
+    lib_cfg = lib._nvs.lib_cfg()
+    primary_storage_id = list(lib_cfg.storage_by_id.keys())[0]
+    secondary_storage_id = "abc"
+    new_storage_by_id = {
+        secondary_storage_id: list(s3_version_store_v1.lib_cfg().storage_by_id.values())[0],
+        primary_storage_id: lib_cfg.storage_by_id[primary_storage_id],
+    }
+    lib_cfg.lib_desc.storage_ids.append(secondary_storage_id)
+    # The order of protobuf map is an UB but dict is insertion ordered
+    class LibraryConfigWrapper:
+        def __init__(self, original_lib_cfg, controlled_storage_by_id):
+            self._original = original_lib_cfg
+            self._storage_by_id = controlled_storage_by_id
+        
+        @property
+        def storage_by_id(self): # Can't patch _storage_by_id
+            return self._storage_by_id
+        
+        def __getattr__(self, name):
+            return getattr(self._original, name)
+    new_lib_cfg = LibraryConfigWrapper(lib_cfg, new_storage_by_id)
+    # get_backing_store() was only returning backed storage at the beginning of the list
+    # so we need to recreate the situation so confirm now it returns primary storage
+    assert list(new_lib_cfg.storage_by_id.keys())[0] == secondary_storage_id # insertion order
+    lib_with_s3 = NativeVersionStore.create_store_from_lib_config(
+        new_lib_cfg, env=Defaults.ENV, open_mode=OpenMode.DELETE
+    )
+    assert lib_with_s3.get_backing_store() == "mongo_storage"
+


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Fix get_backing_store could check non-primary storage
#### What does this implement or fix?
Originally the function always check the first item at `storage_id` map. It's a protobuf map so the order of the items in it is undefined. Therefore non-primary storage could end up at the top and being evaluated.
If the the storage being evaluated is different in type of primary storage, incorrect result could be returned.

Now the API will always evaluated primary storage.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
