### PR TITLE
Fix release build on GCC 13.3

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -161,6 +161,8 @@ if (NOT MSVC)
         # Compilers on conda-forge are relatively strict.
         # For now, we do not want to treat warnings as errors for those builds.
         add_compile_options("-Werror")
+        # folly::ConcurrentHashMap default ctor trips this warning on GCC 13.3
+        add_compile_options("-Wno-stringop-overflow")
     endif()
     add_compile_options("-ggdb")
     add_compile_options("-fvisibility=hidden")

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -161,8 +161,6 @@ if (NOT MSVC)
         # Compilers on conda-forge are relatively strict.
         # For now, we do not want to treat warnings as errors for those builds.
         add_compile_options("-Werror")
-        # folly::ConcurrentHashMap default ctor trips this warning on GCC 13.3
-        add_compile_options("-Wno-stringop-overflow")
     endif()
     add_compile_options("-ggdb")
     add_compile_options("-fvisibility=hidden")

--- a/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
+++ b/cpp/arcticdb/storage/coalesced/multi_segment_utils.hpp
@@ -27,7 +27,7 @@ uint64_t get_symbol_prefix(const StreamId& stream_id) {
             for(size_t p = begin, i = 0; p < end && i < string_id.size(); ++p, ++i) {
                 const auto c = string_id[i];
                 util::check(c < 127, "Out of bounds character {}", c);
-                target[p] = c;
+                target[i] = c;
             }
         },
         [&data] (const NumericId& numeric_id) {

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -310,6 +310,7 @@ namespace arcticdb {
     template<class TracingPolicy, class ClockType>
     std::pair<uint8_t*, entity::timestamp>
     AllocatorImpl<TracingPolicy, ClockType>::realloc(std::pair<uint8_t*, entity::timestamp> ptr, size_t size) {
+        AddrIdentifier old_addr{uintptr_t(ptr.first), ptr.second};
         auto ret = internal_realloc(ptr.first, size);
 
 #ifdef ARCTICDB_TRACK_ALLOCS
@@ -319,7 +320,7 @@ namespace arcticdb {
             uintptr_t(ret));
 #endif
         auto ts = current_timestamp();
-        TracingPolicy::track_realloc(std::make_pair(uintptr_t(ptr.first), ptr.second), std::make_pair(uintptr_t(ret), ts), size);
+        TracingPolicy::track_realloc(old_addr, std::make_pair(uintptr_t(ret), ts), size);
         return { ret, ts };
     }
 


### PR DESCRIPTION
#### What does this implement or fix?
GCC 13.3 release build has some stricter checks than compilers we use in our CI, see comments on individual changes for details
Still does not work out of the box due to a bug in the `stringop-overflow` check