### PR TITLE
Restrict aws-sdk-cpp version range in environment-dev.yml

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,7 +31,7 @@ dependencies:
   - pybind11
   - pcre2
   - cyrus-sasl
-  - aws-sdk-cpp >=1.11.405
+  - aws-sdk-cpp >=1.11.405,<=1.11.591
   - prometheus-cpp
   - libprotobuf <7
   - openssl

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,7 +31,7 @@ dependencies:
   - pybind11
   - pcre2
   - cyrus-sasl
-  - aws-sdk-cpp >=1.11.405,<=1.11.591
+  - aws-sdk-cpp >=1.11.405,<=1.11.591 # Upper bound added due to an issue with STS, see aws/aws-sdk-cpp PR #3505
   - prometheus-cpp
   - libprotobuf <7
   - openssl


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
There is an issue with STS flow in the latest `aws sdk` version on conda.
This PR pins the version to the latest known working version.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
