### PR TITLE
Merge update initial implementation

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -411,6 +411,7 @@ set(arcticdb_srcs
         version/version_store_api.hpp
         version/version_store_objects.hpp
         version/version_utils.hpp
+        version/merge_options.hpp
         # CPP files
         arrow/arrow_handlers.cpp
         arrow/arrow_output_frame.cpp

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -65,7 +65,7 @@ class SegmentInMemory {
     }
 
     template<typename T>
-    requires std::same_as<std::decay_t<T>, std::string>
+    requires std::convertible_to<T, std::string_view>
     void set_scalar(position_t idx, const T& val) {
         impl_->set_string(idx, val);
     }

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -481,6 +481,7 @@ requires std::is_base_of_v<DataTypeTagBase, DT> && std::is_base_of_v<DimensionTa
 struct TypeDescriptorTag {
     using DataTypeTag = DT;
     using DimensionTag = D;
+    using RawType = typename DataTypeTag::raw_type;
     explicit constexpr operator TypeDescriptor() const { return type_descriptor(); }
 
     [[nodiscard]] static constexpr Dimension dimension() { return DimensionTag::value; }

--- a/cpp/arcticdb/pipeline/frame_slice.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice.hpp
@@ -256,9 +256,16 @@ struct SliceAndKey {
 
     bool invalid() const { return (!segment_ && !key_) || (segment_ && segment_->is_null()); }
 
-    const AtomKey& key() const {
+    const AtomKey& key() const& {
         util::check(static_cast<bool>(key_), "No key found");
         return *key_;
+    }
+
+    void set_key(AtomKey&& key) { key_ = std::move(key); }
+
+    AtomKey&& key() && {
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(key_, "No key found");
+        return std::move(*key_);
     }
 
     void unset_segment() { segment_ = std::nullopt; }

--- a/cpp/arcticdb/pipeline/input_tensor_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_tensor_frame.hpp
@@ -56,6 +56,8 @@ struct InputTensorFrame {
         }
     }
 
+    SortedValue sorted() const { return desc.sorted(); }
+
     void set_bucketize_dynamic(bool bucketize) const { bucketize_dynamic = bucketize; }
 
     bool has_index() const { return desc.index().field_count() != 0ULL; }

--- a/cpp/arcticdb/python/normalization_checks.hpp
+++ b/cpp/arcticdb/python/normalization_checks.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <arcticdb/util/error_code.hpp>
+#include <arcticdb/version/schema_checks.hpp>
 
 namespace arcticdb {
 
@@ -25,7 +26,7 @@ struct IndexSegmentReader;
  * The new frame for append/update is compatible with the existing index. Throws various exceptions if not.
  */
 void fix_normalization_or_throw(
-        bool is_append, const pipelines::index::IndexSegmentReader& existing_isr,
+        NormalizationOperation op, const pipelines::index::IndexSegmentReader& existing_isr,
         const pipelines::InputTensorFrame& new_frame
 );
 } // namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -603,6 +603,31 @@ VersionedItem LocalVersionedEngine::delete_range_internal(
     return versioned_item;
 }
 
+VersionedItem LocalVersionedEngine::merge_internal(
+        const StreamId& stream_id, const std::shared_ptr<InputTensorFrame>& source, bool prune_previous_versions,
+        const MergeStrategy& strategy, std::span<const std::string> on, bool match_on_timeseries_index
+) {
+    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: merge");
+    py::gil_scoped_release release_gil;
+    const auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    if (update_info.previous_index_key_.has_value()) {
+        if (source->empty()) {
+            ARCTICDB_DEBUG(
+                    log::version(),
+                    "Merging into existing data with an empty source has no effect. \n No new version is being created "
+                    "for symbol='{}', and the last version is returned",
+                    stream_id
+            );
+            return VersionedItem{*std::move(update_info.previous_index_key_)};
+        }
+        auto versioned_item =
+                merge_impl(store(), source, update_info, get_write_options(), strategy, on, match_on_timeseries_index);
+        write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
+        return versioned_item;
+    }
+    storage::raise<ErrorCode::E_SYMBOL_NOT_FOUND>("Cannot merge into non-existent symbol \"{}\".", stream_id);
+}
+
 VersionedItem LocalVersionedEngine::update_internal(
         const StreamId& stream_id, const UpdateQuery& query, const std::shared_ptr<InputTensorFrame>& frame,
         bool upsert, bool dynamic_schema, bool prune_previous_versions

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -21,6 +21,7 @@
 #include <arcticdb/version/versioned_engine.hpp>
 #include <arcticdb/entity/descriptor_item.hpp>
 #include <arcticdb/entity/data_error.hpp>
+#include <arcticdb/version/merge_options.hpp>
 
 namespace arcticdb::version_store {
 
@@ -66,6 +67,11 @@ class LocalVersionedEngine : public VersionedEngine {
     explicit LocalVersionedEngine(const std::shared_ptr<storage::Library>& library, const ClockType& = ClockType{});
 
     virtual ~LocalVersionedEngine() = default;
+
+    VersionedItem merge_internal(
+            const StreamId& stream_id, const std::shared_ptr<InputTensorFrame>& source, bool prune_previous_versions,
+            const MergeStrategy& strategy, std::span<const std::string> on, bool match_on_timeseries_index
+    ) override;
 
     VersionedItem update_internal(
             const StreamId& stream_id, const UpdateQuery& query, const std::shared_ptr<InputTensorFrame>& frame,

--- a/cpp/arcticdb/version/merge_options.hpp
+++ b/cpp/arcticdb/version/merge_options.hpp
@@ -1,0 +1,17 @@
+/* Copyright 2025 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+#pragma once
+
+namespace arcticdb {
+enum class MergeAction : uint8_t { DO_NOTHING, UPDATE, INSERT };
+struct MergeStrategy {
+    MergeAction matched;
+    MergeAction not_matched_by_target;
+};
+
+} // namespace arcticdb

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -25,6 +25,7 @@
 #include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
 #include <arcticdb/storage/storage_exceptions.hpp>
+#include <arcticdb/version/merge_options.hpp>
 
 namespace arcticdb::version_store {
 
@@ -240,6 +241,12 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
     py::enum_<OutputFormat>(version, "InternalOutputFormat")
             .value("PANDAS", OutputFormat::PANDAS)
             .value("ARROW", OutputFormat::ARROW);
+
+    py::enum_<MergeAction>(version, "MergeAction")
+            .value("DO_NOTHING", MergeAction::DO_NOTHING)
+            .value("UPDATE", MergeAction::UPDATE)
+            .value("INSERT", MergeAction::INSERT)
+            .export_values();
 
     py::class_<ReadOptions>(version, "PythonVersionStoreReadOptions")
             .def(py::init())
@@ -632,6 +639,10 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                  &PythonVersionStore::append,
                  py::call_guard<SingleThreadMutexHolder>(),
                  "Append a dataframe to the most recent version")
+            .def("merge",
+                 &PythonVersionStore::merge,
+                 py::call_guard<SingleThreadMutexHolder>(),
+                 "Merge a dataframe into the most recent version")
             .def("append_incomplete",
                  &PythonVersionStore::append_incomplete,
                  py::call_guard<SingleThreadMutexHolder>(),

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -21,6 +21,7 @@
 #include <arcticdb/version/version_store_objects.hpp>
 #include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
+#include <arcticdb/version/merge_options.hpp>
 #include <string>
 
 namespace arcticdb::version_store {
@@ -86,6 +87,12 @@ VersionedItem append_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info,
         const std::shared_ptr<InputTensorFrame>& frame, const WriteOptions& options, bool validate_index,
         bool empty_types
+);
+
+VersionedItem merge_impl(
+        const std::shared_ptr<Store>& store, const std::shared_ptr<InputTensorFrame>& frame,
+        const UpdateInfo& update_info, WriteOptions&& options, const MergeStrategy& strategy,
+        std::span<const std::string> on, bool match_on_timeseries_index
 );
 
 VersionedItem update_impl(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -654,6 +654,24 @@ VersionedItem PythonVersionStore::append(
     );
 }
 
+VersionedItem PythonVersionStore::merge(
+        const StreamId& stream_id, const py::tuple& source, const py::object& norm, const py::object& user_meta,
+        bool prune_previous_versions, const py::tuple& py_strategy, const std::vector<std::string>& on,
+        bool match_on_timeseries_index
+) {
+    const MergeStrategy strategy{
+            .matched = py_strategy[0].cast<MergeAction>(), .not_matched_by_target = py_strategy[1].cast<MergeAction>()
+    };
+    return merge_internal(
+            stream_id,
+            convert::py_ndf_to_frame(stream_id, source, norm, user_meta, cfg().write_options().empty_types()),
+            prune_previous_versions,
+            strategy,
+            on,
+            match_on_timeseries_index
+    );
+}
+
 VersionedItem PythonVersionStore::update(
         const StreamId& stream_id, const UpdateQuery& query, const py::tuple& item, const py::object& norm,
         const py::object& user_meta, bool upsert, bool dynamic_schema, bool prune_previous_versions

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -75,6 +75,12 @@ class PythonVersionStore : public LocalVersionedEngine {
             bool upsert, bool prune_previous_versions, bool validate_index
     );
 
+    VersionedItem merge(
+            const StreamId& stream_id, const py::tuple& source, const py::object& norm, const py::object& user_meta,
+            bool prune_previous_versions, const py::tuple& py_strategy, const std::vector<std::string>& on,
+            bool match_on_timeseries_index
+    );
+
     VersionedItem update(
             const StreamId& stream_id, const UpdateQuery& query, const py::tuple& item, const py::object& norm,
             const py::object& user_meta, bool upsert, bool dynamic_schema, bool prune_previous_versions

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -20,6 +20,7 @@
 #include <arcticdb/pipeline/input_tensor_frame.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
+#include <arcticdb/version/merge_options.hpp>
 
 namespace arcticdb::version_store {
 
@@ -42,6 +43,10 @@ enum class Slicing { NoSlicing, RowSlicing };
 class VersionedEngine {
 
   public:
+    virtual VersionedItem merge_internal(
+            const StreamId& stream_id, const std::shared_ptr<InputTensorFrame>& source, bool prune_previous_versions,
+            const MergeStrategy& strategy, std::span<const std::string> on, bool match_on_timeseries_index
+    ) = 0;
     virtual VersionedItem update_internal(
             const StreamId& stream_id, const UpdateQuery& query, const std::shared_ptr<InputTensorFrame>& frame,
             bool upsert, bool dynamic_schema, bool prune_previous_versions

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -1203,3 +1203,16 @@ def compute_common_type_for_columns(segment_columns: List[dict]):
             else:
                 common_types[name] = valid_common_type(common_types[name], np.dtype(dtype))
     return common_types
+
+
+def assert_vit_equals_except_data(left, right):
+    """
+    Checks if two VersionedItem objects are equal disregarding differences in the data field. This is because when a
+    write is performed the returned VersionedItem does not contain a data field.
+    """
+    assert left.symbol == right.symbol
+    assert left.library == right.library
+    assert left.version == right.version
+    assert left.metadata == right.metadata
+    assert left.host == right.host
+    assert left.timestamp == right.timestamp

--- a/python/tests/unit/arcticdb/version_store/test_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge.py
@@ -1,0 +1,1277 @@
+"""
+Copyright 2025 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import pytest
+import pandas as pd
+from enum import Enum
+from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data
+import arcticdb
+from arcticdb.version_store import VersionedItem
+from arcticdb_ext.storage import KeyType
+import numpy as np
+from arcticdb.exceptions import SchemaException, UserInputException, SortingException, StorageException
+from typing import NamedTuple
+
+
+class MergeAction(Enum):
+    UPDATE = 1
+    INSERT = 2
+    DO_NOTHING = 3
+
+
+class MergeStrategy(NamedTuple):
+    matched: MergeAction = MergeAction.UPDATE
+    not_matched_by_target: MergeAction = MergeAction.INSERT
+
+
+def mock_find_keys_for_symbol(key_types):
+    keys = {kt: [f"{kt}_{i}" for i in range(key_types[kt])] for kt in key_types}
+    return lambda key_type, symbol: keys[key_type]
+
+
+def raise_wrapper(exception, message=None):
+    def _raise(*args, **kwargs):
+        raise exception(message)
+
+    return _raise
+
+
+class TestMergeTimeseries:
+
+    # ================================================================================================
+    # ================================= APPLIES TO ALL STRATEGIES ====================================
+    # ================================================================================================
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
+            MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
+            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
+        ),
+    )
+    def test_merge_matched_update_with_metadata(self, lmdb_library, strategy, monkeypatch):
+        lib = lmdb_library
+
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        write_vit = lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [1, 20, 3], "b": [1.0, 20.0, 3.0]},
+            index=pd.DatetimeIndex(["2024-01-01 10:00:00", "2024-01-02", "2024-01-04"]),
+        )
+
+        metadata = {"meta": "data"}
+        monkeypatch.setattr(
+            lib,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=write_vit.version + 1,
+                metadata=metadata,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+
+        merge_vit = lib.merge("sym", source, metadata=metadata, strategy=strategy)
+        assert merge_vit.version == 1
+        assert merge_vit.symbol == write_vit.symbol
+        assert merge_vit.timestamp > write_vit.timestamp
+        assert merge_vit.metadata == metadata
+        assert merge_vit.library == write_vit.library
+        assert merge_vit.host == write_vit.host
+        assert merge_vit.data is None
+
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=None,  # Not going to check the data, only the metadata
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(merge_vit, read_vit)
+
+        lt = lib._dev_tools.library_tool()
+
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 2, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}),
+        )
+
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    @pytest.mark.parametrize("metadata", ({"meta": "data"}, None))
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
+            MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
+            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
+        ),
+    )
+    def test_merge_does_not_write_new_version_with_empty_source(self, lmdb_library, metadata, strategy, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        write_vit = lib.write("sym", target)
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: write_vit, raising=False)
+        merge_vit = lib.merge("sym", pd.DataFrame(), metadata=metadata, strategy=strategy)
+        assert_vit_equals_except_data(write_vit, merge_vit)
+        assert merge_vit.data is None and write_vit.data is None
+        lt = lib._dev_tools.library_tool()
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 1
+
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            None,
+            MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
+            MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
+            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
+        ),
+    )
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pd.DataFrame(
+                {"a": np.array([1, 2, 3], dtype=np.int8), "b": [1.0, 2.0, 3.0]},
+                index=pd.DatetimeIndex(
+                    [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01 10:00:00"), pd.Timestamp("2024-01-02")]
+                ),
+            ),
+            pd.DataFrame(
+                {"c": np.array([1, 2, 3], dtype=np.int8), "b": [1.0, 2.0, 3.0]},
+                index=pd.DatetimeIndex(
+                    [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01 10:00:00"), pd.Timestamp("2024-01-02")]
+                ),
+            ),
+            pd.DataFrame(
+                {"b": [1.0, 2.0, 3.0]},
+                index=pd.DatetimeIndex(
+                    [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01 10:00:00"), pd.Timestamp("2024-01-02")]
+                ),
+            ),
+        ],
+    )
+    def test_static_schema_merge_throws_when_schemas_differ(self, lmdb_library, strategy, source, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+
+        monkeypatch.setattr(lib.__class__, "merge", raise_wrapper(SchemaException), raising=False)
+
+        with pytest.raises(SchemaException):
+            lib.merge("sym", source, strategy=strategy)
+
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
+            MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
+            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
+        ),
+    )
+    def test_throws_if_source_is_not_sorted(self, lmdb_library, strategy, monkeypatch):
+        # This requirement can be lifted, however, passing a sorted source will be faster. We can start with it and
+        # extend if needed.
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [10, 20, 30], "b": [10.1, 20.1, 30.1]},
+            index=pd.DatetimeIndex(
+                [pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-01")]
+            ),
+        )
+
+        monkeypatch.setattr(lib.__class__, "merge", raise_wrapper(SortingException), raising=False)
+
+        with pytest.raises(SortingException):
+            lib.merge("sym", source, strategy=strategy)
+
+    # ================================================================================================
+    # ==================================== TEST UPDATE ON MATCH ======================================
+    # ================================================================================================
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
+            MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING),
+            MergeStrategy(not_matched_by_target="do_nothing"),
+            MergeStrategy("update", "do_nothing"),
+            MergeStrategy("UPDATE", "DO_NOTHING"),
+            MergeStrategy(MergeAction.UPDATE, "do_nothing"),
+            MergeStrategy("update", MergeAction.DO_NOTHING),
+        ),
+    )
+    def test_merge_update(self, lmdb_library, monkeypatch, strategy):
+        lib = lmdb_library
+
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        write_vit = lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [4, 5, 6], "b": [7.0, 8.0, 9.0]},
+            # Only the second row: "2024-01-02" matches
+            index=pd.DatetimeIndex(["2024-01-01 10:00:00", "2024-01-02", "2024-01-04"]),
+        )
+        monkeypatch.setattr(
+            lib.__class__,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=1,
+                metadata=write_vit.metadata,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+
+        merge_vit = lib.merge("sym", source, strategy=strategy)
+        assert merge_vit.version == 1
+        assert merge_vit.symbol == write_vit.symbol
+        assert merge_vit.timestamp > write_vit.timestamp
+        assert merge_vit.metadata == write_vit.metadata
+        assert merge_vit.library == write_vit.library
+        assert merge_vit.host == write_vit.host
+        assert merge_vit.data is None
+
+        # Only the second row: "2024-01-02" is updated
+        expected = pd.DataFrame({"a": [1, 4, 3], "b": [1.0, 8.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=expected,
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(merge_vit, read_vit)
+        assert_frame_equal(read_vit.data, expected)
+
+        lt = lib._dev_tools.library_tool()
+
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 2, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}),
+        )
+
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    def test_merge_update_writes_new_version_even_if_nothing_is_changed(self, lmdb_library, monkeypatch):
+        # In theory, it's possible to make so that it doesn't write a new version when nothing is matched, but the source
+        # is not empty. This has lots of edge cases and will burden the implementation for almost no gain. If nothing is
+        #  changed, we'll keep the same index and data keys and just write a new version key which is cheap.
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        write_vit = lib.write("sym", target)
+        monkeypatch.setattr(
+            lib,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=write_vit.version + 1,
+                metadata=write_vit.metadata,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+        source = pd.DataFrame({"a": [4, 5], "b": [4.0, 5.0]}, index=pd.date_range("2023-01-01", periods=2))
+        merge_vit = lib.merge("sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING))
+        assert merge_vit.version == 1
+        assert merge_vit.timestamp > write_vit.timestamp
+
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=target,
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(merge_vit, read_vit)
+        assert_frame_equal(read_vit.data, target)
+
+        lt = lib._dev_tools.library_tool()
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 1, KeyType.TABLE_INDEX: 1, KeyType.VERSION: 2}),
+        )
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    @pytest.mark.parametrize(
+        "slicing_policy",
+        [{"rows_per_segment": 2}, {"columns_per_segment": 2}, {"rows_per_segment": 2, "columns_per_segment": 2}],
+    )
+    def test_merge_update_row_slicing(self, lmdb_library_factory, slicing_policy, monkeypatch):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(**slicing_policy))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 5.0], "c": ["a", "b", "c", "d", "e"]},
+            index=pd.date_range("2024-01-01", periods=5),
+        )
+        lib.write("sym", target)
+
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+
+        source = pd.DataFrame(
+            {"a": [30, 50], "b": [30.1, 50.1]},
+            index=pd.DatetimeIndex([pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-05")]),
+        )
+        lib.merge("sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING))
+
+        expected = pd.DataFrame({"a": [1, 2, 30, 4, 50], "b": [1.0, 2.0, 31.1, 4.0, 50.1]})
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+        lt = lib._dev_tools.library_tool()
+        if "rows_per_segment" in slicing_policy and "columns_per_segment" in slicing_policy:
+            # Start with 3 row slices and 2 column slices = 6 data keys
+            # The second segment is overwritten with column slicing = 2 data keys
+            # The third segment is overwritten with column slicing = 2 data keys
+            expected_data_keys = 10
+        elif "rows_per_segment" in slicing_policy:
+            # Start with 3 row slices and no column slices -> 3 data keys
+            # The second segment is overwritten with column slicing = 1 data key
+            # The third segment is overwritten with column slicing = 1 data key
+            expected_data_keys = 5
+        elif "columns_per_segment" in slicing_policy:
+            # Start with one row slice and 2 column slices -> 2 data keys
+            # The segment is overwritten with column slicing = 2 data key
+            expected_data_keys = 4
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol(
+                {KeyType.TABLE_DATA: expected_data_keys, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}
+            ),
+        )
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == expected_data_keys
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    def test_merge_update_on_index_and_column(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [1, 2, 30, 40], "b": [10.0, 20.0, 30.0, 40.0]},
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",  # Matches index and column
+                    "2024-01-02 01:00:00",  # Matches column, but not index
+                    "2024-01-03",  # Matches index, but not column
+                    "2024-01-04",  # Does not match either
+                ]
+            ),
+        )
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge("sym", source, on=["a"], strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING))
+
+        expected = pd.DataFrame({"a": [1, 2, 3], "b": [10.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+
+        assert_frame_equal(received, expected)
+
+    def test_merge_update_multiple_columns(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4],
+                "b": ["a", "b", "c", "d"],
+                "c": ["A", "B", "A", "C"],
+                "d": [10.1, 20.2, 30.3, 40.4],
+                "e": [100, 200, 300, 400],
+            },
+            index=pd.date_range("2024-01-01", periods=4),
+        )
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {
+                "a": [10, 20, 30, 40, 50],
+                "b": ["a", "b", "c", "d", "e"],
+                "c": ["A", "D", "A", "B", "C"],
+                "d": [10.1, 50.5, 30.3, 40.4, 70.7],
+                "e": [100, 500, 600, 400, 800],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",  # index + b + d + e match (should update)
+                    "2024-01-02",  # index + b match, but d + e differ (do nothing)
+                    "2024-01-03",  # index + b + d match, e differs (do nothing)
+                    "2024-01-05",  # new index, b+d+e match (do nothing)
+                    "2024-01-06",  # new index, new b, new d, new e (do nothing)
+                ]
+            ),
+        )
+
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge(
+            "sym", source, on=["b", "d", "e"], strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING)
+        )
+
+        expected = pd.DataFrame(
+            {
+                "a": [10, 2, 3, 4],
+                "b": ["a", "b", "c", "d"],
+                "c": ["A", "B", "A", "C"],
+                "d": [10.1, 20.2, 30.3, 40.4],
+                "e": [100, 200, 300, 400],
+            },
+            index=pd.date_range("2024-01-01", periods=4),
+        )
+
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+    def test_merge_update_row_from_source_matches_multiple_rows_from_target(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex(
+                [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")]
+            ),
+        )
+        lib.write("sym", target)
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        source = pd.DataFrame({"a": [5], "b": [20.0]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")]))
+        lib.merge("sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING))
+        expected = pd.DataFrame(
+            {"a": [5, 5, 3], "b": [20.0, 20.0, 3.0]},
+            index=pd.DatetimeIndex(
+                [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")]
+            ),
+        )
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
+            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
+        ),
+    )
+    def test_merge_update_throws_when_target_row_is_matched_more_than_once(self, lmdb_library, strategy, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),  # Matches first row of target
+                    pd.Timestamp("2024-01-01"),  # Also matches first row of target
+                    pd.Timestamp("2024-01-03"),
+                ]
+            ),
+        )
+
+        monkeypatch.setattr(lib.__class__, "merge", raise_wrapper(UserInputException), raising=False)
+        with pytest.raises(UserInputException):
+            lib.merge("sym", source, strategy=strategy)
+
+    @pytest.mark.parametrize("merge_metadata", (None, "meta"))
+    def test_merge_update_target_is_empty(self, lmdb_library, monkeypatch, merge_metadata):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
+        write_vit = lib.write("sym", target)
+
+        source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
+        monkeypatch.setattr(
+            lib.__class__,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=1,
+                metadata=merge_metadata,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+        # NOTE: detecting that nothing will be changed is easier when the target is empty. It will be easy to not
+        # increase the version number. However, this will create two different behaviors because we currently increase
+        # the version if nothing is updated. I think having too many different behaviors will be confusing. IMO this
+        # must have the same behavior as test_merge_update_writes_new_version_even_if_nothing_is_changed.
+        merge_vit = lib.merge(
+            "sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING), metadata=merge_metadata
+        )
+        expected = target
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=expected,
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(merge_vit, read_vit)
+        assert_frame_equal(read_vit.data, expected)
+
+    @pytest.mark.parametrize(
+        "source",
+        (
+            pd.DataFrame([], index=pd.DatetimeIndex([])),
+            pd.DataFrame({"a": []}, index=pd.DatetimeIndex([])),
+            pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")])),
+        ),
+    )
+    @pytest.mark.parametrize("upsert", (True, False))
+    def test_update_on_match_target_symbol_does_not_exist(self, lmdb_library, monkeypatch, source, upsert):
+        # Model non-existing target after Library.update
+        # There is an upsert parameter to control whether to create the index. If upsert=False exception is thrown.
+        # Since we're doing a merge on non-existing data, I think it's logical to assume that nothing matches. If
+        # upsert=True, we will create an empty dataframe with the same schema of the source.
+        lib = lmdb_library
+
+        if not upsert:
+            monkeypatch.setattr(lib.__class__, "merge", raise_wrapper(StorageException), raising=False)
+            with pytest.raises(StorageException):
+                lib.merge(
+                    "sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING), upsert=upsert
+                )
+        else:
+            import datetime
+
+            monkeypatch.setattr(
+                lib.__class__,
+                "merge",
+                lambda *args, **kwargs: VersionedItem(
+                    symbol="sym",
+                    library=lmdb_library.name,
+                    data=None,
+                    version=0,
+                    metadata=None,
+                    host=lmdb_library._nvs.env,
+                    timestamp=pd.Timestamp(datetime.datetime.now()),
+                ),
+                raising=False,
+            )
+            merge_vit = lib.merge(
+                "sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING), upsert=upsert
+            )
+            expected = pd.DataFrame({"a": []}, index=pd.DatetimeIndex([]))
+            monkeypatch.setattr(
+                lib,
+                "read",
+                lambda *args, **kwargs: VersionedItem(
+                    symbol=merge_vit.symbol,
+                    library=merge_vit.library,
+                    data=expected,
+                    version=merge_vit.version,
+                    metadata=merge_vit.metadata,
+                    host=merge_vit.host,
+                    timestamp=merge_vit.timestamp,
+                ),
+            )
+            read_vit = lib.read("sym")
+            assert_vit_equals_except_data(merge_vit, read_vit)
+            assert_frame_equal(read_vit.data, expected)
+
+    # ================================================================================================
+    # ================================= TEST INSERT NOT MATCHED ======================================
+    # ================================================================================================
+
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
+            MergeStrategy("do_nothing", "insert"),
+            MergeStrategy("DO_NOTHING", "INSERT"),
+            MergeStrategy(MergeAction.DO_NOTHING, "insert"),
+            MergeStrategy("do_nothing", MergeAction.INSERT),
+        ),
+    )
+    def test_merge_insert_not_matched(self, lmdb_library, monkeypatch, strategy):
+        lib = lmdb_library
+
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        write_vit = lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [-1, -2, -3], "b": [-1.0, -2.0, -3.0]},
+            index=pd.DatetimeIndex(["2023-01-01", "2024-01-01 10:00:00", "2025-01-04"]),
+        )
+        monkeypatch.setattr(
+            lib.__class__,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=1,
+                metadata=write_vit.metadata,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+
+        merge_vit = lib.merge("sym", source, strategy=strategy)
+        assert merge_vit.version == 1
+        assert merge_vit.symbol == write_vit.symbol
+        assert merge_vit.timestamp > write_vit.timestamp
+        assert merge_vit.metadata == write_vit.metadata
+        assert merge_vit.library == write_vit.library
+        assert merge_vit.host == write_vit.host
+        assert merge_vit.data is None
+
+        expected = pd.concat([target, source]).sort_index()
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 1))
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    @pytest.mark.parametrize(
+        "date",
+        (
+            pd.Timestamp("2023-01-01"),  # Before first value
+            pd.Timestamp("2024-01-01 10:00:00"),  # After first value and before second value
+            pd.Timestamp("2024-01-02 10:00:00"),  # After second value
+        ),
+    )
+    def test_merge_insert_not_matched_in_full_segment(self, lmdb_library_factory, date, monkeypatch):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=2, columns_per_segment=2))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]}, index=pd.date_range("2024-01-01", periods=3)
+        )
+        lib.write("sym", target)
+        lt = lib._dev_tools.library_tool()
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 4
+
+        source = pd.DataFrame({"a": [10], "b": [20.0], "c": ["A"]}, index=pd.DatetimeIndex([date]))
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
+        expected = pd.concat([target, source]).sort_index()
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+        lt = lib._dev_tools.library_tool()
+        # The first segment is changed
+        # A new segment is created because after the insert the first segment overflows the rows_per_segment setting
+        # Each new segment is column sliced -> 2 * 2 = 4 new data keys
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 8, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}),
+        )
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 8
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    def test_merge_insert_not_matched_writes_new_version_even_if_nothing_is_changed(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        write_vit = lib.write("sym", target)
+        monkeypatch.setattr(
+            lib,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=write_vit.version + 1,
+                metadata=write_vit.metadata,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+        source = pd.DataFrame(
+            {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]}, index=pd.date_range("2024-01-01", periods=3)
+        )
+        merge_vit = lib.merge("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
+        assert merge_vit.version == 1
+        assert merge_vit.timestamp > write_vit.timestamp
+
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=target,
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(read_vit, merge_vit)
+        assert_frame_equal(read_vit.data, target)
+
+        lt = lib._dev_tools.library_tool()
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 1, KeyType.TABLE_INDEX: 1, KeyType.VERSION: 2}),
+        )
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    def test_merge_insert_not_matched_on_index_and_column(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [1, 2, 30, 40], "b": [10.0, 20.0, 30.0, 40.0]},
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",  # Matches index and column
+                    "2024-01-02 01:00:00",  # Matches column, but not index
+                    "2024-01-03",  # Matches index, but not column
+                    "2024-01-04",  # Does not match either
+                ]
+            ),
+        )
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge("sym", source, on=["a"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
+
+        # The first row is matched, but the strategy for matched rows is DO_NOTHING, so no update
+        # the rest rows are inserted
+        expected = pd.concat([target, source.tail(len(source) - 1)]).sort_index()
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+    def test_merge_insert_not_matched_on_multiple_columns(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4],
+                "b": ["a", "b", "c", "d"],
+                "c": ["A", "B", "A", "C"],
+                "d": [10.1, 20.2, 30.3, 40.4],
+                "e": [100, 200, 300, 400],
+            },
+            index=pd.date_range("2024-01-01", periods=4),
+        )
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {
+                "a": [10, 20, 30, 40, 50],
+                "b": ["a", "b", "c", "d", "e"],
+                "c": ["A", "D", "A", "B", "C"],
+                "d": [10.1, 50.5, 30.3, 40.4, 70.7],
+                "e": [100, 500, 600, 400, 800],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",  # MATCH: index + b + d + e match
+                    "2024-01-02",  # NOT_MATCH: index + b match, but d + e differ
+                    "2024-01-03",  # NOT_MATCH: index + b + d match, e differs
+                    "2024-01-05",  # NOT_MATCH: new index, b+d+e match
+                    "2024-01-06",  # NOT_MATCH: new index, new b, new d, new e
+                ]
+            ),
+        )
+
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge("sym", source, on=["b", "d", "e"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
+        expected = pd.concat([target, source.tail(len(source) - 1)]).sort_index()
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+    def test_merge_insert_does_not_throw_when_target_row_is_matched_more_than_once_when_matched_is_do_nothing(
+        self, lmdb_library, monkeypatch
+    ):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [1, 2, 4], "b": [1.0, 2.0, 4.0]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),  # Matches first row of target
+                    pd.Timestamp("2024-01-01"),  # Also matches first row of target
+                    pd.Timestamp("2024-01-04"),
+                ]
+            ),
+        )
+
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
+        expected = pd.DataFrame(
+            {"a": [1, 2, 3, 4], "b": [1.0, 2.0, 3.0, 4.0]}, index=pd.date_range("2024-01-01", periods=4)
+        )
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+    def test_merge_insert_target_is_empty(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
+        write_vit = lib.write("sym", target)
+
+        source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
+        monkeypatch.setattr(
+            lib.__class__,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=1,
+                metadata=None,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+        merge_vit = lib.merge("sym", source, strategy=MergeStrategy("do_nothing", "insert"))
+        expected = source
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=expected,
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(merge_vit, read_vit)
+        assert_frame_equal(read_vit.data, expected)
+
+    # ================================================================================================
+    # =================================== TEST UPDATE AND INSERT =====================================
+    # ================================================================================================
+
+    @pytest.mark.parametrize(
+        "strategy",
+        (
+            None,
+            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
+            MergeStrategy("update", "insert"),
+            MergeStrategy("UPDATE", "INSERT"),
+            MergeStrategy("update", MergeAction.INSERT),
+            MergeStrategy(MergeAction.UPDATE, "insert"),
+        ),
+    )
+    def test_update_and_insert(self, lmdb_library, monkeypatch, strategy):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]}, index=pd.date_range("2024-01-01", periods=3)
+        )
+        write_vit = lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [-1, 20, -2], "b": [-1.1, 20.1, -3.1], "c": ["a", "c", "d"]},
+            index=pd.DatetimeIndex(
+                [pd.Timestamp("2024-01-01 15:00:00"), pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-02 01:00:00")]
+            ),
+        )
+
+        monkeypatch.setattr(
+            lib.__class__,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=1,
+                metadata=write_vit.metadata,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+
+        merge_vit = lib.merge("sym", source, strategy=strategy) if strategy else lib.merge("sym", source)
+        assert merge_vit.version == 1
+        assert merge_vit.symbol == write_vit.symbol
+        assert merge_vit.timestamp > write_vit.timestamp
+        assert merge_vit.metadata == write_vit.metadata
+        assert merge_vit.library == write_vit.library
+        assert merge_vit.host == write_vit.host
+        assert merge_vit.data is None
+
+        expected = pd.DataFrame(
+            {"a": [1, -1, 20, -2, 3], "b": [1.0, -1.1, 20.1, -3.1, 3.0], "c": ["a", "a", "c", "d", "c"]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),
+                    pd.Timestamp("2024-01-01 15:00:00"),
+                    pd.Timestamp("2024-01-02"),
+                    pd.Timestamp("2024-01-02 01:00:00"),
+                    pd.Timestamp("2024-01-03"),
+                ]
+            ),
+        )
+
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=expected,
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(read_vit, merge_vit)
+        assert_frame_equal(read_vit.data, expected)
+
+        lt = lib._dev_tools.library_tool()
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 2, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}),
+        )
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    @pytest.mark.parametrize(
+        "slicing_policy",
+        [{"rows_per_segment": 2}, {"columns_per_segment": 2}, {"rows_per_segment": 2, "columns_per_segment": 2}],
+    )
+    def test_update_and_insert_with_slicing(self, lmdb_library_factory, monkeypatch, slicing_policy):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(**slicing_policy))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 5.0], "c": ["a", "b", "c", "d", "e"]},
+            index=pd.date_range("2024-01-01", periods=5),
+        )
+        lib.write("sym", target)
+
+        # Insertion pushes the row to be updated into a new segment
+        source = pd.DataFrame(
+            {"a": [-1, 40], "b": [-1.1, 40.4], "c": ["a", "f"]},
+            index=pd.DatetimeIndex([pd.Timestamp("2024-01-03 15:00:00"), pd.Timestamp("2024-01-04")]),
+        )
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge("sym", source)
+
+        expected = pd.DataFrame(
+            {"a": [1, 2, 3, -1, 40, 5], "b": [1.0, 2.0, 3.0, -1.1, 40.4, 5.0], "c": ["a", "b", "c", "a", "f", "e"]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),
+                    pd.Timestamp("2024-01-02"),
+                    pd.Timestamp("2024-01-03"),
+                    pd.Timestamp("2024-01-03 15:00:00"),
+                    pd.Timestamp("2024-01-04"),
+                    pd.Timestamp("2024-01-05"),
+                ]
+            ),
+        )
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        assert_frame_equal(lib.read("sym").data, expected)
+
+        lt = lib._dev_tools.library_tool()
+        if "rows_per_segment" in slicing_policy and "columns_per_segment" in slicing_policy:
+            expected_data_keys = 10
+        elif "rows_per_segment" in slicing_policy:
+            expected_data_keys = 5
+        elif "columns_per_segment" in slicing_policy:
+            expected_data_keys = 4
+        monkeypatch.setattr(
+            lt,
+            "find_keys_for_symbol",
+            mock_find_keys_for_symbol(
+                {KeyType.TABLE_DATA: expected_data_keys, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}
+            ),
+        )
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == expected_data_keys
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
+
+    @pytest.mark.parametrize(
+        "source",
+        (
+            pd.DataFrame([], index=pd.DatetimeIndex([])),
+            pd.DataFrame({"a": []}, index=pd.DatetimeIndex([])),
+            pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")])),
+        ),
+    )
+    @pytest.mark.parametrize("upsert", (True, False))
+    @pytest.mark.parametrize("strategy", (MergeStrategy("update", "insert"), MergeStrategy("do_nothing", "insert")))
+    def test_insert_when_target_symbol_does_not_exist(self, lmdb_library, monkeypatch, source, upsert, strategy):
+        # Model non-existing target after Library.update
+        # There is an upsert parameter to control whether to create the index. If upsert=False exception is thrown.
+        # Since we're doing a merge on non-existing data, I think it's logical to assume that nothing matches. No
+        # updates are performed. The insert operation will insert the data into the newly created target symbol.
+        lib = lmdb_library
+
+        if not upsert:
+            monkeypatch.setattr(lib.__class__, "merge", raise_wrapper(StorageException), raising=False)
+            with pytest.raises(StorageException):
+                lib.merge("sym", source, strategy=strategy, upsert=upsert)
+        else:
+            import datetime
+
+            monkeypatch.setattr(
+                lib.__class__,
+                "merge",
+                lambda *args, **kwargs: VersionedItem(
+                    symbol="sym",
+                    library=lmdb_library.name,
+                    data=None,
+                    version=0,
+                    metadata=None,
+                    host=lmdb_library._nvs.env,
+                    timestamp=pd.Timestamp(datetime.datetime.now()),
+                ),
+                raising=False,
+            )
+            merge_vit = lib.merge("sym", source, strategy=strategy, upsert=upsert)
+            expected = source
+            monkeypatch.setattr(
+                lib,
+                "read",
+                lambda *args, **kwargs: VersionedItem(
+                    symbol=merge_vit.symbol,
+                    library=merge_vit.library,
+                    data=expected,
+                    version=merge_vit.version,
+                    metadata=merge_vit.metadata,
+                    host=merge_vit.host,
+                    timestamp=merge_vit.timestamp,
+                ),
+            )
+            read_vit = lib.read("sym")
+            assert_vit_equals_except_data(merge_vit, read_vit)
+            assert_frame_equal(read_vit.data, expected)
+
+    def test_update_and_insert_on_index_and_column(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]}, index=pd.date_range("2024-01-01", periods=3)
+        )
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {"a": [1, 2, 30, 40], "b": [10.0, 20.0, 30.0, 40.0], "c": ["A", "B", "A", "C"]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),  # Matches index and column
+                    pd.Timestamp("2024-01-02 01:00:00"),  # Matches column, but not index
+                    pd.Timestamp("2024-01-03"),  # Matches index, but not column
+                    pd.Timestamp("2024-01-04"),  # Does not match either
+                ]
+            ),
+        )
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge("sym", source, on=["a"])
+
+        expected = pd.DataFrame(
+            {"a": [1, 2, 2, 3, 30, 40], "b": [10.0, 2.0, 20.0, 3.0, 30.0, 40.0], "c": ["A", "b", "B", "c", "A", "C"]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),
+                    pd.Timestamp("2024-01-02"),
+                    pd.Timestamp("2024-01-02 01:00:00"),
+                    pd.Timestamp("2024-01-03"),
+                    pd.Timestamp("2024-01-03"),
+                    pd.Timestamp("2024-01-04"),
+                ]
+            ),
+        )
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+
+        assert_frame_equal(received, expected)
+
+    def test_update_and_insert_multiple_columns(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4],
+                "b": ["a", "b", "c", "d"],
+                "c": ["A", "B", "A", "C"],
+                "d": [10.1, 20.2, 30.3, 40.4],
+                "e": [100, 200, 300, 400],
+            },
+            index=pd.date_range("2024-01-01", periods=4),
+        )
+        lib.write("sym", target)
+
+        source = pd.DataFrame(
+            {
+                "a": [10, 20, 30, 40, 50],
+                "b": ["a", "b", "c", "d", "e"],
+                "c": ["A", "D", "A", "B", "C"],
+                "d": [10.1, 50.5, 30.3, 40.4, 70.7],
+                "e": [100, 500, 600, 400, 800],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",  # index + b + d + e match (update)
+                    "2024-01-02",  # index + b match, but d + e differ (insert)
+                    "2024-01-03",  # index + b + d match, e differs (insert)
+                    "2024-01-05",  # new index, b+d+e match (insert)
+                    "2024-01-06",  # new index, new b, new d, new e (insert)
+                ]
+            ),
+        )
+
+        monkeypatch.setattr(lib.__class__, "merge", lambda *args, **kwargs: None, raising=False)
+        lib.merge(
+            "sym", source, on=["b", "d", "e"], strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING)
+        )
+        expected = pd.DataFrame(
+            {
+                "a": [10, 2, 20, 3, 30, 4, 40, 50],
+                "b": ["a", "b", "b", "c", "c", "d", "d", "e"],
+                "c": ["A", "B", "D", "A", "A", "C", "B", "C"],
+                "d": [10.1, 20.2, 50.5, 30.3, 30.3, 40.4, 40.4, 70.7],
+                "e": [100, 200, 500, 300, 600, 400, 400, 800],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",  # Updated: matched on b="a", d=10.1, e=100
+                    "2024-01-02",  # Original target row
+                    "2024-01-02",  # Inserted: no match for b="b", d=50.5, e=500
+                    "2024-01-03",  # Original target row
+                    "2024-01-03",  # Inserted: no match for b="c", d=30.3, e=600
+                    "2024-01-04",  # Original target row
+                    "2024-01-05",  # Inserted: no match for b="d", d=40.4, e=400 (different index)
+                    "2024-01-06",  # Inserted: completely new b="e", d=70.7, e=800
+                ]
+            ),
+        )
+
+        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
+        received = lib.read("sym").data
+        assert_frame_equal(received, expected)
+
+    def test_merge_update_and_insert_target_is_empty(self, lmdb_library, monkeypatch):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
+        write_vit = lib.write("sym", target)
+
+        source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
+        monkeypatch.setattr(
+            lib.__class__,
+            "merge",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=write_vit.symbol,
+                library=write_vit.library,
+                data=None,
+                version=1,
+                metadata=None,
+                host=write_vit.host,
+                timestamp=write_vit.timestamp + 1,
+            ),
+            raising=False,
+        )
+        merge_vit = lib.merge("sym", source)
+        expected = source
+        monkeypatch.setattr(
+            lib,
+            "read",
+            lambda *args, **kwargs: VersionedItem(
+                symbol=merge_vit.symbol,
+                library=merge_vit.library,
+                data=expected,
+                version=merge_vit.version,
+                metadata=merge_vit.metadata,
+                host=merge_vit.host,
+                timestamp=merge_vit.timestamp,
+            ),
+        )
+        read_vit = lib.read("sym")
+        assert_vit_equals_except_data(merge_vit, read_vit)
+        assert_frame_equal(read_vit.data, expected)
+
+    class TestMergeRowRange:
+        """Not implemented yet"""
+
+        def test_merge_not_implemented_with_row_range_yet(self, lmdb_library, monkeypatch):
+            lib = lmdb_library
+            target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+            lib.write("sym", target)
+
+            source = pd.DataFrame({"a": [1], "b": [2]})
+            monkeypatch.setattr(lib.__class__, "merge", raise_wrapper(UserInputException), raising=False)
+            with pytest.raises(UserInputException):
+                lib.merge("sym", source)
+
+    class TestMergeMultiindex:
+        """Not implemented yet"""
+
+        def test_merge_not_implemented_with_multiindex_yet(self, lmdb_library, monkeypatch):
+            lib = lmdb_library
+            target = pd.DataFrame(
+                {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.MultiIndex.from_tuples([("A", 1), ("B", 2), ("C", 3)])
+            )
+            lib.write("sym", target)
+            source = pd.DataFrame({"a": [2], "b": [3.0]}, index=pd.MultiIndex.from_tuples([("A", 1)]))
+            monkeypatch.setattr(lib.__class__, "merge", raise_wrapper(UserInputException), raising=False)
+            with pytest.raises(UserInputException):
+                lib.merge("sym", source)

--- a/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
+++ b/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
@@ -14,7 +14,7 @@ from arcticdb.version_store._custom_normalizers import CustomNormalizer, registe
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata  # Importing from arcticdb dynamically loads arcticc.pb2
 from arcticdb.exceptions import ArcticDbNotYetImplemented
 from arcticdb.util.venv import CompatLibrary
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data
 from arcticdb.exceptions import (
     DataTooNestedException,
     UnsupportedKeyInDictionary,
@@ -42,19 +42,6 @@ class AlmostAListNormalizer(CustomNormalizer):
 
     def denormalize(self, item, norm_meta):
         return AlmostAList(item)
-
-
-def assert_vit_equals_except_data(left, right):
-    """
-    Checks if two VersionedItem objects are equal disregarding differences in the data field. This is because when a
-    write is performed the returned VersionedItem does not contain a data field.
-    """
-    assert left.symbol == right.symbol
-    assert left.library == right.library
-    assert left.version == right.version
-    assert left.metadata == right.metadata
-    assert left.host == right.host
-    assert left.timestamp == right.timestamp
 
 
 @pytest.mark.parametrize("read", (lambda lib, sym: lib.batch_read([sym])[sym], lambda lib, sym: lib.read(sym)))


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 

#### What does this implement or fix?
This provides initial implementation of merge functionality supporting only the update part of it. It supports only matching on an ordered DatetimeIndex and static schema.

The algorithm takes advantage that both the source and the target are ordered.
1. Iterate over all slices in the index key and produce a list of object describing which of the slices can contain rows in source. This is done by performing lower_bound (binary_search) in the source index, searching for start index value stored in the slice. If the returned value is between key_start_index and key_end_index then the data segment could be affected. The complexity is `O(index_row_count * log(source_row_count))`. The information is stored as a pair, the index of the affected slice in the index key and the first index value from the source that falls into that slice.
2. Only the potentially affected data keys are read.
3. For each data key (in parallel) iterate over all index values in source that are between the first and last index values of the data key and perform lower_bound (binary search) to check if the index value from source is in the segment. If it is perform update. Complexity O(source_row_count * log(segment_size))

Next steps:
The iteration in step 3 above is row wise. This will be slow for DataFrames containing UTF string values as reading UTF strings requires holding the GIL and in general row wise iterations are not cache friendly. The reason this initial implementation uses row wise iteration is that it's easier to implement. Column wise iterations would need to either perfrom `O(slice_column_count * source_row_count * log(segment_size))` or use a caching mechanism matching source row to segment row another difficulty will be related to having the on clause. With on clause we need to check the entire row (across all segments) to know if update should be performed. The long term plan is to add additional step before `update_segment_inplace` that will iterate over all slices and generate a list of of pairs (UPDATE/INSERT, row_in_target_segment, row_in_source).

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
