### PR TITLE
2. ASV performance improvements

### DIFF
--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -256,7 +256,7 @@
         "warmup_time": -1
     },
     "basic_functions.BasicFunctions.peakmem_read": {
-        "code": "class BasicFunctions:\n    def peakmem_read(self, rows):\n        self.lib.read(f\"sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def peakmem_read(self, rows):\n        self.lib.read(f\"sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "basic_functions.BasicFunctions.peakmem_read",
         "param_names": [
             "rows"
@@ -264,53 +264,16 @@
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:39",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "3b847508b2a63c58c508dc7e7aec08547e2ca09a57bcf3f6777619a5cb149b7f"
-    },
-    "basic_functions.BasicFunctions.peakmem_read_short_wide": {
-        "code": "class BasicFunctions:\n    def peakmem_read_short_wide(self, rows):\n        lib = self.ac[get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)]\n        lib.read(\"short_wide_sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
-        "name": "basic_functions.BasicFunctions.peakmem_read_short_wide",
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
-        "type": "peakmemory",
-        "unit": "bytes",
-        "version": "a4ca2ebef508c6560b98af94d69ba7cd459cc02976eaed2aad41ac976d932b11"
-    },
-    "basic_functions.BasicFunctions.peakmem_read_ultra_short_wide": {
-        "code": "class BasicFunctions:\n    def peakmem_read_ultra_short_wide(self, rows):\n        lib = self.ac[get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)]\n        lib.read(\"ultra_short_wide_sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
-        "name": "basic_functions.BasicFunctions.peakmem_read_ultra_short_wide",
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
-        "type": "peakmemory",
-        "unit": "bytes",
-        "version": "74f0d776147883a788c405dd90a8490ea4b766f2946aaf5ab43cc48076c2b929"
+        "version": "4ed305e5b21d4c3df22cc239ad54e2ab9b8acf19c2a689e264e9145eca1a2094"
     },
     "basic_functions.BasicFunctions.peakmem_read_with_columns": {
-        "code": "class BasicFunctions:\n    def peakmem_read_with_columns(self, rows):\n        COLS = [\"value\"]\n        self.lib.read(f\"sym\", columns=COLS).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def peakmem_read_with_columns(self, rows):\n        COLS = [\"value\"]\n        self.lib.read(f\"sym\", columns=COLS).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "basic_functions.BasicFunctions.peakmem_read_with_columns",
         "param_names": [
             "rows"
@@ -318,17 +281,16 @@
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:39",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "34501bd0311c8b2644012b8f713f8a596bba14dbf1976cbbded37060cf77709f"
+        "version": "0655902640cee72832e909202e4187147f1378b546bd5b3518ab19f4004d5b32"
     },
     "basic_functions.BasicFunctions.peakmem_read_with_date_ranges": {
-        "code": "class BasicFunctions:\n    def peakmem_read_with_date_ranges(self, rows):\n        self.lib.read(f\"sym\", date_range=BasicFunctions.DATE_RANGE).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def peakmem_read_with_date_ranges(self, rows):\n        self.lib.read(f\"sym\", date_range=DATE_RANGE).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "basic_functions.BasicFunctions.peakmem_read_with_date_ranges",
         "param_names": [
             "rows"
@@ -336,17 +298,16 @@
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:39",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "908e8e1658fc2235b08f2996edb57c49852791e6f6c187165b3b931e7d7e896c"
+        "version": "a12a8dd0cf3e4d5ab9c8535fcaec9647a533644933a4b5c643a7f99723015fa3"
     },
     "basic_functions.BasicFunctions.peakmem_read_with_date_ranges_query_builder": {
-        "code": "class BasicFunctions:\n    def peakmem_read_with_date_ranges_query_builder(self, rows):\n        q = QueryBuilder().date_range(BasicFunctions.DATE_RANGE)\n        self.lib.read(f\"sym\", query_builder=q).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def peakmem_read_with_date_ranges_query_builder(self, rows):\n        q = QueryBuilder().date_range(DATE_RANGE)\n        self.lib.read(f\"sym\", query_builder=q).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "basic_functions.BasicFunctions.peakmem_read_with_date_ranges_query_builder",
         "param_names": [
             "rows"
@@ -354,17 +315,16 @@
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:39",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "7870e015641ad2975bbc58ad43428c0e65d3771d1cd2838d2f72f4d6c57aa926"
+        "version": "a0dbc5843fc9f5b31ccf981b2a6b6569880b0841b684163e617368071e48e2c7"
     },
     "basic_functions.BasicFunctions.peakmem_write": {
-        "code": "class BasicFunctions:\n    def peakmem_write(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def peakmem_write(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "basic_functions.BasicFunctions.peakmem_write",
         "param_names": [
             "rows"
@@ -372,35 +332,16 @@
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:39",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "0db13340295d95fa06e3f786be93bbc345a0f67ffe4fdcd226189c2b82aecb5e"
-    },
-    "basic_functions.BasicFunctions.peakmem_write_short_wide": {
-        "code": "class BasicFunctions:\n    def peakmem_write_short_wide(self, rows):\n        self.fresh_lib.write(\"short_wide_sym\", self.df_short_wide)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
-        "name": "basic_functions.BasicFunctions.peakmem_write_short_wide",
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
-        "type": "peakmemory",
-        "unit": "bytes",
-        "version": "3128ed9e1a62c74b07c0c51e215080ecb9ccb8284e6221dadb0d4b229acceb2d"
+        "version": "530fec1ac85f134bab26649b2579b205a87c1b01dc5d972f324e452e6a4633cd"
     },
     "basic_functions.BasicFunctions.peakmem_write_staged": {
-        "code": "class BasicFunctions:\n    def peakmem_write_staged(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df, staged=True)\n        self.fresh_lib._nvs.compact_incomplete(f\"sym\", False, False)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def peakmem_write_staged(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df, staged=True)\n        self.fresh_lib._nvs.compact_incomplete(f\"sym\", False, False)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "basic_functions.BasicFunctions.peakmem_write_staged",
         "param_names": [
             "rows"
@@ -408,230 +349,151 @@
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:39",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "42c10f3b6072be6b54db49e98670de0ce65dc2d7e543f6b1af53bd4fd28bba5f"
+        "version": "a19002933078e96e583a65bb547e86712f87c841e877a54fba4fce777ac6ab05"
     },
     "basic_functions.BasicFunctions.time_read": {
-        "code": "class BasicFunctions:\n    def time_read(self, rows):\n        self.lib.read(f\"sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def time_read(self, rows):\n        self.lib.read(f\"sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BasicFunctions.time_read",
-        "number": 5,
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
         "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:39",
         "type": "time",
         "unit": "seconds",
-        "version": "99231807c0927256747827b6d0d3bf8d565cae9f2b6955d40e3c403ff162daac",
-        "warmup_time": 0
-    },
-    "basic_functions.BasicFunctions.time_read_short_wide": {
-        "code": "class BasicFunctions:\n    def time_read_short_wide(self, rows):\n        lib = self.ac[get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)]\n        lib.read(\"short_wide_sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
-        "min_run_count": 2,
-        "name": "basic_functions.BasicFunctions.time_read_short_wide",
-        "number": 5,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 0,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "18cb78627bc67fc910cdce20943fb32ba17bc8271a1b13de73393d76c1411f9e",
-        "warmup_time": 0
-    },
-    "basic_functions.BasicFunctions.time_read_ultra_short_wide": {
-        "code": "class BasicFunctions:\n    def time_read_ultra_short_wide(self, rows):\n        lib = self.ac[get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)]\n        lib.read(\"ultra_short_wide_sym\").data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
-        "min_run_count": 2,
-        "name": "basic_functions.BasicFunctions.time_read_ultra_short_wide",
-        "number": 5,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 0,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "f5a362303294a64862824aa956d62c05bac490feb7438d742720d341274beeb7",
-        "warmup_time": 0
+        "version": "0790a17ac39caedc1cea887331e48e2b607f4bbdbde59ebdf2a16e220e680c81",
+        "warmup_time": -1
     },
     "basic_functions.BasicFunctions.time_read_with_columns": {
-        "code": "class BasicFunctions:\n    def time_read_with_columns(self, rows):\n        COLS = [\"value\"]\n        self.lib.read(f\"sym\", columns=COLS).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def time_read_with_columns(self, rows):\n        COLS = [\"value\"]\n        self.lib.read(f\"sym\", columns=COLS).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BasicFunctions.time_read_with_columns",
-        "number": 5,
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
         "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:39",
         "type": "time",
         "unit": "seconds",
-        "version": "97fab62dd3036b086e61d8e193b02c3c566b76c76cb514b44dfd3d9090a2bbe7",
-        "warmup_time": 0
+        "version": "d66332f438d375470e7b471b2641664ce03a5043765b8aecb701ba028940504d",
+        "warmup_time": -1
     },
     "basic_functions.BasicFunctions.time_read_with_date_ranges": {
-        "code": "class BasicFunctions:\n    def time_read_with_date_ranges(self, rows):\n        self.lib.read(f\"sym\", date_range=BasicFunctions.DATE_RANGE).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def time_read_with_date_ranges(self, rows):\n        self.lib.read(f\"sym\", date_range=DATE_RANGE).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BasicFunctions.time_read_with_date_ranges",
-        "number": 5,
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
         "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:39",
         "type": "time",
         "unit": "seconds",
-        "version": "8fe0b03e88febe68a480effc73ec81b1c3bbb24fa31f8d4868db79760d58ccdd",
-        "warmup_time": 0
+        "version": "c1fdcddf679a65c0f96b011e2f091c21b3f6fa603b9dd9c3daf20698273e1245",
+        "warmup_time": -1
     },
     "basic_functions.BasicFunctions.time_read_with_date_ranges_query_builder": {
-        "code": "class BasicFunctions:\n    def time_read_with_date_ranges_query_builder(self, rows):\n        q = QueryBuilder().date_range(BasicFunctions.DATE_RANGE)\n        self.lib.read(f\"sym\", query_builder=q).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def time_read_with_date_ranges_query_builder(self, rows):\n        q = QueryBuilder().date_range(DATE_RANGE)\n        self.lib.read(f\"sym\", query_builder=q).data\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BasicFunctions.time_read_with_date_ranges_query_builder",
-        "number": 5,
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
         "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:39",
         "type": "time",
         "unit": "seconds",
-        "version": "50281bd8fb1b296b9de072d72b5bb207d9b5d1700949b1d911f7475339110289",
-        "warmup_time": 0
+        "version": "e30effe8e084ada39a8d4f7e123d6253b483a434a3a59c65fcb1dc2a04377959",
+        "warmup_time": -1
     },
     "basic_functions.BasicFunctions.time_write": {
-        "code": "class BasicFunctions:\n    def time_write(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def time_write(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BasicFunctions.time_write",
-        "number": 5,
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
         "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:39",
         "type": "time",
         "unit": "seconds",
-        "version": "a399d5220450caaa75806e22756b1bfcf8b27c050fa15dd9165be085ae2b0b63",
-        "warmup_time": 0
-    },
-    "basic_functions.BasicFunctions.time_write_short_wide": {
-        "code": "class BasicFunctions:\n    def time_write_short_wide(self, rows):\n        self.fresh_lib.write(\"short_wide_sym\", self.df_short_wide)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
-        "min_run_count": 2,
-        "name": "basic_functions.BasicFunctions.time_write_short_wide",
-        "number": 5,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 0,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "7d9de7789dd1f63d916bd3e86d00c633177462a29f323774fd022cebf75e92ab",
-        "warmup_time": 0
+        "version": "eb258ad770b5f9d0220957f1fce0410b51de9964c6a1744919abda640feec054",
+        "warmup_time": -1
     },
     "basic_functions.BasicFunctions.time_write_staged": {
-        "code": "class BasicFunctions:\n    def time_write_staged(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df, staged=True)\n        self.fresh_lib._nvs.compact_incomplete(f\"sym\", False, False)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class BasicFunctions:\n    def time_write_staged(self, rows):\n        self.fresh_lib.write(f\"sym\", self.df, staged=True)\n        self.fresh_lib._nvs.compact_incomplete(f\"sym\", False, False)\n\n    def setup(self, rows):\n        self.ac = Arctic(BasicFunctions.CONNECTION_STRING)\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n    \n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BasicFunctions.time_write_staged",
-        "number": 5,
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
                 "1000000",
-                "1500000"
+                "10000000"
             ]
         ],
         "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:48",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:39",
         "type": "time",
         "unit": "seconds",
-        "version": "00d21f9de9837bdad48c5ad99e7c3312e1a2825b119b58548d7fd703481d9501",
-        "warmup_time": 0
+        "version": "bb986153ea43fb78204ded8a63c102b4718197158c8f81d6c28e17cfa39d3282",
+        "warmup_time": -1
     },
     "basic_functions.BatchBasicFunctions.peakmem_read_batch": {
         "code": "class BatchBasicFunctions:\n    def peakmem_read_batch(self, rows, num_symbols):\n        read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n        self.lib.read_batch(read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
@@ -646,12 +508,11 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:185",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "1154d4d002a16465c10fd5e41721ed25ee8d4a5fa3790c7718d7f309f1b8b29c"
@@ -669,12 +530,11 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:185",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "eb2f74f4dab10d4472f2349a2d539c9609baaaa6debf7206c064a2b93c495bfc"
@@ -692,12 +552,11 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:185",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "114711c1c4ebf66c64ab33fb81f5f8cc73ce78984e2472f492d0c80f96f331d8"
@@ -715,12 +574,11 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:185",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "e29d7bab3ecd450da657f11c448f62bbb39d5a2607fb6f4cc5b92db2dee50dc9"
@@ -729,7 +587,7 @@
         "code": "class BatchBasicFunctions:\n    def time_read_batch(self, rows, num_symbols):\n        read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n        self.lib.read_batch(read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BatchBasicFunctions.time_read_batch",
-        "number": 1,
+        "number": 0,
         "param_names": [
             "rows",
             "num_symbols"
@@ -740,54 +598,24 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "repeat": 3,
+        "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:185",
         "type": "time",
         "unit": "seconds",
         "version": "95a87e9c330d6f1b83b13cdf87403e69a4c2d4a3992430942454acfd5021b73a",
-        "warmup_time": 0
-    },
-    "basic_functions.BatchBasicFunctions.time_read_batch_pure": {
-        "code": "class BatchBasicFunctions:\n    def time_read_batch_pure(self, rows, num_symbols):\n        self.lib.read_batch(self.read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
-        "min_run_count": 2,
-        "name": "basic_functions.BatchBasicFunctions.time_read_batch_pure",
-        "number": 1,
-        "param_names": [
-            "rows",
-            "num_symbols"
-        ],
-        "params": [
-            [
-                "25000",
-                "50000"
-            ],
-            [
-                "500",
-                "1000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "9a6a0b018e486ac4f51dcd497fd51d6394c9b92418337aab1e6bbc5347b3674c",
-        "warmup_time": 0
+        "warmup_time": -1
     },
     "basic_functions.BatchBasicFunctions.time_read_batch_with_columns": {
         "code": "class BatchBasicFunctions:\n    def time_read_batch_with_columns(self, rows, num_symbols):\n        COLS = [\"value\"]\n        read_reqs = [ReadRequest(f\"{sym}_sym\", columns=COLS) for sym in range(num_symbols)]\n        self.lib.read_batch(read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BatchBasicFunctions.time_read_batch_with_columns",
-        "number": 1,
+        "number": 0,
         "param_names": [
             "rows",
             "num_symbols"
@@ -798,25 +626,24 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "repeat": 3,
+        "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:185",
         "type": "time",
         "unit": "seconds",
         "version": "2c798cded56db601f7a5e81cf0d0e77407d3717695a4c4863d4e68c96618393b",
-        "warmup_time": 0
+        "warmup_time": -1
     },
     "basic_functions.BatchBasicFunctions.time_read_batch_with_date_ranges": {
         "code": "class BatchBasicFunctions:\n    def time_read_batch_with_date_ranges(self, rows, num_symbols):\n        read_reqs = [ReadRequest(f\"{sym}_sym\", date_range=BatchBasicFunctions.DATE_RANGE) for sym in range(num_symbols)]\n        self.lib.read_batch(read_reqs)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BatchBasicFunctions.time_read_batch_with_date_ranges",
-        "number": 1,
+        "number": 0,
         "param_names": [
             "rows",
             "num_symbols"
@@ -827,25 +654,24 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "repeat": 3,
+        "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:185",
         "type": "time",
         "unit": "seconds",
         "version": "04e761907c8cd5b7d21ef3beadec4150292a508c0de7c9fd36305f118c97ceb3",
-        "warmup_time": 0
+        "warmup_time": -1
     },
     "basic_functions.BatchBasicFunctions.time_update_batch": {
         "code": "class BatchBasicFunctions:\n    def time_update_batch(self, rows, num_symbols):\n        payloads = [UpdatePayload(f\"{sym}_sym\", self.update_df) for sym in range(num_symbols)]\n        results = self.lib.update_batch(payloads)\n        assert results[0].version >= 1\n        assert results[-1].version >= 1\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BatchBasicFunctions.time_update_batch",
-        "number": 1,
+        "number": 0,
         "param_names": [
             "rows",
             "num_symbols"
@@ -856,25 +682,24 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "repeat": 3,
+        "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:185",
         "type": "time",
         "unit": "seconds",
         "version": "ae298ed42a2bc58a2d14509b1578a2ecd7c11cab6f15200ef8ebfbc4f9924a27",
-        "warmup_time": 0
+        "warmup_time": -1
     },
     "basic_functions.BatchBasicFunctions.time_write_batch": {
         "code": "class BatchBasicFunctions:\n    def time_write_batch(self, rows, num_symbols):\n        payloads = [WritePayload(f\"{sym}_sym\", self.df) for sym in range(num_symbols)]\n        self.fresh_lib.write_batch(payloads)\n\n    def setup(self, rows, num_symbols):\n        self.ac = Arctic(BatchBasicFunctions.CONNECTION_STRING)\n        self.read_reqs = [ReadRequest(f\"{sym}_sym\") for sym in range(num_symbols)]\n    \n        self.df = generate_pseudo_random_dataframe(rows)\n        self.update_df = generate_pseudo_random_dataframe(rows // 2)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.fresh_lib = self.get_fresh_lib()\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "basic_functions.BatchBasicFunctions.time_write_batch",
-        "number": 1,
+        "number": 0,
         "param_names": [
             "rows",
             "num_symbols"
@@ -885,283 +710,96 @@
                 "50000"
             ],
             [
-                "500",
-                "1000"
+                "100",
+                "200"
             ]
         ],
-        "repeat": 3,
+        "repeat": 0,
         "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:181",
-        "timeout": 6000,
+        "sample_time": 0.1,
+        "setup_cache_key": "basic_functions:185",
         "type": "time",
         "unit": "seconds",
         "version": "49522447c3d9ac6f75f9df9a159dbbaeb95553440cf4bbb98303fce0c490bd66",
-        "warmup_time": 0
+        "warmup_time": -1
     },
-    "basic_functions.ModificationFunctions.time_append_large": {
-        "code": "class ModificationFunctions:\n    def time_append_large(self, lad: LargeAppendDataModify, rows):\n        large: pd.DataFrame = lad.df_append_large[rows].pop(0)\n        self.lib.append(\"sym\", large)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_append_large",
-        "number": 1,
+    "basic_functions.ShortWideRead.peakmem_read": {
+        "code": "class ShortWideRead:\n    def peakmem_read(self, rows):\n        self.lib.read(f\"sym_{rows}\")\n\n    def setup(self, rows):\n        ac = Arctic(ShortWideRead.CONNECTION_STRING)\n        self.lib = ac[\"lib\"]\n\n    def setup_cache(self):\n        ac = Arctic(ShortWideRead.CONNECTION_STRING)\n        lib = ac.create_library(\"lib\")\n        for r in ShortWideRead.ROWS:\n            df = generate_random_floats_dataframe(r, ShortWideRead.COLS)\n            lib.write(f\"sym_{r}\", df)",
+        "name": "basic_functions.ShortWideRead.peakmem_read",
         "param_names": [
             "rows"
         ],
         "params": [
             [
-                "1000000",
-                "1500000"
+                "1",
+                "5000"
             ]
         ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "8d1e9a72db76b8a1a5e0215330c54476f80a05dbea2174186950370cd831245e",
-        "warmup_time": 0
+        "setup_cache_key": "basic_functions:155",
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "0c9e4ed77543c683169797f90579b45d91798edff513d7b6eeac570b958822eb"
     },
-    "basic_functions.ModificationFunctions.time_append_short_wide": {
-        "code": "class ModificationFunctions:\n    def time_append_short_wide(self, lad: LargeAppendDataModify, rows):\n        large: pd.DataFrame = lad.df_append_short_wide[rows].pop(0)\n        self.lib_short_wide.append(\"short_wide_sym\", large)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+    "basic_functions.ShortWideRead.time_read": {
+        "code": "class ShortWideRead:\n    def time_read(self, rows):\n        self.lib.read(f\"sym_{rows}\")\n\n    def setup(self, rows):\n        ac = Arctic(ShortWideRead.CONNECTION_STRING)\n        self.lib = ac[\"lib\"]\n\n    def setup_cache(self):\n        ac = Arctic(ShortWideRead.CONNECTION_STRING)\n        lib = ac.create_library(\"lib\")\n        for r in ShortWideRead.ROWS:\n            df = generate_random_floats_dataframe(r, ShortWideRead.COLS)\n            lib.write(f\"sym_{r}\", df)",
         "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_append_short_wide",
-        "number": 1,
+        "name": "basic_functions.ShortWideRead.time_read",
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
-                "1000000",
-                "1500000"
+                "1",
+                "5000"
             ]
         ],
-        "repeat": 3,
-        "rounds": 1,
+        "repeat": 0,
+        "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
+        "setup_cache_key": "basic_functions:155",
         "type": "time",
         "unit": "seconds",
-        "version": "b15a42ff2e9792de5c9bee4cbf108d57071a6c2b2b504997406e7a848b83b0dc",
-        "warmup_time": 0
+        "version": "de731d8892af34ed745e455464ee25c7a3144744c6a19440e2b1f4726623ad2c",
+        "warmup_time": -1
     },
-    "basic_functions.ModificationFunctions.time_append_single": {
-        "code": "class ModificationFunctions:\n    def time_append_single(self, lad: LargeAppendDataModify, rows):\n        self.lib.append(\"sym\", self.df_append_single)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_append_single",
-        "number": 1,
+    "basic_functions.ShortWideWrite.peakmem_write": {
+        "code": "class ShortWideWrite:\n    def peakmem_write(self, *args):\n        self.lib.write(\"sym\", self.df)\n\n    def setup(self, rows):\n        self.ac = Arctic(ShortWideWrite.CONNECTION_STRING)\n        self.lib = self.ac.create_library(\"lib\")\n        self.df = generate_random_floats_dataframe(rows, ShortWideWrite.COLS)",
+        "name": "basic_functions.ShortWideWrite.peakmem_write",
         "param_names": [
             "rows"
         ],
         "params": [
             [
-                "1000000",
-                "1500000"
+                "1",
+                "5000"
             ]
         ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "52acfbd4409bdcadf8af0cf5bd559122d5d467b56650bbb381c2d332a1aece2e",
-        "warmup_time": 0
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "6f39a68c95fd453da7306d8525332a7b86b00e84643407c6e7e94f9d3560295f"
     },
-    "basic_functions.ModificationFunctions.time_delete": {
-        "code": "class ModificationFunctions:\n    def time_delete(self, lad: LargeAppendDataModify, rows):\n        self.lib.delete(\"sym\")\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+    "basic_functions.ShortWideWrite.time_write": {
+        "code": "class ShortWideWrite:\n    def time_write(self, *args):\n        self.lib.write(\"sym\", self.df)\n\n    def setup(self, rows):\n        self.ac = Arctic(ShortWideWrite.CONNECTION_STRING)\n        self.lib = self.ac.create_library(\"lib\")\n        self.df = generate_random_floats_dataframe(rows, ShortWideWrite.COLS)",
         "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_delete",
-        "number": 1,
+        "name": "basic_functions.ShortWideWrite.time_write",
+        "number": 0,
         "param_names": [
             "rows"
         ],
         "params": [
             [
-                "1000000",
-                "1500000"
+                "1",
+                "5000"
             ]
         ],
-        "repeat": 3,
-        "rounds": 1,
+        "repeat": 0,
+        "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
         "type": "time",
         "unit": "seconds",
-        "version": "672259b2998d092f121f5de4c7b4327ebe5c3e444b677994c276755dc72bcffa",
-        "warmup_time": 0
-    },
-    "basic_functions.ModificationFunctions.time_delete_multiple_versions": {
-        "code": "class ModificationFunctions:\n    def time_delete_multiple_versions(self, lad: LargeAppendDataModify, rows):\n        self.lib.delete(\"sym_delete_multiple\", list(range(99)))\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_delete_multiple_versions",
-        "number": 1,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "2f548b89ece0762d3a4ca804f4cebacdc407c72b720b63927a70a48213bd7b95",
-        "warmup_time": 0
-    },
-    "basic_functions.ModificationFunctions.time_delete_over_time": {
-        "code": "class ModificationFunctions:\n    def time_delete_over_time(self, lad: LargeAppendDataModify, rows):\n        with config_context(\"VersionMap.ReloadInterval\", 0):\n            for i in range(100):\n                self.lib.write(\"delete_over_time\", pd.DataFrame())\n                self.lib.delete(\"delete_over_time\")\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_delete_over_time",
-        "number": 1,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "77d3d9f015b1ff0e318bd419a22aeca9b56c22cd174c0efd80e2909b9b68ceb5",
-        "warmup_time": 0
-    },
-    "basic_functions.ModificationFunctions.time_delete_short_wide": {
-        "code": "class ModificationFunctions:\n    def time_delete_short_wide(self, lad: LargeAppendDataModify, rows):\n        self.lib_short_wide.delete(\"short_wide_sym\")\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_delete_short_wide",
-        "number": 1,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "2409d72e307e71748c55e973bf651e1c775a5ed31869e089c243223efbb83df3",
-        "warmup_time": 0
-    },
-    "basic_functions.ModificationFunctions.time_update_half": {
-        "code": "class ModificationFunctions:\n    def time_update_half(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(\"sym\", self.df_update_half)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_update_half",
-        "number": 1,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "7bde302f3062e94d0fe774eeebb7ad10585c4e40e525dbd3e05b25c0a7798ce1",
-        "warmup_time": 0
-    },
-    "basic_functions.ModificationFunctions.time_update_short_wide": {
-        "code": "class ModificationFunctions:\n    def time_update_short_wide(self, lad: LargeAppendDataModify, rows):\n        self.lib_short_wide.update(\"short_wide_sym\", self.df_update_short_wide)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_update_short_wide",
-        "number": 1,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "c012d3639c8e84e4a2e654631211e110644fd75bf36de8576515355a72d9409c",
-        "warmup_time": 0
-    },
-    "basic_functions.ModificationFunctions.time_update_single": {
-        "code": "class ModificationFunctions:\n    def time_update_single(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(\"sym\", self.df_update_single)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_update_single",
-        "number": 1,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "d0b4f92fc686ee91643527d18268011dbe2053d2f5463efb671d28d1fe2e388a",
-        "warmup_time": 0
-    },
-    "basic_functions.ModificationFunctions.time_update_upsert": {
-        "code": "class ModificationFunctions:\n    def time_update_upsert(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(\"sym\", self.df_update_upsert, upsert=True)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(\n            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS\n        )\n    \n        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]\n    \n        # Used by time_delete_multiple_versions\n        for i in range(100):\n            self.lib.write(\"sym_delete_multiple\", pd.DataFrame(), prune_previous_versions=False)\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
-        "min_run_count": 2,
-        "name": "basic_functions.ModificationFunctions.time_update_upsert",
-        "number": 1,
-        "param_names": [
-            "rows"
-        ],
-        "params": [
-            [
-                "1000000",
-                "1500000"
-            ]
-        ],
-        "repeat": 3,
-        "rounds": 1,
-        "sample_time": 0.01,
-        "setup_cache_key": "basic_functions:340",
-        "timeout": 6000,
-        "type": "time",
-        "unit": "seconds",
-        "version": "916a69cac80c70e2fe053b743904459170731ac657c2efbe0222daafcdd9ba9e",
-        "warmup_time": 0
+        "version": "b65576b24b68bea4080deca2d075daaa74a809c4f9d379ea8143e02a7c3b8413",
+        "warmup_time": -1
     },
     "bi_benchmarks.BIBenchmarks.peakmem_query_groupby_city_count_all": {
         "code": "class BIBenchmarks:\n    def peakmem_query_groupby_city_count_all(self, times_bigger) -> pd.DataFrame:\n        return self.query_groupby_city_count_all(times_bigger)\n\n    def setup(self, num_rows):\n        self.ac = Arctic(f\"lmdb://opensource_datasets_{self.lib_name}?map_size=20GB\")\n        self.lib = self.ac.get_library(self.lib_name)\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
@@ -1332,59 +970,54 @@
         "warmup_time": 0
     },
     "comparison_benchmarks.ComparisonBenchmarks.peakmem_create_dataframe": {
-        "code": "class ComparisonBenchmarks:\n    def peakmem_create_dataframe(self, tpl):\n        df, dict = tpl\n        df = pd.DataFrame(dict)\n\n    def setup(self, tpl):\n        df, dict = tpl\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df, dict = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return (df, dict)",
+        "code": "class ComparisonBenchmarks:\n    def peakmem_create_dataframe(self, df):\n        # Just measure how much memory the df takes up\n        pass\n\n    def setup(self, df):\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return df",
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_create_dataframe",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:44",
-        "timeout": 60000,
+        "setup_cache_key": "comparison_benchmarks:36",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "3580ee58cdf2db23481a370c46cd60e321e4c5b6b763d8a56a905cd857b05b65"
+        "version": "3dbeea3695e339eb9a36d6c4d304def34873f669945b845a9777305a3c6f1bfe"
     },
     "comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_arctic": {
-        "code": "class ComparisonBenchmarks:\n    def peakmem_read_dataframe_arctic(self, tpl):\n        self.lib.read(ComparisonBenchmarks.SYMBOL)\n\n    def setup(self, tpl):\n        df, dict = tpl\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df, dict = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return (df, dict)",
+        "code": "class ComparisonBenchmarks:\n    def peakmem_read_dataframe_arctic(self, df):\n        self.lib.read(ComparisonBenchmarks.SYMBOL)\n\n    def setup(self, df):\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return df",
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_arctic",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:44",
-        "timeout": 60000,
+        "setup_cache_key": "comparison_benchmarks:36",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "f13bf3d2bdd1f6129281823f3ac4a1c6c7d7b97be21efe3ae0d1065b07f89050"
+        "version": "1a2fc88bbf876be7b742ec67aa4eb97f72d7812b1a9d6da39c0a430e113be691"
     },
     "comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_parquet": {
-        "code": "class ComparisonBenchmarks:\n    def peakmem_read_dataframe_parquet(self, tpl):\n        pd.read_parquet(self.path_to_read)\n\n    def setup(self, tpl):\n        df, dict = tpl\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df, dict = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return (df, dict)",
+        "code": "class ComparisonBenchmarks:\n    def peakmem_read_dataframe_parquet(self, df):\n        pd.read_parquet(self.path_to_read)\n\n    def setup(self, df):\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return df",
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_read_dataframe_parquet",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:44",
-        "timeout": 60000,
+        "setup_cache_key": "comparison_benchmarks:36",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "7d5db25fdc879f9e0da495f2f228353425dd662cc2ad93eecf662c2dd9be1c55"
+        "version": "8f040aeef356d5a57d074e39f72086e447999cf119676d507e4bf380cfa8823d"
     },
     "comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_arctic": {
-        "code": "class ComparisonBenchmarks:\n    def peakmem_write_dataframe_arctic(self, tpl):\n        df, dict = tpl\n        self.lib.write(\"symbol\", df)\n\n    def setup(self, tpl):\n        df, dict = tpl\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df, dict = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return (df, dict)",
+        "code": "class ComparisonBenchmarks:\n    def peakmem_write_dataframe_arctic(self, df):\n        self.lib.write(\"symbol\", df)\n\n    def setup(self, df):\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return df",
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_arctic",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:44",
-        "timeout": 60000,
+        "setup_cache_key": "comparison_benchmarks:36",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "cd90a2c0309608e8c86b47a91b2a4c26ba9ba6b7bc50ca115f0d62b4ab82d064"
+        "version": "e9358ae2be195d8aa27b975337a5c6a84d2514be2f0837834ed78a70e462b25a"
     },
     "comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_parquet": {
-        "code": "class ComparisonBenchmarks:\n    def peakmem_write_dataframe_parquet(self, tpl):\n        df, dict = tpl\n        df.to_parquet(self.path, index=True)\n\n    def setup(self, tpl):\n        df, dict = tpl\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df, dict = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return (df, dict)",
+        "code": "class ComparisonBenchmarks:\n    def peakmem_write_dataframe_parquet(self, df):\n        df.to_parquet(self.path, index=True)\n\n    def setup(self, df):\n        self.ac = Arctic(ComparisonBenchmarks.URL)\n        self.lib = self.ac[ComparisonBenchmarks.LIB_NAME]\n        self.path = f\"{tempfile.gettempdir()}/df.parquet\"\n        self.path_to_read = f\"{tempfile.gettempdir()}/df_to_read.parquet\"\n        self.delete_if_exists(self.path)\n        df.to_parquet(self.path_to_read, index=True)\n\n    def setup_cache(self):\n        start = time.time()\n        df = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return df",
         "name": "comparison_benchmarks.ComparisonBenchmarks.peakmem_write_dataframe_parquet",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "comparison_benchmarks:44",
-        "timeout": 60000,
+        "setup_cache_key": "comparison_benchmarks:36",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "166a93976c1ae0088bbb2477ee1d3e92672e7477a811b64747ee2b97bb078f26"
+        "version": "04b12bd96d5626c3cbd842567a904be81f4798b8a55eef94563304659ef22fec"
     },
     "finalize_staged_data.FinalizeStagedData.peakmem_finalize_staged_data": {
         "code": "class FinalizeStagedData:\n    def peakmem_finalize_staged_data(self, param: int):\n        self.logger.info(f\"LIBRARY: {self.lib}\")\n        self.logger.info(f\"Created Symbol: {self.symbol}\")\n        self.lib.finalize_staged_data(self.symbol, mode=StagedDataFinalizeMethod.WRITE)\n\n    def setup(self, param: int):\n        self.ac = Arctic(FinalizeStagedData.CONNECTION_STRING)\n        self.lib = self.ac.get_library(self.lib_name)\n        self.symbol = f\"symbol{param}\"\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache(CachedDFGenerator(350000, [5]))\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
@@ -2044,6 +1677,222 @@
         "unit": "seconds",
         "version": "2b556ee72fdb8b5b25072c8e0df67fb3264fc3f2fa724c453a6522ef98392f93",
         "warmup_time": -1
+    },
+    "modification_functions.DeleteMultipleVersions.time_delete_multiple_versions": {
+        "code": "class DeleteMultipleVersions:\n    def time_delete_multiple_versions(self):\n        self.lib.delete(self.sym, list(range(99)))\n\n    def setup(self):\n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.ac.delete_library(\"test_lib\")\n        self.lib = self.ac.create_library(\"test_lib\")\n        self.sym = f\"sym_{random.randint(0, 1_000_000)}\"\n    \n        for i in range(100):\n            self.lib.write(self.sym, pd.DataFrame({\"a\": [0]}), prune_previous_versions=False)",
+        "min_run_count": 2,
+        "name": "modification_functions.DeleteMultipleVersions.time_delete_multiple_versions",
+        "number": 1,
+        "param_names": [],
+        "params": [],
+        "repeat": 0,
+        "rounds": 2,
+        "sample_time": 0.01,
+        "type": "time",
+        "unit": "seconds",
+        "version": "5ff8e79225dba7a420094c75efc2b950b018c92c5dafe32e54c2ec67f7b5054f",
+        "warmup_time": 0
+    },
+    "modification_functions.DeleteOverTimeModificationFunctions.time_delete_over_time": {
+        "code": "class DeleteOverTimeModificationFunctions:\n    def time_delete_over_time(self):\n        sym = f\"sym_{random.randint(0, 1_000_000)}\"\n        with config_context(\"VersionMap.ReloadInterval\", 0):\n            for i in range(100):\n                self.lib.write(sym, pd.DataFrame({\"a\": [1]}))\n                self.lib.delete(sym)\n\n    def setup(self):\n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.ac.delete_library(\"test_lib\")\n        self.lib = self.ac.create_library(\"test_lib\")",
+        "min_run_count": 2,
+        "name": "modification_functions.DeleteOverTimeModificationFunctions.time_delete_over_time",
+        "number": 0,
+        "param_names": [],
+        "params": [],
+        "repeat": 0,
+        "rounds": 2,
+        "sample_time": 0.01,
+        "type": "time",
+        "unit": "seconds",
+        "version": "9fccfe476a9df615a7647e269f078d8d154caf9a77a75d0666b465c250e09aba",
+        "warmup_time": -1
+    },
+    "modification_functions.ModificationFunctions.time_append_large": {
+        "code": "class ModificationFunctions:\n    def time_append_large(self, lad: LargeAppendDataModify, rows):\n        large: pd.DataFrame = lad.df_append_large[rows].pop(0)\n        self.lib.append(\"sym\", large)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+        "min_run_count": 2,
+        "name": "modification_functions.ModificationFunctions.time_append_large",
+        "number": 1,
+        "param_names": [
+            "rows"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ]
+        ],
+        "repeat": 3,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:61",
+        "type": "time",
+        "unit": "seconds",
+        "version": "fb86070d8db7d4773154494c7220f394f778f12fb7743699da53caa56ef9e8dd",
+        "warmup_time": 0
+    },
+    "modification_functions.ModificationFunctions.time_append_single": {
+        "code": "class ModificationFunctions:\n    def time_append_single(self, lad: LargeAppendDataModify, rows):\n        self.lib.append(\"sym\", self.df_append_single)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+        "min_run_count": 2,
+        "name": "modification_functions.ModificationFunctions.time_append_single",
+        "number": 1,
+        "param_names": [
+            "rows"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ]
+        ],
+        "repeat": 3,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:61",
+        "type": "time",
+        "unit": "seconds",
+        "version": "38998c47434fe01c7d369271a506dd30542427915409b7bdbcb60659fd2f3cf8",
+        "warmup_time": 0
+    },
+    "modification_functions.ModificationFunctions.time_delete": {
+        "code": "class ModificationFunctions:\n    def time_delete(self, lad: LargeAppendDataModify, rows):\n        self.lib.delete(\"sym\")\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+        "min_run_count": 2,
+        "name": "modification_functions.ModificationFunctions.time_delete",
+        "number": 1,
+        "param_names": [
+            "rows"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ]
+        ],
+        "repeat": 3,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:61",
+        "type": "time",
+        "unit": "seconds",
+        "version": "c49859046e3271f14a0b2ad1a8b19bbb81a74971b1f36968829958444d5c626f",
+        "warmup_time": 0
+    },
+    "modification_functions.ModificationFunctions.time_update_half": {
+        "code": "class ModificationFunctions:\n    def time_update_half(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(\"sym\", self.df_update_half)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+        "min_run_count": 2,
+        "name": "modification_functions.ModificationFunctions.time_update_half",
+        "number": 1,
+        "param_names": [
+            "rows"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ]
+        ],
+        "repeat": 3,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:61",
+        "type": "time",
+        "unit": "seconds",
+        "version": "f5bf7080565adb1ea9b6a39c44910eb51dde1069676886d2628087176897ef75",
+        "warmup_time": 0
+    },
+    "modification_functions.ModificationFunctions.time_update_single": {
+        "code": "class ModificationFunctions:\n    def time_update_single(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(\"sym\", self.df_update_single)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+        "min_run_count": 2,
+        "name": "modification_functions.ModificationFunctions.time_update_single",
+        "number": 1,
+        "param_names": [
+            "rows"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ]
+        ],
+        "repeat": 3,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:61",
+        "type": "time",
+        "unit": "seconds",
+        "version": "c4d4d94b931b60f5e9ef723c994f4688965d1021bc41031d99761221af51b474",
+        "warmup_time": 0
+    },
+    "modification_functions.ModificationFunctions.time_update_upsert": {
+        "code": "class ModificationFunctions:\n    def time_update_upsert(self, lad: LargeAppendDataModify, rows):\n        self.lib.update(\"sym\", self.df_update_upsert, upsert=True)\n\n    def setup(self, lad: LargeAppendDataModify, rows):\n        self.df_update_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(0.5, rows))\n        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, \"s\", get_time_at_fraction_of_df(0.75, rows))\n        self.df_update_upsert = generate_pseudo_random_dataframe(rows, \"s\", get_time_at_fraction_of_df(1.5, rows))\n        self.df_append_single = generate_pseudo_random_dataframe(1, \"s\", get_time_at_fraction_of_df(1.1, rows))\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib = self.ac[get_prewritten_lib_name(rows)]\n\n    def setup_cache(self):\n        start = time.time()\n        lad = self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return lad",
+        "min_run_count": 2,
+        "name": "modification_functions.ModificationFunctions.time_update_upsert",
+        "number": 1,
+        "param_names": [
+            "rows"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ]
+        ],
+        "repeat": 3,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:61",
+        "type": "time",
+        "unit": "seconds",
+        "version": "60f6425aed7b7fe2b97435325f21ac1822a9dea5344f2eb6a14cf554cc9dfce7",
+        "warmup_time": 0
+    },
+    "modification_functions.ShortWideModificationFunctions.time_append_short_wide": {
+        "code": "class ShortWideModificationFunctions:\n    def time_append_short_wide(self, wide_append_data: ShortWideAppendData):\n        large: pd.DataFrame = wide_append_data.append_dfs.pop(0)\n        self.lib_short_wide.append(\"short_wide_sym\", large)\n\n    def setup(self, wide_append_data: ShortWideAppendData):\n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(self.WIDE_DF_ROWS, self.WIDE_DF_COLS)\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(self.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        wide_append_data = self._setup_cache()\n        return wide_append_data",
+        "min_run_count": 2,
+        "name": "modification_functions.ShortWideModificationFunctions.time_append_short_wide",
+        "number": 1,
+        "param_names": [],
+        "params": [],
+        "repeat": 2,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:154",
+        "type": "time",
+        "unit": "seconds",
+        "version": "0718f2707bedadfbde65661a5faf806e09236332e3002438a0637f00e8cc6aa0",
+        "warmup_time": 0
+    },
+    "modification_functions.ShortWideModificationFunctions.time_delete_short_wide": {
+        "code": "class ShortWideModificationFunctions:\n    def time_delete_short_wide(self, wide_append_data: ShortWideAppendData):\n        self.lib_short_wide.delete(\"short_wide_sym\")\n\n    def setup(self, wide_append_data: ShortWideAppendData):\n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(self.WIDE_DF_ROWS, self.WIDE_DF_COLS)\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(self.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        wide_append_data = self._setup_cache()\n        return wide_append_data",
+        "min_run_count": 2,
+        "name": "modification_functions.ShortWideModificationFunctions.time_delete_short_wide",
+        "number": 1,
+        "param_names": [],
+        "params": [],
+        "repeat": 2,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:154",
+        "type": "time",
+        "unit": "seconds",
+        "version": "ea0d16462ea088dd30272c8a6e35952e7b43bac6b1f2cac423de50271138d487",
+        "warmup_time": 0
+    },
+    "modification_functions.ShortWideModificationFunctions.time_update_short_wide": {
+        "code": "class ShortWideModificationFunctions:\n    def time_update_short_wide(self, wide_append_data: ShortWideAppendData):\n        self.lib_short_wide.update(\"short_wide_sym\", self.df_update_short_wide)\n\n    def setup(self, wide_append_data: ShortWideAppendData):\n        self.df_update_short_wide = generate_random_floats_dataframe_with_index(self.WIDE_DF_ROWS, self.WIDE_DF_COLS)\n    \n        self.ac = Arctic(self.CONNECTION_STRING)\n        self.lib_short_wide = self.ac[get_prewritten_lib_name(self.WIDE_DF_ROWS)]\n\n    def setup_cache(self):\n        wide_append_data = self._setup_cache()\n        return wide_append_data",
+        "min_run_count": 2,
+        "name": "modification_functions.ShortWideModificationFunctions.time_update_short_wide",
+        "number": 1,
+        "param_names": [],
+        "params": [],
+        "repeat": 2,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:154",
+        "type": "time",
+        "unit": "seconds",
+        "version": "0c499be36152b0f962116c641928b8a0f2bfca6bab12e9c4d30461c8509bdc2b",
+        "warmup_time": 0
     },
     "real_batch_functions.AWSBatchBasicFunctions.peakmem_read_batch": {
         "code": "class AWSBatchBasicFunctions:\n    def peakmem_read_batch(self, num_symbols, num_rows):\n        read_batch_result = self.lib.read_batch(self.read_reqs)\n        # Quick check all is ok (will not affect bemchmarks)\n        assert read_batch_result[0].data.shape[0] == num_rows\n        assert read_batch_result[-1].data.shape[0] == num_rows\n\n    def setup(self, num_symbols, num_rows):\n        self.manager = self.get_library_manager()\n        self.population_policy = self.get_population_policy()\n        # We use the same generator as the policy\n    \n        self.lib: Library = self.manager.get_library(LibraryType.PERSISTENT, num_symbols)\n        self.write_lib: Library = self.manager.get_library(LibraryType.MODIFIABLE, num_symbols)\n        self.get_logger().info(f\"Library {self.lib}\")\n        self.get_logger().debug(f\"Symbols {self.lib.list_symbols()}\")\n    \n        # Get generated symbol names\n        self.symbols = []\n        for num_symb_idx in range(num_symbols):\n            # the name is constructed of 2 parts index + number of rows\n            sym_name = self.population_policy.get_symbol_name(num_symb_idx, num_rows)\n            if not self.lib.has_symbol(sym_name):\n                self.get_logger().error(f\"symbol not found {sym_name}\")\n            self.symbols.append(sym_name)\n    \n        # Construct read requests (will equal to number of symbols)\n        self.read_reqs = [ReadRequest(symbol) for symbol in self.symbols]\n    \n        # Construct dataframe that will be used for write requests, not whole DF (will equal to number of symbols)\n        self.df = self.population_policy.df_generator.get_dataframe(num_rows, AWSBatchBasicFunctions.number_columns)\n    \n        # Construct read requests based on 2 colmns, not whole DF (will equal to number of symbols)\n        COLS = self.df.columns[2:4]\n        self.read_reqs_with_cols = [ReadRequest(symbol, columns=COLS) for symbol in self.symbols]\n    \n        # Construct read request with date_range\n        self.date_range = self.get_last_x_percent_date_range(num_rows, 0.05)\n        self.read_reqs_date_range = [ReadRequest(symbol, date_range=self.date_range) for symbol in self.symbols]\n\n    def setup_cache(self):\n        manager = self.get_library_manager()\n        policy = self.get_population_policy()\n        logger = self.get_logger()\n        number_symbols_list, number_rows_list = AWSBatchBasicFunctions.params\n        for number_symbols in number_symbols_list:\n            lib_suffix = number_symbols\n            if not manager.has_library(LibraryType.PERSISTENT, lib_suffix):\n                start = time.time()\n                for number_rows in number_rows_list:\n                    policy.set_parameters([number_rows] * lib_suffix, AWSBatchBasicFunctions.number_columns)\n                    # the name of symbols during generation will have now 2 parameters:\n                    # the index of symbol + number of rows\n                    # that allows generating more than one symbol in a library\n                    policy.set_symbol_fixed_str(number_rows)\n                    populate_library(manager, policy, LibraryType.PERSISTENT, lib_suffix)\n                    logger.info(f\"Generated {number_symbols} with {number_rows} each for {time.time()- start}\")\n        manager.log_info()  # Always log the ArcticURIs",
@@ -4332,7 +4181,7 @@
         "rounds": 2,
         "sample_time": 2,
         "setup_cache_key": "version_chain:48",
-        "timeout": 6000,
+        "timeout": 1000,
         "type": "time",
         "unit": "seconds",
         "version": "c994d17e8987906e0964cc8145263dc8ddba0f0e1ec0b8fc729ea437a390605c",
@@ -4366,7 +4215,7 @@
         "rounds": 2,
         "sample_time": 2,
         "setup_cache_key": "version_chain:48",
-        "timeout": 6000,
+        "timeout": 1000,
         "type": "time",
         "unit": "seconds",
         "version": "e68f85572eefce903e6c90ac005474274128cf893551579dded0dbfa891eb4bf",
@@ -4400,7 +4249,7 @@
         "rounds": 2,
         "sample_time": 2,
         "setup_cache_key": "version_chain:48",
-        "timeout": 6000,
+        "timeout": 1000,
         "type": "time",
         "unit": "seconds",
         "version": "117a257c8033130bab1d83ea4c8993283739842e87dccd898107f8ecbd8fd714",
@@ -4434,7 +4283,7 @@
         "rounds": 2,
         "sample_time": 2,
         "setup_cache_key": "version_chain:48",
-        "timeout": 6000,
+        "timeout": 1000,
         "type": "time",
         "unit": "seconds",
         "version": "65cf6d6226805c2655d981a065b9e345cc8b00424f8f35965407dfdc1b8da504",
@@ -4468,7 +4317,7 @@
         "rounds": 2,
         "sample_time": 2,
         "setup_cache_key": "version_chain:48",
-        "timeout": 6000,
+        "timeout": 1000,
         "type": "time",
         "unit": "seconds",
         "version": "e086c5206ded034b9ab56b93a7c774085fd00125211350aee5d2fa3b2a700321",

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -544,7 +544,8 @@ def random_floats(num):
 
 def random_dates(num):
     base_date = np.datetime64("2017-01-01")
-    return np.array([base_date + random.randint(0, 100) for _ in range(num)])
+    offsets = np.random.randint(low=0, high=100, size=num)
+    return base_date + offsets
 
 
 def dataframe_for_date(dt, identifiers):

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -3875,13 +3875,13 @@ def _log_warning_on_writing_empty_dataframe(dataframe, symbol):
         empty_column_type = pd.DataFrame({"a": []}).dtypes["a"] if is_dataframe else pd.Series([]).dtype
         current_dtypes = list(dataframe.dtypes.items()) if is_dataframe else [(dataframe.name, dataframe.dtype)]
         log.warning(
-            'Writing empty dataframe to ArcticDB for symbol "{}". The dtypes of empty columns depend on the'
-            "Pandas version being used. This can lead to unexpected behavior in the processing pipeline. For"
-            " example if the empty columns are of object dtype they cannot be part of numeric computations in"
-            "the processing pipeline such as filtering (qb = qb[qb['empty_column'] < 5]) or projection"
-            "(qb = qb.apply('new', qb['empty_column'] + 5)). Pandas version is: {}, the default dtype for empty"
-            ' column is: {}. Column types in the original input: {}. Parameter "coerce_columns" can be used'
-            " to explicitly set the types of dataframe columns",
+            'Writing empty dataframe to ArcticDB for symbol "{}". The dtypes of empty columns depend on the '
+            "Pandas version being used. This can lead to unexpected behavior when using the QueryBuilder. For "
+            "example, if the empty columns are of object dtype they cannot be part of numeric computations "
+            "such as filtering `qb = qb[qb['empty_column'] < 5]` or projection "
+            "`qb = qb.apply('new', qb['empty_column'] + 5)`. Pandas version is: {}, the default dtype for empty "
+            'column is: {}. Column types in the original input: {}. Parameter "coerce_columns" can be used '
+            "to explicitly set the types of dataframe columns",
             symbol,
             PANDAS_VERSION,
             empty_column_type,

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -7,40 +7,31 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import time
-from typing import List
+
 from arcticdb import Arctic, QueryBuilder
 from arcticdb.version_store.library import UpdatePayload, WritePayload, ReadRequest
-from arcticdb.util.test import config_context
-from arcticdb_ext.version_store import DataError
 from asv_runner.benchmarks.mark import skip_benchmark
 
 import pandas as pd
 
 from benchmarks.common import *
 
-# Common parameters between BasicFunctions and ModificationFunctions
-WIDE_DF_ROWS = 5_000
-WIDE_DF_COLS = 30_000
 # We use larger dataframes for non-batch methods
-PARAMS = [1_000_000, 1_500_000]
+PARAMS = [1_000_000, 10_000_000]
 PARAM_NAMES = ["rows"]
-BATCH_PARAMS = ([25_000, 50_000], [500, 1000])
+BATCH_PARAMS = ([25_000, 50_000], [100, 200])
 BATCH_PARAM_NAMES = ["rows", "num_symbols"]
 DATE_RANGE = (pd.Timestamp("2022-12-31"), pd.Timestamp("2023-01-01"))
 
 
 class BasicFunctions:
-    number = 5
-    warmup_time = 0
-    timeout = 6000
+    sample_time = 0.1
     rounds = 1
-    CONNECTION_STRING = "lmdb://basic_functions?map_size=20GB"
-    ULTRA_SHORT_WIDE_DF_ROWS = 1
-    WIDE_DF_ROWS = WIDE_DF_ROWS
-    WIDE_DF_COLS = WIDE_DF_COLS
-    DATE_RANGE = DATE_RANGE
+
     params = PARAMS
     param_names = PARAM_NAMES
+
+    CONNECTION_STRING = "lmdb://basic_functions"
 
     def __init__(self):
         self.logger = get_logger()
@@ -62,22 +53,6 @@ class BasicFunctions:
             lib = self.ac[lib]
             lib.write(f"sym", self.dfs[rows])
 
-        lib_name = get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)
-        self.ac.delete_library(lib_name)
-        lib = self.ac.create_library(lib_name)
-        lib.write(
-            "short_wide_sym",
-            generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),
-        )
-
-        lib_name = get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)
-        self.ac.delete_library(lib_name)
-        lib = self.ac.create_library(lib_name)
-        lib.write(
-            "ultra_short_wide_sym",
-            generate_random_floats_dataframe(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS),
-        )
-
     def teardown(self, rows):
         for lib in self.ac.list_libraries():
             if "prewritten" in lib:
@@ -90,7 +65,6 @@ class BasicFunctions:
         self.ac = Arctic(BasicFunctions.CONNECTION_STRING)
 
         self.df = generate_pseudo_random_dataframe(rows)
-        self.df_short_wide = generate_random_floats_dataframe(BasicFunctions.WIDE_DF_ROWS, BasicFunctions.WIDE_DF_COLS)
 
         self.lib = self.ac[get_prewritten_lib_name(rows)]
         self.fresh_lib = self.get_fresh_lib()
@@ -105,33 +79,11 @@ class BasicFunctions:
     def peakmem_write(self, rows):
         self.fresh_lib.write(f"sym", self.df)
 
-    def time_write_short_wide(self, rows):
-        self.fresh_lib.write("short_wide_sym", self.df_short_wide)
-
-    def peakmem_write_short_wide(self, rows):
-        self.fresh_lib.write("short_wide_sym", self.df_short_wide)
-
     def time_read(self, rows):
         self.lib.read(f"sym").data
 
     def peakmem_read(self, rows):
         self.lib.read(f"sym").data
-
-    def time_read_short_wide(self, rows):
-        lib = self.ac[get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)]
-        lib.read("short_wide_sym").data
-
-    def peakmem_read_short_wide(self, rows):
-        lib = self.ac[get_prewritten_lib_name(BasicFunctions.WIDE_DF_ROWS)]
-        lib.read("short_wide_sym").data
-
-    def time_read_ultra_short_wide(self, rows):
-        lib = self.ac[get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)]
-        lib.read("ultra_short_wide_sym").data
-
-    def peakmem_read_ultra_short_wide(self, rows):
-        lib = self.ac[get_prewritten_lib_name(BasicFunctions.ULTRA_SHORT_WIDE_DF_ROWS)]
-        lib.read("ultra_short_wide_sym").data
 
     def time_read_with_columns(self, rows):
         COLS = ["value"]
@@ -142,17 +94,17 @@ class BasicFunctions:
         self.lib.read(f"sym", columns=COLS).data
 
     def time_read_with_date_ranges(self, rows):
-        self.lib.read(f"sym", date_range=BasicFunctions.DATE_RANGE).data
+        self.lib.read(f"sym", date_range=DATE_RANGE).data
 
     def peakmem_read_with_date_ranges(self, rows):
-        self.lib.read(f"sym", date_range=BasicFunctions.DATE_RANGE).data
+        self.lib.read(f"sym", date_range=DATE_RANGE).data
 
     def time_read_with_date_ranges_query_builder(self, rows):
-        q = QueryBuilder().date_range(BasicFunctions.DATE_RANGE)
+        q = QueryBuilder().date_range(DATE_RANGE)
         self.lib.read(f"sym", query_builder=q).data
 
     def peakmem_read_with_date_ranges_query_builder(self, rows):
-        q = QueryBuilder().date_range(BasicFunctions.DATE_RANGE)
+        q = QueryBuilder().date_range(DATE_RANGE)
         self.lib.read(f"sym", query_builder=q).data
 
     def time_write_staged(self, rows):
@@ -164,13 +116,65 @@ class BasicFunctions:
         self.fresh_lib._nvs.compact_incomplete(f"sym", False, False)
 
 
+class ShortWideWrite:
+    CONNECTION_STRING = "lmdb://short_wide_write"
+    COLS = 30_000
+
+    params = [1, 5_000]
+    param_names = ["rows"]
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup(self, rows):
+        self.ac = Arctic(ShortWideWrite.CONNECTION_STRING)
+        self.lib = self.ac.create_library("lib")
+        self.df = generate_random_floats_dataframe(rows, ShortWideWrite.COLS)
+
+    def teardown(self, *args):
+        self.ac.delete_library("lib")
+
+    def time_write(self, *args):
+        self.lib.write("sym", self.df)
+
+    def peakmem_write(self, *args):
+        self.lib.write("sym", self.df)
+
+
+class ShortWideRead:
+    CONNECTION_STRING = "lmdb://short_wide_read"
+    ROWS = [1, 5_000]
+    COLS = 30_000
+
+    params = ROWS
+    param_names = ["rows"]
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        ac = Arctic(ShortWideRead.CONNECTION_STRING)
+        lib = ac.create_library("lib")
+        for r in ShortWideRead.ROWS:
+            df = generate_random_floats_dataframe(r, ShortWideRead.COLS)
+            lib.write(f"sym_{r}", df)
+
+    def setup(self, rows):
+        ac = Arctic(ShortWideRead.CONNECTION_STRING)
+        self.lib = ac["lib"]
+
+    def time_read(self, rows):
+        self.lib.read(f"sym_{rows}")
+
+    def peakmem_read(self, rows):
+        self.lib.read(f"sym_{rows}")
+
+
 class BatchBasicFunctions:
     rounds = 1
-    number = 1
-    repeat = 3
-    warmup_time = 0
-    timeout = 6000
-    CONNECTION_STRING = "lmdb://batch_basic_functions?map_size=20GB"
+    sample_time = 0.1
+
+    CONNECTION_STRING = "lmdb://batch_basic_functions"
     DATE_RANGE = DATE_RANGE
     params = BATCH_PARAMS
     param_names = BATCH_PARAM_NAMES
@@ -242,9 +246,6 @@ class BatchBasicFunctions:
         read_reqs = [ReadRequest(f"{sym}_sym") for sym in range(num_symbols)]
         self.lib.read_batch(read_reqs)
 
-    def time_read_batch_pure(self, rows, num_symbols):
-        self.lib.read_batch(self.read_reqs)
-
     def peakmem_read_batch(self, rows, num_symbols):
         read_reqs = [ReadRequest(f"{sym}_sym") for sym in range(num_symbols)]
         self.lib.read_batch(read_reqs)
@@ -266,174 +267,3 @@ class BatchBasicFunctions:
     def peakmem_read_batch_with_date_ranges(self, rows, num_symbols):
         read_reqs = [ReadRequest(f"{sym}_sym", date_range=BatchBasicFunctions.DATE_RANGE) for sym in range(num_symbols)]
         self.lib.read_batch(read_reqs)
-
-
-def get_time_at_fraction_of_df(fraction, rows):
-    end_time = pd.Timestamp("1/1/2023")
-    time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction - 1)))
-    return end_time + time_delta
-
-
-from shutil import copytree, rmtree
-
-
-class ModificationFunctions:
-    """
-    Modification functions (update, append, delete) need a different setup/teardown process, thus we place them in a
-    separate group.
-    """
-
-    rounds = 1
-    number = 1  # We do a single run between setup and teardown because we e.g. can't delete a symbol twice
-    repeat = 3
-    warmup_time = 0
-
-    timeout = 6000
-    ARCTIC_DIR = "modification_functions"
-    ARCTIC_DIR_ORIGINAL = "modification_functions_original"
-    CONNECTION_STRING = f"lmdb://{ARCTIC_DIR}?map_size=20GB"
-    WIDE_DF_ROWS = WIDE_DF_ROWS
-    WIDE_DF_COLS = WIDE_DF_COLS
-
-    params = PARAMS
-    param_names = PARAM_NAMES
-
-    class LargeAppendDataModify:
-        """
-        This class will hold a cache of append large dataframes
-        The purpose of this cache is to create dataframes
-        which timestamps are sequenced over time so that
-        overlap does not occur
-        """
-
-        def __init__(self, num_rows_list: List[int], number_elements: int):
-            self.df_append_large = {}
-            self.df_append_short_wide = {}
-            start_time = time.time()
-            for rows in num_rows_list:
-                print("Generating dataframe with rows: ", rows)
-                lst = list()
-                lst_saw = list()
-                for n in range(number_elements + 1):
-                    print("Generating dataframe no: ", n)
-
-                    df = generate_pseudo_random_dataframe(rows, "s", get_time_at_fraction_of_df(2 * (n + 1), rows))
-                    df_saw = generate_random_floats_dataframe_with_index(
-                        ModificationFunctions.WIDE_DF_ROWS,
-                        ModificationFunctions.WIDE_DF_COLS,
-                        "s",
-                        get_time_at_fraction_of_df(2 * (n + 1), rows=ModificationFunctions.WIDE_DF_ROWS),
-                    )
-
-                    lst.append(df)
-                    lst_saw.append(df_saw)
-                    print(f"STANDARD     Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}")
-                    print(f"SHORT_n_WIDE Index {df_saw.iloc[0].name} - {df_saw.iloc[df_saw.shape[0] - 1].name}")
-                print("Add dataframes: ", len(lst))
-                self.df_append_large[rows] = lst
-                self.df_append_short_wide[rows] = lst_saw
-            print("APPEND LARGE cache generation took (s) :", time.time() - start_time)
-
-    def __init__(self):
-        self.logger = get_logger()
-
-    def setup_cache(self):
-        start = time.time()
-        lad = self._setup_cache()
-        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
-        return lad
-
-    def _setup_cache(self):
-        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)
-        rows_values = ModificationFunctions.params
-
-        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}
-        for rows in rows_values:
-            lib_name = get_prewritten_lib_name(rows)
-            self.ac.delete_library(lib_name)
-            lib = self.ac.create_library(lib_name)
-            df = self.init_dfs[rows]
-            lib.write("sym", df)
-            print(f"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}")
-
-        lib_name = get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)
-        self.ac.delete_library(lib_name)
-        lib = self.ac.create_library(lib_name)
-        lib.write(
-            "short_wide_sym",
-            generate_random_floats_dataframe_with_index(
-                ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS
-            ),
-        )
-
-        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.
-        # Then on each teardown we restore the initial state by overwriting the modified with the original.
-        copytree(ModificationFunctions.ARCTIC_DIR, ModificationFunctions.ARCTIC_DIR_ORIGINAL)
-
-        number_iteration = ModificationFunctions.repeat * ModificationFunctions.number * ModificationFunctions.rounds
-
-        lad = ModificationFunctions.LargeAppendDataModify(ModificationFunctions.params, number_iteration)
-
-        return lad
-
-    def setup(self, lad: LargeAppendDataModify, rows):
-        self.df_update_single = generate_pseudo_random_dataframe(1, "s", get_time_at_fraction_of_df(0.5, rows))
-        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, "s", get_time_at_fraction_of_df(0.75, rows))
-        self.df_update_upsert = generate_pseudo_random_dataframe(rows, "s", get_time_at_fraction_of_df(1.5, rows))
-        self.df_append_single = generate_pseudo_random_dataframe(1, "s", get_time_at_fraction_of_df(1.1, rows))
-
-        self.df_update_short_wide = generate_random_floats_dataframe_with_index(
-            ModificationFunctions.WIDE_DF_ROWS, ModificationFunctions.WIDE_DF_COLS
-        )
-
-        self.ac = Arctic(ModificationFunctions.CONNECTION_STRING)
-        self.lib = self.ac[get_prewritten_lib_name(rows)]
-        self.lib_short_wide = self.ac[get_prewritten_lib_name(ModificationFunctions.WIDE_DF_ROWS)]
-
-        # Used by time_delete_multiple_versions
-        for i in range(100):
-            self.lib.write("sym_delete_multiple", pd.DataFrame(), prune_previous_versions=False)
-
-    def teardown(self, lad: LargeAppendDataModify, rows):
-        rmtree(ModificationFunctions.ARCTIC_DIR)
-        copytree(ModificationFunctions.ARCTIC_DIR_ORIGINAL, ModificationFunctions.ARCTIC_DIR, dirs_exist_ok=True)
-
-        del self.ac
-
-    def time_update_single(self, lad: LargeAppendDataModify, rows):
-        self.lib.update("sym", self.df_update_single)
-
-    def time_update_half(self, lad: LargeAppendDataModify, rows):
-        self.lib.update("sym", self.df_update_half)
-
-    def time_update_upsert(self, lad: LargeAppendDataModify, rows):
-        self.lib.update("sym", self.df_update_upsert, upsert=True)
-
-    def time_update_short_wide(self, lad: LargeAppendDataModify, rows):
-        self.lib_short_wide.update("short_wide_sym", self.df_update_short_wide)
-
-    def time_append_single(self, lad: LargeAppendDataModify, rows):
-        self.lib.append("sym", self.df_append_single)
-
-    def time_append_large(self, lad: LargeAppendDataModify, rows):
-        large: pd.DataFrame = lad.df_append_large[rows].pop(0)
-        self.lib.append("sym", large)
-
-    def time_append_short_wide(self, lad: LargeAppendDataModify, rows):
-        large: pd.DataFrame = lad.df_append_short_wide[rows].pop(0)
-        self.lib_short_wide.append("short_wide_sym", large)
-
-    def time_delete(self, lad: LargeAppendDataModify, rows):
-        self.lib.delete("sym")
-
-    def time_delete_multiple_versions(self, lad: LargeAppendDataModify, rows):
-        self.lib.delete("sym_delete_multiple", list(range(99)))
-
-    def time_delete_short_wide(self, lad: LargeAppendDataModify, rows):
-        self.lib_short_wide.delete("short_wide_sym")
-
-    def time_delete_over_time(self, lad: LargeAppendDataModify, rows):
-        with config_context("VersionMap.ReloadInterval", 0):
-            for i in range(100):
-                self.lib.write("delete_over_time", pd.DataFrame())
-                self.lib.delete("delete_over_time")

