### PR TITLE
Fix for cc (Ubuntu 11.4.0-1ubuntu1~22.04.2) compilation

### DIFF
--- a/cpp/arcticdb/entity/test/test_atom_key.cpp
+++ b/cpp/arcticdb/entity/test/test_atom_key.cpp
@@ -95,7 +95,8 @@ TEST(Key, Library) {
     using namespace arcticdb::storage;
 
     LibraryPath lib{"a", "b"};
-    LibraryPath lib2(std::views::all(std::vector<std::string>{"a", "b"}));
+    std::vector<std::string> parts{"a", "b"};
+    LibraryPath lib2(std::views::all(parts));
 
     ASSERT_EQ(lib.hash(), lib2.hash());
     ASSERT_EQ(lib, lib2);


### PR DESCRIPTION
Fix for the build machine running cc (Ubuntu 11.4.0-1ubuntu1~22.04.2), which enforces to have L value for the `std::views::all`

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
