### PR TITLE
Fix mac conda CI hang at pytest

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -59,7 +59,6 @@ from .util.mark import (
     EXTENDED_MARKS,
     LMDB_TESTS_MARK,
     LOCAL_STORAGE_TESTS_ENABLED,
-    MACOS_WHEEL_BUILD,
     MEM_TESTS_MARK,
     REAL_AZURE_TESTS_MARK,
     SIM_GCP_TESTS_MARK,
@@ -76,6 +75,7 @@ from .util.mark import (
     VENV_COMPAT_TESTS_MARK,
     PANDAS_2_COMPAT_TESTS_MARK,
     MACOS,
+    ARM64,
     ARCTICDB_USING_CONDA,
 )
 from arcticdb.storage_fixtures.utils import safer_rmtree
@@ -721,7 +721,7 @@ def version_store_factory(lib_name, lmdb_storage) -> Generator[Callable[..., Nat
     # Otherwise there will be no storage space left for unit tests
     # very peculiar behavior for LMDB, not investigated yet
     # On MacOS ARM build this will sometimes hang test execution, so no clearing there either
-    yield from _store_factory(lib_name, lmdb_storage, not (WINDOWS or MACOS_WHEEL_BUILD))
+    yield from _store_factory(lib_name, lmdb_storage, not (WINDOWS or (MACOS and ARM64)))
 
 
 @pytest.fixture


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://man312219.monday.com/boards/7852509418/pulses/18088327032

#### What does this implement or fix?
The test has been previosuly identified but the incorrect flag has been used for the fix. 
The original fix worked for a period of time but no longer valid after a silent upgrade of github runner from x86 base to arm base.
The flag will be updated in the PR
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
