### PR TITLE
Update copyright notices to 2026

### DIFF
--- a/cpp/arcticdb/arrow/arrow_handlers.cpp
+++ b/cpp/arcticdb/arrow/arrow_handlers.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/arrow_handlers.hpp
+++ b/cpp/arcticdb/arrow/arrow_handlers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/arrow_output_frame.cpp
+++ b/cpp/arcticdb/arrow/arrow_output_frame.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/arrow_output_frame.hpp
+++ b/cpp/arcticdb/arrow/arrow_output_frame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/arrow_output_options.hpp
+++ b/cpp/arcticdb/arrow/arrow_output_options.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/arrow_utils.cpp
+++ b/cpp/arcticdb/arrow/arrow_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/arrow_utils.hpp
+++ b/cpp/arcticdb/arrow/arrow_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/test/arrow_test_utils.cpp
+++ b/cpp/arcticdb/arrow/test/arrow_test_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/test/arrow_test_utils.hpp
+++ b/cpp/arcticdb/arrow/test/arrow_test_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/test/benchmark_arrow_reads.cpp
+++ b/cpp/arcticdb/arrow/test/benchmark_arrow_reads.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/test/benchmark_arrow_writes.cpp
+++ b/cpp/arcticdb/arrow/test/benchmark_arrow_writes.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/test/test_arrow_read.cpp
+++ b/cpp/arcticdb/arrow/test/test_arrow_read.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/arrow/test/test_arrow_write.cpp
+++ b/cpp/arcticdb/arrow/test/test_arrow_write.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/async_store.cpp
+++ b/cpp/arcticdb/async/async_store.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/base_task.hpp
+++ b/cpp/arcticdb/async/base_task.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/batch_read_args.hpp
+++ b/cpp/arcticdb/async/batch_read_args.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/python_bindings.cpp
+++ b/cpp/arcticdb/async/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/python_bindings.hpp
+++ b/cpp/arcticdb/async/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/codec-inl.hpp
+++ b/cpp/arcticdb/codec/codec-inl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/codec.cpp
+++ b/cpp/arcticdb/codec/codec.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/codec.hpp
+++ b/cpp/arcticdb/codec/codec.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/core.hpp
+++ b/cpp/arcticdb/codec/core.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/default_codecs.hpp
+++ b/cpp/arcticdb/codec/default_codecs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/encode_common.hpp
+++ b/cpp/arcticdb/codec/encode_common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/encode_v1.cpp
+++ b/cpp/arcticdb/codec/encode_v1.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/encode_v2.cpp
+++ b/cpp/arcticdb/codec/encode_v2.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/encoded_field.cpp
+++ b/cpp/arcticdb/codec/encoded_field.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/encoded_field.hpp
+++ b/cpp/arcticdb/codec/encoded_field.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/encoded_field_collection.hpp
+++ b/cpp/arcticdb/codec/encoded_field_collection.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/encoding_sizes.hpp
+++ b/cpp/arcticdb/codec/encoding_sizes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/lz4.hpp
+++ b/cpp/arcticdb/codec/lz4.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/magic_words.hpp
+++ b/cpp/arcticdb/codec/magic_words.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/passthrough.hpp
+++ b/cpp/arcticdb/codec/passthrough.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/protobuf_mappings.cpp
+++ b/cpp/arcticdb/codec/protobuf_mappings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/protobuf_mappings.hpp
+++ b/cpp/arcticdb/codec/protobuf_mappings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/python_bindings.cpp
+++ b/cpp/arcticdb/codec/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/python_bindings.hpp
+++ b/cpp/arcticdb/codec/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/segment.cpp
+++ b/cpp/arcticdb/codec/segment.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/segment.hpp
+++ b/cpp/arcticdb/codec/segment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/segment_header.cpp
+++ b/cpp/arcticdb/codec/segment_header.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/segment_header.hpp
+++ b/cpp/arcticdb/codec/segment_header.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/segment_identifier.hpp
+++ b/cpp/arcticdb/codec/segment_identifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/slice_data_sink.hpp
+++ b/cpp/arcticdb/codec/slice_data_sink.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/test/test_codec.cpp
+++ b/cpp/arcticdb/codec/test/test_codec.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/test/test_encode_field_collection.cpp
+++ b/cpp/arcticdb/codec/test/test_encode_field_collection.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/test/test_encoded_field.cpp
+++ b/cpp/arcticdb/codec/test/test_encoded_field.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/test/test_segment_header.cpp
+++ b/cpp/arcticdb/codec/test/test_segment_header.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/tp4.hpp
+++ b/cpp/arcticdb/codec/tp4.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/codec/zstd.hpp
+++ b/cpp/arcticdb/codec/zstd.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/block.hpp
+++ b/cpp/arcticdb/column_store/block.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/chunked_buffer.hpp
+++ b/cpp/arcticdb/column_store/chunked_buffer.hpp
@@ -1,6 +1,6 @@
 
 
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_algorithms.hpp
+++ b/cpp/arcticdb/column_store/column_algorithms.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_data.cpp
+++ b/cpp/arcticdb/column_store/column_data.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_data_random_accessor.cpp
+++ b/cpp/arcticdb/column_store/column_data_random_accessor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_data_random_accessor.hpp
+++ b/cpp/arcticdb/column_store/column_data_random_accessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_map.hpp
+++ b/cpp/arcticdb/column_store/column_map.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_utils.cpp
+++ b/cpp/arcticdb/column_store/column_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/column_utils.hpp
+++ b/cpp/arcticdb/column_store/column_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/key_segment.cpp
+++ b/cpp/arcticdb/column_store/key_segment.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/key_segment.hpp
+++ b/cpp/arcticdb/column_store/key_segment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/memory_segment.cpp
+++ b/cpp/arcticdb/column_store/memory_segment.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/python_bindings.cpp
+++ b/cpp/arcticdb/column_store/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/python_bindings.hpp
+++ b/cpp/arcticdb/column_store/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/row_ref.hpp
+++ b/cpp/arcticdb/column_store/row_ref.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/segment_utils.hpp
+++ b/cpp/arcticdb/column_store/segment_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/benchmark_column.cpp
+++ b/cpp/arcticdb/column_store/test/benchmark_column.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/benchmark_memory_segment.cpp
+++ b/cpp/arcticdb/column_store/test/benchmark_memory_segment.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
+++ b/cpp/arcticdb/column_store/test/ingestion_stress_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/rapidcheck_chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_chunked_buffer.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/rapidcheck_column.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/rapidcheck_column_data_random_accessor.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column_data_random_accessor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/rapidcheck_column_map.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column_map.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/rapidcheck_column_store.cpp
+++ b/cpp/arcticdb/column_store/test/rapidcheck_column_store.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
+++ b/cpp/arcticdb/column_store/test/test_chunked_buffer.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/test_column.cpp
+++ b/cpp/arcticdb/column_store/test/test_column.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/test_column_data_random_accessor.cpp
+++ b/cpp/arcticdb/column_store/test/test_column_data_random_accessor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/test_index_filtering.cpp
+++ b/cpp/arcticdb/column_store/test/test_index_filtering.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/test_memory_segment.cpp
+++ b/cpp/arcticdb/column_store/test/test_memory_segment.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/column_store/test/test_statistics.cpp
+++ b/cpp/arcticdb/column_store/test/test_statistics.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/atom_key.hpp
+++ b/cpp/arcticdb/entity/atom_key.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/data_error.cpp
+++ b/cpp/arcticdb/entity/data_error.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/data_error.hpp
+++ b/cpp/arcticdb/entity/data_error.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/descriptor_item.hpp
+++ b/cpp/arcticdb/entity/descriptor_item.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/descriptors.hpp
+++ b/cpp/arcticdb/entity/descriptors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/field_collection.cpp
+++ b/cpp/arcticdb/entity/field_collection.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/field_collection.hpp
+++ b/cpp/arcticdb/entity/field_collection.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/field_collection_proto.cpp
+++ b/cpp/arcticdb/entity/field_collection_proto.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/field_collection_proto.hpp
+++ b/cpp/arcticdb/entity/field_collection_proto.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/frame_and_descriptor.hpp
+++ b/cpp/arcticdb/entity/frame_and_descriptor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/index_range.hpp
+++ b/cpp/arcticdb/entity/index_range.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/key.cpp
+++ b/cpp/arcticdb/entity/key.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/key.hpp
+++ b/cpp/arcticdb/entity/key.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/merge_descriptors.cpp
+++ b/cpp/arcticdb/entity/merge_descriptors.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/merge_descriptors.hpp
+++ b/cpp/arcticdb/entity/merge_descriptors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/metrics.cpp
+++ b/cpp/arcticdb/entity/metrics.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/metrics.hpp
+++ b/cpp/arcticdb/entity/metrics.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/output_format.hpp
+++ b/cpp/arcticdb/entity/output_format.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/performance_tracing.cpp
+++ b/cpp/arcticdb/entity/performance_tracing.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/performance_tracing.hpp
+++ b/cpp/arcticdb/entity/performance_tracing.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/protobuf_mappings.cpp
+++ b/cpp/arcticdb/entity/protobuf_mappings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/protobuf_mappings.hpp
+++ b/cpp/arcticdb/entity/protobuf_mappings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/protobufs.hpp
+++ b/cpp/arcticdb/entity/protobufs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/read_result.hpp
+++ b/cpp/arcticdb/entity/read_result.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/ref_key.hpp
+++ b/cpp/arcticdb/entity/ref_key.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/serialized_key.hpp
+++ b/cpp/arcticdb/entity/serialized_key.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/stage_result.hpp
+++ b/cpp/arcticdb/entity/stage_result.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/test/test_atom_key.cpp
+++ b/cpp/arcticdb/entity/test/test_atom_key.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/test/test_field_collection.cpp
+++ b/cpp/arcticdb/entity/test/test_field_collection.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/test/test_key_serialization.cpp
+++ b/cpp/arcticdb/entity/test/test_key_serialization.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/test/test_metrics.cpp
+++ b/cpp/arcticdb/entity/test/test_metrics.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/test/test_ref_key.cpp
+++ b/cpp/arcticdb/entity/test/test_ref_key.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/test/test_stream_descriptor.cpp
+++ b/cpp/arcticdb/entity/test/test_stream_descriptor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/test/test_tensor.cpp
+++ b/cpp/arcticdb/entity/test/test_tensor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/timeseries_descriptor.hpp
+++ b/cpp/arcticdb/entity/timeseries_descriptor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/type_conversion.hpp
+++ b/cpp/arcticdb/entity/type_conversion.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/type_utils.cpp
+++ b/cpp/arcticdb/entity/type_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/type_utils.hpp
+++ b/cpp/arcticdb/entity/type_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/types-inl.hpp
+++ b/cpp/arcticdb/entity/types-inl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/types.cpp
+++ b/cpp/arcticdb/entity/types.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/types_proto.cpp
+++ b/cpp/arcticdb/entity/types_proto.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/types_proto.hpp
+++ b/cpp/arcticdb/entity/types_proto.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/variant_key.hpp
+++ b/cpp/arcticdb/entity/variant_key.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/entity/versioned_item.hpp
+++ b/cpp/arcticdb/entity/versioned_item.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/log/log.hpp
+++ b/cpp/arcticdb/log/log.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/log/test/test_log.cpp
+++ b/cpp/arcticdb/log/test/test_log.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/log/trace.hpp
+++ b/cpp/arcticdb/log/trace.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/column_mapping.cpp
+++ b/cpp/arcticdb/pipeline/column_mapping.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/column_mapping.hpp
+++ b/cpp/arcticdb/pipeline/column_mapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/execution.hpp
+++ b/cpp/arcticdb/pipeline/execution.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/filter_segment.hpp
+++ b/cpp/arcticdb/pipeline/filter_segment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/frame_slice.cpp
+++ b/cpp/arcticdb/pipeline/frame_slice.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/frame_slice.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/frame_slice_map.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice_map.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/index_fields.hpp
+++ b/cpp/arcticdb/pipeline/index_fields.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/index_segment_reader.cpp
+++ b/cpp/arcticdb/pipeline/index_segment_reader.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/index_segment_reader.hpp
+++ b/cpp/arcticdb/pipeline/index_segment_reader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/index_utils.cpp
+++ b/cpp/arcticdb/pipeline/index_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/index_utils.hpp
+++ b/cpp/arcticdb/pipeline/index_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/index_writer.hpp
+++ b/cpp/arcticdb/pipeline/index_writer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/input_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_frame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/pandas_output_frame.hpp
+++ b/cpp/arcticdb/pipeline/pandas_output_frame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/pipeline_common.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/query.cpp
+++ b/cpp/arcticdb/pipeline/query.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/read_options.hpp
+++ b/cpp/arcticdb/pipeline/read_options.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/read_pipeline.hpp
+++ b/cpp/arcticdb/pipeline/read_pipeline.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/slicing.cpp
+++ b/cpp/arcticdb/pipeline/slicing.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/slicing.hpp
+++ b/cpp/arcticdb/pipeline/slicing.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/string_pool_utils.cpp
+++ b/cpp/arcticdb/pipeline/string_pool_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/string_pool_utils.hpp
+++ b/cpp/arcticdb/pipeline/string_pool_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/test/test_container.hpp
+++ b/cpp/arcticdb/pipeline/test/test_container.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/test/test_pipeline.cpp
+++ b/cpp/arcticdb/pipeline/test/test_pipeline.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/test/test_query.cpp
+++ b/cpp/arcticdb/pipeline/test/test_query.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/test/test_rollback.cpp
+++ b/cpp/arcticdb/pipeline/test/test_rollback.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/value.hpp
+++ b/cpp/arcticdb/pipeline/value.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/value_set.cpp
+++ b/cpp/arcticdb/pipeline/value_set.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/value_set.hpp
+++ b/cpp/arcticdb/pipeline/value_set.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/pipeline/write_options.hpp
+++ b/cpp/arcticdb/pipeline/write_options.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/aggregation_interface.hpp
+++ b/cpp/arcticdb/processing/aggregation_interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/aggregation_utils.cpp
+++ b/cpp/arcticdb/processing/aggregation_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/aggregation_utils.hpp
+++ b/cpp/arcticdb/processing/aggregation_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/bucketizer.hpp
+++ b/cpp/arcticdb/processing/bucketizer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/component_manager.cpp
+++ b/cpp/arcticdb/processing/component_manager.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/expression_context.hpp
+++ b/cpp/arcticdb/processing/expression_context.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/grouper.hpp
+++ b/cpp/arcticdb/processing/grouper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_eq.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_eq.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_gt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_gte.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_gte.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_lt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_lte.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_lte.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_neq.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_neq.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_divide.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_divide.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_minus.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_minus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_plus.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_plus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_binary_operator_times.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary_operator_times.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_ternary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_ternary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_ternary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_ternary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_unary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Man Group Operations Limited
+ * Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/processing_unit.cpp
+++ b/cpp/arcticdb/processing/processing_unit.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/processing_unit.hpp
+++ b/cpp/arcticdb/processing/processing_unit.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/query_planner.cpp
+++ b/cpp/arcticdb/processing/query_planner.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/query_planner.hpp
+++ b/cpp/arcticdb/processing/query_planner.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/signed_unsigned_comparison.hpp
+++ b/cpp/arcticdb/processing/signed_unsigned_comparison.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/sorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/sorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/ternary_utils.hpp
+++ b/cpp/arcticdb/processing/ternary_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/benchmark_binary.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_binary.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/benchmark_clause.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_clause.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/benchmark_common.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_common.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/benchmark_common.hpp
+++ b/cpp/arcticdb/processing/test/benchmark_common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/benchmark_projection.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_projection.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/benchmark_ternary.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_ternary.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/rapidcheck_resample.cpp
+++ b/cpp/arcticdb/processing/test/rapidcheck_resample.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_arithmetic_type_promotion.cpp
+++ b/cpp/arcticdb/processing/test/test_arithmetic_type_promotion.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_clause.cpp
+++ b/cpp/arcticdb/processing/test/test_clause.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_component_manager.cpp
+++ b/cpp/arcticdb/processing/test/test_component_manager.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_expression.cpp
+++ b/cpp/arcticdb/processing/test/test_expression.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
+++ b/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_join_schemas.cpp
+++ b/cpp/arcticdb/processing/test/test_join_schemas.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_output_schema_aggregator_types.cpp
+++ b/cpp/arcticdb/processing/test/test_output_schema_aggregator_types.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_output_schema_ast_validity.cpp
+++ b/cpp/arcticdb/processing/test/test_output_schema_ast_validity.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_output_schema_basic.cpp
+++ b/cpp/arcticdb/processing/test/test_output_schema_basic.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_parallel_processing.cpp
+++ b/cpp/arcticdb/processing/test/test_parallel_processing.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_resample.cpp
+++ b/cpp/arcticdb/processing/test/test_resample.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_set_membership.cpp
+++ b/cpp/arcticdb/processing/test/test_set_membership.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_signed_unsigned_comparison.cpp
+++ b/cpp/arcticdb/processing/test/test_signed_unsigned_comparison.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_type_comparison.cpp
+++ b/cpp/arcticdb/processing/test/test_type_comparison.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/test/test_type_promotion.cpp
+++ b/cpp/arcticdb/processing/test/test_type_promotion.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/processing/unsorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/adapt_read_dataframe.hpp
+++ b/cpp/arcticdb/python/adapt_read_dataframe.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/arctic_version.cpp
+++ b/cpp/arcticdb/python/arctic_version.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/arctic_version.hpp
+++ b/cpp/arcticdb/python/arctic_version.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/normalization_checks.cpp
+++ b/cpp/arcticdb/python/normalization_checks.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/normalization_checks.hpp
+++ b/cpp/arcticdb/python/normalization_checks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/numpy_buffer_holder.cpp
+++ b/cpp/arcticdb/python/numpy_buffer_holder.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/numpy_buffer_holder.hpp
+++ b/cpp/arcticdb/python/numpy_buffer_holder.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_handlers.cpp
+++ b/cpp/arcticdb/python/python_handlers.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_handlers.hpp
+++ b/cpp/arcticdb/python/python_handlers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_strings.cpp
+++ b/cpp/arcticdb/python/python_strings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_strings.hpp
+++ b/cpp/arcticdb/python/python_strings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_types.hpp
+++ b/cpp/arcticdb/python/python_types.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/python_utils.hpp
+++ b/cpp/arcticdb/python/python_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/python/reader.hpp
+++ b/cpp/arcticdb/python/reader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/azure/azure_client_impl.cpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/azure/azure_client_impl.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/azure/azure_client_interface.hpp
+++ b/cpp/arcticdb/storage/azure/azure_client_interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/common.hpp
+++ b/cpp/arcticdb/storage/common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/config_cache.hpp
+++ b/cpp/arcticdb/storage/config_cache.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/config_resolvers.cpp
+++ b/cpp/arcticdb/storage/config_resolvers.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/config_resolvers.hpp
+++ b/cpp/arcticdb/storage/config_resolvers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/constants.hpp
+++ b/cpp/arcticdb/storage/constants.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/failure_simulation.hpp
+++ b/cpp/arcticdb/storage/failure_simulation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/file/file_store.hpp
+++ b/cpp/arcticdb/storage/file/file_store.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/file/mapped_file_storage.cpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/file/mapped_file_storage.hpp
+++ b/cpp/arcticdb/storage/file/mapped_file_storage.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/key_segment_pair.hpp
+++ b/cpp/arcticdb/storage/key_segment_pair.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/library_index.hpp
+++ b/cpp/arcticdb/storage/library_index.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/library_path.hpp
+++ b/cpp/arcticdb/storage/library_path.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_impl.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_impl.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/lmdb/lmdb_client_interface.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_client_interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/memory/memory_storage.cpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/memory/memory_storage.hpp
+++ b/cpp/arcticdb/storage/memory/memory_storage.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/memory_layout.hpp
+++ b/cpp/arcticdb/storage/memory_layout.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/azure_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/azure_mock_client.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/azure_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/azure_mock_client.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/lmdb_mock_client.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/lmdb_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/lmdb_mock_client.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/mongo_mock_client.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/mongo_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/mongo_mock_client.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/s3_mock_client.cpp
+++ b/cpp/arcticdb/storage/mock/s3_mock_client.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/s3_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/s3_mock_client.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mock/storage_mock_client.hpp
+++ b/cpp/arcticdb/storage/mock/storage_mock_client.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mongo/mongo_client.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mongo/mongo_client.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mongo/mongo_client_interface.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_client_interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mongo/mongo_instance.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_instance.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mongo/mongo_instance.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_instance.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/object_store_utils.hpp
+++ b/cpp/arcticdb/storage/object_store_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/open_mode.hpp
+++ b/cpp/arcticdb/storage/open_mode.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/protobuf_mappings.hpp
+++ b/cpp/arcticdb/storage/protobuf_mappings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/python_bindings.hpp
+++ b/cpp/arcticdb/storage/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/aws_provider_chain.cpp
+++ b/cpp/arcticdb/storage/s3/aws_provider_chain.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/aws_provider_chain.hpp
+++ b/cpp/arcticdb/storage/s3/aws_provider_chain.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_api.hpp
+++ b/cpp/arcticdb/storage/s3/s3_api.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_client_impl.cpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_client_impl.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_client_interface.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_client_wrapper.cpp
+++ b/cpp/arcticdb/storage/s3/s3_client_wrapper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_wrapper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_settings.hpp
+++ b/cpp/arcticdb/storage/s3/s3_settings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_storage_tool.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage_tool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/s3/s3_storage_tool.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage_tool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/storage_exceptions.hpp
+++ b/cpp/arcticdb/storage/storage_exceptions.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/storage_factory.cpp
+++ b/cpp/arcticdb/storage/storage_factory.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/storage_factory.hpp
+++ b/cpp/arcticdb/storage/storage_factory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/storage_options.hpp
+++ b/cpp/arcticdb/storage/storage_options.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/storage_utils.hpp
+++ b/cpp/arcticdb/storage/storage_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/store.hpp
+++ b/cpp/arcticdb/storage/store.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/common.hpp
+++ b/cpp/arcticdb/storage/test/common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/mongo_server_fixture.hpp
+++ b/cpp/arcticdb/storage/test/mongo_server_fixture.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_azure_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_azure_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_azure_transport.cpp
+++ b/cpp/arcticdb/storage/test/test_azure_transport.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_local_storages.cpp
+++ b/cpp/arcticdb/storage/test/test_local_storages.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_memory_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_memory_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_storage_exceptions.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_exceptions.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_storage_factory.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_factory.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/storage/test/test_storage_operations.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_operations.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/aggregator-inl.hpp
+++ b/cpp/arcticdb/stream/aggregator-inl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/aggregator.cpp
+++ b/cpp/arcticdb/stream/aggregator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/aggregator.hpp
+++ b/cpp/arcticdb/stream/aggregator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/incompletes.hpp
+++ b/cpp/arcticdb/stream/incompletes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/index.cpp
+++ b/cpp/arcticdb/stream/index.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/index.hpp
+++ b/cpp/arcticdb/stream/index.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/index_aggregator.hpp
+++ b/cpp/arcticdb/stream/index_aggregator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/merge.hpp
+++ b/cpp/arcticdb/stream/merge.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/protobuf_mappings.cpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/protobuf_mappings.hpp
+++ b/cpp/arcticdb/stream/protobuf_mappings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/python_bindings.cpp
+++ b/cpp/arcticdb/stream/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/python_bindings.hpp
+++ b/cpp/arcticdb/stream/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/row_builder.hpp
+++ b/cpp/arcticdb/stream/row_builder.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/schema.cpp
+++ b/cpp/arcticdb/stream/schema.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/schema.hpp
+++ b/cpp/arcticdb/stream/schema.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/segment_aggregator.hpp
+++ b/cpp/arcticdb/stream/segment_aggregator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/stream_reader.hpp
+++ b/cpp/arcticdb/stream/stream_reader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/stream_utils.hpp
+++ b/cpp/arcticdb/stream/stream_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/stream_writer.hpp
+++ b/cpp/arcticdb/stream/stream_writer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/test/stream_test_common.cpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/test/stream_test_common.hpp
+++ b/cpp/arcticdb/stream/test/stream_test_common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/test/test_aggregator.cpp
+++ b/cpp/arcticdb/stream/test/test_aggregator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/test/test_incompletes.cpp
+++ b/cpp/arcticdb/stream/test/test_incompletes.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/test/test_row_builder.cpp
+++ b/cpp/arcticdb/stream/test/test_row_builder.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/test/test_segment_aggregator.cpp
+++ b/cpp/arcticdb/stream/test/test_segment_aggregator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/stream/test/test_types.cpp
+++ b/cpp/arcticdb/stream/test/test_types.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/toolbox/library_tool.hpp
+++ b/cpp/arcticdb/toolbox/library_tool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/toolbox/python_bindings.cpp
+++ b/cpp/arcticdb/toolbox/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/toolbox/python_bindings.hpp
+++ b/cpp/arcticdb/toolbox/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/toolbox/query_stats.cpp
+++ b/cpp/arcticdb/toolbox/query_stats.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/toolbox/query_stats.hpp
+++ b/cpp/arcticdb/toolbox/query_stats.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/bitset.cpp
+++ b/cpp/arcticdb/util/bitset.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/bitset.hpp
+++ b/cpp/arcticdb/util/bitset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/buffer_pool.cpp
+++ b/cpp/arcticdb/util/buffer_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/buffer_pool.hpp
+++ b/cpp/arcticdb/util/buffer_pool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/clock.hpp
+++ b/cpp/arcticdb/util/clock.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/composite.hpp
+++ b/cpp/arcticdb/util/composite.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/configs_map.hpp
+++ b/cpp/arcticdb/util/configs_map.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/constants.hpp
+++ b/cpp/arcticdb/util/constants.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/constructors.hpp
+++ b/cpp/arcticdb/util/constructors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/container_filter_wrapper.hpp
+++ b/cpp/arcticdb/util/container_filter_wrapper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/cursor.hpp
+++ b/cpp/arcticdb/util/cursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/cursored_buffer.hpp
+++ b/cpp/arcticdb/util/cursored_buffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/decimal.cpp
+++ b/cpp/arcticdb/util/decimal.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/decimal.hpp
+++ b/cpp/arcticdb/util/decimal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/decode_path_data.hpp
+++ b/cpp/arcticdb/util/decode_path_data.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/dump_bytes.hpp
+++ b/cpp/arcticdb/util/dump_bytes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/encoding_conversion.hpp
+++ b/cpp/arcticdb/util/encoding_conversion.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/error_code.cpp
+++ b/cpp/arcticdb/util/error_code.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/exponential_backoff.hpp
+++ b/cpp/arcticdb/util/exponential_backoff.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/flatten_utils.hpp
+++ b/cpp/arcticdb/util/flatten_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/format_bytes.hpp
+++ b/cpp/arcticdb/util/format_bytes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/format_date.hpp
+++ b/cpp/arcticdb/util/format_date.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/global_lifetimes.cpp
+++ b/cpp/arcticdb/util/global_lifetimes.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/global_lifetimes.hpp
+++ b/cpp/arcticdb/util/global_lifetimes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/hash.hpp
+++ b/cpp/arcticdb/util/hash.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/home_directory.hpp
+++ b/cpp/arcticdb/util/home_directory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/lock_table.hpp
+++ b/cpp/arcticdb/util/lock_table.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/lru_cache.hpp
+++ b/cpp/arcticdb/util/lru_cache.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/magic_num.hpp
+++ b/cpp/arcticdb/util/magic_num.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/memory_tracing.hpp
+++ b/cpp/arcticdb/util/memory_tracing.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/movable_priority_queue.hpp
+++ b/cpp/arcticdb/util/movable_priority_queue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/name_validation.cpp
+++ b/cpp/arcticdb/util/name_validation.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/name_validation.hpp
+++ b/cpp/arcticdb/util/name_validation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/offset_string.cpp
+++ b/cpp/arcticdb/util/offset_string.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/offset_string.hpp
+++ b/cpp/arcticdb/util/offset_string.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/optional_defaults.hpp
+++ b/cpp/arcticdb/util/optional_defaults.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/pb_util.hpp
+++ b/cpp/arcticdb/util/pb_util.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/preprocess.hpp
+++ b/cpp/arcticdb/util/preprocess.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/python_bindings.cpp
+++ b/cpp/arcticdb/util/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/python_bindings.hpp
+++ b/cpp/arcticdb/util/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/ranges_from_future.hpp
+++ b/cpp/arcticdb/util/ranges_from_future.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/regex_filter.hpp
+++ b/cpp/arcticdb/util/regex_filter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/reliable_storage_lock-inl.hpp
+++ b/cpp/arcticdb/util/reliable_storage_lock-inl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/reliable_storage_lock.hpp
+++ b/cpp/arcticdb/util/reliable_storage_lock.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/simple_string_hash.hpp
+++ b/cpp/arcticdb/util/simple_string_hash.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/slab_allocator.hpp
+++ b/cpp/arcticdb/util/slab_allocator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/sparse_utils.cpp
+++ b/cpp/arcticdb/util/sparse_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/sparse_utils.hpp
+++ b/cpp/arcticdb/util/sparse_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/spinlock.hpp
+++ b/cpp/arcticdb/util/spinlock.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/storage_lock.hpp
+++ b/cpp/arcticdb/util/storage_lock.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/string_utils.cpp
+++ b/cpp/arcticdb/util/string_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/string_utils.hpp
+++ b/cpp/arcticdb/util/string_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/string_wrapping_value.hpp
+++ b/cpp/arcticdb/util/string_wrapping_value.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/benchmark_bitset.cpp
+++ b/cpp/arcticdb/util/test/benchmark_bitset.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/config_common.hpp
+++ b/cpp/arcticdb/util/test/config_common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/gtest_main.cpp
+++ b/cpp/arcticdb/util/test/gtest_main.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/gtest_utils.hpp
+++ b/cpp/arcticdb/util/test/gtest_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/random_throw.hpp
+++ b/cpp/arcticdb/util/test/random_throw.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/rapidcheck.hpp
+++ b/cpp/arcticdb/util/test/rapidcheck.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/rapidcheck_bitset.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_bitset.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/rapidcheck_decimal.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_decimal.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/rapidcheck_generators.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_generators.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/rapidcheck_generators.hpp
+++ b/cpp/arcticdb/util/test/rapidcheck_generators.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/rapidcheck_main.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_main.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/rapidcheck_string_pool.cpp
+++ b/cpp/arcticdb/util/test/rapidcheck_string_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_bitmagic.cpp
+++ b/cpp/arcticdb/util/test/test_bitmagic.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_buffer_pool.cpp
+++ b/cpp/arcticdb/util/test/test_buffer_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_composite.cpp
+++ b/cpp/arcticdb/util/test/test_composite.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_cursor.cpp
+++ b/cpp/arcticdb/util/test/test_cursor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_error_code.cpp
+++ b/cpp/arcticdb/util/test/test_error_code.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_exponential_backoff.cpp
+++ b/cpp/arcticdb/util/test/test_exponential_backoff.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_folly.cpp
+++ b/cpp/arcticdb/util/test/test_folly.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_format_date.cpp
+++ b/cpp/arcticdb/util/test/test_format_date.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_hash.cpp
+++ b/cpp/arcticdb/util/test/test_hash.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_id_transformation.cpp
+++ b/cpp/arcticdb/util/test/test_id_transformation.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_key_utils.cpp
+++ b/cpp/arcticdb/util/test/test_key_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_ranges_from_future.cpp
+++ b/cpp/arcticdb/util/test/test_ranges_from_future.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_regex.cpp
+++ b/cpp/arcticdb/util/test/test_regex.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_reliable_storage_lock.cpp
+++ b/cpp/arcticdb/util/test/test_reliable_storage_lock.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_slab_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_slab_allocator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_storage_lock.cpp
+++ b/cpp/arcticdb/util/test/test_storage_lock.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_string_pool.cpp
+++ b/cpp/arcticdb/util/test/test_string_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_string_utils.cpp
+++ b/cpp/arcticdb/util/test/test_string_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_tracing_allocator.cpp
+++ b/cpp/arcticdb/util/test/test_tracing_allocator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/test/test_utils.hpp
+++ b/cpp/arcticdb/util/test/test_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/thread_cached_int.hpp
+++ b/cpp/arcticdb/util/thread_cached_int.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/timeouts.hpp
+++ b/cpp/arcticdb/util/timeouts.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/timer.hpp
+++ b/cpp/arcticdb/util/timer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/trace.cpp
+++ b/cpp/arcticdb/util/trace.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/trace.hpp
+++ b/cpp/arcticdb/util/trace.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/type_handler.cpp
+++ b/cpp/arcticdb/util/type_handler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/type_handler.hpp
+++ b/cpp/arcticdb/util/type_handler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/type_traits.hpp
+++ b/cpp/arcticdb/util/type_traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/util/variant.hpp
+++ b/cpp/arcticdb/util/variant.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/de_dup_map.hpp
+++ b/cpp/arcticdb/version/de_dup_map.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/key_block.cpp
+++ b/cpp/arcticdb/version/key_block.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/key_block.hpp
+++ b/cpp/arcticdb/version/key_block.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/op_log.cpp
+++ b/cpp/arcticdb/version/op_log.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/op_log.hpp
+++ b/cpp/arcticdb/version/op_log.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/python_bindings.hpp
+++ b/cpp/arcticdb/version/python_bindings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
+++ b/cpp/arcticdb/version/test/rapidcheck_version_map.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_append.cpp
+++ b/cpp/arcticdb/version/test/test_append.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_key_block.cpp
+++ b/cpp/arcticdb/version/test/test_key_block.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_sort_index.cpp
+++ b/cpp/arcticdb/version/test/test_sort_index.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_sorting_info_state_machine.cpp
+++ b/cpp/arcticdb/version/test/test_sorting_info_state_machine.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_sparse.cpp
+++ b/cpp/arcticdb/version/test/test_sparse.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_version_common.hpp
+++ b/cpp/arcticdb/version/test/test_version_common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/test/version_map_model.hpp
+++ b/cpp/arcticdb/version/test/version_map_model.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_constants.hpp
+++ b/cpp/arcticdb/version/version_constants.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_log.hpp
+++ b/cpp/arcticdb/version/version_log.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_map_batch_methods.cpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_store_objects.hpp
+++ b/cpp/arcticdb/version/version_store_objects.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_utils.cpp
+++ b/cpp/arcticdb/version/version_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Man Group Operations Limited
+/* Copyright 2026 Man Group Operations Limited
  *
  * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
  *

--- a/cpp/proto/arcticc/pb2/azure_storage.proto
+++ b/cpp/proto/arcticc/pb2/azure_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/config.proto
+++ b/cpp/proto/arcticc/pb2/config.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/descriptors.proto
+++ b/cpp/proto/arcticc/pb2/descriptors.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/encoding.proto
+++ b/cpp/proto/arcticc/pb2/encoding.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/gcp_storage.proto
+++ b/cpp/proto/arcticc/pb2/gcp_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/in_memory_storage.proto
+++ b/cpp/proto/arcticc/pb2/in_memory_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/lmdb_storage.proto
+++ b/cpp/proto/arcticc/pb2/lmdb_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/logger.proto
+++ b/cpp/proto/arcticc/pb2/logger.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/mapped_file_storage.proto
+++ b/cpp/proto/arcticc/pb2/mapped_file_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/mongo_storage.proto
+++ b/cpp/proto/arcticc/pb2/mongo_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/nfs_backed_storage.proto
+++ b/cpp/proto/arcticc/pb2/nfs_backed_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/s3_storage.proto
+++ b/cpp/proto/arcticc/pb2/s3_storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/storage.proto
+++ b/cpp/proto/arcticc/pb2/storage.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/cpp/proto/arcticc/pb2/utils.proto
+++ b/cpp/proto/arcticc/pb2/utils.proto
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/azure_library_adapter.py
+++ b/python/arcticdb/adapters/azure_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/gcpxml_library_adapter.py
+++ b/python/arcticdb/adapters/gcpxml_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/in_memory_library_adapter.py
+++ b/python/arcticdb/adapters/in_memory_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/lmdb_library_adapter.py
+++ b/python/arcticdb/adapters/lmdb_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/mongo_library_adapter.py
+++ b/python/arcticdb/adapters/mongo_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/prefixing_library_adapter_decorator.py
+++ b/python/arcticdb/adapters/prefixing_library_adapter_decorator.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/adapters/s3_library_adapter.py
+++ b/python/arcticdb/adapters/s3_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/authorization/permissions.py
+++ b/python/arcticdb/authorization/permissions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/config.py
+++ b/python/arcticdb/config.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/encoding_version.py
+++ b/python/arcticdb/encoding_version.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/exceptions.py
+++ b/python/arcticdb/exceptions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/flattener.py
+++ b/python/arcticdb/flattener.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/log.py
+++ b/python/arcticdb/log.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/options.py
+++ b/python/arcticdb/options.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/preconditions.py
+++ b/python/arcticdb/preconditions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/storage_fixtures/api.py
+++ b/python/arcticdb/storage_fixtures/api.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/storage_fixtures/azure.py
+++ b/python/arcticdb/storage_fixtures/azure.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/storage_fixtures/in_memory.py
+++ b/python/arcticdb/storage_fixtures/in_memory.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/storage_fixtures/lmdb.py
+++ b/python/arcticdb/storage_fixtures/lmdb.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/storage_fixtures/mongo.py
+++ b/python/arcticdb/storage_fixtures/mongo.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/supported_types.py
+++ b/python/arcticdb/supported_types.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/toolbox/library_tool.py
+++ b/python/arcticdb/toolbox/library_tool.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/arcticdb/tools.py
+++ b/python/arcticdb/tools.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/util/_versions.py
+++ b/python/arcticdb/util/_versions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/util/arctic_simulator.py
+++ b/python/arcticdb/util/arctic_simulator.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/util/defrag_timeseries.py
+++ b/python/arcticdb/util/defrag_timeseries.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/arcticdb/util/errors.py
+++ b/python/arcticdb/util/errors.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/util/hypothesis.py
+++ b/python/arcticdb/util/hypothesis.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/util/logger.py
+++ b/python/arcticdb/util/logger.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/arcticdb/util/tasks.py
+++ b/python/arcticdb/util/tasks.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/util/utils.py
+++ b/python/arcticdb/util/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/arcticdb/version_store/_common.py
+++ b/python/arcticdb/version_store/_common.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/_custom_normalizers.py
+++ b/python/arcticdb/version_store/_custom_normalizers.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/admin_tools.py
+++ b/python/arcticdb/version_store/admin_tools.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/helper.py
+++ b/python/arcticdb/version_store/helper.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/arcticdb/version_store/read_result.py
+++ b/python/arcticdb/version_store/read_result.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/arrow.py
+++ b/python/benchmarks/arrow.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/bi_benchmarks.py
+++ b/python/benchmarks/bi_benchmarks.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/common.py
+++ b/python/benchmarks/common.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/comparison_benchmarks.py
+++ b/python/benchmarks/comparison_benchmarks.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/finalize_staged_data.py
+++ b/python/benchmarks/finalize_staged_data.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 from arcticdb import Arctic

--- a/python/benchmarks/list_snapshots.py
+++ b/python/benchmarks/list_snapshots.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/list_symbols.py
+++ b/python/benchmarks/list_symbols.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/list_versions.py
+++ b/python/benchmarks/list_versions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/local_query_builder.py
+++ b/python/benchmarks/local_query_builder.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/non_asv/profile_billion_row_challenge.py
+++ b/python/benchmarks/non_asv/profile_billion_row_challenge.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/non_asv/profile_resample.py
+++ b/python/benchmarks/non_asv/profile_resample.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/real_batch_functions.py
+++ b/python/benchmarks/real_batch_functions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/real_comparison_benchmarks.py
+++ b/python/benchmarks/real_comparison_benchmarks.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/benchmarks/real_finalize_staged_data.py
+++ b/python/benchmarks/real_finalize_staged_data.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/real_list_operations.py
+++ b/python/benchmarks/real_list_operations.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/real_modification_functions.py
+++ b/python/benchmarks/real_modification_functions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/real_query_builder.py
+++ b/python/benchmarks/real_query_builder.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/real_read_write.py
+++ b/python/benchmarks/real_read_write.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/recursive_normalizer.py
+++ b/python/benchmarks/recursive_normalizer.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/resample.py
+++ b/python/benchmarks/resample.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/benchmarks/version_chain.py
+++ b/python/benchmarks/version_chain.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/installation_tests/client_utils.py
+++ b/python/installation_tests/client_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/installation_tests/conftest.py
+++ b/python/installation_tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/installation_tests/test_installation.py
+++ b/python/installation_tests/test_installation.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/hypothesis/arcticdb/test_aggregation_hypothesis.py
+++ b/python/tests/hypothesis/arcticdb/test_aggregation_hypothesis.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
+++ b/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_admin_tools.py
+++ b/python/tests/integration/arcticdb/test_admin_tools.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_azure_transport.py
+++ b/python/tests/integration/arcticdb/test_azure_transport.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Man Group Operations Limited
+# Copyright 2026 Man Group Operations Limited
 #
 # Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 #

--- a/python/tests/integration/arcticdb/test_finalize_staged_data.py
+++ b/python/tests/integration/arcticdb/test_finalize_staged_data.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_lmdb.py
+++ b/python/tests/integration/arcticdb/test_lmdb.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_read_batch_more.py
+++ b/python/tests/integration/arcticdb/test_read_batch_more.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/test_update.py
+++ b/python/tests/integration/arcticdb/test_update.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_categorical.py
+++ b/python/tests/integration/arcticdb/version_store/test_categorical.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_dedup.py
+++ b/python/tests/integration/arcticdb/version_store/test_dedup.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/tests/integration/arcticdb/version_store/test_deletion.py
+++ b/python/tests/integration/arcticdb/version_store/test_deletion.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_file_config.py
+++ b/python/tests/integration/arcticdb/version_store/test_file_config.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_metadata_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_metadata_support.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_pandas_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_pandas_support.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_snapshot.py
+++ b/python/tests/integration/arcticdb/version_store/test_snapshot.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_symbol_list.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_list.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
+++ b/python/tests/integration/arcticdb/version_store/test_update_with_date_range.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/tests/nonreg/arcticdb/adapters/test_lmdb_library_adapter.py
+++ b/python/tests/nonreg/arcticdb/adapters/test_lmdb_library_adapter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/pytest_xfail.py
+++ b/python/tests/pytest_xfail.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/sanitizers/arcticdb/version_store/test_mem_leaks.py
+++ b/python/tests/sanitizers/arcticdb/version_store/test_mem_leaks.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_deallocation.py
+++ b/python/tests/stress/arcticdb/version_store/test_deallocation.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_large_df.py
+++ b/python/tests/stress/arcticdb/version_store/test_large_df.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_long_running.py
+++ b/python/tests/stress/arcticdb/version_store/test_long_running.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_append.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_append.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_delete.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_delete.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/tests/stress/arcticdb/version_store/test_stress_dynamic_bucketize.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_dynamic_bucketize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_finalize_staged_data.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_finalize_staged_data.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_generated.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_generated.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_indexing.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_indexing.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_multicolumn.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_multicolumn.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_version_map_compact.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_version_map_compact.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/stress/arcticdb/version_store/test_stress_versions.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_versions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_column_stats.py
+++ b/python/tests/unit/arcticdb/test_column_stats.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_config.py
+++ b/python/tests/unit/arcticdb/test_config.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_defrag_timeseries.py
+++ b/python/tests/unit/arcticdb/test_defrag_timeseries.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/tests/unit/arcticdb/test_env_vars.py
+++ b/python/tests/unit/arcticdb/test_env_vars.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_flattener.py
+++ b/python/tests/unit/arcticdb/test_flattener.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_import.py
+++ b/python/tests/unit/arcticdb/test_import.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_permissions.py
+++ b/python/tests/unit/arcticdb/test_permissions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_string.py
+++ b/python/tests/unit/arcticdb/test_string.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_version_store_api.py
+++ b/python/tests/unit/arcticdb/test_version_store_api.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/test_write_read.py
+++ b/python/tests/unit/arcticdb/test_write_read.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_array_column_type.py
+++ b/python/tests/unit/arcticdb/version_store/test_array_column_type.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_arrow_pandas_interop.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_pandas_interop.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_column_type_changes.py
+++ b/python/tests/unit/arcticdb/version_store/test_column_type_changes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_date_range.py
+++ b/python/tests/unit/arcticdb/version_store/test_date_range.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_deletion.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion_batch.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_empty_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_writes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_engine.py
+++ b/python/tests/unit/arcticdb/version_store/test_engine.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_filtering_hypothesis.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering_hypothesis.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_head.py
+++ b/python/tests/unit/arcticdb/version_store/test_head.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_incompletes.py
+++ b/python/tests/unit/arcticdb/version_store/test_incompletes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_list_versions.py
+++ b/python/tests/unit/arcticdb/version_store/test_list_versions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_missing_empty.py
+++ b/python/tests/unit/arcticdb/version_store/test_missing_empty.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_nullable_boolean_column_type.py
+++ b/python/tests/unit/arcticdb/version_store/test_nullable_boolean_column_type.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_observation_time.py
+++ b/python/tests/unit/arcticdb/version_store/test_observation_time.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_pickle_atomkey.py
+++ b/python/tests/unit/arcticdb/version_store/test_pickle_atomkey.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_projection.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_projection_hypothesis.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection_hypothesis.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_sparse.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_sparse.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_read_index.py
+++ b/python/tests/unit/arcticdb/version_store/test_read_index.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt. As of the
 Change Date specified in that file, in accordance with the Business Source License, use of this software will be
 governed by the Apache License, version 2.0.

--- a/python/tests/unit/arcticdb/version_store/test_resample.py
+++ b/python/tests/unit/arcticdb/version_store/test_resample.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_row_range.py
+++ b/python/tests/unit/arcticdb/version_store/test_row_range.py
@@ -1,5 +1,5 @@
 """
-Copyright 2024 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_stage.py
+++ b/python/tests/unit/arcticdb/version_store/test_stage.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_string_dedup.py
+++ b/python/tests/unit/arcticdb/version_store/test_string_dedup.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
+++ b/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_tail.py
+++ b/python/tests/unit/arcticdb/version_store/test_tail.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_ternary.py
+++ b/python/tests/unit/arcticdb/version_store/test_ternary.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_unicode.py
+++ b/python/tests/unit/arcticdb/version_store/test_unicode.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_version_chain.py
+++ b/python/tests/unit/arcticdb/version_store/test_version_chain.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/arcticdb/version_store/test_write.py
+++ b/python/tests/unit/arcticdb/version_store/test_write.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/unit/simulator/test_symbol_simulator.py
+++ b/python/tests/unit/simulator/test_symbol_simulator.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/util/mark.py
+++ b/python/tests/util/mark.py
@@ -1,5 +1,5 @@
 """
-Copyright 2023 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/tests/util/marking.py
+++ b/python/tests/util/marking.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """

--- a/python/tests/util/naughty_strings.py
+++ b/python/tests/util/naughty_strings.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
 

--- a/python/utils/bucket_management.py
+++ b/python/utils/bucket_management.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 

--- a/python/utils/cleanup_test_buckets.py
+++ b/python/utils/cleanup_test_buckets.py
@@ -1,5 +1,5 @@
 """
-Copyright 2025 Man Group Operations Limited
+Copyright 2026 Man Group Operations Limited
 
 Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
 


### PR DESCRIPTION
#### What does this implement or fix?
Update all years in copyright notices to 2026. Done mechanically by running:
`find . -type f -exec sed -i 's/Copyright 2023 Man Group Operations Limited/Copyright 2026 Man Group Operations Limited/' {} \;`
for 2023/4/5 in `cpp/arcticdb`, `cpp/proto` and `python` directories.