### PR TITLE
Fix man.arcticdb tests

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_arrow.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow.py
@@ -567,7 +567,7 @@ def test_arrow_sparse_floats_row_range(version_store_factory, dynamic_schema, ro
     df=data_frames(
         columns(
             ["col"],
-            elements=st.floats(min_value=0, max_value=1000, allow_nan=False, allow_subnormal=False),
+            elements=st.floats(min_value=0, max_value=1000, allow_nan=False),
             fill=st.just(np.nan)
         ),
     ),


### PR DESCRIPTION
#### What does this implement or fix?
`man.arcticdb` uses an old version of hypothesis that doesn't understand the `allow_subnormal` argument when generating floats