### PR TITLE
Change version filter to 5.3.0 for tags

### DIFF
--- a/build_tooling/get_commits_for_benchmark.py
+++ b/build_tooling/get_commits_for_benchmark.py
@@ -14,14 +14,19 @@ from argparse import ArgumentParser
 def get_git_tags():
     result = subprocess.run(["git", "tag", "--list"], capture_output=True, text=True)
 
+    def get_version_from_tag(tag):
+        version = tag.split(".")
+        major = int(version[0].replace("v", ""))
+        minor = int(version[1])
+        patch = int(version[2])
+        return major, minor, patch
+
     # Filter the tags using a regular expression
     pattern = r"^v[0-9]+\.[0-9]+\.[0-9]+$"
     tags = [tag for tag in result.stdout.splitlines() if re.match(pattern, tag)]
-    # We are only interested in tags with version 3.0.0 or higher
-    # Because there are strange bugs with the lower versions
-    filtered_tags = [
-        tag for tag in tags if int(tag.split(".")[0].replace("v", "")) >= 3
-    ]
+    # We are only interested in tags with version 5.3.0 or higher
+    # Because older versions are trying to use depricated Numpy versions
+    filtered_tags = [tag for tag in tags if get_version_from_tag(tag) >= (5, 3, 0)]
     return filtered_tags
 
 


### PR DESCRIPTION
Updated version filtering to require tags of version 5.3.0 or higher due to deprecated Numpy issues.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
