### PR TITLE
Faster and error free ASV benchmarks

### DIFF
--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -107,6 +107,8 @@ jobs:
             fi
             echo "FINAL selection to execute SUITE=$SUITE"
             echo "SUITE=$SUITE" >> $GITHUB_ENV
+            # Now lets reduce logging
+            echo "ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0" >> $GITHUB_ENV 
 
       - name: Benchmark given commit
         if: github.event_name != 'pull_request_target' || inputs.run_all_benchmarks == true

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -401,6 +401,7 @@ jobs:
       - name: Run test
         run: |
           ulimit -a
+          export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
           if [[ "$(echo "$ARCTICDB_PYTEST_ARGS" | xargs)" == pytest* ]]; then
             python -m pip  install pytest-repeat setuptools wheel
             python setup.py protoc --build-lib python

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -113,6 +113,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export ARCTICDB_RAND_SEED=$RANDOM
+          export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
           if [[ "$(echo "$ARCTICDB_PYTEST_ARGS" | xargs)" == *pytest* ]]; then
             command="python -m $ARCTICDB_PYTEST_ARGS"
             python -m pip  install pytest-repeat
@@ -194,6 +195,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export ARCTICDB_RAND_SEED=$RANDOM
+          export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
           if [[ "$(echo "$ARCTICDB_PYTEST_ARGS" | xargs)" == pytest* ]]; then
             command="python -m $ARCTICDB_PYTEST_ARGS"
             echo "Run custom pytest command: $command"

--- a/.github/workflows/installation_tests.yml
+++ b/.github/workflows/installation_tests.yml
@@ -220,6 +220,7 @@ jobs:
         echo "ARCTICDB_STORAGE_AWS_S3=${{ env.real_s3 }}" >> $GITHUB_ENV        
         echo "ARCTICDB_STORAGE_GCP=0" >> $GITHUB_ENV        
         echo "ARCTICDB_PERSISTENT_STORAGE_TESTS=1" >> $GITHUB_ENV
+        echo "ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0" >> $GITHUB_ENV
 
     - name: Run tests
       if: ${{ env.SKIP_JOB != 'true' }}

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -21,6 +21,7 @@ if [ "$VERSION_MAP_RELOAD_INTERVAL" != "-1" ]; then
     export ARCTICDB_VersionMap_ReloadInterval_int=$VERSION_MAP_RELOAD_INTERVAL
 fi
 
