### PR TITLE
Added new test utilities

### DIFF
--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -369,7 +369,7 @@ inline auto get_test_config_data(std::string name = "test") {
 }
 
 inline std::shared_ptr<arcticdb::storage::Library> get_test_library(storage::LibraryDescriptor::VariantStoreConfig cfg = {}, std::string name = "test") {
-    auto [path, storages] = get_test_config_data_named(name);
+    auto [path, storages] = get_test_config_data(name);
     auto library = std::make_shared<arcticdb::storage::Library>(path, std::move(storages), std::move(cfg));
     return library;
 }

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -361,12 +361,19 @@ inline SegmentInMemory get_sparse_timeseries_segment_floats(const std::string& n
  *
  * To use LMDB storage, try the factories in stream_test_common.hpp.
  */
-inline auto get_test_config_data() {
+inline auto get_test_config_data(std::string name = "test") {
     using namespace arcticdb::storage;
-    LibraryPath path{"test", "store"};
+    LibraryPath path{name.c_str(), "store"};
     auto storages = create_storages(path, OpenMode::DELETE, {memory::pack_config()});
     return std::make_tuple(path, std::move(storages));
 }
+
+inline std::shared_ptr<arcticdb::storage::Library> get_test_library(storage::LibraryDescriptor::VariantStoreConfig cfg = {}, std::string name = "test") {
+    auto [path, storages] = get_test_config_data_named(name);
+    auto library = std::make_shared<arcticdb::storage::Library>(path, std::move(storages), std::move(cfg));
+    return library;
+}
+
 
 /**
  * Creates a LocalVersionedEngine from get_test_config_data().
@@ -374,10 +381,8 @@ inline auto get_test_config_data() {
  * See also python_version_store_in_memory() and stream_test_common.hpp for alternatives using LMDB.
  */
 template<typename VersionStoreType = version_store::LocalVersionedEngine>
-inline VersionStoreType get_test_engine(storage::LibraryDescriptor::VariantStoreConfig cfg = {}) {
-    auto [path, storages] = get_test_config_data();
-    auto library = std::make_shared<arcticdb::storage::Library>(path, std::move(storages), std::move(cfg));
-    return VersionStoreType(library);
+inline VersionStoreType get_test_engine(storage::LibraryDescriptor::VariantStoreConfig cfg = {}, std::string name = "test") {
+    return VersionStoreType(get_test_library(cfg, name));
 }
 
 /**

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -412,7 +412,7 @@ def test_read_segment_in_memory_to_dataframe(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     lib_tool = lib.library_tool()
     sym = "sym"
-    lib.write(sym, sample_dataframe)
+    lib.write(sym, df)
 
     tdata_key = lib_tool.find_keys(KeyType.TABLE_DATA)[0]
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
The test utility function `get_test_config_data` now enables setting the name of the library up to some extent, which can be useful if a test needs libraries to have different names. 

The function `get_test_engine` now uses `get_test_library`, changing essentially nothing but allowing us to directly create a test library if needed. 

Also fixed a wrong usage of the method `sample_dataframe`.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
