### PR TITLE
Fix changed message for GCP

### DIFF
--- a/python/tests/enduser/test_authentication.py
+++ b/python/tests/enduser/test_authentication.py
@@ -131,7 +131,7 @@ def test_arcticdb_s3_uri(uri: str, expected: List[str]):
         ),
         (
             f"gcpxml://storage.googleapis.com:{gcp_bucket}?access={access_mark}1fds&secret={secret_mark}",
-            ["S3Error#22 SignatureDoesNotMatch"],
+            ["S3Error#22 SignatureDoesNotMatch", "S3Error:22, HttpResponseCode:403, SignatureDoesNotMatch"],
         ),
         (
             f"gcpxml://storage.googleapis.com:{gcp_bucket}?secret={secret_mark}",


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

Addresses an changed error message as per run: https://github.com/man-group/ArcticDB/actions/runs/18113172688/job/51544021095

```
FAILED tests/enduser/test_authentication.py::test_arcticdb_gcpxml_uri[gcpxml://storage.googleapis.com:arcticdb-github?access=*access*1fds&secret=*secret*-expected7] - arcticdb.util.logger.GitHubSanitizingException: Uri gcpxml://storage.googleapis.com:arcticdb-github?access=***&secret=*** expected to FAIL with any of [['S3Error#22 SignatureDoesNotMatch']] in message.
 Failed with different error: E_PERMISSION Permission error: S3Error:22, HttpResponseCode:403, SignatureDoesNotMatch: Access denied. for object '_arctic_cfg/cref/'
```

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
