### PR TITLE
Add docstring and warning for disparity between `will_item_be_pickled` and `is_symbol_pickle`

### DIFF
--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -95,6 +95,15 @@ If only `NumCPUThreads` is set, `NumIOThreads` will still default to x1.5 `NumCP
 
 <sup>\*</sup>On Linux machines, this core count takes cgroups into account. In particular, this means that CPU limits are respected in processes running in Kubernetes.
 
+### VersionStore.WillItemBePickledWarningMsg
+
+Control whether a detailed message explaining how the item is normalized is logged when calling the `will_item_be_pickled` function.
+Please note that this message is logged as a warning. Therefore, setting the log level to below `warning` will also suppress the log in the `will_item_be_pickled` function.
+
+Values:
+* 0: Disable
+* 1: Enable (Default)
+
 ## Logging configuration
 
 ArcticDB has multiple log streams, and the verbosity of each can be configured independently. 

--- a/python/arcticdb/log.py
+++ b/python/arcticdb/log.py
@@ -16,7 +16,7 @@ class _Logger(object):
         self._id = id
 
     def log(self, lvl, msg, *args, **kwargs):
-        if not _is_active(self._id, lvl):
+        if not self.is_active(lvl):
             return
         _log(self._id, lvl, msg.format(*args, **kwargs))
 
@@ -28,6 +28,9 @@ class _Logger(object):
 
     def warning(self, msg, *args, **kwargs):
         self.log(_Lvl.WARN, msg, *args, **kwargs)
+
+    def is_active(self, lvl):
+        return _is_active(self._id, lvl)
 
     warn = warning
 

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -547,6 +547,23 @@ def test_will_item_be_pickled(lmdb_version_store, sym):
     assert_frame_equal(not_so_bad_df, lmdb_version_store.read(sym).data)
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"a": {"b": {"c": {"d": np.arange(24)}}}},
+        {"a": [1, 2, 3], "b": {"c": np.arange(24)}, "d": [TestCustomNormalizer()]} # A random item that will be pickled
+    ]
+)
+def test_will_item_be_pickled_recursive_normalizer(lmdb_version_store_v1, data):
+    lib = lmdb_version_store_v1
+    assert lib.will_item_be_pickled(data, recursive_normalizers=True) == True
+
+
+def test_will_item_pickled_msgpack(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    assert lib.will_item_be_pickled({"hello": "there"}) == True
+
+
 def test_numpy_ts_col_with_none(lmdb_version_store):
     df = pd.DataFrame(data={"a": [None, None]})
     df.loc[0, "a"] = pd.Timestamp(0)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://man312219.monday.com/boards/7852509418/pulses/9122332360
#### What does this implement or fix?
The [PR](https://github.com/man-group/ArcticDB/pull/2468) that trying to align `will_item_be_pickled` and `is_symbol_pickled` has been scrapped as the change is likely to break users' logic.
Instead better docstrings are added for both. Better warning for `will_item_be_pickled` only as doing so for `is_symbol_pickle` requires substantatial effort
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
