### PR TITLE
Fix entire column default initialize for arrow

### DIFF
--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -386,6 +386,9 @@ class ChunkedBufferImpl {
 
     template<typename T>
     T *ptr_cast(size_t pos_bytes, size_t required_bytes) {
+        // TODO: This check doesn't verify we're overreaching outside of block boundaries.
+        // We should instead use `bytes_at` which does the correct check like so:
+        // return reinterpret_cast<T *>(bytes_at(pos_bytes, required_bytes))
         check_bytes(pos_bytes, required_bytes);
         return reinterpret_cast<T *>(&operator[](pos_bytes));
     }

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -387,7 +387,7 @@ void Column::default_initialize_rows(size_t start_pos, size_t num_rows, bool ens
                 data_.ensure<uint8_t>(bytes);
             }
             // This doesn't work if we default_initialize bytes which span across multiple blocks.
-            auto type_ptr = reinterpret_cast<RawType *>(data_.bytes_at(start_pos, bytes));
+            auto type_ptr = reinterpret_cast<RawType *>(data_.bytes_at(start_pos * sizeof(RawType), bytes));
             util::initialize<T>(reinterpret_cast<uint8_t*>(type_ptr), bytes, default_value);
             if (ensure_alloc) {
                 data_.commit();

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -386,7 +386,8 @@ void Column::default_initialize_rows(size_t start_pos, size_t num_rows, bool ens
             if (ensure_alloc) {
                 data_.ensure<uint8_t>(bytes);
             }
-            auto type_ptr = data_.ptr_cast<RawType>(start_pos, bytes);
+            // This doesn't work if we default_initialize bytes which span across multiple blocks.
+            auto type_ptr = reinterpret_cast<RawType *>(data_.bytes_at(start_pos, bytes));
             util::initialize<T>(reinterpret_cast<uint8_t*>(type_ptr), bytes, default_value);
             if (ensure_alloc) {
                 data_.commit();

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -925,7 +925,8 @@ struct ReduceColumnTask : async::BaseTask {
                     auto& prev_buffer = column.buffer();
                     swap(prev_buffer, new_buffer);
                 } else {
-                    column.default_initialize_rows(0, frame_.row_count(), false, default_value);
+                    NullValueReducer null_reducer{column, context_, frame_, shared_data_, handler_data_, read_options_.output_format(), default_value};
+                    null_reducer.finalize();
                 }
             }
         } else if (column_data != slice_map_->columns_.end()) {

--- a/cpp/arcticdb/util/cursored_buffer.hpp
+++ b/cpp/arcticdb/util/cursored_buffer.hpp
@@ -141,13 +141,11 @@ public:
     }
 
     uint8_t* bytes_at(size_t bytes, size_t required) {
-        util::check(bytes + required <= buffer_.bytes(), "Bytes overflow, can't write {} bytes at position {} in buffer of size {}", required, bytes, buffer_.bytes());
-        return &buffer_[bytes];
+        return buffer_.bytes_at(bytes, required);
     }
 
     const uint8_t* bytes_at(size_t bytes, size_t required) const {
-        util::check(bytes + required <= buffer_.bytes(), "Bytes overflow, can't write {} bytes at position {} in buffer of size {}", required, bytes, buffer_.bytes());
-        return &buffer_[bytes];
+        return buffer_.bytes_at(bytes, required);
     }
 
     void clear() {


### PR DESCRIPTION
Arrow uses chunked buffers but default_initialize assumed that data is contiguous, which was causing segfaults.

Adds:
- Test which repro-ed the segfault
- Fix by using `NullValueReducer::finalize`
- Change `Column::default_initialize_rows` to use `bytes_at` which does correct boundary checks
- Adds a TODO comment to replace all `ptr_cast` calls to use `bytes_at`. Not done in this PR to avoid risk of touching very low level code.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
