### PR TITLE
Fix hypothesis tests that occasionally make the CI runners OOM [9796087821]

### DIFF
--- a/python/tests/hypothesis/arcticdb/test_resample.py
+++ b/python/tests/hypothesis/arcticdb/test_resample.py
@@ -19,10 +19,11 @@ from arcticdb.util.logger import get_logger
 COLUMN_DTYPE = ["float", "int", "uint"]
 ALL_AGGREGATIONS = ["sum", "mean", "min", "max", "first", "last", "count"]
 # Make sure the start date is pre-epoch so that we can test pre-epoch dates. Not all C++ libraries handle pre-epoch well.
-MIN_DATE = np.datetime64('1960-01-01')
-MAX_DATE = np.datetime64('2025-01-01')
+MIN_DATE = np.datetime64("1960-01-01")
+MAX_DATE = np.datetime64("2025-01-01")
 
 pytestmark = pytest.mark.pipeline
+
 
 def dense_row_count_in_resampled_dataframe(df_list, rule):
     """
@@ -30,6 +31,7 @@ def dense_row_count_in_resampled_dataframe(df_list, rule):
     with `rule`.  Assumes df_list is sorted by start date and the indexes are not overlapping.
     """
     return (df_list[-1].index[-1] - df_list[0].index[0]).value // pd.Timedelta(rule).value
+
 
 @st.composite
 def date(draw, min_date, max_date, unit="ns"):
@@ -109,14 +111,14 @@ def freq_fits_in_64_bits(count, unit):
     This is used to check if a frequency is usable by Arctic. ArcticDB converts the frequency to signed 64-bit integer.
     """
     billion = 1_000_000_000
-    mult = {'h': 3600 * billion, 'min': 60 * billion, 's': billion, 'ms': billion // 1000, 'us' : 1000,'ns': 1}
+    mult = {"h": 3600 * billion, "min": 60 * billion, "s": billion, "ms": billion // 1000, "us": 1000, "ns": 1}
     return (mult[unit] * count).bit_length() <= 63
 
 
 @st.composite
 def rule(draw):
     count = draw(st.integers(min_value=1, max_value=10_000))
-    unit = draw(st.sampled_from(['min', 'h', 's', 'ms', 'us', 'ns']))
+    unit = draw(st.sampled_from(["min", "h", "s", "ms", "us", "ns"]))
     result = f"{count}{unit}"
     assume(freq_fits_in_64_bits(count=count, unit=unit))
     return result
@@ -124,7 +126,7 @@ def rule(draw):
 
 @st.composite
 def offset(draw):
-    unit = draw(st.sampled_from(['s', 'min', 'h', 'ms', 'us', 'ns', None]))
+    unit = draw(st.sampled_from(["s", "min", "h", "ms", "us", "ns", None]))
     if unit is None:
         return None
     count = draw(st.integers(min_value=1, max_value=100))


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Monday 9796087821
#### What does this implement or fix?
The issue is that we need to output a dense dataframe for Pandas. So if the date range is big and the frequency is small we can end up with too many rows in the output dataframe eating the memory of the runner.

This also allows us to test all possible frequencies and extend the date range for generating dataframes.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
