### PR TITLE
Create common logger for all tests

### DIFF
--- a/python/arcticdb/util/logger.py
+++ b/python/arcticdb/util/logger.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2025 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import inspect
+import logging
+import os
+import re
+from typing import Any, Dict, Union
+
+
+class GitHubSanitizingHandler(logging.StreamHandler):
+    """
+    The handler sanitizes messages only when execution is in GitHub
+    """
+
+    def emit(self, record: logging.LogRecord):
+        # Sanitize the message here
+        record.msg = self.sanitize_message(record.msg)
+        super().emit(record)
+
+    @staticmethod
+    def sanitize_message(message: str) -> str:
+        if (os.getenv("GITHUB_ACTIONS") == "true") and isinstance(message, str):
+            # Use regex to find and replace sensitive access keys
+            sanitized_message = re.sub(r'(secret=)[^\s&]+', r'\1***', message)
+            sanitized_message = re.sub(r'(access=)[^\s&]+', r'\1***', sanitized_message)
+            sanitized_message = re.sub(r'AccountKey=([^;]+)', r'AccountKey=***', sanitized_message) 
+            return sanitized_message
+        return message
+
+
+loggers:Dict[str, logging.Logger] = {}
+
+
+def get_logger(bencmhark_cls: Union[str, Any] = None):
+    """
+    Creates logger instance with associated console handler.
+    The logger name can be either passed as string or class,
+    or if not automatically will assume the caller module name
+    """
+    logLevel = logging.INFO
+    if bencmhark_cls:
+        if isinstance(bencmhark_cls, str):
+            value = bencmhark_cls
+        else:
+            value = type(bencmhark_cls).__name__
+        name = value
+    else:
+        frame = inspect.stack()[1]
+        module = inspect.getmodule(frame[0])
+        name = module.__name__
+
+    logger = loggers.get(name, None)
+    if logger :
+        return logger
+    logger = logging.getLogger(name)    
+    logger.setLevel(logLevel)
+    console_handler = GitHubSanitizingHandler()
+    console_handler.setLevel(logLevel)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    loggers[name] = logger
+    return logger
+
+
+class GitHubSanitizingException(Exception):
+    def __init__(self, message: str):
+        # Sanitize the message
+        sanitized_message = GitHubSanitizingHandler.sanitize_message(message)
+        super().__init__(sanitized_message)
+


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

ASV Tests need logger
unit and functional tests need logger
installation tests need logger

All those types of tests need one logger that will do Sanitization and other things. Currenlty ASV has one and unit and functional tests have another and they cannot share it due to limitations imposed by ASV. This PR creates a common one that is needed by the Azure PR https://github.com/man-group/ArcticDB/pull/2498 which unites all tets to use this logger. 

However ASV tests cannot run successfully unless this logger is already present in master. So this PR is to fix this problem by merging it to master prior and then update the Azure PR to verify all is fine

The logger location should be at arcticdb\util so that all types of tests have access to it. ASV tests do not have access to tests package


#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