--- a/python/benchmarks/modification_functions.py
+++ b/python/benchmarks/modification_functions.py
@@ -1,0 +1,243 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import random
+import time
+from typing import List
+from shutil import copytree, rmtree
+
+from arcticdb import Arctic
+from arcticdb.util.test import config_context
+
+import pandas as pd
+
+from benchmarks.common import *
+
+
+def get_time_at_fraction_of_df(fraction, rows):
+    end_time = pd.Timestamp("1/1/2023")
+    time_delta = pd.tseries.offsets.DateOffset(seconds=round(rows * (fraction - 1)))
+    return end_time + time_delta
+
+
+class ModificationFunctions:
+    rounds = 1
+    number = 1  # We do a single run between setup and teardown because we e.g. can't delete a symbol twice
+    repeat = 3
+    warmup_time = 0
+
+    ARCTIC_DIR = "modification_functions"
+    ARCTIC_DIR_ORIGINAL = "modification_functions_original"
+    CONNECTION_STRING = f"lmdb://{ARCTIC_DIR}"
+
+    params = [1_000_000, 10_000_000]
+    param_names = ["rows"]
+
+    class LargeAppendDataModify:
+        """
+        This class will hold a cache of append large dataframes.
+
+        This cache is to create dataframes with timestamps sequenced over time so that overlap does not occur.
+        """
+
+        def __init__(self, num_rows_list: List[int], number_elements: int):
+            self.df_append_large = {}
+            for rows in num_rows_list:
+                lst = list()
+                for n in range(number_elements + 1):
+                    df = generate_pseudo_random_dataframe(rows, "s", get_time_at_fraction_of_df(2 * (n + 1), rows))
+
+                    lst.append(df)
+                self.df_append_large[rows] = lst
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        start = time.time()
+        lad = self._setup_cache()
+        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+        return lad
+
+    def _setup_cache(self):
+        self.ac = Arctic(self.CONNECTION_STRING)
+        rows_values = self.params
+
+        self.init_dfs = {rows: generate_pseudo_random_dataframe(rows) for rows in rows_values}
+        for rows in rows_values:
+            lib_name = get_prewritten_lib_name(rows)
+            self.ac.delete_library(lib_name)
+            lib = self.ac.create_library(lib_name)
+            df = self.init_dfs[rows]
+            lib.write("sym", df)
+            print(f"INITIAL DATAFRAME {rows} rows has Index {df.iloc[0].name} - {df.iloc[df.shape[0] - 1].name}")
+
+        # We use the fact that we're running on LMDB to store a copy of the initial arctic directory.
+        # Then on each teardown we restore the initial state by overwriting the modified with the original.
+        copytree(self.ARCTIC_DIR, self.ARCTIC_DIR_ORIGINAL)
+
+        number_iteration = self.repeat * self.number * self.rounds
+
+        lad = self.LargeAppendDataModify(self.params, number_iteration)
+
+        return lad
+
+    def setup(self, lad: LargeAppendDataModify, rows):
+        self.df_update_single = generate_pseudo_random_dataframe(1, "s", get_time_at_fraction_of_df(0.5, rows))
+        self.df_update_half = generate_pseudo_random_dataframe(rows // 2, "s", get_time_at_fraction_of_df(0.75, rows))
+        self.df_update_upsert = generate_pseudo_random_dataframe(rows, "s", get_time_at_fraction_of_df(1.5, rows))
+        self.df_append_single = generate_pseudo_random_dataframe(1, "s", get_time_at_fraction_of_df(1.1, rows))
+
+        self.ac = Arctic(self.CONNECTION_STRING)
+        self.lib = self.ac[get_prewritten_lib_name(rows)]
+
+    def teardown(self, lad: LargeAppendDataModify, rows):
+        rmtree(self.ARCTIC_DIR)
+        copytree(self.ARCTIC_DIR_ORIGINAL, self.ARCTIC_DIR, dirs_exist_ok=True)
+
+        del self.ac
+
+    def time_update_single(self, lad: LargeAppendDataModify, rows):
+        self.lib.update("sym", self.df_update_single)
+
+    def time_update_half(self, lad: LargeAppendDataModify, rows):
+        self.lib.update("sym", self.df_update_half)
+
+    def time_update_upsert(self, lad: LargeAppendDataModify, rows):
+        self.lib.update("sym", self.df_update_upsert, upsert=True)
+
+    def time_append_single(self, lad: LargeAppendDataModify, rows):
+        self.lib.append("sym", self.df_append_single)
+
+    def time_append_large(self, lad: LargeAppendDataModify, rows):
+        large: pd.DataFrame = lad.df_append_large[rows].pop(0)
+        self.lib.append("sym", large)
+
+    def time_delete(self, lad: LargeAppendDataModify, rows):
+        self.lib.delete("sym")
+
+
+class ShortWideModificationFunctions:
+    rounds = 1
+    number = 1  # We do a single run between setup and teardown because we e.g. can't delete a symbol twice
+    repeat = 2
+    warmup_time = 0
+
+    ARCTIC_DIR = "modification_functions_short_wide"
+    ARCTIC_DIR_ORIGINAL = "modification_functions_short_wide_original"
+    CONNECTION_STRING = f"lmdb://{ARCTIC_DIR}"
+    WIDE_DF_ROWS = 5_000
+    WIDE_DF_COLS = 30_000
+
+    class ShortWideAppendData:
+        def __init__(self, number_elements: int):
+            append_dfs = list()
+            for n in range(number_elements + 1):
+                df = generate_random_floats_dataframe_with_index(
+                    ShortWideModificationFunctions.WIDE_DF_ROWS,
+                    ShortWideModificationFunctions.WIDE_DF_COLS,
+                    "s",
+                    get_time_at_fraction_of_df(2 * (n + 1), rows=ShortWideModificationFunctions.WIDE_DF_ROWS),
+                )
+
+                append_dfs.append(df)
+            self.append_dfs = append_dfs
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        wide_append_data = self._setup_cache()
+        return wide_append_data
+
+    def _setup_cache(self):
+        self.ac = Arctic(self.CONNECTION_STRING)
+
+        lib_name = get_prewritten_lib_name(self.WIDE_DF_ROWS)
+        self.ac.delete_library(lib_name)
+        lib = self.ac.create_library(lib_name)
+        lib.write(
+            "short_wide_sym",
+            generate_random_floats_dataframe_with_index(self.WIDE_DF_ROWS, self.WIDE_DF_COLS),
+        )
+
+        copytree(self.ARCTIC_DIR, self.ARCTIC_DIR_ORIGINAL)
+
+        number_iteration = self.repeat * self.number * self.rounds
+
+        return self.ShortWideAppendData(number_iteration)
+
+    def setup(self, wide_append_data: ShortWideAppendData):
+        self.df_update_short_wide = generate_random_floats_dataframe_with_index(self.WIDE_DF_ROWS, self.WIDE_DF_COLS)
+
+        self.ac = Arctic(self.CONNECTION_STRING)
+        self.lib_short_wide = self.ac[get_prewritten_lib_name(self.WIDE_DF_ROWS)]
+
+    def teardown(self, wide_append_data: ShortWideAppendData):
+        rmtree(self.ARCTIC_DIR)
+        copytree(self.ARCTIC_DIR_ORIGINAL, self.ARCTIC_DIR, dirs_exist_ok=True)
+
+        del self.ac
+
+    def time_update_short_wide(self, wide_append_data: ShortWideAppendData):
+        self.lib_short_wide.update("short_wide_sym", self.df_update_short_wide)
+
+    def time_append_short_wide(self, wide_append_data: ShortWideAppendData):
+        large: pd.DataFrame = wide_append_data.append_dfs.pop(0)
+        self.lib_short_wide.append("short_wide_sym", large)
+
+    def time_delete_short_wide(self, wide_append_data: ShortWideAppendData):
+        self.lib_short_wide.delete("short_wide_sym")
+
+
+class DeleteOverTimeModificationFunctions:
+
+    ARCTIC_DIR = "modification_functions_delete"
+    CONNECTION_STRING = f"lmdb://{ARCTIC_DIR}"
+
+    def setup(self):
+        self.ac = Arctic(self.CONNECTION_STRING)
+        self.ac.delete_library("test_lib")
+        self.lib = self.ac.create_library("test_lib")
+
+    def teardown(self):
+        self.ac.delete_library("test_lib")
+        del self.ac
+        rmtree(self.ARCTIC_DIR, ignore_errors=True)
+
+    def time_delete_over_time(self):
+        sym = f"sym_{random.randint(0, 1_000_000)}"
+        with config_context("VersionMap.ReloadInterval", 0):
+            for i in range(100):
+                self.lib.write(sym, pd.DataFrame({"a": [1]}))
+                self.lib.delete(sym)
+
+
+class DeleteMultipleVersions:
+    number = 1  # need to prepare the symbol in setup so can only run a single time per setup
+    warmup_time = 0
+
+    ARCTIC_DIR = "modification_functions_delete_versions"
+    CONNECTION_STRING = f"lmdb://{ARCTIC_DIR}"
+
+    def setup(self):
+        self.ac = Arctic(self.CONNECTION_STRING)
+        self.ac.delete_library("test_lib")
+        self.lib = self.ac.create_library("test_lib")
+        self.sym = f"sym_{random.randint(0, 1_000_000)}"
+
+        for i in range(100):
+            self.lib.write(self.sym, pd.DataFrame({"a": [0]}), prune_previous_versions=False)
+
+    def teardown(self):
+        self.ac.delete_library("test_lib")
+        del self.ac
+        rmtree(self.ARCTIC_DIR, ignore_errors=True)
+
+    def time_delete_multiple_versions(self):
+        self.lib.delete(self.sym, list(range(99)))

--- a/python/benchmarks/version_chain.py
+++ b/python/benchmarks/version_chain.py
@@ -21,7 +21,7 @@ from .common import *
 
 
 class IterateVersionChain:
-    timeout = 6000
+    timeout = 1000
     sample_time = 2
     rounds = 2
 
@@ -68,7 +68,6 @@ class IterateVersionChain:
         # Step 1 - write 99% of the versions to one library
         # Step 2 - copy the library directory
         # Step 3 - delete the symbol on the copy. Write the remaining versions to both source and copy.
-        start_time = time.time()
         adb._ext.set_config_int("VersionMap.ReloadInterval", sys.maxsize)
 
         for num_versions in num_versions_list:


### PR DESCRIPTION
Note that this includes a non-test change I came across while working on this, just to fix the logging when we write empty dataframes, which was malformed. This is e7ecd73.

The other changes are to speed up or otherwise improve our ASV execution.

- Adjust batch parameters to get a sensible execution time
- Remove time_read_batch_pure
- Test batch functions with 1M and 10M rows, not 1M and 1.5M rows which is not interesting
- Several changes to decompose benchmarks in to smaller classes. We have a pattern in several places where a parameterized benchmark class includes some functions that do not actually vary based on the parameters, so they run once for each parameterization for no reason.
- Improve the setup_cache time in comparison_benchmarks.py from about 60s to about 3s
- Fix some places where we write empty dataframes, which causes a lot of log warnings

This has reduced the benchmarking time to roughly 1h40 down from about 2h20m.

Please review commit-by-commit.