### PR TITLE
Fix OverflowError from to_json() call

### DIFF
--- a/python/tests/integration/arcticdb/test_update.py
+++ b/python/tests/integration/arcticdb/test_update.py
@@ -16,6 +16,7 @@ from pandas import Timestamp
 import pytest
 import pandas as pd
 import numpy as np
+import string
 
 from arcticdb.options import LibraryOptions
 from arcticdb.util._versions import IS_PANDAS_ONE
@@ -245,8 +246,7 @@ def custom_library(arctic_client, lib_name, request) -> Generator[Library, None,
         pass
 
 
-def get_metadata_safe() -> str:
-    import string
+def random_metadata() -> str:
     size_in_bytes = 1024 * 1024  
     chars = string.ascii_letters + string.digits
     return ''.join(random.choices(chars, k=size_in_bytes))
@@ -293,7 +293,7 @@ def test_update_batch_all_supported_datatypes_over_several_segments(custom_libra
     df3_num_rows = ROWS_PER_SEGMENT*2 - 1
     df3 = g.get_dataframe(number_columns=df3_num_cols, number_rows=df3_num_rows, start_time=start_time)
     update3 = ug.generate_update(df3, UpdatePositionType.INSIDE_OVERLAP_END, df3_num_cols, ROWS_PER_SEGMENT - 2)
-    metadata3 = get_metadata_safe()
+    metadata3 = random_metadata()
     expected_updated_df3 = dataframe_simulate_arcticdb_update_static(df3, update3) 
 
     # Error update due to mismatch in columns


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Fix: https://manbuild-ci.res.m/job/manbuilds/job/pegasus/job/next/job/DATA/job/man.arcticdb-master/job/master/338/testReport/junit/python.tests.integration.arcticdb/test_update/test_update_batch_all_supported_datatypes_over_several_segments_lmdb_EncodingVersion_V1_custom_library0_/

to_json() pandas call seems to have problem on old pandas version - the current version handles those problems

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
