### PR TITLE
Improve version map cache validation for as_of queries by version and timestamp

### DIFF
--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -1466,7 +1466,10 @@ TEST(VersionMap, HasCachedEntryDowntoReloadsWhenVersionNotLoaded) {
     // from has_cached_entry, causing check_reload to actually reload from storage).
     // Note: DOWNTO 5 will only load from latest (v5) down to v5, so just v5.
     entry = version_map_b->check_reload(
-            store, id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)}, __FUNCTION__
+            store,
+            id,
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)},
+            __FUNCTION__
     );
     // The entry should now include version 5
     auto opt_v5 = entry->get_first_index(true);
@@ -1609,11 +1612,14 @@ TEST(VersionMap, FromTimeCacheInvalidationOnNewVersion) {
     // Client B reloads with FROM_TIME=250, which loads from newest (300) back to earliest <= 250 (200)
     // This loads v2 (300) and v1 (200), but not v0 (100)
     entry_b = version_map_b->check_reload(
-            store, id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)}, __FUNCTION__
+            store,
+            id,
+            LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)},
+            __FUNCTION__
     );
-    ASSERT_EQ(entry_b->get_indexes(true).size(), 2);  // v2 and v1
-    EXPECT_EQ(entry_b->load_progress_.latest_loaded_timestamp_, 300);  // newest loaded is v2
-    EXPECT_EQ(entry_b->load_progress_.earliest_loaded_timestamp_, 200);  // earliest loaded is v1
+    ASSERT_EQ(entry_b->get_indexes(true).size(), 2);                    // v2 and v1
+    EXPECT_EQ(entry_b->load_progress_.latest_loaded_timestamp_, 300);   // newest loaded is v2
+    EXPECT_EQ(entry_b->load_progress_.earliest_loaded_timestamp_, 200); // earliest loaded is v1
 
     // Now Client B's cache should be valid for timestamp 250 (100 <= 250 <= 300)
     // Wait, earliest is now 200, so 200 <= 250 <= 300 is still valid

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -1392,6 +1392,100 @@ TEST(VersionMap, TombstoneAllFromEntry) {
     ASSERT_EQ(version_id, 2);
 }
 
+// Test that has_cached_entry correctly returns false for DOWNTO requests
+// when the requested version hasn't been loaded, even if is_earliest_version_loaded is true.
+// This tests the fix for the case where:
+// 1. Client A loads all versions and caches them (is_earliest_version_loaded = true)
+// 2. Client B writes new versions to storage
+// 3. Client A's cache shouldn't claim to have versions it hasn't loaded
+TEST(VersionMap, HasCachedEntryDowntoReloadsWhenVersionNotLoaded) {
+    ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
+    auto store = std::make_shared<InMemoryStore>();
+    StreamId id{"test"};
+
+    // Client A writes versions v0, v1, v2
+    auto version_map_a = std::make_shared<VersionMap>();
+    write_versions(store, version_map_a, id, 3);
+
+    // Client B creates a new version map and loads all versions
+    auto version_map_b = std::make_shared<VersionMap>();
+    auto entry = version_map_b->check_reload(
+            store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+    );
+
+    // Verify that all versions are loaded and is_earliest_version_loaded is true
+    ASSERT_TRUE(entry->load_progress_.is_earliest_version_loaded);
+    ASSERT_EQ(entry->load_progress_.oldest_loaded_index_version_, VersionId{0});
+    ASSERT_EQ(entry->get_indexes(true).size(), 3); // v0, v1, v2
+
+    // Verify has_cached_entry returns true for all existing versions
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(0)}
+    ));
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(1)}
+    ));
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(2)}
+    ));
+
+    // Client A writes new versions v3, v4, v5 that Client B doesn't know about
+    for (int i = 3; i < 6; ++i) {
+        auto key = atom_key_with_version(id, i, i);
+        version_map_a->write_version(store, key, std::nullopt);
+    }
+
+    // Client B's cache still has is_earliest_version_loaded = true, but it doesn't have v3, v4, v5
+    // has_cached_entry should return false for DOWNTO requests for these new versions
+    // because even though is_earliest_version_loaded is true, the specific versions aren't in the cache
+    EXPECT_FALSE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(3)}
+    ));
+    EXPECT_FALSE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(4)}
+    ));
+    EXPECT_FALSE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)}
+    ));
+
+    // DOWNTO with negative indices should also correctly reload
+    // At this point, Client B thinks latest is v2, so -1 = v2, -2 = v1, -3 = v0
+    // But in storage, latest is actually v5
+    // The cache can still serve requests that resolve to loaded versions
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-1)}
+    )); // -1 resolves to v2 in cache, which is loaded
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-2)}
+    )); // -2 resolves to v1 in cache, which is loaded
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-3)}
+    )); // -3 resolves to v0 in cache, which is loaded
+
+    // Trigger a reload by requesting version 5 via DOWNTO (which should return false
+    // from has_cached_entry, causing check_reload to actually reload from storage).
+    // Note: DOWNTO 5 will only load from latest (v5) down to v5, so just v5.
+    entry = version_map_b->check_reload(
+            store, id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)}, __FUNCTION__
+    );
+    // The entry should now include version 5
+    auto opt_v5 = entry->get_first_index(true);
+    ASSERT_TRUE(opt_v5.first.has_value());
+    ASSERT_EQ(opt_v5.first->version_id(), 5);
+
+    // has_cached_entry should now return true for version 5
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)}
+    ));
+
+    // Now request ALL to load all versions. Since is_earliest_version_loaded is now false
+    // (we only loaded down to v5, not v0), has_cached_entry should return false and trigger a full reload.
+    entry = version_map_b->check_reload(
+            store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+    );
+    ASSERT_EQ(entry->get_indexes(true).size(), 6); // v0-v5
+}
+
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"
 
 TEST_F(VersionMapStore, StressTestWrite) {

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -1486,6 +1486,142 @@ TEST(VersionMap, HasCachedEntryDowntoReloadsWhenVersionNotLoaded) {
     ASSERT_EQ(entry->get_indexes(true).size(), 6); // v0-v5
 }
 
+TEST(VersionMap, LatestLoadedTimestampTracking) {
+    // Test that latest_loaded_timestamp_ is correctly populated and used for FROM_TIME cache validation
+    ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
+    auto store = std::make_shared<InMemoryStore>();
+    auto version_map = std::make_shared<VersionMap>();
+    StreamId id{"test"};
+
+    auto entry = version_map->check_reload(
+            store, id, LoadStrategy{LoadType::NOT_LOADED, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+    );
+
+    // Write versions with specific timestamps: v0 at ts=100, v1 at ts=200, v2 at ts=300
+    auto key0 = atom_key_with_version(id, 0, 100);
+    version_map->do_write(store, key0, entry);
+    write_symbol_ref(store, key0, std::nullopt, entry->head_.value());
+
+    auto key1 = atom_key_with_version(id, 1, 200);
+    version_map->do_write(store, key1, entry);
+    write_symbol_ref(store, key1, std::nullopt, entry->head_.value());
+
+    auto key2 = atom_key_with_version(id, 2, 300);
+    version_map->do_write(store, key2, entry);
+    write_symbol_ref(store, key2, std::nullopt, entry->head_.value());
+
+    // Create a fresh version_map to test caching behavior
+    version_map = std::make_shared<VersionMap>();
+
+    // Load only the latest version
+    entry = version_map->check_reload(
+            store, id, LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+    );
+    ASSERT_EQ(entry->get_indexes(true).size(), 1);
+    // After loading LATEST, latest_loaded_timestamp_ should be 300 (newest), earliest should also be 300
+    EXPECT_EQ(entry->load_progress_.latest_loaded_timestamp_, 300);
+    EXPECT_EQ(entry->load_progress_.earliest_loaded_timestamp_, 300);
+
+    // FROM_TIME with timestamp 250 should be cached (200 <= 300 newest, but need to load more for earliest)
+    // Since earliest is 300 and we need earliest <= 200, cache should NOT be valid
+    EXPECT_FALSE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(200)}
+    ));
+
+    // FROM_TIME with timestamp 350 should NOT be cached because 350 > 300 (newest loaded)
+    // This is the key test - we might have missed a version written at ts=320
+    EXPECT_FALSE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(350)}
+    ));
+
+    // Load all versions
+    entry = version_map->check_reload(
+            store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+    );
+    ASSERT_EQ(entry->get_indexes(true).size(), 3);
+    // After loading ALL, latest_loaded_timestamp_ should be 300 (newest), earliest should be 100 (oldest)
+    EXPECT_EQ(entry->load_progress_.latest_loaded_timestamp_, 300);
+    EXPECT_EQ(entry->load_progress_.earliest_loaded_timestamp_, 100);
+
+    // Now FROM_TIME with timestamp 200 should be cached (100 <= 200 <= 300)
+    EXPECT_TRUE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(200)}
+    ));
+
+    // FROM_TIME with timestamp 350 should still NOT be cached (350 > 300)
+    EXPECT_FALSE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(350)}
+    ));
+
+    // FROM_TIME with timestamp 50 is STILL cached because we've loaded everything.
+    // Even though 50 < 100 (earliest), we can answer "no version at that timestamp" from cache.
+    EXPECT_TRUE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(50)}
+    ));
+}
+
+TEST(VersionMap, FromTimeCacheInvalidationOnNewVersion) {
+    // Test that FROM_TIME cache correctly detects when new versions have been written
+    ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
+    auto store = std::make_shared<InMemoryStore>();
+    StreamId id{"test"};
+
+    // Client A writes initial versions
+    auto version_map_a = std::make_shared<VersionMap>();
+    auto entry_a = version_map_a->check_reload(
+            store, id, LoadStrategy{LoadType::NOT_LOADED, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+    );
+
+    auto key0 = atom_key_with_version(id, 0, 100);
+    version_map_a->do_write(store, key0, entry_a);
+    write_symbol_ref(store, key0, std::nullopt, entry_a->head_.value());
+
+    auto key1 = atom_key_with_version(id, 1, 200);
+    version_map_a->do_write(store, key1, entry_a);
+    write_symbol_ref(store, key1, std::nullopt, entry_a->head_.value());
+
+    // Client B loads all versions
+    auto version_map_b = std::make_shared<VersionMap>();
+    auto entry_b = version_map_b->check_reload(
+            store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+    );
+    ASSERT_EQ(entry_b->get_indexes(true).size(), 2);
+    EXPECT_EQ(entry_b->load_progress_.latest_loaded_timestamp_, 200);
+    EXPECT_EQ(entry_b->load_progress_.earliest_loaded_timestamp_, 100);
+
+    // Client B's cache should be valid for timestamps between 100 and 200
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(150)}
+    ));
+
+    // Client A writes a new version at ts=300
+    auto key2 = atom_key_with_version(id, 2, 300);
+    version_map_a->do_write(store, key2, entry_a);
+    write_symbol_ref(store, key2, std::nullopt, entry_a->head_.value());
+
+    // Client B's cache should NOT be valid for timestamp 250 anymore
+    // because 250 > 200 (Client B's newest loaded timestamp)
+    // A version might have been written between 200 and 250
+    EXPECT_FALSE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)}
+    ));
+
+    // Client B reloads with FROM_TIME=250, which loads from newest (300) back to earliest <= 250 (200)
+    // This loads v2 (300) and v1 (200), but not v0 (100)
+    entry_b = version_map_b->check_reload(
+            store, id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)}, __FUNCTION__
+    );
+    ASSERT_EQ(entry_b->get_indexes(true).size(), 2);  // v2 and v1
+    EXPECT_EQ(entry_b->load_progress_.latest_loaded_timestamp_, 300);  // newest loaded is v2
+    EXPECT_EQ(entry_b->load_progress_.earliest_loaded_timestamp_, 200);  // earliest loaded is v1
+
+    // Now Client B's cache should be valid for timestamp 250 (100 <= 250 <= 300)
+    // Wait, earliest is now 200, so 200 <= 250 <= 300 is still valid
+    EXPECT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)}
+    ));
+}
+
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"
 
 TEST_F(VersionMapStore, StressTestWrite) {

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -489,7 +489,7 @@ TEST(VersionMap, FixRefKey) {
     ASSERT_TRUE(version_map->check_ref_key(store, id));
 
     auto key4 = key3;
-    EXPECT_THROW(
+    ASSERT_THROW(
             {
                 // We should raise if we try to write a non-increasing index key
                 version_map->write_version(store, key4, key3);
@@ -528,11 +528,11 @@ TEST(VersionMap, FixRefKeyTombstones) {
     auto key1 = atom_key_with_version(id, 0, 1696590624524585339);
     version_map->write_version(store, key1, std::nullopt);
     auto key2 = atom_key_with_version(id, 0, 1696590624387628801);
-    EXPECT_THROW({ version_map->write_version(store, key2, key1); }, NonIncreasingIndexVersionException);
+    ASSERT_THROW({ version_map->write_version(store, key2, key1); }, NonIncreasingIndexVersionException);
     auto key3 = atom_key_with_version(id, 0, 1696590624532320286);
-    EXPECT_THROW({ version_map->write_version(store, key3, key2); }, NonIncreasingIndexVersionException);
+    ASSERT_THROW({ version_map->write_version(store, key3, key2); }, NonIncreasingIndexVersionException);
     auto key4 = atom_key_with_version(id, 0, 1696590624554476875);
-    EXPECT_THROW({ version_map->write_version(store, key4, key3); }, NonIncreasingIndexVersionException);
+    ASSERT_THROW({ version_map->write_version(store, key4, key3); }, NonIncreasingIndexVersionException);
     auto key5 = atom_key_with_version(id, 1, 1696590624590123209);
     version_map->write_version(store, key5, key4);
     auto entry = version_map->check_reload(
@@ -629,7 +629,7 @@ TEST(VersionMap, RecoverDeleted) {
 
     deleted = version_map->find_deleted_version_keys(store, id);
     ASSERT_EQ(deleted.size(), 3);
-    EXPECT_THROW({ get_all_versions(store, version_map, id); }, std::runtime_error);
+    ASSERT_THROW({ get_all_versions(store, version_map, id); }, std::runtime_error);
     version_map->recover_deleted(store, id);
 
     std::vector<AtomKey> expected{key3, key2, key1};
@@ -753,7 +753,7 @@ TEST(VersionMap, FollowingVersionChain) {
         auto follow_result = std::make_shared<VersionMapEntry>();
 
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
-        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{should_load_to});
+        ASSERT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{should_load_to});
     };
 
     check_strategy_loads_to(
@@ -805,8 +805,8 @@ TEST(VersionMap, FollowingVersionChainWithCaching) {
     auto check_loads_versions = [&](LoadStrategy load_strategy, uint32_t should_load_any, uint32_t should_load_undeleted
                                 ) {
         auto loaded = version_map->check_reload(store, id, load_strategy, __FUNCTION__);
-        EXPECT_EQ(loaded->get_indexes(true).size(), should_load_any);
-        EXPECT_EQ(loaded->get_indexes(false).size(), should_load_undeleted);
+        ASSERT_EQ(loaded->get_indexes(true).size(), should_load_any);
+        ASSERT_EQ(loaded->get_indexes(false).size(), should_load_undeleted);
     };
 
     check_loads_versions(
@@ -834,7 +834,7 @@ TEST(VersionMap, FollowingVersionChainWithCaching) {
 
     // LATEST should still be cached, but the cached entry now needs to have no undeleted keys
     check_loads_versions(LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, 2, 0);
-    EXPECT_FALSE(version_map->has_cached_entry(
+    ASSERT_FALSE(version_map->has_cached_entry(
             id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(-1)}
     ));
     // FROM_TIME UNDELETED_ONLY should no longer be cached even though we used the same request before because the
@@ -844,14 +844,14 @@ TEST(VersionMap, FollowingVersionChainWithCaching) {
     );
     // We have the full version chain loaded, so has_cached_entry should always return true (even when requesting
     // timestamp before earliest version)
-    EXPECT_TRUE(version_map->has_cached_entry(
+    ASSERT_TRUE(version_map->has_cached_entry(
             id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(-1)}
     ));
-    EXPECT_TRUE(version_map->has_cached_entry(
+    ASSERT_TRUE(version_map->has_cached_entry(
             id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(-1)}
     ));
-    EXPECT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}));
-    EXPECT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}));
+    ASSERT_TRUE(version_map->has_cached_entry(id, LoadStrategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY}));
 
     // We add a new undeleted key
     auto key4 = atom_key_with_version(id, 3, 5);
@@ -890,7 +890,7 @@ TEST(VersionMap, FollowingVersionChainEndEarlyOnTombstoneAll) {
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
         // When loading with any of the specified load strategies with include_deleted=false we should end following the
         // version chain early at version 1 because that's when we encounter the TOMBSTONE_ALL.
-        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{1});
+        ASSERT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{1});
     }
 
     for (auto load_strategy :
@@ -901,7 +901,7 @@ TEST(VersionMap, FollowingVersionChainEndEarlyOnTombstoneAll) {
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
         // When loading with any of the specified load strategies with include_deleted=true we should continue to the
         // beginning at version 0 even though it was deleted.
-        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{0});
+        ASSERT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{0});
     }
 }
 
@@ -932,7 +932,7 @@ TEST(VersionMap, FollowingVersionChainWithWriteAndPrunePrevious) {
           LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}}) {
         follow_result->clear();
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
-        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{3});
+        ASSERT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{3});
     }
 
     for (auto load_strategy : {
@@ -944,7 +944,7 @@ TEST(VersionMap, FollowingVersionChainWithWriteAndPrunePrevious) {
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
         // When loading with any of the specified load strategies with include_deleted=false we should end following the
         // version chain early at version 2 because that's when we encounter the TOMBSTONE_ALL.
-        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{2});
+        ASSERT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{2});
     }
 
     for (auto load_strategy :
@@ -955,7 +955,7 @@ TEST(VersionMap, FollowingVersionChainWithWriteAndPrunePrevious) {
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
         // When loading with any of the specified load strategies with include_deleted=true we should continue to the
         // beginning at version 0 even though it was deleted.
-        EXPECT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{0});
+        ASSERT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{0});
     }
 }
 
@@ -981,7 +981,7 @@ TEST(VersionMap, HasCachedEntry) {
         // Load to_load inside the clean version map cache
         clean_version_map->check_reload(store, id, to_load, __FUNCTION__);
         // Check whether to_check_if_cached is being cached by to_load
-        EXPECT_EQ(clean_version_map->has_cached_entry(id, to_check_if_cached), expected_outcome);
+        ASSERT_EQ(clean_version_map->has_cached_entry(id, to_check_if_cached), expected_outcome);
     };
 
     auto check_all_caching = [&](const std::vector<LoadStrategy>& to_load,
@@ -1394,20 +1394,16 @@ TEST(VersionMap, TombstoneAllFromEntry) {
 
 // Test that has_cached_entry correctly returns false for DOWNTO requests
 // when the requested version hasn't been loaded, even if is_earliest_version_loaded is true.
-// This tests the fix for the case where:
-// 1. Client A loads all versions and caches them (is_earliest_version_loaded = true)
-// 2. Client B writes new versions to storage
-// 3. Client A's cache shouldn't claim to have versions it hasn't loaded
 TEST(VersionMap, HasCachedEntryDowntoReloadsWhenVersionNotLoaded) {
     ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
     auto store = std::make_shared<InMemoryStore>();
     StreamId id{"test"};
 
-    // Client A writes versions v0, v1, v2
+    // Client a writes versions v0, v1
     auto version_map_a = std::make_shared<VersionMap>();
-    write_versions(store, version_map_a, id, 3);
+    write_versions(store, version_map_a, id, 2);
 
-    // Client B creates a new version map and loads all versions
+    // Client b creates a new version map and loads all versions
     auto version_map_b = std::make_shared<VersionMap>();
     auto entry = version_map_b->check_reload(
             store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
@@ -1416,216 +1412,110 @@ TEST(VersionMap, HasCachedEntryDowntoReloadsWhenVersionNotLoaded) {
     // Verify that all versions are loaded and is_earliest_version_loaded is true
     ASSERT_TRUE(entry->load_progress_.is_earliest_version_loaded);
     ASSERT_EQ(entry->load_progress_.oldest_loaded_index_version_, VersionId{0});
-    ASSERT_EQ(entry->get_indexes(true).size(), 3); // v0, v1, v2
+    ASSERT_EQ(entry->get_indexes(true).size(), 2); // v0, v1
 
     // Verify has_cached_entry returns true for all existing versions
-    EXPECT_TRUE(version_map_b->has_cached_entry(
+    ASSERT_TRUE(version_map_b->has_cached_entry(
             id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(0)}
     ));
-    EXPECT_TRUE(version_map_b->has_cached_entry(
+    ASSERT_TRUE(version_map_b->has_cached_entry(
             id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(1)}
     ));
-    EXPECT_TRUE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(2)}
-    ));
 
-    // Client A writes new versions v3, v4, v5 that Client B doesn't know about
-    for (int i = 3; i < 6; ++i) {
+    // Client a writes new versions v2, v3 that Client b doesn't know about
+    for (int i = 2; i < 4; ++i) {
         auto key = atom_key_with_version(id, i, i);
         version_map_a->write_version(store, key, std::nullopt);
     }
 
-    // Client B's cache still has is_earliest_version_loaded = true, but it doesn't have v3, v4, v5
+    // Client b's cache still has is_earliest_version_loaded = true, but it doesn't have v2, v3
     // has_cached_entry should return false for DOWNTO requests for these new versions
     // because even though is_earliest_version_loaded is true, the specific versions aren't in the cache
-    EXPECT_FALSE(version_map_b->has_cached_entry(
+    ASSERT_FALSE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(2)}
+    ));
+    ASSERT_FALSE(version_map_b->has_cached_entry(
             id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(3)}
-    ));
-    EXPECT_FALSE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(4)}
-    ));
-    EXPECT_FALSE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)}
     ));
 
     // DOWNTO with negative indices should also correctly reload
-    // At this point, Client B thinks latest is v2, so -1 = v2, -2 = v1, -3 = v0
-    // But in storage, latest is actually v5
+    // At this point, Client b thinks latest is v1, so -1 = v0
     // The cache can still serve requests that resolve to loaded versions
-    EXPECT_TRUE(version_map_b->has_cached_entry(
+    ASSERT_TRUE(version_map_b->has_cached_entry(
             id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-1)}
-    )); // -1 resolves to v2 in cache, which is loaded
-    EXPECT_TRUE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-2)}
-    )); // -2 resolves to v1 in cache, which is loaded
-    EXPECT_TRUE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(-3)}
-    )); // -3 resolves to v0 in cache, which is loaded
+    )); // -1 resolves to v0 in cache, which is loaded
 
-    // Trigger a reload by requesting version 5 via DOWNTO (which should return false
+    // Trigger a reload by requesting version 3 via DOWNTO (which should return false
     // from has_cached_entry, causing check_reload to actually reload from storage).
-    // Note: DOWNTO 5 will only load from latest (v5) down to v5, so just v5.
+    // Note: DOWNTO 3 will only load from latest (v3) down to v3, so just v3.
     entry = version_map_b->check_reload(
             store,
             id,
-            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(3)},
             __FUNCTION__
     );
-    // The entry should now include version 5
-    auto opt_v5 = entry->get_first_index(true);
-    ASSERT_TRUE(opt_v5.first.has_value());
-    ASSERT_EQ(opt_v5.first->version_id(), 5);
+    // The entry should now include version 3
+    auto opt_v3 = entry->get_first_index(true);
+    ASSERT_TRUE(opt_v3.first.has_value());
+    ASSERT_EQ(opt_v3.first->version_id(), 3);
 
-    // has_cached_entry should now return true for version 5
-    EXPECT_TRUE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(5)}
+    // has_cached_entry should now return true for version 3
+    ASSERT_TRUE(version_map_b->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(3)}
     ));
 
     // Now request ALL to load all versions. Since is_earliest_version_loaded is now false
-    // (we only loaded down to v5, not v0), has_cached_entry should return false and trigger a full reload.
+    // (we only loaded down to v3, not v0), has_cached_entry should return false and trigger a full reload.
     entry = version_map_b->check_reload(
             store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
     );
-    ASSERT_EQ(entry->get_indexes(true).size(), 6); // v0-v5
+    ASSERT_EQ(entry->get_indexes(true).size(), 4); // v0-v3
 }
 
-TEST(VersionMap, LatestLoadedTimestampTracking) {
-    // Test that latest_loaded_timestamp_ is correctly populated and used for FROM_TIME cache validation
-    ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
-    auto store = std::make_shared<InMemoryStore>();
-    auto version_map = std::make_shared<VersionMap>();
-    StreamId id{"test"};
-
-    auto entry = version_map->check_reload(
-            store, id, LoadStrategy{LoadType::NOT_LOADED, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
-    );
-
-    // Write versions with specific timestamps: v0 at ts=100, v1 at ts=200, v2 at ts=300
-    auto key0 = atom_key_with_version(id, 0, 100);
-    version_map->do_write(store, key0, entry);
-    write_symbol_ref(store, key0, std::nullopt, entry->head_.value());
-
-    auto key1 = atom_key_with_version(id, 1, 200);
-    version_map->do_write(store, key1, entry);
-    write_symbol_ref(store, key1, std::nullopt, entry->head_.value());
-
-    auto key2 = atom_key_with_version(id, 2, 300);
-    version_map->do_write(store, key2, entry);
-    write_symbol_ref(store, key2, std::nullopt, entry->head_.value());
-
-    // Create a fresh version_map to test caching behavior
-    version_map = std::make_shared<VersionMap>();
-
-    // Load only the latest version
-    entry = version_map->check_reload(
-            store, id, LoadStrategy{LoadType::LATEST, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
-    );
-    ASSERT_EQ(entry->get_indexes(true).size(), 1);
-    // After loading LATEST, latest_loaded_timestamp_ should be 300 (newest), earliest should also be 300
-    EXPECT_EQ(entry->load_progress_.latest_loaded_timestamp_, 300);
-    EXPECT_EQ(entry->load_progress_.earliest_loaded_timestamp_, 300);
-
-    // FROM_TIME with timestamp 250 should be cached (200 <= 300 newest, but need to load more for earliest)
-    // Since earliest is 300 and we need earliest <= 200, cache should NOT be valid
-    EXPECT_FALSE(version_map->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(200)}
-    ));
-
-    // FROM_TIME with timestamp 350 should NOT be cached because 350 > 300 (newest loaded)
-    // This is the key test - we might have missed a version written at ts=320
-    EXPECT_FALSE(version_map->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(350)}
-    ));
-
-    // Load all versions
-    entry = version_map->check_reload(
-            store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
-    );
-    ASSERT_EQ(entry->get_indexes(true).size(), 3);
-    // After loading ALL, latest_loaded_timestamp_ should be 300 (newest), earliest should be 100 (oldest)
-    EXPECT_EQ(entry->load_progress_.latest_loaded_timestamp_, 300);
-    EXPECT_EQ(entry->load_progress_.earliest_loaded_timestamp_, 100);
-
-    // Now FROM_TIME with timestamp 200 should be cached (100 <= 200 <= 300)
-    EXPECT_TRUE(version_map->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(200)}
-    ));
-
-    // FROM_TIME with timestamp 350 should still NOT be cached (350 > 300)
-    EXPECT_FALSE(version_map->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(350)}
-    ));
-
-    // FROM_TIME with timestamp 50 is STILL cached because we've loaded everything.
-    // Even though 50 < 100 (earliest), we can answer "no version at that timestamp" from cache.
-    EXPECT_TRUE(version_map->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(50)}
-    ));
-}
-
-TEST(VersionMap, FromTimeCacheInvalidationOnNewVersion) {
-    // Test that FROM_TIME cache correctly detects when new versions have been written
+// Test that if we load with a DOWNTO strategy that doesn't include the earliest version
+// then the indication of the whether the earliest version is loaded should correctly reflect
+// with the _is_earliest_version_loaded flag
+TEST(VersionMap, PartialLoadCacheEarliestVersionNotLoaded) {
     ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
     auto store = std::make_shared<InMemoryStore>();
     StreamId id{"test"};
 
-    // Client A writes initial versions
     auto version_map_a = std::make_shared<VersionMap>();
+    write_versions(store, version_map_a, id, 2);
+
     auto entry_a = version_map_a->check_reload(
-            store, id, LoadStrategy{LoadType::NOT_LOADED, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+            store,
+            id,
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(1)},
+            __FUNCTION__
     );
+    ASSERT_EQ(entry_a->get_indexes(true).size(), 1); // v1 only
 
-    auto key0 = atom_key_with_version(id, 0, 100);
-    version_map_a->do_write(store, key0, entry_a);
-    write_symbol_ref(store, key0, std::nullopt, entry_a->head_.value());
-
-    auto key1 = atom_key_with_version(id, 1, 200);
-    version_map_a->do_write(store, key1, entry_a);
-    write_symbol_ref(store, key1, std::nullopt, entry_a->head_.value());
-
-    // Client B loads all versions
     auto version_map_b = std::make_shared<VersionMap>();
     auto entry_b = version_map_b->check_reload(
-            store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+            store,
+            id,
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(1)},
+            __FUNCTION__
     );
-    ASSERT_EQ(entry_b->get_indexes(true).size(), 2);
-    EXPECT_EQ(entry_b->load_progress_.latest_loaded_timestamp_, 200);
-    EXPECT_EQ(entry_b->load_progress_.earliest_loaded_timestamp_, 100);
+    ASSERT_EQ(entry_b->get_indexes(true).size(), 1); // v1 only
+    ASSERT_FALSE(entry_b->load_progress_.is_earliest_version_loaded
+    ); // We didn't load the earliest version, so this should be false
 
-    // Client B's cache should be valid for timestamps between 100 and 200
-    EXPECT_TRUE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(150)}
-    ));
+    for (int i = 2; i < 4; ++i) {
+        auto key = atom_key_with_version(id, i, i);
+        version_map_a->write_version(store, key, std::nullopt);
+    }
 
