### PR TITLE
Use s3 for sccache in ASV related builds

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -128,9 +128,19 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/man-group/arcticdb-dev:${{ inputs.dev_image_tag || 'latest' }}
     env:
-        SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
+        # 0 - uses S3 Cache, 1 - uses GHA cache
+        # this way the external PRs can use the GHA cache
+        SCCACHE_GHA_VERSION: ${{secrets.AWS_S3_ACCESS_KEY == null}}
+        SCCACHE_BUCKET: arcticdb-ci-sccache-bucket
+        SCCACHE_ENDPOINT: http://s3.eu-west-1.amazonaws.com
+        SCCACHE_REGION: eu-west-1
+        SCCACHE_S3_USE_SSL: false
+        AWS_ACCESS_KEY_ID: ${{secrets.AWS_S3_ACCESS_KEY}}
+        AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_S3_SECRET_KEY}}
         VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
         VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
+        VCPKG_MAN_NUGET_USER: ${{secrets.VCPKG_MAN_NUGET_USER}} # For forks to download pre-compiled dependencies from the Man repo
+        VCPKG_MAN_NUGET_TOKEN: ${{secrets.VCPKG_MAN_NUGET_TOKEN}}
         CMAKE_C_COMPILER_LAUNCHER: sccache
         CMAKE_CXX_COMPILER_LAUNCHER: sccache
         ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
@@ -151,7 +161,8 @@ jobs:
       - name: Extra envs
         shell: bash -l {0}
         run: |
-          . build_tooling/vcpkg_caching.sh # Linux follower needs another call in CIBW
+          . build_tooling/prep_cpp_build.sh
+          . build_tooling/vcpkg_caching.sh
           echo -e "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES
           VCPKG_ROOT=$PLATFORM_VCPKG_ROOT" | tee -a $GITHUB_ENV
           cmake -P cpp/CMake/CpuCount.cmake | sed 's/^-- //' | tee -a $GITHUB_ENV

--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -25,9 +25,19 @@ jobs:
     container: ghcr.io/man-group/arcticdb-dev:${{ inputs.dev_image_tag }}
     env:
       # this is potentially overflowing the cache, so should be looked into after we address issue #1057
-      SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}} # Setting this env var enables the caching
+      # 0 - uses S3 Cache, 1 - uses GHA cache
+      # this way the external PRs can use the GHA cache
+      SCCACHE_GHA_VERSION: ${{secrets.AWS_S3_ACCESS_KEY == null}}
+      SCCACHE_BUCKET: arcticdb-ci-sccache-bucket
+      SCCACHE_ENDPOINT: http://s3.eu-west-1.amazonaws.com
+      SCCACHE_REGION: eu-west-1
+      SCCACHE_S3_USE_SSL: false
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_S3_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_S3_SECRET_KEY}}
       VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
       VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
+      VCPKG_MAN_NUGET_USER: ${{secrets.VCPKG_MAN_NUGET_USER}} # For forks to download pre-compiled dependencies from the Man repo
+      VCPKG_MAN_NUGET_TOKEN: ${{secrets.VCPKG_MAN_NUGET_TOKEN}}
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       # 0 - uses S3 Cache, 1 - uses GHA cache
       # this way the external PRs can use the GHA cache
-      SCCACHE_GHA_VERSION: ${{secrets.AWS_S3_ACCESS_KEY && 0 || 1}}
+      SCCACHE_GHA_VERSION: ${{secrets.AWS_S3_ACCESS_KEY == null}}
       SCCACHE_BUCKET: arcticdb-ci-sccache-bucket
       SCCACHE_ENDPOINT: http://s3.eu-west-1.amazonaws.com
       SCCACHE_REGION: eu-west-1


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ticket ref: 10079294063

#### What does this implement or fix?
Changed the  ASV builds to use S3 for sccache as is done in the regular builds.
Also fixes the [VCPKG caching in one of the builds](https://github.com/man-group/ArcticDB/pull/2657/files#diff-8f568f466457a96303cbb4eed3d01446c3d3e5f8e522f58ffa4e78a13f04d64eR164).

Tested manually in [this build](https://github.com/man-group/ArcticDB/actions/runs/17821717217/job/50665565352).

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
