### PR TITLE
Performance 18254756429: Improve hash grouping aggregation parallelism

### DIFF
--- a/cpp/arcticdb/util/hash.hpp
+++ b/cpp/arcticdb/util/hash.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string_view>
 
 #include <folly/hash/Hash.h>
 
@@ -21,10 +20,13 @@ namespace arcticdb {
 
 template<class T>
 inline size_t hash(T d) {
-    return std::hash<T>{}(d);
+    // Poor quality hash implementations of integral types, including at least some implementations of std::hash are
+    // basically a static cast. e.g. std::hash<int64_t>{}(100) == 100. This is fast, but leads to poor distributions in
+    // our bucketing, where we mod the hash with the number of buckets. In particular, if performing a grouping hash on
+    // a timeseries where the time points are dates results in all of the rows being partitioned into bucket zero, which
+    // then results in no parallelism in the aggregation clause.
+    return folly::hasher<T>{}(d);
 }
-
-inline size_t hash(std::string_view sv) { return std::hash<std::string_view>{}(sv); }
 
 using HashedValue = XXH64_hash_t;
 


### PR DESCRIPTION
#### Reference Issues/PRs
[18254756429](https://man312219.monday.com/boards/7852509418/pulses/18254756429)

#### What does this implement or fix?
Poor quality hash implementations of integral types, including at least some implementations of `std::hash `are basically a static cast. e.g. `std::hash<int64_t>{}(100) == 100`. This is fast, but leads to poor distributions in our bucketing, where we mod the hash with the number of buckets. In particular, if performing a grouping hash on a timeseries where the time points are dates results in all of the rows being partitioned into bucket zero, which then results in no parallelism in the aggregation clause.

Swap to using a consistent hash function across all supported platforms with improved uniformity.