### PR TITLE
Speed up the resample benchmark run

### DIFF
--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -4208,7 +4208,7 @@
         "code": "class Resample:\n    def time_resample(self, num_rows, downsampling_factor, col_type, aggregation):\n        self.lib.read(col_type, date_range=self.date_range, query_builder=self.query_builder)\n\n    def setup(self, num_rows, downsampling_factor, col_type, aggregation):\n        if (\n            col_type == \"datetime\"\n            and aggregation == \"sum\"\n            or col_type == \"str\"\n            and aggregation in [\"sum\", \"mean\", \"min\", \"max\"]\n        ):\n            self.skipped = True\n            raise NotImplementedError(f\"{aggregation} not supported on columns of type {col_type}\")\n    \n        self.skipped = False\n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[self.LIB_NAME]\n        self.date_range = (pd.Timestamp(0), pd.Timestamp(num_rows, unit=\"us\"))\n        self.query_builder = QueryBuilder().resample(f\"{downsampling_factor}us\").agg({\"col\": aggregation})\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "resample.Resample.time_resample",
-        "number": 10,
+        "number": 5,
         "param_names": [
             "num_rows",
             "downsampling_factor",

--- a/python/benchmarks/resample.py
+++ b/python/benchmarks/resample.py
@@ -20,7 +20,7 @@ from asv_runner.benchmarks.mark import skip_benchmark
 
 
 class Resample:
-    number = 10
+    number = 5
 
     LIB_NAME = "resample"
     CONNECTION_STRING = "lmdb://resample"


### PR DESCRIPTION
It is dominating benchmarking on PRs at the moment.

After we turned these back on, the benchmarking time on PRs jumped from about 2h20m to about 4h30m.

I followed the approach here https://github.com/man-group/ArcticDB/wiki/Dev:-ASV-Benchmarks#flakiness to verify that the benchmark is stable with the new parameters, and an order of magnitude faster.