### PR TITLE
Upgrade compiler used for coverity runs

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -10,7 +10,7 @@
       name: Polaris Coverity Static Analysis
       permissions:
         packages: write
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       env:
         VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
         VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
@@ -28,7 +28,7 @@
         - name: Setup build dependencies
           run: |
             sudo apt-get update
-            sudo apt-get install -y gcc-11 g++-11 make mono-complete libkrb5-dev libsasl2-dev
+            sudo apt-get install -y clang-19 make mono-complete libkrb5-dev libsasl2-dev
 
         - name: Setup VCPKG cache
           run: |
@@ -44,12 +44,12 @@
         - name: CMake configure
           uses: lukka/run-cmake@v10
           env:
-            CC: "gcc-11"
-            CXX: "g++-11"
+            CC: "clang"
+            CXX: "clang++"
           with:
             cmakeListsTxtPath: ${{github.workspace}}/cpp/CMakeLists.txt
             configurePreset: linux-release
-            configurePresetAdditionalArgs: "['-DVCPKG_INSTALL_OPTIONS=--clean-after-build', '-DCMAKE_C_COMPILER=gcc-11', '-DCMAKE_CXX_COMPILER=g++-11']"
+            configurePresetAdditionalArgs: "['-DVCPKG_INSTALL_OPTIONS=--clean-after-build', '-DCMAKE_C_COMPILER=clang', '-DCMAKE_CXX_COMPILER=clang++']"
 
         - name: Copy Coverity config
           run: cp ${{github.workspace}}/coverity.yaml ${{github.workspace}}/cpp/out/linux-release-build


### PR DESCRIPTION
#### Reference Issues/PRs
Monday 9738042489

#### What does this implement or fix?
Recent changes to `test_atom_key.cpp` added `LibraryPath lib2(std::views::all(std::vector<std::string>{"a", "b"}));` as a replacement for folly::range. This doesn't compile with gcc-11 which was originally used.

The compiler doesn't really matter as long as the code compiles. This is not compiled in the dev container so I just picked clang-19 which can compile the source.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