+export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
 if [ -z "$ARCTICDB_PYTEST_ARGS" ]; then
     echo "Executing tests with no additional arguments"
     $catch python -m pytest --timeout=3600 $PYTEST_XDIST_MODE -v \

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -11,7 +11,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -29,7 +29,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -47,7 +47,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -65,7 +65,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -83,7 +83,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -101,7 +101,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -119,7 +119,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -137,7 +137,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -155,7 +155,7 @@
                 "1500000"
             ]
         ],
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -178,12 +178,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "a70c622c0ad6fd9d008c2b36342666f99b8c14f75d14c859d619cf2cc37e34ad",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_read_short_wide": {
         "code": "class BasicFunctions:\n    def time_read_short_wide(self, rows):\n        lib = self.ac[get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)]\n        lib.read(\"short_wide_sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -202,12 +202,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "8527c0bb585ee2f0d4d115dd110b8911b243e6ddd28139771dcdd158fc4ad124",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_read_ultra_short_wide": {
         "code": "class BasicFunctions:\n    def time_read_ultra_short_wide(self, rows):\n        lib = self.ac[get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)]\n        lib.read(\"ultra_short_wide_sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -226,12 +226,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "591d23399ad85009e024d4ee18eb2b5a4a844d6ea0b937c49adee40d8f24bc8e",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_read_with_columns": {
         "code": "class BasicFunctions:\n    def time_read_with_columns(self, rows):\n        COLS = [\"value\"]\n        self.lib.read(f\"sym\", columns=COLS).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -250,12 +250,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "19bbbb9d179141472b122afd3ad90408e2a3546eaeb640514c2c6b1fca9fa686",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_read_with_date_ranges": {
         "code": "class BasicFunctions:\n    def time_read_with_date_ranges(self, rows):\n        self.lib.read(f\"sym\", date_range=BasicFunctions.DATE_RANGE).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -274,12 +274,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "f59257c55a9106758070701cec081f4bf021bf1cbcb6d698dcf694419cd9bddc",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_read_with_date_ranges_query_builder": {
         "code": "class BasicFunctions:\n    def time_read_with_date_ranges_query_builder(self, rows):\n        q = QueryBuilder().date_range(BasicFunctions.DATE_RANGE)\n        self.lib.read(f\"sym\", query_builder=q).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -298,12 +298,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "2c5d17c2d1bd6212c16a5127aea1ca379224ef610b06111a93c5b80e04922f8d",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_write": {
         "code": "class BasicFunctions:\n    def time_write(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -322,12 +322,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "54f11aa38218f73c7a34bec5c71fc51af8b57ff2ac64f2cf3db688dc462efcdf",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_write_short_wide": {
         "code": "class BasicFunctions:\n    def time_write_short_wide(self, rows):\n        self.fresh_lib.write(\"short_wide_sym\", self.df_short_wide)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -346,12 +346,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "9c7467ee5cd1c182f05a78de9dff71956edf647d369b0cdbcc0cc431f96e2c24",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BasicFunctions.time_write_staged": {
         "code": "class BasicFunctions:\n    def time_write_staged(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df, staged=True)\n        self.fresh_lib._nvs.compact_incomplete(f\"sym\", False, False)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n        rows_values = BasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            lib.write(f\"sym\", self.dfs[rows])\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )\n    \n        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"ultra_short_wide_sym\",\n            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),\n        )",
@@ -370,12 +370,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:43",
+        "setup_cache_key": "basic_functions:44",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "71e4fffc77870273e8186b7b0a8a275fd2062d2eec72a11834004b88c2bca07c",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BatchBasicFunctions.peakmem_read_batch": {
         "code": "class BatchBasicFunctions:\n    def peakmem_read_batch(self, rows, num_symbols):\n        read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n        self.lib.read_batch(read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        rows_values, num_symbols_values = BatchBasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            for sym in range(num_symbols_values[-1]):\n                lib.write(f\"{sym}_sym\", self.dfs[rows])",
@@ -394,7 +394,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -417,7 +417,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -440,7 +440,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -463,7 +463,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -486,7 +486,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -514,12 +514,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "91fcac5344d14a496a34cbd4cafc3b187e9579d1912b6156ecae8087d80df7b2",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BatchBasicFunctions.time_read_batch_pure": {
         "code": "class BatchBasicFunctions:\n    def time_read_batch_pure(self, rows, num_symbols):\n        self.lib.read_batch(self.read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        rows_values, num_symbols_values = BatchBasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            for sym in range(num_symbols_values[-1]):\n                lib.write(f\"{sym}_sym\", self.dfs[rows])",
@@ -543,12 +543,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "bd42aec09d03cbf1c6f55d86f114ea0f5627950c8a255ce64ccdcc8cedaa029a",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BatchBasicFunctions.time_read_batch_with_columns": {
         "code": "class BatchBasicFunctions:\n    def time_read_batch_with_columns(self, rows, num_symbols):\n        COLS = [\"value\"]\n        read_reqs = [ReadRequest(f\"{sym}_sym\", columns=COLS) for sym in range(num_symbols)]\n        self.lib.read_batch(read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        rows_values, num_symbols_values = BatchBasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            for sym in range(num_symbols_values[-1]):\n                lib.write(f\"{sym}_sym\", self.dfs[rows])",
@@ -572,12 +572,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "e11e8495b1ac21d015735c6d9bd38a219ad0c386063557efa4673c881155d331",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BatchBasicFunctions.time_read_batch_with_date_ranges": {
         "code": "class BatchBasicFunctions:\n    def time_read_batch_with_date_ranges(self, rows, num_symbols):\n        read_reqs = [ReadRequest(f\"{sym}_sym\", date_range=BatchBasicFunctions.DATE_RANGE) for sym in range(num_symbols)]\n        self.lib.read_batch(read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        rows_values, num_symbols_values = BatchBasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            for sym in range(num_symbols_values[-1]):\n                lib.write(f\"{sym}_sym\", self.dfs[rows])",
@@ -601,12 +601,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "b90235fb10cb19836b85cf7de7316d780ebd9b4d015e906fbbb3840a556f55b9",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BatchBasicFunctions.time_update_batch": {
         "code": "class BatchBasicFunctions:\n    def time_update_batch(self, rows, num_symbols):\n        payloads = [UpdatePayload(f\"{sym}_sym\", self.update_df) for sym in range(num_symbols)]\n        results = self.lib.update_batch(payloads)\n        assert results[0].version >= 1\n        assert results[-1].version >= 1\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        rows_values, num_symbols_values = BatchBasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            for sym in range(num_symbols_values[-1]):\n                lib.write(f\"{sym}_sym\", self.dfs[rows])",
@@ -630,12 +630,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "15c4acc46acc92479e795e0cbf8664b0a75afd63f626f799457d10fde36d928b",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.BatchBasicFunctions.time_write_batch": {
         "code": "class BatchBasicFunctions:\n    def time_write_batch(self, rows, num_symbols):\n        payloads = [WritePayload(f\"{sym}_sym\", self.df) for sym in range(num_symbols)]\n        self.fresh_lib.write_batch(payloads)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        rows_values, num_symbols_values = BatchBasicFunctions.params\n    \n        self.dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib)\n            self.ac.create_library(lib)\n            lib = self.ac[lib]\n            for sym in range(num_symbols_values[-1]):\n                lib.write(f\"{sym}_sym\", self.dfs[rows])",
@@ -659,12 +659,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:165",
+        "setup_cache_key": "basic_functions:167",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "71706b100e9d76919fe5a09b6dd6d60999519ea4acd92879edbbf7a95ee919a0",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "basic_functions.ModificationFunctions.time_append_large": {
         "code": "class ModificationFunctions:\n    def time_append_large(self, lad: LargeAppendDataModify, rows):\n        large: pd.DataFrame = lad.df_append_large[rows].pop(0)\n        self.lib.append(\"sym\", large)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        rows_values = ModificationFunctions.params\n    \n        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}\n        for rows in rows_values:\n            lib_name = get_prewritten_lib_name(rows)\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            df = self.init_dfs[rows]\n            lib.write(\"sym\", df)\n            print(f\"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}\")\n    \n        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)\n        self.ac.delete_library(lib_name)\n        lib = self.ac.create_library(lib_name)\n        lib.write(\n            \"short_wide_sym\",\n            generate_random_floats_dataframe_with_index(\n                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n            ),\n        )\n    \n        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.\n        # Then on each teardown we restore the initial state by overwriting the modified with the original.\n        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)\n    \n        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds\n    \n        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)\n    \n        return lad",
@@ -683,7 +683,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -707,7 +707,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -731,7 +731,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -755,7 +755,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -779,7 +779,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -803,7 +803,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -827,7 +827,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -851,7 +851,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -875,7 +875,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -899,7 +899,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -923,7 +923,7 @@
         "repeat": 3,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:314",
+        "setup_cache_key": "basic_functions:316",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
@@ -942,7 +942,7 @@
                 "10"
             ]
         ],
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -960,7 +960,7 @@
                 "10"
             ]
         ],
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -978,7 +978,7 @@
                 "10"
             ]
         ],
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -996,7 +996,7 @@
                 "10"
             ]
         ],
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1019,12 +1019,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "f3e937a52faf63c837949a6eb48debf02755ddd4b699c5c3800831a5cda9ad67",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "bi_benchmarks.BIBenchmarks.time_query_groupby_city_count_filter_two_aggregations": {
         "code": "class BIBenchmarks:\n    def time_query_groupby_city_count_filter_two_aggregations(self, times_bigger) -> pd.DataFrame:\n        return self.query_groupby_city_count_filter_two_aggregations(times_bigger)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(f\"lmdb://opensource_datasets_{self.lib_name}?map_size=20GB\")\n        self.lib = self.ac.get_library(self.lib_name)\n\n    def setup_cache(self):\n    \n        start_time = time.time()\n    \n        file = os.path.join(Path(__file__).resolve().parent.parent, BIBenchmarks.CITY_BI_FILE2)\n        if (not os.path.exists(file)) :\n            dfo = download_and_process_city_to_parquet(file)\n            dff = pd.read_parquet(file)\n            pd.testing.assert_frame_equal(dfo,dff)\n        else:\n            print(\"Parquet file exists!\")\n    \n        # read data from bz.2 file\n        # abs_path = os.path.join(Path(__file__).resolve().parent.parent,BIBenchmarks.CITY_BI_FILE)\n        # self.df : pd.DataFrame = process_city(abs_path)\n    \n        self.df : pd.DataFrame = pd.read_parquet(file)\n    \n        self.ac = Arctic(f\"lmdb://opensource_datasets_{self.lib_name}?map_size=20GB\")\n        self.ac.delete_library(self.lib_name)\n        self.lib = self.ac.create_library(self.lib_name)\n    \n        print(\"The procedure is creating N times larger dataframes\")\n        print(\"by concatenating original DF N times\")\n        print(\"Size of original Dataframe: \", self.df.shape[0])\n        for num in BIBenchmarks.params:\n            _df = pd.concat([self.df] * num)\n            print(\"DF for iterration xSize original ready: \", num)\n            self.lib.write(f\"{self.symbol}{num}\", _df)\n    \n        print(\"If pandas query produces different dataframe than arctic one stop tests!\")\n        print(\"This will mean query problem is there most likely\")\n    \n        print(\"Pre-check correctness for query_groupby_city_count_all\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_all(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_all(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"Pre-check correctness for query_groupby_city_count_isin_filter\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_isin_filter(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_isin_filter(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"Pre-check correctness for query_groupby_city_count_filter_two_aggregations\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_filter_two_aggregations(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_filter_two_aggregations(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"All pre-checks completed SUCCESSFULLY. Time: \", time.time() - start_time)\n    \n        del self.ac",
@@ -1043,12 +1043,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "5dc7443c6e30c3fe69bfc4f04cb28fb5aa503162cab5e204606a9f6e2233e581",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "bi_benchmarks.BIBenchmarks.time_query_groupby_city_count_isin_filter": {
         "code": "class BIBenchmarks:\n    def time_query_groupby_city_count_isin_filter(self, times_bigger) -> pd.DataFrame:\n        return self.query_groupby_city_count_isin_filter(times_bigger)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(f\"lmdb://opensource_datasets_{self.lib_name}?map_size=20GB\")\n        self.lib = self.ac.get_library(self.lib_name)\n\n    def setup_cache(self):\n    \n        start_time = time.time()\n    \n        file = os.path.join(Path(__file__).resolve().parent.parent, BIBenchmarks.CITY_BI_FILE2)\n        if (not os.path.exists(file)) :\n            dfo = download_and_process_city_to_parquet(file)\n            dff = pd.read_parquet(file)\n            pd.testing.assert_frame_equal(dfo,dff)\n        else:\n            print(\"Parquet file exists!\")\n    \n        # read data from bz.2 file\n        # abs_path = os.path.join(Path(__file__).resolve().parent.parent,BIBenchmarks.CITY_BI_FILE)\n        # self.df : pd.DataFrame = process_city(abs_path)\n    \n        self.df : pd.DataFrame = pd.read_parquet(file)\n    \n        self.ac = Arctic(f\"lmdb://opensource_datasets_{self.lib_name}?map_size=20GB\")\n        self.ac.delete_library(self.lib_name)\n        self.lib = self.ac.create_library(self.lib_name)\n    \n        print(\"The procedure is creating N times larger dataframes\")\n        print(\"by concatenating original DF N times\")\n        print(\"Size of original Dataframe: \", self.df.shape[0])\n        for num in BIBenchmarks.params:\n            _df = pd.concat([self.df] * num)\n            print(\"DF for iterration xSize original ready: \", num)\n            self.lib.write(f\"{self.symbol}{num}\", _df)\n    \n        print(\"If pandas query produces different dataframe than arctic one stop tests!\")\n        print(\"This will mean query problem is there most likely\")\n    \n        print(\"Pre-check correctness for query_groupby_city_count_all\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_all(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_all(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"Pre-check correctness for query_groupby_city_count_isin_filter\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_isin_filter(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_isin_filter(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"Pre-check correctness for query_groupby_city_count_filter_two_aggregations\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_filter_two_aggregations(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_filter_two_aggregations(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"All pre-checks completed SUCCESSFULLY. Time: \", time.time() - start_time)\n    \n        del self.ac",
@@ -1067,12 +1067,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "46c41f587be844def6cad1cefd995ea32c9719285172e8a0ecc3ad193b991247",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "bi_benchmarks.BIBenchmarks.time_query_readall": {
         "code": "class BIBenchmarks:\n    def time_query_readall(self, times_bigger):\n        self.lib.read(f\"{self.symbol}{times_bigger}\")\n\n    def setup(self, num_rows):\n        self.ac = Arctic(f\"lmdb://opensource_datasets_{self.lib_name}?map_size=20GB\")\n        self.lib = self.ac.get_library(self.lib_name)\n\n    def setup_cache(self):\n    \n        start_time = time.time()\n    \n        file = os.path.join(Path(__file__).resolve().parent.parent, BIBenchmarks.CITY_BI_FILE2)\n        if (not os.path.exists(file)) :\n            dfo = download_and_process_city_to_parquet(file)\n            dff = pd.read_parquet(file)\n            pd.testing.assert_frame_equal(dfo,dff)\n        else:\n            print(\"Parquet file exists!\")\n    \n        # read data from bz.2 file\n        # abs_path = os.path.join(Path(__file__).resolve().parent.parent,BIBenchmarks.CITY_BI_FILE)\n        # self.df : pd.DataFrame = process_city(abs_path)\n    \n        self.df : pd.DataFrame = pd.read_parquet(file)\n    \n        self.ac = Arctic(f\"lmdb://opensource_datasets_{self.lib_name}?map_size=20GB\")\n        self.ac.delete_library(self.lib_name)\n        self.lib = self.ac.create_library(self.lib_name)\n    \n        print(\"The procedure is creating N times larger dataframes\")\n        print(\"by concatenating original DF N times\")\n        print(\"Size of original Dataframe: \", self.df.shape[0])\n        for num in BIBenchmarks.params:\n            _df = pd.concat([self.df] * num)\n            print(\"DF for iterration xSize original ready: \", num)\n            self.lib.write(f\"{self.symbol}{num}\", _df)\n    \n        print(\"If pandas query produces different dataframe than arctic one stop tests!\")\n        print(\"This will mean query problem is there most likely\")\n    \n        print(\"Pre-check correctness for query_groupby_city_count_all\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_all(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_all(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"Pre-check correctness for query_groupby_city_count_isin_filter\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_isin_filter(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_isin_filter(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"Pre-check correctness for query_groupby_city_count_filter_two_aggregations\")\n        _df = self.df.copy(deep=True)\n        arctic_df = self.time_query_groupby_city_count_filter_two_aggregations(BIBenchmarks.params[0])\n        _df = get_query_groupby_city_count_filter_two_aggregations(_df)\n        _df.sort_index(inplace=True, axis=1)\n        arctic_df.sort_index(inplace=True, axis=1)\n        assert_frame_equal(_df, arctic_df)\n    \n        print(\"All pre-checks completed SUCCESSFULLY. Time: \", time.time() - start_time)\n    \n        del self.ac",
@@ -1091,19 +1091,19 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "bi_benchmarks:72",
+        "setup_cache_key": "bi_benchmarks:73",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "16923258b23421434453a4143833cd446747e065f3e982bfd61ed19a3ee0130f",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "comparison_benchmarks.ComparisonBenchmarks.peakmem_create_dataframe": {
         "code": "class ComparisonBenchmarks:\n    def peakmem_create_dataframe(self, tpl):\n        df, dict = tpl\n        df = pd.DataFrame(dict)\n\n    def setup(self, tpl):\n        df, dict = tpl\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        st = time.time()\n        dict = self.create_dict(ComparisonBenchmarks.NUMBER_ROWS)\n        df = pd.DataFrame(dict)\n        print(f\"DF generated {time.time() - st}\")\n        ac = Arctic(ComparisonBenchmarks.URL)\n        ac.delete_library(ComparisonBenchmarks.LIB_NAME)\n        lib = ac.create_library(ComparisonBenchmarks.LIB_NAME)\n        lib.write(symbol=ComparisonBenchmarks.SYMBOL, data=df)\n        return (df, dict)",
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_create_dataframe",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:37",
+        "setup_cache_key": "comparison_benchmarks:38",
         "timeout": 60000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1114,7 +1114,7 @@
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_arctic",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:37",
+        "setup_cache_key": "comparison_benchmarks:38",
         "timeout": 60000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1125,7 +1125,7 @@
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_parquet",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:37",
+        "setup_cache_key": "comparison_benchmarks:38",
         "timeout": 60000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1136,7 +1136,7 @@
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_arctic",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:37",
+        "setup_cache_key": "comparison_benchmarks:38",
         "timeout": 60000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1147,7 +1147,7 @@
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_parquet",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:37",
+        "setup_cache_key": "comparison_benchmarks:38",
         "timeout": 60000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1165,7 +1165,7 @@
                 "2000"
             ]
         ],
-        "setup_cache_key": "finalize_staged_data:40",
+        "setup_cache_key": "finalize_staged_data:41",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1188,12 +1188,12 @@
         "repeat": 1,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "finalize_staged_data:40",
+        "setup_cache_key": "finalize_staged_data:41",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "c3c02d1e2369dd420b2e241fc69c4c8872d31da89d0c19c1111d503a84fb9521",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "finalize_staged_data.FinalizeStagedDataWiderDataframeX3.peakmem_finalize_staged_data": {
         "code": "class FinalizeStagedDataWiderDataframeX3:\n    def peakmem_finalize_staged_data(self, cache: CachedDFGenerator, param: int):\n        if not SLOW_TESTS:\n            raise SkipNotImplemented(\"Slow tests are skipped\")\n        super().peakmem_finalize_staged_data(cache, param)\n\n    def setup(self, cache: CachedDFGenerator, param: int):\n        if not SLOW_TESTS:\n            raise SkipNotImplemented(\"Slow tests are skipped\")\n        super().setup(cache, param)\n\n    def setup_cache(self):\n        # Generating dataframe with all kind of supported data type\n        cachedDF = CachedDFGenerator(\n            350000, [5, 25, 50]\n        )  # 3 times wider DF with bigger string columns\n        return cachedDF",
@@ -1207,7 +1207,7 @@
                 "2000"
             ]
         ],
-        "setup_cache_key": "finalize_staged_data:90",
+        "setup_cache_key": "finalize_staged_data:92",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1230,12 +1230,12 @@
         "repeat": 1,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "finalize_staged_data:90",
+        "setup_cache_key": "finalize_staged_data:92",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "a7673a8f559a07772f7a7a8e105774090534c7eb1b644b2d6247e7b792645809",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "list_functions.ListFunctions.peakmem_list_symbols": {
         "code": "class ListFunctions:\n    def peakmem_list_symbols(self, num_symbols):\n        self.lib.list_symbols()\n\n    def setup(self, num_symbols):\n        self.ac = Arctic(\"lmdb://list_functions\")\n        self.lib = self.ac[f\"{num_symbols}_num_symbols\"]\n\n    def setup_cache(self):\n        self.ac = Arctic(\"lmdb://list_functions\")\n    \n        num_symbols = ListFunctions.params\n        for syms in num_symbols:\n            lib_name = f\"{syms}_num_symbols\"\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            for sym in range(syms):\n                lib.write(f\"{sym}_sym\", generate_benchmark_df(ListFunctions.rows))",
@@ -1249,7 +1249,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "list_functions:23",
+        "setup_cache_key": "list_functions:24",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1267,7 +1267,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "list_functions:23",
+        "setup_cache_key": "list_functions:24",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1290,12 +1290,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "list_functions:23",
+        "setup_cache_key": "list_functions:24",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "00a6aba7cd18f9fbbfa18c85961d58a03a291bfe32bf033e8d7b88c7b960da90",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "list_functions.ListFunctions.time_list_symbols": {
         "code": "class ListFunctions:\n    def time_list_symbols(self, num_symbols):\n        self.lib.list_symbols()\n\n    def setup(self, num_symbols):\n        self.ac = Arctic(\"lmdb://list_functions\")\n        self.lib = self.ac[f\"{num_symbols}_num_symbols\"]\n\n    def setup_cache(self):\n        self.ac = Arctic(\"lmdb://list_functions\")\n    \n        num_symbols = ListFunctions.params\n        for syms in num_symbols:\n            lib_name = f\"{syms}_num_symbols\"\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            for sym in range(syms):\n                lib.write(f\"{sym}_sym\", generate_benchmark_df(ListFunctions.rows))",
@@ -1314,12 +1314,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "list_functions:23",
+        "setup_cache_key": "list_functions:24",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "7457ceb57b7adfda687387a4599ff60b20ecb6ef556b80329ad2e8ec433fbb17",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "list_functions.ListFunctions.time_list_versions": {
         "code": "class ListFunctions:\n    def time_list_versions(self, num_symbols):\n        self.lib.list_versions()\n\n    def setup(self, num_symbols):\n        self.ac = Arctic(\"lmdb://list_functions\")\n        self.lib = self.ac[f\"{num_symbols}_num_symbols\"]\n\n    def setup_cache(self):\n        self.ac = Arctic(\"lmdb://list_functions\")\n    \n        num_symbols = ListFunctions.params\n        for syms in num_symbols:\n            lib_name = f\"{syms}_num_symbols\"\n            self.ac.delete_library(lib_name)\n            lib = self.ac.create_library(lib_name)\n            for sym in range(syms):\n                lib.write(f\"{sym}_sym\", generate_benchmark_df(ListFunctions.rows))",
@@ -1338,12 +1338,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "list_functions:23",
+        "setup_cache_key": "list_functions:24",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "cc2c68ce66d0087882fffcb8be554f525c3f314c8693a37897d37cc18373f1ff",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "list_snapshots.SnaphotFunctions.peakmem_snapshots_no_metadata_list": {
         "code": "class SnaphotFunctions:\n    def peakmem_snapshots_no_metadata_list(self, symbols_x_snaps_per_sym):\n        list = self.lib_no_meta.list_snapshots(load_metadata=False)\n\n    def setup(self, symbols_x_snaps_per_sym):\n        num_symbols = self.get_symbols(symbols_x_snaps_per_sym)\n        self.ac = Arctic(SnaphotFunctions.ARCTIC_URL)\n        self.lib = self.ac[self.get_lib_name(num_symbols, True)]\n        self.lib_no_meta = self.ac[self.get_lib_name(num_symbols, False)]\n\n    def setup_cache(self):\n        start = time.time()\n        self.ac = Arctic(SnaphotFunctions.ARCTIC_URL)\n    \n        self.create_test_library(True)\n        self.create_test_library(False)\n    \n        print(f\"Libraries generation took [{time.time() - start}]\")",
@@ -1357,7 +1357,7 @@
                 "'40x20'"
             ]
         ],
-        "setup_cache_key": "list_snapshots:40",
+        "setup_cache_key": "list_snapshots:41",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1375,7 +1375,7 @@
                 "'40x20'"
             ]
         ],
-        "setup_cache_key": "list_snapshots:40",
+        "setup_cache_key": "list_snapshots:41",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1398,12 +1398,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "list_snapshots:40",
+        "setup_cache_key": "list_snapshots:41",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "706e811eef8155e3494d1a30ae8920e15ae32e0b69826eaa92388d620a5bb4ff",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "list_snapshots.SnaphotFunctions.time_snapshots_with_metadata_list_with_load_meta": {
         "code": "class SnaphotFunctions:\n    def time_snapshots_with_metadata_list_with_load_meta(self, symbols_x_snaps_per_sym):\n        list = self.lib.list_snapshots(load_metadata=True)\n\n    def setup(self, symbols_x_snaps_per_sym):\n        num_symbols = self.get_symbols(symbols_x_snaps_per_sym)\n        self.ac = Arctic(SnaphotFunctions.ARCTIC_URL)\n        self.lib = self.ac[self.get_lib_name(num_symbols, True)]\n        self.lib_no_meta = self.ac[self.get_lib_name(num_symbols, False)]\n\n    def setup_cache(self):\n        start = time.time()\n        self.ac = Arctic(SnaphotFunctions.ARCTIC_URL)\n    \n        self.create_test_library(True)\n        self.create_test_library(False)\n    \n        print(f\"Libraries generation took [{time.time() - start}]\")",
@@ -1422,12 +1422,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "list_snapshots:40",
+        "setup_cache_key": "list_snapshots:41",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "d4090a8af79a8cd45f87d87a807c4f344d86fa4e51e528809922b6a602ce06f9",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "list_snapshots.SnaphotFunctions.time_snapshots_with_metadata_list_without_load_meta": {
         "code": "class SnaphotFunctions:\n    def time_snapshots_with_metadata_list_without_load_meta(self, symbols_x_snaps_per_sym):\n        list = self.lib.list_snapshots(load_metadata=False)\n\n    def setup(self, symbols_x_snaps_per_sym):\n        num_symbols = self.get_symbols(symbols_x_snaps_per_sym)\n        self.ac = Arctic(SnaphotFunctions.ARCTIC_URL)\n        self.lib = self.ac[self.get_lib_name(num_symbols, True)]\n        self.lib_no_meta = self.ac[self.get_lib_name(num_symbols, False)]\n\n    def setup_cache(self):\n        start = time.time()\n        self.ac = Arctic(SnaphotFunctions.ARCTIC_URL)\n    \n        self.create_test_library(True)\n        self.create_test_library(False)\n    \n        print(f\"Libraries generation took [{time.time() - start}]\")",
@@ -1446,12 +1446,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "list_snapshots:40",
+        "setup_cache_key": "list_snapshots:41",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "71446e73206e086160b0733fdec4689d0c813c036e061f99d6f4ef372dd49b3b",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.peakmem_filtering_numeric": {
         "code": "class LocalQueryBuilderFunctions:\n    def peakmem_filtering_numeric(self, num_rows):\n        q = QueryBuilder()\n        # v3 is random floats between 0 and 100\n        q = q[q[\"v3\"] < 10.0]\n        self.lib.read(f\"{num_rows}_rows\", columns=[\"v3\"], query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1465,7 +1465,7 @@
                 "10000000"
             ]
         ],
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1483,7 +1483,7 @@
                 "10000000"
             ]
         ],
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1501,7 +1501,7 @@
                 "10000000"
             ]
         ],
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1519,7 +1519,7 @@
                 "10000000"
             ]
         ],
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1537,7 +1537,7 @@
                 "10000000"
             ]
         ],
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1555,7 +1555,7 @@
                 "10000000"
             ]
         ],
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1573,7 +1573,7 @@
                 "10000000"
             ]
         ],
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "peakmemory",
         "unit": "bytes",