-    // Client A writes a new version at ts=300
-    auto key2 = atom_key_with_version(id, 2, 300);
-    version_map_a->do_write(store, key2, entry_a);
-    write_symbol_ref(store, key2, std::nullopt, entry_a->head_.value());
-
-    // Client B's cache should NOT be valid for timestamp 250 anymore
-    // because 250 > 200 (Client B's newest loaded timestamp)
-    // A version might have been written between 200 and 250
-    EXPECT_FALSE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)}
-    ));
-
-    // Client B reloads with FROM_TIME=250, which loads from newest (300) back to earliest <= 250 (200)
-    // This loads v2 (300) and v1 (200), but not v0 (100)
     entry_b = version_map_b->check_reload(
             store,
             id,
-            LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)},
+            LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(2)},
             __FUNCTION__
     );
-    ASSERT_EQ(entry_b->get_indexes(true).size(), 2);                    // v2 and v1
-    EXPECT_EQ(entry_b->load_progress_.latest_loaded_timestamp_, 300);   // newest loaded is v2
-    EXPECT_EQ(entry_b->load_progress_.earliest_loaded_timestamp_, 200); // earliest loaded is v1
-
-    // Now Client B's cache should be valid for timestamp 250 (100 <= 250 <= 300)
-    // Wait, earliest is now 200, so 200 <= 250 <= 300 is still valid
-    EXPECT_TRUE(version_map_b->has_cached_entry(
-            id, LoadStrategy{LoadType::FROM_TIME, LoadObjective::INCLUDE_DELETED, static_cast<timestamp>(250)}
-    ));
+    ASSERT_EQ(entry_b->get_indexes(true).size(), 2); // v3, v2 only
+    ASSERT_FALSE(entry_b->load_progress_.is_earliest_version_loaded
+    ); // We didn't load the earliest version, so this should be false
 }
 
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -1518,6 +1518,63 @@ TEST(VersionMap, PartialLoadCacheEarliestVersionNotLoaded) {
     ); // We didn't load the earliest version, so this should be false
 }
 
