### PR TITLE
Remove xfail from test_os_exit_exits_within_timeout

### DIFF
--- a/python/tests/stress/arcticdb/version_store/test_deallocation.py
+++ b/python/tests/stress/arcticdb/version_store/test_deallocation.py
@@ -41,7 +41,6 @@ def killed_worker(lib, io_threads, cpu_threads):
 
 @pytest.mark.parametrize("io_threads_spawned_in_child", [True, False])
 @pytest.mark.parametrize("cpu_threads_spawned_in_child", [True, False])
-@pytest.mark.xfail(reason="Intermittent failure 9917390284", strict=False)
 def test_os_exit_exits_within_timeout(
     lmdb_storage, lib_name, io_threads_spawned_in_child, cpu_threads_spawned_in_child
 ):


### PR DESCRIPTION
Removed xfail marker from test_os_exit_exits_within_timeout.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
