### PR TITLE
Enhancement 18352299908: Allow configuring multiindex string column Arrow return format

### DIFF
--- a/cpp/arcticdb/stream/index.cpp
+++ b/cpp/arcticdb/stream/index.cpp
@@ -242,4 +242,9 @@ template class BaseIndex<EmptyIndex>;
 
 std::string mangled_name(std::string_view name) { return fmt::format("__idx__{}", name); }
 
+std::optional<std::string_view> demangled_name(std::string_view name) {
+    const std::string prefix{"__idx__"};
+    return name.starts_with(prefix) ? name.substr(prefix.size()) : std::optional<std::string_view>();
+}
+
 } // namespace arcticdb::stream

--- a/cpp/arcticdb/stream/index.hpp
+++ b/cpp/arcticdb/stream/index.hpp
@@ -171,6 +171,7 @@ class EmptyIndex : public BaseIndex<EmptyIndex> {
 using Index = std::variant<stream::TimeseriesIndex, stream::RowCountIndex, stream::TableIndex, stream::EmptyIndex>;
 
 std::string mangled_name(std::string_view name);
+std::optional<std::string_view> demangled_name(std::string_view name);
 
 Index index_type_from_descriptor(const StreamDescriptor& desc);
 Index default_index_type_from_descriptor(const IndexDescriptorImpl& desc);

--- a/python/tests/unit/arcticdb/version_store/test_arrow_read.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_read.py
@@ -185,7 +185,6 @@ def test_strings_with_nones_and_nans(lmdb_version_store_tiny_segment, row_range,
     assert_frame_equal_with_arrow(table, expected)
 
 
-@pytest.mark.skip(reason="Monday ref: 18352299908")
 def test_strings_in_multi_index(lmdb_version_store_arrow, any_arrow_string_format):
     lib = lmdb_version_store_arrow
     df = pd.DataFrame(
@@ -213,6 +212,18 @@ def test_strings_in_multi_index(lmdb_version_store_arrow, any_arrow_string_forma
     assert table.field("index2").type == expected_type
     assert table.field("x").type == expected_type
     assert_frame_equal_with_arrow(table, df)
+
+
+@pytest.mark.xfail(reason="Monday issue 10679807500")
+def test_explicit_string_format__idx__prefix(lmdb_version_store_arrow):
+    lib = lmdb_version_store_arrow
+    sym = "test_explicit_string_format__idx__prefix"
+    df = pd.DataFrame({"__idx__blah": ["hello"], "blah": ["goodbye"]})
+    lib.write(sym, df)
+    arrow_string_format_per_column = {"blah": ArrowOutputStringFormat.SMALL_STRING}
+    table = lib.read(sym, arrow_string_format_per_column=arrow_string_format_per_column).data
+    assert table.field("blah").type == pa.string()
+    assert table.field("__idx__blah").type == pa.large_string()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
[18352299908](https://man312219.monday.com/boards/7852509418/pulses/18352299908)

#### What does this implement or fix?
The Arrow string return type for named multiindex levels can now be set with the `arrow_string_format_per_column` override.

There is an edge case explained in the comment in `arrow_handlers.cpp` where a column the user has explicitly named `__idx__blah` can get the wrong output format if there is also a column called `blah` with an override return type set, but this is much more painful to fix and seems unlikely to occur in practice. [Ticket](https://man312219.monday.com/boards/7852509418/pulses/10679807500) opened for tracking purposes just in case.