### PR TITLE
Make it possible to run ASV benchmarks without the real storage settings present

### DIFF
--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -367,13 +367,13 @@ def real_s3_from_environment_variables(
     shared_path: bool, native_config: Optional[NativeVariantStorage] = None, additional_suffix: str = ""
 ) -> BaseS3StorageFixtureFactory:
     out = BaseS3StorageFixtureFactory(native_config=native_config)
-    out.endpoint = os.getenv("ARCTICDB_REAL_S3_ENDPOINT")
+    out.endpoint = os.getenv("ARCTICDB_REAL_S3_ENDPOINT", "")
     out.region = os.getenv("ARCTICDB_REAL_S3_REGION")
     out.default_bucket = os.getenv("ARCTICDB_REAL_S3_BUCKET")
     access_key = os.getenv("ARCTICDB_REAL_S3_ACCESS_KEY")
     secret_key = os.getenv("ARCTICDB_REAL_S3_SECRET_KEY")
     out.default_key = Key(id=access_key, secret=secret_key, user_name="unknown user")
-    out.clean_bucket_on_fixture_exit = os.getenv("ARCTICDB_REAL_S3_CLEAR").lower() in ["true", "1"]
+    out.clean_bucket_on_fixture_exit = os.getenv("ARCTICDB_REAL_S3_CLEAR", "").lower() in ["true", "1"]
     out.ssl = out.endpoint.startswith("https://")
     if shared_path:
         out.default_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_SHARED_PATH_PREFIX")

--- a/python/installation_tests/client_utils.py
+++ b/python/installation_tests/client_utils.py
@@ -131,7 +131,7 @@ def real_s3_credentials(shared_path: bool = True):
     else:
         path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX")
 
-    clear = str(os.getenv("ARCTICDB_REAL_S3_CLEAR")).lower() in ("true", "1")
+    clear = os.getenv("ARCTICDB_REAL_S3_CLEAR", "").lower() in ("true", "1")
 
     return endpoint, bucket, region, access_key, secret_key, path_prefix, clear
 
@@ -165,7 +165,7 @@ def real_gcp_credentials(shared_path: bool = True):
     else:
         path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX")
 
-    clear = str(os.getenv("ARCTICDB_REAL_GCP_CLEAR")).lower() in ("true", "1")
+    clear = os.getenv("ARCTICDB_REAL_GCP_CLEAR", "").lower() in ("true", "1")
 
     return endpoint, bucket, region, access_key, secret_key, path_prefix, clear
 

--- a/python/tests/util/storage_test.py
+++ b/python/tests/util/storage_test.py
@@ -73,7 +73,7 @@ def real_s3_credentials(shared_path: bool = True):
     else:
         path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX")
 
-    clear = str(os.getenv("ARCTICDB_REAL_S3_CLEAR")).lower() in ("true", "1")
+    clear = os.getenv("ARCTICDB_REAL_S3_CLEAR", "").lower() in ("true", "1")
 
     return endpoint, bucket, region, access_key, secret_key, path_prefix, clear
 
@@ -91,7 +91,7 @@ def real_gcp_credentials(shared_path: bool = True):
     else:
         path_prefix = os.getenv("ARCTICDB_PERSISTENT_STORAGE_UNIQUE_PATH_PREFIX")
 
-    clear = str(os.getenv("ARCTICDB_REAL_GCP_CLEAR")).lower() in ("true", "1")
+    clear = os.getenv("ARCTICDB_REAL_GCP_CLEAR", "").lower() in ("true", "1")
 
     return endpoint, bucket, region, access_key, secret_key, path_prefix, clear
 
@@ -104,7 +104,7 @@ def real_azure_credentials(shared_path: bool = True):
     constr = (os.getenv("ARCTICDB_REAL_AZURE_CONNECTION_STRING"),)
     container = (os.getenv("ARCTICDB_REAL_AZURE_CONTAINER"),)
 
-    clear = str(os.getenv("ARCTICDB_REALL_AZURE_CLEAR")).lower() in ("true", "1")
+    clear = os.getenv("ARCTICDB_REAL_AZURE_CLEAR", "").lower() in ("true", "1")
 
     return container, constr, path_prefix, clear
 


### PR DESCRIPTION
Many of the ASV benchmarks initialize `TestLibraryManager` instances at test discovery time. This creates clients to all the different real storages we benchmark against and is why running ASV benchmarks can blow up if you do not have the various real storage environment variables present.

This makes some small changes so that at least discovery works.

We should probably refactor away the whole idea of the `TestLibraryManager` but it is baked in to the whole framework with `AsvBase`. I'll try to clean this up, but this PR makes things easier to use in the meantime.