### PR TITLE
Fix getting value of `current_col` and `current_row` when they can be `nullopt`

### DIFF
--- a/cpp/arcticdb/pipeline/index_writer.hpp
+++ b/cpp/arcticdb/pipeline/index_writer.hpp
@@ -98,8 +98,8 @@ class IndexWriter {
 
         bool new_col_group = !current_col_.has_value() || *current_col_ < slice.col_range.first;
         bool missing_row_val = !current_row_.has_value();
-        bool is_valid_col = *current_col_ == slice.col_range.first;
-        bool is_valid_row = *current_row_ < slice.row_range.first;
+        bool is_valid_col = new_col_group || *current_col_ == slice.col_range.first;
+        bool is_valid_row = missing_row_val || *current_row_ < slice.row_range.first;
         bool is_valid = (is_valid_col && is_valid_row);
         util::check_arg(
                 missing_row_val || new_col_group || is_valid,


### PR DESCRIPTION
This has not caused actual issues because in release builds getting the value probably gets optimized away if it is missing.

Still this was caught in a debug build of msvc and is worth fixing as it still undefined behavior.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
