### PR TITLE
Update vcpkg baseline and sparrow to 1.1.0

### DIFF
--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -76,7 +76,7 @@
   ],
   "overrides": [
     { "name": "openssl", "version-string": "3.3.0" },
-    { "name": "arcticdb-sparrow", "version": "1.0.0" },
+    { "name": "arcticdb-sparrow", "version": "1.1.0" },
     { "name": "arrow", "version": "18.1.0" },
     { "name": "aws-sdk-cpp", "version": "1.11.474", "$note": "Update overlay json to upgrade; Upgrade to >=1.11.486 blocked by default integrity change" },
     { "name": "aws-crt-cpp", "version": "0.29.7" },


### PR DESCRIPTION
#### What does this implement or fix?
Update sparrow to 1.1.0 (requires vcpkg baseline update)