### PR TITLE
Register cleanup function reliably

### DIFF
--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -382,15 +382,8 @@ PYBIND11_MODULE(arcticdb_ext, m) {
     register_metrics(m.def_submodule("metrics"));
     register_type_handlers();
 
-    auto cleanup_callback = []() {
-        using namespace arcticdb;
-        ARCTICDB_DEBUG(log::version(), "Running cleanup callback");
-        shutdown_globals();
-    };
-
-    m.add_object("_cleanup", py::capsule(cleanup_callback));
-
     register_termination_handler();
+    Py_AtExit(shutdown_globals);
 
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;

--- a/cpp/arcticdb/util/global_lifetimes.cpp
+++ b/cpp/arcticdb/util/global_lifetimes.cpp
@@ -63,6 +63,7 @@ std::shared_ptr<ModuleData> ModuleData::instance_;
 std::once_flag ModuleData::init_flag_;
 
 void shutdown_globals() {
+    ARCTICDB_DEBUG(log::version(), "Running shutdown_globals");
     async::TaskScheduler::stop_active_threads();
     storage::mongo::MongoInstance::destroy_instance();
     ModuleData::destroy_instance();


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://man312219.monday.com/boards/7852509418/pulses/18261646279

#### What does this implement or fix?
There is possibility which arcticdb python objects has been released only after the library import is cleaned up.
In that case, if any object logs while deconstructing, the null log instance will make the process seg fault.
Register the cleanup function properly so it will cleanup when the interpreter exit
#### Any other comments?
No test can be given as I can't repeat the issue in a standalone script.
Still pybind11 has warned this may happen: https://pybind11.readthedocs.io/en/stable/advanced/misc.html#module-destructors
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
