### PR TITLE
Enable windows arrow pipeline tests if `pyarrow>=22.0.0`

### DIFF
--- a/python/arcticdb/util/_versions.py
+++ b/python/arcticdb/util/_versions.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 import pandas as pd
 import numpy as np
+from arcticdb.dependencies import pyarrow as pa, _PYARROW_AVAILABLE
 from packaging import version
 
 PANDAS_VERSION = version.parse(pd.__version__)
@@ -15,6 +16,11 @@ CHECK_FREQ_VERSION = version.Version("1.1")
 IS_PANDAS_ZERO = PANDAS_VERSION < version.Version("1.0")
 IS_PANDAS_ONE = PANDAS_VERSION >= version.Version("1.0") and PANDAS_VERSION < version.Version("2.0")
 IS_PANDAS_TWO = PANDAS_VERSION >= version.Version("2.0")
+
 NUMPY_VERSION = version.parse(np.__version__)
 IS_NUMPY_ONE = NUMPY_VERSION >= version.Version("1.0") and NUMPY_VERSION < version.Version("2.0")
 IS_NUMPY_TWO = NUMPY_VERSION >= version.Version("2.0") and NUMPY_VERSION < version.Version("3.0")
+
+PYARROW_VERSION = version.parse(pa.__version__) if _PYARROW_AVAILABLE else None
+# Bug with null processing https://github.com/apache/arrow/issues/47234 is fixed as of 22.0.0
+IS_PYARROW_WINDOWS_NULL_COMPUTE_FIXED = PYARROW_VERSION and PYARROW_VERSION >= version.Version("22.0")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1075,7 +1075,6 @@ def lmdb_version_store_arrow(lmdb_version_store_v1) -> NativeVersionStore:
     return store
 
 
-# TODO: Revert to `params=list(OutputFormat)` once bug https://github.com/apache/arrow/issues/47234 is fixed
 @pytest.fixture(
     params=[OutputFormat.PANDAS, pytest.param(OutputFormat.EXPERIMENTAL_ARROW, marks=PYARROW_POST_PROCESSING)]
 )

--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -15,6 +15,7 @@ from datetime import date
 from numpy import datetime64
 from copy import deepcopy
 
+from arcticdb.util._versions import IS_PYARROW_WINDOWS_NULL_COMPUTE_FIXED
 from arcticdb.util import marks
 from arcticdb.util.logger import get_logger
 
@@ -233,7 +234,8 @@ SSL_TEST_SUPPORTED = sys.platform == "linux"
 FORK_SUPPORTED = pytest.mark.skipif(WINDOWS, reason="Fork not supported on Windows")
 
 PYARROW_POST_PROCESSING = pytest.mark.skipif(
-    WINDOWS, reason="pyarrow 21.0.0 doesn't correctly apply fill_null: https://github.com/apache/arrow/issues/47234"
+    WINDOWS and not IS_PYARROW_WINDOWS_NULL_COMPUTE_FIXED,
+    reason="pyarrow 21.0.0 doesn't correctly apply fill_null: https://github.com/apache/arrow/issues/47234",
 )
 
 ZONE_INFO_MARK = pytest.mark.skipif(sys.version_info < (3, 9), reason="zoneinfo module was introduced in Python 3.9")


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ref: 18231275198

#### What does this implement or fix?
`pyarrow==22.0.0` fixes [issue with null calculations](https://github.com/apache/arrow/issues/47234) on windows.

Now recent python builds `>=3.10` get the latest pyarrow by default. This PR tweaks the skipping to allow windows pipeline tests to run with newer pyarrow on windows.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
