### PR TITLE
v1 API  update_time, name, batch_restore_version increase coverage

### DIFF
--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1157,11 +1157,11 @@ def test_update_time(basic_store):
     lib.snapshot("snap")
     lib.write("sym1", df)
 
-    # Negative number for as_of works as expected
+    # Negative number for as_of works as expected (dataframes)
     assert lib.update_time("sym1") == lib.update_time("sym1", -1) == lib.update_time("sym1", 2)
-    # Snapshots are accepted
+    # Snapshots are accepted (series)
     assert lib.update_time("sym1", 1) == lib.update_time("sym1", -2) == lib.update_time("sym1", "snap")
-    # All types of supported data have update_time
+    # and now check for np array
     assert lib.update_time("sym1", 0) == lib.update_time("sym1", -3)
 
     # Times are ordered

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -31,6 +31,7 @@ from arcticdb.exceptions import (
 )
 from arcticdb import QueryBuilder
 from arcticdb.flattener import Flattener
+from arcticdb.util.utils import generate_random_numpy_array, generate_random_series
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._store import VersionedItem
 from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException, StorageException
@@ -1142,6 +1143,37 @@ def test_update_times(basic_store):
     assert update_times_default[0] < update_times_default[1]
     assert len(update_times_versioned) == 3
     assert update_times_versioned[0] < update_times_versioned[1] < update_times_versioned[2]
+
+
+@pytest.mark.storage
+def test_update_time(basic_store):
+    lib: NativeVersionStore = basic_store
+
+    nparr = generate_random_numpy_array(50, np.float32, seed=None)
+    series = generate_random_series(np.uint64, 50, "numbers")
+    df = pd.DataFrame(data={"col1": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))
+    lib.write("sym1", nparr)
+    lib.write("sym1", series)
+    lib.snapshot("snap")
+    lib.write("sym1", df)
+
+    # Negative number for as_of works as expected
+    assert lib.update_time("sym1") == lib.update_time("sym1", -1) == lib.update_time("sym1", 2)
+    # Snapshots are accepted
+    assert lib.update_time("sym1", 1) == lib.update_time("sym1", -2) == lib.update_time("sym1", "snap")
+    # All types of supported data have update_time
+    assert lib.update_time("sym1", 0) == lib.update_time("sym1", -3)
+
+    # Times are ordered
+    assert lib.update_time("sym1") > lib.update_time("sym1", 1) > lib.update_time("sym1", 0)
+
+    # Correct exception thrown if symbol does not exist
+    with pytest.raises(NoDataFoundException):
+        lib.update_time("sym12")
+
+    # Correct exception thrown if version does not exist
+    with pytest.raises(NoDataFoundException):
+        lib.update_time("sym1", 11)
 
 
 @pytest.mark.storage
@@ -2540,6 +2572,7 @@ def test_batch_restore_version_mixed_as_ofs(lmdb_version_store):
     second_ts = pd.Timestamp(2000)
     ManualClockVersionStore.time = second_ts.value
     lib.batch_write(syms, second_data, second_metadata)
+    lib.snapshot("snap")
 
     third_ts = pd.Timestamp(3000)
     ManualClockVersionStore.time = third_ts.value
@@ -2568,6 +2601,32 @@ def test_batch_restore_version_mixed_as_ofs(lmdb_version_store):
     assert_equal(latest["s2"].data, second_data[1])
     assert_equal(latest["s3"].data, first_data[2])
     assert latest["s1"].metadata == "s1-3"
+    assert latest["s2"].metadata == "s2-2"
+    assert latest["s3"].metadata == "s3-1"
+
+    # check restore from snapshot and negative ver number
+    res = lib.batch_restore_version(syms, [-3, "snap", -1])
+
+    # check returned data
+    assert res[0].symbol == "s1"
+    assert res[1].symbol == "s2"
+    assert res[2].symbol == "s3"
+    assert res[0].version == 3
+    assert res[1].version == 4
+    assert res[2].version == 3  # We restored last version (-1 is last)
+    assert res[0].metadata == "s1-1"
+    assert res[1].metadata == "s2-2"
+    assert res[2].metadata == "s3-1"
+
+    # check latest version of symbols from the read
+    latest = lib.batch_read(syms)
+    assert latest["s1"].version == 3
+    assert latest["s2"].version == 4
+    assert latest["s3"].version == 3
+    assert_equal(latest["s1"].data, first_data[0])
+    assert_equal(latest["s2"].data, second_data[1])
+    assert_equal(latest["s3"].data, first_data[2])
+    assert latest["s1"].metadata == "s1-1"
     assert latest["s2"].metadata == "s2-2"
     assert latest["s3"].metadata == "s3-1"
 
@@ -2707,6 +2766,15 @@ def test_batch_restore_version(basic_store_tombstone):
     for d, symbol in enumerate(symbols):
         read_df = lmdb_version_store.read(symbol).data
         assert_equal(read_df, dfs[d])
+
+
+@pytest.mark.storage
+def test_name_method(basic_store_factory):
+
+    for lib_name in ["my name", "1243"]:
+        lib: NativeVersionStore = basic_store_factory(name=lib_name)
+        assert lib_name == lib.name()
+        lib.version_store.clear()
 
 
 @pytest.mark.storage


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

update_time - no coverage in tests. A test for existing/non-existing symbol + versions valid/invalid
batch_restore_version - Good coverage exists. Missing: Test with as_of negative number and a snapshot, unuqual lists
name() - not covered - we could add an a small coverage in a test

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
