### PR TITLE
Bugfix 9685477375: Use std::allocator everywhere sparrow might be involved

### DIFF
--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -533,7 +533,7 @@ class ChunkedBufferImpl {
 
     MemBlock* create_detachable_block(size_t capacity, size_t offset) const {
         auto [ptr, ts] = Allocator::aligned_alloc(sizeof(MemBlock));
-        auto* data = new uint8_t[capacity];
+        auto* data = allocate_detachable_memory(capacity);
         new(ptr) MemBlock(data, capacity, offset, ts, true);
         return reinterpret_cast<BlockType*>(ptr);
     }

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -38,8 +38,7 @@ inline void apply_type_handlers(SegmentInMemory seg, std::any& handler_data, Out
             // manually freed before the column goes out of scope to avoid triggering debug logs in ~MemBlock
             // complaining about freeing external data
             util::check(dest_column.blocks().size() == 1, "Unexpected multi-block column when reading single frame");
-            uint8_t* ptr = dest_column.blocks().at(0)->release();
-            delete[] ptr;
+            dest_column.blocks().at(0)->abandon();
         }
     }
 }

--- a/cpp/arcticdb/python/numpy_buffer_holder.hpp
+++ b/cpp/arcticdb/python/numpy_buffer_holder.hpp
@@ -48,7 +48,8 @@ struct NumpyBufferHolder {
                     }
                 }
             }
-            delete[] ptr_;
+            // See comment on allocate_detachable_memory declaration for why this cannot just be a call to delete[]
+            free_detachable_memory(ptr_, row_count_ * type_.get_type_bytes());
         }
     }
 };

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -19,6 +19,14 @@
 
 namespace arcticdb {
 
+    uint8_t* allocate_detachable_memory(size_t size) {
+        return std::allocator<uint8_t>().allocate(size);
+    }
+
+    void free_detachable_memory(uint8_t* ptr, size_t size) {
+        std::allocator<uint8_t>().deallocate(ptr, size);
+    }
+
     bool use_slab_allocator()
     {
         static const bool use_it = ConfigsMap::instance()->get_int("Allocator.UseSlabAllocator", 1);

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -26,6 +26,16 @@
 
 namespace arcticdb {
 
+// Must be used whenever deallocation COULD be the responsibility of sparrow
+// Explanation: Windows new[]/delete[] do not exactly map onto std::allocator allocate/deallocate
+// In particular, std::allocate has alignment optimisations when allocating larger blocks that
+// are not applied by new[]. sparrow uses the standard allocator to free memory we pass of to it,
+// and this can crash if the memory was allocated with new[] due to a mismatch in alignment expectations
+uint8_t* allocate_detachable_memory(size_t size);
+
+// Must be used whenever memory was allocated with allocate_detachable_memory
+void free_detachable_memory(uint8_t* ptr, size_t size);
+
 static constexpr uint64_t BYTES = 1;
 static constexpr uint64_t KILOBYTES = 1024 * BYTES;
 static constexpr uint64_t MEGABYTES = 1024 * KILOBYTES;

--- a/python/tests/unit/arcticdb/version_store/test_arrow.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow.py
@@ -386,7 +386,6 @@ def test_arrow_dynamic_schema_changing_types(lmdb_version_store_dynamic_schema_v
     assert expected.equals(received)
 
 
-@pytest.mark.skipif(WINDOWS, reason="Segfault as sparrow fails to free memory created by new uint8_t[capacity] (Monday issue 9685477375)")
 @pytest.mark.parametrize("rows_per_column", [1, 7, 8, 9, 100_000])
 @pytest.mark.parametrize("segment_row_size", [1, 2, 100_000])
 def test_arrow_dynamic_schema_missing_columns_numeric(version_store_factory, rows_per_column, segment_row_size):
@@ -404,7 +403,6 @@ def test_arrow_dynamic_schema_missing_columns_numeric(version_store_factory, row
     assert expected.equals(received)
 
 
-@pytest.mark.skipif(WINDOWS, reason="Segfault as sparrow fails to free memory created by new uint8_t[capacity] (Monday issue 9685477375)")
 @pytest.mark.parametrize("rows_per_column", [1, 7, 8, 9, 100_000])
 def test_arrow_dynamic_schema_missing_columns_strings(lmdb_version_store_dynamic_schema_v1, rows_per_column):
     lib = lmdb_version_store_dynamic_schema_v1


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes [9685477375](https://man312219.monday.com/boards/7852509418/pulses/9685477375)

#### What does this implement or fix?
Use `std::allocator` everywhere that could involve `sparrow` being responsible for the deallocation