### PR TITLE
Remove signaled threads on TaskScheduler destruction on Windows

### DIFF
--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -19,14 +19,12 @@ std::once_flag TaskScheduler::init_flag_;
 std::once_flag TaskScheduler::shutdown_flag_;
 bool TaskScheduler::forked_ = false;
 
-void TaskScheduler::destroy_instance() {
-    std::call_once(TaskScheduler::shutdown_flag_, &TaskScheduler::stop_threads);
-}
-
-void TaskScheduler::stop_threads() {
-    if(TaskScheduler::instance_) {
-        TaskScheduler::instance()->stop();
-    }
+void TaskScheduler::stop_active_threads() {
+    std::call_once(shutdown_flag_, [] {
+        if (instance_) {
+            instance()->stop();
+        }
+    });
 }
 
 void TaskScheduler::reattach_instance() {
@@ -52,7 +50,7 @@ void TaskScheduler::init(){
 }
 
 TaskSchedulerPtrWrapper::~TaskSchedulerPtrWrapper() {
-    ptr_->all_threads_dead();
+    ptr_->stop_orphaned_threads();
     delete ptr_;
 }
 

--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -20,14 +20,12 @@ std::once_flag TaskScheduler::shutdown_flag_;
 bool TaskScheduler::forked_ = false;
 
 void TaskScheduler::destroy_instance() {
-    std::call_once(TaskScheduler::shutdown_flag_, &TaskScheduler::stop_and_destroy);
+    std::call_once(TaskScheduler::shutdown_flag_, &TaskScheduler::stop_threads);
 }
 
-void TaskScheduler::stop_and_destroy() {
+void TaskScheduler::stop_threads() {
     if(TaskScheduler::instance_) {
         TaskScheduler::instance()->stop();
-
-        TaskScheduler::instance_.reset();
     }
 }
 

--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -54,6 +54,7 @@ void TaskScheduler::init(){
 }
 
 TaskSchedulerPtrWrapper::~TaskSchedulerPtrWrapper() {
+    ptr_->all_threads_dead();
     delete ptr_;
 }
 

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -101,6 +101,12 @@ struct SchedulerWrapper : public SchedulerType {
     void ensure_active_threads() {
         SchedulerType::ensureActiveThreads();
     }
+
+    void all_threads_dead() {
+        for (const auto& task : SchedulerType::threadList_.get()) {
+            SchedulerType::threadList_.remove(task);
+        }
+    }
 };
 
 struct CGroupValues {
@@ -253,6 +259,11 @@ class TaskScheduler {
     SchedulerWrapper<IOSchedulerType>& io_exec() {
         ARCTICDB_TRACE(log::schedule(), "Getting IO executor: {}", io_exec_.getPendingTaskCount());
         return io_exec_;
+    }
+
+    void all_threads_dead() {
+        cpu_exec_.all_threads_dead();
+        io_exec_.all_threads_dead();
     }
 
     void re_init() {

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -103,8 +103,9 @@ struct SchedulerWrapper : public SchedulerType {
     }
 
     void all_threads_dead() {
-        for (const auto& task : SchedulerType::threadList_.get()) {
-            SchedulerType::threadList_.remove(task);
+        auto threads_to_remove = SchedulerType::threadList_.get();
+        for (const auto& thread : threads_to_remove) {
+            SchedulerType::threadList_.remove(thread);
         }
     }
 };
@@ -222,7 +223,7 @@ class TaskScheduler {
     static TaskScheduler* instance();
     static void reattach_instance();
     static void destroy_instance();
-    static void stop_and_destroy();
+    static void stop_threads();
     static bool forked_;
     static bool is_forked();
     static void set_forked(bool);

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -104,10 +104,11 @@ struct SchedulerWrapper : public SchedulerType {
 
     void stop_orphaned_threads() {
 #ifdef _WIN32
-        for (const auto& thread : SchedulerType::threadList_.get()) {
+        const auto to_remove_copy = SchedulerType::threadList_.get();
+        for (const auto& thread : to_remove_copy) {
             const bool is_signaled = WaitForSingleObject(thread->handle.native_handle(), 0) == WAIT_OBJECT_0;
             if (is_signaled) {
-                SchedulerType::stoppedThreads_.add(thread);
+                SchedulerType::threadList_.remove(thread);
             }
         }
 #endif

--- a/cpp/arcticdb/util/global_lifetimes.cpp
+++ b/cpp/arcticdb/util/global_lifetimes.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<ModuleData> ModuleData::instance_;
 std::once_flag ModuleData::init_flag_;
 
 void shutdown_globals() {
-    async::TaskScheduler::destroy_instance();
+    async::TaskScheduler::stop_active_threads();
     storage::mongo::MongoInstance::destroy_instance();
     ModuleData::destroy_instance();
 }

--- a/python/tests/stress/arcticdb/version_store/test_deallocation.py
+++ b/python/tests/stress/arcticdb/version_store/test_deallocation.py
@@ -5,6 +5,9 @@ Use of this software is governed by the Business Source License 1.1 included in 
 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
+import os
+from multiprocessing import Process
+
 import pandas as pd
 import numpy as np
 import pytest
@@ -25,3 +28,33 @@ def test_many_version_store(basic_store_factory):
         version_store.write(symbol, df2)
         vit = version_store.read(symbol)
         assert_frame_equal(vit.data, df2)
+
+
+def killed_worker(lib, io_threads, cpu_threads):
+    if io_threads:
+        lib.delete_snapshot("snap")
+    if cpu_threads:
+        lib.read("sym")
+    os._exit(0)
+
+@pytest.mark.parametrize("io_threads_cpu_threads_spawned_in_child", [
+    (True, True),
+    (True, False),
+    (False, True),
+    (False, False),
+])
+def test_os_exit_exits_within_timeout(lmdb_storage, lib_name, io_threads_cpu_threads_spawned_in_child):
+    io_threads, cpu_threads = io_threads_cpu_threads_spawned_in_child
+    lib = lmdb_storage.create_arctic().create_library(lib_name)
+    df = pd.DataFrame()
+    lib.write("sym", df)
+    lib.snapshot("snap")
+    proc = Process(target=killed_worker, args=(lib, io_threads, cpu_threads))
+    proc.start()
+    proc.join(timeout=5)
+
+    if proc.is_alive():
+        proc.terminate()
+        pytest.fail("os._exit did not exit within 5 seconds")
+
+    assert proc.exitcode == 0

--- a/python/tests/stress/arcticdb/version_store/test_deallocation.py
+++ b/python/tests/stress/arcticdb/version_store/test_deallocation.py
@@ -37,19 +37,14 @@ def killed_worker(lib, io_threads, cpu_threads):
         lib.read("sym")
     os._exit(0)
 
-@pytest.mark.parametrize("io_threads_cpu_threads_spawned_in_child", [
-    (True, True),
-    (True, False),
-    (False, True),
-    (False, False),
-])
-def test_os_exit_exits_within_timeout(lmdb_storage, lib_name, io_threads_cpu_threads_spawned_in_child):
-    io_threads, cpu_threads = io_threads_cpu_threads_spawned_in_child
+@pytest.mark.parametrize("io_threads_spawned_in_child", [True, False])
+@pytest.mark.parametrize("cpu_threads_spawned_in_child", [True, False])
+def test_os_exit_exits_within_timeout(lmdb_storage, lib_name, io_threads_spawned_in_child, cpu_threads_spawned_in_child):
     lib = lmdb_storage.create_arctic().create_library(lib_name)
     df = pd.DataFrame()
     lib.write("sym", df)
     lib.snapshot("snap")
-    proc = Process(target=killed_worker, args=(lib, io_threads, cpu_threads))
+    proc = Process(target=killed_worker, args=(lib, io_threads_spawned_in_child, cpu_threads_spawned_in_child))
     proc.start()
     proc.join(timeout=5)
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Hang on os._exit() in certain scenarios.

The problem only happens on windows because os._exit() kills all threads except the main one. Where on UNIX systems all threads are cleared and there is no hang. See https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitprocess

This assumes that by the time task scheduler's destructor is called, all spawned threads are no longer alive. They are either 
* Stopped gracefully by global_lifetimes.cpp::shutdown_globals
* Killed abruptly via e.g. `os._exit()` 

The latter was a potential problem until now because if threads are killed this way they aren't removed from `ThreadExecutor::taskList_` and when shutting down the `ThreadExecutor` it waited for all threads from that list to signal that they are done (via [this ](https://github.com/facebook/folly/blob/f4e89e3959fd10a34cd5284c2dbdedc0dab35cd0/folly/executors/ThreadPoolExecutor.cpp#L414) semaphore) . And since they are gone that wait is forever.

The hang only happened if ONLY CPU threads are spawned. Their clearing in the destructor is AFTER IO threads. If IOThreads exist they were killed first. No hang was happening there but again exception was thrown (which is again bad as exception in destructor is UB in c++). This PR reorders their clearing in the stop() method for consistency 

The fix removes orphaned threads from the `threadList_` (windows only) so there are no threads to wait for.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
