### PR TITLE
Better error handling and retries on pip install fails for compat tests

### DIFF
--- a/python/arcticdb/util/venv.py
+++ b/python/arcticdb/util/venv.py
@@ -7,6 +7,7 @@ import tempfile
 import venv
 import pandas as pd
 import numpy as np
+from retrying import retry
 
 
 from typing import Dict, List, Optional, Union
@@ -47,10 +48,12 @@ def run_shell_command(
             stdin=subprocess.DEVNULL,
         )
     if result.returncode != 0:
-        logger.error(
+        error_message = (
             f"Command '{command_string}' failed with return code {result.returncode}\n"
             f"stdout:\n{result.stdout.decode('utf-8')}\nstderr:\n{result.stderr.decode('utf-8')}"
         )
+        logger.error(error_message)
+        raise ErrorInVenv(error_message)
     return result
 
 
@@ -74,6 +77,9 @@ class Venv:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.tear_down_venv()
 
+    # We have seen some flakyness in pip installing the required dependencies. We retry several times in case
+    # installing fails.
+    @retry(stop_max_attempt_number=5, wait_exponential_multiplier=1000, wait_exponential_max=10000)
     def init_venv(self):
         venv.create(self.path, with_pip=True, clear=True)
         command = [
@@ -91,7 +97,7 @@ class Venv:
 
     def execute_python_file(self, python_path: Union[str, os.PathLike]) -> subprocess.CompletedProcess:
         command = [get_os_specific_venv_python(), python_path]
-        return run_shell_command(command, self.path)
+        run_shell_command(command, self.path)
 
     def create_arctic(self, uri: str) -> "VenvArctic":
         return VenvArctic(self, uri)
@@ -183,9 +189,10 @@ class VenvArctic:
             with open(python_path, "w") as python_file:
                 python_file.write("\n".join(python_commands))
 
-            result = self.venv.execute_python_file(python_path)
-            if result.returncode != 0:
-                raise ErrorInVenv(f"Executing {python_commands} failed with return code {result.returncode}: {result}")
+            try:
+                self.venv.execute_python_file(python_path)
+            except Exception as e:
+                raise ErrorInVenv(f"Executing {python_commands} failed with exception: {e}")
 
     def init_storage(self):
         self.execute([])

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,6 +133,7 @@ Testing =
     pymongo
     trustme
     psutil
+    retrying
     memray; platform_system == 'Linux' or platform_system == 'Darwin'
     pytest-memray; platform_system == 'Linux' or platform_system == 'Darwin'
 


### PR DESCRIPTION
Raises exceptions in case Venv.init_venv fails
Also adds retries in case e.g. a network error causes the venv init to fail

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
