### PR TITLE
Only one version when running storage tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,7 +462,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python3: ${{ !inputs.run_full_matrix_of_persistent_tests && (needs.storage_type.outputs.storage != 'no') && '[11]' || '[8, 9, 10, 11]') }}
+        python3: ${{ fromJson( !inputs.run_full_matrix_of_persistent_tests && (needs.storage_type.outputs.storage != 'no') && '[11]' || '[8, 9, 10, 11]' ) }}
         include:
           - python_deps_ids: [""]
             matrix_override: ${{fromJson(needs.common_config.outputs.macos_matrix)}}


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Currently for storage tests we run all OS-Python combinations, although storage tests are executed only with Python 3.11 on Win and Linux. That creates a mix of results where majority 3.8-3.10, 3.12, 3.13 are LMDB tests and only 3.11 are real storage tests. That creates lots of confusion. The ideal solution would be to limit to 3.11 the runs so that only results from real storage tests are in the runs. For example see this link of a run of real_tetsts: https://github.com/man-group/ArcticDB/actions/runs/17659474240. It has so many LMDB runs and only 2 are Real Storages. Can you guess which ones?

A run for GCPXML: https://github.com/man-group/ArcticDB/actions/runs/17643448437
Note: Linux - 3.8 still exists, and that is because it uses matrix-include which cannot be created with a condition. Still all others are gone from the run

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
