### PR TITLE
Performance 10588043604: Decode only required columns in processing pipeline with dynamic schema

### DIFF
--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -49,6 +49,7 @@ pipelines::SegmentAndSlice DecodeSliceTask::decode_into_slice(storage::KeySegmen
     ARCTICDB_TRACE(log::codec(), "Creating segment");
     SegmentInMemory segment_in_memory(std::move(descriptor));
     decode_into_memory_segment(seg, hdr, segment_in_memory, desc);
+    segment_in_memory.set_row_data(std::max(segment_in_memory.row_count() - 1, ranges_and_key_.row_range().diff() - 1));
     return pipelines::SegmentAndSlice(std::move(ranges_and_key_), std::move(segment_in_memory));
 }
 } // namespace arcticdb::async

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -264,10 +264,9 @@ void build_col_read_query_filters(
         };
         queries.push_back(std::move(query));
     } else if (pipeline_context->overall_column_bitset_) {
-        util::check(!dynamic_schema || column_groups, "Did not expect a column bitset with dynamic schema");
         if (column_groups)
             queries.emplace_back(create_dynamic_col_filter(std::move(pipeline_context)));
-        else
+        else if (!dynamic_schema)
             queries.emplace_back(create_static_col_filter(std::move(pipeline_context)));
     }
 }

--- a/cpp/arcticdb/pipeline/read_pipeline.hpp
+++ b/cpp/arcticdb/pipeline/read_pipeline.hpp
@@ -156,9 +156,7 @@ std::vector<FilterQuery<ContainerType>> get_column_bitset_and_query_functions(
         bool column_groups
 ) {
     using namespace arcticdb::pipelines::index;
-    if (!dynamic_schema || column_groups) {
-        get_column_bitset_in_context(query, pipeline_context);
-    }
+    get_column_bitset_in_context(query, pipeline_context);
     return build_read_query_filters<ContainerType>(pipeline_context, query.row_filter, dynamic_schema, column_groups);
 }
 


### PR DESCRIPTION
#### Reference Issues/PRs
[10588043604](https://man312219.monday.com/boards/7852509418/pulses/10588043604)

#### What does this implement or fix?
`PipelineContext::overall_column_bitset_` is used to construct a hash set of columns that are to be decoded in the processing pipeline path.
Prior to this change, this bitset was only populated for static schema and (unsupported) bucketize dynamic schema data. This resulted in all columns being decoded with dynamic schema, which becomes a performance bottleneck with very wide dataframes where only a few columns are required for the processing and output.

Test coverage already fairly comprehensive in `test_basic_version_store.py::test_dynamic_schema_read_columns`, and `read_index` behaviour in `test_read_index.py`.