### PR TITLE
[18242404377] Asserts that no truncation happens for sparse columns

### DIFF
--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -880,33 +880,30 @@ std::vector<std::shared_ptr<Column>> Column::split(const std::shared_ptr<Column>
 }
 
 void Column::truncate_first_block(size_t start_row) {
-    if (!is_sparse()) {
-        auto bytes = start_row * data_type_size(type_, OutputFormat::NATIVE, DataTypeMode::INTERNAL);
-        data_.buffer().truncate_first_block(bytes);
-    }
+    util::check(!is_sparse(), "Truncation should only happen for dense columns.");
+    auto bytes = start_row * data_type_size(type_, OutputFormat::NATIVE, DataTypeMode::INTERNAL);
+    data_.buffer().truncate_first_block(bytes);
 }
 
 void Column::truncate_last_block(size_t end_row) {
-    if (!is_sparse()) {
-        const auto column_row_count = row_count();
-        util::check(
-                column_row_count >= static_cast<int64_t>(end_row),
-                "Cannot truncate column of length {} to row {}",
-                column_row_count,
-                end_row
-        );
-        auto bytes = (column_row_count - end_row) * data_type_size(type_, OutputFormat::NATIVE, DataTypeMode::INTERNAL);
-        data_.buffer().truncate_last_block(bytes);
-    }
+    util::check(!is_sparse(), "Truncation should only happen for dense columns.");
+    const auto column_row_count = row_count();
+    util::check(
+            column_row_count >= static_cast<int64_t>(end_row),
+            "Cannot truncate column of length {} to row {}",
+            column_row_count,
+            end_row
+    );
+    auto bytes = (column_row_count - end_row) * data_type_size(type_, OutputFormat::NATIVE, DataTypeMode::INTERNAL);
+    data_.buffer().truncate_last_block(bytes);
 }
 
 void Column::truncate_single_block(size_t start_row, size_t end_row) {
-    if (!is_sparse()) { // TODO: We need to also do truncation on sparse data
-        const auto type_size = data_type_size(type_, OutputFormat::NATIVE, DataTypeMode::INTERNAL);
-        auto start_offset = type_size * start_row;
-        auto end_offset = type_size * end_row;
-        data_.buffer().truncate_single_block(start_offset, end_offset);
-    }
+    util::check(!is_sparse(), "Truncation should only happen for dense columns.");
+    const auto type_size = data_type_size(type_, OutputFormat::NATIVE, DataTypeMode::INTERNAL);
+    auto start_offset = type_size * start_row;
+    auto end_offset = type_size * end_row;
+    data_.buffer().truncate_single_block(start_offset, end_offset);
 }
 
 /// Bytes from the underlying chunked buffer to include when truncating. Inclusive of start_byte, exclusive of end_byte


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ref: 18242404377

#### What does this implement or fix?
Truncation currently happens only on dense columns because both for arrow and pandas the returned buffers are expanded by the time truncation is required.

There is already existing thorough testing in
`test_arrow_read.py::test_arrow_sparse_floats.*` test truncation both with `row_range` and `date_range`.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
