### PR TITLE
Support open ended row_range on QueryBuilder and read methods

### DIFF
--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -74,15 +74,6 @@ public:
         }
 
         template<class Callable>
-        auto visit_string(Callable &&c) const {
-            return entity::visit_field(parent_->descriptor().field(column_id_), [this, c = std::forward<Callable>(c)](auto type_desc_tag) {
-                using DTT = typename std::decay_t<decltype(type_desc_tag)>::DataTypeTag;
-                if constexpr(is_sequence_type(DTT::data_type))
-                    return c(parent_->string_at(row_id_, position_t(column_id_)));
-            });
-        }
-
-        template<class Callable>
         auto visit_field(Callable &&c) const {
             const auto& field = parent_->descriptor().field(column_id_);
             return entity::visit_field(field, [&field, this, c = std::forward<Callable>(c)](auto type_desc_tag) {

--- a/cpp/arcticdb/pipeline/read_query.cpp
+++ b/cpp/arcticdb/pipeline/read_query.cpp
@@ -12,16 +12,22 @@ void ReadQuery::add_clauses(std::vector<std::shared_ptr<Clause>>& clauses) {
 }
 
 void ReadQuery::convert_to_positive_row_filter(int64_t total_rows) {
-    if (row_range.has_value()) {
-        size_t start = row_range->start_ >= 0 ?
-                       std::min(row_range->start_, total_rows) :
-                       std::max(total_rows + row_range->start_,
-                                static_cast<int64_t>(0));
-        size_t end = row_range->end_ >= 0 ?
-                     std::min(row_range->end_, total_rows) :
-                     std::max(total_rows + row_range->end_, static_cast<int64_t>(0));
-        row_filter = pipelines::RowRange(start, end);
+    if (!row_range) {
+        return;
     }
+
+    int64_t supplied_start = row_range->start_.value_or(0);
+
+    size_t start = supplied_start >= 0 ?
+                   std::min(supplied_start, total_rows) :
+                   std::max(total_rows + supplied_start,
+                            static_cast<int64_t>(0));
+
+    int64_t supplied_end = row_range->end_.value_or(total_rows);
+    size_t end = supplied_end >= 0 ?
+                 std::min(supplied_end, total_rows) :
+                 std::max(total_rows + supplied_end, static_cast<int64_t>(0));
+    row_filter = pipelines::RowRange(start, end);
 }
 
 }  //namespace arcticdb

--- a/cpp/arcticdb/pipeline/read_query.hpp
+++ b/cpp/arcticdb/pipeline/read_query.hpp
@@ -12,8 +12,8 @@ namespace arcticdb::pipelines {
 using FilterRange = std::variant<std::monostate, entity::IndexRange, pipelines::RowRange>;
 
 struct SignedRowRange {
-    int64_t start_;
-    int64_t end_;
+    std::optional<int64_t> start_;
+    std::optional<int64_t> end_;
 };
 
 struct ReadQuery {

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -681,10 +681,20 @@ struct RowRangeClause {
         clause_info_.input_structure_ = ProcessingStructure::ALL;
     }
 
-    explicit RowRangeClause(int64_t start, int64_t end):
-            row_range_type_(RowRangeType::RANGE),
-            user_provided_start_(start),
-            user_provided_end_(end) {
+    explicit RowRangeClause(std::optional<int64_t> start, std::optional<int64_t> end) {
+        util::check(start || end, "Expect at least one of start and end to be present");
+        if (start && end) {
+            row_range_type_ = RowRangeType::RANGE;
+            user_provided_start_ = *start;
+            user_provided_end_ = *end;
+        } else if (start) {
+            util::check(start != 0, "Did not expect end=nullopt and start==0");
+            row_range_type_ = RowRangeType::TAIL;
+            n_ = -1 * start.value();
+        } else if (end) {
+            row_range_type_ = RowRangeType::HEAD;
+            n_ = end.value();
+        }
         clause_info_.input_structure_ = ProcessingStructure::ALL;
     }
 

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -682,12 +682,14 @@ struct RowRangeClause {
     }
 
     explicit RowRangeClause(std::optional<int64_t> start, std::optional<int64_t> end) {
+        // start and end both absent is a no-op, the Python layer just skips the clause in this case
         util::check(start || end, "Expect at least one of start and end to be present");
         if (start && end) {
             row_range_type_ = RowRangeType::RANGE;
             user_provided_start_ = *start;
             user_provided_end_ = *end;
         } else if (start) {
+            // start=0 and end absent is a no-op, the Python layer just skips the clause in this case
             util::check(start != 0, "Did not expect end=nullopt and start==0");
             row_range_type_ = RowRangeType::TAIL;
             n_ = -1 * start.value();

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -456,7 +456,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
 
     py::class_<RowRangeClause, std::shared_ptr<RowRangeClause>>(version, "RowRangeClause")
             .def(py::init<RowRangeClause::RowRangeType, int64_t>())
-            .def(py::init<int64_t, int64_t>())
+            .def(py::init<std::optional<int64_t>, std::optional<int64_t>>())
             .def("__str__", &RowRangeClause::to_string);
 
     py::class_<DateRangeClause, std::shared_ptr<DateRangeClause>>(version, "DateRangeClause")

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -388,7 +388,7 @@ void register_bindings(py::module &version, py::exception<arcticdb::ArcticExcept
         .def_property_readonly("diff", &pipelines::RowRange::diff);
 
     py::class_<pipelines::SignedRowRange, std::shared_ptr<pipelines::SignedRowRange>>(version, "SignedRowRange")
-    .def(py::init([](int64_t start, int64_t end){
+    .def(py::init([](std::optional<int64_t> start, std::optional<int64_t> end){
         return SignedRowRange{start, end};
     }));
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1132,8 +1132,10 @@ class NativeVersionStore:
         date_ranges: `Optional[List[Optional[DateRangeInput]]]`, default=None
             List of date ranges to filter the symbols.
             i-th entry corresponds to i-th element of `symbols`.
-        row_ranges: `Optional[List[Optional[Tuple[int, int]]]]`, default=None
-            List of row ranges to filter the symbols.
+        row_ranges : `Optional[List[Tuple[Optional[int], Optional[int]]]]`, default=None
+            Row range to read data for. Inclusive of the lower bound, exclusive of the upper bound.
+            Leaving either element as None leaves that side of the range open-ended. For example (5, None) would
+            include everything from the 5th row onwards.
             i-th entry corresponds to i-th element of `symbols`.
         columns: `List[List[str]]`, default=None
             Which columns to return for a dataframe.
@@ -2010,10 +2012,12 @@ class NativeVersionStore:
             slower, but return data with a smaller memory footprint. See the QueryBuilder.date_range docstring for more
             details.
             Only one of date_range or row_range can be provided.
-        row_range: `Optional[Tuple[int, int]]`, default=None
-            Row range to read data for. Inclusive of the lower bound, exclusive of the upper bound
+        row_range : `Optional[Tuple[Optional[int], Optional[int]]]`, default=None
+            Row range to read data for. Inclusive of the lower bound, exclusive of the upper bound.
             lib.read(symbol, row_range=(start, end)).data should behave the same as df.iloc[start:end], including in
             the handling of negative start/end values.
+            Leaving either element as None leaves that side of the range open-ended. For example (5, None) would
+            include everything from the 5th row onwards.
             Only one of date_range or row_range can be provided.
         columns: `Optional[List[str]]`, default=None
             Applicable only for dataframes. Determines which columns to return data for.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -263,7 +263,7 @@ class ReadRequest(NamedTuple):
         See `read` method.
     date_range: Optional[Tuple[Optional[Timestamp], Optional[Timestamp]]], default=none
         See `read`method.
-    row_range: Optional[Tuple[int, int]], default=none
+    row_range: Optional[Tuple[Optional[int], Optional[int]]], default=none
         See `read` method.
     columns: Optional[List[str]], default=none
         See `read` method.
@@ -278,7 +278,7 @@ class ReadRequest(NamedTuple):
     symbol: str
     as_of: Optional[AsOf] = None
     date_range: Optional[Tuple[Optional[Timestamp], Optional[Timestamp]]] = None
-    row_range: Optional[Tuple[int, int]] = None
+    row_range: Optional[Tuple[Optional[int], Optional[int]]] = None
     columns: Optional[List[str]] = None
     query_builder: Optional[QueryBuilder] = None
 
@@ -1798,11 +1798,12 @@ class Library:
 
             Only one of date_range or row_range can be provided.
 
-        row_range: `Optional[Tuple[int, int]]`, default=None
-            Row range to read data for. Inclusive of the lower bound, exclusive of the upper bound
+        row_range : `Optional[Tuple[Optional[int], Optional[int]]]`, default=None
+            Row range to read data for. Inclusive of the lower bound, exclusive of the upper bound.
             lib.read(symbol, row_range=(start, end)).data should behave the same as df.iloc[start:end], including in
             the handling of negative start/end values.
-
+            Leaving either element as None leaves that side of the range open-ended. For example (5, None) would
+            include everything from the 5th row onwards.
             Only one of date_range or row_range can be provided.
 
         columns: List[str], default=None

--- a/python/tests/unit/arcticdb/version_store/test_row_range.py
+++ b/python/tests/unit/arcticdb/version_store/test_row_range.py
@@ -104,7 +104,7 @@ def test_row_range_pickled_symbol(lmdb_version_store):
     ((5, 3), pd.DataFrame({"a": []}, dtype=np.int64)),
 ))
 @pytest.mark.parametrize("api", ("query_builder", "read", "read_batch"))
-def test_row_range_open_ended_negative_start(lmdb_version_store_v1, api, row_range, expected):
+def test_row_range_open_ended(lmdb_version_store_v1, api, row_range, expected):
     symbol = "test_row_range"
     df = pd.DataFrame({"a": np.arange(100)})
     lmdb_version_store_v1.write(symbol, df)

--- a/python/tests/unit/arcticdb/version_store/test_row_range.py
+++ b/python/tests/unit/arcticdb/version_store/test_row_range.py
@@ -118,4 +118,4 @@ def test_row_range_open_ended_negative_start(lmdb_version_store_v1, api, row_ran
         assert api == "read_batch"
         received = lmdb_version_store_v1.batch_read([symbol], row_ranges=[row_range])[symbol].data
 
-    assert_frame_equal(received, expected)
+    assert_frame_equal(received, expected, check_dtype=False)


### PR DESCRIPTION
Changes `QueryBuilder.row_range` and `read` and `ReadRequest`'s `row_range` arguments to accept `None` in either position, in order to leave that part of the row range open ended. For example `(5, None)` would include everything from the 5th row onwards.

Monday: 7855088823