### PR TITLE
Remove xfailed tests for projection and filtering on an empty dataframe

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1115,29 +1115,6 @@ def test_float32_binary_comparison(lmdb_version_store_v1):
 # MIXED SCHEMA TESTS FROM HERE #
 ################################
 
-
-@pytest.mark.xfail(reason="""Fails on Pandas < 2 because of this logic:
-    https://github.com/man-group/ArcticDB/blob/fc9514f25712d8e86fbdbd2f7e37e64f3a10df40/python/arcticdb/version_store/_normalization.py#L230
-    The assumptions there however are not correct. The dtype of empty columns is not deterministic and varies between
-    Pandas versions, for example the test passes on the CI with Python > 3.8 because it uses pandas 2.3.0 and the dtype
-    of the column is float64 (note the if in the link above sets the dtype to object only for pandas < 2 because it
-    expects that int Pandas >= 2 it'll always be object). It fails for object dtype because in arcticdb that becomes
-    string type and string types cannot be filtered using < or >, thus modify_schema fails
-    """,
-    strict=False
-)
-@pytest.mark.parametrize("lib_type", ["lmdb_version_store_v1", "lmdb_version_store_dynamic_schema_v1"])
-def test_filter_empty_dataframe(request, lib_type):
-    lib = request.getfixturevalue(lib_type)
-    df = pd.DataFrame({"a": []})
-    q = QueryBuilder()
-    q = q[q["a"] < 5]
-    symbol = "test_filter_empty_dataframe"
-    lib.write(symbol, df)
-    vit = lib.read(symbol, query_builder=q)
-    assert vit.data.empty
-
-
 @pytest.mark.parametrize("lib_type", ["lmdb_version_store_v1", "lmdb_version_store_dynamic_schema_v1"])
 def test_filter_pickled_symbol(request, lib_type):
     lib = request.getfixturevalue(lib_type)

--- a/python/tests/unit/arcticdb/version_store/test_projection.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection.py
@@ -17,27 +17,6 @@ from arcticdb.util.test import assert_frame_equal, make_dynamic, regularize_data
 
 pytestmark = pytest.mark.pipeline
 
-@pytest.mark.xfail(reason="""Fails on Pandas < 2 because of this logic:
-    https://github.com/man-group/ArcticDB/blob/fc9514f25712d8e86fbdbd2f7e37e64f3a10df40/python/arcticdb/version_store/_normalization.py#L230
-    The assumptions there however are not correct. The dtype of empty columns is not deterministic and varies between
-    Pandas versions, for example the test passes on the CI with Python > 3.8 because it uses pandas 2.3.0 and the dtype
-    of the column is float64 (note the if in the link above sets the dtype to object only for pandas < 2 because it
-    expects that int Pandas >= 2 it'll always be object). It fails for object dtype because in arcticdb that becomes
-    string type and string types cannot be summed with a number.
-    """,
-    strict=False
-)
-@pytest.mark.parametrize("lib_type", ["lmdb_version_store_v1", "lmdb_version_store_dynamic_schema_v1"])
-def test_project_empty_dataframe(request, lib_type):
-    lib = request.getfixturevalue(lib_type)
-    df = pd.DataFrame({"a": []})
-    q = QueryBuilder()
-    q = q.apply("new", q["a"] + 1)
-    symbol = "test_project_empty_dataframe"
-    lib.write(symbol, df)
-    vit = lib.read(symbol, query_builder=q)
-    assert vit.data.empty
-
 
 def test_project_column_not_present(lmdb_version_store_v1):
     lib = lmdb_version_store_v1


### PR DESCRIPTION


#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
The types of the empty dataframe depend on the version of Pandas and in V6 these tests can fail with certain pandas versions. There's a warning for this now and it's mentioned in the release notes.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
