### PR TITLE
Remove mongodb storage log

### DIFF
--- a/cpp/arcticdb/storage/mongo/mongo_instance.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_instance.hpp
@@ -9,49 +9,13 @@
 #pragma once
 
 #include <mongocxx/instance.hpp>
-#include <mongocxx/logger.hpp>
 #include <mutex>
 #include <memory>
-#include <arcticdb/log/log.hpp>
 
 namespace arcticdb::storage::mongo {
 
-class logger final : public mongocxx::logger {
-  public:
-    void operator()(
-            mongocxx::log_level level, bsoncxx::stdx::string_view domain, bsoncxx::stdx::string_view message
-    ) noexcept override {
-        spdlog::level::level_enum spdlog_level;
-        switch (level) {
-        case mongocxx::log_level::k_error:
-            spdlog_level = spdlog::level::err;
-            break;
-        case mongocxx::log_level::k_critical:
-            spdlog_level = spdlog::level::critical;
-            break;
-        case mongocxx::log_level::k_warning:
-            spdlog_level = spdlog::level::warn;
-            break;
-        case mongocxx::log_level::k_message:
-        case mongocxx::log_level::k_info:
-            spdlog_level = spdlog::level::info;
-            break;
-        case mongocxx::log_level::k_debug:
-            spdlog_level = spdlog::level::debug;
-            break;
-        case mongocxx::log_level::k_trace:
-            spdlog_level = spdlog::level::trace;
-            break;
-        default:
-            spdlog_level = spdlog::level::info;
-            break;
-        }
-        log::storage().log(spdlog_level, "MONGO [{}@{}] {}", mongocxx::to_string(level), domain, message);
-    }
-};
-
 class MongoInstance {
-    mongocxx::instance api_instance_{std::make_unique<logger>()};
+    mongocxx::instance api_instance_;
 
   public:
     static std::shared_ptr<MongoInstance> instance_;


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
v6.3.0+man0 was found to seg fault while exiting in the internal tests. And the mongo logging is the only suspect on the changelist.
Although the underlying issue has not been identified, given that mongo storage log is not required by any user, it is removed in this PR as a precaution.
#### Any other comments?
Discussion: https://chat-man.slack.com/archives/CKQBVA96D/p1760967991003999
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
