### PR TITLE
Add script to analyze how long our ASV benchmarks take to run.

### DIFF
--- a/.run/analyze ASV results.run.xml
+++ b/.run/analyze ASV results.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="analyze ASV results" type="PythonConfigurationType" factoryName="Python">
+    <module name="project" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/build_tooling" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="RUN_TOOL" value="" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/build_tooling/transform_asv_results.py" />
+    <option name="PARAMETERS" value="--mode=analyze --arcticdb_client_override=&quot;s3://s3.eu-west-1.amazonaws.com:arcticdb-ci-benchmark-results?aws_auth=true&amp;path_prefix=asv_results&quot; --hash=abaaa08b" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
Example output:

```
/home/alex/venvs/adb/bin/python /code/arcticdb.git/project/build_tooling/transform_asv_results.py --mode=analyze --arcticdb_client_override=s3://s3.eu-west-1.amazonaws.com:arcticdb-ci-benchmark-results?aws_auth=true&path_prefix=asv_results --hash=abaaa08b
Time spent outside of benchmarks (excluding build):

                                             Step  Duration (s)
25                 <setup_cache version_chain:42>    585.851281
9                  <setup_cache list_versions:44>    418.163515
18   <setup_cache real_modification_functions:73>    192.683119
4          <setup_cache comparison_benchmarks:44>    133.676543
12    <setup_cache real_comparison_benchmarks:76>     91.077791
16  <setup_cache real_modification_functions:215>     50.894361
7                 <setup_cache list_snapshots:46>     40.629586
2               <setup_cache basic_functions:182>     34.551478
3               <setup_cache basic_functions:341>     29.068089
8                   <setup_cache list_symbols:29>     23.854835
5           <setup_cache finalize_staged_data:47>     19.000038
0                  <setup_cache bi_benchmarks:68>     11.555371
1                <setup_cache basic_functions:49>      8.773198
10           <setup_cache local_query_builder:33>      8.492626
23          <setup_cache recursive_normalizer:47>      6.110230
24                     <setup_cache resample:134>      4.986128
22              <setup_cache real_read_write:212>      4.189118
17  <setup_cache real_modification_functions:261>      3.848478
15         <setup_cache real_list_operations:138>      3.393059
11          <setup_cache real_batch_functions:59>      3.201688
20               <setup_cache real_read_write:87>      3.191894
19            <setup_cache real_query_builder:76>      3.191312
13     <setup_cache real_finalize_staged_data:42>      3.188584
21              <setup_cache real_read_write:243>      3.177817
14          <setup_cache real_list_operations:58>      3.157586
6          <setup_cache finalize_staged_data:100>      0.980301

Time spent in benchmarks:

                                                                                        test_name  Duration (s)
65                                                  list_versions.ListVersions.time_list_versions    291.060000
94                      real_finalize_staged_data.AWSFinalizeStagedData.time_finalize_staged_data    272.440000
93                   real_finalize_staged_data.AWSFinalizeStagedData.peakmem_finalize_staged_data    270.840000
88                                   real_batch_functions.AWSBatchBasicFunctions.time_write_batch    221.730000
81                                 real_batch_functions.AWSBatchBasicFunctions.peakmem_read_batch    147.800000
30                                          basic_functions.BatchBasicFunctions.time_update_batch    145.370000
31                                           basic_functions.BatchBasicFunctions.time_write_batch    143.530000
85                                    real_batch_functions.AWSBatchBasicFunctions.time_read_batch    143.220000
84                                real_batch_functions.AWSBatchBasicFunctions.peakmem_write_batch    135.190000
86                       real_batch_functions.AWSBatchBasicFunctions.time_read_batch_with_columns    128.630000
82                    real_batch_functions.AWSBatchBasicFunctions.peakmem_read_batch_with_columns    125.390000
87                   real_batch_functions.AWSBatchBasicFunctions.time_read_batch_with_date_ranges    124.610000
83                real_batch_functions.AWSBatchBasicFunctions.peakmem_read_batch_with_date_ranges    115.870000
180                                version_chain.IterateVersionChain.time_list_undeleted_versions    112.620000
115                      real_modification_functions.AWSDeleteTestsFewLarge.time_delete_over_time    111.700000
181                                      version_chain.IterateVersionChain.time_load_all_versions    107.230000
40                                   basic_functions.ModificationFunctions.time_update_short_wide     80.245000
33                                   basic_functions.ModificationFunctions.time_append_short_wide     79.857000
92           real_comparison_benchmarks.RealComparisonBenchmarks.time_create_then_write_dataframe     65.084000
182                                       version_chain.IterateVersionChain.time_read_alternating     58.036000
183                                        version_chain.IterateVersionChain.time_read_from_epoch     57.641000
184                                                version_chain.IterateVersionChain.time_read_v0     55.715000
89        real_comparison_benchmarks.RealComparisonBenchmarks.peakmem_create_then_write_dataframe     52.311000
159                                  real_read_write.AWSReadWriteWithQueryStats.time_write_staged     51.610000
147                                                real_read_write.AWSReadWrite.time_write_staged     51.572000
90                     real_comparison_benchmarks.RealComparisonBenchmarks.peakmem_read_dataframe     49.906000
20                                           basic_functions.BasicFunctions.time_write_short_wide     48.876000
25                                        basic_functions.BatchBasicFunctions.peakmem_write_batch     47.924000
91                    real_comparison_benchmarks.RealComparisonBenchmarks.peakmem_write_dataframe     47.278000
14                                            basic_functions.BasicFunctions.time_read_short_wide     45.279000
38                                   basic_functions.ModificationFunctions.time_delete_short_wide     44.919000
15                                      basic_functions.BasicFunctions.time_read_ultra_short_wide     44.252000
32                                        basic_functions.ModificationFunctions.time_append_large     43.218000
141                                             real_read_write.AWSReadWrite.peakmem_write_staged     40.932000
153                               real_read_write.AWSReadWriteWithQueryStats.peakmem_write_staged     40.848000
3                                                   bi_benchmarks.BIBenchmarks.time_query_readall     40.809000
158                                         real_read_write.AWSReadWriteWithQueryStats.time_write     39.828000
146                                                       real_read_write.AWSReadWrite.time_write     38.289000
154                                          real_read_write.AWSReadWriteWithQueryStats.time_read     36.425000
142                                                        real_read_write.AWSReadWrite.time_read     36.359000
144                                 real_read_write.AWSReadWrite.time_read_with_columns_all_types     36.318000
140                                                    real_read_write.AWSReadWrite.peakmem_write     36.284000
152                                      real_read_write.AWSReadWriteWithQueryStats.peakmem_write     36.246000
157     real_read_write.AWSReadWriteWithQueryStats.time_read_with_date_ranges_last20_percent_rows     36.201000
145                   real_read_write.AWSReadWrite.time_read_with_date_ranges_last20_percent_rows     36.145000
156                   real_read_write.AWSReadWriteWithQueryStats.time_read_with_columns_all_types     35.943000
136                                                     real_read_write.AWSReadWrite.peakmem_read     35.618000
155                        real_read_write.AWSReadWriteWithQueryStats.time_read_with_column_float     35.438000
148                                       real_read_write.AWSReadWriteWithQueryStats.peakmem_read     35.271000
139                real_read_write.AWSReadWrite.peakmem_read_with_date_ranges_last20_percent_rows     35.264000
143                                      real_read_write.AWSReadWrite.time_read_with_column_float     35.229000
138                              real_read_write.AWSReadWrite.peakmem_read_with_columns_all_types     35.181000
150                real_read_write.AWSReadWriteWithQueryStats.peakmem_read_with_columns_all_types     35.104000
151  real_read_write.AWSReadWriteWithQueryStats.peakmem_read_with_date_ranges_last20_percent_rows     34.969000
149                     real_read_write.AWSReadWriteWithQueryStats.peakmem_read_with_column_float     34.940000
137                                   real_read_write.AWSReadWrite.peakmem_read_with_column_float     34.696000
21                                               basic_functions.BasicFunctions.time_write_staged     34.338000
37                                    basic_functions.ModificationFunctions.time_delete_over_time     33.129000
101                                    real_list_operations.AWSVersionSymbols.time_list_snapshots     26.859000
19                                                      basic_functions.BasicFunctions.time_write     26.436000
42                                       basic_functions.ModificationFunctions.time_update_upsert     23.613000
39                                         basic_functions.ModificationFunctions.time_update_half     23.413000
41                                       basic_functions.ModificationFunctions.time_update_single     23.088000
34                                       basic_functions.ModificationFunctions.time_append_single     22.928000
36                            basic_functions.ModificationFunctions.time_delete_multiple_versions     22.925000
35                                              basic_functions.ModificationFunctions.time_delete     22.817000
53                              finalize_staged_data.FinalizeStagedData.time_finalize_staged_data     21.817000
77                                    local_query_builder.LocalQueryBuilderFunctions.time_query_1     21.702000
97                                          real_list_operations.AWSListSymbols.time_list_symbols     21.404000
114                                real_modification_functions.AWSDeleteTestsFewLarge.time_delete     20.859000
179                                                      resample.ResampleWide.time_resample_wide     20.469000
64                                               list_versions.ListVersions.peakmem_list_versions     18.056000
121                            real_modification_functions.AWSLargeAppendTests.time_update_upsert     17.228000
119                              real_modification_functions.AWSLargeAppendTests.time_update_half     17.198000
98                                  real_list_operations.AWSVersionSymbols.peakmem_list_snapshots     16.684000
171                                       real_read_write.AWSWideDataFrameTests.time_write_staged     16.446000
116                             real_modification_functions.AWSLargeAppendTests.time_append_large     16.213000
113               real_modification_functions.AWS30kColsWideDFLargeAppendTests.time_update_upsert     16.135000
118                              real_modification_functions.AWSLargeAppendTests.time_update_full     16.130000
108                real_modification_functions.AWS30kColsWideDFLargeAppendTests.time_append_large     15.722000
110                 real_modification_functions.AWS30kColsWideDFLargeAppendTests.time_update_full     15.289000
18                        basic_functions.BasicFunctions.time_read_with_date_ranges_query_builder     15.257000
16                                          basic_functions.BasicFunctions.time_read_with_columns     15.185000
17                                      basic_functions.BasicFunctions.time_read_with_date_ranges     15.184000
13                                                       basic_functions.BasicFunctions.time_read     15.162000
49                      comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_parquet     15.024000
111                 real_modification_functions.AWS30kColsWideDFLargeAppendTests.time_update_half     14.967000
120                            real_modification_functions.AWSLargeAppendTests.time_update_single     14.639000
112               real_modification_functions.AWS30kColsWideDFLargeAppendTests.time_update_single     14.349000
109               real_modification_functions.AWS30kColsWideDFLargeAppendTests.time_append_single     14.010000
96                                real_list_operations.AWSListSymbols.time_has_symbol_nonexisting     13.672000
117                            real_modification_functions.AWSLargeAppendTests.time_append_single     13.539000
59               list_snapshots.SnaphotFunctions.time_snapshots_with_metadata_list_with_load_meta     13.466000
51                     comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_parquet     12.066000
11                                        basic_functions.BasicFunctions.peakmem_write_short_wide     11.429000
48                       comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_arctic     11.229000
47                            comparison_benchmarks.ComparisonBenchmarks.peakmem_create_dataframe     11.071000
169          real_read_write.AWSWideDataFrameTests.time_read_with_date_ranges_last20_percent_rows     10.492000
166                                               real_read_write.AWSWideDataFrameTests.time_read     10.451000
50                      comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_arctic     10.354000
75               local_query_builder.LocalQueryBuilderFunctions.time_filtering_string_regex_match     10.337000
95                                       real_list_operations.AWSListSymbols.peakmem_list_symbols      9.742100
165                                    real_read_write.AWSWideDataFrameTests.peakmem_write_staged      9.663800
74                      local_query_builder.LocalQueryBuilderFunctions.time_filtering_string_isin      9.530400
170                                              real_read_write.AWSWideDataFrameTests.time_write      8.846900
160                                            real_read_write.AWSWideDataFrameTests.peakmem_read      8.766200
80                          local_query_builder.LocalQueryBuilderFunctions.time_query_adv_query_2      7.986400
132                                      real_query_builder.AWSQueryBuilderFunctions.time_query_1      7.780600
163       real_read_write.AWSWideDataFrameTests.peakmem_read_with_date_ranges_last20_percent_rows      7.492200
103                                     real_list_operations.AWSVersionSymbols.time_list_versions      7.362100
78                                    local_query_builder.LocalQueryBuilderFunctions.time_query_3      7.228000
164                                           real_read_write.AWSWideDataFrameTests.peakmem_write      6.918300
130                        real_query_builder.AWSQueryBuilderFunctions.time_filtering_string_isin      6.596300
135                            real_query_builder.AWSQueryBuilderFunctions.time_query_adv_query_2      6.524200
133                                      real_query_builder.AWSQueryBuilderFunctions.time_query_3      6.485300
134                                      real_query_builder.AWSQueryBuilderFunctions.time_query_4      6.453800
131                                   real_query_builder.AWSQueryBuilderFunctions.time_projection      6.414300
104                         real_list_operations.AWSVersionSymbols.time_list_versions_latest_only      6.381200
100                                  real_list_operations.AWSVersionSymbols.peakmem_list_versions      6.338800
129                            real_query_builder.AWSQueryBuilderFunctions.time_filtering_numeric      6.319500
168                        real_read_write.AWSWideDataFrameTests.time_read_with_columns_all_types      6.172600
105      real_list_operations.AWSVersionSymbols.time_list_versions_latest_only_and_skip_snapshots      6.155000
167                             real_read_write.AWSWideDataFrameTests.time_read_with_column_float      6.146300
107                            real_list_operations.AWSVersionSymbols.time_list_versions_snapshot      6.117200
122                         real_query_builder.AWSQueryBuilderFunctions.peakmem_filtering_numeric      6.092300
79                                    local_query_builder.LocalQueryBuilderFunctions.time_query_4      6.015700
0                                    bi_benchmarks.BIBenchmarks.time_query_groupby_city_count_all      5.736300
125                                   real_query_builder.AWSQueryBuilderFunctions.peakmem_query_1      5.643400
106                      real_list_operations.AWSVersionSymbols.time_list_versions_skip_snapshots      5.640500
161                          real_read_write.AWSWideDataFrameTests.peakmem_read_with_column_float      5.627400
162                     real_read_write.AWSWideDataFrameTests.peakmem_read_with_columns_all_types      5.585400
128                         real_query_builder.AWSQueryBuilderFunctions.peakmem_query_adv_query_2      5.349100
126                                   real_query_builder.AWSQueryBuilderFunctions.peakmem_query_3      5.348100
127                                   real_query_builder.AWSQueryBuilderFunctions.peakmem_query_4      5.301100
123                     real_query_builder.AWSQueryBuilderFunctions.peakmem_filtering_string_isin      5.251800
124                                real_query_builder.AWSQueryBuilderFunctions.peakmem_projection      5.248500
1                bi_benchmarks.BIBenchmarks.time_query_groupby_city_count_filter_two_aggregations      5.032400
2                            bi_benchmarks.BIBenchmarks.time_query_groupby_city_count_isin_filter      4.895100
46                                               bi_benchmarks.BIBenchmarks.peakmem_query_readall      4.710000
102                   real_list_operations.AWSVersionSymbols.time_list_snapshots_without_metadata      4.709500
99                 real_list_operations.AWSVersionSymbols.peakmem_list_snapshots_without_metadata      4.599800
76                                 local_query_builder.LocalQueryBuilderFunctions.time_projection      4.350700
29                           basic_functions.BatchBasicFunctions.time_read_batch_with_date_ranges      4.246000
28                               basic_functions.BatchBasicFunctions.time_read_batch_with_columns      4.028800
27                                       basic_functions.BatchBasicFunctions.time_read_batch_pure      4.019900
26                                            basic_functions.BatchBasicFunctions.time_read_batch      3.978500
5                                          basic_functions.BasicFunctions.peakmem_read_short_wide      3.215800
177                           recursive_normalizer.LMDBRecursiveNormalizer.time_write_nested_dict      2.947300
6                                    basic_functions.BasicFunctions.peakmem_read_ultra_short_wide      2.714900
73                          local_query_builder.LocalQueryBuilderFunctions.time_filtering_numeric      2.634200
52                           finalize_staged_data.FinalizeStagedData.peakmem_finalize_staged_data      2.251700
61                                                  list_symbols.ListSymbols.peakmem_list_symbols      2.156800
178                                                   resample.ResampleWide.peakmem_resample_wide      2.149400
12                                            basic_functions.BasicFunctions.peakmem_write_staged      2.051400
24                        basic_functions.BatchBasicFunctions.peakmem_read_batch_with_date_ranges      1.870500
23                            basic_functions.BatchBasicFunctions.peakmem_read_batch_with_columns      1.854900
22                                         basic_functions.BatchBasicFunctions.peakmem_read_batch      1.818300
10                                                   basic_functions.BasicFunctions.peakmem_write      1.816600
4                                                     basic_functions.BasicFunctions.peakmem_read      1.594800
7                                        basic_functions.BasicFunctions.peakmem_read_with_columns      1.588300
9                      basic_functions.BasicFunctions.peakmem_read_with_date_ranges_query_builder      1.540200
8                                    basic_functions.BasicFunctions.peakmem_read_with_date_ranges      1.529600
174                        recursive_normalizer.LMDBRecursiveNormalizer.peakmem_write_nested_dict      1.042200
58                                list_snapshots.SnaphotFunctions.time_snapshots_no_metadata_list      0.896630
175                      recursive_normalizer.LMDBRecursiveNormalizer.time_read_batch_nested_dict      0.760260
69                                 local_query_builder.LocalQueryBuilderFunctions.peakmem_query_1      0.641750
43                                bi_benchmarks.BIBenchmarks.peakmem_query_groupby_city_count_all      0.475820
44            bi_benchmarks.BIBenchmarks.peakmem_query_groupby_city_count_filter_two_aggregations      0.435540
57            list_snapshots.SnaphotFunctions.peakmem_snapshots_with_metadata_list_with_load_meta      0.433460
45                        bi_benchmarks.BIBenchmarks.peakmem_query_groupby_city_count_isin_filter      0.401340
172                   recursive_normalizer.LMDBRecursiveNormalizer.peakmem_read_batch_nested_dict      0.382540
67                   local_query_builder.LocalQueryBuilderFunctions.peakmem_filtering_string_isin      0.350250
72                       local_query_builder.LocalQueryBuilderFunctions.peakmem_query_adv_query_2      0.318930
70                                 local_query_builder.LocalQueryBuilderFunctions.peakmem_query_3      0.312660
71                                 local_query_builder.LocalQueryBuilderFunctions.peakmem_query_4      0.271250
68                              local_query_builder.LocalQueryBuilderFunctions.peakmem_projection      0.226950
176                            recursive_normalizer.LMDBRecursiveNormalizer.time_read_nested_dict      0.201580
66                       local_query_builder.LocalQueryBuilderFunctions.peakmem_filtering_numeric      0.179710
173                         recursive_normalizer.LMDBRecursiveNormalizer.peakmem_read_nested_dict      0.106410
60            list_snapshots.SnaphotFunctions.time_snapshots_with_metadata_list_without_load_meta      0.085671
63                                                     list_symbols.ListSymbols.time_list_symbols      0.079145
62                                                       list_symbols.ListSymbols.time_has_symbol      0.043504
56                             list_snapshots.SnaphotFunctions.peakmem_snapshots_no_metadata_list      0.028348
54           finalize_staged_data.FinalizeStagedDataWiderDataframeX3.peakmem_finalize_staged_data      0.010657
55              finalize_staged_data.FinalizeStagedDataWiderDataframeX3.time_finalize_staged_data      0.008269

Summary:
Total time outside benchmarks (mins): 28.181467100000003
Total time running benchmarks (mins): 91.2721729

Process finished with exit code 0
```

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
