### PR TITLE
Improve build times by removing unused includes [9920308940]

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -8,7 +8,6 @@ include(CTest)
 include(GoogleTest)
 
 include(GenerateExportHeader)
-
 # System and third-party libraries with built-in find_package Config
 cmake_policy(PUSH)
     if (EXISTS "/usr/local/lib64/aws-c-cal/cmake/modules/FindLibCrypto.cmake") # Workaround old AWS SDK bug

--- a/cpp/arcticdb/arrow/arrow_handlers.cpp
+++ b/cpp/arcticdb/arrow/arrow_handlers.cpp
@@ -5,12 +5,10 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 #include <arrow/arrow_handlers.hpp>
-#include <arcticdb/codec/slice_data_sink.hpp>
 #include <arcticdb/codec/encoding_sizes.hpp>
 #include <arcticdb/codec/codec.hpp>
 #include <arcticdb/util/decode_path_data.hpp>
 #include <arcticdb/pipeline/column_mapping.hpp>
-#include <arcticdb/util/sparse_utils.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/arrow/arrow_handlers.hpp
+++ b/cpp/arcticdb/arrow/arrow_handlers.hpp
@@ -8,7 +8,6 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/type_handler.hpp>
-#include <arcticdb/util/bitset.hpp>
 
 namespace arcticdb {
 
@@ -34,7 +33,7 @@ struct ArrowStringHandler {
         std::any& handler_data,
         const std::shared_ptr<StringPool>& string_pool) const;
 
-    [[nodiscard]] TypeDescriptor output_type(const TypeDescriptor& input_type) const;
+    [[nodiscard]] entity::TypeDescriptor output_type(const entity::TypeDescriptor& input_type) const;
 
     void default_initialize(
         ChunkedBuffer& buffer,
@@ -57,8 +56,8 @@ inline void register_arrow_handler_data_factory() {
 
 inline void register_arrow_string_types() {
     using namespace arcticdb;
-    constexpr std::array<DataType, 4> dynamic_string_data_types = {
-        DataType::ASCII_DYNAMIC64, DataType::UTF_DYNAMIC64, DataType::ASCII_FIXED64, DataType::UTF_FIXED64};
+    constexpr std::array<entity::DataType, 4> dynamic_string_data_types = {
+        entity::DataType::ASCII_DYNAMIC64, entity::DataType::UTF_DYNAMIC64, entity::DataType::ASCII_FIXED64, entity::DataType::UTF_FIXED64};
 
     for (auto data_type : dynamic_string_data_types) {
         TypeHandlerRegistry::instance()->register_handler(OutputFormat::ARROW, make_scalar_type(data_type), arcticdb::ArrowStringHandler{});

--- a/cpp/arcticdb/arrow/arrow_output_frame.cpp
+++ b/cpp/arcticdb/arrow/arrow_output_frame.cpp
@@ -6,7 +6,6 @@
 */
 
 
-#include <arcticdb/arrow/arrow_utils.hpp>
 #include <arcticdb/arrow/arrow_output_frame.hpp>
 
 #include <vector>

--- a/cpp/arcticdb/arrow/arrow_output_frame.hpp
+++ b/cpp/arcticdb/arrow/arrow_output_frame.hpp
@@ -6,9 +6,7 @@
  */
 #pragma once
 
-#include <sparrow.hpp>
 #include <sparrow/record_batch.hpp>
-
 #include <vector>
 #include <memory>
 

--- a/cpp/arcticdb/arrow/arrow_utils.cpp
+++ b/cpp/arcticdb/arrow/arrow_utils.cpp
@@ -10,7 +10,6 @@
 #include <arcticdb/column_store/memory_segment.hpp>
 
 #include <sparrow/record_batch.hpp>
-#include <span>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/arrow/arrow_utils.hpp
+++ b/cpp/arcticdb/arrow/arrow_utils.hpp
@@ -6,16 +6,12 @@
  */
 #pragma once
 
-#include <arcticdb/entity/versioned_item.hpp>
 #include <sparrow/record_batch.hpp>
-
 #include <vector>
 
 namespace arcticdb {
 
 class SegmentInMemory;
-struct FrameAndDescriptor;
-struct DecodePathData;
 class Column;
 
 std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::string_view name);

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -10,7 +10,6 @@
 #include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/util/clock.hpp>
 #include <arcticdb/storage/store.hpp>
-#include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/storage/library.hpp>
 #include <folly/futures/Future.h>
 #include <arcticdb/async/tasks.hpp>

--- a/cpp/arcticdb/async/bit_rate_stats.cpp
+++ b/cpp/arcticdb/async/bit_rate_stats.cpp
@@ -2,9 +2,10 @@
 
 #include <folly/Likely.h>
 
-#include "log/log.hpp"
-#include "util/format_bytes.hpp"
-#include "entity/performance_tracing.hpp"
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/util/format_bytes.hpp>
+#include <arcticdb/entity/performance_tracing.hpp>
+#include <arcticdb/util/clock.hpp>
 
 constexpr uint64_t max_bytes{0xFFFFFFFFFF};
 constexpr uint64_t max_time_ms{0xFFFFFF};

--- a/cpp/arcticdb/async/bit_rate_stats.hpp
+++ b/cpp/arcticdb/async/bit_rate_stats.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <atomic>
-#include <mutex>
 
-#include "arcticdb/util/clock.hpp"
-#include "arcticdb/util/constructors.hpp"
+#include <arcticdb/util/constructors.hpp>
+
+namespace arcticdb::entity {
+    using timestamp = int64_t;
+}
 
 namespace arcticdb::async {
 

--- a/cpp/arcticdb/async/python_bindings.cpp
+++ b/cpp/arcticdb/async/python_bindings.cpp
@@ -5,7 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/async/python_bindings.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
 

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -7,27 +7,19 @@
 
 #pragma once
 
-#include <arcticdb/entity/atom_key.hpp>
-#include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/hash.hpp>
-#include <arcticdb/util/exponential_backoff.hpp>
 #include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/util/home_directory.hpp>
 #include <arcticdb/util/string_utils.hpp>
-
 #include <arcticdb/async/base_task.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
-
 #include <folly/executors/FutureExecutor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
-
+#include <fmt/format.h>
 #include <thread>
 #include <algorithm>
 #include <filesystem>
 #include <string>
 #include <fstream>
-#include <fmt/format.h>
 #include <type_traits>
 
 namespace arcticdb::async {

--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/async/tasks.hpp>
-#include <arcticdb/pipeline/read_frame.hpp>
 
 namespace arcticdb::async {
 

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -22,12 +22,9 @@
 #include <arcticdb/async/base_task.hpp>
 #include <arcticdb/async/bit_rate_stats.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
-#include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/codec/codec.hpp>
 #include <arcticdb/util/test/random_throw.hpp>
-
-#include <type_traits>
 
 namespace arcticdb::async {
 

--- a/cpp/arcticdb/codec/codec-inl.hpp
+++ b/cpp/arcticdb/codec/codec-inl.hpp
@@ -16,9 +16,7 @@
 #include <arcticdb/codec/encoded_field.hpp>
 #include <arcticdb/codec/magic_words.hpp>
 #include <arcticdb/util/bitset.hpp>
-#include <arcticdb/util/buffer.hpp>
 #include <arcticdb/util/sparse_utils.hpp>
-
 #include <type_traits>
 
 namespace arcticdb {

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -9,16 +9,13 @@
 #include <arcticdb/stream/protobuf_mappings.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
-#include <arcticdb/codec/default_codecs.hpp>
 #include <arcticdb/codec/encoded_field.hpp>
 #include <arcticdb/codec/encoded_field_collection.hpp>
 #include <arcticdb/entity/stream_descriptor.hpp>
 #include <arcticdb/codec/encode_common.hpp>
 #include <arcticdb/codec/segment_identifier.hpp>
 
-#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <arcticdb/codec/encode_common.hpp>
-#include <string>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -15,8 +15,6 @@
 #include <arcticdb/codec/encode_common.hpp>
 #include <arcticdb/codec/segment_identifier.hpp>
 
-#include <arcticdb/codec/encode_common.hpp>
-
 namespace arcticdb {
 
 constexpr TypeDescriptor metadata_type_desc() {

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <arcticdb/codec/core.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/codec/encode_common.hpp>
 #include <arcticdb/entity/protobufs.hpp>
@@ -15,9 +14,6 @@
 #include <arcticdb/codec/segment_header.hpp>
 
 namespace arcticdb {
-
-class Segment;
-class SegmentInMemory;
 
 using ShapesBlockTDT = entity::TypeDescriptorTag<entity::DataTypeTag<entity::DataType::INT64>, entity::DimensionTag<entity::Dimension::Dim0>>;
 

--- a/cpp/arcticdb/codec/encoded_field.cpp
+++ b/cpp/arcticdb/codec/encoded_field.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/codec/encoded_field.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/codec/segment.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/codec/protobuf_mappings.cpp
+++ b/cpp/arcticdb/codec/protobuf_mappings.cpp
@@ -4,7 +4,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/codec/encoded_field.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include "arcticdb/storage/memory_layout.hpp"

--- a/cpp/arcticdb/codec/python_bindings.cpp
+++ b/cpp/arcticdb/codec/python_bindings.cpp
@@ -10,18 +10,14 @@
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/column_store/column_data.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/python/python_utils.hpp>
-#include <arcticdb/util/flatten_utils.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
 
-#include <fmt/format.h>
 
 #include <memory>
 #include <algorithm>
-#include <string>
 
 
 namespace py = pybind11;

--- a/cpp/arcticdb/codec/segment.hpp
+++ b/cpp/arcticdb/codec/segment.hpp
@@ -9,14 +9,9 @@
 
 #include <arcticdb/storage/common.hpp>
 #include <arcticdb/codec/segment_header.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
 #include <arcticdb/entity/stream_descriptor.hpp>
 #include <arcticdb/util/variant.hpp>
-
-#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/arena.h>
-
-#include <iostream>
 #include <variant>
 #include <any>
 

--- a/cpp/arcticdb/codec/segment_header.hpp
+++ b/cpp/arcticdb/codec/segment_header.hpp
@@ -8,7 +8,6 @@
 
 #include <arcticdb/codec/encoded_field.hpp>
 #include <arcticdb/codec/encoded_field_collection.hpp>
-#include <arcticdb/util/cursored_buffer.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/magic_num.hpp>
 #include <arcticdb/util/allocator.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/column_store/block.hpp>

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -25,9 +25,7 @@
 #ifdef __APPLE__
 #include <cstdio>
 #endif
-#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
-
 #include <concepts>
 #include <numeric>
 #include <optional>
@@ -98,8 +96,6 @@ struct ExtraBufferContainer {
     bool has_buffer(size_t offset, ExtraBufferType type) const;
 };
 
-class Column;
-class StringPool;
 
 template <typename T>
 JiveTable create_jive_table(const Column& col);

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -10,29 +10,15 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/util/preconditions.hpp>
-
 #include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/util/magic_num.hpp>
 #include <arcticdb/util/constructors.hpp>
-
 #include <boost/iterator/iterator_facade.hpp>
-
-
-namespace google::protobuf {
-    class Any;
-}
 
 namespace arcticdb {
 
 class ColumnMap;
-
-namespace entity {
-    struct StreamDescriptor;
-}
-
-
-class SegmentInMemoryImpl;
 
 class SegmentInMemoryImpl {
 public:

--- a/cpp/arcticdb/column_store/python_bindings.cpp
+++ b/cpp/arcticdb/column_store/python_bindings.cpp
@@ -10,7 +10,6 @@
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/column_store/column_data.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
-#include <arcticdb/python/python_utils.hpp>
 
 namespace py = pybind11;
 

--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -11,7 +11,6 @@
 #include <arcticdb/util/regex_filter.hpp>
 #include <ankerl/unordered_dense.h>
 
-#include <pybind11/pybind11.h>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -7,15 +7,14 @@
 
 #pragma once
 
-#include <string_view>
-#include <unordered_set>
-
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/buffer.hpp>
 #include <arcticdb/util/cursored_buffer.hpp>
 #include <arcticdb/util/regex_filter.hpp>
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/column_store/column_data.hpp>
+#include <string_view>
+#include <unordered_set>
 
 namespace pybind11 {
     struct buffer_info;
@@ -27,7 +26,6 @@ namespace py = pybind11;
 
 namespace arcticdb {
 
-class StringPool;
 class Column;
 
 

--- a/cpp/arcticdb/column_store/test/test_index_filtering.cpp
+++ b/cpp/arcticdb/column_store/test/test_index_filtering.cpp
@@ -14,6 +14,7 @@
 #include <arcticdb/storage/test/in_memory_store.hpp>
 #include <arcticdb/pipeline/index_writer.hpp>
 #include <arcticdb/codec/codec.hpp>
+#include <arcticdb/pipeline/read_pipeline.hpp>
 
 namespace arcticdb {
 using namespace arcticdb::pipelines;

--- a/cpp/arcticdb/entity/atom_key.hpp
+++ b/cpp/arcticdb/entity/atom_key.hpp
@@ -10,6 +10,7 @@
 #include <arcticdb/entity/key.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/index_range.hpp>
+#include <arcticdb/util/hash.hpp>
 #include <variant>
 #include <optional>
 #include <fmt/format.h>

--- a/cpp/arcticdb/entity/data_error.cpp
+++ b/cpp/arcticdb/entity/data_error.cpp
@@ -7,7 +7,6 @@
 
 #include <arcticdb/entity/data_error.hpp>
 
-#include <fmt/format.h>
 
 namespace arcticdb::entity {
 

--- a/cpp/arcticdb/entity/key.hpp
+++ b/cpp/arcticdb/entity/key.hpp
@@ -8,14 +8,10 @@
 #pragma once
 
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/hash.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <string_view>
-#include <memory>
 #include <algorithm>
 #include <variant>
 #include <array>
-#include <ranges>
 
 namespace rng = std::ranges;
 

--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -7,7 +7,6 @@
 
 #include <arcticdb/entity/metrics.hpp>
 #include <arcticdb/log/log.hpp>
-#include <arcticdb/util/pb_util.hpp>
 
 #ifdef _WIN32
 #    include <Winsock.h> // for gethostname

--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -9,7 +9,10 @@
 #include <arcticdb/log/log.hpp>
 
 #ifdef _WIN32
-#    include <Winsock.h> // for gethostname
+    #include <Winsock.h> // for gethostname
+#else
+    #include <sys/param.h>
+    #include <unistd.h>
 #endif
 
 using namespace prometheus;

--- a/cpp/arcticdb/entity/metrics.hpp
+++ b/cpp/arcticdb/entity/metrics.hpp
@@ -14,19 +14,14 @@
 #include <prometheus/exposer.h>
 #include <prometheus/family.h>
 #include <prometheus/histogram.h>
-
-#ifndef _WIN32
-#include <sys/param.h>
-#include <unistd.h>
-#endif
-
-#include <arcticdb/util/hash.hpp>
-#include <arcticdb/util/timer.hpp>
+#include <fmt/format.h>
 #include <map>
 #include <unordered_map>
 #include <memory>
 #include <utility>
-#include <fmt/format.h>
+#include <arcticdb/util/preconditions.hpp>
+#include <folly/hash/Hash.h>
+
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/entity/protobuf_mappings.cpp
+++ b/cpp/arcticdb/entity/protobuf_mappings.cpp
@@ -4,7 +4,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>

--- a/cpp/arcticdb/entity/protobuf_mappings.hpp
+++ b/cpp/arcticdb/entity/protobuf_mappings.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/types.hpp>
 

--- a/cpp/arcticdb/entity/test/test_ref_key.cpp
+++ b/cpp/arcticdb/entity/test/test_ref_key.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <arcticdb/util/hash.hpp>
 #include <arcticdb/entity/ref_key.hpp>
 
 TEST(RefKey, Basic) {

--- a/cpp/arcticdb/entity/type_utils.hpp
+++ b/cpp/arcticdb/entity/type_utils.hpp
@@ -12,10 +12,6 @@
 
 namespace arcticdb {
 
-namespace entity {
-    struct TypeDescriptor;
-}
-
 /// Defines which static casts from int to float are permitted in is_valid_type_promotion_to_target
 enum class IntToFloatConversion {
     /// Avoids lossy casting from int to float and tries to make sure that the integer can be represented exactly using

--- a/cpp/arcticdb/entity/types-inl.hpp
+++ b/cpp/arcticdb/entity/types-inl.hpp
@@ -10,7 +10,6 @@
 #endif
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <variant>
 
 namespace arcticdb::entity {

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -14,14 +14,12 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/details/periodic_worker.h>
-#include <arcticdb/util/configs_map.hpp>
 #include <filesystem>
 
 #include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/async.h>
 #include <spdlog/async_logger.h>
 #include <spdlog/sinks/stdout_sinks.h>
-
+#include <spdlog/async.h>
 #include <logger.pb.h>
 
 #include <memory>

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -7,21 +7,17 @@
 
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/util/preprocess.hpp>
-
 #include <arcticdb/util/pb_util.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/sinks/daily_file_sink.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/details/periodic_worker.h>
-#include <filesystem>
-
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/async_logger.h>
-#include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/async.h>
 #include <logger.pb.h>
-
+#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/cpp/arcticdb/log/log.hpp
+++ b/cpp/arcticdb/log/log.hpp
@@ -7,9 +7,8 @@
 
 #pragma once
 
-#include <memory>
-
 #include <spdlog/spdlog.h>
+#include <memory>
 #ifdef DEBUG_BUILD
 #define ARCTICDB_DEBUG(logger, ...) logger.debug(__VA_ARGS__)
 #define ARCTICDB_TRACE(logger, ...) logger.trace(__VA_ARGS__)
@@ -22,8 +21,6 @@
 #define ARCTICDB_RUNTIME_DEBUG(logger, ...) logger.debug(__VA_ARGS__)
 
 namespace arcticc::pb2::logger_pb2 {
-    // to use these types where needed in user code: #include <logger.pb.h>
-    class LoggerConfig;
     class LoggersConfig;
 }
 
@@ -68,6 +65,7 @@ class Loggers {
 
 
     struct Impl;
+
     std::unique_ptr<Impl> impl_;
 
 };

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <arcticdb/processing/clause.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <ankerl/unordered_dense.h>
-
 #include <map>
 #include <set>
 #include <string>

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/pipeline/frame_utils.hpp>
-#include <arcticdb/stream/aggregator.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
 

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -12,7 +12,6 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
-#include <arcticdb/stream/protobuf_mappings.hpp>
 #include <arcticdb/python/gil_lock.hpp>
 #include <arcticdb/python/python_types.hpp>
 #include <arcticdb/python/python_to_tensor_frame.hpp>
@@ -352,11 +351,6 @@ std::optional<convert::StringEncodingError> aggregator_set_data(
         }
         return std::optional<convert::StringEncodingError>();
     });
-}
-
-namespace pipelines {
-struct SliceAndKey;
-struct PipelineContext;
 }
 
 size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey>& slice_and_keys);

--- a/cpp/arcticdb/pipeline/index_segment_reader.cpp
+++ b/cpp/arcticdb/pipeline/index_segment_reader.cpp
@@ -7,7 +7,10 @@
 
 #include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/pipeline/index_fields.hpp>
-#include <arcticdb/pipeline/query.hpp>
+#include <arcticdb/entity/variant_key.hpp>
+#include <arcticdb/storage/store.hpp>
+#include <arcticdb/stream/stream_utils.hpp>
+#include <arcticdb/pipeline/read_query.hpp>
 
 using namespace arcticdb::entity;
 using namespace arcticdb::stream;

--- a/cpp/arcticdb/pipeline/index_segment_reader.cpp
+++ b/cpp/arcticdb/pipeline/index_segment_reader.cpp
@@ -5,11 +5,7 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <arcticdb/util/variant.hpp>
-#include <arcticdb/python/python_utils.hpp>
-#include <arcticdb/stream/protobuf_mappings.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
-#include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/pipeline/query.hpp>
 

--- a/cpp/arcticdb/pipeline/index_segment_reader.hpp
+++ b/cpp/arcticdb/pipeline/index_segment_reader.hpp
@@ -12,10 +12,6 @@
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <folly/futures/Future.h>
 
-namespace arcticdb {
-class Store;
-}
-
 namespace arcticdb::pipelines {
 struct ReadQuery;
 }

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -11,9 +11,7 @@
 #include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/entity/versioned_item.hpp>
 #include <arcticdb/pipeline/pipeline_common.hpp>
-#include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/stream/index.hpp>
-
 #include <folly/futures/Future.h>
 
 namespace arcticdb {

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -6,8 +6,6 @@
  */
 
 #include <arcticdb/pipeline/pipeline_context.hpp>
-#include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/stream/protobuf_mappings.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/pipeline/read_pipeline.hpp>
 #include <arcticdb/column_store/column_map.hpp>

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -8,12 +8,8 @@
 #pragma once
 
 #include <arcticdb/column_store/string_pool.hpp>
-
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/bitset.hpp>
-
-#include <boost/iterator_adaptors.hpp>
-#include <ranges>
 #include <memory>
 
 namespace arcticdb::pipelines {

--- a/cpp/arcticdb/pipeline/query.cpp
+++ b/cpp/arcticdb/pipeline/query.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/pipeline/query.hpp>
-
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/test/test_container.hpp>

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -9,22 +9,17 @@
 
 #include <arcticdb/util/bitset.hpp>
 #include <arcticdb/entity/index_range.hpp>
-#include <arcticdb/processing/expression_context.hpp>
-#include <arcticdb/pipeline/write_frame.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/stream/stream_utils.hpp>
-#include <arcticdb/processing/clause.hpp>
 #include <arcticdb/util/simple_string_hash.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
 #include <arcticdb/pipeline/read_query.hpp>
-
 #include <algorithm>
 #include <vector>
 #include <string>
 #include <variant>
-#include <ranges>
 #include <span>
 
 namespace arcticdb::pipelines {
@@ -220,14 +215,14 @@ inline FilterQuery<ContainerType> create_index_filter(const IndexRange &range, b
         const auto index_type = IndexDescriptor::Type(maybe_index_type.value());
         switch (index_type) {
         case IndexDescriptorImpl::Type::TIMESTAMP: {
-            return build_bitset_for_index<ContainerType, TimeseriesIndex>(container,
+            return build_bitset_for_index<ContainerType, stream::TimeseriesIndex>(container,
                                                                           rg,
                                                                           dynamic_schema,
                                                                           column_groups,
                                                                           std::move(input));
         }
         case IndexDescriptorImpl::Type::STRING: {
-            return build_bitset_for_index<ContainerType, TableIndex>(container, rg, dynamic_schema, column_groups, std::move(input));
+            return build_bitset_for_index<ContainerType, stream::TableIndex>(container, rg, dynamic_schema, column_groups, std::move(input));
         }
         default:util::raise_rte("Unknown index type {} in create_index_filter", uint32_t(index_type));
         }

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -18,7 +18,6 @@
 #include <arcticdb/util/type_handler.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/codec/slice_data_sink.hpp>
-#include <arcticdb/storage/store.hpp>
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/pipeline/column_mapping.hpp>
 #include <arcticdb/util/magic_num.hpp>

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -11,14 +11,8 @@
 #include <arcticdb/pipeline/pipeline_context.hpp>
 #include <arcticdb/pipeline/read_options.hpp>
 #include <arcticdb/util/bitset.hpp>
-
 #include <folly/futures/Future.h>
-
 #include <memory>
-
-namespace arcticdb {
-    struct BufferHolder;
-}
 
 namespace arcticdb::pipelines {
 

--- a/cpp/arcticdb/pipeline/read_pipeline.hpp
+++ b/cpp/arcticdb/pipeline/read_pipeline.hpp
@@ -7,16 +7,13 @@
 
 #pragma once
 
-#include <variant>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/util/bitset.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
-#include <arcticdb/pipeline/pandas_output_frame.hpp>
 #include <arcticdb/pipeline/query.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
-#include <arcticdb/pipeline/read_options.hpp>
 
 namespace arcticdb::pipelines {
 

--- a/cpp/arcticdb/pipeline/read_query.hpp
+++ b/cpp/arcticdb/pipeline/read_query.hpp
@@ -1,12 +1,11 @@
-#include <cstdint>
-#include <cstddef>
-#include <optional>
-#include <variant>
-#include <numeric>
+#pragma once
 
 #include <arcticdb/entity/index_range.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/processing/clause.hpp>
+#include <cstdint>
+#include <optional>
+#include <variant>
 
 namespace arcticdb::pipelines {
 using FilterRange = std::variant<std::monostate, entity::IndexRange, pipelines::RowRange>;

--- a/cpp/arcticdb/pipeline/slicing.hpp
+++ b/cpp/arcticdb/pipeline/slicing.hpp
@@ -7,19 +7,12 @@
 
 #pragma once
 
-#include <arcticdb/stream/index.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
-#include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/storage/store.hpp>
 #include <arcticdb/pipeline/pipeline_common.hpp>
-#include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/pipeline/write_options.hpp>
-
-#include <folly/futures/Future.h>
-
 #include <optional>
 #include <vector>
 #include <cstddef>

--- a/cpp/arcticdb/pipeline/string_pool_utils.cpp
+++ b/cpp/arcticdb/pipeline/string_pool_utils.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <arcticdb/pipeline/string_pool_utils.hpp>
-#include <arcticdb/pipeline/pipeline_context.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
 
 namespace arcticdb {
 size_t first_context_row(const pipelines::SliceAndKey& slice_and_key, size_t first_row_in_frame) {

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -9,7 +9,6 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
-#include <arcticdb/stream/protobuf_mappings.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/stream/aggregator.hpp>
@@ -21,7 +20,6 @@
 
 #include <vector>
 #include <array>
-#include <ranges>
 
 namespace arcticdb::pipelines {
 

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -20,6 +20,7 @@
 #include <ankerl/unordered_dense.h>
 #include <arcticdb/util/movable_priority_queue.hpp>
 #include <arcticdb/stream/merge_utils.hpp>
+#include <arcticdb/processing/unsorted_aggregation.hpp>
 
 #include <ranges>
 

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -16,10 +16,10 @@
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
-#include <arcticdb/stream/segment_aggregator.hpp>
 #include <arcticdb/util/test/random_throw.hpp>
 #include <ankerl/unordered_dense.h>
 #include <arcticdb/util/movable_priority_queue.hpp>
+#include <arcticdb/stream/merge_utils.hpp>
 
 #include <ranges>
 

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -13,14 +13,11 @@
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/processing/clause_utils.hpp>
-#include <arcticdb/processing/unsorted_aggregation.hpp>
 #include <arcticdb/processing/aggregation_interface.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/processing/sorted_aggregation.hpp>
 #include <arcticdb/stream/aggregator.hpp>
-
 #include <folly/Poly.h>
-
 #include <vector>
 #include <string>
 #include <variant>

--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -5,8 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <ranges>
-
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/processing/clause_utils.hpp>

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -5,8 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/processing_unit.hpp>

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -7,14 +7,13 @@
 
 #pragma once
 
-#include <memory>
-
 #include <arcticdb/util/bitset.hpp>
 #include <arcticdb/util/string_wrapping_value.hpp>
 #include <arcticdb/util/regex_filter.hpp>
 #include <arcticdb/processing/operation_types.hpp>
 #include <arcticdb/pipeline/value.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
+#include <memory>
 #include <utility>
 
 

--- a/cpp/arcticdb/processing/operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <arcticdb/processing/operation_dispatch.hpp>
+#include <arcticdb/column_store/column.hpp>
+#include <arcticdb/entity/type_utils.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/operation_dispatch.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch.hpp
@@ -7,23 +7,7 @@
  */
 
 #pragma once
-#include <cstdint>
-#include <variant>
-#include <memory>
-#include <type_traits>
-
-#include <folly/futures/Future.h>
-
-#include <arcticdb/pipeline/value.hpp>
-#include <arcticdb/pipeline/value_set.hpp>
-#include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/memory_segment.hpp>
-#include <arcticdb/util/variant.hpp>
-#include <arcticdb/entity/types.hpp>
-#include <arcticdb/entity/type_utils.hpp>
-#include <arcticdb/processing/operation_dispatch.hpp>
 #include <arcticdb/processing/expression_node.hpp>
-#include <arcticdb/entity/type_conversion.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -8,16 +8,9 @@
 
 #pragma once
 
-#include <variant>
-#include <memory>
-#include <type_traits>
-
-#include <folly/futures/Future.h>
-
 #include <arcticdb/pipeline/value.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
 #include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/type_utils.hpp>
@@ -25,6 +18,9 @@
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/entity/type_conversion.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
+#include <variant>
+#include <memory>
+#include <type_traits>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/operation_dispatch_binary_eq.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_eq.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_gte.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_gte.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_lte.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_lte.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_neq.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_neq.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_divide.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_divide.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_minus.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_minus.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_plus.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_plus.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_times.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_times.cpp
@@ -5,7 +5,6 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-
 #include <arcticdb/processing/operation_dispatch_binary.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -8,23 +8,16 @@
 
 #pragma once
 
-#include <cstdint>
-#include <variant>
-#include <memory>
-#include <type_traits>
-
-#include <folly/futures/Future.h>
-
 #include <arcticdb/pipeline/value.hpp>
-#include <arcticdb/pipeline/value_set.hpp>
 #include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/operation_dispatch.hpp>
-#include <arcticdb/entity/type_conversion.hpp>
+#include <variant>
+#include <memory>
+#include <type_traits>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/processing_unit.hpp
+++ b/cpp/arcticdb/processing/processing_unit.hpp
@@ -7,11 +7,7 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <vector>
-
 #include <fmt/core.h>
-
 #include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/processing/component_manager.hpp>
@@ -19,9 +15,8 @@
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/filter_segment.hpp>
-#include <arcticdb/util/composite.hpp>
-#include <arcticdb/util/string_utils.hpp>
-#include <arcticdb/util/variant.hpp>
+#include <unordered_map>
+#include <vector>
 
 namespace arcticdb {
     enum class PipelineOptimisation : uint8_t {

--- a/cpp/arcticdb/processing/test/rapidcheck_resample.cpp
+++ b/cpp/arcticdb/processing/test/rapidcheck_resample.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <algorithm>
+#include <random>
 
 #include "gtest/gtest.h"
 #include <arcticdb/util/test/rapidcheck.hpp>

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -10,7 +10,6 @@
 #include <arcticdb/entity/types.hpp>
 
 #include <cmath>
-#include <ranges>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/unsorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.hpp
@@ -9,7 +9,6 @@
 
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/python/gil_lock.hpp
+++ b/cpp/arcticdb/python/gil_lock.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <pybind11/pybind11.h>
 namespace arcticdb {
 
 struct GILLock {

--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -8,7 +8,6 @@
 #include <arcticdb/python/normalization_checks.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>

--- a/cpp/arcticdb/python/python_handlers.cpp
+++ b/cpp/arcticdb/python/python_handlers.cpp
@@ -5,7 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 #include <python/python_handlers.hpp>
-#include <arcticdb/codec/slice_data_sink.hpp>
 #include <arcticdb/codec/encoding_sizes.hpp>
 #include <arcticdb/codec/codec.hpp>
 #include <arcticdb/util/decode_path_data.hpp>

--- a/cpp/arcticdb/python/python_handlers.hpp
+++ b/cpp/arcticdb/python/python_handlers.hpp
@@ -8,16 +8,11 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/type_handler.hpp>
-#include <arcticdb/util/bitset.hpp>
 #include <arcticdb/python/python_handler_data.hpp>
-#include <arcticdb/arrow/arrow_handlers.hpp>
 
 // Handlers for various non-trivial Python types,
 // that conform to the interface ITypeHandler
 namespace arcticdb {
-
-struct ColumnMapping;
-class Column;
 
 struct PythonEmptyHandler {
     void handle_type(
@@ -41,7 +36,7 @@ struct PythonEmptyHandler {
         std::any& handler_data,
         const std::shared_ptr<StringPool>& string_pool) const;
 
-    [[nodiscard]] TypeDescriptor output_type(const TypeDescriptor& input_type) const;
+    [[nodiscard]] entity::TypeDescriptor output_type(const entity::TypeDescriptor& input_type) const;
 
     void default_initialize(
         ChunkedBuffer& buffer,
@@ -65,7 +60,7 @@ struct PythonStringHandler {
 
     [[nodiscard]] int type_size() const;
 
-    [[nodiscard]] TypeDescriptor output_type(const TypeDescriptor& input_type) const;
+    [[nodiscard]] entity::TypeDescriptor output_type(const entity::TypeDescriptor& input_type) const;
     
     void convert_type(
         const Column& source_column,
@@ -105,7 +100,7 @@ struct PythonBoolHandler {
         std::any& handler_data,
         const std::shared_ptr<StringPool>& string_pool) const;
 
-    [[nodiscard]] TypeDescriptor output_type(const TypeDescriptor& input_type) const;
+    [[nodiscard]] entity::TypeDescriptor output_type(const entity::TypeDescriptor& input_type) const;
 
     void default_initialize(
         ChunkedBuffer& buffer,
@@ -129,7 +124,7 @@ struct PythonArrayHandler {
 
     [[nodiscard]] int type_size() const;
 
-    [[nodiscard]] TypeDescriptor output_type(const TypeDescriptor& input_type) const;
+    [[nodiscard]] entity::TypeDescriptor output_type(const entity::TypeDescriptor& input_type) const;
 
     void default_initialize(
         ChunkedBuffer& buffer,
@@ -149,8 +144,8 @@ struct PythonArrayHandler {
 
 inline void register_python_array_types() {
     using namespace arcticdb;
-    constexpr std::array<DataType, 5> array_data_types = {
-        DataType::INT64, DataType::FLOAT64, DataType::EMPTYVAL, DataType::FLOAT32, DataType::INT32};
+    constexpr std::array<entity::DataType, 5> array_data_types = {
+        entity::DataType::INT64, entity::DataType::FLOAT64, entity::DataType::EMPTYVAL, entity::DataType::FLOAT32, entity::DataType::INT32};
 
     for (auto data_type : array_data_types) {
         TypeHandlerRegistry::instance()->register_handler(OutputFormat::PANDAS, make_array_type(data_type), arcticdb::PythonArrayHandler());
@@ -159,8 +154,8 @@ inline void register_python_array_types() {
 
 inline void register_python_string_types() {
     using namespace arcticdb;
-    constexpr std::array<DataType, 5> string_data_types = {
-        DataType::ASCII_DYNAMIC64, DataType::UTF_DYNAMIC64};
+    constexpr std::array<entity::DataType, 5> string_data_types = {
+        entity::DataType::ASCII_DYNAMIC64, entity::DataType::UTF_DYNAMIC64};
 
     for (auto data_type :string_data_types) {
         TypeHandlerRegistry::instance()->register_handler(OutputFormat::PANDAS, make_scalar_type(data_type), arcticdb::PythonStringHandler());

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -9,7 +9,6 @@
 #include <arcticdb/codec/python_bindings.hpp>
 #include <arcticdb/column_store/python_bindings.hpp>
 #include <arcticdb/storage/python_bindings.hpp>
-#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/lmdb/lmdb_storage.hpp>
 #include <arcticdb/stream/python_bindings.hpp>
 #include <arcticdb/toolbox/python_bindings.hpp>
@@ -29,7 +28,6 @@
 #include <arcticdb/python/python_handlers.hpp>
 #include <arcticdb/arrow/arrow_handlers.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
-#include <arcticdb/util/storage_lock.hpp>
 
 #include <pybind11/pybind11.h>
 #include <mongocxx/exception/logic_error.hpp>

--- a/cpp/arcticdb/python/python_strings.cpp
+++ b/cpp/arcticdb/python/python_strings.cpp
@@ -5,11 +5,10 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 #include <arcticdb/python/python_strings.hpp>
-
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/util/decode_path_data.hpp>
-#include <arcticdb/python/python_handlers.hpp>
+#include <arcticdb/entity/type_utils.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/python/python_strings.cpp
+++ b/cpp/arcticdb/python/python_strings.cpp
@@ -8,7 +8,6 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/column_store/column.hpp>
-#include <arcticdb/pipeline/frame_utils.hpp>
 #include <arcticdb/util/decode_path_data.hpp>
 #include <arcticdb/python/python_handlers.hpp>
 

--- a/cpp/arcticdb/python/python_strings.hpp
+++ b/cpp/arcticdb/python/python_strings.hpp
@@ -5,14 +5,11 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/column_store/column.hpp>
-#include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/pipeline/string_pool_utils.hpp>
 #include <arcticdb/util/decode_path_data.hpp>
 #include <arcticdb/python/python_utils.hpp>
-#include <arcticdb/python/python_to_tensor_frame.hpp>
 #include <arcticdb/python/python_handler_data.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -7,7 +7,6 @@
 
 
 #include <arcticdb/python/python_to_tensor_frame.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/entity/native_tensor.hpp>
 #include <arcticdb/python/python_utils.hpp>

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <pybind11/pybind11.h>
 #include <arcticdb/python/gil_lock.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/entity/native_tensor.hpp>

--- a/cpp/arcticdb/python/python_utils.hpp
+++ b/cpp/arcticdb/python/python_utils.hpp
@@ -14,16 +14,11 @@
 #include <arcticdb/entity/index_range.hpp>
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/stream/stream_reader.hpp>
 #include <arcticdb/util/variant.hpp>
-#include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/python/python_handler_data.hpp>
+#include <arcticdb/column_store/row_ref.hpp>
 
 namespace py = pybind11;
-
-namespace arcticdb {
-    struct PythonHandlerData;
-}
 
 namespace arcticdb::python_util {
 

--- a/cpp/arcticdb/storage/azure/azure_client_impl.cpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.cpp
@@ -7,13 +7,10 @@
 
 
 #include <azure/core/http/curl_transport.hpp>
-#include <azure/core.hpp>
-#include <azure/storage/blobs.hpp>
 
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/azure/azure_client_impl.hpp>
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
-#include <arcticdb/storage/object_store_utils.hpp>
+#include<arcticdb/storage/object_store_utils.hpp>
 
 namespace arcticdb::storage {
 using namespace object_store_utils;

--- a/cpp/arcticdb/storage/azure/azure_client_impl.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.hpp
@@ -7,11 +7,6 @@
 
 #pragma once
 
-#include <azure/core/http/curl_transport.hpp>
-#include <azure/core.hpp>
-#include <azure/storage/blobs.hpp>
-
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
 
 namespace arcticdb::storage::azure {

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -8,13 +8,9 @@
 #include <arcticdb/storage/azure/azure_storage.hpp>
 
 #include <arcticdb/log/log.hpp>
-#include <azure/core/http/curl_transport.hpp>
 
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
 
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/entity/serialized_key.hpp>
@@ -24,9 +20,7 @@
 #include <arcticdb/storage/mock/azure_mock_client.hpp>
 #include <arcticdb/storage/storage_exceptions.hpp>
 
-#include <azure/storage/blobs.hpp>
 
-#include <boost/interprocess/streams/bufferstream.hpp>
 
 #include <folly/gen/Base.h>
 

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -8,20 +8,10 @@
 #pragma once
 
 #include <arcticdb/storage/storage.hpp>
-#include <arcticdb/storage/storage_factory.hpp>
-#include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
-#include <arcticdb/log/log.hpp>
 #include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/util/composite.hpp>
-#include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/util/pb_util.hpp>
-#include <azure/core.hpp>
-#include <azure/storage/blobs.hpp>
-#include <cstdlib>
-#include <sstream>
 #include <string>
-#include <vector>
 
 namespace arcticdb::storage::azure {
 

--- a/cpp/arcticdb/storage/config_resolvers.cpp
+++ b/cpp/arcticdb/storage/config_resolvers.cpp
@@ -6,16 +6,8 @@
  */
 
 #include <arcticdb/storage/config_resolvers.hpp>
-#include <arcticdb/async/async_store.hpp>
-#include <arcticdb/codec/default_codecs.hpp>
 #include <arcticdb/storage/common.hpp>
-#include <arcticdb/storage/protobuf_mappings.hpp>
-#include <arcticdb/util/string_utils.hpp>
-#include <arcticdb/util/pb_util.hpp>
 
-#include <fstream>
-#include <string>
-#include <string_view>
 
 namespace arcticdb::storage::details {
 

--- a/cpp/arcticdb/storage/config_resolvers.hpp
+++ b/cpp/arcticdb/storage/config_resolvers.hpp
@@ -7,13 +7,9 @@
 
 #pragma once
 
-#include <arcticdb/async/async_store.hpp>
-#include <arcticdb/storage/storage_factory.hpp>
-#include <arcticdb/storage/mongo/mongo_client.hpp>
 #include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/storage/library.hpp>
-
-#include <mutex>
+#include <arcticdb/storage/library_path.hpp>
+#include <arcticdb/storage/common.hpp>
 
 namespace arcticdb::storage {
 class ConfigResolver {

--- a/cpp/arcticdb/storage/file/file_store.hpp
+++ b/cpp/arcticdb/storage/file/file_store.hpp
@@ -4,6 +4,7 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
+#pragma once
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/codec/codec.hpp>
@@ -11,8 +12,6 @@
 #include <arcticdb/codec/default_codecs.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/storage/storage.hpp>
-#include <arcticdb/storage/storage_options.hpp>
-#include <arcticdb/util/optional_defaults.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/codec/segment.hpp>
 #include <arcticdb/log/log.hpp>
@@ -21,8 +20,8 @@
 #include <arcticdb/storage/library.hpp>
 #include <arcticdb/storage/library_path.hpp>
 #include <arcticdb/stream/piloted_clock.hpp>
-#include <arcticdb/version/version_core.hpp>
 #include <arcticdb/entity/serialized_key.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/storage/file/mapped_file_storage.cpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.cpp
@@ -7,13 +7,10 @@
 #include <arcticdb/storage/file/mapped_file_storage.hpp>
 
 #include <arcticdb/log/log.hpp>
-#include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
-#include <arcticdb/storage/constants.hpp>
 #include <arcticdb/storage/library_path.hpp>
 #include <arcticdb/storage/open_mode.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/codec/codec.hpp>
 #include <arcticdb/entity/serialized_key.hpp>

--- a/cpp/arcticdb/storage/file/mapped_file_storage.hpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.hpp
@@ -8,10 +8,8 @@
 #pragma once
 
 #include <arcticdb/storage/single_file_storage.hpp>
-#include <arcticdb/storage/storage_factory.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
-#include <arcticdb/util/composite.hpp>
 #include <arcticdb/util/memory_mapped_file.hpp>
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/storage/coalesced/multi_segment_header.hpp>

--- a/cpp/arcticdb/storage/library_manager.cpp
+++ b/cpp/arcticdb/storage/library_manager.cpp
@@ -4,16 +4,13 @@
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/name_validation.hpp>
 #include <arcticdb/entity/key.hpp>
-#include <arcticdb/storage/storage_exceptions.hpp>
 #include <arcticdb/storage/open_mode.hpp>
 #include <arcticdb/storage/storages.hpp>
 #include <arcticdb/storage/s3/s3_storage.hpp>
 #include <arcticdb/codec/codec.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/codec/default_codecs.hpp>
 
-#include <filesystem>
 
 namespace arcticdb::storage {
 

--- a/cpp/arcticdb/storage/library_manager.cpp
+++ b/cpp/arcticdb/storage/library_manager.cpp
@@ -1,5 +1,4 @@
 #include <arcticdb/storage/library_manager.hpp>
-
 #include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/name_validation.hpp>
@@ -7,7 +6,6 @@
 #include <arcticdb/storage/open_mode.hpp>
 #include <arcticdb/storage/storages.hpp>
 #include <arcticdb/storage/s3/s3_storage.hpp>
-#include <arcticdb/codec/codec.hpp>
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/codec/default_codecs.hpp>
 

--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <numeric>
+#include <ranges>
 
 namespace arcticdb::storage {
 

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_impl.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_impl.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/codec/segment.hpp>
-#include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/serialized_key.hpp>
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/lmdb/lmdb_client_impl.hpp>

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_impl.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_impl.hpp
@@ -8,11 +8,7 @@
 #pragma once
 
 #include <arcticdb/storage/lmdb/lmdb_client_interface.hpp>
-
-#include <arcticdb/codec/segment.hpp>
-#include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/variant_key.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
 
 
 namespace arcticdb::storage::lmdb {

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -22,7 +22,6 @@
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/util/test/random_throw.hpp>
 
-#include <folly/gen/Base.h>
 #include <arcticdb/storage/storage_exceptions.hpp>
 
 namespace arcticdb::storage::lmdb {

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -9,10 +9,8 @@
 
 #include <arcticdb/storage/storage.hpp>
 #include <arcticdb/util/pb_util.hpp>
-#include <arcticdb/storage/lmdb/lmdb.hpp>
-#include <arcticdb/util/composite.hpp>
 #include <arcticdb/storage/lmdb/lmdb_client_interface.hpp>
-
+#include <arcticdb/storage/lmdb/lmdb.hpp>
 #include <filesystem>
 
 namespace fs = std::filesystem;

--- a/cpp/arcticdb/storage/memory/memory_storage.cpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.cpp
@@ -6,10 +6,8 @@
  */
 #include <arcticdb/storage/memory/memory_storage.hpp>
 
-#include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/storage/storage_options.hpp>
-#include <arcticdb/codec/protobuf_mappings.hpp>
 #include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/storage_exceptions.hpp>
 

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -8,12 +8,8 @@
 #pragma once
 
 #include <arcticdb/storage/storage.hpp>
-#include <arcticdb/storage/storage_factory.hpp>
 #include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/util/composite.hpp>
-#include <folly/Range.h>
 #include <folly/concurrency/ConcurrentHashMap.h>
-#include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/util/pb_util.hpp>
 
 namespace arcticdb::storage::memory {

--- a/cpp/arcticdb/storage/mock/azure_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/azure_mock_client.cpp
@@ -4,14 +4,9 @@
  *
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
 #include <arcticdb/storage/mock/azure_mock_client.hpp>
-#include <arcticdb/storage/object_store_utils.hpp>
 
-#include <azure/core/http/curl_transport.hpp>
-#include <azure/core.hpp>
-#include <azure/storage/blobs.hpp>
 
 namespace arcticdb::storage::azure {
 

--- a/cpp/arcticdb/storage/mock/azure_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/azure_mock_client.hpp
@@ -7,12 +7,7 @@
 
 #pragma once
 
-#include <azure/core/http/curl_transport.hpp>
 #include <azure/core/http/http_status_code.hpp>
-#include <azure/core.hpp>
-#include <azure/storage/blobs.hpp>
-
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
 #include <arcticdb/storage/mock/storage_mock_client.hpp>
 

--- a/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
@@ -8,7 +8,6 @@
 #include <arcticdb/storage/mock/lmdb_mock_client.hpp>
 
 #include <arcticdb/codec/segment.hpp>
-#include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/serialized_key.hpp>
 #include <arcticdb/util/string_utils.hpp>
 #include <arcticdb/storage/lmdb/lmdb.hpp>

--- a/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/storage/mock/lmdb_mock_client.hpp>
-
 #include <arcticdb/codec/segment.hpp>
 #include <arcticdb/entity/serialized_key.hpp>
 #include <arcticdb/util/string_utils.hpp>

--- a/cpp/arcticdb/storage/mock/lmdb_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/lmdb_mock_client.hpp
@@ -8,12 +8,9 @@
 #pragma once
 
 #include <arcticdb/storage/lmdb/lmdb_client_interface.hpp>
-
 #include <arcticdb/codec/segment.hpp>
-#include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/mock/storage_mock_client.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
 
 namespace arcticdb::storage::lmdb {
 

--- a/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
@@ -8,9 +8,7 @@
 #include <arcticdb/storage/mongo/mongo_client_interface.hpp>
 #include <arcticdb/storage/mock/mongo_mock_client.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
-
 #include <bsoncxx/builder/basic/document.hpp>
-#include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/query_exception.hpp>
 

--- a/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
@@ -7,7 +7,6 @@
 
 #include <arcticdb/storage/mongo/mongo_client_interface.hpp>
 #include <arcticdb/storage/mock/mongo_mock_client.hpp>
-#include <arcticdb/storage/object_store_utils.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/query_exception.hpp>

--- a/cpp/arcticdb/storage/mock/mongo_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/mongo_mock_client.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/mongo/mongo_client_interface.hpp>
 #include <arcticdb/storage/mock/storage_mock_client.hpp>
 #include <mongocxx/exception/operation_exception.hpp>

--- a/cpp/arcticdb/storage/mock/s3_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/s3_mock_client.cpp
@@ -7,9 +7,6 @@
 
 #include <arcticdb/storage/mock/s3_mock_client.hpp>
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
-#include <arcticdb/log/log.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
 
 #include <aws/s3/S3Errors.h>
 

--- a/cpp/arcticdb/storage/mock/s3_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/s3_mock_client.hpp
@@ -7,22 +7,8 @@
 
 #pragma once
 
-#include <aws/s3/S3Client.h>
-
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
 #include <arcticdb/storage/mock/storage_mock_client.hpp>
-
-#include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/pb_util.hpp>
-#include <arcticdb/log/log.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
-
-#include <arcticdb/storage/object_store_utils.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
-#include <arcticdb/entity/serialized_key.hpp>
-#include <arcticdb/util/exponential_backoff.hpp>
-#include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/util/composite.hpp>
 
 namespace arcticdb::storage::s3 {
 

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -10,7 +10,6 @@
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/types.hpp>
-#include <mongocxx/uri.hpp>
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/mongo/mongo_instance.hpp>
 #include <mongocxx/client.hpp>

--- a/cpp/arcticdb/storage/mongo/mongo_client.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.hpp
@@ -6,9 +6,6 @@
  */
 
 #pragma once
-#include <fmt/format.h>
-
-#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/mongo/mongo_client_interface.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 

--- a/cpp/arcticdb/storage/mongo/mongo_instance.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_instance.hpp
@@ -7,10 +7,9 @@
 
 #pragma once
 
+#include <mongocxx/instance.hpp>
 #include <mutex>
 #include <memory>
-#include <mongocxx/instance.hpp>
-#include <arcticdb/util/preprocess.hpp>
 
 namespace arcticdb::storage::mongo {
 

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -8,13 +8,9 @@
 
 #include <arcticdb/storage/mongo/mongo_storage.hpp>
 
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <arcticdb/util/configs_map.hpp>
-#include <fmt/format.h>
 #include <folly/gen/Base.h>
 
-#include <arcticdb/storage/mongo/mongo_instance.hpp>
-#include <arcticdb/entity/index_range.hpp>
 #include <arcticdb/storage/mongo/mongo_client.hpp>
 #include <arcticdb/storage/mock/mongo_mock_client.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -8,16 +8,11 @@
 #pragma once
 
 #include <arcticdb/storage/storage.hpp>
-#include <arcticdb/storage/storage_factory.hpp>
 #include <arcticdb/storage/mongo/mongo_client_interface.hpp>
 #include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/util/composite.hpp>
 #include <arcticdb/util/pb_util.hpp>
 
 namespace arcticdb::storage::mongo {
-
-class MongoInstance;
-class MongoClient;
 
 class MongoStorage final : public Storage {
   public:

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -7,8 +7,6 @@
 
 #include <arcticdb/storage/python_bindings.hpp>
 #include <arcticdb/python/python_utils.hpp>
-#include <arcticdb/entity/protobufs.hpp>
-#include <pybind11/stl.h>
 
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
@@ -18,7 +16,6 @@
 #include <arcticdb/storage/library_index.hpp>
 #include <arcticdb/storage/config_resolvers.hpp>
 #include <arcticdb/storage/constants.hpp>
-#include <arcticdb/storage/s3/s3_storage.hpp>
 #include <arcticdb/storage/s3/s3_settings.hpp>
 
 namespace py = pybind11;

--- a/cpp/arcticdb/storage/python_bindings.hpp
+++ b/cpp/arcticdb/storage/python_bindings.hpp
@@ -8,10 +8,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-#include <pybind11/stl_bind.h>
-
-#include <arcticdb/entity/key.hpp>
-#include <arcticdb/storage/open_mode.hpp>
 #include <arcticdb/util/error_code.hpp>
 
 namespace arcticdb::storage::apy {

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/storage/s3/s3_storage.hpp>
 #include <arcticdb/storage/s3/s3_client_impl.hpp>
 #include <arcticdb/util/simple_string_hash.hpp>
+#include <arcticdb/storage/s3/detail-inl.hpp>
 namespace arcticdb::storage::nfs_backed {
 
 std::string add_suffix_char(const std::string& str) {

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -9,9 +9,7 @@
 #include <arcticdb/storage/mock/s3_mock_client.hpp>
 #include <arcticdb/storage/s3/s3_storage.hpp>
 #include <arcticdb/storage/s3/s3_client_impl.hpp>
-#include <arcticdb/storage/s3/s3_client_interface.hpp>
 #include <arcticdb/util/simple_string_hash.hpp>
-#include <arcticdb/storage/s3/s3_client_wrapper.hpp>
 namespace arcticdb::storage::nfs_backed {
 
 std::string add_suffix_char(const std::string& str) {

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -8,19 +8,9 @@
 #pragma once
 
 #include <arcticdb/storage/storage.hpp>
-#include <arcticdb/storage/storage_factory.hpp>
-#include <aws/core/Aws.h>
-#include <aws/s3/model/PutObjectRequest.h>
-#include <aws/core/auth/AWSCredentialsProvider.h>
-#include <arcticdb/log/log.hpp>
-#include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/util/composite.hpp>
-#include <arcticdb/storage/s3/s3_storage.hpp>
 #include <arcticdb/storage/s3/s3_api.hpp>
-
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
-#include <arcticdb/storage/s3/detail-inl.hpp>
 
 namespace arcticdb::storage::nfs_backed {
 

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/storage/s3/s3_api.hpp>
-#include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/logging/DefaultLogSystem.h>
 #include <aws/core/utils/logging/AWSLogging.h>
 #include <arcticdb/util/configs_map.hpp>

--- a/cpp/arcticdb/storage/s3/s3_client_impl.cpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.cpp
@@ -11,11 +11,8 @@
 #include <aws/s3/S3Client.h>
 
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/log/log.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
 
-#include <arcticdb/storage/storage_utils.hpp>
 
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>

--- a/cpp/arcticdb/storage/s3/s3_client_impl.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.hpp
@@ -8,20 +8,7 @@
 #pragma once
 
 #include <aws/s3/S3Client.h>
-
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
-
-#include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/pb_util.hpp>
-#include <arcticdb/log/log.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
-
-#include <arcticdb/storage/object_store_utils.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
-#include <arcticdb/entity/serialized_key.hpp>
-#include <arcticdb/util/exponential_backoff.hpp>
-#include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/util/composite.hpp>
 
 namespace arcticdb::storage::s3 {
 

--- a/cpp/arcticdb/storage/s3/s3_client_wrapper.cpp
+++ b/cpp/arcticdb/storage/s3/s3_client_wrapper.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/s3/s3_client_wrapper.hpp>
 
 #include <aws/s3/S3Errors.h>

--- a/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
@@ -7,21 +7,7 @@
 
 #pragma once
 
-#include <aws/s3/S3Client.h>
-
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
-#include <arcticdb/storage/s3/s3_client_impl.hpp>
-
-#include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/pb_util.hpp>
-#include <arcticdb/log/log.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
-
-#include <arcticdb/storage/object_store_utils.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
-#include <arcticdb/entity/serialized_key.hpp>
-#include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/util/composite.hpp>
 
 namespace arcticdb::storage::s3 {
 

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -15,13 +15,10 @@
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/s3/s3_api.hpp>
 #include <arcticdb/storage/s3/s3_client_wrapper.hpp>
-#include <arcticdb/util/buffer_pool.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/storage/storage_options.hpp>
-#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/entity/serialized_key.hpp>
 #include <arcticdb/util/configs_map.hpp>
-#include <aws/s3/model/DeleteObjectRequest.h>
 #include <arcticdb/storage/s3/s3_client_impl.hpp>
 #include <arcticdb/storage/mock/s3_mock_client.hpp>
 #include <arcticdb/storage/s3/detail-inl.hpp>

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -8,24 +8,18 @@
 #pragma once
 
 #include <aws/sts/STSClient.h>
-
 #include <arcticdb/storage/storage.hpp>
-#include <arcticdb/storage/storage_factory.hpp>
-#include <aws/core/Aws.h>
-#include <aws/s3/model/PutObjectRequest.h>
-#include <aws/core/auth/AWSCredentialsProvider.h>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/s3/s3_api.hpp>
 #include <arcticdb/storage/s3/s3_settings.hpp>
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
-#include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/util/composite.hpp>
 #include <arcticdb/util/configs_map.hpp>
 #include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <aws/core/auth/AWSCredentials.h>
 
 namespace arcticdb::storage::s3 {
 

--- a/cpp/arcticdb/storage/s3/s3_storage_tool.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage_tool.cpp
@@ -6,12 +6,19 @@
  */
 
 #include <arcticdb/storage/s3/s3_storage_tool.hpp>
+#include <arcticdb/log/log.hpp>
+#include <arcticdb/storage/s3/s3_api.hpp>
+#include <arcticdb/storage/s3/s3_storage.hpp>
 
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/DeleteObjectRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <arcticdb/storage/common.hpp>
+
+#include <arcticdb/util/preconditions.hpp>
 
 namespace arcticdb::storage::s3 {
 

--- a/cpp/arcticdb/storage/s3/s3_storage_tool.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage_tool.hpp
@@ -7,10 +7,16 @@
 
 #pragma once
 
-#include <arcticdb/storage/s3/s3_storage.hpp>
 #include <aws/s3/S3Client.h>
+#include <s3_storage.pb.h>
+
+namespace arcticdb::proto {
+    namespace s3_storage = arcticc::pb2::s3_storage_pb2;
+}
 
 namespace arcticdb::storage::s3 {
+
+class S3ApiInstance;
 
 class S3StorageTool {
 public:

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -12,8 +12,8 @@
 #include <arcticdb/storage/storage_options.hpp>
 #include <arcticdb/util/composite.hpp>
 #include <arcticdb/codec/codec.hpp>
-
-#include <folly/futures/Future.h>
+#include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/stream/index.hpp>
 
 #include <span>
 

--- a/cpp/arcticdb/storage/storage_factory.hpp
+++ b/cpp/arcticdb/storage/storage_factory.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <arcticdb/storage/common.hpp>
 #include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/library_path.hpp>
 #include <arcticdb/storage/open_mode.hpp>

--- a/cpp/arcticdb/stream/aggregator.hpp
+++ b/cpp/arcticdb/stream/aggregator.hpp
@@ -12,8 +12,6 @@
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/util/constants.hpp>
 
-#include <memory>
-
 namespace arcticdb::stream {
 
 namespace {

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -8,18 +8,15 @@
 #include <ranges>
 #include <iterator>
 #include <arcticdb/stream/incompletes.hpp>
-#include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/stream/schema.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
 #include <arcticdb/util/name_validation.hpp>
 #include <arcticdb/util/key_utils.hpp>
-#include <arcticdb/async/tasks.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/pipeline/query.hpp>
 #include <arcticdb/pipeline/write_options.hpp>
-#include <folly/futures/FutureSplitter.h>
 #include <arcticdb/codec/codec.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
 #include <arcticdb/stream/stream_source.hpp>
@@ -28,8 +25,6 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/pipeline/write_frame.hpp>
-#include <arcticdb/stream/segment_aggregator.hpp>
-#include <arcticdb/version/version_functions.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -5,17 +5,13 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <ranges>
-#include <iterator>
 #include <arcticdb/stream/incompletes.hpp>
-#include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/stream/schema.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
 #include <arcticdb/util/name_validation.hpp>
 #include <arcticdb/util/key_utils.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
-#include <arcticdb/pipeline/query.hpp>
 #include <arcticdb/pipeline/write_options.hpp>
 #include <arcticdb/codec/codec.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
@@ -25,6 +21,8 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/pipeline/write_frame.hpp>
+#include <arcticdb/pipeline/read_query.hpp>
+#include <iterator>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/stream/incompletes.hpp
+++ b/cpp/arcticdb/stream/incompletes.hpp
@@ -15,20 +15,8 @@
 #include <arcticdb/storage/store.hpp>
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/pipeline/write_options.hpp>
-#include <arcticdb/version/version_map.hpp>
-#include <arcticdb/entity/versioned_item.hpp>
-#include <arcticdb/pipeline/column_stats.hpp>
-#include <arcticdb/pipeline/query.hpp>
-#include <arcticdb/async/task_scheduler.hpp>
-#include <arcticdb/stream/incompletes.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
-#include <arcticdb/pipeline/read_options.hpp>
-#include <arcticdb/stream/stream_reader.hpp>
-#include <arcticdb/stream/aggregator.hpp>
-#include <arcticdb/stream/segment_aggregator.hpp>
-#include <arcticdb/entity/frame_and_descriptor.hpp>
-#include <arcticdb/version/version_store_objects.hpp>
-#include <arcticdb/version/schema_checks.hpp>
+#include <arcticdb/pipeline/read_query.hpp>
 #include <string>
 
 namespace arcticdb {

--- a/cpp/arcticdb/stream/index.cpp
+++ b/cpp/arcticdb/stream/index.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/entity/type_utils.hpp>
+#include <ranges>
 
 namespace arcticdb::stream {
 

--- a/cpp/arcticdb/stream/piloted_clock.hpp
+++ b/cpp/arcticdb/stream/piloted_clock.hpp
@@ -1,5 +1,4 @@
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/preprocess.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/stream/protobuf_mappings.cpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.cpp
@@ -8,12 +8,9 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/column_store/statistics.hpp>
-
 #include <string>
 
 namespace arcticdb {
-
-struct FrameDescriptorImpl;
 
 arcticdb::proto::descriptors::NormalizationMetadata make_timeseries_norm_meta(const StreamId& stream_id) {
     using namespace arcticdb::proto::descriptors;

--- a/cpp/arcticdb/stream/protobuf_mappings.cpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.cpp
@@ -9,7 +9,6 @@
 #include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/column_store/statistics.hpp>
 
-#include <google/protobuf/text_format.h>
 #include <string>
 
 namespace arcticdb {

--- a/cpp/arcticdb/stream/protobuf_mappings.hpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.hpp
@@ -11,8 +11,6 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/column_store/statistics.hpp>
 
-#include <string>
-
 namespace arcticdb {
 
 struct FrameDescriptorImpl;

--- a/cpp/arcticdb/stream/python_bindings.cpp
+++ b/cpp/arcticdb/stream/python_bindings.cpp
@@ -7,15 +7,12 @@
 
 #include <arcticdb/stream/python_bindings.hpp>
 
-#include <pybind11/stl_bind.h>
 #include <pybind11/operators.h>
 #include <arcticdb/python/reader.hpp>
 
 #include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/stream/row_builder.hpp>
 #include <arcticdb/stream/aggregator.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
 #include <arcticdb/entity/types_proto.hpp>
 

--- a/cpp/arcticdb/stream/test/test_incompletes.cpp
+++ b/cpp/arcticdb/stream/test/test_incompletes.cpp
@@ -13,6 +13,7 @@
 #include <arcticdb/storage/test/in_memory_store.hpp>
 #include <arcticdb/entity/merge_descriptors.hpp>
 #include <arcticdb/pipeline/read_frame.hpp>
+#include <arcticdb/pipeline/read_pipeline.hpp>
 
 TEST(Append, Simple) {
     using namespace arcticdb;

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -9,7 +9,6 @@
 
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/entity/atom_key.hpp>
-#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/pipeline/pipeline_utils.hpp>
 #include <arcticdb/storage/library.hpp>

--- a/cpp/arcticdb/toolbox/library_tool.hpp
+++ b/cpp/arcticdb/toolbox/library_tool.hpp
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <pybind11/pybind11.h>
-
 #include <arcticdb/entity/key.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/variant_key.hpp>
@@ -16,15 +14,7 @@
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/entity/read_result.hpp>
 #include <arcticdb/version/local_versioned_engine.hpp>
-#include <arcticdb/python/adapt_read_dataframe.hpp>
-
 #include <memory>
-
-namespace arcticdb::storage {
-class Library;
-
-class LibraryIndex;
-}
 
 namespace arcticdb::toolbox::apy {
 

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -5,7 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <pybind11/functional.h>
 
 #include <arcticdb/python/adapt_read_dataframe.hpp>
 #include <arcticdb/storage/library.hpp>

--- a/cpp/arcticdb/toolbox/query_stats.cpp
+++ b/cpp/arcticdb/toolbox/query_stats.cpp
@@ -6,7 +6,6 @@
 */
 
 #include <arcticdb/toolbox/query_stats.hpp>
-#include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/log/log.hpp>
 

--- a/cpp/arcticdb/toolbox/query_stats.hpp
+++ b/cpp/arcticdb/toolbox/query_stats.hpp
@@ -7,17 +7,14 @@
 
 #pragma once
 
+#include <folly/ThreadCachedInt.h>
+#include <arcticdb/entity/key.hpp>
+#include <arcticdb/util/constants.hpp>
 #include <atomic>
-#include <type_traits>
 #include <string>
 #include <chrono>
 #include <array>
 #include <memory>
-#include <folly/ThreadCachedInt.h>
-
-#include <arcticdb/entity/key.hpp>
-#include <arcticdb/util/constants.hpp>
-#include <arcticdb/column_store/memory_segment.hpp>
 
 namespace arcticdb::query_stats{
 enum class TaskType : size_t {

--- a/cpp/arcticdb/util/allocation_tracing.hpp
+++ b/cpp/arcticdb/util/allocation_tracing.hpp
@@ -1,19 +1,5 @@
 #pragma once
 
-#include <algorithm>
-#include <cstdlib>
-#include <iostream>
-#include <new>
-#include <string>
-#include <memory>
-#include <mutex>
-
-#include <arcticdb/util/trace.hpp>
-#include <arcticdb/util/constructors.hpp>
-
-#include <ankerl/unordered_dense.h>
-#include <iostream>
-
 #ifdef ARCTICDB_COUNT_ALLOCATIONS
 
 namespace arcticdb {

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -15,7 +15,6 @@
 #include <arcticdb/util/thread_cached_int.hpp>
 #include <folly/concurrency/ConcurrentHashMap.h>
 
-#include <fmt/std.h>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -8,14 +8,7 @@
 #pragma once
 
 #include <arcticdb/util/clock.hpp>
-
-
 #include <memory>
-
-// for malloc_trim on linux
-#if defined(__linux__) && defined(__GLIBC__)
-    #include <malloc.h>
-#endif
 
 #if USE_SLAB_ALLOCATOR
     #include <arcticdb/util/slab_allocator.hpp>
@@ -69,6 +62,7 @@ struct TracingData {
 
 private:
     struct Impl;
+
     std::unique_ptr<Impl> impl_;
     friend class InMemoryTracingPolicy;
 };

--- a/cpp/arcticdb/util/decimal.cpp
+++ b/cpp/arcticdb/util/decimal.cpp
@@ -9,9 +9,9 @@
 #include <string>
 #include <cassert>
 #include <cmath>
-#include <boost/multiprecision/cpp_int.hpp>
 #include <arcticdb/util/preprocess.hpp>
 #include <arcticdb/util/preconditions.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -7,12 +7,11 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <folly/Function.h>
 #include <cstdint>
 #include <stdexcept>
 #include <vector>
 #include <unordered_map>
-#include <folly/Function.h>
 #include <variant>
 
 namespace arcticdb {

--- a/cpp/arcticdb/util/format_date.cpp
+++ b/cpp/arcticdb/util/format_date.cpp
@@ -1,6 +1,5 @@
 #define BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG // Allows using nanoseconds in boost.
 #include <arcticdb/util/format_date.hpp>
-#include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 #include <boost/date_time/posix_time/conversion.hpp>
 #include <arcticdb/util/constants.hpp>

--- a/cpp/arcticdb/util/global_lifetimes.cpp
+++ b/cpp/arcticdb/util/global_lifetimes.cpp
@@ -14,7 +14,6 @@
 #include <arcticdb/entity/metrics.hpp>
 #include <arcticdb/util/buffer_pool.hpp>
 #include <arcticdb/util/type_handler.hpp>
-#include <arcticdb/util/allocation_tracing.hpp>
 
 #if defined(_MSC_VER) && defined(_DEBUG)
 #include <crtdbg.h>

--- a/cpp/arcticdb/util/name_validation.cpp
+++ b/cpp/arcticdb/util/name_validation.cpp
@@ -7,10 +7,8 @@
 
 #include <arcticdb/util/name_validation.hpp>
 
-#include <arcticdb/entity/key.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/stream/index.hpp>
 #include <arcticdb/storage/store.hpp>
 
 namespace arcticdb {

--- a/cpp/arcticdb/util/name_validation.hpp
+++ b/cpp/arcticdb/util/name_validation.hpp
@@ -7,10 +7,7 @@
 
 #pragma once
 
-#include <arcticdb/entity/key.hpp>
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/stream/index.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/util/error_code.hpp>
 

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -7,11 +7,6 @@
 
 #pragma once
 
-#include <limits>
-
-// For `PyObject` and `PyFloat_FromDouble`
-#include <Python.h>
-
 // Unset the definition of `copysign` that is defined in `Python.h` for Python < 3.8 on Windows.
 // See: https://github.com/python/cpython/pull/23326
 #if defined(_MSC_VER) && PY_VERSION_HEX < 0x03080000
@@ -19,7 +14,6 @@
 #endif
 
 #include <ankerl/unordered_dense.h>
-
 #include <arcticdb/entity/types.hpp> // for entity::position_t
 #include <arcticdb/util/constants.hpp>
 

--- a/cpp/arcticdb/util/python_bindings.cpp
+++ b/cpp/arcticdb/util/python_bindings.cpp
@@ -5,7 +5,6 @@
  * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
  */
 
-#include <pybind11/functional.h>
 
 #include <arcticdb/util/python_bindings.hpp>
 #include <arcticdb/util/regex_filter.hpp>

--- a/cpp/arcticdb/util/sparse_utils.cpp
+++ b/cpp/arcticdb/util/sparse_utils.cpp
@@ -6,7 +6,7 @@
 */
 
 #include <arcticdb/util/sparse_utils.hpp>
-#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 
 namespace arcticdb::util {
 

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -17,6 +17,7 @@
 #include <arcticdb/column_store/column_data.hpp>
 #include <arcticdb/column_store/chunked_buffer.hpp>
 #include <arcticdb/pipeline/value.hpp>
+#include <fmt/ranges.h>
 
 #include <bitmagic/bmserial.h>
 

--- a/cpp/arcticdb/util/test/test_key_utils.cpp
+++ b/cpp/arcticdb/util/test/test_key_utils.cpp
@@ -8,6 +8,7 @@
 #include <arcticdb/util/key_utils.hpp>
 #include <arcticdb/storage/test/in_memory_store.hpp>
 #include <arcticdb/util/test/generators.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
 
 using namespace arcticdb;
 

--- a/cpp/arcticdb/util/trace.cpp
+++ b/cpp/arcticdb/util/trace.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/util/trace.hpp>
-#include <sstream>
 
 #ifndef  _WIN32
 #include <cxxabi.h>

--- a/cpp/arcticdb/util/type_handler.hpp
+++ b/cpp/arcticdb/util/type_handler.hpp
@@ -9,11 +9,9 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/column_store/chunked_buffer.hpp>
-#include <arcticdb/codec/segment_header.hpp>
 #include <arcticdb/entity/output_format.hpp>
-
+#include <arcticdb/codec/encoded_field.hpp>
 #include <folly/Poly.h>
-
 #include <memory>
 #include <mutex>
 #include <any>
@@ -75,7 +73,7 @@ struct ITypeHandler {
             return folly::poly_call<2>(*this);
         }
 
-        TypeDescriptor output_type(const TypeDescriptor& input_type) const {
+        entity::TypeDescriptor output_type(const entity::TypeDescriptor& input_type) const {
             return folly::poly_call<3>(*this, input_type);
         }
 
@@ -141,11 +139,11 @@ private:
     std::array<TypeHandlerMap, static_cast<size_t>(OutputFormat::COUNT)> handlers_;
 };
 
-inline std::shared_ptr<TypeHandler> get_type_handler(OutputFormat output_format, TypeDescriptor source) {
+inline std::shared_ptr<TypeHandler> get_type_handler(OutputFormat output_format, entity::TypeDescriptor source) {
     return TypeHandlerRegistry::instance()->get_handler(output_format, source);
 }
 
-inline std::shared_ptr<TypeHandler> get_type_handler(OutputFormat output_format, TypeDescriptor source, TypeDescriptor target) {
+inline std::shared_ptr<TypeHandler> get_type_handler(OutputFormat output_format, entity::TypeDescriptor source, entity::TypeDescriptor target) {
     auto handler = TypeHandlerRegistry::instance()->get_handler(output_format, source);
     if(handler)
         return handler;

--- a/cpp/arcticdb/version/key_block.hpp
+++ b/cpp/arcticdb/version/key_block.hpp
@@ -6,7 +6,6 @@
  */
 #pragma once
 
-#include <utility>
 #include <arcticdb/storage/store.hpp>
 #include <arcticdb/entity/key.hpp>
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -19,6 +19,8 @@
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/util/container_filter_wrapper.hpp>
+#include <arcticdb/version/version_functions.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
 
 namespace arcticdb::version_store {
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -15,12 +15,10 @@
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/storage_lock.hpp>
-#include <arcticdb/entity/metrics.hpp>
 #include <arcticdb/version/version_tasks.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/util/container_filter_wrapper.hpp>
-#include <arcticdb/util/allocation_tracing.hpp>
 
 namespace arcticdb::version_store {
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <arcticdb/version/version_map.hpp>
-#include <arcticdb/async/async_store.hpp>
 #include <arcticdb/version/symbol_list.hpp>
 #include <arcticdb/version/snapshot.hpp>
 #include <arcticdb/entity/protobufs.hpp>

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -9,7 +9,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
-#include <arcticdb/column_store/column_utils.hpp>
 #include <arcticdb/entity/data_error.hpp>
 #include <arcticdb/version/version_store_api.hpp>
 #include <arcticdb/python/python_utils.hpp>

--- a/cpp/arcticdb/version/schema_checks.cpp
+++ b/cpp/arcticdb/version/schema_checks.cpp
@@ -1,5 +1,6 @@
 #include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
+#include <arcticdb/entity/type_utils.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -2,7 +2,6 @@
 
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/python/normalization_checks.hpp>
-#include <arcticdb/entity/type_utils.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <arcticdb/version/snapshot.hpp>
-#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/version/version_log.hpp>
 
 #include <algorithm>

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -7,6 +7,8 @@
 
 #include <arcticdb/version/snapshot.hpp>
 #include <arcticdb/version/version_log.hpp>
+#include <arcticdb/stream/index_aggregator.hpp>
+#include <arcticdb/python/python_utils.hpp>
 
 #include <algorithm>
 

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -10,14 +10,9 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/variant_key.hpp>
-#include <arcticdb/stream/index.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
-#include <arcticdb/stream/stream_writer.hpp>
-#include <arcticdb/stream/stream_reader.hpp>
-#include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/storage/store.hpp>
-#include <arcticdb/util/variant.hpp>
 
 
 namespace arcticdb {

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -9,18 +9,14 @@
 
 
 #include <arcticdb/entity/types.hpp>
-
 #include <arcticdb/async/base_task.hpp>
 #include <arcticdb/version/version_map.hpp>
-
 #include <folly/futures/Future.h>
-
 #include <set>
 
 namespace arcticdb {
 
 struct LoadResult;
-class Store;
 
 struct SymbolListData {
     StreamId type_holder_;

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -16,6 +16,7 @@
 #include <arcticdb/version/version_functions.hpp>
 #include <arcticdb/version/local_versioned_engine.hpp>
 #include <arcticdb/util/native_handler.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
 
 #include <chrono>
 #include <thread>

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -9,13 +9,10 @@
 #include <arcticdb/stream/segment_aggregator.hpp>
 #include <arcticdb/pipeline/write_frame.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
-#include <iterator>
 #include <arcticdb/pipeline/frame_utils.hpp>
 #include <pipeline/frame_slice.hpp>
-#include <arcticdb/entity/protobuf_mappings.hpp>
 #include <arcticdb/codec/codec.hpp>
 #include <folly/futures/FutureSplitter.h>
-
 #include <arcticdb/pipeline/write_options.hpp>
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/pipeline/query.hpp>
@@ -37,6 +34,7 @@
 #include <arcticdb/entity/merge_descriptors.hpp>
 #include <arcticdb/processing/component_manager.hpp>
 #include <arcticdb/util/format_date.hpp>
+#include <iterator>
 
 
 namespace arcticdb::version_store {

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -6,14 +6,12 @@
  */
 
 #include <arcticdb/version/version_core.hpp>
-#include <arcticdb/version/version_functions.hpp>
 #include <arcticdb/stream/segment_aggregator.hpp>
 #include <arcticdb/pipeline/write_frame.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 #include <iterator>
 #include <arcticdb/pipeline/frame_utils.hpp>
 #include <pipeline/frame_slice.hpp>
-#include <arcticdb/stream/stream_source.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
 #include <arcticdb/codec/codec.hpp>
 #include <folly/futures/FutureSplitter.h>
@@ -40,7 +38,6 @@
 #include <arcticdb/processing/component_manager.hpp>
 #include <arcticdb/util/format_date.hpp>
 
-#include <ranges>
 
 namespace arcticdb::version_store {
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -11,19 +11,15 @@
 #include <arcticdb/pipeline/column_stats.hpp>
 #include <arcticdb/pipeline/query.hpp>
 #include <arcticdb/pipeline/write_options.hpp>
-#include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/stream/incompletes.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
 #include <arcticdb/pipeline/read_options.hpp>
 #include <arcticdb/entity/atom_key.hpp>
-#include <arcticdb/entity/stage_result.hpp>
-#include <arcticdb/stream/stream_reader.hpp>
-#include <arcticdb/stream/aggregator.hpp>
 #include <arcticdb/stream/segment_aggregator.hpp>
 #include <arcticdb/entity/frame_and_descriptor.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
 #include <arcticdb/version/schema_checks.hpp>
-
+#include <arcticdb/pipeline/slicing.hpp>
 #include <string>
 
 namespace arcticdb::version_store {

--- a/cpp/arcticdb/version/version_log.hpp
+++ b/cpp/arcticdb/version/version_log.hpp
@@ -9,12 +9,11 @@
 
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/storage/store.hpp>
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/version/op_log.hpp>
 #include <arcticdb/version/version_constants.hpp>
+#include <arcticdb/util/exponential_backoff.hpp>
 
-#include <folly/futures/Future.h>
 
 namespace arcticdb {
     using namespace arcticdb::entity;

--- a/cpp/arcticdb/version/version_map_batch_methods.cpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <arcticdb/version/version_map_batch_methods.hpp>
+#include <arcticdb/version/version_functions.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -7,15 +7,11 @@
 
 #pragma once
 
-#include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/version/version_map.hpp>
 #include <arcticdb/version/version_tasks.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
 #include <arcticdb/pipeline/query.hpp>
-#include <arcticdb/version/version_functions.hpp>
 #include <arcticdb/version/snapshot.hpp>
-
-#include <folly/futures/FutureSplitter.h>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -8,10 +8,7 @@
 #include <arcticdb/version/version_store_api.hpp>
 
 #include <arcticdb/python/python_utils.hpp>
-#include <arcticdb/async/async_store.hpp>
 #include <arcticdb/version/version_map.hpp>
-#include <arcticdb/entity/protobufs.hpp>
-#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/util/ranges_from_future.hpp>
 
@@ -21,12 +18,9 @@
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/util/optional_defaults.hpp>
 #include <arcticdb/python/python_to_tensor_frame.hpp>
-#include <arcticdb/pipeline/read_frame.hpp>
-#include <arcticdb/version/version_tasks.hpp>
 #include <arcticdb/version/version_map_batch_methods.hpp>
 #include <arcticdb/version/version_utils.hpp>
 #include <arcticdb/pipeline/pipeline_utils.hpp>
-#include <arcticdb/pipeline/frame_utils.hpp>
 #include <arcticdb/version/snapshot.hpp>
 #include <storage/file/file_store.hpp>
 

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -6,12 +6,10 @@
  */
 
 #include <arcticdb/version/version_store_api.hpp>
-
 #include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/version/version_map.hpp>
 #include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/util/ranges_from_future.hpp>
-
 #include <arcticdb/entity/versioned_item.hpp>
 #include <arcticdb/entity/descriptor_item.hpp>
 #include <arcticdb/pipeline/query.hpp>
@@ -22,9 +20,8 @@
 #include <arcticdb/version/version_utils.hpp>
 #include <arcticdb/pipeline/pipeline_utils.hpp>
 #include <arcticdb/version/snapshot.hpp>
-#include <storage/file/file_store.hpp>
-
-#include <regex>
+#include <arcticdb/storage/file/file_store.hpp>
+#include <arcticdb/version/version_functions.hpp>
 
 namespace arcticdb::version_store {
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -9,17 +9,10 @@
 
 #include <arcticdb/entity/data_error.hpp>
 #include <arcticdb/entity/types.hpp>
-#include <arcticdb/stream/index.hpp>
-#include <pybind11/pybind11.h>
-#include <arcticdb/python/python_utils.hpp>
-#include <arcticdb/async/async_store.hpp>
 #include <arcticdb/version/version_map.hpp>
-#include <arcticdb/version/snapshot.hpp>
-#include <arcticdb/version/symbol_list.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
 #include <arcticdb/entity/versioned_item.hpp>
 #include <arcticdb/pipeline/query.hpp>
-#include <arcticdb/pipeline/read_pipeline.hpp>
 #include <arcticdb/pipeline/read_options.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/version/local_versioned_engine.hpp>

--- a/cpp/arcticdb/version/version_utils.cpp
+++ b/cpp/arcticdb/version/version_utils.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/store.hpp>
 #include <arcticdb/stream/protobuf_mappings.hpp>
+#include <arcticdb/python/python_utils.hpp>
 
 
 

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -13,9 +13,7 @@
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/stream/index_aggregator.hpp>
 #include <arcticdb/version/version_map_entry.hpp>
-#include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/entity/frame_and_descriptor.hpp>
-
 #include <utility>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Monday 9920308940
#### What does this implement or fix?
The changes here are touching only `#include` declarations. There are no functional changes to the code. The changes are:
* add/move/remove include declarations
* add forward declaration
* add namespace specifier

99% of the changes are automatic via clang-tidy and include-what-you-use. There are some manual changes to fix compilation errors.

| Commit | Clang 19.1.7 (20 threads) ms | Speedup | Improvement | Gcc 11.3.0 (20 threads) ms | Speedup | Improvement |
|---|---:|---:|---:|---:|---:|---:|
| 341e0047349c08f050f28db44010bf7a67726094 | 163076.2 | - | - | 297348 | - | - |
| 02079df447e17d869883a4822ae5e2d29baa718f | 155362.5 | 1.04964969024057 | 4.7% | 276853.333333333 | 1.07402716239646 | 6.8% |
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
