### PR TITLE
Fix pytest_terminal_summary for pytest<4.2

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1505,8 +1505,8 @@ def pytest_runtest_makereport(item, call):
     from tests.pytest_xfail import  pytest_runtest_makereport
     return pytest_runtest_makereport(item, call)
 
-def pytest_terminal_summary(terminalreporter, exitstatus, config):
+def pytest_terminal_summary(terminalreporter, exitstatus):
     from tests.pytest_xfail import  pytest_terminal_summary
-    pytest_terminal_summary(terminalreporter, exitstatus, config)
+    pytest_terminal_summary(terminalreporter, exitstatus)
 
 #endregion    

--- a/python/tests/pytest_xfail.py
+++ b/python/tests/pytest_xfail.py
@@ -36,7 +36,7 @@ def pytest_runtest_makereport(item, call):
                 marked_tests.append(item.nodeid)
                 return report
 
-def pytest_terminal_summary(terminalreporter, exitstatus, config):
+def pytest_terminal_summary(terminalreporter, exitstatus):
     if marked_tests:
         terminalreporter.write("\n=== SPECIAL XFAIL SUMMARY ===\n", bold=True)
         for test_id in marked_tests:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Man group's pegasus next vevn uses an old version of pytest which does
not support the `config` argument. We're not using it anyway so just
removing it.
The config flag was added in 4.2 as per [docs](https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_terminal_summary)

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
