### PR TITLE
Pin exact dependency versions in compat venvs

### DIFF
--- a/build_tooling/requirements-compatibility-py311.txt
+++ b/build_tooling/requirements-compatibility-py311.txt
@@ -1,9 +1,9 @@
 # Makes sure we are able to use Numpy 1
-pandas~=2.1
-numpy~=1.24
-protobuf~=4.25
-attrs~=23.1
-msgpack~=1.0
-prometheus_client~=0.21
-pyyaml~=6.0
-packaging~=24.2
+pandas==2.1.4
+numpy==1.24.4
+protobuf==4.25.1
+attrs==23.1.0
+msgpack==1.0.5
+prometheus_client==0.21.1
+pyyaml==6.0.1
+packaging==24.2

--- a/build_tooling/requirements-compatibility-py38.txt
+++ b/build_tooling/requirements-compatibility-py38.txt
@@ -1,9 +1,9 @@
 # The second oldest tested deps, for Python 3.8
-pandas~=1.0
-numpy~=1.18
-protobuf~=3.20
-attrs~=21.3
-msgpack~=1.0
-prometheus_client~=0.14
-pyyaml~=3.13
-packaging~=21.3
+pandas==1.0.5
+numpy==1.18.5
+protobuf==3.20.2
+attrs==21.3.0
+msgpack==1.0.5
+prometheus_client==0.14.1
+pyyaml==3.13
+packaging==21.3

--- a/build_tooling/requirements-compatibility-py38.txt
+++ b/build_tooling/requirements-compatibility-py38.txt
@@ -1,9 +1,9 @@
 # The second oldest tested deps, for Python 3.8
-pandas==1.0.5
-numpy==1.18.5
-protobuf==3.20.2
-attrs==21.3.0
-msgpack==1.0.5
-prometheus_client==0.14.1
-pyyaml==3.13
-packaging==21.3
+pandas~=1.0
+numpy~=1.18
+protobuf~=3.20
+attrs~=21.3
+msgpack~=1.0
+prometheus_client~=0.14
+pyyaml~=3.13
+packaging~=21.3


### PR DESCRIPTION
#### What does this implement or fix?
Pin to exact versions of dependencies in 3.11 compatibility venv.
The previous `~=` version would match on newer minor versions. So (for example) [this change](https://github.com/man-group/ArcticDB/commit/478e5ea89de9926008089fcbec1fdccd11f33c54#diff-5655e4ba4963abf1e2102a959b70700c916963cf1d0b45cac33c40b601c75bd4R14), which introduced importing `numpy.typing`, which was introduced in `numpy==1.21`, ran our compat tests with the latest `1.X` release (`1.24`). These tests passed, but failed in our internal build against the numpy version we actually care about (`1.18.5`)
Tried this on 3.8 as well, but the tests failed. Presumably some Man patches backport features from newer package versions that we depend on, but we will stop building this internally next month so no point worrying about it.