### PR TITLE
Fine tune  flaky resampling peakmem benchmark

### DIFF
--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -4240,7 +4240,7 @@
                 "'count'"
             ]
         ],
-        "setup_cache_key": "resample:52",
+        "setup_cache_key": "resample:53",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "20835daa6c6fd2af13420212c35b87cdac7153f782b2bc02cb2535131bd654d8"
@@ -4286,7 +4286,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "resample:52",
+        "setup_cache_key": "resample:53",
         "type": "time",
         "unit": "seconds",
         "version": "5a8f9ae968dbf11481dbe381bcb072c86f46190c9e10951ab2ec80ad9c9f116e",
@@ -4297,7 +4297,7 @@
         "name": "resample.ResampleWide.peakmem_resample_wide",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "resample:126",
+        "setup_cache_key": "resample:129",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "53f042192048c92d282637c1bbcee9e52dacec9086c534782de30d7ff67e77eb"
@@ -4312,7 +4312,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "resample:126",
+        "setup_cache_key": "resample:129",
         "type": "time",
         "unit": "seconds",
         "version": "ece714f981e8de31ee8296644624bf8f5fb895e6bf48d64a6ae2a9c50c5db7a2",

--- a/python/benchmarks/resample.py
+++ b/python/benchmarks/resample.py
@@ -12,6 +12,7 @@ import time
 import numpy as np
 import pandas as pd
 import itertools
+import random
 
 from arcticdb import Arctic
 from arcticdb import QueryBuilder
@@ -55,6 +56,8 @@ class Resample:
         self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
 
     def _setup_cache(self):
+        random.seed(42)
+        np.random.seed(42)
         ac = Arctic(self.CONNECTION_STRING)
         ac.delete_library(self.LIB_NAME)
         lib = ac.create_library(self.LIB_NAME)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Peakmem params are tuned for the machine that runs the tests. It has 16 CPU threads and 24 IO threads. Having too much segments on leads to variability of ~20% in the processing pipeline because of the scheduling. 3_000_000 rows are 30 segments, a bit more than the number of IO threads but still not enough to cause large variability
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
