### PR TITLE
conda-build: Pin libcurl <8.17

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -33,7 +33,8 @@ dependencies:
   - prometheus-cpp
   - libprotobuf <7
   - openssl
-  - libcurl
+  # TODO: understand failures with libcurl>=8.17
+  - libcurl <8.17
   - bitmagic
   - sparrow-devel==1.3.0
   - spdlog


### PR DESCRIPTION
#### Reference Issues/PRs

`libcurl 8.17` was released yesterday with https://github.com/conda-forge/curl-feedstock/pull/158 and causes failures with ArcticDB.

See https://github.com/man-group/ArcticDB/pull/2645, at [51253af](https://github.com/man-group/ArcticDB/pull/2645/commits/51253af591623c988d91003c079da626039130fc):

<details>

<summary>Test failures</summary>

```
2025-11-05T17:58:12.7801061Z =========================== short test summary info ============================
2025-11-05T17:58:12.7804002Z FAILED tests/integration/arcticdb/test_arctic.py::test_azurite_ssl_verification[ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.NOT_SHOW] - arcticdb_ext.exceptions.StorageException: E_UNEXPECTED_AZURE_ERROR Unexpected Error: AzureError#0 :  Fail to get a new connection for: https://localhost:11584. SSL peer certificate or SSH remote key was not OK. Underlying error: unable to get local issuer certificate for object _arctic_cfg/cref/*sUt*test_azurite_ssl_verification_.19565_140132944204864_2025-11-05T17_40_51__b5d0a13d-ed2b-4f9b-869d-357816be7f66
2025-11-05T17:58:12.7807306Z FAILED tests/integration/arcticdb/test_arctic.py::test_azurite_ssl_verification[ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.DISABLE] - arcticdb_ext.exceptions.StorageException: E_UNEXPECTED_AZURE_ERROR Unexpected Error: AzureError#0 :  Fail to get a new connection for: https://localhost:11584. SSL peer certificate or SSH remote key was not OK. Underlying error: unable to get local issuer certificate for object _arctic_cfg/cref/*sUt*test_azurite_ssl_verification_.19565_140132944204864_2025-11-05T17_41_03__fb041b62-5c8d-4105-b5ae-3377a2323f77
2025-11-05T17:58:12.7812273Z FAILED tests/integration/arcticdb/test_arctic.py::test_s3_verification[gcp_storage-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.NOT_SHOW] - arcticdb_ext.exceptions.StorageException: E_S3_RETRYABLE Retry-able error: Network error: S3Error:99, HttpResponseCode:-1, : curlCode: 60, SSL peer certificate or SSH remote key was not OK; Details: SSL certificate OpenSSL verify result: unable to get local issuer certificate (20) for object '_arctic_cfg/cref/*sUt*test_s3_verification_gcp_stora.19565_140132944204864_2025-11-05T17_42_09__c700b2e9-1753-4fac-a071-588b9d1897cc' This could be due to a connectivity issue or exhausted file descriptors. Having more than one open Arctic instance will use multiple file descriptors, you should reuse Arctic instances. If you need many file descriptors, consider increasing `ulimit -n`.
2025-11-05T17:58:14.3770435Z 2025-11-05 17:06:53,194 - tests.util.mark - INFO - ------------------------------------------------------------------------------------------------------------------------
2025-11-05T17:58:14.3772045Z INFO:tests.util.mark:------------------------------------------------------------------------------------------------------------------------
2025-11-05T17:58:14.3773253Z 2025-11-05 17:06:53,195 - tests.util.mark - INFO -   ARCTICDB ENVIRONMENT VARIABLES:
2025-11-05T17:58:14.3774148Z INFO:tests.util.mark:  ARCTICDB ENVIRONMENT VARIABLES:
2025-11-05T17:58:14.3775427Z 2025-11-05 17:06:53,195 - tests.util.mark - INFO - ARCTICDB_REAL_S3_BUCKET=arcticdb-ci-test-bucket-02
2025-11-05T17:58:14.3777016Z INFO:tests.util.mark:ARCTICDB_REAL_S3_BUCKET=arcticdb-ci-test-bucket-02
2025-11-05T17:58:14.3778719Z 2025-11-05 17:06:53,195 - tests.util.mark - INFO - ARCTICDB_REAL_S3_STS_TEST_POLICY_NAME=gh_sts_test_policy_name_861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3780022Z INFO:tests.util.mark:ARCTICDB_REAL_S3_STS_TEST_POLICY_NAME=gh_sts_test_policy_name_861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3781011Z 2025-11-05 17:06:53,195 - tests.util.mark - INFO - ARCTICDB_REAL_S3_STS_PREFIX=gh_sts_test
2025-11-05T17:58:14.3781751Z INFO:tests.util.mark:ARCTICDB_REAL_S3_STS_PREFIX=gh_sts_test
2025-11-05T17:58:14.3782893Z 2025-11-05 17:06:53,195 - tests.util.mark - INFO - ARCTICDB_PERSISTENT_STORAGE_UNIQUE_ID=2645/merge_19102909716
2025-11-05T17:58:14.3783828Z INFO:tests.util.mark:ARCTICDB_PERSISTENT_STORAGE_UNIQUE_ID=2645/merge_19102909716
2025-11-05T17:58:14.3784662Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_REAL_GCP_SECRET_KEY=***
2025-11-05T17:58:14.3785330Z INFO:tests.util.mark:ARCTICDB_REAL_GCP_SECRET_KEY=***
2025-11-05T17:58:14.3786030Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_REAL_S3_SECRET_KEY=***
2025-11-05T17:58:14.3786683Z INFO:tests.util.mark:ARCTICDB_REAL_S3_SECRET_KEY=***
2025-11-05T17:58:14.3787550Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_REAL_S3_ENDPOINT=https://s3.eu-west-1.amazonaws.com
2025-11-05T17:58:14.3788623Z INFO:tests.util.mark:ARCTICDB_REAL_S3_ENDPOINT=https://s3.eu-west-1.amazonaws.com
2025-11-05T17:58:14.3789830Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX=ci_tests/2645/merge_19102909716
2025-11-05T17:58:14.3790967Z INFO:tests.util.mark:ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX=ci_tests/2645/merge_19102909716
2025-11-05T17:58:14.3792061Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_REAL_AZURE_CONTAINER=githubblob
2025-11-05T17:58:14.3792818Z INFO:tests.util.mark:ARCTICDB_REAL_AZURE_CONTAINER=githubblob
2025-11-05T17:58:14.3793832Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_REAL_S3_STS_TEST_USERNAME=gh_sts_test_user_861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3794947Z INFO:tests.util.mark:ARCTICDB_REAL_S3_STS_TEST_USERNAME=gh_sts_test_user_861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3795808Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_PYTEST_ARGS=
2025-11-05T17:58:14.3796388Z INFO:tests.util.mark:ARCTICDB_PYTEST_ARGS=
2025-11-05T17:58:14.3796918Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
2025-11-05T17:58:14.3797462Z INFO:tests.util.mark:ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
2025-11-05T17:58:14.3798277Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_PERSISTENT_STORAGE_STRATEGY_BRANCH=ignore
2025-11-05T17:58:14.3798901Z INFO:tests.util.mark:ARCTICDB_PERSISTENT_STORAGE_STRATEGY_BRANCH=ignore
2025-11-05T17:58:14.3799496Z 2025-11-05 17:06:53,196 - tests.util.mark - INFO - ARCTICDB_REAL_AZURE_CONNECTION_STRING=***
2025-11-05T17:58:14.3800025Z INFO:tests.util.mark:ARCTICDB_REAL_AZURE_CONNECTION_STRING=***
2025-11-05T17:58:14.3800716Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX=861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3801464Z INFO:tests.util.mark:ARCTICDB_REAL_S3_STS_TEST_CREDENTIALS_POSTFIX=861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3802052Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_GCP_CLEAR=1
2025-11-05T17:58:14.3802478Z INFO:tests.util.mark:ARCTICDB_REAL_GCP_CLEAR=1
2025-11-05T17:58:14.3802948Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_GCP_ACCESS_KEY=***
2025-11-05T17:58:14.3803420Z INFO:tests.util.mark:ARCTICDB_REAL_GCP_ACCESS_KEY=***
2025-11-05T17:58:14.3803883Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_RAND_SEED=14011
2025-11-05T17:58:14.3804293Z INFO:tests.util.mark:ARCTICDB_RAND_SEED=14011
2025-11-05T17:58:14.3804719Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_USING_CONDA=1
2025-11-05T17:58:14.3805111Z INFO:tests.util.mark:ARCTICDB_USING_CONDA=1
2025-11-05T17:58:14.3805582Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_S3_ACCESS_KEY=***
2025-11-05T17:58:14.3806042Z INFO:tests.util.mark:ARCTICDB_REAL_S3_ACCESS_KEY=***
2025-11-05T17:58:14.3806499Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_S3_CLEAR=1
2025-11-05T17:58:14.3806905Z INFO:tests.util.mark:ARCTICDB_REAL_S3_CLEAR=1
2025-11-05T17:58:14.3807372Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_S3_REGION=eu-west-1
2025-11-05T17:58:14.3807835Z INFO:tests.util.mark:ARCTICDB_REAL_S3_REGION=eu-west-1
2025-11-05T17:58:14.3808845Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_S3_STS_TEST_ROLE=gh_sts_test_role_861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3809583Z INFO:tests.util.mark:ARCTICDB_REAL_S3_STS_TEST_ROLE=gh_sts_test_role_861_2025-11-05T17_06_50_586891
2025-11-05T17:58:14.3810223Z 2025-11-05 17:06:53,197 - tests.util.mark - INFO - ARCTICDB_REAL_GCP_BUCKET=arcticdb-github
2025-11-05T17:58:14.3810738Z INFO:tests.util.mark:ARCTICDB_REAL_GCP_BUCKET=arcticdb-github
2025-11-05T17:58:14.3811460Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX=ci_tests/2645/merge_19102909716_ignore
2025-11-05T17:58:14.3812279Z INFO:tests.util.mark:ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX=ci_tests/2645/merge_19102909716_ignore
2025-11-05T17:58:14.3813032Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - ARCTICDB_REAL_GCP_ENDPOINT=https://storage.googleapis.com
2025-11-05T17:58:14.3813777Z INFO:tests.util.mark:ARCTICDB_REAL_GCP_ENDPOINT=https://storage.googleapis.com
2025-11-05T17:58:14.3814587Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - ------------------------------------------------------------------------------------------------------------------------
2025-11-05T17:58:14.3815458Z INFO:tests.util.mark:------------------------------------------------------------------------------------------------------------------------
2025-11-05T17:58:14.3816038Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO -   STORAGE STATUS:
2025-11-05T17:58:14.3816416Z INFO:tests.util.mark:  STORAGE STATUS:
2025-11-05T17:58:14.3816884Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - RUNS_ON_GITHUB                   =True
2025-11-05T17:58:14.3817364Z INFO:tests.util.mark:RUNS_ON_GITHUB                   =True
2025-11-05T17:58:14.3817878Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - LOCAL_STORAGE_TESTS_ENABLED      =True
2025-11-05T17:58:14.3818599Z INFO:tests.util.mark:LOCAL_STORAGE_TESTS_ENABLED      =True
2025-11-05T17:58:14.3819194Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - STORAGE_LMDB                     =True
2025-11-05T17:58:14.3819670Z INFO:tests.util.mark:STORAGE_LMDB                     =True
2025-11-05T17:58:14.3820168Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - STORAGE_MEM                      =True
2025-11-05T17:58:14.3820632Z INFO:tests.util.mark:STORAGE_MEM                      =True
2025-11-05T17:58:14.3821132Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - STORAGE_S3  (SIMULATED)          =True
2025-11-05T17:58:14.3821599Z INFO:tests.util.mark:STORAGE_S3  (SIMULATED)          =True
2025-11-05T17:58:14.3822103Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - STORAGE_GCP (SIMULATED)          =True
2025-11-05T17:58:14.3822579Z INFO:tests.util.mark:STORAGE_GCP (SIMULATED)          =True
2025-11-05T17:58:14.3823082Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - STORAGE_AZURITE                  =True
2025-11-05T17:58:14.3823550Z INFO:tests.util.mark:STORAGE_AZURITE                  =True
2025-11-05T17:58:14.3824051Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - STORAGE_NFS                      =True
2025-11-05T17:58:14.3824520Z INFO:tests.util.mark:STORAGE_NFS                      =True
2025-11-05T17:58:14.3825035Z 2025-11-05 17:06:53,198 - tests.util.mark - INFO - STORAGE_MONGO                    =True
2025-11-05T17:58:14.3825505Z INFO:tests.util.mark:STORAGE_MONGO                    =True
2025-11-05T17:58:14.3826026Z 2025-11-05 17:06:53,199 - tests.util.mark - INFO - PERSISTENT_STORAGE_TESTS_ENABLED =False
2025-11-05T17:58:14.3826531Z INFO:tests.util.mark:PERSISTENT_STORAGE_TESTS_ENABLED =False
2025-11-05T17:58:14.3827050Z 2025-11-05 17:06:53,199 - tests.util.mark - INFO - STORAGE_AWS_S3                   =False
2025-11-05T17:58:14.3827521Z INFO:tests.util.mark:STORAGE_AWS_S3                   =False
2025-11-05T17:58:14.3828230Z 2025-11-05 17:06:53,199 - tests.util.mark - INFO - STORAGE_GCP                      =False
2025-11-05T17:58:14.3829000Z INFO:tests.util.mark:STORAGE_GCP                      =False
2025-11-05T17:58:14.3829640Z 2025-11-05 17:06:53,199 - tests.util.mark - INFO - STORAGE_AZURE                    =False
2025-11-05T17:58:14.3830118Z INFO:tests.util.mark:STORAGE_AZURE                    =False
2025-11-05T17:58:14.3830637Z 2025-11-05 17:06:53,199 - tests.util.mark - INFO - Enc.V1                           =True
2025-11-05T17:58:14.3831113Z INFO:tests.util.mark:Enc.V1                           =True
2025-11-05T17:58:14.3831612Z 2025-11-05 17:06:53,199 - tests.util.mark - INFO - Enc.V2                           =True
2025-11-05T17:58:14.3832069Z INFO:tests.util.mark:Enc.V2                           =True
2025-11-05T17:58:14.3832765Z 2025-11-05 17:06:53,199 - tests.util.mark - INFO - ------------------------------------------------------------------------------------------------------------------------
2025-11-05T17:58:14.3833557Z INFO:tests.util.mark:------------------------------------------------------------------------------------------------------------------------
2025-11-05T17:58:14.3837649Z FAILED tests/integration/arcticdb/test_arctic.py::test_s3_verification[gcp_storage-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.DISABLE] - arcticdb_ext.exceptions.StorageException: E_S3_RETRYABLE Retry-able error: Network error: S3Error:99, HttpResponseCode:-1, : curlCode: 60, SSL peer certificate or SSH remote key was not OK; Details: SSL certificate OpenSSL verify result: unable to get local issuer certificate (20) for object '_arctic_cfg/cref/*sUt*test_s3_verification_gcp_stora.19565_140132944204864_2025-11-05T17_43_00__a6389c48-c553-45c7-b06d-5e7504fbb65a' This could be due to a connectivity issue or exhausted file descriptors. Having more than one open Arctic instance will use multiple file descriptors, you should reuse Arctic instances. If you need many file descriptors, consider increasing `ulimit -n`.
2025-11-05T17:58:14.3844121Z FAILED tests/integration/arcticdb/test_arctic.py::test_s3_verification[s3_storage-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.NOT_SHOW] - arcticdb_ext.exceptions.StorageException: E_S3_RETRYABLE Retry-able error: Network error: S3Error:99, HttpResponseCode:-1, : curlCode: 60, SSL peer certificate or SSH remote key was not OK; Details: SSL certificate OpenSSL verify result: unable to get local issuer certificate (20) for object '_arctic_cfg/cref/*sUt*test_s3_verification_s3_storag.19574_140255904371776_2025-11-05T17_47_28__1a364051-f6cd-433e-aeba-047b64d8f127' This could be due to a connectivity issue or exhausted file descriptors. Having more than one open Arctic instance will use multiple file descriptors, you should reuse Arctic instances. If you need many file descriptors, consider increasing `ulimit -n`.
2025-11-05T17:58:14.3850629Z FAILED tests/integration/arcticdb/test_arctic.py::test_s3_verification[s3_storage-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.ENABLE-ParameterDisplayStatus.DISABLE] - arcticdb_ext.exceptions.StorageException: E_S3_RETRYABLE Retry-able error: Network error: S3Error:99, HttpResponseCode:-1, : curlCode: 60, SSL peer certificate or SSH remote key was not OK; Details: SSL certificate OpenSSL verify result: unable to get local issuer certificate (20) for object '_arctic_cfg/cref/*sUt*test_s3_verification_s3_storag.19574_140255904371776_2025-11-05T17_48_20__d688092d-ca52-4da2-a15c-eb0bff117d37' This could be due to a connectivity issue or exhausted file descriptors. Having more than one open Arctic instance will use multiple file descriptors, you should reuse Arctic instances. If you need many file descriptors, consider increasing `ulimit -n`.
2025-11-05T17:58:14.3853697Z = 6 failed, 16005 passed, 3250 skipped, 45 xfailed, 6 xpassed, 169176 warnings in 3079.41s (0:51:19) =
```

</detail>

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [x] Are API changes highlighted in the PR description?
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>