### PR TITLE
Fix flaky filter test

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1143,7 +1143,7 @@ def test_float32_binary_comparison(lmdb_version_store_v1):
             generic_filter_test(lib, symbol, q, expected)
 
 
-@pytest.mark.parametrize("data", ({"a": pd.DataFrame({"col": [0]})}, np.array([1, 2, 3, 4]), np.ndarray((3, 3))))
+@pytest.mark.parametrize("data", ({"a": pd.DataFrame({"col": [0]})}, np.array([1, 2, 3, 4]), np.zeros((3, 3, 3))))
 @pytest.mark.parametrize("empty", (True, False))
 def test_filter_unfilterable_data(lmdb_version_store_v1, empty, data, sym):
     lib = lmdb_version_store_v1


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Use initialized numpy array for test_filter_unfilterable_data instead of unintialized one in the hope that the flakiness will be gone, as uninitialized value could result in np.nan which are considered not equal in `np.allcose`
```
In [1]: import numpy as np

In [2]: arr = np.full((3,4), np.nan)

In [3]: arr2 = np.full((3,4), np.nan)

In [4]: np.allclose(arr, arr2)
Out[4]: False

In [5]: arr = np.zeros((3,4))

In [6]: arr2 = np.zeros((3,4))

In [7]: np.allclose(arr, arr2)
Out[7]: True
```
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
