### PR TITLE
test: ARM64-check  `test_type_promotion_int64_and_float64_up_to_float64`

### DIFF
--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -9,6 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import os
 import sys
 import pytest
+import platform
 from typing import Optional, Union
 from datetime import date
 from numpy import datetime64
@@ -20,6 +21,9 @@ from arcticdb.util.logger import get_logger
 MACOS = sys.platform.lower().startswith("darwin")
 LINUX = sys.platform.lower().startswith("linux")
 WINDOWS = sys.platform.lower().startswith("win32")
+
+# Architecture detection
+ARM64 = platform.machine().lower() in ("arm64", "aarch64")
 
 
 # Defined shorter logs on errors


### PR DESCRIPTION
#### Reference Issues/PRs

Backport of https://github.com/conda-forge/arcticdb-feedstock/pull/503/commits/9ffd206ff1ead985e79d368308a88f926aeaf954.

#### What does this implement or fix?

Make `test_type_promotion_int64_and_float64_up_to_float64` overflow check depend on the architecture rather than on the OS.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
