### PR TITLE
Fix defragment_symbol_data dropping user metadata (#9889436827)

### DIFF
--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2774,13 +2774,14 @@ VersionedItem defragment_symbol_data_impl(
     return util::variant_match(
             std::move(result),
             [&slices, &pre_defragmentation_info, &store](CompactionWrittenKeys&& written_keys) -> VersionedItem {
+                const auto& user_meta_ptr = pre_defragmentation_info.pipeline_context->user_meta_;
                 return collate_and_write(
                         store,
                         pre_defragmentation_info.pipeline_context,
                         slices,
                         std::move(written_keys),
                         pre_defragmentation_info.append_after.value(),
-                        std::nullopt
+                        user_meta_ptr ? std::make_optional(*user_meta_ptr) : std::nullopt
                 );
             },
             [](Error&& error) -> VersionedItem {

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4230,15 +4230,10 @@ class NativeVersionStore:
         )
 
         result = self.version_store.defragment_symbol_data(symbol, segment_size, prune_previous_version)
-        return VersionedItem(
-            symbol=result.symbol,
-            library=self._library.library_path,
-            version=result.version,
-            metadata=None,
-            data=None,
-            host=self.env,
-            timestamp=result.timestamp,
-        )
+        version_query = self._get_version_query(result.version)
+        _, udm = self.version_store.read_metadata(symbol, version_query)
+        meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
+        return self._convert_thin_cxx_item_to_python(result, meta)
 
     def library(self):
         return self._library

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4230,10 +4230,15 @@ class NativeVersionStore:
         )
 
         result = self.version_store.defragment_symbol_data(symbol, segment_size, prune_previous_version)
-        version_query = self._get_version_query(result.version)
-        _, udm = self.version_store.read_metadata(symbol, version_query)
-        meta = denormalize_user_metadata(udm, self._normalizer) if udm else None
-        return self._convert_thin_cxx_item_to_python(result, meta)
+        return VersionedItem(
+            symbol=result.symbol,
+            library=self._library.library_path,
+            version=result.version,
+            metadata=None,
+            data=None,
+            host=self.env,
+            timestamp=result.timestamp,
+        )
 
     def library(self):
         return self._library

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3368,7 +3368,9 @@ class Library:
         Returns
         -------
         VersionedItem
-            Structure containing metadata and version number of the defragmented symbol in the store.
+            Structure containing version number of the defragmented symbol in the store. The ``metadata``
+            and ``data`` fields of the returned object will always be ``None``; call ``read_metadata`` or
+            ``read`` to retrieve the metadata or data associated with the defragmented version.
 
         Raises
         ------

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -693,7 +693,7 @@ def test_defragment_preserves_metadata(sym, lmdb_version_store):
     df2 = pd.DataFrame({"a": [3, 4]}, index=pd.date_range("2020-01-03", periods=2))
 
     lmdb_version_store.write(sym, df1, metadata=meta)
-    lmdb_version_store.append(sym, df2)
+    lmdb_version_store.append(sym, df2, metadata=meta)
 
     with config_context("SymbolDataCompact.SegmentCount", 1):
         assert lmdb_version_store.is_symbol_fragmented(sym)

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -699,7 +699,7 @@ def test_defragment_preserves_metadata(sym, lmdb_version_store):
         assert lmdb_version_store.is_symbol_fragmented(sym)
         versioned_item = lmdb_version_store.defragment_symbol_data(sym)
 
-    assert versioned_item.metadata == meta
+    assert versioned_item.metadata is None
     assert lmdb_version_store.read_metadata(sym).metadata == meta
 
 

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -14,7 +14,7 @@ import arcticdb.exceptions
 from arcticdb.version_store import NativeVersionStore
 from arcticdb_ext.exceptions import InternalException, NormalizationException, UnsortedDataException, SchemaException
 from arcticdb_ext import set_config_int
-from arcticdb.util.test import random_integers, assert_frame_equal
+from arcticdb.util.test import random_integers, assert_frame_equal, config_context
 from arcticdb.config import set_log_level
 from arcticdb.util.test_utils import generate_random_numpy_array, supported_types_list
 from arcticdb.util.logger import get_logger
@@ -685,6 +685,22 @@ def test_defragment_no_work_to_do(sym, lmdb_version_store):
     assert list(lmdb_version_store.list_versions(sym))[0]["version"] == 0
     with pytest.raises(InternalException):
         lmdb_version_store.defragment_symbol_data(sym)
+
+
+def test_defragment_preserves_metadata(sym, lmdb_version_store):
+    meta = {"key": "value", "number": 42}
+    df1 = pd.DataFrame({"a": [1, 2]}, index=pd.date_range("2020-01-01", periods=2))
+    df2 = pd.DataFrame({"a": [3, 4]}, index=pd.date_range("2020-01-03", periods=2))
+
+    lmdb_version_store.write(sym, df1, metadata=meta)
+    lmdb_version_store.append(sym, df2)
+
+    with config_context("SymbolDataCompact.SegmentCount", 1):
+        assert lmdb_version_store.is_symbol_fragmented(sym)
+        versioned_item = lmdb_version_store.defragment_symbol_data(sym)
+
+    assert versioned_item.metadata == meta
+    assert lmdb_version_store.read_metadata(sym).metadata == meta
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
defragment_symbol_data_impl passed std::nullopt to collate_and_write for user_meta, silently discarding the metadata that had been correctly read into pipeline_context->user_meta_ from the previous version. Fix by passing the actual user_meta_ptr from the pipeline context.

Also fix the Python wrapper which hardcoded metadata=None in the returned VersionedItem regardless of what was stored; it now reads the metadata back from the newly-written version using the existing read_metadata pattern.

Add regression test test_defragment_preserves_metadata.

#### Reference Issues/PRs
https://github.com/man-group/ArcticDB/issues/2611

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