+// Regression test: after loading the version chain via FROM_TIME with a tombstone_all boundary,
+// a subsequent DOWNTO query for a version below the oldest loaded index should be a cache hit
+// because the tombstone_all means all older versions are deleted and we've loaded everything relevant.
+TEST(VersionMap, DowntoCacheHitAfterFromTimeWithTombstoneAll) {
+    ScopedConfig sc("VersionMap.ReloadInterval", std::numeric_limits<int64_t>::max());
+    auto store = std::make_shared<InMemoryStore>();
+    auto version_map = std::make_shared<VersionMap>();
+    StreamId id{"test"};
+
+    // Set up: v0 <- v1 <- tombstone_all(v1) <- v2 <- v3
+    // tombstone_all covers v0 and v1, v2 and v3 are undeleted.
+    using Type = VersionChainOperation::Type;
+    write_versions(
+            store,
+            version_map,
+            id,
+            {
+                    {Type::WRITE, 0},
+                    {Type::WRITE, 1},
+                    {Type::TOMBSTONE_ALL},
+                    {Type::WRITE, 2},
+                    {Type::WRITE, 3},
+            }
+    );
+
+    // Fresh version map (empty cache)
+    version_map = std::make_shared<VersionMap>();
+
+    // Load via FROM_TIME with timestamp 0 (undeleted only).
+    // Walking the chain: v3(ts=3), v2(ts=2), tombstone_all(v1), v1(tombstoned) -> STOP.
+    // Stops at v1 because tombstone_all(v1) covers oldest_loaded(v1). Does NOT load v0.
+    // After this, has_loaded_earliest_undeleted is true (tombstone_all covers remainder).
+    version_map->check_reload(
+            store,
+            id,
+            LoadStrategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, static_cast<timestamp>(0)},
+            __FUNCTION__
+    );
+
+    // DOWNTO v0 (undeleted only) should be a cache hit because tombstone_all covers everything
+    // below the oldest loaded index — there are no undeleted versions we haven't seen.
+    ASSERT_TRUE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(0)}
+    ));
+
+    // Negative index resolving to v0 should also be a cache hit
+    ASSERT_TRUE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(-4)}
+    ));
+
+    // However, DOWNTO v0 with INCLUDE_DELETED should NOT be a cache hit because
+    // we haven't actually loaded v0 (we stopped at the tombstone_all boundary).
+    ASSERT_FALSE(version_map->has_cached_entry(
+            id, LoadStrategy{LoadType::DOWNTO, LoadObjective::INCLUDE_DELETED, static_cast<SignedVersionId>(0)}
+    ));
+}
+
 #define GTEST_COUT std::cerr << "[          ] [ INFO ]"
 
 TEST_F(VersionMapStore, StressTestWrite) {

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -753,7 +753,7 @@ class VersionMapImpl {
                 entry->tombstone_all_.has_value() &&
                 entry->load_progress_.oldest_loaded_index_version_ <= entry->tombstone_all_->version_id();
 
-        if ((has_loaded_everything && has_loaded_requested_version_id && has_loaded_requested_timestamp) ||
+        if ((has_loaded_earliest_version && has_loaded_requested_version_id && has_loaded_requested_timestamp) ||
             (!requested_load_strategy.should_include_deleted() && has_loaded_earliest_undeleted)) {
             return true;
         }

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -750,13 +750,10 @@ class VersionMapImpl {
         const bool has_loaded_earliest_undeleted =
                 entry->tombstone_all_.has_value() &&
                 entry->load_progress_.oldest_loaded_index_version_ <= entry->tombstone_all_->version_id();
-        
-        if ((has_loaded_everything && 
-             has_loaded_requested_version_id && 
-             has_loaded_requested_timestamp) ||
-            (!requested_load_strategy.should_include_deleted() && 
-              has_loaded_earliest_undeleted && 
-              has_loaded_requested_timestamp)) {
+
+        if ((has_loaded_everything && has_loaded_requested_version_id && has_loaded_requested_timestamp) ||
+            (!requested_load_strategy.should_include_deleted() && has_loaded_earliest_undeleted &&
+             has_loaded_requested_timestamp)) {
             return true;
         }
 

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -737,24 +737,28 @@ class VersionMapImpl {
             return false;
         }
 
-        const bool has_loaded_earliest_version = entry->load_progress_.is_earliest_version_loaded;
-        const bool has_loaded_requested_version_id =
-                requested_load_type == LoadType::DOWNTO
-                        ? loaded_as_far_as_version_id(*entry, requested_load_strategy.load_until_version_.value())
-                        : true;
-        const bool has_loaded_requested_timestamp = requested_load_type == LoadType::FROM_TIME
-                                                            ? loaded_as_far_as_timestamp(
-                                                                      *entry,
-                                                                      requested_load_strategy.load_from_time_.value(),
-                                                                      requested_load_strategy.should_include_deleted()
-                                                              )
-                                                            : true;
+        const bool has_loaded_earliest_version_all = entry->load_progress_.is_earliest_version_loaded;
         const bool has_loaded_earliest_undeleted =
                 entry->tombstone_all_.has_value() &&
                 entry->load_progress_.oldest_loaded_index_version_ <= entry->tombstone_all_->version_id();
+        const bool has_loaded_earliest =
+                has_loaded_earliest_version_all ||
+                (!requested_load_strategy.should_include_deleted() && has_loaded_earliest_undeleted);
 
-        if ((has_loaded_earliest_version && has_loaded_requested_version_id && has_loaded_requested_timestamp) ||
-            (!requested_load_strategy.should_include_deleted() && has_loaded_earliest_undeleted)) {
+        if (requested_load_type == LoadType::DOWNTO) {
+            return loaded_as_far_as_version_id(*entry, requested_load_strategy.load_until_version_.value());
+        }
+
+        if (requested_load_type == LoadType::FROM_TIME) {
+            return loaded_as_far_as_timestamp(
+                    *entry,
+                    requested_load_strategy.load_from_time_.value(),
+                    requested_load_strategy.should_include_deleted(),
+                    has_loaded_earliest
+            );
+        }
+
+        if (has_loaded_earliest) {
             return true;
         }
 
@@ -769,13 +773,6 @@ class VersionMapImpl {
             // we have an undeleted version.
             auto opt_latest = entry->get_first_index(requested_load_strategy.should_include_deleted()).first;
             return opt_latest.has_value();
-        }
-        case LoadType::DOWNTO:
-            // We check whether the oldest loaded version is before or at the requested one
-            return has_loaded_requested_version_id;
-        case LoadType::FROM_TIME: {
-            // We check whether the cached timestamps cover the requested one
-            return has_loaded_requested_timestamp;
         }
         case LoadType::ALL:
         case LoadType::UNKNOWN:
@@ -863,12 +860,12 @@ class VersionMapImpl {
      * @return true if and only if entry already contains data at least as far back as load_param requests
      */
     bool loaded_as_far_as_version_id(const VersionMapEntry& entry, SignedVersionId requested_version_id) const {
+        auto opt_latest = entry.get_first_index(true).first;
         if (requested_version_id >= 0) {
             // For positive version IDs, we need to check two things:
             // 1. We have loaded far enough back: oldest_loaded_index_version_ <= requested_version_id
             // 2. The requested version is within our known range: requested_version_id <= latest_known_version_id
             // Without check 2, we'd incorrectly claim to have versions that were written after our cache was populated
-            auto opt_latest = entry.get_first_index(true).first;
             if (opt_latest.has_value() && static_cast<VersionId>(requested_version_id) <= opt_latest->version_id() &&
                 entry.load_progress_.oldest_loaded_index_version_ <= static_cast<VersionId>(requested_version_id)) {
                 ARCTICDB_DEBUG(
@@ -881,7 +878,6 @@ class VersionMapImpl {
                 return true;
             }
         } else {
-            auto opt_latest = entry.get_first_index(true).first;
             if (opt_latest.has_value()) {
                 auto opt_version_id = get_version_id_negative_index(opt_latest->version_id(), requested_version_id);
                 if (opt_version_id.has_value() &&
@@ -905,7 +901,8 @@ class VersionMapImpl {
      * the loaded timestamps cover the requested timestamp range.
      */
     bool loaded_as_far_as_timestamp(
-            const VersionMapEntry& entry, timestamp requested_timestamp, bool include_deleted_versions
+            const VersionMapEntry& entry, timestamp requested_timestamp, bool include_deleted_versions,
+            bool has_loaded_earliest
     ) const {
         if (requested_timestamp < 0) {
             // In case of the negative timestamp, we check if everything was already loaded
@@ -920,8 +917,12 @@ class VersionMapImpl {
         timestamp earliest_loaded_timestamp = include_deleted_versions
                                                       ? entry.load_progress_.earliest_loaded_timestamp_
                                                       : entry.load_progress_.earliest_loaded_undeleted_timestamp_;
+        // Lower bound can be relaxed when:
+        // 1. We loaded the entire version chain (is_earliest_version_loaded), OR
+        // 2. For undeleted queries, tombstone_all covers all loaded versions - meaning all undeleted
+        //    versions are known (there are none before the tombstone_all point)
         if (latest_loaded_timestamp >= requested_timestamp &&
-            (earliest_loaded_timestamp <= requested_timestamp || entry.load_progress_.is_earliest_version_loaded)) {
+            (earliest_loaded_timestamp <= requested_timestamp || has_loaded_earliest)) {
             ARCTICDB_DEBUG(
                     log::version(),
                     "Loaded as far as required timestamp {}, have latest loaded timestamp {}",

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -904,7 +904,8 @@ class VersionMapImpl {
      * Whether entry contains as much of the version map as specified by load_param. Checks whether
      * the loaded timestamps cover the requested timestamp range.
      */
-    bool loaded_as_far_as_timestamp(const VersionMapEntry& entry, timestamp requested_timestamp, bool include_deleted_versions) const {
+    bool loaded_as_far_as_timestamp(
+            const VersionMapEntry& entry, timestamp requested_timestamp, bool include_deleted_versions) const {
         // Upper bound: always use latest_loaded_timestamp (including deleted) because we need to
         // know if the requested timestamp within the loaded range
         timestamp latest_loaded_timestamp = entry.load_progress_.latest_loaded_timestamp_;

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -737,19 +737,11 @@ class VersionMapImpl {
             return false;
         }
 
-        const bool has_loaded_earliest_include_deleted = entry->load_progress_.is_earliest_version_loaded;
-        const bool has_loaded_earliest_undeleted =
-                entry->tombstone_all_.has_value() &&
-                entry->load_progress_.oldest_loaded_index_version_ <= entry->tombstone_all_->version_id();
-        const bool has_loaded_earliest =
-                has_loaded_earliest_include_deleted ||
-                (!requested_load_strategy.should_include_deleted() && has_loaded_earliest_undeleted);
-
         if (requested_load_type == LoadType::DOWNTO) {
-            return loaded_as_far_as_version_id(*entry, requested_load_strategy.load_until_version_.value());
+            return loaded_as_far_as_version_id(*entry, requested_load_strategy);
         }
 
-        if (has_loaded_earliest) {
+        if (has_loaded_earliest_version(*entry, requested_load_strategy)) {
             return true;
         }
 
@@ -849,48 +841,52 @@ class VersionMapImpl {
         return true;
     }
 
+    bool inline has_loaded_earliest_version(const VersionMapEntry& entry, const LoadStrategy& requested_load_strategy)
+            const {
+        const bool has_loaded_earliest_include_deleted = entry.load_progress_.is_earliest_version_loaded;
+        const bool tombstone_all_covers_remainder =
+                entry.is_tombstoned_via_tombstone_all(entry.load_progress_.oldest_loaded_index_version_);
+        return has_loaded_earliest_include_deleted ||
+               (!requested_load_strategy.should_include_deleted() && tombstone_all_covers_remainder);
+    }
+
     /**
-     * Whether entry contains as much of the version map as specified by load_param. Checks whether
-     * oldest_loaded_index_version_ in entry is earlier than that specified in load_param.
+     * Whether entry contains as much of the version map as specified by load_param.
      *
-     * @param entry the version map state to check
-     * @param load_param the load request to test for completeness
      * @return true if and only if entry already contains data at least as far back as load_param requests
      */
-    bool loaded_as_far_as_version_id(const VersionMapEntry& entry, SignedVersionId requested_version_id) const {
+    bool loaded_as_far_as_version_id(const VersionMapEntry& entry, const LoadStrategy& requested_load_strategy) const {
+        const bool has_loaded_earliest = has_loaded_earliest_version(entry, requested_load_strategy);
+        const SignedVersionId requested_version_id = requested_load_strategy.load_until_version_.value();
         auto opt_latest = entry.get_first_index(true).first;
-        if (requested_version_id >= 0) {
-            // For positive version IDs, we need to check two things:
-            // 1. We have loaded far enough back: oldest_loaded_index_version_ <= requested_version_id
-            // 2. The requested version is within our known range: requested_version_id <= latest_known_version_id
-            // Without check 2, we'd incorrectly claim to have versions that were written after our cache was populated
-            if (opt_latest.has_value() && static_cast<VersionId>(requested_version_id) <= opt_latest->version_id() &&
-                entry.load_progress_.oldest_loaded_index_version_ <= static_cast<VersionId>(requested_version_id)) {
-                ARCTICDB_DEBUG(
-                        log::version(),
-                        "Loaded as far as required value {}, have {} to {}",
-                        requested_version_id,
-                        entry.load_progress_.oldest_loaded_index_version_,
-                        opt_latest->version_id()
-                );
-                return true;
+        if (!opt_latest.has_value()) {
+            return false;
+        }
+        VersionId resolved_version_id;
+        if (requested_version_id < 0) {
+            auto negative_resolved_version_id =
+                    get_version_id_negative_index(opt_latest->version_id(), requested_version_id);
+            if (negative_resolved_version_id.has_value()) {
+                resolved_version_id = static_cast<VersionId>(*negative_resolved_version_id);
+            } else {
+                return false;
             }
         } else {
-            if (opt_latest.has_value()) {
-                auto opt_version_id = get_version_id_negative_index(opt_latest->version_id(), requested_version_id);
-                if (opt_version_id.has_value() &&
-                    entry.load_progress_.oldest_loaded_index_version_ <= *opt_version_id) {
-                    ARCTICDB_DEBUG(
-                            log::version(),
-                            "Loaded as far as required value {}, have {} and there are {} total versions",
-                            requested_version_id,
-                            entry.load_progress_.oldest_loaded_index_version_,
-                            opt_latest->version_id()
-                    );
-                    return true;
-                }
-            }
+            resolved_version_id = static_cast<VersionId>(requested_version_id);
         }
+
+        if (resolved_version_id <= opt_latest->version_id() &&
+            (entry.load_progress_.oldest_loaded_index_version_ <= resolved_version_id || has_loaded_earliest)) {
+            ARCTICDB_DEBUG(
+                    log::version(),
+                    "Loaded as far as required value {}, have {} to {}",
+                    resolved_version_id,
+                    entry.load_progress_.oldest_loaded_index_version_,
+                    opt_latest->version_id()
+            );
+            return true;
+        }
+
         return false;
     }
 

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -737,25 +737,16 @@ class VersionMapImpl {
             return false;
         }
 
-        const bool has_loaded_earliest_version_all = entry->load_progress_.is_earliest_version_loaded;
+        const bool has_loaded_earliest_include_deleted = entry->load_progress_.is_earliest_version_loaded;
         const bool has_loaded_earliest_undeleted =
                 entry->tombstone_all_.has_value() &&
                 entry->load_progress_.oldest_loaded_index_version_ <= entry->tombstone_all_->version_id();
         const bool has_loaded_earliest =
-                has_loaded_earliest_version_all ||
+                has_loaded_earliest_include_deleted ||
                 (!requested_load_strategy.should_include_deleted() && has_loaded_earliest_undeleted);
 
         if (requested_load_type == LoadType::DOWNTO) {
             return loaded_as_far_as_version_id(*entry, requested_load_strategy.load_until_version_.value());
-        }
-
-        if (requested_load_type == LoadType::FROM_TIME) {
-            return loaded_as_far_as_timestamp(
-                    *entry,
-                    requested_load_strategy.load_from_time_.value(),
-                    requested_load_strategy.should_include_deleted(),
-                    has_loaded_earliest
-            );
         }
 
         if (has_loaded_earliest) {
@@ -773,6 +764,13 @@ class VersionMapImpl {
             // we have an undeleted version.
             auto opt_latest = entry->get_first_index(requested_load_strategy.should_include_deleted()).first;
             return opt_latest.has_value();
+        }
+        case LoadType::FROM_TIME: {
+            // We check whether the cached (deleted or undeleted) timestamp is before or at the requested one
+            auto cached_timestamp = requested_load_strategy.should_include_deleted()
+                                            ? entry->load_progress_.earliest_loaded_timestamp_
+                                            : entry->load_progress_.earliest_loaded_undeleted_timestamp_;
+            return cached_timestamp <= requested_load_strategy.load_from_time_.value();
         }
         case LoadType::ALL:
         case LoadType::UNKNOWN:
@@ -892,44 +890,6 @@ class VersionMapImpl {
                     return true;
                 }
             }
-        }
-        return false;
-    }
-
-    /**
-     * Whether entry contains as much of the version map as specified by load_param. Checks whether
-     * the loaded timestamps cover the requested timestamp range.
-     */
-    bool loaded_as_far_as_timestamp(
-            const VersionMapEntry& entry, timestamp requested_timestamp, bool include_deleted_versions,
-            bool has_loaded_earliest
-    ) const {
-        if (requested_timestamp < 0) {
-            // In case of the negative timestamp, we check if everything was already loaded
-            return entry.load_progress_.is_earliest_version_loaded;
-        }
-
-        // Upper bound: always use latest_loaded_timestamp (including deleted) because we need to
-        // know if the requested timestamp within the loaded range
-        timestamp latest_loaded_timestamp = entry.load_progress_.latest_loaded_timestamp_;
-
-        // Lower bound: use the appropriate timestamp based on whether we need deleted versions
-        timestamp earliest_loaded_timestamp = include_deleted_versions
-                                                      ? entry.load_progress_.earliest_loaded_timestamp_
-                                                      : entry.load_progress_.earliest_loaded_undeleted_timestamp_;
-        // Lower bound can be relaxed when:
-        // 1. We loaded the entire version chain (is_earliest_version_loaded), OR
-        // 2. For undeleted queries, tombstone_all covers all loaded versions - meaning all undeleted
-        //    versions are known (there are none before the tombstone_all point)
-        if (latest_loaded_timestamp >= requested_timestamp &&
-            (earliest_loaded_timestamp <= requested_timestamp || has_loaded_earliest)) {
-            ARCTICDB_DEBUG(
-                    log::version(),
-                    "Loaded as far as required timestamp {}, have latest loaded timestamp {}",
-                    requested_timestamp,
-                    latest_loaded_timestamp
-            );
-            return true;
         }
         return false;
     }

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -209,6 +209,7 @@ struct LoadProgress {
     VersionId oldest_loaded_undeleted_index_version_ = std::numeric_limits<VersionId>::max();
     timestamp earliest_loaded_timestamp_ = std::numeric_limits<timestamp>::max();
     timestamp earliest_loaded_undeleted_timestamp_ = std::numeric_limits<timestamp>::max();
+    timestamp latest_loaded_timestamp_ = std::numeric_limits<timestamp>::min();
     bool is_earliest_version_loaded{false};
 };
 

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -209,7 +209,6 @@ struct LoadProgress {
     VersionId oldest_loaded_undeleted_index_version_ = std::numeric_limits<VersionId>::max();
     timestamp earliest_loaded_timestamp_ = std::numeric_limits<timestamp>::max();
     timestamp earliest_loaded_undeleted_timestamp_ = std::numeric_limits<timestamp>::max();
-    timestamp latest_loaded_timestamp_ = std::numeric_limits<timestamp>::min();
     bool is_earliest_version_loaded{false};
 };
 

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -35,6 +35,7 @@ inline std::optional<AtomKey> read_segment_with_keys(
     VersionId oldest_loaded_undeleted_index = std::numeric_limits<VersionId>::max();
     timestamp earliest_loaded_timestamp = std::numeric_limits<timestamp>::max();
     timestamp earliest_loaded_undeleted_timestamp = std::numeric_limits<timestamp>::max();
+    timestamp latest_loaded_timestamp = std::numeric_limits<timestamp>::min();
 
     for (; row < ssize_t(seg.row_count()); ++row) {
         auto key = read_key_row(seg, row);
@@ -44,10 +45,11 @@ inline std::optional<AtomKey> read_segment_with_keys(
             entry.keys_.push_back(key);
             oldest_loaded_index = std::min(oldest_loaded_index, key.version_id());
             earliest_loaded_timestamp = std::min(earliest_loaded_timestamp, key.creation_ts());
+            latest_loaded_timestamp = std::max(latest_loaded_timestamp, key.creation_ts());
 
             if (!entry.is_tombstoned(key)) {
                 oldest_loaded_undeleted_index = std::min(oldest_loaded_undeleted_index, key.version_id());
-                earliest_loaded_undeleted_timestamp = std::min(earliest_loaded_timestamp, key.creation_ts());
+                earliest_loaded_undeleted_timestamp = std::min(earliest_loaded_undeleted_timestamp, key.creation_ts());
             }
 
         } else if (key.type() == KeyType::TOMBSTONE) {
@@ -74,6 +76,8 @@ inline std::optional<AtomKey> read_segment_with_keys(
             std::min(load_progress.earliest_loaded_timestamp_, earliest_loaded_timestamp);
     load_progress.earliest_loaded_undeleted_timestamp_ =
             std::min(load_progress.earliest_loaded_undeleted_timestamp_, earliest_loaded_undeleted_timestamp);
+    load_progress.latest_loaded_timestamp_ =
+            std::max(load_progress.latest_loaded_timestamp_, latest_loaded_timestamp);
     load_progress.is_earliest_version_loaded = !next.has_value();
     return next;
 }

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -76,8 +76,7 @@ inline std::optional<AtomKey> read_segment_with_keys(
             std::min(load_progress.earliest_loaded_timestamp_, earliest_loaded_timestamp);
     load_progress.earliest_loaded_undeleted_timestamp_ =
             std::min(load_progress.earliest_loaded_undeleted_timestamp_, earliest_loaded_undeleted_timestamp);
-    load_progress.latest_loaded_timestamp_ =
-            std::max(load_progress.latest_loaded_timestamp_, latest_loaded_timestamp);
+    load_progress.latest_loaded_timestamp_ = std::max(load_progress.latest_loaded_timestamp_, latest_loaded_timestamp);
     load_progress.is_earliest_version_loaded = !next.has_value();
     return next;
 }

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -35,7 +35,6 @@ inline std::optional<AtomKey> read_segment_with_keys(
     VersionId oldest_loaded_undeleted_index = std::numeric_limits<VersionId>::max();
     timestamp earliest_loaded_timestamp = std::numeric_limits<timestamp>::max();
     timestamp earliest_loaded_undeleted_timestamp = std::numeric_limits<timestamp>::max();
-    timestamp latest_loaded_timestamp = std::numeric_limits<timestamp>::min();
 
     for (; row < ssize_t(seg.row_count()); ++row) {
         auto key = read_key_row(seg, row);
@@ -45,7 +44,6 @@ inline std::optional<AtomKey> read_segment_with_keys(
             entry.keys_.push_back(key);
             oldest_loaded_index = std::min(oldest_loaded_index, key.version_id());
             earliest_loaded_timestamp = std::min(earliest_loaded_timestamp, key.creation_ts());
-            latest_loaded_timestamp = std::max(latest_loaded_timestamp, key.creation_ts());
 
             if (!entry.is_tombstoned(key)) {
                 oldest_loaded_undeleted_index = std::min(oldest_loaded_undeleted_index, key.version_id());
@@ -76,7 +74,6 @@ inline std::optional<AtomKey> read_segment_with_keys(
             std::min(load_progress.earliest_loaded_timestamp_, earliest_loaded_timestamp);
     load_progress.earliest_loaded_undeleted_timestamp_ =
             std::min(load_progress.earliest_loaded_undeleted_timestamp_, earliest_loaded_undeleted_timestamp);
-    load_progress.latest_loaded_timestamp_ = std::max(load_progress.latest_loaded_timestamp_, latest_loaded_timestamp);
     load_progress.is_earliest_version_loaded = !next.has_value();
     return next;
 }

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -3423,11 +3423,6 @@ def test_read_specific_version_reloads_when_new_versions_written(basic_store_fac
         for i in range(3):
             lib_a.write(symbol, dataframes[i])
 
-        # Client B reads all versions to populate its cache
-        # This sets is_earliest_version_loaded=true in its version map cache
-        all_versions_b = lib_b.list_versions(symbol)
-        assert len(all_versions_b) == 3
-
         # Verify Client B can read all versions
         for i in range(3):
             result = lib_b.read(symbol, as_of=i)
@@ -3443,12 +3438,21 @@ def test_read_specific_version_reloads_when_new_versions_written(basic_store_fac
             result = lib_a.read(symbol, as_of=i)
             assert result.version == i
 
+        # Test reading by negative index (relative to existing versions in cache)
+        # -1 should be v2, -2 should be v1, etc.
+        result = lib_b.read(symbol, as_of=-1)
+        assert result.version == 2
+        assert_equal(result.data, dataframes[2])
+
+        result = lib_b.read(symbol, as_of=-2)
+        assert result.version == 1
+        assert_equal(result.data, dataframes[1])
+
         # Client B should be able to read the new versions by triggering a reload
-        # Test reading by explicit version number
-        for i in range(3, 6):
-            result = lib_b.read(symbol, as_of=i)
-            assert result.version == i
-            assert_equal(result.data, dataframes[i])
+        # Reloading version 3 will reload all versions up to version 3
+        result = lib_b.read(symbol, as_of=3)
+        assert result.version == 3
+        assert_equal(result.data, dataframes[3])
 
         # Test reading by negative index (relative to latest)
         # -1 should be v5, -2 should be v4, etc.
@@ -3460,71 +3464,7 @@ def test_read_specific_version_reloads_when_new_versions_written(basic_store_fac
         assert result.version == 4
         assert_equal(result.data, dataframes[4])
 
+        # This should trigger reload for the rest of the chain
         result = lib_b.read(symbol, as_of=-6)
         assert result.version == 0
         assert_equal(result.data, dataframes[0])
-
-        # Now list_versions should show all 6 versions
-        all_versions_b = lib_b.list_versions(symbol)
-        assert len(all_versions_b) == 6
-
-
-@pytest.mark.storage
-def test_as_of_timestamp_cache_invalidation_on_new_version(basic_store_factory):
-    """
-    Test that reading with as_of timestamp correctly reloads the version chain when new versions
-    have been written by another client after the cached newest version's timestamp.
-
-    This tests the fix for FROM_TIME cache validation where the cache needs to track the newest
-    loaded timestamp (latest_loaded_timestamp_) to detect when a requested timestamp is newer
-    than what's cached, potentially missing newly written versions.
-    """
-    # Set a very long reload interval to ensure the fix is being tested
-    with config_context("VersionMap.ReloadInterval", sys.maxsize):
-        # Create two library instances pointing to the same storage (simulating two clients)
-        lib_a = basic_store_factory()
-        lib_b = basic_store_factory(reuse_name=True)
-
-        symbol = "test_as_of_timestamp_reload"
-        dataframes = [sample_dataframe() for _ in range(4)]
-
-        # Client A writes initial versions v0, v1
-        timestamps = []
-        for i in range(2):
-            with distinct_timestamps(lib_a) as ts:
-                lib_a.write(symbol, dataframes[i])
-            timestamps.append(ts)
-
-        # Client B reads all versions to populate its cache
-        all_versions_b = lib_b.list_versions(symbol)
-        assert len(all_versions_b) == 2
-
-        # Verify Client B can read by timestamp within the cached range
-        result = lib_b.read(symbol, as_of=timestamps[1].after)
-        assert result.version == 1
-        assert_equal(result.data, dataframes[1])
-
-        result = lib_b.read(symbol, as_of=timestamps[0].after)
-        assert result.version == 0
-        assert_equal(result.data, dataframes[0])
-
-        # Client A writes new versions v2, v3
-        for i in range(2, 4):
-            with distinct_timestamps(lib_a) as ts:
-                lib_a.write(symbol, dataframes[i])
-            timestamps.append(ts)
-
-        # Client B should be able to read using a timestamp after the new versions
-        # This should trigger a reload since the timestamp is newer than Client B's cached newest
-        result = lib_b.read(symbol, as_of=timestamps[3].after)
-        assert result.version == 3
-        assert_equal(result.data, dataframes[3])
-
-        # Client B should also be able to read the intermediate version
-        result = lib_b.read(symbol, as_of=timestamps[2].after)
-        assert result.version == 2
-        assert_equal(result.data, dataframes[2])
-
-        # Verify all versions are now visible
-        all_versions_b = lib_b.list_versions(symbol)
-        assert len(all_versions_b) == 4

--- a/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
+++ b/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
@@ -105,7 +105,7 @@ def test_read_from_time_now(in_memory_store_factory, clear_query_stats):
             lib.write(sym, make_df())
         qs.enable()
         qs.reset_stats()
-        lib.read(sym, as_of=pd.Timestamp.now())
+        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
         stats = qs.get_query_stats()
         assert get_version_reads(stats) == 0
         assert get_version_ref_reads(stats) == 1
@@ -277,7 +277,7 @@ def test_from_time_then_downto_with_tombstone_all(in_memory_store_factory, clear
         lib.write(sym, make_df())
         lib.write(sym, make_df())
         # FROM_TIME(now) loads all version keys including tombstone_all
-        lib.read(sym, as_of=pd.Timestamp.now())
+        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
         qs.enable()
         qs.reset_stats()
         # DOWNTO(2) - oldest live version after delete+rewrite
@@ -296,7 +296,7 @@ def test_from_time_then_downto_nonexistent_with_tombstone_all(in_memory_store_fa
         lib.delete(sym)
         lib.write(sym, make_df())
         lib.write(sym, make_df())
-        lib.read(sym, as_of=pd.Timestamp.now())
+        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
         qs.enable()
         qs.reset_stats()
         # DOWNTO(0) - version 0 was deleted, but cache should know this
@@ -319,7 +319,7 @@ def test_alternating_reads_after_delete_rewrite(in_memory_store_factory, clear_q
         qs.enable()
         qs.reset_stats()
         # FROM_TIME loads all versions - writes already populated cache so no storage reads
-        lib.read(sym, as_of=pd.Timestamp.now())
+        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
         stats = qs.get_query_stats()
         assert get_version_reads(stats) == 0
         assert get_version_ref_reads(stats) == 0

--- a/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
+++ b/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
@@ -3,21 +3,30 @@ Tests that verify VERSION key storage read counts for version map cache behavior
 
 Uses in-memory storage because it is instrumented with query_stats (LMDB and Azure are not).
 S3 is also instrumented but requires external infrastructure. The operation key is Memory_GetObject.
+
+Test dimensions:
+- Version chain shapes (simple, tombstone_all, individual tombstone, append, update, prune)
+- Cache options (no_cache=ReloadInterval 0, cache_on=ReloadInterval MAX)
+- as_of query types (None/LATEST, int/DOWNTO, Timestamp/FROM_TIME, str/SNAPSHOT)
+- Read functions (read, head, tail, read_metadata, has_symbol, batch_read)
+- Write operations (write, append, update, batch_write, batch_append, write_metadata, snapshot)
 """
 
 import time
+import uuid
+from collections import namedtuple
 
 import pandas as pd
 import pytest
 
 import arcticdb.toolbox.query_stats as qs
+from arcticdb.exceptions import NoSuchVersionException
 from arcticdb.util.test import config_context
 from tests.util.mark import MEM_TESTS_MARK
 
 pytestmark = MEM_TESTS_MARK
 
-# Large reload interval to effectively disable TTL-based cache invalidation
-MAX_RELOAD_INTERVAL = 2_000_000_000
+MAX_RELOAD_INTERVAL = 2_000_000_000_000
 
 
 def make_df():
@@ -25,338 +34,479 @@ def make_df():
 
 
 def make_ts_df(start_day=0, periods=3):
-    """Create a DataFrame with a DatetimeIndex, suitable for append/update operations."""
     return pd.DataFrame({"col": range(periods)}, index=pd.date_range(f"2020-01-{start_day + 1:02d}", periods=periods))
 
 
 def get_version_reads(stats):
-    """Get the count of VERSION key reads from query stats."""
     return stats.get("storage_operations", {}).get("Memory_GetObject", {}).get("VERSION", {}).get("count", 0)
 
 
 def get_version_ref_reads(stats):
-    """Get the count of VERSION_REF key reads from query stats."""
     return stats.get("storage_operations", {}).get("Memory_GetObject", {}).get("VERSION_REF", {}).get("count", 0)
 
 
-def test_read_latest_one_version(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_read_latest_one_version"
-    with config_context("VersionMap.ReloadInterval", 0):
+# =============================================================================
+# Chain setup functions
+# =============================================================================
+# Each returns a ChainInfo with metadata about the created version chain.
+
+ChainInfo = namedtuple("ChainInfo", ["latest_version", 
+                                     "oldest_undeleted_version", 
+                                     "mid_version", 
+                                     "snapshot", 
+                                     "mid_ts", 
+                                     "total_versions"])
+
+
+def _ts_from_version_info(version_info):
+    """Convert VersionedItem.timestamp (nanosecond int) to pd.Timestamp for FROM_TIME queries."""
+    return pd.Timestamp(version_info.timestamp, unit="ns", tz="UTC")
+
+
+def setup_simple_6(lib, sym):
+    """v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
+    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    lib.snapshot(sym + "_snap", versions={sym: 3})
+    return ChainInfo(5, 0, 3, sym + "_snap", _ts_from_version_info(vinfos[3]), 6)
+
+
+def setup_multi_tombstone_all(lib, sym):
+    """v4 -> v3 -> v2 -> TOMBSTONE_ALL -> v1 -> TOMBSTONE_ALL -> v0"""
+    lib.write(sym, make_df())
+    lib.delete(sym)
+    lib.write(sym, make_df())
+    lib.delete(sym)
+    vinfos = [lib.write(sym, make_df()) for _ in range(3)]
+    lib.snapshot(sym + "_snap", versions={sym: 3})
+    return ChainInfo(4, 2, 3, sym + "_snap", _ts_from_version_info(vinfos[1]), 5)
+
+
+def setup_multi_individual_tombstone(lib, sym):
+    """v5 -> TOMBSTONE(v3) -> TOMBSTONE(v1) -> v4 -> v3 -> v2 -> v1 -> v0"""
+    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    lib.delete_version(sym, 1)
+    lib.delete_version(sym, 3)
+    lib.snapshot(sym + "_snap", versions={sym: 2})
+    return ChainInfo(5, 0, 2, sym + "_snap", _ts_from_version_info(vinfos[2]), 6)
+
+
+def setup_append_chain(lib, sym):
+    """v2 -> v1 -> v0 via write + 2 appends"""
+    vinfos = [
+        lib.write(sym, make_ts_df(0, 2)),
+        lib.append(sym, make_ts_df(2, 2)),
+        lib.append(sym, make_ts_df(4, 2)),
+    ]
+    lib.snapshot(sym + "_snap", versions={sym: 1})
+    return ChainInfo(2, 0, 1, sym + "_snap", _ts_from_version_info(vinfos[1]), 3)
+
+
+def setup_update_chain(lib, sym):
+    """v2 -> v1 -> v0 via write + 2 updates"""
+    vinfos = [
+        lib.write(sym, make_ts_df(0, 3)),
+        lib.update(sym, make_ts_df(1, 1)),
+        lib.update(sym, make_ts_df(2, 1)),
+    ]
+    lib.snapshot(sym + "_snap", versions={sym: 1})
+    return ChainInfo(2, 0, 1, sym + "_snap", _ts_from_version_info(vinfos[1]), 3)
+
+
+def setup_prune_chain(lib, sym):
+    """v2 only (v0, v1 pruned)"""
+    vinfos = [lib.write(sym, make_df()) for _ in range(3)]
+    lib.prune_previous_versions(sym)
+    lib.snapshot(sym + "_snap", versions={sym: 2})
+    return ChainInfo(2, 2, 2, sym + "_snap", _ts_from_version_info(vinfos[2]), 3)
+
+
+def setup_tombstone_all_then_writes(lib, sym):
+    """v6 -> v5 -> v4 -> v3 -> v2 ->TOMBSTONE_ALL -> v1 (delete all first, then 6 writes)"""
+    lib.write(sym, make_df())
+    lib.delete(sym)
+    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    lib.snapshot(sym + "_snap", versions={sym: 4})
+    return ChainInfo(6, 1, 4, sym + "_snap", _ts_from_version_info(vinfos[3]), 7)
+
+
+def setup_tombstone_latest(lib, sym):
+    """TOMBSTONE(v5) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0 (delete latest version only)"""
+    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    lib.delete_version(sym, 5)
+    lib.snapshot(sym + "_snap", versions={sym: 3})
+    return ChainInfo(4, 0, 3, sym + "_snap", _ts_from_version_info(vinfos[3]), 6)
+
+
+def setup_tombstone_all_every_version(lib, sym):
+    """v11->...->TOMBSTONE_ALL->v5->TOMBSTONE_ALL->...->v0 (delete after each of 6 writes, then 6 more)"""
+    for _ in range(6):
         lib.write(sym, make_df())
+        lib.delete(sym)
+    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    lib.snapshot(sym + "_snap", versions={sym: 9})
+    return ChainInfo(11, 6, 9, sym + "_snap", _ts_from_version_info(vinfos[3]), 12)
+
+
+def setup_tombstone_even_plus_latest(lib, sym):
+    """TOMBSTONE(v5)->TOMBSTONE(v4)->v5->v4->TOMBSTONE(v2)->v3->v2->TOMBSTONE(v0)->v1->v0"""
+    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    lib.delete_version(sym, 0)
+    lib.delete_version(sym, 2)
+    lib.delete_version(sym, 4)
+    lib.delete_version(sym, 5)
+    lib.snapshot(sym + "_snap", versions={sym: 3})
+    return ChainInfo(3, 1, 3, sym + "_snap", _ts_from_version_info(vinfos[3]), 6)
+
+
+CHAIN_SETUPS = [
+    pytest.param(setup_simple_6, id="simple_6"),
+    pytest.param(setup_multi_tombstone_all, id="multi_tombstone_all"),
+    pytest.param(setup_multi_individual_tombstone, id="multi_individual_tombstone"),
+    pytest.param(setup_append_chain, id="append_chain"),
+    pytest.param(setup_update_chain, id="update_chain"),
+    pytest.param(setup_prune_chain, id="prune_chain"),
+    pytest.param(setup_tombstone_all_then_writes, id="tombstone_all_then_writes"),
+    pytest.param(setup_tombstone_latest, id="tombstone_latest"),
+    pytest.param(setup_tombstone_all_every_version, id="tombstone_all_every_version"),
+    pytest.param(setup_tombstone_even_plus_latest, id="tombstone_even_plus_latest"),
+]
+
+# Expected (VERSION_reads, VERSION_REF_reads) for each (chain, cache, as_of) combination.
+# Measured empirically with a fresh library per combination. Snapshot reads always bypass
+# the version map cache (0, 0). Chains with delete/delete_version do a full chain load
+# during setup, so cache_on results are often (0, 0) even for historical reads.
+EXPECTED_COUNTS = {
+    ("simple_6", "no_cache", "latest"): (0, 1),
+    ("simple_6", "no_cache", "version_latest"): (0, 1),
+    ("simple_6", "no_cache", "oldest_undeleted_version"): (6, 1),
+    ("simple_6", "no_cache", "version_mid"): (3, 1),
+    ("simple_6", "no_cache", "timestamp_mid"): (3, 1),
+    ("simple_6", "no_cache", "snapshot"): (0, 0),
+    ("simple_6", "no_cache", "list_versions"): (6, 1),
+    ("simple_6", "cache_on", "latest"): (0, 0),
+    ("simple_6", "cache_on", "version_latest"): (0, 0),
+    ("simple_6", "cache_on", "oldest_undeleted_version"): (6, 1),
+    ("simple_6", "cache_on", "version_mid"): (0, 0),
+    ("simple_6", "cache_on", "timestamp_mid"): (0, 0),
+    ("simple_6", "cache_on", "snapshot"): (0, 0),
+    ("simple_6", "cache_on", "list_versions"): (6, 1),
+    ("multi_tombstone_all", "no_cache", "latest"): (0, 1),
+    ("multi_tombstone_all", "no_cache", "version_latest"): (0, 1),
+    ("multi_tombstone_all", "no_cache", "oldest_undeleted_version"): (3, 1),
+    ("multi_tombstone_all", "no_cache", "version_mid"): (0, 1),
+    ("multi_tombstone_all", "no_cache", "timestamp_mid"): (0, 1),
+    ("multi_tombstone_all", "no_cache", "snapshot"): (0, 0),
+    ("multi_tombstone_all", "no_cache", "list_versions"): (5, 1),
+    ("multi_tombstone_all", "cache_on", "latest"): (0, 0),
+    ("multi_tombstone_all", "cache_on", "version_latest"): (0, 0),
+    ("multi_tombstone_all", "cache_on", "oldest_undeleted_version"): (0, 0),
+    ("multi_tombstone_all", "cache_on", "version_mid"): (0, 0),
+    ("multi_tombstone_all", "cache_on", "timestamp_mid"): (0, 0),
+    ("multi_tombstone_all", "cache_on", "snapshot"): (0, 0),
+    ("multi_tombstone_all", "cache_on", "list_versions"): (0, 0),
+    ("multi_individual_tombstone", "no_cache", "latest"): (3, 1),
+    ("multi_individual_tombstone", "no_cache", "version_latest"): (3, 1),
+    ("multi_individual_tombstone", "no_cache", "oldest_undeleted_version"): (8, 1),
+    ("multi_individual_tombstone", "no_cache", "version_mid"): (6, 1),
+    ("multi_individual_tombstone", "no_cache", "timestamp_mid"): (6, 1),
+    ("multi_individual_tombstone", "no_cache", "snapshot"): (0, 0),
+    ("multi_individual_tombstone", "no_cache", "list_versions"): (8, 1),
+    ("multi_individual_tombstone", "cache_on", "latest"): (0, 0),
+    ("multi_individual_tombstone", "cache_on", "version_latest"): (0, 0),
+    ("multi_individual_tombstone", "cache_on", "oldest_undeleted_version"): (0, 0),
+    ("multi_individual_tombstone", "cache_on", "version_mid"): (0, 0),
+    ("multi_individual_tombstone", "cache_on", "timestamp_mid"): (0, 0),
+    ("multi_individual_tombstone", "cache_on", "snapshot"): (0, 0),
+    ("multi_individual_tombstone", "cache_on", "list_versions"): (0, 0),
+    ("append_chain", "no_cache", "latest"): (0, 1),
+    ("append_chain", "no_cache", "version_latest"): (0, 1),
+    ("append_chain", "no_cache", "oldest_undeleted_version"): (3, 1),
+    ("append_chain", "no_cache", "version_mid"): (0, 1),
+    ("append_chain", "no_cache", "timestamp_mid"): (0, 1),
+    ("append_chain", "no_cache", "snapshot"): (0, 0),
+    ("append_chain", "no_cache", "list_versions"): (3, 1),
+    ("append_chain", "cache_on", "latest"): (0, 0),
+    ("append_chain", "cache_on", "version_latest"): (0, 0),
+    ("append_chain", "cache_on", "oldest_undeleted_version"): (3, 1),
+    ("append_chain", "cache_on", "version_mid"): (0, 0),
+    ("append_chain", "cache_on", "timestamp_mid"): (0, 0),
+    ("append_chain", "cache_on", "snapshot"): (0, 0),
+    ("append_chain", "cache_on", "list_versions"): (3, 1),
+    ("update_chain", "no_cache", "latest"): (0, 1),
+    ("update_chain", "no_cache", "version_latest"): (0, 1),
+    ("update_chain", "no_cache", "oldest_undeleted_version"): (3, 1),
+    ("update_chain", "no_cache", "version_mid"): (0, 1),
+    ("update_chain", "no_cache", "timestamp_mid"): (0, 1),
+    ("update_chain", "no_cache", "snapshot"): (0, 0),
+    ("update_chain", "no_cache", "list_versions"): (3, 1),
+    ("update_chain", "cache_on", "latest"): (0, 0),
+    ("update_chain", "cache_on", "version_latest"): (0, 0),
+    ("update_chain", "cache_on", "oldest_undeleted_version"): (3, 1),
+    ("update_chain", "cache_on", "version_mid"): (0, 0),
+    ("update_chain", "cache_on", "timestamp_mid"): (0, 0),
+    ("update_chain", "cache_on", "snapshot"): (0, 0),
+    ("update_chain", "cache_on", "list_versions"): (3, 1),
+    ("prune_chain", "no_cache", "latest"): (2, 1),
+    ("prune_chain", "no_cache", "version_latest"): (2, 1),
+    ("prune_chain", "no_cache", "oldest_undeleted_version"): (2, 1),
+    ("prune_chain", "no_cache", "version_mid"): (2, 1),
+    ("prune_chain", "no_cache", "timestamp_mid"): (2, 1),
+    ("prune_chain", "no_cache", "snapshot"): (0, 0),
+    ("prune_chain", "no_cache", "list_versions"): (3, 1),
+    ("prune_chain", "cache_on", "latest"): (0, 0),
+    ("prune_chain", "cache_on", "version_latest"): (0, 0),
+    ("prune_chain", "cache_on", "oldest_undeleted_version"): (0, 0),
+    ("prune_chain", "cache_on", "version_mid"): (0, 0),
+    ("prune_chain", "cache_on", "timestamp_mid"): (0, 0),
+    ("prune_chain", "cache_on", "snapshot"): (0, 0),
+    ("prune_chain", "cache_on", "list_versions"): (0, 0),
+    ("tombstone_all_then_writes", "no_cache", "latest"): (0, 1),
+    ("tombstone_all_then_writes", "no_cache", "version_latest"): (0, 1),
+    ("tombstone_all_then_writes", "no_cache", "oldest_undeleted_version"): (6, 1),
+    ("tombstone_all_then_writes", "no_cache", "version_mid"): (3, 1),
+    ("tombstone_all_then_writes", "no_cache", "timestamp_mid"): (3, 1),
+    ("tombstone_all_then_writes", "no_cache", "snapshot"): (0, 0),
+    ("tombstone_all_then_writes", "no_cache", "list_versions"): (8, 1),
+    ("tombstone_all_then_writes", "cache_on", "latest"): (0, 0),
+    ("tombstone_all_then_writes", "cache_on", "version_latest"): (0, 0),
+    ("tombstone_all_then_writes", "cache_on", "oldest_undeleted_version"): (0, 0),
+    ("tombstone_all_then_writes", "cache_on", "version_mid"): (0, 0),
+    ("tombstone_all_then_writes", "cache_on", "timestamp_mid"): (0, 0),
+    ("tombstone_all_then_writes", "cache_on", "snapshot"): (0, 0),
+    ("tombstone_all_then_writes", "cache_on", "list_versions"): (0, 0),
+    ("tombstone_latest", "no_cache", "latest"): (3, 1),
+    ("tombstone_latest", "no_cache", "version_latest"): (3, 1),
+    ("tombstone_latest", "no_cache", "oldest_undeleted_version"): (7, 1),
+    ("tombstone_latest", "no_cache", "version_mid"): (4, 1),
+    ("tombstone_latest", "no_cache", "timestamp_mid"): (4, 1),
+    ("tombstone_latest", "no_cache", "snapshot"): (0, 0),
+    ("tombstone_latest", "no_cache", "list_versions"): (7, 1),
+    ("tombstone_latest", "cache_on", "latest"): (0, 0),
+    ("tombstone_latest", "cache_on", "version_latest"): (0, 0),
+    ("tombstone_latest", "cache_on", "oldest_undeleted_version"): (0, 0),
+    ("tombstone_latest", "cache_on", "version_mid"): (0, 0),
+    ("tombstone_latest", "cache_on", "timestamp_mid"): (0, 0),
+    ("tombstone_latest", "cache_on", "snapshot"): (0, 0),
+    ("tombstone_latest", "cache_on", "list_versions"): (0, 0),
+    ("tombstone_all_every_version", "no_cache", "latest"): (0, 1),
+    ("tombstone_all_every_version", "no_cache", "version_latest"): (0, 1),
+    ("tombstone_all_every_version", "no_cache", "oldest_undeleted_version"): (6, 1),
+    ("tombstone_all_every_version", "no_cache", "version_mid"): (3, 1),
+    ("tombstone_all_every_version", "no_cache", "timestamp_mid"): (3, 1),
+    ("tombstone_all_every_version", "no_cache", "snapshot"): (0, 0),
+    ("tombstone_all_every_version", "no_cache", "list_versions"): (8, 1),
+    ("tombstone_all_every_version", "cache_on", "latest"): (0, 0),
+    ("tombstone_all_every_version", "cache_on", "version_latest"): (0, 0),
+    ("tombstone_all_every_version", "cache_on", "oldest_undeleted_version"): (0, 0),
+    ("tombstone_all_every_version", "cache_on", "version_mid"): (0, 0),
+    ("tombstone_all_every_version", "cache_on", "timestamp_mid"): (0, 0),
+    ("tombstone_all_every_version", "cache_on", "snapshot"): (0, 0),
+    ("tombstone_all_every_version", "cache_on", "list_versions"): (0, 0),
+    ("tombstone_even_plus_latest", "no_cache", "latest"): (7, 1),
+    ("tombstone_even_plus_latest", "no_cache", "version_latest"): (7, 1),
+    ("tombstone_even_plus_latest", "no_cache", "oldest_undeleted_version"): (9, 1),
+    ("tombstone_even_plus_latest", "no_cache", "version_mid"): (7, 1),
+    ("tombstone_even_plus_latest", "no_cache", "timestamp_mid"): (7, 1),
+    ("tombstone_even_plus_latest", "no_cache", "snapshot"): (0, 0),
+    ("tombstone_even_plus_latest", "no_cache", "list_versions"): (10, 1),
+    ("tombstone_even_plus_latest", "cache_on", "latest"): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", "version_latest"): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", "oldest_undeleted_version"): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", "version_mid"): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", "timestamp_mid"): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", "snapshot"): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", "list_versions"): (0, 0),
+}
+
+AS_OF_TYPES = ["latest", "version_latest", "oldest_undeleted_version", "version_mid", "timestamp_mid", "snapshot"]
+
+
+def resolve_as_of(as_of_type, chain_info):
+    if as_of_type == "latest":
+        return None
+    elif as_of_type == "version_latest":
+        return chain_info.latest_version
+    elif as_of_type == "oldest_undeleted_version":
+        return chain_info.oldest_undeleted_version
+    elif as_of_type == "version_mid":
+        return chain_info.mid_version
+    elif as_of_type == "timestamp_mid":
+        return chain_info.mid_ts
+    elif as_of_type == "snapshot":
+        return chain_info.snapshot
+
+
+# =============================================================================
+# Test 1: Core cross-product — chain × cache × as_of
+# =============================================================================
+
+
+@pytest.mark.parametrize("chain_setup", CHAIN_SETUPS)
+@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
+@pytest.mark.parametrize("as_of_type", AS_OF_TYPES)
+def test_read_version_chain(in_memory_store_factory, clear_query_stats, chain_setup, reload_interval, as_of_type):
+    """Test VERSION/VERSION_REF read counts for read() across all chain shapes, cache states, and as_of types."""
+    lib = in_memory_store_factory()
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
+    cache_id = "no_cache" if reload_interval == 0 else "cache_on"
+    chain_id = chain_setup.__name__.replace("setup_", "")
+
+    with config_context("VersionMap.ReloadInterval", reload_interval):
+        chain_info = chain_setup(lib, sym)
+        as_of = resolve_as_of(as_of_type, chain_info)
+
         qs.enable()
         qs.reset_stats()
-        lib.read(sym)
+        lib.read(sym, as_of=as_of)
         stats = qs.get_query_stats()
-        # LATEST only reads VERSION_REF, not VERSION keys
-        assert get_version_ref_reads(stats) == 1
-        assert get_version_reads(stats) == 0
+
+        expected_ver, expected_ref = EXPECTED_COUNTS[(chain_id, cache_id, as_of_type)]
+        assert get_version_reads(stats) == expected_ver
+        assert get_version_ref_reads(stats) == expected_ref
 
 
-def test_read_latest_many_versions(in_memory_store_factory, clear_query_stats):
+# =============================================================================
+# Test 2: list_versions across chains
+# =============================================================================
+
+
+@pytest.mark.parametrize("chain_setup", CHAIN_SETUPS)
+@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
+def test_list_versions_chain(in_memory_store_factory, clear_query_stats, chain_setup, reload_interval):
+    """Test VERSION/VERSION_REF read counts for list_versions across all chain shapes."""
     lib = in_memory_store_factory()
-    sym = "test_read_latest_many_versions"
-    with config_context("VersionMap.ReloadInterval", 0):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_ref_reads(stats) == 1
-        assert get_version_reads(stats) == 0
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
+    cache_id = "no_cache" if reload_interval == 0 else "cache_on"
+    chain_id = chain_setup.__name__.replace("setup_", "")
 
+    with config_context("VersionMap.ReloadInterval", reload_interval):
+        chain_setup(lib, sym) if callable(chain_setup) else chain_setup.values[0](lib, sym)
 
-def test_read_downto_oldest(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_read_downto_oldest"
-    with config_context("VersionMap.ReloadInterval", 0):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 5
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_read_downto_latest(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_read_downto_latest"
-    with config_context("VersionMap.ReloadInterval", 0):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=4)
-        stats = qs.get_query_stats()
-        # DOWNTO(4) finds the version in the ref, so no VERSION key reads needed
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_read_from_time_now(in_memory_store_factory, clear_query_stats):
-    """FROM_TIME with a recent timestamp should find the latest version."""
-    lib = in_memory_store_factory()
-    sym = "test_read_from_time_now"
-    with config_context("VersionMap.ReloadInterval", 0):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_list_versions(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_list_versions"
-    with config_context("VersionMap.ReloadInterval", 0):
-        for _ in range(5):
-            lib.write(sym, make_df())
         qs.enable()
         qs.reset_stats()
         lib.list_versions(sym)
         stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 5
-        assert get_version_ref_reads(stats) == 1
+
+        expected_ver, expected_ref = EXPECTED_COUNTS[(chain_id, cache_id, "list_versions")]
+        assert get_version_reads(stats) == expected_ver
+        assert get_version_ref_reads(stats) == expected_ref
 
 
-def test_read_after_delete_all(in_memory_store_factory, clear_query_stats):
+# =============================================================================
+# Test 3: Read-like ops equivalence (warm cache)
+# =============================================================================
+# After list_versions warms the cache, all read-like ops should produce 0 VERSION
+# and 0 VERSION_REF reads for version/latest/snapshot as_of queries.
+
+
+@pytest.mark.parametrize(
+    "read_fn",
+    [
+        pytest.param(lambda lib, sym, as_of: lib.read(sym, as_of=as_of), id="read"),
+        pytest.param(lambda lib, sym, as_of: lib.head(sym, 1, as_of=as_of), id="head"),
+        pytest.param(lambda lib, sym, as_of: lib.tail(sym, 1, as_of=as_of), id="tail"),
+        pytest.param(lambda lib, sym, as_of: lib.read_metadata(sym, as_of=as_of), id="read_metadata"),
+        pytest.param(lambda lib, sym, as_of: lib.has_symbol(sym, as_of=as_of), id="has_symbol"),
+        pytest.param(lambda lib, sym, as_of: lib.batch_read([sym], as_ofs=[as_of]), id="batch_read"),
+    ],
+)
+@pytest.mark.parametrize("as_of_type", AS_OF_TYPES)
+def test_read_ops_warm_cache(in_memory_store_factory, clear_query_stats, read_fn, as_of_type):
+    """After list_versions warms the cache, all read-like ops use it."""
     lib = in_memory_store_factory()
-    sym = "test_read_after_delete_all"
-    with config_context("VersionMap.ReloadInterval", 0):
-        for _ in range(3):
-            lib.write(sym, make_df())
-        lib.delete(sym)
-        for _ in range(2):
-            lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        # LATEST only needs VERSION_REF
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_read_latest_then_read_latest(in_memory_store_factory, clear_query_stats):
-    """LATEST -> LATEST should be a full cache hit (0 storage reads)."""
-    lib = in_memory_store_factory()
-    sym = "test_read_latest_then_read_latest"
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
     with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        lib.read(sym)
+        chain_info = setup_simple_6(lib, sym)
+        lib.list_versions(sym)  # warm cache fully
+
+        as_of = resolve_as_of(as_of_type, chain_info)
         qs.enable()
         qs.reset_stats()
-        lib.read(sym)
+        read_fn(lib, sym, as_of)
         stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
 
-
-def test_read_latest_then_read_specific(in_memory_store_factory, clear_query_stats):
-    """LATEST -> DOWNTO(0) should be a cache miss (needs to load earlier versions)."""
-    lib = in_memory_store_factory()
-    sym = "test_read_latest_then_read_specific"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        lib.read(sym)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        # Cache miss: must load all 5 VERSION keys + re-read VERSION_REF
-        # The current limitation with current version map cache.
-        # When we do writes, we add the version in the cache, but we never
-        # update the oldest_loaded_index_version_ in the LoadProgress
-        # as result of this the cache is not very useful and result in cache miss
-        assert get_version_reads(stats) == 5
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_read_oldest_then_read_latest(in_memory_store_factory, clear_query_stats):
-    """DOWNTO(0) -> LATEST should be a cache hit (all versions already loaded)."""
-    lib = in_memory_store_factory()
-    sym = "test_read_oldest_then_read_latest"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        lib.read(sym, as_of=0)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
+        # After list_versions fully warms the cache, all read-like ops
+        # should be cache hits regardless of as_of type
         assert get_version_reads(stats) == 0
         assert get_version_ref_reads(stats) == 0
 
 
-def test_read_oldest_then_read_any(in_memory_store_factory, clear_query_stats):
-    """DOWNTO(0) -> DOWNTO(3) should be a cache hit."""
+# =============================================================================
+# Test 4: Mutation → read latest (cache hit)
+# =============================================================================
+
+
+def _mut_write(lib, sym):
+    lib.write(sym, make_df())
+
+
+def _mut_append(lib, sym):
+    lib.write(sym, make_ts_df(0))
+    lib.append(sym, make_ts_df(3))
+
+
+def _mut_update(lib, sym):
+    lib.write(sym, make_ts_df(0))
+    lib.update(sym, make_ts_df(1, periods=1))
+
+
+def _mut_batch_write(lib, sym):
+    lib.batch_write([sym], [make_df()])
+
+
+def _mut_batch_append(lib, sym):
+    lib.write(sym, make_ts_df(0))
+    lib.batch_append([sym], [make_ts_df(3)])
+
+
+def _mut_write_metadata(lib, sym):
+    lib.write(sym, make_df())
+    lib.write_metadata(sym, {"key": "value"})
+
+
+def _mut_snapshot(lib, sym):
+    lib.write(sym, make_df())
+    lib.snapshot(sym + "_snap")
+
+
+@pytest.mark.parametrize(
+    "mutation_fn",
+    [
+        pytest.param(_mut_write, id="write"),
+        pytest.param(_mut_append, id="append"),
+        pytest.param(_mut_update, id="update"),
+        pytest.param(_mut_batch_write, id="batch_write"),
+        pytest.param(_mut_batch_append, id="batch_append"),
+        pytest.param(_mut_write_metadata, id="write_metadata"),
+        pytest.param(_mut_snapshot, id="snapshot"),
+    ],
+)
+@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
+def test_mutation_then_read_latest(in_memory_store_factory, clear_query_stats, mutation_fn, reload_interval):
+    """After any mutation, reading latest should be a cache hit (cache_on) or 1 VERSION_REF read (no_cache)."""
     lib = in_memory_store_factory()
-    sym = "test_read_oldest_then_read_any"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        lib.read(sym, as_of=0)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=3)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_read_latest_then_read_oldest(in_memory_store_factory, clear_query_stats):
-    """DOWNTO(4) -> DOWNTO(0) should be a cache miss."""
-    lib = in_memory_store_factory()
-    sym = "test_read_latest_then_read_oldest"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        # This will trigger the cache load
-        # The current limitation with current version map cache.
-        # When we do writes, we add the version in the cache, but we never
-        # update the oldest_loaded_index_version_ in the LoadProgress
-        # as result of this the cache is not very useful and result in cache miss
-        lib.read(sym, as_of=4)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        # Cache miss: must load all 5 VERSION keys + re-read VERSION_REF
-        assert get_version_reads(stats) == 5
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_list_versions_then_read(in_memory_store_factory, clear_query_stats):
-    """list_versions (ALL) -> LATEST should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_list_versions_then_read"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        lib.list_versions(sym)
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
+    with config_context("VersionMap.ReloadInterval", reload_interval):
+        mutation_fn(lib, sym)
         qs.enable()
         qs.reset_stats()
         lib.read(sym)
         stats = qs.get_query_stats()
         assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
+        if reload_interval == 0:
+            assert get_version_ref_reads(stats) == 1
+        else:
+            assert get_version_ref_reads(stats) == 0
 
 
-def test_read_latest_then_list_versions(in_memory_store_factory, clear_query_stats):
-    """LATEST -> list_versions (ALL) should be a cache miss."""
-    lib = in_memory_store_factory()
-    sym = "test_read_latest_then_list_versions"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(5):
-            lib.write(sym, make_df())
-        lib.read(sym)
-        qs.enable()
-        qs.reset_stats()
-        lib.list_versions(sym)
-        stats = qs.get_query_stats()
-        # Cache miss: must load all 5 VERSION keys + re-read VERSION_REF
-        assert get_version_reads(stats) == 5
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_from_time_then_downto_with_tombstone_all(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_from_time_then_downto_with_tombstone_all"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.delete(sym)
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        # FROM_TIME(now) loads all version keys including tombstone_all
-        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
-        qs.enable()
-        qs.reset_stats()
-        # DOWNTO(2) - oldest live version after delete+rewrite
-        lib.read(sym, as_of=2)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_from_time_then_downto_nonexistent_with_tombstone_all(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_from_time_then_downto_nonexistent_with_tombstone_all"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.delete(sym)
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
-        qs.enable()
-        qs.reset_stats()
-        # DOWNTO(0) - version 0 was deleted, but cache should know this
-        with pytest.raises(Exception):
-            lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_alternating_reads_after_delete_rewrite(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_alternating_reads_after_delete_rewrite"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.delete(sym)
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        # FROM_TIME loads all versions - writes already populated cache so no storage reads
-        lib.read(sym, as_of=pd.Timestamp.now("UTC"))
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-        qs.reset_stats()
-        # DOWNTO(2) - oldest live version, should be cache hit
-        lib.read(sym, as_of=2)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_latest_then_downto_with_tombstone_all(in_memory_store_factory, clear_query_stats):
-    lib_writer = in_memory_store_factory()
-    lib_reader = in_memory_store_factory(reuse_name=True)
-    sym = "test_latest_then_downto_with_tombstone_all"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib_writer.write(sym, make_df())
-        lib_writer.write(sym, make_df())
-        lib_writer.delete(sym)
-        # Write enough versions after delete so LATEST doesn't cache all of them
-        for _ in range(5):
-            lib_writer.write(sym, make_df())
-        lib_reader.read(sym)  # LATEST - reader only loads top of chain
-        qs.enable()
-        qs.reset_stats()
-        # DOWNTO(2) - oldest live version, beyond what LATEST cached
-        lib_reader.read(sym, as_of=2)
-        stats = qs.get_query_stats()
-        # Cache miss: must load 5 VERSION keys + re-read VERSION_REF
-        assert get_version_reads(stats) == 5
-        assert get_version_ref_reads(stats) == 1
+# =============================================================================
+# Test 5: TTL Invalidation (standalone, require time.sleep)
+# =============================================================================
 
 
 def test_reload_interval_zero_always_reloads(in_memory_store_factory, clear_query_stats):
-    """With ReloadInterval=0, every LATEST read should check VERSION_REF."""
     lib = in_memory_store_factory()
-    sym = "test_reload_interval_zero_always_reloads"
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
     with config_context("VersionMap.ReloadInterval", 0):
         lib.write(sym, make_df())
         qs.enable()
@@ -373,13 +523,12 @@ def test_reload_interval_zero_always_reloads(in_memory_store_factory, clear_quer
 
 
 def test_cache_expires_after_ttl(in_memory_store_factory, clear_query_stats):
-    """After TTL expires, the cache should be invalidated and VERSION_REF re-read."""
     lib = in_memory_store_factory()
-    sym = "test_cache_expires_after_ttl"
-    with config_context("VersionMap.ReloadInterval", 100):  # 100ms
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
+    with config_context("VersionMap.ReloadInterval", 100_000_000):  # 100ms in nanoseconds
         lib.write(sym, make_df())
-        lib.read(sym)  # Populate cache
-        time.sleep(0.2)  # Wait for TTL to expire
+        lib.read(sym)
+        time.sleep(0.2)
         qs.enable()
         qs.reset_stats()
         lib.read(sym)
@@ -389,9 +538,8 @@ def test_cache_expires_after_ttl(in_memory_store_factory, clear_query_stats):
 
 
 def test_cache_valid_within_ttl(in_memory_store_factory, clear_query_stats):
-    """Within TTL, the second read should be a full cache hit (0 storage reads)."""
     lib = in_memory_store_factory()
-    sym = "test_cache_valid_within_ttl"
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
     with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
         lib.write(sym, make_df())
         lib.read(sym)
@@ -403,14 +551,15 @@ def test_cache_valid_within_ttl(in_memory_store_factory, clear_query_stats):
         assert get_version_ref_reads(stats) == 0
 
 
+# =============================================================================
+# Test 6: Two-Client Scenarios
+# =============================================================================
+
+
 def test_client_b_sees_stale_cache(in_memory_store_factory, clear_query_stats):
-    """
-    Client B caches v0. Client A writes v1. Client B reads latest with cache still valid
-    and gets stale v0 (0 storage reads).
-    """
     lib_a = in_memory_store_factory()
     lib_b = in_memory_store_factory(reuse_name=True)
-    sym = "test_client_b_sees_stale_cache"
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
     with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
         lib_a.write(sym, pd.DataFrame({"col": [0]}))
         result_b1 = lib_b.read(sym)
@@ -422,629 +571,275 @@ def test_client_b_sees_stale_cache(in_memory_store_factory, clear_query_stats):
         stats = qs.get_query_stats()
         assert get_version_reads(stats) == 0
         assert get_version_ref_reads(stats) == 0
-        assert result_b2.data["col"].iloc[0] == 0, "Expected stale v0 from cache"
+        assert result_b2.data["col"].iloc[0] == 0
 
 
 def test_client_b_reloads_for_unknown_version(in_memory_store_factory, clear_query_stats):
-    """
-    Client B has v0 cached. When B tries to read v1 (not in cache), it must reload
-    from storage.
-    """
     lib_a = in_memory_store_factory()
     lib_b = in_memory_store_factory(reuse_name=True)
-    sym = "test_client_b_reloads_for_unknown_version"
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
     with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
         lib_a.write(sym, pd.DataFrame({"col": [0]}))
-        lib_b.read(sym)  # B caches v0
+        lib_b.read(sym)
         lib_a.write(sym, pd.DataFrame({"col": [1]}))
         qs.enable()
         qs.reset_stats()
         result = lib_b.read(sym, as_of=1)
         stats = qs.get_query_stats()
-        # B must read VERSION_REF to discover v1
         assert get_version_reads(stats) == 0
         assert get_version_ref_reads(stats) == 1
         assert result.data["col"].iloc[0] == 1
 
 
-def test_write_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After a write, reading latest should be a cache hit (0 storage reads)."""
+# =============================================================================
+# Test 7: Cross-query-type sequences (timestamp <-> version <-> snapshot)
+# =============================================================================
+# Tests that a first read with one as_of type correctly populates (or doesn't
+# populate) the cache for a second read with a different as_of type.
+# Parametrized across all chain shapes.
+
+def _resolve_cross_as_of(label, chain_info):
+    if label == "latest":
+        return None
+    if label == "from_time":
+        return chain_info.mid_ts
+    elif label == "downto_oldest":
+        return chain_info.oldest_undeleted_version
+    elif label == "downto_mid":
+        return chain_info.mid_version
+    elif label == "snapshot":
+        return chain_info.snapshot
+
+
+CROSS_QUERY_SEQUENCES = [
+    pytest.param("latest", "latest", id="latest_then_latest"),
+    pytest.param("downto_oldest", "latest", id="downto_oldest_then_latest"),
+    pytest.param("from_time", "downto_oldest", id="from_time_then_downto_oldest"),
+    pytest.param("from_time", "downto_mid", id="from_time_then_downto_mid"),
+    pytest.param("downto_mid", "from_time", id="downto_mid_then_from_time"),
+    pytest.param("downto_oldest", "from_time", id="downto_oldest_then_from_time"),
+    pytest.param("snapshot", "downto_oldest", id="snapshot_then_downto_oldest"),
+    pytest.param("snapshot", "from_time", id="snapshot_then_from_time"),
+    pytest.param("from_time", "snapshot", id="from_time_then_snapshot"),
+    pytest.param("downto_mid", "snapshot", id="downto_mid_then_snapshot"),
+    pytest.param("snapshot", "snapshot", id="snapshot_then_snapshot"),
+]
+
+# Expected (VERSION_reads, VERSION_REF_reads) for the second read in each
+# (chain, sequence) combination. Measured empirically with a fresh library
+# per combination.
+EXPECTED_CROSS_QUERY_COUNTS = {
+    ("simple_6", "latest_then_latest"): (0, 0),
+    ("simple_6", "downto_oldest_then_latest"): (0, 0),
+    ("simple_6", "from_time_then_downto_oldest"): (6, 1),
+    ("simple_6", "from_time_then_downto_mid"): (0, 0),
+    ("simple_6", "downto_mid_then_from_time"): (0, 0),
+    ("simple_6", "downto_oldest_then_from_time"): (0, 0),
+    ("simple_6", "snapshot_then_downto_oldest"): (6, 1),
+    ("simple_6", "snapshot_then_from_time"): (0, 0),
+    ("simple_6", "from_time_then_snapshot"): (0, 0),
+    ("simple_6", "downto_mid_then_snapshot"): (0, 0),
+    ("simple_6", "snapshot_then_snapshot"): (0, 0),
+    ("multi_tombstone_all", "latest_then_latest"): (0, 0),
+    ("multi_tombstone_all", "downto_oldest_then_latest"): (0, 0),
+    ("multi_tombstone_all", "from_time_then_downto_oldest"): (0, 0),
+    ("multi_tombstone_all", "from_time_then_downto_mid"): (0, 0),
+    ("multi_tombstone_all", "downto_mid_then_from_time"): (0, 0),
+    ("multi_tombstone_all", "downto_oldest_then_from_time"): (0, 0),
+    ("multi_tombstone_all", "snapshot_then_downto_oldest"): (0, 0),
+    ("multi_tombstone_all", "snapshot_then_from_time"): (0, 0),
+    ("multi_tombstone_all", "from_time_then_snapshot"): (0, 0),
+    ("multi_tombstone_all", "downto_mid_then_snapshot"): (0, 0),
+    ("multi_tombstone_all", "snapshot_then_snapshot"): (0, 0),
+    ("multi_individual_tombstone", "latest_then_latest"): (0, 0),
+    ("multi_individual_tombstone", "downto_oldest_then_latest"): (0, 0),
+    ("multi_individual_tombstone", "from_time_then_downto_oldest"): (0, 0),
+    ("multi_individual_tombstone", "from_time_then_downto_mid"): (0, 0),
+    ("multi_individual_tombstone", "downto_mid_then_from_time"): (0, 0),
+    ("multi_individual_tombstone", "downto_oldest_then_from_time"): (0, 0),
+    ("multi_individual_tombstone", "snapshot_then_downto_oldest"): (0, 0),
+    ("multi_individual_tombstone", "snapshot_then_from_time"): (0, 0),
+    ("multi_individual_tombstone", "from_time_then_snapshot"): (0, 0),
+    ("multi_individual_tombstone", "downto_mid_then_snapshot"): (0, 0),
+    ("multi_individual_tombstone", "snapshot_then_snapshot"): (0, 0),
+    ("append_chain", "latest_then_latest"): (0, 0),
+    ("append_chain", "downto_oldest_then_latest"): (0, 0),
+    ("append_chain", "from_time_then_downto_oldest"): (3, 1),
+    ("append_chain", "from_time_then_downto_mid"): (0, 0),
+    ("append_chain", "downto_mid_then_from_time"): (0, 0),
+    ("append_chain", "downto_oldest_then_from_time"): (0, 0),
+    ("append_chain", "snapshot_then_downto_oldest"): (3, 1),
+    ("append_chain", "snapshot_then_from_time"): (0, 0),
+    ("append_chain", "from_time_then_snapshot"): (0, 0),
+    ("append_chain", "downto_mid_then_snapshot"): (0, 0),
+    ("append_chain", "snapshot_then_snapshot"): (0, 0),
+    ("update_chain", "latest_then_latest"): (0, 0),
+    ("update_chain", "downto_oldest_then_latest"): (0, 0),
+    ("update_chain", "from_time_then_downto_oldest"): (3, 1),
+    ("update_chain", "from_time_then_downto_mid"): (0, 0),
+    ("update_chain", "downto_mid_then_from_time"): (0, 0),
+    ("update_chain", "downto_oldest_then_from_time"): (0, 0),
+    ("update_chain", "snapshot_then_downto_oldest"): (3, 1),
+    ("update_chain", "snapshot_then_from_time"): (0, 0),
+    ("update_chain", "from_time_then_snapshot"): (0, 0),
+    ("update_chain", "downto_mid_then_snapshot"): (0, 0),
+    ("update_chain", "snapshot_then_snapshot"): (0, 0),
+    ("prune_chain", "latest_then_latest"): (0, 0),
+    ("prune_chain", "downto_oldest_then_latest"): (0, 0),
+    ("prune_chain", "from_time_then_downto_oldest"): (0, 0),
+    ("prune_chain", "from_time_then_downto_mid"): (0, 0),
+    ("prune_chain", "downto_mid_then_from_time"): (0, 0),
+    ("prune_chain", "downto_oldest_then_from_time"): (0, 0),
+    ("prune_chain", "snapshot_then_downto_oldest"): (0, 0),
+    ("prune_chain", "snapshot_then_from_time"): (0, 0),
+    ("prune_chain", "from_time_then_snapshot"): (0, 0),
+    ("prune_chain", "downto_mid_then_snapshot"): (0, 0),
+    ("prune_chain", "snapshot_then_snapshot"): (0, 0),
+    ("tombstone_all_then_writes", "latest_then_latest"): (0, 0),
+    ("tombstone_all_then_writes", "downto_oldest_then_latest"): (0, 0),
+    ("tombstone_all_then_writes", "from_time_then_downto_oldest"): (0, 0),
+    ("tombstone_all_then_writes", "from_time_then_downto_mid"): (0, 0),
+    ("tombstone_all_then_writes", "downto_mid_then_from_time"): (0, 0),
+    ("tombstone_all_then_writes", "downto_oldest_then_from_time"): (0, 0),
+    ("tombstone_all_then_writes", "snapshot_then_downto_oldest"): (0, 0),
+    ("tombstone_all_then_writes", "snapshot_then_from_time"): (0, 0),
+    ("tombstone_all_then_writes", "from_time_then_snapshot"): (0, 0),
+    ("tombstone_all_then_writes", "downto_mid_then_snapshot"): (0, 0),
+    ("tombstone_all_then_writes", "snapshot_then_snapshot"): (0, 0),
+    ("tombstone_latest", "latest_then_latest"): (0, 0),
+    ("tombstone_latest", "downto_oldest_then_latest"): (0, 0),
+    ("tombstone_latest", "from_time_then_downto_oldest"): (0, 0),
+    ("tombstone_latest", "from_time_then_downto_mid"): (0, 0),
+    ("tombstone_latest", "downto_mid_then_from_time"): (0, 0),
+    ("tombstone_latest", "downto_oldest_then_from_time"): (0, 0),
+    ("tombstone_latest", "snapshot_then_downto_oldest"): (0, 0),
+    ("tombstone_latest", "snapshot_then_from_time"): (0, 0),
+    ("tombstone_latest", "from_time_then_snapshot"): (0, 0),
+    ("tombstone_latest", "downto_mid_then_snapshot"): (0, 0),
+    ("tombstone_latest", "snapshot_then_snapshot"): (0, 0),
+    ("tombstone_all_every_version", "latest_then_latest"): (0, 0),
+    ("tombstone_all_every_version", "downto_oldest_then_latest"): (0, 0),
+    ("tombstone_all_every_version", "from_time_then_downto_oldest"): (0, 0),
+    ("tombstone_all_every_version", "from_time_then_downto_mid"): (0, 0),
+    ("tombstone_all_every_version", "downto_mid_then_from_time"): (0, 0),
+    ("tombstone_all_every_version", "downto_oldest_then_from_time"): (0, 0),
+    ("tombstone_all_every_version", "snapshot_then_downto_oldest"): (0, 0),
+    ("tombstone_all_every_version", "snapshot_then_from_time"): (0, 0),
+    ("tombstone_all_every_version", "from_time_then_snapshot"): (0, 0),
+    ("tombstone_all_every_version", "downto_mid_then_snapshot"): (0, 0),
+    ("tombstone_all_every_version", "snapshot_then_snapshot"): (0, 0),
+    ("tombstone_even_plus_latest", "latest_then_latest"): (0, 0),
+    ("tombstone_even_plus_latest", "downto_oldest_then_latest"): (0, 0),
+    ("tombstone_even_plus_latest", "from_time_then_downto_oldest"): (0, 0),
+    ("tombstone_even_plus_latest", "from_time_then_downto_mid"): (0, 0),
+    ("tombstone_even_plus_latest", "downto_mid_then_from_time"): (0, 0),
+    ("tombstone_even_plus_latest", "downto_oldest_then_from_time"): (0, 0),
+    ("tombstone_even_plus_latest", "snapshot_then_downto_oldest"): (0, 0),
+    ("tombstone_even_plus_latest", "snapshot_then_from_time"): (0, 0),
+    ("tombstone_even_plus_latest", "from_time_then_snapshot"): (0, 0),
+    ("tombstone_even_plus_latest", "downto_mid_then_snapshot"): (0, 0),
+    ("tombstone_even_plus_latest", "snapshot_then_snapshot"): (0, 0),
+}
+
+
+@pytest.mark.parametrize("chain_setup", CHAIN_SETUPS)
+@pytest.mark.parametrize("first_label, second_label", CROSS_QUERY_SEQUENCES)
+def test_cross_query_type_sequence(
+    in_memory_store_factory,
+    clear_query_stats,
+    chain_setup,
+    first_label,
+    second_label,
+):
+    """Test that reads with different as_of types interact correctly with the cache."""
     lib = in_memory_store_factory()
-    sym = "test_write_populates_cache"
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
+    chain_id = chain_setup.__name__.replace("setup_", "")
+
     with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
+        chain_info = chain_setup(lib, sym)
+        first_as_of = _resolve_cross_as_of(first_label, chain_info)
+        second_as_of = _resolve_cross_as_of(second_label, chain_info)
+
+        # First read (warms cache in some way)
+        lib.read(sym, as_of=first_as_of)
+
+        # Measure second read
         qs.enable()
         qs.reset_stats()
-        lib.read(sym)
+        lib.read(sym, as_of=second_as_of)
         stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
+
+        seq_id = f"{first_label}_then_{second_label}"
+        expected_ver, expected_ref = EXPECTED_CROSS_QUERY_COUNTS[(chain_id, seq_id)]
+        assert get_version_reads(stats) == expected_ver
+        assert get_version_ref_reads(stats) == expected_ref
 
 
-def test_write_historical_read_misses_cache(in_memory_store_factory, clear_query_stats):
-    """After multiple writes, reading a historical version misses the cache.
+# =============================================================================
+# Test 8: Reading tombstoned versions — exception + storage read counts
+# =============================================================================
+# Verifies that reading a deleted version raises NoSuchVersionException and
+# that the number of VERSION/VERSION_REF reads matches expectations.
+# DOWNTO walks the chain until it finds the requested version or reaches the
+# end; for individually tombstoned versions the walk depth depends on how
+# far down the chain the version sits.
 
-    Writes add entries to the cache but never update oldest_loaded_index_version_
-    in LoadProgress, so DOWNTO queries must reload the full chain from storage.
-    """
+EXPECTED_TOMBSTONED_VERSIONS_COUNTS = {
+    # tombstone_all_every_version: versions 0-5 deleted via tombstone_all after each write,
+    # then 6 more writes (live: 6-11). delete() does LoadType::ALL during setup, so cache_on
+    # has full chain loaded.
+    ("tombstone_all_every_version", "no_cache", 0): (8, 1),
+    ("tombstone_all_every_version", "no_cache", 3): (8, 1),
+    ("tombstone_all_every_version", "no_cache", 5): (8, 1),
+    ("tombstone_all_every_version", "cache_on", 0): (0, 0),
+    ("tombstone_all_every_version", "cache_on", 3): (0, 0),
+    ("tombstone_all_every_version", "cache_on", 5): (0, 0),
+    # tombstone_even_plus_latest: versions 0,2,4,5 deleted via delete_version,
+    # live: 1,3. delete_version() does LoadType::ALL during setup, so cache_on
+    # has full chain loaded. no_cache walks further for older versions.
+    ("tombstone_even_plus_latest", "no_cache", 0): (10, 1),
+    ("tombstone_even_plus_latest", "no_cache", 2): (8, 1),
+    ("tombstone_even_plus_latest", "no_cache", 4): (6, 1),
+    ("tombstone_even_plus_latest", "no_cache", 5): (5, 1),
+    ("tombstone_even_plus_latest", "cache_on", 0): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", 2): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", 4): (0, 0),
+    ("tombstone_even_plus_latest", "cache_on", 5): (0, 0),
+}
+
+
+@pytest.mark.parametrize(
+    "chain_setup, deleted_version",
+    [
+        pytest.param(setup_tombstone_all_every_version, 0, id="tombstone_all_every_version-v0"),
+        pytest.param(setup_tombstone_all_every_version, 3, id="tombstone_all_every_version-v3"),
+        pytest.param(setup_tombstone_all_every_version, 5, id="tombstone_all_every_version-v5"),
+        pytest.param(setup_tombstone_even_plus_latest, 0, id="tombstone_even_plus_latest-v0"),
+        pytest.param(setup_tombstone_even_plus_latest, 2, id="tombstone_even_plus_latest-v2"),
+        pytest.param(setup_tombstone_even_plus_latest, 4, id="tombstone_even_plus_latest-v4"),
+        pytest.param(setup_tombstone_even_plus_latest, 5, id="tombstone_even_plus_latest-v5"),
+    ],
+)
+@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
+def test_read_tombstoned_version(
+    in_memory_store_factory, clear_query_stats, chain_setup, deleted_version, reload_interval
+):
+    """Reading a tombstoned version raises NoSuchVersionException with expected storage read counts."""
     lib = in_memory_store_factory()
-    sym = "test_write_historical_read_misses_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(3):
-            lib.write(sym, make_df())
+    sym = f"sym_{uuid.uuid4().hex[:8]}"
+    chain_id = chain_setup.__name__.replace("setup_", "")
+    cache_id = "no_cache" if reload_interval == 0 else "cache_on"
+
+    with config_context("VersionMap.ReloadInterval", reload_interval):
+        chain_setup(lib, sym)
+
         qs.enable()
         qs.reset_stats()
-        lib.read(sym, as_of=0)
+        with pytest.raises(NoSuchVersionException):
+            lib.read(sym, as_of=deleted_version)
         stats = qs.get_query_stats()
-        # Cache miss: oldest_loaded_index_version_ is MAX after writes, must reload all 3
-        assert get_version_reads(stats) == 3
-        assert get_version_ref_reads(stats) == 1
-        # After the reload, subsequent historical reads are cache hits
-        qs.reset_stats()
-        lib.read(sym, as_of=1)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
 
-
-def test_write_prune_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After a write with prune_previous_versions, reading latest should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_write_prune_populates_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        # Note this is v1 api using prune_previous_version
-        lib.write(sym, make_df(), prune_previous_version=True)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_append_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After write + append (2 versions), reading latest should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_append_populates_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_ts_df(0))
-        lib.append(sym, make_ts_df(3))
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_append_historical_read_one_prior_version(in_memory_store_factory, clear_query_stats):
-    """After write + append, reading v0 needs only VERSION_REF (1 prior version).
-
-    When there's only 1 version before the append, the append's LATEST reload walks
-    the entire chain (1 entry) and sets is_earliest_version_loaded=true, so
-    DOWNTO(0) is satisfied by the cache.
-    """
-    lib = in_memory_store_factory()
-    sym = "test_append_historical_read_one_prior_version"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_ts_df(0))
-        lib.append(sym, make_ts_df(3))
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_append_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
-    """After 3 writes + append, reading v0 misses the cache.
-
-    The append's LATEST reload only finds the latest version, not the full chain.
-    """
-    lib = in_memory_store_factory()
-    sym = "test_append_historical_read_many_prior_versions"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_ts_df(0, periods=1))
-        lib.write(sym, make_ts_df(0, periods=2))
-        lib.write(sym, make_ts_df(0, periods=3))
-        lib.append(sym, make_ts_df(3, periods=1))
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        # Cache miss: 4 versions (3 writes + 1 append) must be loaded
-        assert get_version_reads(stats) == 4
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_update_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After write + update (2 versions), reading latest should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_update_populates_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_ts_df(0))
-        lib.update(sym, make_ts_df(1, periods=1))
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_update_historical_read_one_prior_version(in_memory_store_factory, clear_query_stats):
-    """After write + update, reading v0 needs only VERSION_REF (1 prior version)."""
-    lib = in_memory_store_factory()
-    sym = "test_update_historical_read_one_prior_version"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_ts_df(0))
-        lib.update(sym, make_ts_df(1, periods=1))
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_update_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
-    """After 3 writes + update, reading v0 misses the cache."""
-    lib = in_memory_store_factory()
-    sym = "test_update_historical_read_many_prior_versions"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_ts_df(0))
-        lib.write(sym, make_ts_df(0))
-        lib.write(sym, make_ts_df(0))
-        lib.update(sym, make_ts_df(1, periods=1))
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 4
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_delete_version_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After deleting a specific version, reading latest should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_delete_version_populates_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.delete_version(sym, 0)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_delete_version_historical_read_hits_cache(in_memory_store_factory, clear_query_stats):
-    """After delete_version, reading a remaining historical version is a cache hit.
-
-    delete_version does a full chain load, setting oldest_loaded_index_version_ correctly.
-    """
-    lib = in_memory_store_factory()
-    sym = "test_delete_version_historical_read_hits_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(3):
-            lib.write(sym, make_df())
-        lib.delete_version(sym, 1)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_write_metadata_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After write_metadata, reading latest should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_write_metadata_populates_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write_metadata(sym, {"key": "value"})
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_write_metadata_historical_read_one_prior_version(in_memory_store_factory, clear_query_stats):
-    """After write + write_metadata, reading v0 needs only VERSION_REF."""
-    lib = in_memory_store_factory()
-    sym = "test_write_metadata_historical_read_one_prior_version"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write_metadata(sym, {"key": "value"})
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_write_metadata_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
-    """After 3 writes + write_metadata, reading v0 misses the cache."""
-    lib = in_memory_store_factory()
-    sym = "test_write_metadata_historical_read_many_prior_versions"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(3):
-            lib.write(sym, make_df())
-        lib.write_metadata(sym, {"key": "value"})
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        # Cache miss: 4 versions (3 writes + 1 write_metadata)
-        assert get_version_reads(stats) == 4
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_delete_all_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After delete (all versions) + new writes, reading latest should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_delete_all_populates_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.delete(sym)
-        lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_delete_all_rewrite_historical_read(in_memory_store_factory, clear_query_stats):
-    """After delete_all + 3 writes, reading the oldest live version is a cache hit.
-
-    The delete operation does a full chain load, and subsequent writes preserve
-    is_earliest_version_loaded=true via the tombstone_all marker.
-    """
-    lib = in_memory_store_factory()
-    sym = "test_delete_all_rewrite_historical_read"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for _ in range(3):
-            lib.write(sym, make_df())
-        lib.delete(sym)
-        for _ in range(3):
-            lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        # v3 is the oldest live version after delete+rewrite
-        lib.read(sym, as_of=3)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_prune_previous_versions_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After prune_previous_versions, reading latest should be a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_prune_previous_versions_populates_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.prune_previous_versions(sym)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_prune_then_read_remaining_version(in_memory_store_factory, clear_query_stats):
-    """After prune, reading the only remaining version (by id) is a cache hit."""
-    lib = in_memory_store_factory()
-    sym = "test_prune_then_read_remaining_version"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.write(sym, make_df())
-        lib.prune_previous_versions(sym)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=2)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_snapshot_does_not_invalidate_cache(in_memory_store_factory, clear_query_stats):
-    """Creating a snapshot should not invalidate the version map cache."""
-    lib = in_memory_store_factory()
-    sym = "test_snapshot_does_not_invalidate_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.snapshot("snap1")
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_head_uses_cache(in_memory_store_factory, clear_query_stats):
-    """head() should use the version map cache when available."""
-    lib = in_memory_store_factory()
-    sym = "test_head_uses_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.read(sym)  # populate cache
-        qs.enable()
-        qs.reset_stats()
-        lib.head(sym, 2)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_tail_uses_cache(in_memory_store_factory, clear_query_stats):
-    """tail() should use the version map cache when available."""
-    lib = in_memory_store_factory()
-    sym = "test_tail_uses_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.read(sym)  # populate cache
-        qs.enable()
-        qs.reset_stats()
-        lib.tail(sym, 2)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_read_metadata_uses_cache(in_memory_store_factory, clear_query_stats):
-    """read_metadata() should use the version map cache when available."""
-    lib = in_memory_store_factory()
-    sym = "test_read_metadata_uses_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df(), metadata={"key": "val"})
-        lib.read(sym)  # populate cache
-        qs.enable()
-        qs.reset_stats()
-        lib.read_metadata(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_has_symbol_uses_cache(in_memory_store_factory, clear_query_stats):
-    """has_symbol() should use the version map cache when available."""
-    lib = in_memory_store_factory()
-    sym = "test_has_symbol_uses_cache"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.read(sym)  # populate cache
-        qs.enable()
-        qs.reset_stats()
-        assert lib.has_symbol(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_write_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After batch_write, reading latest of each symbol should be a cache hit."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_write_0", "test_batch_write_1", "test_batch_write_2"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.batch_write(syms, [make_df() for _ in syms])
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_write_historical_read_misses_cache(in_memory_store_factory, clear_query_stats):
-    """After multiple batch_writes, reading historical versions misses the cache."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_write_hist_0", "test_batch_write_hist_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.batch_write(syms, [make_df() for _ in syms])
-        lib.batch_write(syms, [make_df() for _ in syms])
-        lib.batch_write(syms, [make_df() for _ in syms])
-        qs.enable()
-        qs.reset_stats()
-        # Read v0 of each symbol — cache miss for each
-        for sym in syms:
-            lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        # 3 VERSION reads per symbol * 2 symbols = 6
-        assert get_version_reads(stats) == 6
-        assert get_version_ref_reads(stats) == 2
-
-
-def test_batch_append_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After batch_append, reading latest of each symbol should be a cache hit."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_append_0", "test_batch_append_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            lib.write(sym, make_ts_df(0))
-        lib.batch_append(syms, [make_ts_df(3) for _ in syms])
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_append_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
-    """After 2 writes + batch_append, reading v0 misses the cache."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_append_hist_0", "test_batch_append_hist_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            lib.write(sym, make_ts_df(0, periods=1))
-            lib.write(sym, make_ts_df(0, periods=2))
-        lib.batch_append(syms, [make_ts_df(2, periods=1) for _ in syms])
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        # 3 VERSION reads per symbol * 2 symbols = 6
-        assert get_version_reads(stats) == 6
-        assert get_version_ref_reads(stats) == 2
-
-
-def test_batch_read_uses_cache(in_memory_store_factory, clear_query_stats):
-    """batch_read should use cached version maps when available."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_read_0", "test_batch_read_1", "test_batch_read_2"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            lib.write(sym, make_df())
-        # All writes populate cache
-        qs.enable()
-        qs.reset_stats()
-        lib.batch_read(syms)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_read_historical_misses_cache(in_memory_store_factory, clear_query_stats):
-    """batch_read with as_of for historical versions misses the cache after writes."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_read_hist_0", "test_batch_read_hist_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            for _ in range(3):
-                lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.batch_read(syms, as_ofs=[0, 0])
-        stats = qs.get_query_stats()
-        # 3 VERSION reads per symbol * 2 symbols = 6
-        assert get_version_reads(stats) == 6
-        assert get_version_ref_reads(stats) == 2
-
-
-def test_batch_write_metadata_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After batch_write_metadata, reading latest of each symbol should be a cache hit."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_wm_0", "test_batch_wm_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            lib.write(sym, make_df())
-        lib.batch_write_metadata(syms, [{"k": i} for i in range(len(syms))])
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_write_metadata_historical_read(in_memory_store_factory, clear_query_stats):
-    """After 3 writes + batch_write_metadata, reading v0 misses the cache."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_wm_hist_0", "test_batch_wm_hist_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            for _ in range(3):
-                lib.write(sym, make_df())
-        lib.batch_write_metadata(syms, [{"k": i} for i in range(len(syms))])
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        # 4 VERSION reads per symbol (3 writes + 1 write_metadata) * 2 symbols = 8
-        assert get_version_reads(stats) == 8
-        assert get_version_ref_reads(stats) == 2
-
-
-def test_batch_read_metadata_uses_cache(in_memory_store_factory, clear_query_stats):
-    """batch_read_metadata should use cached version maps when available."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_rm_0", "test_batch_rm_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            lib.write(sym, make_df(), metadata={"k": "v"})
-        # Writes populate cache
-        qs.enable()
-        qs.reset_stats()
-        lib.batch_read_metadata(syms)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_delete_symbols_then_write_read(in_memory_store_factory, clear_query_stats):
-    """After batch_delete_symbols + new writes, reads should be cache hits."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_del_0", "test_batch_del_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            lib.write(sym, make_df())
-        lib.batch_delete_symbols(syms)
-        for sym in syms:
-            lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_delete_versions_populates_cache(in_memory_store_factory, clear_query_stats):
-    """After batch_delete_versions, reading latest of each symbol should be a cache hit."""
-    lib = in_memory_store_factory()
-    syms = ["test_batch_delv_0", "test_batch_delv_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            lib.write(sym, make_df())
-            lib.write(sym, make_df())
-        lib.batch_delete_versions(syms, [[0], [0]])
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-def test_batch_delete_versions_historical_read_hits_cache(in_memory_store_factory, clear_query_stats):
-    """After batch_delete_versions, reading remaining historical versions is a cache hit.
-
-    Like delete_version, batch_delete_versions does a full chain load.
-    """
-    lib = in_memory_store_factory()
-    syms = ["test_batch_delv_hist_0", "test_batch_delv_hist_1"]
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        for sym in syms:
-            for _ in range(3):
-                lib.write(sym, make_df())
-        lib.batch_delete_versions(syms, [[1], [1]])
-        qs.enable()
-        qs.reset_stats()
-        for sym in syms:
-            lib.read(sym, as_of=0)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
+        expected_ver, expected_ref = EXPECTED_TOMBSTONED_VERSIONS_COUNTS[(chain_id, cache_id, deleted_version)]
+        assert get_version_reads(stats) == expected_ver
+        assert get_version_ref_reads(stats) == expected_ref

--- a/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
+++ b/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
@@ -50,12 +50,9 @@ def get_version_ref_reads(stats):
 # =============================================================================
 # Each returns a ChainInfo with metadata about the created version chain.
 
-ChainInfo = namedtuple("ChainInfo", ["latest_version", 
-                                     "oldest_undeleted_version", 
-                                     "mid_version", 
-                                     "snapshot", 
-                                     "mid_ts", 
-                                     "total_versions"])
+ChainInfo = namedtuple(
+    "ChainInfo", ["latest_version", "oldest_undeleted_version", "mid_version", "snapshot", "mid_ts", "total_versions"]
+)
 
 
 def _ts_from_version_info(version_info):
@@ -597,6 +594,7 @@ def test_client_b_reloads_for_unknown_version(in_memory_store_factory, clear_que
 # Tests that a first read with one as_of type correctly populates (or doesn't
 # populate) the cache for a second read with a different as_of type.
 # Parametrized across all chain shapes.
+
 
 def _resolve_cross_as_of(label, chain_info):
     if label == "latest":

--- a/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
+++ b/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
@@ -1,0 +1,1050 @@
+"""
+Tests that verify VERSION key storage read counts for version map cache behavior.
+
+Uses in-memory storage because it is instrumented with query_stats (LMDB and Azure are not).
+S3 is also instrumented but requires external infrastructure. The operation key is Memory_GetObject.
+"""
+
+import time
+
+import pandas as pd
+import pytest
+
+import arcticdb.toolbox.query_stats as qs
+from arcticdb.util.test import config_context
+from tests.util.mark import MEM_TESTS_MARK
+
+pytestmark = MEM_TESTS_MARK
+
+# Large reload interval to effectively disable TTL-based cache invalidation
+MAX_RELOAD_INTERVAL = 2_000_000_000
+
+
+def make_df():
+    return pd.DataFrame({"col": [1, 2, 3]})
+
+
+def make_ts_df(start_day=0, periods=3):
+    """Create a DataFrame with a DatetimeIndex, suitable for append/update operations."""
+    return pd.DataFrame({"col": range(periods)}, index=pd.date_range(f"2020-01-{start_day + 1:02d}", periods=periods))
+
+
+def get_version_reads(stats):
+    """Get the count of VERSION key reads from query stats."""
+    return stats.get("storage_operations", {}).get("Memory_GetObject", {}).get("VERSION", {}).get("count", 0)
+
+
+def get_version_ref_reads(stats):
+    """Get the count of VERSION_REF key reads from query stats."""
+    return stats.get("storage_operations", {}).get("Memory_GetObject", {}).get("VERSION_REF", {}).get("count", 0)
+
+
+def test_read_latest_one_version(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_read_latest_one_version"
+    with config_context("VersionMap.ReloadInterval", 0):
+        lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        # LATEST only reads VERSION_REF, not VERSION keys
+        assert get_version_ref_reads(stats) == 1
+        assert get_version_reads(stats) == 0
+
+
+def test_read_latest_many_versions(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_read_latest_many_versions"
+    with config_context("VersionMap.ReloadInterval", 0):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_ref_reads(stats) == 1
+        assert get_version_reads(stats) == 0
+
+
+def test_read_downto_oldest(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_read_downto_oldest"
+    with config_context("VersionMap.ReloadInterval", 0):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 5
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_read_downto_latest(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_read_downto_latest"
+    with config_context("VersionMap.ReloadInterval", 0):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=4)
+        stats = qs.get_query_stats()
+        # DOWNTO(4) finds the version in the ref, so no VERSION key reads needed
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_read_from_time_now(in_memory_store_factory, clear_query_stats):
+    """FROM_TIME with a recent timestamp should find the latest version."""
+    lib = in_memory_store_factory()
+    sym = "test_read_from_time_now"
+    with config_context("VersionMap.ReloadInterval", 0):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=pd.Timestamp.now())
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_list_versions(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_list_versions"
+    with config_context("VersionMap.ReloadInterval", 0):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.list_versions(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 5
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_read_after_delete_all(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_read_after_delete_all"
+    with config_context("VersionMap.ReloadInterval", 0):
+        for _ in range(3):
+            lib.write(sym, make_df())
+        lib.delete(sym)
+        for _ in range(2):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        # LATEST only needs VERSION_REF
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_read_latest_then_read_latest(in_memory_store_factory, clear_query_stats):
+    """LATEST -> LATEST should be a full cache hit (0 storage reads)."""
+    lib = in_memory_store_factory()
+    sym = "test_read_latest_then_read_latest"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        lib.read(sym)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_read_latest_then_read_specific(in_memory_store_factory, clear_query_stats):
+    """LATEST -> DOWNTO(0) should be a cache miss (needs to load earlier versions)."""
+    lib = in_memory_store_factory()
+    sym = "test_read_latest_then_read_specific"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        lib.read(sym)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # Cache miss: must load all 5 VERSION keys + re-read VERSION_REF
+        # The current limitation with current version map cache.
+        # When we do writes, we add the version in the cache, but we never
+        # update the oldest_loaded_index_version_ in the LoadProgress
+        # as result of this the cache is not very useful and result in cache miss
+        assert get_version_reads(stats) == 5
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_read_oldest_then_read_latest(in_memory_store_factory, clear_query_stats):
+    """DOWNTO(0) -> LATEST should be a cache hit (all versions already loaded)."""
+    lib = in_memory_store_factory()
+    sym = "test_read_oldest_then_read_latest"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        lib.read(sym, as_of=0)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_read_oldest_then_read_any(in_memory_store_factory, clear_query_stats):
+    """DOWNTO(0) -> DOWNTO(3) should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_read_oldest_then_read_any"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        lib.read(sym, as_of=0)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=3)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_read_latest_then_read_oldest(in_memory_store_factory, clear_query_stats):
+    """DOWNTO(4) -> DOWNTO(0) should be a cache miss."""
+    lib = in_memory_store_factory()
+    sym = "test_read_latest_then_read_oldest"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        # This will trigger the cache load
+        # The current limitation with current version map cache.
+        # When we do writes, we add the version in the cache, but we never
+        # update the oldest_loaded_index_version_ in the LoadProgress
+        # as result of this the cache is not very useful and result in cache miss
+        lib.read(sym, as_of=4)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # Cache miss: must load all 5 VERSION keys + re-read VERSION_REF
+        assert get_version_reads(stats) == 5
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_list_versions_then_read(in_memory_store_factory, clear_query_stats):
+    """list_versions (ALL) -> LATEST should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_list_versions_then_read"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        lib.list_versions(sym)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_read_latest_then_list_versions(in_memory_store_factory, clear_query_stats):
+    """LATEST -> list_versions (ALL) should be a cache miss."""
+    lib = in_memory_store_factory()
+    sym = "test_read_latest_then_list_versions"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(5):
+            lib.write(sym, make_df())
+        lib.read(sym)
+        qs.enable()
+        qs.reset_stats()
+        lib.list_versions(sym)
+        stats = qs.get_query_stats()
+        # Cache miss: must load all 5 VERSION keys + re-read VERSION_REF
+        assert get_version_reads(stats) == 5
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_from_time_then_downto_with_tombstone_all(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_from_time_then_downto_with_tombstone_all"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.delete(sym)
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        # FROM_TIME(now) loads all version keys including tombstone_all
+        lib.read(sym, as_of=pd.Timestamp.now())
+        qs.enable()
+        qs.reset_stats()
+        # DOWNTO(2) - oldest live version after delete+rewrite
+        lib.read(sym, as_of=2)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_from_time_then_downto_nonexistent_with_tombstone_all(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_from_time_then_downto_nonexistent_with_tombstone_all"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.delete(sym)
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.read(sym, as_of=pd.Timestamp.now())
+        qs.enable()
+        qs.reset_stats()
+        # DOWNTO(0) - version 0 was deleted, but cache should know this
+        with pytest.raises(Exception):
+            lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_alternating_reads_after_delete_rewrite(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_alternating_reads_after_delete_rewrite"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.delete(sym)
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        # FROM_TIME loads all versions - writes already populated cache so no storage reads
+        lib.read(sym, as_of=pd.Timestamp.now())
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+        qs.reset_stats()
+        # DOWNTO(2) - oldest live version, should be cache hit
+        lib.read(sym, as_of=2)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_latest_then_downto_with_tombstone_all(in_memory_store_factory, clear_query_stats):
+    lib_writer = in_memory_store_factory()
+    lib_reader = in_memory_store_factory(reuse_name=True)
+    sym = "test_latest_then_downto_with_tombstone_all"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib_writer.write(sym, make_df())
+        lib_writer.write(sym, make_df())
+        lib_writer.delete(sym)
+        # Write enough versions after delete so LATEST doesn't cache all of them
+        for _ in range(5):
+            lib_writer.write(sym, make_df())
+        lib_reader.read(sym)  # LATEST - reader only loads top of chain
+        qs.enable()
+        qs.reset_stats()
+        # DOWNTO(2) - oldest live version, beyond what LATEST cached
+        lib_reader.read(sym, as_of=2)
+        stats = qs.get_query_stats()
+        # Cache miss: must load 5 VERSION keys + re-read VERSION_REF
+        assert get_version_reads(stats) == 5
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_reload_interval_zero_always_reloads(in_memory_store_factory, clear_query_stats):
+    """With ReloadInterval=0, every LATEST read should check VERSION_REF."""
+    lib = in_memory_store_factory()
+    sym = "test_reload_interval_zero_always_reloads"
+    with config_context("VersionMap.ReloadInterval", 0):
+        lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_cache_expires_after_ttl(in_memory_store_factory, clear_query_stats):
+    """After TTL expires, the cache should be invalidated and VERSION_REF re-read."""
+    lib = in_memory_store_factory()
+    sym = "test_cache_expires_after_ttl"
+    with config_context("VersionMap.ReloadInterval", 100):  # 100ms
+        lib.write(sym, make_df())
+        lib.read(sym)  # Populate cache
+        time.sleep(0.2)  # Wait for TTL to expire
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_cache_valid_within_ttl(in_memory_store_factory, clear_query_stats):
+    """Within TTL, the second read should be a full cache hit (0 storage reads)."""
+    lib = in_memory_store_factory()
+    sym = "test_cache_valid_within_ttl"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.read(sym)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_client_b_sees_stale_cache(in_memory_store_factory, clear_query_stats):
+    """
+    Client B caches v0. Client A writes v1. Client B reads latest with cache still valid
+    and gets stale v0 (0 storage reads).
+    """
+    lib_a = in_memory_store_factory()
+    lib_b = in_memory_store_factory(reuse_name=True)
+    sym = "test_client_b_sees_stale_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib_a.write(sym, pd.DataFrame({"col": [0]}))
+        result_b1 = lib_b.read(sym)
+        assert result_b1.data["col"].iloc[0] == 0
+        lib_a.write(sym, pd.DataFrame({"col": [1]}))
+        qs.enable()
+        qs.reset_stats()
+        result_b2 = lib_b.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+        assert result_b2.data["col"].iloc[0] == 0, "Expected stale v0 from cache"
+
+
+def test_client_b_reloads_for_unknown_version(in_memory_store_factory, clear_query_stats):
+    """
+    Client B has v0 cached. When B tries to read v1 (not in cache), it must reload
+    from storage.
+    """
+    lib_a = in_memory_store_factory()
+    lib_b = in_memory_store_factory(reuse_name=True)
+    sym = "test_client_b_reloads_for_unknown_version"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib_a.write(sym, pd.DataFrame({"col": [0]}))
+        lib_b.read(sym)  # B caches v0
+        lib_a.write(sym, pd.DataFrame({"col": [1]}))
+        qs.enable()
+        qs.reset_stats()
+        result = lib_b.read(sym, as_of=1)
+        stats = qs.get_query_stats()
+        # B must read VERSION_REF to discover v1
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+        assert result.data["col"].iloc[0] == 1
+
+
+def test_write_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After a write, reading latest should be a cache hit (0 storage reads)."""
+    lib = in_memory_store_factory()
+    sym = "test_write_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_write_historical_read_misses_cache(in_memory_store_factory, clear_query_stats):
+    """After multiple writes, reading a historical version misses the cache.
+
+    Writes add entries to the cache but never update oldest_loaded_index_version_
+    in LoadProgress, so DOWNTO queries must reload the full chain from storage.
+    """
+    lib = in_memory_store_factory()
+    sym = "test_write_historical_read_misses_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(3):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # Cache miss: oldest_loaded_index_version_ is MAX after writes, must reload all 3
+        assert get_version_reads(stats) == 3
+        assert get_version_ref_reads(stats) == 1
+        # After the reload, subsequent historical reads are cache hits
+        qs.reset_stats()
+        lib.read(sym, as_of=1)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_write_prune_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After a write with prune_previous_versions, reading latest should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_write_prune_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        # Note this is v1 api using prune_previous_version
+        lib.write(sym, make_df(), prune_previous_version=True)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_append_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After write + append (2 versions), reading latest should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_append_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_ts_df(0))
+        lib.append(sym, make_ts_df(3))
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_append_historical_read_one_prior_version(in_memory_store_factory, clear_query_stats):
+    """After write + append, reading v0 needs only VERSION_REF (1 prior version).
+
+    When there's only 1 version before the append, the append's LATEST reload walks
+    the entire chain (1 entry) and sets is_earliest_version_loaded=true, so
+    DOWNTO(0) is satisfied by the cache.
+    """
+    lib = in_memory_store_factory()
+    sym = "test_append_historical_read_one_prior_version"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_ts_df(0))
+        lib.append(sym, make_ts_df(3))
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_append_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
+    """After 3 writes + append, reading v0 misses the cache.
+
+    The append's LATEST reload only finds the latest version, not the full chain.
+    """
+    lib = in_memory_store_factory()
+    sym = "test_append_historical_read_many_prior_versions"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_ts_df(0, periods=1))
+        lib.write(sym, make_ts_df(0, periods=2))
+        lib.write(sym, make_ts_df(0, periods=3))
+        lib.append(sym, make_ts_df(3, periods=1))
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # Cache miss: 4 versions (3 writes + 1 append) must be loaded
+        assert get_version_reads(stats) == 4
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_update_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After write + update (2 versions), reading latest should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_update_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_ts_df(0))
+        lib.update(sym, make_ts_df(1, periods=1))
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_update_historical_read_one_prior_version(in_memory_store_factory, clear_query_stats):
+    """After write + update, reading v0 needs only VERSION_REF (1 prior version)."""
+    lib = in_memory_store_factory()
+    sym = "test_update_historical_read_one_prior_version"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_ts_df(0))
+        lib.update(sym, make_ts_df(1, periods=1))
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_update_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
+    """After 3 writes + update, reading v0 misses the cache."""
+    lib = in_memory_store_factory()
+    sym = "test_update_historical_read_many_prior_versions"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_ts_df(0))
+        lib.write(sym, make_ts_df(0))
+        lib.write(sym, make_ts_df(0))
+        lib.update(sym, make_ts_df(1, periods=1))
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 4
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_delete_version_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After deleting a specific version, reading latest should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_delete_version_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.delete_version(sym, 0)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_delete_version_historical_read_hits_cache(in_memory_store_factory, clear_query_stats):
+    """After delete_version, reading a remaining historical version is a cache hit.
+
+    delete_version does a full chain load, setting oldest_loaded_index_version_ correctly.
+    """
+    lib = in_memory_store_factory()
+    sym = "test_delete_version_historical_read_hits_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(3):
+            lib.write(sym, make_df())
+        lib.delete_version(sym, 1)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_write_metadata_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After write_metadata, reading latest should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_write_metadata_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write_metadata(sym, {"key": "value"})
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_write_metadata_historical_read_one_prior_version(in_memory_store_factory, clear_query_stats):
+    """After write + write_metadata, reading v0 needs only VERSION_REF."""
+    lib = in_memory_store_factory()
+    sym = "test_write_metadata_historical_read_one_prior_version"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write_metadata(sym, {"key": "value"})
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_write_metadata_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
+    """After 3 writes + write_metadata, reading v0 misses the cache."""
+    lib = in_memory_store_factory()
+    sym = "test_write_metadata_historical_read_many_prior_versions"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(3):
+            lib.write(sym, make_df())
+        lib.write_metadata(sym, {"key": "value"})
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # Cache miss: 4 versions (3 writes + 1 write_metadata)
+        assert get_version_reads(stats) == 4
+        assert get_version_ref_reads(stats) == 1
+
+
+def test_delete_all_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After delete (all versions) + new writes, reading latest should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_delete_all_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.delete(sym)
+        lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_delete_all_rewrite_historical_read(in_memory_store_factory, clear_query_stats):
+    """After delete_all + 3 writes, reading the oldest live version is a cache hit.
+
+    The delete operation does a full chain load, and subsequent writes preserve
+    is_earliest_version_loaded=true via the tombstone_all marker.
+    """
+    lib = in_memory_store_factory()
+    sym = "test_delete_all_rewrite_historical_read"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for _ in range(3):
+            lib.write(sym, make_df())
+        lib.delete(sym)
+        for _ in range(3):
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        # v3 is the oldest live version after delete+rewrite
+        lib.read(sym, as_of=3)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_prune_previous_versions_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After prune_previous_versions, reading latest should be a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_prune_previous_versions_populates_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.prune_previous_versions(sym)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_prune_then_read_remaining_version(in_memory_store_factory, clear_query_stats):
+    """After prune, reading the only remaining version (by id) is a cache hit."""
+    lib = in_memory_store_factory()
+    sym = "test_prune_then_read_remaining_version"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.write(sym, make_df())
+        lib.prune_previous_versions(sym)
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym, as_of=2)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_snapshot_does_not_invalidate_cache(in_memory_store_factory, clear_query_stats):
+    """Creating a snapshot should not invalidate the version map cache."""
+    lib = in_memory_store_factory()
+    sym = "test_snapshot_does_not_invalidate_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.snapshot("snap1")
+        qs.enable()
+        qs.reset_stats()
+        lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_head_uses_cache(in_memory_store_factory, clear_query_stats):
+    """head() should use the version map cache when available."""
+    lib = in_memory_store_factory()
+    sym = "test_head_uses_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.read(sym)  # populate cache
+        qs.enable()
+        qs.reset_stats()
+        lib.head(sym, 2)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_tail_uses_cache(in_memory_store_factory, clear_query_stats):
+    """tail() should use the version map cache when available."""
+    lib = in_memory_store_factory()
+    sym = "test_tail_uses_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.read(sym)  # populate cache
+        qs.enable()
+        qs.reset_stats()
+        lib.tail(sym, 2)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_read_metadata_uses_cache(in_memory_store_factory, clear_query_stats):
+    """read_metadata() should use the version map cache when available."""
+    lib = in_memory_store_factory()
+    sym = "test_read_metadata_uses_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df(), metadata={"key": "val"})
+        lib.read(sym)  # populate cache
+        qs.enable()
+        qs.reset_stats()
+        lib.read_metadata(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_has_symbol_uses_cache(in_memory_store_factory, clear_query_stats):
+    """has_symbol() should use the version map cache when available."""
+    lib = in_memory_store_factory()
+    sym = "test_has_symbol_uses_cache"
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write(sym, make_df())
+        lib.read(sym)  # populate cache
+        qs.enable()
+        qs.reset_stats()
+        assert lib.has_symbol(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_write_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After batch_write, reading latest of each symbol should be a cache hit."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_write_0", "test_batch_write_1", "test_batch_write_2"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.batch_write(syms, [make_df() for _ in syms])
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_write_historical_read_misses_cache(in_memory_store_factory, clear_query_stats):
+    """After multiple batch_writes, reading historical versions misses the cache."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_write_hist_0", "test_batch_write_hist_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.batch_write(syms, [make_df() for _ in syms])
+        lib.batch_write(syms, [make_df() for _ in syms])
+        lib.batch_write(syms, [make_df() for _ in syms])
+        qs.enable()
+        qs.reset_stats()
+        # Read v0 of each symbol — cache miss for each
+        for sym in syms:
+            lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # 3 VERSION reads per symbol * 2 symbols = 6
+        assert get_version_reads(stats) == 6
+        assert get_version_ref_reads(stats) == 2
+
+
+def test_batch_append_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After batch_append, reading latest of each symbol should be a cache hit."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_append_0", "test_batch_append_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            lib.write(sym, make_ts_df(0))
+        lib.batch_append(syms, [make_ts_df(3) for _ in syms])
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_append_historical_read_many_prior_versions(in_memory_store_factory, clear_query_stats):
+    """After 2 writes + batch_append, reading v0 misses the cache."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_append_hist_0", "test_batch_append_hist_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            lib.write(sym, make_ts_df(0, periods=1))
+            lib.write(sym, make_ts_df(0, periods=2))
+        lib.batch_append(syms, [make_ts_df(2, periods=1) for _ in syms])
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # 3 VERSION reads per symbol * 2 symbols = 6
+        assert get_version_reads(stats) == 6
+        assert get_version_ref_reads(stats) == 2
+
+
+def test_batch_read_uses_cache(in_memory_store_factory, clear_query_stats):
+    """batch_read should use cached version maps when available."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_read_0", "test_batch_read_1", "test_batch_read_2"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            lib.write(sym, make_df())
+        # All writes populate cache
+        qs.enable()
+        qs.reset_stats()
+        lib.batch_read(syms)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_read_historical_misses_cache(in_memory_store_factory, clear_query_stats):
+    """batch_read with as_of for historical versions misses the cache after writes."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_read_hist_0", "test_batch_read_hist_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            for _ in range(3):
+                lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        lib.batch_read(syms, as_ofs=[0, 0])
+        stats = qs.get_query_stats()
+        # 3 VERSION reads per symbol * 2 symbols = 6
+        assert get_version_reads(stats) == 6
+        assert get_version_ref_reads(stats) == 2
+
+
+def test_batch_write_metadata_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After batch_write_metadata, reading latest of each symbol should be a cache hit."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_wm_0", "test_batch_wm_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            lib.write(sym, make_df())
+        lib.batch_write_metadata(syms, [{"k": i} for i in range(len(syms))])
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_write_metadata_historical_read(in_memory_store_factory, clear_query_stats):
+    """After 3 writes + batch_write_metadata, reading v0 misses the cache."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_wm_hist_0", "test_batch_wm_hist_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            for _ in range(3):
+                lib.write(sym, make_df())
+        lib.batch_write_metadata(syms, [{"k": i} for i in range(len(syms))])
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        # 4 VERSION reads per symbol (3 writes + 1 write_metadata) * 2 symbols = 8
+        assert get_version_reads(stats) == 8
+        assert get_version_ref_reads(stats) == 2
+
+
+def test_batch_read_metadata_uses_cache(in_memory_store_factory, clear_query_stats):
+    """batch_read_metadata should use cached version maps when available."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_rm_0", "test_batch_rm_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            lib.write(sym, make_df(), metadata={"k": "v"})
+        # Writes populate cache
+        qs.enable()
+        qs.reset_stats()
+        lib.batch_read_metadata(syms)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_delete_symbols_then_write_read(in_memory_store_factory, clear_query_stats):
+    """After batch_delete_symbols + new writes, reads should be cache hits."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_del_0", "test_batch_del_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            lib.write(sym, make_df())
+        lib.batch_delete_symbols(syms)
+        for sym in syms:
+            lib.write(sym, make_df())
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_delete_versions_populates_cache(in_memory_store_factory, clear_query_stats):
+    """After batch_delete_versions, reading latest of each symbol should be a cache hit."""
+    lib = in_memory_store_factory()
+    syms = ["test_batch_delv_0", "test_batch_delv_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            lib.write(sym, make_df())
+            lib.write(sym, make_df())
+        lib.batch_delete_versions(syms, [[0], [0]])
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+
+def test_batch_delete_versions_historical_read_hits_cache(in_memory_store_factory, clear_query_stats):
+    """After batch_delete_versions, reading remaining historical versions is a cache hit.
+
+    Like delete_version, batch_delete_versions does a full chain load.
+    """
+    lib = in_memory_store_factory()
+    syms = ["test_batch_delv_hist_0", "test_batch_delv_hist_1"]
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        for sym in syms:
+            for _ in range(3):
+                lib.write(sym, make_df())
+        lib.batch_delete_versions(syms, [[1], [1]])
+        qs.enable()
+        qs.reset_stats()
+        for sym in syms:
+            lib.read(sym, as_of=0)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0

--- a/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
+++ b/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
@@ -1,11 +1,13 @@
 import uuid
+from enum import Enum
+from typing import NamedTuple
 
 import pandas as pd
 import pytest
 
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.exceptions import NoSuchVersionException
-from arcticdb.util.test import config_context
+from arcticdb.util.test import config_context, query_stats_operation_count
 from tests.util.mark import MEM_TESTS_MARK
 
 pytestmark = MEM_TESTS_MARK
@@ -22,14 +24,21 @@ def make_ts_df(start_day=0, periods=3):
 
 
 def get_version_reads(stats):
-    return stats.get("storage_operations", {}).get("Memory_GetObject", {}).get("VERSION", {}).get("count", 0)
+    return query_stats_operation_count(stats, "Memory_GetObject", "VERSION")
 
 
 def get_version_ref_reads(stats):
-    return stats.get("storage_operations", {}).get("Memory_GetObject", {}).get("VERSION_REF", {}).get("count", 0)
+    return query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF")
 
 
-TOMBSTONE_ALL = "tombstone_all"
+class TombstoneType(Enum):
+    INDIVIDUAL = 0
+    ALL = 1
+
+
+class Tombstone(NamedTuple):
+    version_id: int
+    type: TombstoneType
 
 
 def _ts_from_version_info(version_info):
@@ -39,151 +48,164 @@ def _ts_from_version_info(version_info):
 def _iter_versions(chain):
     """Yield (vinfo, is_deleted) newest-to-oldest"""
     tombstoned_ids = set()
-    tombstone_all_seen = False
+    tombstone_all_version = None
     for entry in chain:
-        if isinstance(entry, tuple):
-            tombstoned_ids.add(entry[1])
-        elif entry == TOMBSTONE_ALL:
-            tombstone_all_seen = True
+        if isinstance(entry, Tombstone):
+            if entry.type == TombstoneType.INDIVIDUAL:
+                tombstoned_ids.add(entry.version_id)
+            else:
+                if tombstone_all_version is None or entry.version_id > tombstone_all_version:
+                    tombstone_all_version = entry.version_id
         else:
-            yield entry, entry.version in tombstoned_ids or tombstone_all_seen
+            deleted = entry.version in tombstoned_ids or (
+                tombstone_all_version is not None and entry.version <= tombstone_all_version
+            )
+            yield entry, deleted
 
 
-def _is_tombstone_head(ci):
-    return isinstance(ci[0], tuple) or ci[0] == TOMBSTONE_ALL
+def _is_tombstone_head(chain_info):
+    return isinstance(chain_info[0], Tombstone)
 
 
-def _latest_version(ci):
-    return next(v.version for v, deleted in _iter_versions(ci) if not deleted)
+def _latest_version(chain_info):
+    return next(v.version for v, deleted in _iter_versions(chain_info) if not deleted)
 
 
-def _oldest_undeleted(ci):
-    return min(v.version for v, deleted in _iter_versions(ci) if not deleted)
+def _oldest_undeleted(chain_info):
+    return min(v.version for v, deleted in _iter_versions(chain_info) if not deleted)
 
 
-def _total_versions(ci):
-    return sum(1 for e in ci if not isinstance(e, tuple) and e != TOMBSTONE_ALL)
+def _total_versions(chain_info):
+    return sum(1 for e in chain_info if not isinstance(e, Tombstone))
 
 
-def _ts_of(ci, version_id):
-    return next(_ts_from_version_info(v) for v, _ in _iter_versions(ci) if v.version == version_id)
+def _ts_of(chain_info, version_id):
+    return next(_ts_from_version_info(v) for v, _ in _iter_versions(chain_info) if v.version == version_id)
 
 
-def _mid_version(ci):
-    undeleted = sorted(v.version for v, deleted in _iter_versions(ci) if not deleted)
+def _mid_version(chain_info):
+    undeleted = sorted(v.version for v, deleted in _iter_versions(chain_info) if not deleted)
     return undeleted[len(undeleted) // 2]
 
 
-def _is_index_head(ci):
-    return not _is_tombstone_head(ci)
+def _is_index_head(chain_info):
+    return not _is_tombstone_head(chain_info)
 
 
-def _oldest_loaded_after_cold_read(as_of_type, ci):
+def _oldest_loaded_after_cold_read(as_of_type, chain_info):
     """Derive oldest_loaded_index_version_ from chain structure and as_of type."""
-    is_idx_head = _is_index_head(ci)
-    undeleted_asc = sorted(v.version for v, deleted in _iter_versions(ci) if not deleted)
+    is_idx_head = _is_index_head(chain_info)
+    undeleted_asc = sorted(v.version for v, deleted in _iter_versions(chain_info) if not deleted)
 
     if not is_idx_head or len(undeleted_asc) == 1:
         if as_of_type in ("latest", "version_latest"):
             return undeleted_asc[-1]
         elif as_of_type == "version_neg_1":
-            return _total_versions(ci) - 1
+            return _total_versions(chain_info) - 1
         elif as_of_type in ("version_mid", "version_neg_mid", "timestamp_mid"):
-            return _mid_version(ci)
+            return _mid_version(chain_info)
         elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
             return undeleted_asc[0]
+        else:
+            raise Exception("Unexpected as_of_type")
     elif len(undeleted_asc) > 1:  # we have penultimate index also cached
         penultimate = undeleted_asc[-2]
         if as_of_type in ("latest", "version_latest", "version_neg_1"):
             return penultimate
         elif as_of_type in ("version_mid", "version_neg_mid", "timestamp_mid"):
-            v = _mid_version(ci)
+            v = _mid_version(chain_info)
             return penultimate if v >= penultimate else v
         elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
             v = undeleted_asc[0]
             return penultimate if v >= penultimate else v
+        else:
+            raise Exception("Unexpected as_of_type")
     return None
 
 
 def setup_simple_6(lib, sym):
     """v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
     w = [lib.write(sym, make_df()) for _ in range(6)]
-    return [w[5], w[4], w[3], w[2], w[1], w[0]]
+    return w[::-1]
 
 
 def setup_multi_tombstone_all(lib, sym):
-    """v4 -> v3 -> v2 -> TOMBSTONE_ALL -> v1 -> TOMBSTONE_ALL -> v0"""
+    """v4 -> v3 -> v2 -> Tombstone(ALL,1) -> v1 -> Tombstone(ALL,0) -> v0"""
     v0 = lib.write(sym, make_df())
     lib.delete(sym)
     v1 = lib.write(sym, make_df())
     lib.delete(sym)
     v2, v3, v4 = lib.write(sym, make_df()), lib.write(sym, make_df()), lib.write(sym, make_df())
-    return [v4, v3, v2, TOMBSTONE_ALL, v1, TOMBSTONE_ALL, v0]
+    return [v4, v3, v2, Tombstone(v1.version, TombstoneType.ALL), v1, Tombstone(v0.version, TombstoneType.ALL), v0]
 
 
 def setup_multi_individual_tombstone(lib, sym):
-    """("tombstone",3) -> ("tombstone",1) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
+    """Tombstone(INDIVIDUAL,3) -> Tombstone(INDIVIDUAL,1) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
     w = [lib.write(sym, make_df()) for _ in range(6)]
     lib.delete_version(sym, 1)
     lib.delete_version(sym, 3)
-    return [("tombstone", 3), ("tombstone", 1), w[5], w[4], w[3], w[2], w[1], w[0]]
+    return [Tombstone(3, TombstoneType.INDIVIDUAL), Tombstone(1, TombstoneType.INDIVIDUAL)] + w[::-1]
 
 
 def setup_append_chain(lib, sym):
     """v2 -> v1 -> v0 via write + 2 appends"""
     w = [lib.write(sym, make_ts_df(0, 2)), lib.append(sym, make_ts_df(2, 2)), lib.append(sym, make_ts_df(4, 2))]
-    return [w[2], w[1], w[0]]
+    return w[::-1]
 
 
 def setup_update_chain(lib, sym):
     """v2 -> v1 -> v0 via write + 2 updates"""
     w = [lib.write(sym, make_ts_df(0, 3)), lib.update(sym, make_ts_df(1, 1)), lib.update(sym, make_ts_df(2, 1))]
-    return [w[2], w[1], w[0]]
+    return w[::-1]
 
 
 def setup_prune_chain(lib, sym):
-    """v2 only (v0, v1 pruned)"""
+    """Tombstone(ALL,1) -> v2 -> v1 -> v0"""
     w = [lib.write(sym, make_df()) for _ in range(3)]
     lib.prune_previous_versions(sym)
-    return [w[2], TOMBSTONE_ALL, w[1], w[0]]
+    return [Tombstone(w[1].version, TombstoneType.ALL), w[2], w[1], w[0]]
 
 
 def setup_tombstone_all_then_writes(lib, sym):
-    """v6 -> v5 -> v4 -> v3 -> v2 -> v1 -> TOMBSTONE_ALL -> v0"""
+    """v6 -> v5 -> v4 -> v3 -> v2 -> v1 -> Tombstone(ALL,0) -> v0"""
     v0 = lib.write(sym, make_df())
     lib.delete(sym)
     w = [lib.write(sym, make_df()) for _ in range(6)]  # v1..v6
-    return [w[5], w[4], w[3], w[2], w[1], w[0], TOMBSTONE_ALL, v0]
+    return w[::-1] + [Tombstone(v0.version, TombstoneType.ALL), v0]
 
 
 def setup_tombstone_latest(lib, sym):
-    """("tombstone",5) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
+    """Tombstone(INDIVIDUAL,5) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
     w = [lib.write(sym, make_df()) for _ in range(6)]
     lib.delete_version(sym, 5)
-    return [("tombstone", 5), w[5], w[4], w[3], w[2], w[1], w[0]]
+    return [Tombstone(5, TombstoneType.INDIVIDUAL)] + w[::-1]
 
 
 def setup_tombstone_all_every_version(lib, sym):
-    """v11->...->v6 -> TOMBSTONE_ALL->v5->...->TOMBSTONE_ALL->v0"""
+    """v11->...->v6 -> Tombstone(ALL,5)->v5->...->Tombstone(ALL,0)->v0"""
     initial = []
     for _ in range(6):
-        initial.append(lib.write(sym, make_df()))
+        v = lib.write(sym, make_df())
         lib.delete(sym)
+        initial.append(v)
+        initial.append(Tombstone(v.version, TombstoneType.ALL))
     rest = [lib.write(sym, make_df()) for _ in range(6)]  # v6..v11
-    chain = list(reversed(rest))
-    for v in reversed(initial):
-        chain.extend([TOMBSTONE_ALL, v])
-    return chain
+    return rest[::-1] + initial[::-1]
 
 
 def setup_tombstone_even_plus_latest(lib, sym):
-    """("tombstone",5)->("tombstone",4)->("tombstone",2)->("tombstone",0)->v5->v4->v3->v2->v1->v0"""
+    """Tombstone(INDIVIDUAL,5)->...->Tombstone(INDIVIDUAL,0)->v5->v4->v3->v2->v1->v0"""
     w = [lib.write(sym, make_df()) for _ in range(6)]
     lib.delete_version(sym, 0)
     lib.delete_version(sym, 2)
     lib.delete_version(sym, 4)
     lib.delete_version(sym, 5)
-    return [("tombstone", 5), ("tombstone", 4), ("tombstone", 2), ("tombstone", 0), w[5], w[4], w[3], w[2], w[1], w[0]]
+    return [
+        Tombstone(5, TombstoneType.INDIVIDUAL),
+        Tombstone(4, TombstoneType.INDIVIDUAL),
+        Tombstone(2, TombstoneType.INDIVIDUAL),
+        Tombstone(0, TombstoneType.INDIVIDUAL),
+    ] + w[::-1]
 
 
 CHAIN_SETUPS = [
@@ -303,48 +325,50 @@ EXPECTED_RAISES = {
 }
 
 
-def resolve_as_of(as_of_type, ci):
+def resolve_as_of(as_of_type, chain_info):
     if as_of_type == "latest":
         return None
     elif as_of_type == "version_latest":
-        return _latest_version(ci)
+        return _latest_version(chain_info)
     elif as_of_type == "oldest_undeleted_version":
-        return _oldest_undeleted(ci)
+        return _oldest_undeleted(chain_info)
     elif as_of_type == "version_mid":
-        return _mid_version(ci)
+        return _mid_version(chain_info)
     elif as_of_type == "timestamp_mid":
-        return _ts_of(ci, _mid_version(ci))
+        return _ts_of(chain_info, _mid_version(chain_info))
     elif as_of_type == "version_neg_1":
         return -1
     elif as_of_type == "version_neg_mid":
-        return _mid_version(ci) - _total_versions(ci)
+        return _mid_version(chain_info) - _total_versions(chain_info)
     elif as_of_type == "version_neg_oldest":
-        return _oldest_undeleted(ci) - _total_versions(ci)
+        return _oldest_undeleted(chain_info) - _total_versions(chain_info)
 
 
-def required_version(as_of_type, ci):
+def required_version(as_of_type, chain_info):
     if as_of_type in ("latest", "version_latest"):
-        return _latest_version(ci)
+        return _latest_version(chain_info)
     elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
-        return _oldest_undeleted(ci)
+        return _oldest_undeleted(chain_info)
     elif as_of_type in ("version_mid", "version_neg_mid"):
-        return _mid_version(ci)
+        return _mid_version(chain_info)
     elif as_of_type == "timestamp_mid":
-        return _ts_of(ci, _mid_version(ci))
+        return _ts_of(chain_info, _mid_version(chain_info))
     elif as_of_type == "version_neg_1":
-        return _total_versions(ci) - 1
+        return _total_versions(chain_info) - 1
     return None
 
 
-def is_cached(chain_id, as_of_type_first_read, as_of_type_second_read, ci):
-    if EXPECTED_COUNTS.get((chain_id, as_of_type_first_read)) is None:
-        return False
-    oldest_loaded = _oldest_loaded_after_cold_read(as_of_type_first_read, ci)
-    req = required_version(as_of_type_second_read, ci)
+def is_cached(chain_id, as_of_type_first_read, as_of_type_second_read, chain_info):
+    assert (
+        chain_id,
+        as_of_type_first_read,
+    ) in EXPECTED_COUNTS, f"Missing EXPECTED_COUNTS entry for ({chain_id!r}, {as_of_type_first_read!r})"
+    oldest_loaded = _oldest_loaded_after_cold_read(as_of_type_first_read, chain_info)
+    req = required_version(as_of_type_second_read, chain_info)
     if req is None or oldest_loaded is None:
         return False
     if isinstance(req, pd.Timestamp):
-        return req >= _ts_of(ci, oldest_loaded)
+        return req >= _ts_of(chain_info, oldest_loaded)
     return req >= oldest_loaded
 
 
@@ -360,8 +384,8 @@ def test_read_version_chain(
     chain_id, chain_setup_fn = chain_setup
 
     with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        ci = chain_setup_fn(lib_chain_setup, sym)
-        as_of_first_read = resolve_as_of(as_of_type_first_read, ci)
+        chain_info = chain_setup_fn(lib_chain_setup, sym)
+        as_of_first_read = resolve_as_of(as_of_type_first_read, chain_info)
         key = (chain_id, as_of_type_first_read)
 
         qs.enable()
@@ -391,7 +415,7 @@ def test_read_version_chain(
 
         # Cache check with the second as_of type read
         qs.reset_stats()
-        as_of_second_read = resolve_as_of(as_of_type_second_read, ci)
+        as_of_second_read = resolve_as_of(as_of_type_second_read, chain_info)
         second_read_key = (chain_id, as_of_type_second_read)
         if second_read_key in EXPECTED_RAISES:
             with pytest.raises(NoSuchVersionException):
@@ -399,7 +423,7 @@ def test_read_version_chain(
         else:
             lib_read.read(sym, as_of=as_of_second_read)
         stats = qs.get_query_stats()
-        if is_cached(chain_id, as_of_type_first_read, as_of_type_second_read, ci):
+        if is_cached(chain_id, as_of_type_first_read, as_of_type_second_read, chain_info):
             assert get_version_reads(stats) == 0
             assert get_version_ref_reads(stats) == 0
         else:

--- a/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
+++ b/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
@@ -97,30 +97,25 @@ def _oldest_loaded_after_cold_read(as_of_type, chain_info):
     is_idx_head = _is_index_head(chain_info)
     undeleted_asc = sorted(v.version for v, deleted in _iter_versions(chain_info) if not deleted)
 
-    if not is_idx_head or len(undeleted_asc) == 1:
-        if as_of_type in ("latest", "version_latest"):
-            return undeleted_asc[-1]
-        elif as_of_type == "version_neg_1":
-            return _total_versions(chain_info) - 1
-        elif as_of_type in ("version_mid", "version_neg_mid", "timestamp_mid"):
-            return _mid_version(chain_info)
-        elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
-            return undeleted_asc[0]
-        else:
-            raise Exception("Unexpected as_of_type")
-    elif len(undeleted_asc) > 1:  # we have penultimate index also cached
+    if as_of_type == "oldest":
+        return 0
+
+    if as_of_type in ("latest", "version_latest"):
+        loaded = undeleted_asc[-1]
+    elif as_of_type == "version_neg_1":
+        loaded = _total_versions(chain_info) - 1
+    elif as_of_type in ("version_mid", "version_neg_mid", "timestamp_mid"):
+        loaded = _mid_version(chain_info)
+    elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
+        loaded = undeleted_asc[0]
+    else:
+        raise Exception("Unexpected as_of_type")
+
+    if is_idx_head and len(undeleted_asc) > 1:  # we have penultimate index also cached
         penultimate = undeleted_asc[-2]
-        if as_of_type in ("latest", "version_latest", "version_neg_1"):
-            return penultimate
-        elif as_of_type in ("version_mid", "version_neg_mid", "timestamp_mid"):
-            v = _mid_version(chain_info)
-            return penultimate if v >= penultimate else v
-        elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
-            v = undeleted_asc[0]
-            return penultimate if v >= penultimate else v
-        else:
-            raise Exception("Unexpected as_of_type")
-    return None
+        return min(loaded, penultimate)
+    else:
+        return loaded
 
 
 def setup_simple_6(lib, sym):
@@ -230,6 +225,7 @@ AS_OF_TYPES = [
     "version_neg_1",
     "version_neg_mid",
     "version_neg_oldest",
+    "oldest",
 ]
 
 # Expected VERSION key read count for each (chain, as_of) combination on a cold read.
@@ -242,6 +238,7 @@ EXPECTED_COUNTS = {
     ("simple_6", "version_neg_1"): 0,
     ("simple_6", "version_neg_mid"): 3,
     ("simple_6", "version_neg_oldest"): 6,
+    ("simple_6", "oldest"): 6,
     ("multi_tombstone_all", "latest"): 0,
     ("multi_tombstone_all", "version_latest"): 0,
     ("multi_tombstone_all", "oldest_undeleted_version"): 3,
@@ -250,6 +247,7 @@ EXPECTED_COUNTS = {
     ("multi_tombstone_all", "version_neg_1"): 0,
     ("multi_tombstone_all", "version_neg_mid"): 2,
     ("multi_tombstone_all", "version_neg_oldest"): 3,
+    ("multi_tombstone_all", "oldest"): 5,
     ("multi_individual_tombstone", "latest"): 3,
     ("multi_individual_tombstone", "version_latest"): 3,
     ("multi_individual_tombstone", "oldest_undeleted_version"): 8,
@@ -258,6 +256,7 @@ EXPECTED_COUNTS = {
     ("multi_individual_tombstone", "version_neg_1"): 3,
     ("multi_individual_tombstone", "version_neg_mid"): 4,
     ("multi_individual_tombstone", "version_neg_oldest"): 8,
+    ("multi_individual_tombstone", "oldest"): 8,
     ("append_chain", "latest"): 0,
     ("append_chain", "version_latest"): 0,
     ("append_chain", "oldest_undeleted_version"): 3,
@@ -266,6 +265,7 @@ EXPECTED_COUNTS = {
     ("append_chain", "version_neg_1"): 0,
     ("append_chain", "version_neg_mid"): 2,
     ("append_chain", "version_neg_oldest"): 3,
+    ("append_chain", "oldest"): 3,
     ("update_chain", "latest"): 0,
     ("update_chain", "version_latest"): 0,
     ("update_chain", "oldest_undeleted_version"): 3,
@@ -274,6 +274,7 @@ EXPECTED_COUNTS = {
     ("update_chain", "version_neg_1"): 0,
     ("update_chain", "version_neg_mid"): 2,
     ("update_chain", "version_neg_oldest"): 3,
+    ("update_chain", "oldest"): 3,
     ("prune_chain", "latest"): 2,
     ("prune_chain", "version_latest"): 2,
     ("prune_chain", "oldest_undeleted_version"): 2,
@@ -282,6 +283,7 @@ EXPECTED_COUNTS = {
     ("prune_chain", "version_neg_1"): 2,
     ("prune_chain", "version_neg_mid"): 2,
     ("prune_chain", "version_neg_oldest"): 2,
+    ("prune_chain", "oldest"): 3,
     ("tombstone_all_then_writes", "latest"): 0,
     ("tombstone_all_then_writes", "version_latest"): 0,
     ("tombstone_all_then_writes", "oldest_undeleted_version"): 6,
@@ -290,6 +292,7 @@ EXPECTED_COUNTS = {
     ("tombstone_all_then_writes", "version_neg_1"): 0,
     ("tombstone_all_then_writes", "version_neg_mid"): 3,
     ("tombstone_all_then_writes", "version_neg_oldest"): 6,
+    ("tombstone_all_then_writes", "oldest"): 8,
     ("tombstone_latest", "latest"): 3,
     ("tombstone_latest", "version_latest"): 3,
     ("tombstone_latest", "oldest_undeleted_version"): 7,
@@ -298,6 +301,7 @@ EXPECTED_COUNTS = {
     ("tombstone_latest", "version_neg_1"): 2,
     ("tombstone_latest", "version_neg_mid"): 5,
     ("tombstone_latest", "version_neg_oldest"): 7,
+    ("tombstone_latest", "oldest"): 7,
     ("tombstone_all_every_version", "latest"): 0,
     ("tombstone_all_every_version", "version_latest"): 0,
     ("tombstone_all_every_version", "oldest_undeleted_version"): 6,
@@ -306,6 +310,7 @@ EXPECTED_COUNTS = {
     ("tombstone_all_every_version", "version_neg_1"): 0,
     ("tombstone_all_every_version", "version_neg_mid"): 3,
     ("tombstone_all_every_version", "version_neg_oldest"): 6,
+    ("tombstone_all_every_version", "oldest"): 8,
     ("tombstone_even_plus_latest", "latest"): 7,
     ("tombstone_even_plus_latest", "version_latest"): 7,
     ("tombstone_even_plus_latest", "oldest_undeleted_version"): 9,
@@ -314,14 +319,21 @@ EXPECTED_COUNTS = {
     ("tombstone_even_plus_latest", "version_neg_1"): 5,
     ("tombstone_even_plus_latest", "version_neg_mid"): 7,
     ("tombstone_even_plus_latest", "version_neg_oldest"): 9,
+    ("tombstone_even_plus_latest", "oldest"): 10,
 }
 
 # Combinations where the negative as_of resolves to a tombstoned version,
 # causing NoSuchVersionException. -1 resolves based on the latest version_id
 # including tombstoned ones (get_first_index(include_deleted=true)).
+# "oldest" (as_of=0) raises when v0 is deleted.
 EXPECTED_RAISES = {
     ("tombstone_latest", "version_neg_1"),
     ("tombstone_even_plus_latest", "version_neg_1"),
+    ("multi_tombstone_all", "oldest"),
+    ("prune_chain", "oldest"),
+    ("tombstone_all_then_writes", "oldest"),
+    ("tombstone_all_every_version", "oldest"),
+    ("tombstone_even_plus_latest", "oldest"),
 }
 
 
@@ -342,6 +354,8 @@ def resolve_as_of(as_of_type, chain_info):
         return _mid_version(chain_info) - _total_versions(chain_info)
     elif as_of_type == "version_neg_oldest":
         return _oldest_undeleted(chain_info) - _total_versions(chain_info)
+    elif as_of_type == "oldest":
+        return 0
 
 
 def required_version(as_of_type, chain_info):
@@ -355,6 +369,8 @@ def required_version(as_of_type, chain_info):
         return _ts_of(chain_info, _mid_version(chain_info))
     elif as_of_type == "version_neg_1":
         return _total_versions(chain_info) - 1
+    elif as_of_type == "oldest":
+        return 0
     return None
 
 

--- a/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
+++ b/python/tests/integration/arcticdb/version_store/test_version_map_cache_storage_ops.py
@@ -1,20 +1,4 @@
-"""
-Tests that verify VERSION key storage read counts for version map cache behavior.
-
-Uses in-memory storage because it is instrumented with query_stats (LMDB and Azure are not).
-S3 is also instrumented but requires external infrastructure. The operation key is Memory_GetObject.
-
-Test dimensions:
-- Version chain shapes (simple, tombstone_all, individual tombstone, append, update, prune)
-- Cache options (no_cache=ReloadInterval 0, cache_on=ReloadInterval MAX)
-- as_of query types (None/LATEST, int/DOWNTO, Timestamp/FROM_TIME, str/SNAPSHOT)
-- Read functions (read, head, tail, read_metadata, has_symbol, batch_read)
-- Write operations (write, append, update, batch_write, batch_append, write_metadata, snapshot)
-"""
-
-import time
 import uuid
-from collections import namedtuple
 
 import pandas as pd
 import pytest
@@ -45,799 +29,383 @@ def get_version_ref_reads(stats):
     return stats.get("storage_operations", {}).get("Memory_GetObject", {}).get("VERSION_REF", {}).get("count", 0)
 
 
-# =============================================================================
-# Chain setup functions
-# =============================================================================
-# Each returns a ChainInfo with metadata about the created version chain.
-
-ChainInfo = namedtuple(
-    "ChainInfo", ["latest_version", "oldest_undeleted_version", "mid_version", "snapshot", "mid_ts", "total_versions"]
-)
+TOMBSTONE_ALL = "tombstone_all"
 
 
 def _ts_from_version_info(version_info):
-    """Convert VersionedItem.timestamp (nanosecond int) to pd.Timestamp for FROM_TIME queries."""
     return pd.Timestamp(version_info.timestamp, unit="ns", tz="UTC")
+
+
+def _iter_versions(chain):
+    """Yield (vinfo, is_deleted) newest-to-oldest"""
+    tombstoned_ids = set()
+    tombstone_all_seen = False
+    for entry in chain:
+        if isinstance(entry, tuple):
+            tombstoned_ids.add(entry[1])
+        elif entry == TOMBSTONE_ALL:
+            tombstone_all_seen = True
+        else:
+            yield entry, entry.version in tombstoned_ids or tombstone_all_seen
+
+
+def _is_tombstone_head(ci):
+    return isinstance(ci[0], tuple) or ci[0] == TOMBSTONE_ALL
+
+
+def _latest_version(ci):
+    return next(v.version for v, deleted in _iter_versions(ci) if not deleted)
+
+
+def _oldest_undeleted(ci):
+    return min(v.version for v, deleted in _iter_versions(ci) if not deleted)
+
+
+def _total_versions(ci):
+    return sum(1 for e in ci if not isinstance(e, tuple) and e != TOMBSTONE_ALL)
+
+
+def _ts_of(ci, version_id):
+    return next(_ts_from_version_info(v) for v, _ in _iter_versions(ci) if v.version == version_id)
+
+
+def _mid_version(ci):
+    undeleted = sorted(v.version for v, deleted in _iter_versions(ci) if not deleted)
+    return undeleted[len(undeleted) // 2]
+
+
+def _is_index_head(ci):
+    return not _is_tombstone_head(ci)
+
+
+def _oldest_loaded_after_cold_read(as_of_type, ci):
+    """Derive oldest_loaded_index_version_ from chain structure and as_of type."""
+    is_idx_head = _is_index_head(ci)
+    undeleted_asc = sorted(v.version for v, deleted in _iter_versions(ci) if not deleted)
+
+    if not is_idx_head or len(undeleted_asc) == 1:
+        if as_of_type in ("latest", "version_latest"):
+            return undeleted_asc[-1]
+        elif as_of_type == "version_neg_1":
+            return _total_versions(ci) - 1
+        elif as_of_type in ("version_mid", "version_neg_mid", "timestamp_mid"):
+            return _mid_version(ci)
+        elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
+            return undeleted_asc[0]
+    elif len(undeleted_asc) > 1:  # we have penultimate index also cached
+        penultimate = undeleted_asc[-2]
+        if as_of_type in ("latest", "version_latest", "version_neg_1"):
+            return penultimate
+        elif as_of_type in ("version_mid", "version_neg_mid", "timestamp_mid"):
+            v = _mid_version(ci)
+            return penultimate if v >= penultimate else v
+        elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
+            v = undeleted_asc[0]
+            return penultimate if v >= penultimate else v
+    return None
 
 
 def setup_simple_6(lib, sym):
     """v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
-    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
-    lib.snapshot(sym + "_snap", versions={sym: 3})
-    return ChainInfo(5, 0, 3, sym + "_snap", _ts_from_version_info(vinfos[3]), 6)
+    w = [lib.write(sym, make_df()) for _ in range(6)]
+    return [w[5], w[4], w[3], w[2], w[1], w[0]]
 
 
 def setup_multi_tombstone_all(lib, sym):
     """v4 -> v3 -> v2 -> TOMBSTONE_ALL -> v1 -> TOMBSTONE_ALL -> v0"""
-    lib.write(sym, make_df())
+    v0 = lib.write(sym, make_df())
     lib.delete(sym)
-    lib.write(sym, make_df())
+    v1 = lib.write(sym, make_df())
     lib.delete(sym)
-    vinfos = [lib.write(sym, make_df()) for _ in range(3)]
-    lib.snapshot(sym + "_snap", versions={sym: 3})
-    return ChainInfo(4, 2, 3, sym + "_snap", _ts_from_version_info(vinfos[1]), 5)
+    v2, v3, v4 = lib.write(sym, make_df()), lib.write(sym, make_df()), lib.write(sym, make_df())
+    return [v4, v3, v2, TOMBSTONE_ALL, v1, TOMBSTONE_ALL, v0]
 
 
 def setup_multi_individual_tombstone(lib, sym):
-    """v5 -> TOMBSTONE(v3) -> TOMBSTONE(v1) -> v4 -> v3 -> v2 -> v1 -> v0"""
-    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    """("tombstone",3) -> ("tombstone",1) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
+    w = [lib.write(sym, make_df()) for _ in range(6)]
     lib.delete_version(sym, 1)
     lib.delete_version(sym, 3)
-    lib.snapshot(sym + "_snap", versions={sym: 2})
-    return ChainInfo(5, 0, 2, sym + "_snap", _ts_from_version_info(vinfos[2]), 6)
+    return [("tombstone", 3), ("tombstone", 1), w[5], w[4], w[3], w[2], w[1], w[0]]
 
 
 def setup_append_chain(lib, sym):
     """v2 -> v1 -> v0 via write + 2 appends"""
-    vinfos = [
-        lib.write(sym, make_ts_df(0, 2)),
-        lib.append(sym, make_ts_df(2, 2)),
-        lib.append(sym, make_ts_df(4, 2)),
-    ]
-    lib.snapshot(sym + "_snap", versions={sym: 1})
-    return ChainInfo(2, 0, 1, sym + "_snap", _ts_from_version_info(vinfos[1]), 3)
+    w = [lib.write(sym, make_ts_df(0, 2)), lib.append(sym, make_ts_df(2, 2)), lib.append(sym, make_ts_df(4, 2))]
+    return [w[2], w[1], w[0]]
 
 
 def setup_update_chain(lib, sym):
     """v2 -> v1 -> v0 via write + 2 updates"""
-    vinfos = [
-        lib.write(sym, make_ts_df(0, 3)),
-        lib.update(sym, make_ts_df(1, 1)),
-        lib.update(sym, make_ts_df(2, 1)),
-    ]
-    lib.snapshot(sym + "_snap", versions={sym: 1})
-    return ChainInfo(2, 0, 1, sym + "_snap", _ts_from_version_info(vinfos[1]), 3)
+    w = [lib.write(sym, make_ts_df(0, 3)), lib.update(sym, make_ts_df(1, 1)), lib.update(sym, make_ts_df(2, 1))]
+    return [w[2], w[1], w[0]]
 
 
 def setup_prune_chain(lib, sym):
     """v2 only (v0, v1 pruned)"""
-    vinfos = [lib.write(sym, make_df()) for _ in range(3)]
+    w = [lib.write(sym, make_df()) for _ in range(3)]
     lib.prune_previous_versions(sym)
-    lib.snapshot(sym + "_snap", versions={sym: 2})
-    return ChainInfo(2, 2, 2, sym + "_snap", _ts_from_version_info(vinfos[2]), 3)
+    return [w[2], TOMBSTONE_ALL, w[1], w[0]]
 
 
 def setup_tombstone_all_then_writes(lib, sym):
-    """v6 -> v5 -> v4 -> v3 -> v2 ->TOMBSTONE_ALL -> v1 (delete all first, then 6 writes)"""
-    lib.write(sym, make_df())
+    """v6 -> v5 -> v4 -> v3 -> v2 -> v1 -> TOMBSTONE_ALL -> v0"""
+    v0 = lib.write(sym, make_df())
     lib.delete(sym)
-    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
-    lib.snapshot(sym + "_snap", versions={sym: 4})
-    return ChainInfo(6, 1, 4, sym + "_snap", _ts_from_version_info(vinfos[3]), 7)
+    w = [lib.write(sym, make_df()) for _ in range(6)]  # v1..v6
+    return [w[5], w[4], w[3], w[2], w[1], w[0], TOMBSTONE_ALL, v0]
 
 
 def setup_tombstone_latest(lib, sym):
-    """TOMBSTONE(v5) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0 (delete latest version only)"""
-    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    """("tombstone",5) -> v5 -> v4 -> v3 -> v2 -> v1 -> v0"""
+    w = [lib.write(sym, make_df()) for _ in range(6)]
     lib.delete_version(sym, 5)
-    lib.snapshot(sym + "_snap", versions={sym: 3})
-    return ChainInfo(4, 0, 3, sym + "_snap", _ts_from_version_info(vinfos[3]), 6)
+    return [("tombstone", 5), w[5], w[4], w[3], w[2], w[1], w[0]]
 
 
 def setup_tombstone_all_every_version(lib, sym):
-    """v11->...->TOMBSTONE_ALL->v5->TOMBSTONE_ALL->...->v0 (delete after each of 6 writes, then 6 more)"""
+    """v11->...->v6 -> TOMBSTONE_ALL->v5->...->TOMBSTONE_ALL->v0"""
+    initial = []
     for _ in range(6):
-        lib.write(sym, make_df())
+        initial.append(lib.write(sym, make_df()))
         lib.delete(sym)
-    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
-    lib.snapshot(sym + "_snap", versions={sym: 9})
-    return ChainInfo(11, 6, 9, sym + "_snap", _ts_from_version_info(vinfos[3]), 12)
+    rest = [lib.write(sym, make_df()) for _ in range(6)]  # v6..v11
+    chain = list(reversed(rest))
+    for v in reversed(initial):
+        chain.extend([TOMBSTONE_ALL, v])
+    return chain
 
 
 def setup_tombstone_even_plus_latest(lib, sym):
-    """TOMBSTONE(v5)->TOMBSTONE(v4)->v5->v4->TOMBSTONE(v2)->v3->v2->TOMBSTONE(v0)->v1->v0"""
-    vinfos = [lib.write(sym, make_df()) for _ in range(6)]
+    """("tombstone",5)->("tombstone",4)->("tombstone",2)->("tombstone",0)->v5->v4->v3->v2->v1->v0"""
+    w = [lib.write(sym, make_df()) for _ in range(6)]
     lib.delete_version(sym, 0)
     lib.delete_version(sym, 2)
     lib.delete_version(sym, 4)
     lib.delete_version(sym, 5)
-    lib.snapshot(sym + "_snap", versions={sym: 3})
-    return ChainInfo(3, 1, 3, sym + "_snap", _ts_from_version_info(vinfos[3]), 6)
+    return [("tombstone", 5), ("tombstone", 4), ("tombstone", 2), ("tombstone", 0), w[5], w[4], w[3], w[2], w[1], w[0]]
 
 
 CHAIN_SETUPS = [
-    pytest.param(setup_simple_6, id="simple_6"),
-    pytest.param(setup_multi_tombstone_all, id="multi_tombstone_all"),
-    pytest.param(setup_multi_individual_tombstone, id="multi_individual_tombstone"),
-    pytest.param(setup_append_chain, id="append_chain"),
-    pytest.param(setup_update_chain, id="update_chain"),
-    pytest.param(setup_prune_chain, id="prune_chain"),
-    pytest.param(setup_tombstone_all_then_writes, id="tombstone_all_then_writes"),
-    pytest.param(setup_tombstone_latest, id="tombstone_latest"),
-    pytest.param(setup_tombstone_all_every_version, id="tombstone_all_every_version"),
-    pytest.param(setup_tombstone_even_plus_latest, id="tombstone_even_plus_latest"),
+    ("simple_6", setup_simple_6),
+    ("multi_tombstone_all", setup_multi_tombstone_all),
+    ("multi_individual_tombstone", setup_multi_individual_tombstone),
+    ("append_chain", setup_append_chain),
+    ("update_chain", setup_update_chain),
+    ("prune_chain", setup_prune_chain),
+    ("tombstone_all_then_writes", setup_tombstone_all_then_writes),
+    ("tombstone_latest", setup_tombstone_latest),
+    ("tombstone_all_every_version", setup_tombstone_all_every_version),
+    ("tombstone_even_plus_latest", setup_tombstone_even_plus_latest),
 ]
 
-# Expected (VERSION_reads, VERSION_REF_reads) for each (chain, cache, as_of) combination.
-# Measured empirically with a fresh library per combination. Snapshot reads always bypass
-# the version map cache (0, 0). Chains with delete/delete_version do a full chain load
-# during setup, so cache_on results are often (0, 0) even for historical reads.
+AS_OF_TYPES = [
+    "latest",
+    "version_latest",
+    "oldest_undeleted_version",
+    "version_mid",
+    "timestamp_mid",
+    "version_neg_1",
+    "version_neg_mid",
+    "version_neg_oldest",
+]
+
+# Expected VERSION key read count for each (chain, as_of) combination on a cold read.
 EXPECTED_COUNTS = {
-    ("simple_6", "no_cache", "latest"): (0, 1),
-    ("simple_6", "no_cache", "version_latest"): (0, 1),
-    ("simple_6", "no_cache", "oldest_undeleted_version"): (6, 1),
-    ("simple_6", "no_cache", "version_mid"): (3, 1),
-    ("simple_6", "no_cache", "timestamp_mid"): (3, 1),
-    ("simple_6", "no_cache", "snapshot"): (0, 0),
-    ("simple_6", "no_cache", "list_versions"): (6, 1),
-    ("simple_6", "cache_on", "latest"): (0, 0),
-    ("simple_6", "cache_on", "version_latest"): (0, 0),
-    ("simple_6", "cache_on", "oldest_undeleted_version"): (6, 1),
-    ("simple_6", "cache_on", "version_mid"): (0, 0),
-    ("simple_6", "cache_on", "timestamp_mid"): (0, 0),
-    ("simple_6", "cache_on", "snapshot"): (0, 0),
-    ("simple_6", "cache_on", "list_versions"): (6, 1),
-    ("multi_tombstone_all", "no_cache", "latest"): (0, 1),
-    ("multi_tombstone_all", "no_cache", "version_latest"): (0, 1),
-    ("multi_tombstone_all", "no_cache", "oldest_undeleted_version"): (3, 1),
-    ("multi_tombstone_all", "no_cache", "version_mid"): (0, 1),
-    ("multi_tombstone_all", "no_cache", "timestamp_mid"): (0, 1),
-    ("multi_tombstone_all", "no_cache", "snapshot"): (0, 0),
-    ("multi_tombstone_all", "no_cache", "list_versions"): (5, 1),
-    ("multi_tombstone_all", "cache_on", "latest"): (0, 0),
-    ("multi_tombstone_all", "cache_on", "version_latest"): (0, 0),
-    ("multi_tombstone_all", "cache_on", "oldest_undeleted_version"): (0, 0),
-    ("multi_tombstone_all", "cache_on", "version_mid"): (0, 0),
-    ("multi_tombstone_all", "cache_on", "timestamp_mid"): (0, 0),
-    ("multi_tombstone_all", "cache_on", "snapshot"): (0, 0),
-    ("multi_tombstone_all", "cache_on", "list_versions"): (0, 0),
-    ("multi_individual_tombstone", "no_cache", "latest"): (3, 1),
-    ("multi_individual_tombstone", "no_cache", "version_latest"): (3, 1),
-    ("multi_individual_tombstone", "no_cache", "oldest_undeleted_version"): (8, 1),
-    ("multi_individual_tombstone", "no_cache", "version_mid"): (6, 1),
-    ("multi_individual_tombstone", "no_cache", "timestamp_mid"): (6, 1),
-    ("multi_individual_tombstone", "no_cache", "snapshot"): (0, 0),
-    ("multi_individual_tombstone", "no_cache", "list_versions"): (8, 1),
-    ("multi_individual_tombstone", "cache_on", "latest"): (0, 0),
-    ("multi_individual_tombstone", "cache_on", "version_latest"): (0, 0),
-    ("multi_individual_tombstone", "cache_on", "oldest_undeleted_version"): (0, 0),
-    ("multi_individual_tombstone", "cache_on", "version_mid"): (0, 0),
-    ("multi_individual_tombstone", "cache_on", "timestamp_mid"): (0, 0),
-    ("multi_individual_tombstone", "cache_on", "snapshot"): (0, 0),
-    ("multi_individual_tombstone", "cache_on", "list_versions"): (0, 0),
-    ("append_chain", "no_cache", "latest"): (0, 1),
-    ("append_chain", "no_cache", "version_latest"): (0, 1),
-    ("append_chain", "no_cache", "oldest_undeleted_version"): (3, 1),
-    ("append_chain", "no_cache", "version_mid"): (0, 1),
-    ("append_chain", "no_cache", "timestamp_mid"): (0, 1),
-    ("append_chain", "no_cache", "snapshot"): (0, 0),
-    ("append_chain", "no_cache", "list_versions"): (3, 1),
-    ("append_chain", "cache_on", "latest"): (0, 0),
-    ("append_chain", "cache_on", "version_latest"): (0, 0),
-    ("append_chain", "cache_on", "oldest_undeleted_version"): (3, 1),
-    ("append_chain", "cache_on", "version_mid"): (0, 0),
-    ("append_chain", "cache_on", "timestamp_mid"): (0, 0),
-    ("append_chain", "cache_on", "snapshot"): (0, 0),
-    ("append_chain", "cache_on", "list_versions"): (3, 1),
-    ("update_chain", "no_cache", "latest"): (0, 1),
-    ("update_chain", "no_cache", "version_latest"): (0, 1),
-    ("update_chain", "no_cache", "oldest_undeleted_version"): (3, 1),
-    ("update_chain", "no_cache", "version_mid"): (0, 1),
-    ("update_chain", "no_cache", "timestamp_mid"): (0, 1),
-    ("update_chain", "no_cache", "snapshot"): (0, 0),
-    ("update_chain", "no_cache", "list_versions"): (3, 1),
-    ("update_chain", "cache_on", "latest"): (0, 0),
-    ("update_chain", "cache_on", "version_latest"): (0, 0),
-    ("update_chain", "cache_on", "oldest_undeleted_version"): (3, 1),
-    ("update_chain", "cache_on", "version_mid"): (0, 0),
-    ("update_chain", "cache_on", "timestamp_mid"): (0, 0),
-    ("update_chain", "cache_on", "snapshot"): (0, 0),
-    ("update_chain", "cache_on", "list_versions"): (3, 1),
-    ("prune_chain", "no_cache", "latest"): (2, 1),
-    ("prune_chain", "no_cache", "version_latest"): (2, 1),
-    ("prune_chain", "no_cache", "oldest_undeleted_version"): (2, 1),
-    ("prune_chain", "no_cache", "version_mid"): (2, 1),
-    ("prune_chain", "no_cache", "timestamp_mid"): (2, 1),
-    ("prune_chain", "no_cache", "snapshot"): (0, 0),
-    ("prune_chain", "no_cache", "list_versions"): (3, 1),
-    ("prune_chain", "cache_on", "latest"): (0, 0),
-    ("prune_chain", "cache_on", "version_latest"): (0, 0),
-    ("prune_chain", "cache_on", "oldest_undeleted_version"): (0, 0),
-    ("prune_chain", "cache_on", "version_mid"): (0, 0),
-    ("prune_chain", "cache_on", "timestamp_mid"): (0, 0),
-    ("prune_chain", "cache_on", "snapshot"): (0, 0),
-    ("prune_chain", "cache_on", "list_versions"): (0, 0),
-    ("tombstone_all_then_writes", "no_cache", "latest"): (0, 1),
-    ("tombstone_all_then_writes", "no_cache", "version_latest"): (0, 1),
-    ("tombstone_all_then_writes", "no_cache", "oldest_undeleted_version"): (6, 1),
-    ("tombstone_all_then_writes", "no_cache", "version_mid"): (3, 1),
-    ("tombstone_all_then_writes", "no_cache", "timestamp_mid"): (3, 1),
-    ("tombstone_all_then_writes", "no_cache", "snapshot"): (0, 0),
-    ("tombstone_all_then_writes", "no_cache", "list_versions"): (8, 1),
-    ("tombstone_all_then_writes", "cache_on", "latest"): (0, 0),
-    ("tombstone_all_then_writes", "cache_on", "version_latest"): (0, 0),
-    ("tombstone_all_then_writes", "cache_on", "oldest_undeleted_version"): (0, 0),
-    ("tombstone_all_then_writes", "cache_on", "version_mid"): (0, 0),
-    ("tombstone_all_then_writes", "cache_on", "timestamp_mid"): (0, 0),
-    ("tombstone_all_then_writes", "cache_on", "snapshot"): (0, 0),
-    ("tombstone_all_then_writes", "cache_on", "list_versions"): (0, 0),
-    ("tombstone_latest", "no_cache", "latest"): (3, 1),
-    ("tombstone_latest", "no_cache", "version_latest"): (3, 1),
-    ("tombstone_latest", "no_cache", "oldest_undeleted_version"): (7, 1),
-    ("tombstone_latest", "no_cache", "version_mid"): (4, 1),
-    ("tombstone_latest", "no_cache", "timestamp_mid"): (4, 1),
-    ("tombstone_latest", "no_cache", "snapshot"): (0, 0),
-    ("tombstone_latest", "no_cache", "list_versions"): (7, 1),
-    ("tombstone_latest", "cache_on", "latest"): (0, 0),
-    ("tombstone_latest", "cache_on", "version_latest"): (0, 0),
-    ("tombstone_latest", "cache_on", "oldest_undeleted_version"): (0, 0),
-    ("tombstone_latest", "cache_on", "version_mid"): (0, 0),
-    ("tombstone_latest", "cache_on", "timestamp_mid"): (0, 0),
-    ("tombstone_latest", "cache_on", "snapshot"): (0, 0),
-    ("tombstone_latest", "cache_on", "list_versions"): (0, 0),
-    ("tombstone_all_every_version", "no_cache", "latest"): (0, 1),
-    ("tombstone_all_every_version", "no_cache", "version_latest"): (0, 1),
-    ("tombstone_all_every_version", "no_cache", "oldest_undeleted_version"): (6, 1),
-    ("tombstone_all_every_version", "no_cache", "version_mid"): (3, 1),
-    ("tombstone_all_every_version", "no_cache", "timestamp_mid"): (3, 1),
-    ("tombstone_all_every_version", "no_cache", "snapshot"): (0, 0),
-    ("tombstone_all_every_version", "no_cache", "list_versions"): (8, 1),
-    ("tombstone_all_every_version", "cache_on", "latest"): (0, 0),
-    ("tombstone_all_every_version", "cache_on", "version_latest"): (0, 0),
-    ("tombstone_all_every_version", "cache_on", "oldest_undeleted_version"): (0, 0),
-    ("tombstone_all_every_version", "cache_on", "version_mid"): (0, 0),
-    ("tombstone_all_every_version", "cache_on", "timestamp_mid"): (0, 0),
-    ("tombstone_all_every_version", "cache_on", "snapshot"): (0, 0),
-    ("tombstone_all_every_version", "cache_on", "list_versions"): (0, 0),
-    ("tombstone_even_plus_latest", "no_cache", "latest"): (7, 1),
-    ("tombstone_even_plus_latest", "no_cache", "version_latest"): (7, 1),
-    ("tombstone_even_plus_latest", "no_cache", "oldest_undeleted_version"): (9, 1),
-    ("tombstone_even_plus_latest", "no_cache", "version_mid"): (7, 1),
-    ("tombstone_even_plus_latest", "no_cache", "timestamp_mid"): (7, 1),
-    ("tombstone_even_plus_latest", "no_cache", "snapshot"): (0, 0),
-    ("tombstone_even_plus_latest", "no_cache", "list_versions"): (10, 1),
-    ("tombstone_even_plus_latest", "cache_on", "latest"): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", "version_latest"): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", "oldest_undeleted_version"): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", "version_mid"): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", "timestamp_mid"): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", "snapshot"): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", "list_versions"): (0, 0),
+    ("simple_6", "latest"): 0,
+    ("simple_6", "version_latest"): 0,
+    ("simple_6", "oldest_undeleted_version"): 6,
+    ("simple_6", "version_mid"): 3,
+    ("simple_6", "timestamp_mid"): 3,
+    ("simple_6", "version_neg_1"): 0,
+    ("simple_6", "version_neg_mid"): 3,
+    ("simple_6", "version_neg_oldest"): 6,
+    ("multi_tombstone_all", "latest"): 0,
+    ("multi_tombstone_all", "version_latest"): 0,
+    ("multi_tombstone_all", "oldest_undeleted_version"): 3,
+    ("multi_tombstone_all", "version_mid"): 0,
+    ("multi_tombstone_all", "timestamp_mid"): 0,
+    ("multi_tombstone_all", "version_neg_1"): 0,
+    ("multi_tombstone_all", "version_neg_mid"): 2,
+    ("multi_tombstone_all", "version_neg_oldest"): 3,
+    ("multi_individual_tombstone", "latest"): 3,
+    ("multi_individual_tombstone", "version_latest"): 3,
+    ("multi_individual_tombstone", "oldest_undeleted_version"): 8,
+    ("multi_individual_tombstone", "version_mid"): 4,
+    ("multi_individual_tombstone", "timestamp_mid"): 4,
+    ("multi_individual_tombstone", "version_neg_1"): 3,
+    ("multi_individual_tombstone", "version_neg_mid"): 4,
+    ("multi_individual_tombstone", "version_neg_oldest"): 8,
+    ("append_chain", "latest"): 0,
+    ("append_chain", "version_latest"): 0,
+    ("append_chain", "oldest_undeleted_version"): 3,
+    ("append_chain", "version_mid"): 0,
+    ("append_chain", "timestamp_mid"): 0,
+    ("append_chain", "version_neg_1"): 0,
+    ("append_chain", "version_neg_mid"): 2,
+    ("append_chain", "version_neg_oldest"): 3,
+    ("update_chain", "latest"): 0,
+    ("update_chain", "version_latest"): 0,
+    ("update_chain", "oldest_undeleted_version"): 3,
+    ("update_chain", "version_mid"): 0,
+    ("update_chain", "timestamp_mid"): 0,
+    ("update_chain", "version_neg_1"): 0,
+    ("update_chain", "version_neg_mid"): 2,
+    ("update_chain", "version_neg_oldest"): 3,
+    ("prune_chain", "latest"): 2,
+    ("prune_chain", "version_latest"): 2,
+    ("prune_chain", "oldest_undeleted_version"): 2,
+    ("prune_chain", "version_mid"): 2,
+    ("prune_chain", "timestamp_mid"): 2,
+    ("prune_chain", "version_neg_1"): 2,
+    ("prune_chain", "version_neg_mid"): 2,
+    ("prune_chain", "version_neg_oldest"): 2,
+    ("tombstone_all_then_writes", "latest"): 0,
+    ("tombstone_all_then_writes", "version_latest"): 0,
+    ("tombstone_all_then_writes", "oldest_undeleted_version"): 6,
+    ("tombstone_all_then_writes", "version_mid"): 3,
+    ("tombstone_all_then_writes", "timestamp_mid"): 3,
+    ("tombstone_all_then_writes", "version_neg_1"): 0,
+    ("tombstone_all_then_writes", "version_neg_mid"): 3,
+    ("tombstone_all_then_writes", "version_neg_oldest"): 6,
+    ("tombstone_latest", "latest"): 3,
+    ("tombstone_latest", "version_latest"): 3,
+    ("tombstone_latest", "oldest_undeleted_version"): 7,
+    ("tombstone_latest", "version_mid"): 5,
+    ("tombstone_latest", "timestamp_mid"): 5,
+    ("tombstone_latest", "version_neg_1"): 2,
+    ("tombstone_latest", "version_neg_mid"): 5,
+    ("tombstone_latest", "version_neg_oldest"): 7,
+    ("tombstone_all_every_version", "latest"): 0,
+    ("tombstone_all_every_version", "version_latest"): 0,
+    ("tombstone_all_every_version", "oldest_undeleted_version"): 6,
+    ("tombstone_all_every_version", "version_mid"): 3,
+    ("tombstone_all_every_version", "timestamp_mid"): 3,
+    ("tombstone_all_every_version", "version_neg_1"): 0,
+    ("tombstone_all_every_version", "version_neg_mid"): 3,
+    ("tombstone_all_every_version", "version_neg_oldest"): 6,
+    ("tombstone_even_plus_latest", "latest"): 7,
+    ("tombstone_even_plus_latest", "version_latest"): 7,
+    ("tombstone_even_plus_latest", "oldest_undeleted_version"): 9,
+    ("tombstone_even_plus_latest", "version_mid"): 7,
+    ("tombstone_even_plus_latest", "timestamp_mid"): 7,
+    ("tombstone_even_plus_latest", "version_neg_1"): 5,
+    ("tombstone_even_plus_latest", "version_neg_mid"): 7,
+    ("tombstone_even_plus_latest", "version_neg_oldest"): 9,
 }
 
-AS_OF_TYPES = ["latest", "version_latest", "oldest_undeleted_version", "version_mid", "timestamp_mid", "snapshot"]
+# Combinations where the negative as_of resolves to a tombstoned version,
+# causing NoSuchVersionException. -1 resolves based on the latest version_id
+# including tombstoned ones (get_first_index(include_deleted=true)).
+EXPECTED_RAISES = {
+    ("tombstone_latest", "version_neg_1"),
+    ("tombstone_even_plus_latest", "version_neg_1"),
+}
 
 
-def resolve_as_of(as_of_type, chain_info):
+def resolve_as_of(as_of_type, ci):
     if as_of_type == "latest":
         return None
     elif as_of_type == "version_latest":
-        return chain_info.latest_version
+        return _latest_version(ci)
     elif as_of_type == "oldest_undeleted_version":
-        return chain_info.oldest_undeleted_version
+        return _oldest_undeleted(ci)
     elif as_of_type == "version_mid":
-        return chain_info.mid_version
+        return _mid_version(ci)
     elif as_of_type == "timestamp_mid":
-        return chain_info.mid_ts
-    elif as_of_type == "snapshot":
-        return chain_info.snapshot
+        return _ts_of(ci, _mid_version(ci))
+    elif as_of_type == "version_neg_1":
+        return -1
+    elif as_of_type == "version_neg_mid":
+        return _mid_version(ci) - _total_versions(ci)
+    elif as_of_type == "version_neg_oldest":
+        return _oldest_undeleted(ci) - _total_versions(ci)
 
 
-# =============================================================================
-# Test 1: Core cross-product — chain × cache × as_of
-# =============================================================================
+def required_version(as_of_type, ci):
+    if as_of_type in ("latest", "version_latest"):
+        return _latest_version(ci)
+    elif as_of_type in ("oldest_undeleted_version", "version_neg_oldest"):
+        return _oldest_undeleted(ci)
+    elif as_of_type in ("version_mid", "version_neg_mid"):
+        return _mid_version(ci)
+    elif as_of_type == "timestamp_mid":
+        return _ts_of(ci, _mid_version(ci))
+    elif as_of_type == "version_neg_1":
+        return _total_versions(ci) - 1
+    return None
 
 
-@pytest.mark.parametrize("chain_setup", CHAIN_SETUPS)
-@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
-@pytest.mark.parametrize("as_of_type", AS_OF_TYPES)
-def test_read_version_chain(in_memory_store_factory, clear_query_stats, chain_setup, reload_interval, as_of_type):
-    """Test VERSION/VERSION_REF read counts for read() across all chain shapes, cache states, and as_of types."""
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    cache_id = "no_cache" if reload_interval == 0 else "cache_on"
-    chain_id = chain_setup.__name__.replace("setup_", "")
-
-    with config_context("VersionMap.ReloadInterval", reload_interval):
-        chain_info = chain_setup(lib, sym)
-        as_of = resolve_as_of(as_of_type, chain_info)
-
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=as_of)
-        stats = qs.get_query_stats()
-
-        expected_ver, expected_ref = EXPECTED_COUNTS[(chain_id, cache_id, as_of_type)]
-        assert get_version_reads(stats) == expected_ver
-        assert get_version_ref_reads(stats) == expected_ref
-
-
-# =============================================================================
-# Test 2: list_versions across chains
-# =============================================================================
+def is_cached(chain_id, as_of_type_first_read, as_of_type_second_read, ci):
+    if EXPECTED_COUNTS.get((chain_id, as_of_type_first_read)) is None:
+        return False
+    oldest_loaded = _oldest_loaded_after_cold_read(as_of_type_first_read, ci)
+    req = required_version(as_of_type_second_read, ci)
+    if req is None or oldest_loaded is None:
+        return False
+    if isinstance(req, pd.Timestamp):
+        return req >= _ts_of(ci, oldest_loaded)
+    return req >= oldest_loaded
 
 
 @pytest.mark.parametrize("chain_setup", CHAIN_SETUPS)
-@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
-def test_list_versions_chain(in_memory_store_factory, clear_query_stats, chain_setup, reload_interval):
-    """Test VERSION/VERSION_REF read counts for list_versions across all chain shapes."""
-    lib = in_memory_store_factory()
+@pytest.mark.parametrize("as_of_type_first_read", AS_OF_TYPES)
+@pytest.mark.parametrize("as_of_type_second_read", AS_OF_TYPES)
+def test_read_version_chain(
+    in_memory_store_factory, clear_query_stats, chain_setup, as_of_type_first_read, as_of_type_second_read
+):
+    lib_chain_setup = in_memory_store_factory()
+    lib_read = in_memory_store_factory(reuse_name=True)
     sym = f"sym_{uuid.uuid4().hex[:8]}"
-    cache_id = "no_cache" if reload_interval == 0 else "cache_on"
-    chain_id = chain_setup.__name__.replace("setup_", "")
+    chain_id, chain_setup_fn = chain_setup
 
-    with config_context("VersionMap.ReloadInterval", reload_interval):
-        chain_setup(lib, sym) if callable(chain_setup) else chain_setup.values[0](lib, sym)
-
-        qs.enable()
-        qs.reset_stats()
-        lib.list_versions(sym)
-        stats = qs.get_query_stats()
-
-        expected_ver, expected_ref = EXPECTED_COUNTS[(chain_id, cache_id, "list_versions")]
-        assert get_version_reads(stats) == expected_ver
-        assert get_version_ref_reads(stats) == expected_ref
-
-
-# =============================================================================
-# Test 3: Read-like ops equivalence (warm cache)
-# =============================================================================
-# After list_versions warms the cache, all read-like ops should produce 0 VERSION
-# and 0 VERSION_REF reads for version/latest/snapshot as_of queries.
-
-
-@pytest.mark.parametrize(
-    "read_fn",
-    [
-        pytest.param(lambda lib, sym, as_of: lib.read(sym, as_of=as_of), id="read"),
-        pytest.param(lambda lib, sym, as_of: lib.head(sym, 1, as_of=as_of), id="head"),
-        pytest.param(lambda lib, sym, as_of: lib.tail(sym, 1, as_of=as_of), id="tail"),
-        pytest.param(lambda lib, sym, as_of: lib.read_metadata(sym, as_of=as_of), id="read_metadata"),
-        pytest.param(lambda lib, sym, as_of: lib.has_symbol(sym, as_of=as_of), id="has_symbol"),
-        pytest.param(lambda lib, sym, as_of: lib.batch_read([sym], as_ofs=[as_of]), id="batch_read"),
-    ],
-)
-@pytest.mark.parametrize("as_of_type", AS_OF_TYPES)
-def test_read_ops_warm_cache(in_memory_store_factory, clear_query_stats, read_fn, as_of_type):
-    """After list_versions warms the cache, all read-like ops use it."""
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
     with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        chain_info = setup_simple_6(lib, sym)
-        lib.list_versions(sym)  # warm cache fully
+        ci = chain_setup_fn(lib_chain_setup, sym)
+        as_of_first_read = resolve_as_of(as_of_type_first_read, ci)
+        key = (chain_id, as_of_type_first_read)
 
-        as_of = resolve_as_of(as_of_type, chain_info)
         qs.enable()
+
+        # No cache reading
         qs.reset_stats()
-        read_fn(lib, sym, as_of)
-        stats = qs.get_query_stats()
-
-        # After list_versions fully warms the cache, all read-like ops
-        # should be cache hits regardless of as_of type
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-# =============================================================================
-# Test 4: Mutation → read latest (cache hit)
-# =============================================================================
-
-
-def _mut_write(lib, sym):
-    lib.write(sym, make_df())
-
-
-def _mut_append(lib, sym):
-    lib.write(sym, make_ts_df(0))
-    lib.append(sym, make_ts_df(3))
-
-
-def _mut_update(lib, sym):
-    lib.write(sym, make_ts_df(0))
-    lib.update(sym, make_ts_df(1, periods=1))
-
-
-def _mut_batch_write(lib, sym):
-    lib.batch_write([sym], [make_df()])
-
-
-def _mut_batch_append(lib, sym):
-    lib.write(sym, make_ts_df(0))
-    lib.batch_append([sym], [make_ts_df(3)])
-
-
-def _mut_write_metadata(lib, sym):
-    lib.write(sym, make_df())
-    lib.write_metadata(sym, {"key": "value"})
-
-
-def _mut_snapshot(lib, sym):
-    lib.write(sym, make_df())
-    lib.snapshot(sym + "_snap")
-
-
-@pytest.mark.parametrize(
-    "mutation_fn",
-    [
-        pytest.param(_mut_write, id="write"),
-        pytest.param(_mut_append, id="append"),
-        pytest.param(_mut_update, id="update"),
-        pytest.param(_mut_batch_write, id="batch_write"),
-        pytest.param(_mut_batch_append, id="batch_append"),
-        pytest.param(_mut_write_metadata, id="write_metadata"),
-        pytest.param(_mut_snapshot, id="snapshot"),
-    ],
-)
-@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
-def test_mutation_then_read_latest(in_memory_store_factory, clear_query_stats, mutation_fn, reload_interval):
-    """After any mutation, reading latest should be a cache hit (cache_on) or 1 VERSION_REF read (no_cache)."""
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    with config_context("VersionMap.ReloadInterval", reload_interval):
-        mutation_fn(lib, sym)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        if reload_interval == 0:
-            assert get_version_ref_reads(stats) == 1
+        if key in EXPECTED_RAISES:
+            with pytest.raises(NoSuchVersionException):
+                lib_read.read(sym, as_of=as_of_first_read)
         else:
+            lib_read.read(sym, as_of=as_of_first_read)
+        stats = qs.get_query_stats()
+
+        assert get_version_reads(stats) == EXPECTED_COUNTS[key]
+        assert get_version_ref_reads(stats) == 1
+
+        # Expected cache hit same read
+        qs.reset_stats()
+        if key in EXPECTED_RAISES:
+            with pytest.raises(NoSuchVersionException):
+                lib_read.read(sym, as_of=as_of_first_read)
+        else:
+            lib_read.read(sym, as_of=as_of_first_read)
+        stats = qs.get_query_stats()
+        assert get_version_reads(stats) == 0
+        assert get_version_ref_reads(stats) == 0
+
+        # Cache check with the second as_of type read
+        qs.reset_stats()
+        as_of_second_read = resolve_as_of(as_of_type_second_read, ci)
+        second_read_key = (chain_id, as_of_type_second_read)
+        if second_read_key in EXPECTED_RAISES:
+            with pytest.raises(NoSuchVersionException):
+                lib_read.read(sym, as_of=as_of_second_read)
+        else:
+            lib_read.read(sym, as_of=as_of_second_read)
+        stats = qs.get_query_stats()
+        if is_cached(chain_id, as_of_type_first_read, as_of_type_second_read, ci):
+            assert get_version_reads(stats) == 0
             assert get_version_ref_reads(stats) == 0
+        else:
+            assert get_version_reads(stats) == EXPECTED_COUNTS[second_read_key]
+            assert get_version_ref_reads(stats) == 1
 
-
-# =============================================================================
-# Test 5: TTL Invalidation (standalone, require time.sleep)
-# =============================================================================
-
-
-def test_reload_interval_zero_always_reloads(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    with config_context("VersionMap.ReloadInterval", 0):
-        lib.write(sym, make_df())
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_cache_expires_after_ttl(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    with config_context("VersionMap.ReloadInterval", 100_000_000):  # 100ms in nanoseconds
-        lib.write(sym, make_df())
-        lib.read(sym)
-        time.sleep(0.2)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-
-
-def test_cache_valid_within_ttl(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib.write(sym, make_df())
-        lib.read(sym)
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-
-
-# =============================================================================
-# Test 6: Two-Client Scenarios
-# =============================================================================
-
-
-def test_client_b_sees_stale_cache(in_memory_store_factory, clear_query_stats):
-    lib_a = in_memory_store_factory()
-    lib_b = in_memory_store_factory(reuse_name=True)
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib_a.write(sym, pd.DataFrame({"col": [0]}))
-        result_b1 = lib_b.read(sym)
-        assert result_b1.data["col"].iloc[0] == 0
-        lib_a.write(sym, pd.DataFrame({"col": [1]}))
-        qs.enable()
-        qs.reset_stats()
-        result_b2 = lib_b.read(sym)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 0
-        assert result_b2.data["col"].iloc[0] == 0
-
-
-def test_client_b_reloads_for_unknown_version(in_memory_store_factory, clear_query_stats):
-    lib_a = in_memory_store_factory()
-    lib_b = in_memory_store_factory(reuse_name=True)
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        lib_a.write(sym, pd.DataFrame({"col": [0]}))
-        lib_b.read(sym)
-        lib_a.write(sym, pd.DataFrame({"col": [1]}))
-        qs.enable()
-        qs.reset_stats()
-        result = lib_b.read(sym, as_of=1)
-        stats = qs.get_query_stats()
-        assert get_version_reads(stats) == 0
-        assert get_version_ref_reads(stats) == 1
-        assert result.data["col"].iloc[0] == 1
-
-
-# =============================================================================
-# Test 7: Cross-query-type sequences (timestamp <-> version <-> snapshot)
-# =============================================================================
-# Tests that a first read with one as_of type correctly populates (or doesn't
-# populate) the cache for a second read with a different as_of type.
-# Parametrized across all chain shapes.
-
-
-def _resolve_cross_as_of(label, chain_info):
-    if label == "latest":
-        return None
-    if label == "from_time":
-        return chain_info.mid_ts
-    elif label == "downto_oldest":
-        return chain_info.oldest_undeleted_version
-    elif label == "downto_mid":
-        return chain_info.mid_version
-    elif label == "snapshot":
-        return chain_info.snapshot
-
-
-CROSS_QUERY_SEQUENCES = [
-    pytest.param("latest", "latest", id="latest_then_latest"),
-    pytest.param("downto_oldest", "latest", id="downto_oldest_then_latest"),
-    pytest.param("from_time", "downto_oldest", id="from_time_then_downto_oldest"),
-    pytest.param("from_time", "downto_mid", id="from_time_then_downto_mid"),
-    pytest.param("downto_mid", "from_time", id="downto_mid_then_from_time"),
-    pytest.param("downto_oldest", "from_time", id="downto_oldest_then_from_time"),
-    pytest.param("snapshot", "downto_oldest", id="snapshot_then_downto_oldest"),
-    pytest.param("snapshot", "from_time", id="snapshot_then_from_time"),
-    pytest.param("from_time", "snapshot", id="from_time_then_snapshot"),
-    pytest.param("downto_mid", "snapshot", id="downto_mid_then_snapshot"),
-    pytest.param("snapshot", "snapshot", id="snapshot_then_snapshot"),
-]
-
-# Expected (VERSION_reads, VERSION_REF_reads) for the second read in each
-# (chain, sequence) combination. Measured empirically with a fresh library
-# per combination.
-EXPECTED_CROSS_QUERY_COUNTS = {
-    ("simple_6", "latest_then_latest"): (0, 0),
-    ("simple_6", "downto_oldest_then_latest"): (0, 0),
-    ("simple_6", "from_time_then_downto_oldest"): (6, 1),
-    ("simple_6", "from_time_then_downto_mid"): (0, 0),
-    ("simple_6", "downto_mid_then_from_time"): (0, 0),
-    ("simple_6", "downto_oldest_then_from_time"): (0, 0),
-    ("simple_6", "snapshot_then_downto_oldest"): (6, 1),
-    ("simple_6", "snapshot_then_from_time"): (0, 0),
-    ("simple_6", "from_time_then_snapshot"): (0, 0),
-    ("simple_6", "downto_mid_then_snapshot"): (0, 0),
-    ("simple_6", "snapshot_then_snapshot"): (0, 0),
-    ("multi_tombstone_all", "latest_then_latest"): (0, 0),
-    ("multi_tombstone_all", "downto_oldest_then_latest"): (0, 0),
-    ("multi_tombstone_all", "from_time_then_downto_oldest"): (0, 0),
-    ("multi_tombstone_all", "from_time_then_downto_mid"): (0, 0),
-    ("multi_tombstone_all", "downto_mid_then_from_time"): (0, 0),
-    ("multi_tombstone_all", "downto_oldest_then_from_time"): (0, 0),
-    ("multi_tombstone_all", "snapshot_then_downto_oldest"): (0, 0),
-    ("multi_tombstone_all", "snapshot_then_from_time"): (0, 0),
-    ("multi_tombstone_all", "from_time_then_snapshot"): (0, 0),
-    ("multi_tombstone_all", "downto_mid_then_snapshot"): (0, 0),
-    ("multi_tombstone_all", "snapshot_then_snapshot"): (0, 0),
-    ("multi_individual_tombstone", "latest_then_latest"): (0, 0),
-    ("multi_individual_tombstone", "downto_oldest_then_latest"): (0, 0),
-    ("multi_individual_tombstone", "from_time_then_downto_oldest"): (0, 0),
-    ("multi_individual_tombstone", "from_time_then_downto_mid"): (0, 0),
-    ("multi_individual_tombstone", "downto_mid_then_from_time"): (0, 0),
-    ("multi_individual_tombstone", "downto_oldest_then_from_time"): (0, 0),
-    ("multi_individual_tombstone", "snapshot_then_downto_oldest"): (0, 0),
-    ("multi_individual_tombstone", "snapshot_then_from_time"): (0, 0),
-    ("multi_individual_tombstone", "from_time_then_snapshot"): (0, 0),
-    ("multi_individual_tombstone", "downto_mid_then_snapshot"): (0, 0),
-    ("multi_individual_tombstone", "snapshot_then_snapshot"): (0, 0),
-    ("append_chain", "latest_then_latest"): (0, 0),
-    ("append_chain", "downto_oldest_then_latest"): (0, 0),
-    ("append_chain", "from_time_then_downto_oldest"): (3, 1),
-    ("append_chain", "from_time_then_downto_mid"): (0, 0),
-    ("append_chain", "downto_mid_then_from_time"): (0, 0),
-    ("append_chain", "downto_oldest_then_from_time"): (0, 0),
-    ("append_chain", "snapshot_then_downto_oldest"): (3, 1),
-    ("append_chain", "snapshot_then_from_time"): (0, 0),
-    ("append_chain", "from_time_then_snapshot"): (0, 0),
-    ("append_chain", "downto_mid_then_snapshot"): (0, 0),
-    ("append_chain", "snapshot_then_snapshot"): (0, 0),
-    ("update_chain", "latest_then_latest"): (0, 0),
-    ("update_chain", "downto_oldest_then_latest"): (0, 0),
-    ("update_chain", "from_time_then_downto_oldest"): (3, 1),
-    ("update_chain", "from_time_then_downto_mid"): (0, 0),
-    ("update_chain", "downto_mid_then_from_time"): (0, 0),
-    ("update_chain", "downto_oldest_then_from_time"): (0, 0),
-    ("update_chain", "snapshot_then_downto_oldest"): (3, 1),
-    ("update_chain", "snapshot_then_from_time"): (0, 0),
-    ("update_chain", "from_time_then_snapshot"): (0, 0),
-    ("update_chain", "downto_mid_then_snapshot"): (0, 0),
-    ("update_chain", "snapshot_then_snapshot"): (0, 0),
-    ("prune_chain", "latest_then_latest"): (0, 0),
-    ("prune_chain", "downto_oldest_then_latest"): (0, 0),
-    ("prune_chain", "from_time_then_downto_oldest"): (0, 0),
-    ("prune_chain", "from_time_then_downto_mid"): (0, 0),
-    ("prune_chain", "downto_mid_then_from_time"): (0, 0),
-    ("prune_chain", "downto_oldest_then_from_time"): (0, 0),
-    ("prune_chain", "snapshot_then_downto_oldest"): (0, 0),
-    ("prune_chain", "snapshot_then_from_time"): (0, 0),
-    ("prune_chain", "from_time_then_snapshot"): (0, 0),
-    ("prune_chain", "downto_mid_then_snapshot"): (0, 0),
-    ("prune_chain", "snapshot_then_snapshot"): (0, 0),
-    ("tombstone_all_then_writes", "latest_then_latest"): (0, 0),
-    ("tombstone_all_then_writes", "downto_oldest_then_latest"): (0, 0),
-    ("tombstone_all_then_writes", "from_time_then_downto_oldest"): (0, 0),
-    ("tombstone_all_then_writes", "from_time_then_downto_mid"): (0, 0),
-    ("tombstone_all_then_writes", "downto_mid_then_from_time"): (0, 0),
-    ("tombstone_all_then_writes", "downto_oldest_then_from_time"): (0, 0),
-    ("tombstone_all_then_writes", "snapshot_then_downto_oldest"): (0, 0),
-    ("tombstone_all_then_writes", "snapshot_then_from_time"): (0, 0),
-    ("tombstone_all_then_writes", "from_time_then_snapshot"): (0, 0),
-    ("tombstone_all_then_writes", "downto_mid_then_snapshot"): (0, 0),
-    ("tombstone_all_then_writes", "snapshot_then_snapshot"): (0, 0),
-    ("tombstone_latest", "latest_then_latest"): (0, 0),
-    ("tombstone_latest", "downto_oldest_then_latest"): (0, 0),
-    ("tombstone_latest", "from_time_then_downto_oldest"): (0, 0),
-    ("tombstone_latest", "from_time_then_downto_mid"): (0, 0),
-    ("tombstone_latest", "downto_mid_then_from_time"): (0, 0),
-    ("tombstone_latest", "downto_oldest_then_from_time"): (0, 0),
-    ("tombstone_latest", "snapshot_then_downto_oldest"): (0, 0),
-    ("tombstone_latest", "snapshot_then_from_time"): (0, 0),
-    ("tombstone_latest", "from_time_then_snapshot"): (0, 0),
-    ("tombstone_latest", "downto_mid_then_snapshot"): (0, 0),
-    ("tombstone_latest", "snapshot_then_snapshot"): (0, 0),
-    ("tombstone_all_every_version", "latest_then_latest"): (0, 0),
-    ("tombstone_all_every_version", "downto_oldest_then_latest"): (0, 0),
-    ("tombstone_all_every_version", "from_time_then_downto_oldest"): (0, 0),
-    ("tombstone_all_every_version", "from_time_then_downto_mid"): (0, 0),
-    ("tombstone_all_every_version", "downto_mid_then_from_time"): (0, 0),
-    ("tombstone_all_every_version", "downto_oldest_then_from_time"): (0, 0),
-    ("tombstone_all_every_version", "snapshot_then_downto_oldest"): (0, 0),
-    ("tombstone_all_every_version", "snapshot_then_from_time"): (0, 0),
-    ("tombstone_all_every_version", "from_time_then_snapshot"): (0, 0),
-    ("tombstone_all_every_version", "downto_mid_then_snapshot"): (0, 0),
-    ("tombstone_all_every_version", "snapshot_then_snapshot"): (0, 0),
-    ("tombstone_even_plus_latest", "latest_then_latest"): (0, 0),
-    ("tombstone_even_plus_latest", "downto_oldest_then_latest"): (0, 0),
-    ("tombstone_even_plus_latest", "from_time_then_downto_oldest"): (0, 0),
-    ("tombstone_even_plus_latest", "from_time_then_downto_mid"): (0, 0),
-    ("tombstone_even_plus_latest", "downto_mid_then_from_time"): (0, 0),
-    ("tombstone_even_plus_latest", "downto_oldest_then_from_time"): (0, 0),
-    ("tombstone_even_plus_latest", "snapshot_then_downto_oldest"): (0, 0),
-    ("tombstone_even_plus_latest", "snapshot_then_from_time"): (0, 0),
-    ("tombstone_even_plus_latest", "from_time_then_snapshot"): (0, 0),
-    ("tombstone_even_plus_latest", "downto_mid_then_snapshot"): (0, 0),
-    ("tombstone_even_plus_latest", "snapshot_then_snapshot"): (0, 0),
-}
-
-
-@pytest.mark.parametrize("chain_setup", CHAIN_SETUPS)
-@pytest.mark.parametrize("first_label, second_label", CROSS_QUERY_SEQUENCES)
-def test_cross_query_type_sequence(
-    in_memory_store_factory,
-    clear_query_stats,
-    chain_setup,
-    first_label,
-    second_label,
-):
-    """Test that reads with different as_of types interact correctly with the cache."""
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    chain_id = chain_setup.__name__.replace("setup_", "")
-
-    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
-        chain_info = chain_setup(lib, sym)
-        first_as_of = _resolve_cross_as_of(first_label, chain_info)
-        second_as_of = _resolve_cross_as_of(second_label, chain_info)
-
-        # First read (warms cache in some way)
-        lib.read(sym, as_of=first_as_of)
-
-        # Measure second read
-        qs.enable()
-        qs.reset_stats()
-        lib.read(sym, as_of=second_as_of)
-        stats = qs.get_query_stats()
-
-        seq_id = f"{first_label}_then_{second_label}"
-        expected_ver, expected_ref = EXPECTED_CROSS_QUERY_COUNTS[(chain_id, seq_id)]
-        assert get_version_reads(stats) == expected_ver
-        assert get_version_ref_reads(stats) == expected_ref
-
-
-# =============================================================================
-# Test 8: Reading tombstoned versions — exception + storage read counts
-# =============================================================================
-# Verifies that reading a deleted version raises NoSuchVersionException and
-# that the number of VERSION/VERSION_REF reads matches expectations.
-# DOWNTO walks the chain until it finds the requested version or reaches the
-# end; for individually tombstoned versions the walk depth depends on how
-# far down the chain the version sits.
-
-EXPECTED_TOMBSTONED_VERSIONS_COUNTS = {
-    # tombstone_all_every_version: versions 0-5 deleted via tombstone_all after each write,
-    # then 6 more writes (live: 6-11). delete() does LoadType::ALL during setup, so cache_on
-    # has full chain loaded.
-    ("tombstone_all_every_version", "no_cache", 0): (8, 1),
-    ("tombstone_all_every_version", "no_cache", 3): (8, 1),
-    ("tombstone_all_every_version", "no_cache", 5): (8, 1),
-    ("tombstone_all_every_version", "cache_on", 0): (0, 0),
-    ("tombstone_all_every_version", "cache_on", 3): (0, 0),
-    ("tombstone_all_every_version", "cache_on", 5): (0, 0),
-    # tombstone_even_plus_latest: versions 0,2,4,5 deleted via delete_version,
-    # live: 1,3. delete_version() does LoadType::ALL during setup, so cache_on
-    # has full chain loaded. no_cache walks further for older versions.
-    ("tombstone_even_plus_latest", "no_cache", 0): (10, 1),
-    ("tombstone_even_plus_latest", "no_cache", 2): (8, 1),
-    ("tombstone_even_plus_latest", "no_cache", 4): (6, 1),
-    ("tombstone_even_plus_latest", "no_cache", 5): (5, 1),
-    ("tombstone_even_plus_latest", "cache_on", 0): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", 2): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", 4): (0, 0),
-    ("tombstone_even_plus_latest", "cache_on", 5): (0, 0),
-}
-
-
-@pytest.mark.parametrize(
-    "chain_setup, deleted_version",
-    [
-        pytest.param(setup_tombstone_all_every_version, 0, id="tombstone_all_every_version-v0"),
-        pytest.param(setup_tombstone_all_every_version, 3, id="tombstone_all_every_version-v3"),
-        pytest.param(setup_tombstone_all_every_version, 5, id="tombstone_all_every_version-v5"),
-        pytest.param(setup_tombstone_even_plus_latest, 0, id="tombstone_even_plus_latest-v0"),
-        pytest.param(setup_tombstone_even_plus_latest, 2, id="tombstone_even_plus_latest-v2"),
-        pytest.param(setup_tombstone_even_plus_latest, 4, id="tombstone_even_plus_latest-v4"),
-        pytest.param(setup_tombstone_even_plus_latest, 5, id="tombstone_even_plus_latest-v5"),
-    ],
-)
-@pytest.mark.parametrize("reload_interval", [0, MAX_RELOAD_INTERVAL], ids=["no_cache", "cache_on"])
-def test_read_tombstoned_version(
-    in_memory_store_factory, clear_query_stats, chain_setup, deleted_version, reload_interval
-):
-    """Reading a tombstoned version raises NoSuchVersionException with expected storage read counts."""
-    lib = in_memory_store_factory()
-    sym = f"sym_{uuid.uuid4().hex[:8]}"
-    chain_id = chain_setup.__name__.replace("setup_", "")
-    cache_id = "no_cache" if reload_interval == 0 else "cache_on"
-
-    with config_context("VersionMap.ReloadInterval", reload_interval):
-        chain_setup(lib, sym)
-
-        qs.enable()
-        qs.reset_stats()
-        with pytest.raises(NoSuchVersionException):
-            lib.read(sym, as_of=deleted_version)
-        stats = qs.get_query_stats()
-
-        expected_ver, expected_ref = EXPECTED_TOMBSTONED_VERSIONS_COUNTS[(chain_id, cache_id, deleted_version)]
-        assert get_version_reads(stats) == expected_ver
-        assert get_version_ref_reads(stats) == expected_ref
+        # Write the new version and check that it can be loaded despite the cache doesn't have it with as_of
+        vinfo = lib_chain_setup.write(sym, make_df())
+        assert lib_read.read(sym, as_of=vinfo.version).version == vinfo.version


### PR DESCRIPTION
## Summary
- Improve cache validation for `as_of` queries to correctly detect when a reload is needed
- Ensure queries requesting versions beyond what's cached trigger a reload

## Problem
The version map cache could return stale results or incorrectly assume data was cached in two scenarios:

  1. **Version-based queries (DOWNTO):** When requesting a specific version ID that exists in storage but wasn't loaded yet, the cache could incorrectly report a hit.


  **Example:** Client B loads all versions (latest is v2 at ts=200). Client A writes v3 at ts=300. Client B queries `as_of=200`. The old code would incorrectly return from cache, missing v3.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
