### PR TITLE
Fix resample empty bucket with date range

### DIFF
--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -107,11 +107,17 @@ SegmentInMemory allocate_chunked_frame(const std::shared_ptr<PipelineContext>& c
     };
     auto handlers = TypeHandlerRegistry::instance();
 
-    if (row_count > 0) {
-        for (auto& column : output.columns()) {
-            auto handler = handlers->get_handler(output_format, column->type());
-            const auto data_size = data_type_size(column->type(), output_format, DataTypeMode::EXTERNAL);
-            for (auto block_row_count : block_row_counts) {
+    for (auto& column : output.columns()) {
+        auto handler = handlers->get_handler(output_format, column->type());
+        const auto data_size = data_type_size(column->type(), output_format, DataTypeMode::EXTERNAL);
+        for (auto block_row_count : block_row_counts) {
+            if (block_row_count > 0) {
+                // We can end up with empty segments from the processing pipeline, e.g. when:
+                // - Filtering a data key to the empty set (e.g. date_range = (3, 3) in a data key with no index=3)
+                // - Resampling with a date range with a bucket slice containing no indices
+                // 0 sized memory blocks would break the offset assumptions in chunked buffers, and it is fine to have
+                // number of memory blocks not equal number of segments because follow-up methods like
+                // `copy_frame_data_to_buffer` rely on offsets rather than block indices.
                 const auto bytes = block_row_count * data_size;
                 column->allocate_data(bytes);
                 column->advance_data(bytes);


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
In some fairly niche cases processing pipeline can produce empty segments:
- Resampling with dynamic schema
- date range filter with no index values within an intersecting data key (fixed in a previous PR)

We previously tried to allocate a 0 sized memory block which was raising assertions failures.

This PR just skips allocating the 0 sized memory blocks and adds an arrow test to verify it works.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
