### PR TITLE
[9898189624] Fix arrow reading empty frames

### DIFF
--- a/cpp/arcticdb/arrow/arrow_utils.cpp
+++ b/cpp/arcticdb/arrow/arrow_utils.cpp
@@ -229,6 +229,11 @@ std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::
 std::shared_ptr<std::vector<sparrow::record_batch>> segment_to_arrow_data(SegmentInMemory& segment) {
     const auto total_blocks = segment.num_blocks();
     const auto num_columns = segment.num_columns();
+    if (num_columns == 0) {
+        // We can't construct a record batch with no columns, so in this case we return an empty list of record batches,
+        // which needs special handling in python.
+        return {};
+    }
     const auto column_blocks = segment.column(0).num_blocks();
     util::check(total_blocks == column_blocks * num_columns, "Expected regular block size");
 

--- a/cpp/arcticdb/arrow/arrow_utils.cpp
+++ b/cpp/arcticdb/arrow/arrow_utils.cpp
@@ -232,7 +232,7 @@ std::shared_ptr<std::vector<sparrow::record_batch>> segment_to_arrow_data(Segmen
     if (num_columns == 0) {
         // We can't construct a record batch with no columns, so in this case we return an empty list of record batches,
         // which needs special handling in python.
-        return {};
+        return std::make_shared<std::vector<sparrow::record_batch>>();
     }
     const auto column_blocks = segment.column(0).num_blocks();
     util::check(total_blocks == column_blocks * num_columns, "Expected regular block size");

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -742,7 +742,9 @@ class ArrowTableNormalizer(Normalizer):
         index_type = pandas_meta.WhichOneof("index_type")
         if index_type == "index":
             index_meta = pandas_meta.index
-            if index_meta.is_physically_stored:
+            # Empty tables don't have `is_physically_stored=True` but we still output them with an empty DateTimeIndex.
+            is_empty_table_with_datetime_index = len(item) == 0 and not index_meta.step
+            if index_meta.is_physically_stored or is_empty_table_with_datetime_index:
                 pandas_indexes = 1
                 if index_meta.tz:
                     timezones[0] = index_meta.tz

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2432,7 +2432,11 @@ class NativeVersionStore:
             record_batches = []
             for record_batch in frame_data.extract_record_batches():
                 record_batches.append(pa.RecordBatch._import_from_c(record_batch.array(), record_batch.schema()))
-            table = pa.Table.from_batches(record_batches)
+            if len(record_batches) == 0:
+                # We get an empty list of record batches when output has no columns
+                table = pa.Table.from_arrays([])
+            else:
+                table = pa.Table.from_batches(record_batches)
             data = self._arrow_normalizer.denormalize(table, read_result.norm)
         else:
             data = self._normalizer.denormalize(read_result.frame_data, read_result.norm)

--- a/python/tests/unit/arcticdb/version_store/test_arrow.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow.py
@@ -92,6 +92,7 @@ def test_read_empty(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow(table, expected)
 
 
+@pytest.mark.skipif(IS_PANDAS_ONE, reason="Different empty frame handling in pandas 1.x")
 def test_read_empty_with_columns(lmdb_version_store_arrow):
     lib = lmdb_version_store_arrow
     sym = "sym"
@@ -956,6 +957,7 @@ def test_resample_row_slice_responsible_for_no_buckets(lmdb_version_store_tiny_s
     assert_frame_equal_with_arrow(table, expected)
 
 
+@pytest.mark.skipif(IS_PANDAS_ONE, reason="Different empty frame handling in pandas 1.x")
 def test_symbol_concat_empty_intersection(lmdb_version_store_arrow):
     # Tests a failing subset of test_symbol_concat_empty_column_intersection
     # TODO: Remove this test if we enable pipeline tests with arrow


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes monday ref: 9898189624

#### What does this implement or fix?
During symbol concat we can end up with a Segment with zero columns. Convert that to arrow gracefully.

Also uncovered that arrow normalization doesn't correctly construct `pandas_metadata` for empty dataframes. This is also fixed and tested in this PR.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
