### PR TITLE
Enhancement 10753358032: Log string pool decode timings in release builds

### DIFF
--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -366,6 +366,8 @@ void decode_string_pool(
 ) {
     if (hdr.has_string_pool_field()) {
         ARCTICDB_TRACE(log::codec(), "Decoding string pool");
+        interval timer;
+        timer.start();
         util::check(data != end, "Reached end of input block with string pool fields to decode");
         std::optional<util::BitMagic> bv;
         data += decode_ndarray(
@@ -376,8 +378,8 @@ void decode_string_pool(
                 bv,
                 hdr.encoding_version()
         );
-
-        ARCTICDB_TRACE(log::codec(), "Decoded string pool to position {}", data - begin);
+        timer.end();
+        log::codec().debug("Decoded string pool to position {} in {}s", data - begin, timer.get_results_total());
     }
 }
 


### PR DESCRIPTION
#### Reference Issues/PRs
[10753358032](https://man312219.monday.com/boards/7852509418/pulses/10753358032)

#### What does this implement or fix?
Log how long it took to decode the string pool if the codec log level is at least debug