@@ -1596,12 +1596,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "1fd26d5df8e3bd47278b0f1acca9528cc0dadba82788af6e3cfd1812058abef9",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.time_filtering_string_isin": {
         "code": "class LocalQueryBuilderFunctions:\n    def time_filtering_string_isin(self, num_rows):\n        # Selects about 1% of the rows\n        k = num_rows // 1000\n        string_set = [f\"id{str(i).zfill(3)}\" for i in range(1, k + 1)]\n        q = QueryBuilder()\n        q = q[q[\"id1\"].isin(string_set)]\n        self.lib.read(f\"{num_rows}_rows\", columns=[\"v3\"], query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1620,12 +1620,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "a0f79b58b7744e63b2b7df3562f57094fa4ff3a111c172fbe0b03aec197afec8",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.time_filtering_string_regex_match": {
         "code": "class LocalQueryBuilderFunctions:\n    def time_filtering_string_regex_match(self, num_rows):\n        pattern = f\"^id\\d\\d\\d$\"\n        q = QueryBuilder()\n        q = q[q[\"id1\"].regex_match(pattern)]\n        self.lib.read(f\"{num_rows}_rows\", columns=[\"v3\"], query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1644,12 +1644,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "5206453b05dddbb325596b08eae2200fd2193c2e2382ae66982838b1cc97859b",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.time_projection": {
         "code": "class LocalQueryBuilderFunctions:\n    def time_projection(self, num_rows):\n        q = QueryBuilder()\n        q = q.apply(\"new_col\", q[\"v2\"] * q[\"v3\"])\n        self.lib.read(f\"{num_rows}_rows\", columns=[\"new_col\"], query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1668,12 +1668,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "c7f842a915ebd3e278a9a5cea838835a804b463451ebec69829afe871adccfcc",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.time_query_1": {
         "code": "class LocalQueryBuilderFunctions:\n    def time_query_1(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id1\").agg({\"v1\": \"sum\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1692,12 +1692,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "8972136efca70caee7530d031766c4653737a79d09b7c7badaaee274c1caa7da",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.time_query_3": {
         "code": "class LocalQueryBuilderFunctions:\n    def time_query_3(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id3\").agg({\"v1\": \"sum\", \"v3\": \"sum\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1716,12 +1716,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "17ef74af58c623de0ce47d10ad9d52ffc8a1b3c3bb2f57d1391dde34f4af4f29",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.time_query_4": {
         "code": "class LocalQueryBuilderFunctions:\n    def time_query_4(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id6\").agg({\"v1\": \"sum\", \"v2\": \"sum\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1740,12 +1740,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "509ffd471564124f5ea73eab19903e52e70eba728ea59b97ad6bd5b8544c2e60",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "local_query_builder.LocalQueryBuilderFunctions.time_query_adv_query_2": {
         "code": "class LocalQueryBuilderFunctions:\n    def time_query_adv_query_2(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id3\").agg({\"v1\": \"max\", \"v2\": \"min\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n        self.lib = self.ac[LocalQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(LocalQueryBuilderFunctions.CONNECTION_STRING)\n    \n        num_rows = LocalQueryBuilderFunctions.params\n        self.lib_name = LocalQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1764,12 +1764,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "local_query_builder:25",
+        "setup_cache_key": "local_query_builder:26",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "9a923014466d420b857d297f2a8a41983d03d0c3242559a8488a2a9a642440e1",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "persistent_query_builder.PersistentQueryBuilderFunctions.time_query_1": {
         "code": "class PersistentQueryBuilderFunctions:\n    def time_query_1(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id1\").agg({\"v1\": \"sum\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.lib = self.ac[PersistentQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(get_real_s3_uri())\n    \n        num_rows = PersistentQueryBuilderFunctions.params\n        self.lib_name = PersistentQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1788,12 +1788,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "persistent_query_builder:62",
+        "setup_cache_key": "persistent_query_builder:63",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "9d97dcd98574b9edb2038a9d43166c03fb90874813e5fac9c3a44b51194f3dd9",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "persistent_query_builder.PersistentQueryBuilderFunctions.time_query_3": {
         "code": "class PersistentQueryBuilderFunctions:\n    def time_query_3(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id3\").agg({\"v1\": \"sum\", \"v3\": \"sum\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.lib = self.ac[PersistentQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(get_real_s3_uri())\n    \n        num_rows = PersistentQueryBuilderFunctions.params\n        self.lib_name = PersistentQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1812,12 +1812,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "persistent_query_builder:62",
+        "setup_cache_key": "persistent_query_builder:63",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "b1364bf72e616201e384c0b7a9f18b03b078e22452929466a06b35fc64a91bd6",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "persistent_query_builder.PersistentQueryBuilderFunctions.time_query_4": {
         "code": "class PersistentQueryBuilderFunctions:\n    def time_query_4(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id6\").agg({\"v1\": \"sum\", \"v2\": \"sum\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.lib = self.ac[PersistentQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(get_real_s3_uri())\n    \n        num_rows = PersistentQueryBuilderFunctions.params\n        self.lib_name = PersistentQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1836,12 +1836,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "persistent_query_builder:62",
+        "setup_cache_key": "persistent_query_builder:63",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "8f27fb785c7b8b40220191dae6dbb120a49f55e011ae0f7cea6516a47e38c18a",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "persistent_query_builder.PersistentQueryBuilderFunctions.time_query_adv_query_2": {
         "code": "class PersistentQueryBuilderFunctions:\n    def time_query_adv_query_2(self, num_rows):\n        q = QueryBuilder()\n        q = q.groupby(\"id3\").agg({\"v1\": \"max\", \"v2\": \"min\"})\n        self.lib.read(f\"{num_rows}_rows\", query_builder=q)\n\n    def setup(self, num_rows):\n        self.lib = self.ac[PersistentQueryBuilderFunctions.LIB_NAME]\n\n    def setup_cache(self):\n        self.ac = Arctic(get_real_s3_uri())\n    \n        num_rows = PersistentQueryBuilderFunctions.params\n        self.lib_name = PersistentQueryBuilderFunctions.LIB_NAME\n        self.ac.delete_library(self.lib_name)\n        lib = self.ac.create_library(self.lib_name)\n        for rows in num_rows:\n            lib.write(f\"{rows}_rows\", generate_benchmark_df(rows))",
@@ -1860,12 +1860,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "persistent_query_builder:62",
+        "setup_cache_key": "persistent_query_builder:63",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "ed1d1ccb6458095a627788bfa2b53afa310ca8c8118a6405c91204724c865d6c",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "real_batch_functions.AWSBatchBasicFunctions.peakmem_read_batch": {
         "code": "class AWSBatchBasicFunctions:\n    def peakmem_read_batch(self, num_symbols, num_rows):\n        read_batch_result = self.lib.read_batch(self.read_reqs)\n        # Quick check all is ok (will not affect bemchmarks)\n        assert read_batch_result[0].data.shape[0] == num_rows\n        assert read_batch_result[-1].data.shape[0] == num_rows\n\n    def setup(self, num_symbols, num_rows):\n        self.manager = self.get_library_manager()\n        self.population_policy = self.get_population_policy()\n        # We use the same generator as the policy\n    \n        self.lib: Library = self.manager.get_library(LibraryType.PERSISTENT, num_symbols)\n        self.write_lib: Library = self.manager.get_library(LibraryType.MODIFIABLE, num_symbols)\n        self.get_logger().info(f\"Library {self.lib}\")\n        self.get_logger().debug(f\"Symbols {self.lib.list_symbols()}\")\n    \n        # Get generated symbol names\n        self.symbols = []\n        for num_symb_idx in range(num_symbols):\n            # the name is constructed of 2 parts index + number of rows\n            sym_name = self.population_policy.get_symbol_name(num_symb_idx, num_rows)\n            if not self.lib.has_symbol(sym_name):\n                self.get_logger().error(f\"symbol not found {sym_name}\")\n            self.symbols.append(sym_name)\n    \n        #Construct read requests (will equal to number of symbols)\n        self.read_reqs = [ReadRequest(symbol) for symbol in self.symbols]\n    \n        #Construct dataframe that will be used for write requests, not whole DF (will equal to number of symbols)\n        self.df = self.population_policy.df_generator.get_dataframe(num_rows, AWSBatchBasicFunctions.number_columns)\n    \n        #Construct read requests based on 2 colmns, not whole DF (will equal to number of symbols)\n        COLS = self.df.columns[2:4]\n        self.read_reqs_with_cols = [ReadRequest(symbol, columns=COLS) for symbol in self.symbols]\n    \n        #Construct read request with date_range\n        self.date_range = self.get_last_x_percent_date_range(num_rows, 0.05)\n        self.read_reqs_date_range = [ReadRequest(symbol, date_range=self.date_range) for symbol in self.symbols]\n\n    def setup_cache(self):\n        manager = self.get_library_manager()\n        policy = self.get_population_policy()\n        logger = self.get_logger()\n        number_symbols_list, number_rows_list = AWSBatchBasicFunctions.params\n        for number_symbols in number_symbols_list:\n            lib_suffix = number_symbols\n            if not manager.has_library(LibraryType.PERSISTENT, lib_suffix):\n                start = time.time()\n                for number_rows in number_rows_list:\n                    policy.set_parameters([number_rows] * lib_suffix, AWSBatchBasicFunctions.number_columns)\n                    # the name of symbols during generation will have now 2 parameters:\n                    # the index of symbol + number of rows\n                    # that allows generating more than one symbol in a library\n                    policy.set_symbol_fixed_str(number_rows)\n                    populate_library(manager, policy, LibraryType.PERSISTENT, lib_suffix)\n                    logger.info(f\"Generated {number_symbols} with {number_rows} each for {time.time()- start}\")\n        manager.log_info() # Always log the ArcticURIs",
@@ -3917,7 +3917,7 @@
                 "'count'"
             ]
         ],
-        "setup_cache_key": "resample:37",
+        "setup_cache_key": "resample:38",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "760c9d62e17a5467f1e93abb258d89057e8fdf9ee67d98ceb376e731157a4d2e"
@@ -3963,18 +3963,19 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "resample:37",
+        "setup_cache_key": "resample:38",
         "type": "time",
         "unit": "seconds",
         "version": "1381d2db90e66cb5cd04febf62398827a3ac9928795eaced908daec35d5c0c31",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "resample.ResampleWide.peakmem_resample_wide": {
         "code": "class ResampleWide:\n    def peakmem_resample_wide(self):\n        self.lib.read(self.SYM, query_builder=self.query_builder)\n\n    def setup(self):\n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[self.LIB_NAME]\n        aggs = dict()\n        for col in self.COLS:\n            aggs[col] = \"last\"\n        self.query_builder = QueryBuilder().resample(\"30us\").agg(aggs)\n\n    def setup_cache(self):\n        ac = Arctic(self.CONNECTION_STRING)\n        ac.delete_library(self.LIB_NAME)\n        lib = ac.create_library(self.LIB_NAME)\n        rng = np.random.default_rng()\n        num_rows = 3000\n        index = pd.date_range(pd.Timestamp(0, unit=\"us\"), freq=\"us\", periods=num_rows)\n        data = dict()\n        for col in self.COLS:\n            data[col] = 100 * rng.random(num_rows, dtype=np.float64)\n        df = pd.DataFrame(data, index=index)\n        lib.write(self.SYM, df)",
         "name": "resample.ResampleWide.peakmem_resample_wide",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "resample:103",
+        "setup_cache_key": "resample:106",
+        "timeout": 1200,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "53f042192048c92d282637c1bbcee9e52dacec9086c534782de30d7ff67e77eb"
@@ -3989,11 +3990,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "resample:103",
+        "setup_cache_key": "resample:106",
+        "timeout": 1200,
         "type": "time",
         "unit": "seconds",
         "version": "ece714f981e8de31ee8296644624bf8f5fb895e6bf48d64a6ae2a9c50c5db7a2",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "version": 2,
     "version_chain.IterateVersionChain.time_list_undeleted_versions": {
@@ -4023,12 +4025,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "version_chain:36",
+        "setup_cache_key": "version_chain:37",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "6bdd43d7f191d2bbbd30ef740909969e25cbe1cec77f1755c5c3ba58a77f2b88",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "version_chain.IterateVersionChain.time_load_all_versions": {
         "code": "class IterateVersionChain:\n    def time_load_all_versions(self, num_versions, caching, deleted):\n        self.load_all(self.symbol(num_versions, deleted))\n\n    def setup(self, num_versions, caching, deleted):\n        # Disable warnings for version not found\n        set_log_level(\"ERROR\")\n    \n        if caching==\"never\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", 0)\n        if caching==\"forever\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", sys.maxsize)\n        if caching==\"default\":\n            # Leave the default reload interval\n            pass\n    \n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        self.lib = self.ac[IterateVersionChain.LIB_NAME]\n    \n        if caching != \"never\":\n            # Pre-load the cache\n            self.load_all(self.symbol(num_versions, deleted))\n\n    def setup_cache(self):\n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        num_versions_list, caching_list, deleted_list = IterateVersionChain.params\n    \n        self.ac.delete_library(IterateVersionChain.LIB_NAME)\n        lib = self.ac.create_library(IterateVersionChain.LIB_NAME)\n    \n        small_df = generate_random_floats_dataframe(2, 2)\n    \n        for num_versions in num_versions_list:\n            for deleted in deleted_list:\n                symbol = self.symbol(num_versions, deleted)\n                for i in range(num_versions):\n                    lib.write(symbol, small_df)\n                    if (i == math.floor(deleted * num_versions)):\n                        lib.delete(symbol)\n    \n        del self.ac",
@@ -4057,12 +4059,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "version_chain:36",
+        "setup_cache_key": "version_chain:37",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "c40fe3123db9e5d6fdf5f35caecaf42d266328deb78c237e293096ae3a4bcf98",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "version_chain.IterateVersionChain.time_read_alternating": {
         "code": "class IterateVersionChain:\n    def time_read_alternating(self, num_versions, caching, deleted):\n        self.read_from_epoch(self.symbol(num_versions, deleted))\n        self.read_v0(self.symbol(num_versions, deleted))\n\n    def setup(self, num_versions, caching, deleted):\n        # Disable warnings for version not found\n        set_log_level(\"ERROR\")\n    \n        if caching==\"never\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", 0)\n        if caching==\"forever\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", sys.maxsize)\n        if caching==\"default\":\n            # Leave the default reload interval\n            pass\n    \n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        self.lib = self.ac[IterateVersionChain.LIB_NAME]\n    \n        if caching != \"never\":\n            # Pre-load the cache\n            self.load_all(self.symbol(num_versions, deleted))\n\n    def setup_cache(self):\n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        num_versions_list, caching_list, deleted_list = IterateVersionChain.params\n    \n        self.ac.delete_library(IterateVersionChain.LIB_NAME)\n        lib = self.ac.create_library(IterateVersionChain.LIB_NAME)\n    \n        small_df = generate_random_floats_dataframe(2, 2)\n    \n        for num_versions in num_versions_list:\n            for deleted in deleted_list:\n                symbol = self.symbol(num_versions, deleted)\n                for i in range(num_versions):\n                    lib.write(symbol, small_df)\n                    if (i == math.floor(deleted * num_versions)):\n                        lib.delete(symbol)\n    \n        del self.ac",
@@ -4091,12 +4093,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "version_chain:36",
+        "setup_cache_key": "version_chain:37",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "ec1a61c37c4cc7317cfafe554f3eeb7fe2a426068ec412c1d7c6b78f510f6c45",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "version_chain.IterateVersionChain.time_read_from_epoch": {
         "code": "class IterateVersionChain:\n    def time_read_from_epoch(self, num_versions, caching, deleted):\n        self.read_from_epoch(self.symbol(num_versions, deleted))\n\n    def setup(self, num_versions, caching, deleted):\n        # Disable warnings for version not found\n        set_log_level(\"ERROR\")\n    \n        if caching==\"never\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", 0)\n        if caching==\"forever\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", sys.maxsize)\n        if caching==\"default\":\n            # Leave the default reload interval\n            pass\n    \n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        self.lib = self.ac[IterateVersionChain.LIB_NAME]\n    \n        if caching != \"never\":\n            # Pre-load the cache\n            self.load_all(self.symbol(num_versions, deleted))\n\n    def setup_cache(self):\n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        num_versions_list, caching_list, deleted_list = IterateVersionChain.params\n    \n        self.ac.delete_library(IterateVersionChain.LIB_NAME)\n        lib = self.ac.create_library(IterateVersionChain.LIB_NAME)\n    \n        small_df = generate_random_floats_dataframe(2, 2)\n    \n        for num_versions in num_versions_list:\n            for deleted in deleted_list:\n                symbol = self.symbol(num_versions, deleted)\n                for i in range(num_versions):\n                    lib.write(symbol, small_df)\n                    if (i == math.floor(deleted * num_versions)):\n                        lib.delete(symbol)\n    \n        del self.ac",
@@ -4125,12 +4127,12 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "version_chain:36",
+        "setup_cache_key": "version_chain:37",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "5c6aace0b39c7a75f064a61c182cbbb42a35f0e0ee46546579bc641e68dc954a",
-        "warmup_time": -1
+        "warmup_time": 0
     },
     "version_chain.IterateVersionChain.time_read_v0": {
         "code": "class IterateVersionChain:\n    def time_read_v0(self, num_versions, caching, deleted):\n        self.read_v0(self.symbol(num_versions, deleted))\n\n    def setup(self, num_versions, caching, deleted):\n        # Disable warnings for version not found\n        set_log_level(\"ERROR\")\n    \n        if caching==\"never\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", 0)\n        if caching==\"forever\":\n            adb._ext.set_config_int(\"VersionMap.ReloadInterval\", sys.maxsize)\n        if caching==\"default\":\n            # Leave the default reload interval\n            pass\n    \n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        self.lib = self.ac[IterateVersionChain.LIB_NAME]\n    \n        if caching != \"never\":\n            # Pre-load the cache\n            self.load_all(self.symbol(num_versions, deleted))\n\n    def setup_cache(self):\n        self.ac = Arctic(IterateVersionChain.CONNECTION_STRING)\n        num_versions_list, caching_list, deleted_list = IterateVersionChain.params\n    \n        self.ac.delete_library(IterateVersionChain.LIB_NAME)\n        lib = self.ac.create_library(IterateVersionChain.LIB_NAME)\n    \n        small_df = generate_random_floats_dataframe(2, 2)\n    \n        for num_versions in num_versions_list:\n            for deleted in deleted_list:\n                symbol = self.symbol(num_versions, deleted)\n                for i in range(num_versions):\n                    lib.write(symbol, small_df)\n                    if (i == math.floor(deleted * num_versions)):\n                        lib.delete(symbol)\n    \n        del self.ac",
@@ -4159,11 +4161,11 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "version_chain:36",
+        "setup_cache_key": "version_chain:37",
         "timeout": 6000,
         "type": "time",
         "unit": "seconds",
         "version": "4bf693e490128c1cff7500c93799432e7bf150925d3714757219604aa7fa5e9c",
-        "warmup_time": -1
+        "warmup_time": 0
     }
 }

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -30,6 +30,7 @@ DATE_RANGE = (pd.Timestamp("2022-12-31"), pd.Timestamp("2023-01-01"))
 
 
 class BasicFunctions:
+    warmup_time = 0    
     number = 5
     timeout = 6000
     CONNECTION_STRING = "lmdb://basic_functions?map_size=20GB"
@@ -156,6 +157,7 @@ class BasicFunctions:
 
 class BatchBasicFunctions:
     number = 5
+    warmup_time = 0    
     timeout = 6000
     CONNECTION_STRING = "lmdb://batch_basic_functions?map_size=20GB"
     DATE_RANGE = DATE_RANGE

--- a/python/benchmarks/bi_benchmarks.py
+++ b/python/benchmarks/bi_benchmarks.py
@@ -55,6 +55,7 @@ class BIBenchmarks:
 
     number = 2
     timeout = 6000
+    warmup_time = 0    
     LIB_NAME = "BI_benchmark_lib"
     # We use dataframe in this file
     CITY_BI_FILE = "data/CityMaxCapita_1.csv.bz2"

--- a/python/benchmarks/comparison_benchmarks.py
+++ b/python/benchmarks/comparison_benchmarks.py
@@ -27,6 +27,7 @@ class ComparisonBenchmarks:
         - read/write dataframe to arcticdb
     """
     number = 5
+    warmup_time = 0    
     timeout = 60000
 
     LIB_NAME = "compare"

--- a/python/benchmarks/finalize_staged_data.py
+++ b/python/benchmarks/finalize_staged_data.py
@@ -26,6 +26,7 @@ class FinalizeStagedData:
     repeat = 1
     min_run_count = 1
 
+    warmup_time = 0    
     timeout = 600
     LIB_NAME = "Finalize_Staged_Data_LIB"
 
@@ -83,6 +84,7 @@ from asv_runner.benchmarks.mark import SkipNotImplemented
 
 
 class FinalizeStagedDataWiderDataframeX3(FinalizeStagedData):
+    warmup_time = 0    
     """
     The test is meant to be executed with 3 times wider dataframe than the base test
     """

--- a/python/benchmarks/list_functions.py
+++ b/python/benchmarks/list_functions.py
@@ -14,6 +14,7 @@ class ListFunctions:
 
     number = 5
     timeout = 6000
+    warmup_time = 0    
 
     params = [500, 1000]
     param_names = ["num_symbols"]

--- a/python/benchmarks/list_snapshots.py
+++ b/python/benchmarks/list_snapshots.py
@@ -25,6 +25,7 @@ class SnaphotFunctions:
 
     number = 5
     timeout = 6000
+    warmup_time = 0    
 
     # For each test param n1xn2 defined:
     #   n1 - the number of symbols in the library

--- a/python/benchmarks/local_query_builder.py
+++ b/python/benchmarks/local_query_builder.py
@@ -16,6 +16,7 @@ PARAMS_QUERY_BUILDER = [1_000_000, 10_000_000]
 class LocalQueryBuilderFunctions:
     number = 5
     timeout = 6000
+    warmup_time = 0    
     LIB_NAME = "query_builder"
     CONNECTION_STRING = "lmdb://query_builder?map_size=5GB"
 

--- a/python/benchmarks/persistent_query_builder.py
+++ b/python/benchmarks/persistent_query_builder.py
@@ -47,6 +47,7 @@ def get_real_s3_uri(shared_path: bool = False):
 class PersistentQueryBuilderFunctions:
     number = 2
     timeout = 6000
+    warmup_time = 0    
     LIB_NAME = "query_builder_benchmark_lib"
 
     params = [1_000_000, 10_000_000]

--- a/python/benchmarks/resample.py
+++ b/python/benchmarks/resample.py
@@ -16,6 +16,7 @@ from arcticdb.util.test import random_strings_of_length
 
 class Resample:
     number = 5
+    warmup_time = 0    
 
     LIB_NAME = "resample"
     CONNECTION_STRING = "lmdb://resample?map_size=5GB"
@@ -93,6 +94,8 @@ class Resample:
 
 class ResampleWide:
     number = 5
+    timeout= 1200 # Because of recent issue, avoid timeout error
+    warmup_time = 0    
 
     LIB_NAME = "resample_wide"
     CONNECTION_STRING = "lmdb://resample_wide?map_size=5GB"

--- a/python/benchmarks/version_chain.py
+++ b/python/benchmarks/version_chain.py
@@ -22,6 +22,7 @@ from .common import *
 class IterateVersionChain:
     number = 10
     timeout = 6000
+    warmup_time = 0    
     CONNECTION_STRING = "lmdb://version_chain?map_size=20GB"
     LIB_NAME = "lib"
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

1. Remove timeout error for resample
2. warmup_time=0 should have 5-10% increase Why? warmup introduces one additional run, without warmup we will have exact number of runs matching the number=X in the test. With 5 test runs the avg will be very close to a 5 with one warmup run
3. Remove excessive logs on empty dataframes (bonus - eventually increase the performance to old levels, this is speculatice goal)
4. export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0 added for functional test executors also


A link with ALL tests lmdb + Real to confirm if issues are addressed: https://github.com/man-group/ArcticDB/actions/runs/16649808754

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
