### PR TITLE
Suppress mongo endSession warning

### DIFF
--- a/cpp/arcticdb/storage/mongo/mongo_instance.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_instance.hpp
@@ -25,12 +25,11 @@ class logger final : public mongocxx::logger {
         // These are harmless intermittent warnings that occur during interpreter exits. The issue persists even when
         // the resource cleanup order follows the driver's manual. Thus it is suppressed.
         // https://jira.mongodb.org/browse/CXX-3379
-        if (level == mongocxx::log_level::k_warning && 
-            domain == "client" &&
+        if (level == mongocxx::log_level::k_warning && domain == "client" &&
             message.find("Couldn't send \"endSessions\"") != bsoncxx::stdx::string_view::npos) {
             level = mongocxx::log_level::k_debug;
         }
-        
+
         spdlog::level::level_enum spdlog_level;
         switch (level) {
         case mongocxx::log_level::k_error:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
#### What does this implement or fix?
Mongodb C++ driver logs endSession warning while exiting interpreter intermittently. The issue happens while the mongodb connection pool is deconstructing. It looks harmless as arcticdb hadn't logged mongodb log until recently. 
I manage to repeat the issue with a standalone C++ file and the issue is submitted upstream: https://jira.mongodb.org/browse/CXX-3379
Therefore the warning is suppressed for now.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
