### PR TITLE
Set the environment variable ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME to 0 in tests so that it doesn't spam the logs

### DIFF
--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -31,6 +31,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME: "0"
     defaults:
       run: {shell: bash}
     steps:  

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -17,6 +17,7 @@ MSYS=winsymlinks:nativestrict ln -s "$(realpath "$tooling_dir/../python/tests")"
 cd $PARALLEL_TEST_ROOT
 
 export ARCTICDB_RAND_SEED=$RANDOM
+export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME="0"
 if [ "$VERSION_MAP_RELOAD_INTERVAL" != "-1" ]; then
     export ARCTICDB_VersionMap_ReloadInterval_int=$VERSION_MAP_RELOAD_INTERVAL
 fi


### PR DESCRIPTION


#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
