### PR TITLE
[18340938761] Correctly normalize arcticc tick streaming data for arrow

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -823,9 +823,9 @@ class ArrowTableNormalizer(Normalizer):
         index_type = pandas_meta.WhichOneof("index_type")
         if index_type == "index":
             index_meta = pandas_meta.index
-            # Empty tables don't have `is_physically_stored=True` but we still output them with an empty DateTimeIndex.
-            is_empty_table_with_datetime_index = len(item) == 0 and not index_meta.step
-            if index_meta.is_physically_stored or is_empty_table_with_datetime_index:
+            # Old arcticc tick streaming data does not populate `is_physically_stored` field and considers an index
+            # physically stored if `step==0`
+            if index_meta.is_physically_stored or not index_meta.step:
                 if index_meta.tz and len(item.columns) > 0 and pa.types.is_timestamp(item.columns[0].type):
                     # We apply timezone metadata only when the first column is a timestamp column.
                     # This matches the behavior and is required to handle `groupby`s which can change index type.


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ref: 18340938761

#### What does this implement or fix?
arcticc tick streaming data doesn't correctly set `is_physically_stored` instead it relies on missing `step` to detect whether the index is physically stored.

This PR changes the arrow normalization so it can correctly read old arcticc streaming data.

It also adds more parametrization on existing compatibility tests. They don't showcase the problematic behavior because the behavior in arcticc predates the earliest arcticdb version but is still useful to test we don't regress reading older normalization formats with arrow as well.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
