### PR TITLE
Fix normalization of np.str_ and np.bytes_ types

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -157,8 +157,9 @@ _SUPPORTED_NATIVE_RETURN_TYPES = Union[FrameData]
 def _accept_array_string(v):
     # TODO remove this once arctic keeps the string type under the hood
     # and does not transform string into bytes
-    # Use isinstance to also support numpy string types (np.str_, np.bytes_)
-    return isinstance(v, (str, bytes))
+    # Use strict type equality to support numpy string types (np.str_, np.bytes_)
+    # but not arbitrary subclasses (see issue #704)
+    return type(v) in (str, bytes, np.str_, np.bytes_)
 
 
 def _is_nan(element):
@@ -188,8 +189,9 @@ def get_sample_from_non_empty_arr(arr, arr_name):
 
 def coerce_string_column_to_fixed_length_array(arr, to_type, string_max_len):
     # in python3 all text will be treated as unicode
-    # Use issubclass to also support numpy string types (np.str_)
-    if issubclass(to_type, str):
+    # Use strict type equality to support numpy string types (np.str_)
+    # but not arbitrary subclasses (see issue #704)
+    if to_type in (str, np.str_):
         if sys.platform == "win32":
             # See https://sourceforge.net/p/numpy/mailman/numpy-discussion/thread/1139250278.7538.52.camel%40localhost.localdomain/#msg11998404
             # Different wchar size on Windows is not compatible with our current internal representation of Numpy strings

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -157,7 +157,8 @@ _SUPPORTED_NATIVE_RETURN_TYPES = Union[FrameData]
 def _accept_array_string(v):
     # TODO remove this once arctic keeps the string type under the hood
     # and does not transform string into bytes
-    return type(v) in (str, bytes)
+    # Use isinstance to also support numpy string types (np.str_, np.bytes_)
+    return isinstance(v, (str, bytes))
 
 
 def _is_nan(element):
@@ -187,7 +188,8 @@ def get_sample_from_non_empty_arr(arr, arr_name):
 
 def coerce_string_column_to_fixed_length_array(arr, to_type, string_max_len):
     # in python3 all text will be treated as unicode
-    if to_type == str:
+    # Use issubclass to also support numpy string types (np.str_)
+    if issubclass(to_type, str):
         if sys.platform == "win32":
             # See https://sourceforge.net/p/numpy/mailman/numpy-discussion/thread/1139250278.7538.52.camel%40localhost.localdomain/#msg11998404
             # Different wchar size on Windows is not compatible with our current internal representation of Numpy strings


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2800

#### What does this implement or fix?

When you try to write a DataFrame with `np.str_` values, you get this error:

```
ArcticDbNotYetImplemented: Failed to normalize column 'col' with dtype 'object'. 
Found first non-null value of type '<class 'numpy.str_'>', but only strings, unicode, 
and Timestamps are supported.
```

The issue is in `_accept_array_string()` - it checks `type(v) in (str, bytes)` which does an exact type match. But `np.str_` is its own class that inherits from `str`, so the check fails even though it is basically a string.

Switched to `isinstance(v, (str, bytes))` which handles subclasses properly. Same thing for `coerce_string_column_to_fixed_length_array()` - changed `to_type == str` to `issubclass(to_type, str)`.

#### Any other comments?

Quick sanity check that this makes sense:
```python
>>> isinstance(np.str_("hello"), str)
True
>>> isinstance(np.bytes_(b"hello"), bytes)
True
```

The C++ side already does the right thing - `PyUnicode_Check` and `PyBytes_Check` both check the type hierarchy, so `np.str_` values work fine once they get past the Python normalization.

Added some tests to cover this.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
- [x] Have you updated the relevant docstrings, documentation and copyright notice?
- [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
- [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
- [x] Are API changes highlighted in the PR description?
- [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>