### PR TITLE
Unskip windows sample_dataframe test

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_arrow_read.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_read.py
@@ -194,8 +194,6 @@ def test_strings_multiple_segments_and_columns(lmdb_version_store_tiny_segment, 
     assert_frame_equal_with_arrow(table, df)
 
 
-# TODO: Fix unicode strings on windows
-@pytest.mark.skipif(WINDOWS, reason="Unicode arrow strings fail on windows")
 def test_all_types(lmdb_version_store_arrow):
     lib = lmdb_version_store_arrow
     # sample dataframe contains all dtypes + unicode strings


### PR DESCRIPTION
This test was fixed by some of the previous arrow PRs.
Not clear which one but we also have extra arrow write and read testing with unicode which passes [here](https://github.com/man-group/ArcticDB/blob/58c9e61002f7f7ebd5afb4a2392f3eaec719eadb/python/tests/integration/arcticdb/test_unicode_strings.py#L34-L41).

#### Reference Issues/PRs
Moday ref: 9320473632

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
