### PR TITLE
Symbol concatenation with arrow written data

### DIFF
--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -294,12 +294,45 @@ std::unordered_set<size_t> add_index_fields(StreamDescriptor& stream_desc, std::
     return non_matching_name_indices;
 }
 
-NormalizationMetadata generate_norm_meta(
-        const std::vector<OutputSchema>& input_schemas, std::unordered_set<size_t>&& non_matching_name_indices
+// Combines two normalization metadata values, returning the merged result.
+NormalizationMetadata accumulate_norm_metadata(
+        const NormalizationMetadata& accumulated, const NormalizationMetadata& other,
+        std::unordered_set<size_t>& fake_field_pos_acc
 ) {
+    // Arrow + Arrow
+    // Arrow schemas are compatible as long as both have the same `has_index`.
+    // We return the `accumulated` metadata if compatible.
+    if (accumulated.has_experimental_arrow() && other.has_experimental_arrow()) {
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                accumulated.experimental_arrow().has_index() == other.experimental_arrow().has_index(),
+                "Cannot join indexed arrow data with unindexed arrow data"
+        );
+        return accumulated;
+    }
+
+    // One arrow, one pandas
+    // Pandas norm metadata is preferred over arrow when mixing, because it carries more detail
+    // (index name, timezone, range index params, etc.). Arrow and pandas are compatible when:
+    //   arrow.has_index() == pandas.index().is_physically_stored()
+    if (accumulated.has_experimental_arrow() || other.has_experimental_arrow()) {
+        const auto& arrow_meta = accumulated.has_experimental_arrow() ? accumulated : other;
+        const auto& pandas_meta = accumulated.has_experimental_arrow() ? other : accumulated;
+        const auto& common = pandas_meta.has_series() ? pandas_meta.series().common() : pandas_meta.df().common();
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                common.has_index() && !common.has_multi_index(),
+                "Cannot join arrow-written data with multi-indexed pandas data"
+        );
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                arrow_meta.experimental_arrow().has_index() == common.index().is_physically_stored(),
+                "Cannot join unindexed with indexed data"
+        );
+        return pandas_meta;
+    }
+
+    // Pandas + Pandas
     // Ensure:
-    // All are Series or all are DataFrames
-    // All have PandasIndex OR PandasMultiIndex
+    // Both are Series or both are DataFrames
+    // Both have PandasIndex or both have PandasMultiIndex
     // If PandasIndex:
     //  - name/is_int/fake_name - if all the same maintain, otherwise "index"/false/true
     //  - tz - if all the same maintain, otherwise empty string
@@ -312,88 +345,101 @@ NormalizationMetadata generate_norm_meta(
     //  - name/is_int - if all the same maintain, otherwise "index"/false
     //  - field_count must all be same
     //  - tz - if all the same maintain, otherwise empty string
-    //  - fake_field_pos - unioned together, along with non_matching_name_indices
+    //  - fake_field_pos - added to fake_field_pos_acc
     //      fake_field_pos.contains(0) serves same purpose as fake_name flag on PandasIndex
     //  - timezone - Like tz, for a given key all values must be same, otherwise set value to empty string
-    util::check(!input_schemas.empty(), "Cannot join empty list of schemas");
-    auto res = input_schemas.front().norm_metadata_;
     schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-            res.has_series() || res.has_df(), "Multi-symbol joins only supported with Series and DataFrames"
+            accumulated.has_series() == other.has_series(), "Multi-symbol joins cannot join a Series to a DataFrame"
     );
+
+    auto res = accumulated;
     auto* res_common = res.has_series() ? res.mutable_series()->mutable_common() : res.mutable_df()->mutable_common();
+    const auto& other_common = other.has_series() ? other.series().common() : other.df().common();
+
+    if (res.has_series()) {
+        if (res_common->name() != other_common.name() || !other_common.has_name() || !res_common->has_name()) {
+            res_common->set_name("");
+            res_common->set_has_name(false);
+        }
+    }
+
+    schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+            other_common.has_multi_index() == res_common->has_multi_index(), "Mismatching norm metadata in schema join"
+    );
+
     if (res_common->has_multi_index()) {
-        for (auto pos : res_common->multi_index().fake_field_pos()) {
+        auto* res_index = res_common->mutable_multi_index();
+        const auto& other_index = other_common.multi_index();
+        if (other_index.name() != res_index->name() || other_index.is_int() != res_index->is_int()) {
+            res_index->clear_name();
+            res_index->set_is_int(false);
+        }
+        if (other_index.tz() != res_index->tz()) {
+            res_index->clear_tz();
+        }
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                other_index.field_count() == res_index->field_count(), "Mismatching norm metadata in schema join"
+        );
+        for (const auto& [idx, idx_timezone] : other_index.timezone()) {
+            if ((*res_index->mutable_timezone())[idx] != idx_timezone) {
+                (*res_index->mutable_timezone())[idx] = "";
+            }
+        }
+        for (auto pos : other_index.fake_field_pos()) {
+            fake_field_pos_acc.insert(pos);
+        }
+    } else {
+        auto* res_index = res_common->mutable_index();
+        const auto& other_index = other_common.index();
+        if (other_index.name() != res_index->name() || other_index.is_int() != res_index->is_int() ||
+            other_index.fake_name() || res_index->fake_name()) {
+            res_index->set_name("index");
+            res_index->set_is_int(false);
+            res_index->set_fake_name(true);
+        }
+        if (other_index.tz() != res_index->tz()) {
+            res_index->clear_tz();
+        }
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                other_index.is_physically_stored() == res_index->is_physically_stored(),
+                "Mismatching norm metadata in schema join"
+        );
+        if (other_index.step() != res_index->step()) {
+            log::version().warn("Mismatching RangeIndexes being combined, setting to start=0, step=1");
+            res_index->set_start(0);
+            res_index->set_step(1);
+        }
+    }
+    return res;
+}
+
+NormalizationMetadata generate_norm_meta(
+        const std::vector<OutputSchema>& input_schemas, std::unordered_set<size_t>&& non_matching_name_indices
+) {
+    util::check(!input_schemas.empty(), "Cannot join empty list of schemas");
+    for (const auto& schema : input_schemas) {
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                schema.norm_metadata_.has_experimental_arrow() || schema.norm_metadata_.has_series() ||
+                        schema.norm_metadata_.has_df(),
+                "Multi-symbol joins only supported with Arrow, Series, and DataFrames"
+        );
+    }
+    auto res = input_schemas.front().norm_metadata_;
+    for (auto it = std::next(input_schemas.cbegin()); it != input_schemas.cend(); ++it) {
+        res = accumulate_norm_metadata(res, it->norm_metadata_, non_matching_name_indices);
+    }
+    // Apply accumulated non_matching_name_indices to the result multi-index.
+    // non_matching_name_indices contains values from add_index_fields (index fields with mismatched names)
+    // plus fake_field_pos accumulated from all schemas during pairwise merges above.
+    auto* res_common = res.has_series() ? res.mutable_series()->mutable_common()
+                       : res.has_df()   ? res.mutable_df()->mutable_common()
+                                        : nullptr;
+    if (res_common && res_common->has_multi_index()) {
+        auto* index = res_common->mutable_multi_index();
+        // Make sure the result fake_field_pos are also included. E.g. if input_schemas.size() == 1
+        for (auto pos : index->fake_field_pos()) {
             non_matching_name_indices.insert(pos);
         }
-    }
-    for (auto it = std::next(input_schemas.cbegin()); it != input_schemas.cend(); ++it) {
-        const auto& input_schema = *it;
-        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                input_schema.norm_metadata_.has_series() || input_schema.norm_metadata_.has_df(),
-                "Multi-symbol joins only supported with Series and DataFrames"
-        );
-        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                res.has_series() == input_schema.norm_metadata_.has_series(),
-                "Multi-symbol joins cannot join a Series to a DataFrame"
-        );
-        const auto& common = res.has_series() ? input_schema.norm_metadata_.series().common()
-                                              : input_schema.norm_metadata_.df().common();
-        if (res.has_series()) {
-            if (res_common->name() != common.name() || !common.has_name() || !res_common->has_name()) {
-                res_common->set_name("");
-                res_common->set_has_name(false);
-            }
-        }
-        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                common.has_multi_index() == res_common->has_multi_index(), "Mismatching norm metadata in schema join"
-        );
-        if (res_common->has_multi_index()) {
-            auto* res_index = res_common->mutable_multi_index();
-            const auto& index = common.multi_index();
-            if ((index.name() != res_index->name()) || (index.is_int() != res_index->is_int())) {
-                res_index->clear_name();
-                res_index->set_is_int(false);
-            }
-            if (index.tz() != res_index->tz()) {
-                res_index->clear_tz();
-            }
-            schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                    index.field_count() == res_index->field_count(), "Mismatching norm metadata in schema join"
-            );
-            for (const auto& [idx, idx_timezone] : index.timezone()) {
-                (*res_index->mutable_timezone())[idx] =
-                        (*res_index->mutable_timezone())[idx] == idx_timezone ? idx_timezone : "";
-            }
-            for (auto pos : index.fake_field_pos()) {
-                // Do not modify the result fake_field_pos directly as it would likely result in many duplicate values
-                // Track in this set and then just insert them all into the result at the end
-                non_matching_name_indices.insert(pos);
-            }
-        } else {
-            auto* res_index = res_common->mutable_index();
-            const auto& index = common.index();
-            if ((index.name() != res_index->name()) || (index.is_int() != res_index->is_int()) || index.fake_name() ||
-                res_index->fake_name()) {
-                res_index->set_name("index");
-                res_index->set_is_int(false);
-                res_index->set_fake_name(true);
-            }
-            if (index.tz() != res_index->tz()) {
-                res_index->clear_tz();
-            }
-            schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                    index.is_physically_stored() == res_index->is_physically_stored(),
-                    "Mismatching norm metadata in schema join"
-            );
-            if (index.step() != res_index->step()) {
-                log::version().warn("Mismatching RangeIndexes being combined, setting to start=0, step=1");
-                res_index->set_start(0);
-                res_index->set_step(1);
-            }
-        }
-    }
-    if (res_common->has_multi_index()) {
-        auto* index = res_common->mutable_multi_index();
         index->clear_fake_field_pos();
         for (auto idx : non_matching_name_indices) {
             index->add_fake_field_pos(idx);

--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -318,9 +318,10 @@ NormalizationMetadata accumulate_norm_metadata(
         const auto& arrow_meta = accumulated.has_experimental_arrow() ? accumulated : other;
         const auto& pandas_meta = accumulated.has_experimental_arrow() ? other : accumulated;
         const auto& common = pandas_meta.has_series() ? pandas_meta.series().common() : pandas_meta.df().common();
+        // TODO: When arrow normalization metadata is finalized we can consider allowing
+        // concat(arrow,pandas_with_multiindex)
         schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                common.has_index() && !common.has_multi_index(),
-                "Cannot join arrow-written data with multi-indexed pandas data"
+                common.has_index(), "Cannot join arrow-written data with multi-indexed pandas data"
         );
         schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
                 arrow_meta.experimental_arrow().has_index() == common.index().is_physically_stored(),

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -226,6 +226,11 @@ IndexDescriptorImpl generate_index_descriptor(const std::vector<OutputSchema>& i
 
 std::unordered_set<size_t> add_index_fields(StreamDescriptor& stream_desc, std::vector<OutputSchema>& input_schemas);
 
+proto::descriptors::NormalizationMetadata common_norm_metadata(
+        const proto::descriptors::NormalizationMetadata& first, const proto::descriptors::NormalizationMetadata& other,
+        std::unordered_set<size_t>& fake_field_pos_acc
+);
+
 proto::descriptors::NormalizationMetadata generate_norm_meta(
         const std::vector<OutputSchema>& input_schemas, std::unordered_set<size_t>&& non_matching_name_indices
 );

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -226,11 +226,6 @@ IndexDescriptorImpl generate_index_descriptor(const std::vector<OutputSchema>& i
 
 std::unordered_set<size_t> add_index_fields(StreamDescriptor& stream_desc, std::vector<OutputSchema>& input_schemas);
 
-proto::descriptors::NormalizationMetadata common_norm_metadata(
-        const proto::descriptors::NormalizationMetadata& first, const proto::descriptors::NormalizationMetadata& other,
-        std::unordered_set<size_t>& fake_field_pos_acc
-);
-
 proto::descriptors::NormalizationMetadata generate_norm_meta(
         const std::vector<OutputSchema>& input_schemas, std::unordered_set<size_t>&& non_matching_name_indices
 );

--- a/cpp/arcticdb/processing/sorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.cpp
@@ -206,7 +206,8 @@ std::optional<Column> SortedAggregator<aggregation_operator, closed_boundary>::a
                                     schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
                                             !agg_column.column_->is_sparse() &&
                                                     agg_column.column_->row_count() == input_index_column->row_count(),
-                                            "Resample: Cannot aggregate column '{}' as it is sparse",
+                                            "Not implemented yet: Cannot aggregate sparse column '{}' during "
+                                            "resampling.",
                                             get_input_column_name().value
                                     );
                                     auto index_data = input_index_column->data();

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1235,7 +1235,7 @@ def lmdb_version_store_arrow(lmdb_version_store_v1) -> NativeVersionStore:
     return store
 
 
-# Explicitly not including `OutputFormat.EXPERIMENTAL_POLARS` as `polars.to_pandas()` is not index aware, so all
+# Explicitly not including `OutputFormat.POLARS` as `polars.to_pandas()` is not index aware, so all
 # `assert_frame_equal_with_arrow` would not work. Also POLARS is just a thin wrapper on top of pyarrow, so testing
 # just one is sufficent.
 @pytest.fixture(params=[OutputFormat.PANDAS, pytest.param(OutputFormat.PYARROW, marks=PYARROW_POST_PROCESSING)])

--- a/python/tests/unit/arcticdb/version_store/test_arrow_sparse.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_sparse.py
@@ -15,6 +15,7 @@ from hypothesis import assume, given, settings, strategies as st
 from hypothesis.extra.pandas import columns, data_frames
 
 import polars as pl
+from polars.testing import assert_frame_equal as polars_assert_frame_equal
 
 from arcticdb import concat
 from arcticdb.options import LibraryOptions, OutputFormat
@@ -679,15 +680,7 @@ def test_sparse_dynamic_schema_type_upgrade(version_store_factory, write_type, a
     assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
 
-def _assert_polars_equal(received, expected, sort_by=None, count_columns=None, sort_columns=False):
-    if sort_columns:
-        # ArcticDB and polars may return aggregated columns in different order
-        cols = sorted(received.columns)
-        received = received.select(cols)
-        expected = expected.select(cols)
-    if sort_by:
-        received = received.sort(sort_by)
-        expected = expected.sort(sort_by)
+def _assert_polars_equal_for_aggregation(received, expected, count_columns=None, check_row_order=True):
     if count_columns:
         # Polars groupby behaves differently to arcticdb groupby in two ways:
         # - Polars uses uint32 for counts where arcticdb uses uint64
@@ -696,23 +689,25 @@ def _assert_polars_equal(received, expected, sort_by=None, count_columns=None, s
             expected = expected.with_columns(
                 pl.when(pl.col(col) == 0).then(None).otherwise(pl.col(col)).cast(pl.UInt64).alias(col)
             )
-    assert received.equals(expected), (
-        f"DataFrames differ:\nreceived dtypes: {received.dtypes}\nexpected dtypes: {expected.dtypes}\n"
-        f"received:\n{received}\nexpected:\n{expected}"
+    # We use check_column_order=False because arcticdb and polars order aggregated columns differently.
+    # We use check_dtypes=False because sum in polars can have different dtype to arcticdb.
+    polars_assert_frame_equal(
+        received, expected, check_row_order=check_row_order, check_column_order=False, check_dtypes=False
     )
 
 
-def _check_query_result(lib, sym, q, expected, sort_by=None, count_columns=None, **read_kwargs):
+def _check_query_result(lib, sym, q, expected, count_columns=None, check_row_order=True, **read_kwargs):
     received = lib.read(sym, query_builder=q, **read_kwargs).data
-    _assert_polars_equal(received, expected, sort_by=sort_by, count_columns=count_columns, sort_columns=True)
+    _assert_polars_equal_for_aggregation(
+        received, expected, count_columns=count_columns, check_row_order=check_row_order
+    )
     received_pd = lib.read(sym, query_builder=q, output_format="PANDAS", **read_kwargs).data
-    if sort_by:
-        received_pd = received_pd.sort_index().reset_index()
-        expected_pyarrow = expected.sort(sort_by).to_arrow()
-    else:
-        received_pd = received_pd.reset_index()
-        expected_pyarrow = expected.to_arrow()
-    assert_frame_equal_with_arrow_for_sparse(expected_pyarrow, received_pd, check_dtype=False, check_like=True)
+    if not check_row_order:
+        expected = expected.sort(expected.columns[0])
+        received_pd = received_pd.sort_index()
+    assert_frame_equal_with_arrow_for_sparse(
+        expected.to_arrow(), received_pd.reset_index(), check_dtype=False, check_like=True
+    )
 
 
 class TestSparseArrowGroupBy:
@@ -742,7 +737,7 @@ class TestSparseArrowGroupBy:
         q = QueryBuilder().groupby(group_col).agg({agg_col: agg_op})
         expected = self.pldf.group_by(group_col).agg(getattr(pl.col(agg_col), agg_op)())
         count_columns = [agg_col] if agg_op == "count" else None
-        _check_query_result(self.lib, self.sym, q, expected, sort_by=group_col, count_columns=count_columns)
+        _check_query_result(self.lib, self.sym, q, expected, count_columns=count_columns, check_row_order=False)
 
     @pytest.mark.parametrize("group_col", ["group_str", "group_int"])
     def test_named_aggs(self, group_col):
@@ -756,7 +751,7 @@ class TestSparseArrowGroupBy:
         exprs = [getattr(pl.col(col), op)().alias(name) for name, (col, op) in agg_dict.items()]
         expected = self.pldf.group_by(group_col).agg(exprs)
         count_columns = [name for name, (_, op) in agg_dict.items() if op == "count"]
-        _check_query_result(self.lib, self.sym, q, expected, sort_by=group_col, count_columns=count_columns)
+        _check_query_result(self.lib, self.sym, q, expected, count_columns=count_columns, check_row_order=False)
 
 
 @pytest.mark.xfail(
@@ -765,6 +760,10 @@ class TestSparseArrowGroupBy:
 )
 class TestSparseArrowResample:
     sym = "test_sparse_resample"
+
+    # TODO: Also add testing for:
+    # - Aggregating string, datetime columns
+    # - Other resampling kwargs like offset, origin
 
     @pytest.fixture(autouse=True)
     def setup(self, version_store_factory):
@@ -815,10 +814,10 @@ class TestSparseArrowResample:
 
     def test_with_date_range(self):
         start, end = pd.Timestamp("2025-01-01 03:00"), pd.Timestamp("2025-01-01 08:00")
-        q = QueryBuilder().resample("3h").agg({"int_col": "sum"})
+        q = QueryBuilder().date_range((start, end)).resample("3h").agg({"int_col": "sum"})
         sliced = self.pldf.filter(pl.col("ts").is_between(start, end, closed="both"))
         expected = sliced.group_by_dynamic("ts", every="3h").agg(pl.col("int_col").sum())
-        _check_query_result(self.lib, self.sym, q, expected, date_range=(start, end))
+        _check_query_result(self.lib, self.sym, q, expected)
 
 
 class TestSparseArrowConcat:
@@ -873,7 +872,7 @@ class TestSparseArrowConcat:
         self.lib.write("sym2", t2)
         received = concat(self.lib.read_batch(["sym1", "sym2"], lazy=True)).collect().data
         expected = pl.concat([pl.from_arrow(t1), pl.from_arrow(t2)])
-        _assert_polars_equal(received, expected)
+        polars_assert_frame_equal(received, expected)
 
     @pytest.mark.parametrize("join", ["inner", "outer"])
     @pytest.mark.parametrize(
@@ -898,7 +897,7 @@ class TestSparseArrowConcat:
         else:
             common = set(t1.column_names) & set(t2.column_names)
             expected = pl.concat([pl1.select(common), pl2.select(common)], how="vertical_relaxed")
-        _assert_polars_equal(received, expected)
+        polars_assert_frame_equal(received, expected)
 
     def test_concat_with_index(self):
         dates1 = pd.date_range("2025-01-01", periods=3, freq="h")
@@ -919,7 +918,7 @@ class TestSparseArrowConcat:
         self.lib.write("s2", t2, index_column="ts")
         received = concat(self.lib.read_batch(["s1", "s2"], lazy=True)).collect().data
         expected = pl.concat([pl.from_arrow(t1), pl.from_arrow(t2)])
-        _assert_polars_equal(received, expected)
+        polars_assert_frame_equal(received, expected)
 
     @pytest.mark.xfail(
         reason="Resample rejects sparse columns: sorted_aggregation.cpp 'Cannot aggregate column as it is sparse'",
@@ -947,4 +946,4 @@ class TestSparseArrowConcat:
         )
         combined = pl.concat([pl.from_arrow(t1), pl.from_arrow(t2)]).sort("ts")
         expected = combined.group_by_dynamic("ts", every="3h").agg(pl.col("val").sum())
-        _assert_polars_equal(received, expected, sort_by="ts")
+        polars_assert_frame_equal(received, expected)

--- a/python/tests/unit/arcticdb/version_store/test_arrow_sparse.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_sparse.py
@@ -14,7 +14,10 @@ import pytest
 from hypothesis import assume, given, settings, strategies as st
 from hypothesis.extra.pandas import columns, data_frames
 
-from arcticdb.options import OutputFormat
+import polars as pl
+
+from arcticdb import concat
+from arcticdb.options import LibraryOptions, OutputFormat
 from arcticdb.util.hypothesis import use_of_function_scoped_fixtures_in_hypothesis_checked
 from arcticdb.util.test import assert_frame_equal_with_arrow_for_sparse
 from arcticdb.version_store.processing import QueryBuilder
@@ -674,3 +677,274 @@ def test_sparse_dynamic_schema_type_upgrade(version_store_factory, write_type, a
     assert expected.equals(received)
     received_pandas = lib.read(sym, row_range=row_range, output_format="PANDAS").data
     assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
+
+
+def _assert_polars_equal(received, expected, sort_by=None, count_columns=None, sort_columns=False):
+    if sort_columns:
+        # ArcticDB and polars may return aggregated columns in different order
+        cols = sorted(received.columns)
+        received = received.select(cols)
+        expected = expected.select(cols)
+    if sort_by:
+        received = received.sort(sort_by)
+        expected = expected.sort(sort_by)
+    if count_columns:
+        # Polars groupby behaves differently to arcticdb groupby in two ways:
+        # - Polars uses uint32 for counts where arcticdb uses uint64
+        # - Polars returns 0 vs arcticdb returns null for group filled with only `null`s
+        for col in count_columns:
+            expected = expected.with_columns(
+                pl.when(pl.col(col) == 0).then(None).otherwise(pl.col(col)).cast(pl.UInt64).alias(col)
+            )
+    assert received.equals(expected), (
+        f"DataFrames differ:\nreceived dtypes: {received.dtypes}\nexpected dtypes: {expected.dtypes}\n"
+        f"received:\n{received}\nexpected:\n{expected}"
+    )
+
+
+def _check_query_result(lib, sym, q, expected, sort_by=None, count_columns=None, **read_kwargs):
+    received = lib.read(sym, query_builder=q, **read_kwargs).data
+    _assert_polars_equal(received, expected, sort_by=sort_by, count_columns=count_columns, sort_columns=True)
+    received_pd = lib.read(sym, query_builder=q, output_format="PANDAS", **read_kwargs).data
+    if sort_by:
+        received_pd = received_pd.sort_index().reset_index()
+        expected_pyarrow = expected.sort(sort_by).to_arrow()
+    else:
+        received_pd = received_pd.reset_index()
+        expected_pyarrow = expected.to_arrow()
+    assert_frame_equal_with_arrow_for_sparse(expected_pyarrow, received_pd, check_dtype=False, check_like=True)
+
+
+class TestSparseArrowGroupBy:
+    sym = "test_sparse_groupby"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, version_store_factory):
+        self.lib = version_store_factory(segment_row_size=3)
+        self.lib.set_output_format(OutputFormat.POLARS)
+        self.lib._set_allow_arrow_input()
+        self.table = pa.table(
+            {
+                "group_str": pa.array(["a", "a", "b", "b", "b", "a", "all_null", "all_null"], pa.large_string()),
+                "group_int": pa.array([1, 1, 2, 2, 2, 1, 3, 3], pa.int64()),
+                "int_col": pa.array([10, None, 30, None, 50, None, None, None], pa.int64()),
+                "float_col": pa.array([None, 2.0, None, 4.0, None, 6.0, None, None], pa.float64()),
+                "bool_col": pa.array([True, None, False, None, True, None, None, None], pa.bool_()),
+            }
+        )
+        self.lib.write(self.sym, self.table)
+        self.pldf = pl.from_arrow(self.table)
+
+    @pytest.mark.parametrize("agg_op", ["sum", "mean", "min", "max", "count"])
+    @pytest.mark.parametrize("group_col", ["group_str", "group_int"])
+    @pytest.mark.parametrize("agg_col", ["int_col", "float_col", "bool_col"])
+    def test_single_agg(self, agg_op, group_col, agg_col):
+        q = QueryBuilder().groupby(group_col).agg({agg_col: agg_op})
+        expected = self.pldf.group_by(group_col).agg(getattr(pl.col(agg_col), agg_op)())
+        count_columns = [agg_col] if agg_op == "count" else None
+        _check_query_result(self.lib, self.sym, q, expected, sort_by=group_col, count_columns=count_columns)
+
+    @pytest.mark.parametrize("group_col", ["group_str", "group_int"])
+    def test_named_aggs(self, group_col):
+        agg_dict = {
+            "int_sum": ("int_col", "sum"),
+            "int_max": ("int_col", "max"),
+            "float_mean": ("float_col", "mean"),
+            "float_count": ("float_col", "count"),
+        }
+        q = QueryBuilder().groupby(group_col).agg(agg_dict)
+        exprs = [getattr(pl.col(col), op)().alias(name) for name, (col, op) in agg_dict.items()]
+        expected = self.pldf.group_by(group_col).agg(exprs)
+        count_columns = [name for name, (_, op) in agg_dict.items() if op == "count"]
+        _check_query_result(self.lib, self.sym, q, expected, sort_by=group_col, count_columns=count_columns)
+
+
+@pytest.mark.xfail(
+    reason="Resample rejects sparse columns. (monday ref: 11679866800)",
+    raises=Exception,
+)
+class TestSparseArrowResample:
+    sym = "test_sparse_resample"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, version_store_factory):
+        self.lib = version_store_factory(segment_row_size=4)
+        self.lib.set_output_format(OutputFormat.POLARS)
+        self.lib._set_allow_arrow_input()
+        dates = pd.date_range("2025-01-01", periods=12, freq="h")
+        # Bucket 2 (hours 6-8) is fully null for both columns when resampled at 3h
+        self.table = pa.table(
+            {
+                "ts": pa.Array.from_pandas(dates, type=pa.timestamp("ns")),
+                "int_col": pa.array([1, None, 3, None, 5, None, None, None, None, None, 11, None], pa.int64()),
+                "float_col": pa.array(
+                    [None, 2.0, None, 4.0, None, 6.0, None, None, None, 10.0, None, 12.0], pa.float64()
+                ),
+            }
+        )
+        self.lib.write(self.sym, self.table, index_column="ts")
+        self.pldf = pl.from_arrow(self.table).sort("ts")
+
+    @pytest.mark.parametrize("agg_op", ["sum", "mean", "min", "max", "first", "last", "count"])
+    @pytest.mark.parametrize("agg_col", ["int_col", "float_col"])
+    @pytest.mark.parametrize("rule", ["3h", "6h"])
+    def test_single_agg(self, agg_op, agg_col, rule):
+        q = QueryBuilder().resample(rule).agg({agg_col: agg_op})
+        expected = self.pldf.group_by_dynamic("ts", every=rule).agg(getattr(pl.col(agg_col), agg_op)())
+        _check_query_result(self.lib, self.sym, q, expected)
+
+    @pytest.mark.parametrize("rule", ["3h", "6h"])
+    def test_named_aggs(self, rule):
+        agg_dict = {
+            "int_sum": ("int_col", "sum"),
+            "float_max": ("float_col", "max"),
+            "int_count": ("int_col", "count"),
+            "float_first": ("float_col", "first"),
+        }
+        q = QueryBuilder().resample(rule).agg(agg_dict)
+        exprs = [getattr(pl.col(col), op)().alias(name) for name, (col, op) in agg_dict.items()]
+        expected = self.pldf.group_by_dynamic("ts", every=rule).agg(exprs)
+        _check_query_result(self.lib, self.sym, q, expected)
+
+    @pytest.mark.parametrize("closed", ["left", "right"])
+    @pytest.mark.parametrize("label", ["left", "right"])
+    def test_closed_label(self, closed, label):
+        q = QueryBuilder().resample("3h", closed=closed, label=label).agg({"int_col": "sum"})
+        expected = self.pldf.group_by_dynamic("ts", every="3h", closed=closed, label=label).agg(pl.col("int_col").sum())
+        _check_query_result(self.lib, self.sym, q, expected)
+
+    def test_with_date_range(self):
+        start, end = pd.Timestamp("2025-01-01 03:00"), pd.Timestamp("2025-01-01 08:00")
+        q = QueryBuilder().resample("3h").agg({"int_col": "sum"})
+        sliced = self.pldf.filter(pl.col("ts").is_between(start, end, closed="both"))
+        expected = sliced.group_by_dynamic("ts", every="3h").agg(pl.col("int_col").sum())
+        _check_query_result(self.lib, self.sym, q, expected, date_range=(start, end))
+
+
+class TestSparseArrowConcat:
+    @pytest.fixture(autouse=True)
+    def setup(self, lmdb_library_factory):
+        self.lib = lmdb_library_factory(LibraryOptions())
+        self.lib._nvs.set_output_format(OutputFormat.POLARS)
+        self.lib._nvs._set_allow_arrow_input()
+
+    @pytest.mark.parametrize(
+        "t1,t2",
+        [
+            (
+                pa.table(
+                    {
+                        "int_col": pa.array([1, None, 3], pa.int64()),
+                        "float_col": pa.array([None, 2.0, None], pa.float64()),
+                    }
+                ),
+                pa.table(
+                    {
+                        "int_col": pa.array([None, 5, None], pa.int64()),
+                        "float_col": pa.array([4.0, None, 6.0], pa.float64()),
+                    }
+                ),
+            ),
+            (
+                pa.table(
+                    {"a": pa.array([None, None, None], pa.int64()), "b": pa.array([1.0, None, 3.0], pa.float64())}
+                ),
+                pa.table({"a": pa.array([4, None, 6], pa.int64()), "b": pa.array([None, None, None], pa.float64())}),
+            ),
+            (
+                pa.table(
+                    {
+                        "bool_col": pa.array([True, None, False], pa.bool_()),
+                        "str_col": pa.array([None, "b", None], pa.large_string()),
+                    }
+                ),
+                pa.table(
+                    {
+                        "bool_col": pa.array([None, True, None], pa.bool_()),
+                        "str_col": pa.array(["d", None, "f"], pa.large_string()),
+                    }
+                ),
+            ),
+        ],
+        ids=["int_float", "all_sparse", "bool_string"],
+    )
+    def test_basic_concat(self, t1, t2):
+        self.lib.write("sym1", t1)
+        self.lib.write("sym2", t2)
+        received = concat(self.lib.read_batch(["sym1", "sym2"], lazy=True)).collect().data
+        expected = pl.concat([pl.from_arrow(t1), pl.from_arrow(t2)])
+        _assert_polars_equal(received, expected)
+
+    @pytest.mark.parametrize("join", ["inner", "outer"])
+    @pytest.mark.parametrize(
+        "type1,type2",
+        [
+            pytest.param(pa.float64(), pa.float64(), id="same_type"),
+            pytest.param(pa.int32(), pa.int64(), id="int32_and_int64"),
+            pytest.param(pa.int16(), pa.float32(), id="int16_and_float32"),
+            pytest.param(pa.int64(), pa.float32(), id="int64_and_float32"),
+        ],
+    )
+    def test_different_columns(self, join, type1, type2):
+        t1 = pa.table({"a": pa.array([1, None], pa.int64()), "b": pa.array([None, 2], type1)})
+        t2 = pa.table({"b": pa.array([3, None], type2), "c": pa.array([None, 4], pa.int64())})
+        self.lib.write("s1", t1)
+        self.lib.write("s2", t2)
+        received = concat(self.lib.read_batch(["s1", "s2"], lazy=True), join).collect().data
+        pl1 = pl.from_arrow(t1)
+        pl2 = pl.from_arrow(t2)
+        if join == "outer":
+            expected = pl.concat([pl1, pl2], how="diagonal_relaxed")
+        else:
+            common = set(t1.column_names) & set(t2.column_names)
+            expected = pl.concat([pl1.select(common), pl2.select(common)], how="vertical_relaxed")
+        _assert_polars_equal(received, expected)
+
+    def test_concat_with_index(self):
+        dates1 = pd.date_range("2025-01-01", periods=3, freq="h")
+        dates2 = pd.date_range("2025-01-01T03:00:00", periods=3, freq="h")
+        t1 = pa.table(
+            {
+                "ts": pa.Array.from_pandas(dates1, type=pa.timestamp("ns")),
+                "val": pa.array([1, None, 3], pa.int64()),
+            }
+        )
+        t2 = pa.table(
+            {
+                "ts": pa.Array.from_pandas(dates2, type=pa.timestamp("ns")),
+                "val": pa.array([None, 5, None], pa.int64()),
+            }
+        )
+        self.lib.write("s1", t1, index_column="ts")
+        self.lib.write("s2", t2, index_column="ts")
+        received = concat(self.lib.read_batch(["s1", "s2"], lazy=True)).collect().data
+        expected = pl.concat([pl.from_arrow(t1), pl.from_arrow(t2)])
+        _assert_polars_equal(received, expected)
+
+    @pytest.mark.xfail(
+        reason="Resample rejects sparse columns: sorted_aggregation.cpp 'Cannot aggregate column as it is sparse'",
+        raises=Exception,
+    )
+    def test_concat_with_resample(self):
+        dates1 = pd.date_range("2025-01-01", periods=6, freq="h")
+        dates2 = pd.date_range("2025-01-01T06:00:00", periods=6, freq="h")
+        t1 = pa.table(
+            {
+                "ts": pa.Array.from_pandas(dates1, type=pa.timestamp("ns")),
+                "val": pa.array([1, None, 3, None, 5, None], pa.int64()),
+            }
+        )
+        t2 = pa.table(
+            {
+                "ts": pa.Array.from_pandas(dates2, type=pa.timestamp("ns")),
+                "val": pa.array([None, 8, None, 10, None, 12], pa.int64()),
+            }
+        )
+        self.lib.write("r1", t1, index_column="ts")
+        self.lib.write("r2", t2, index_column="ts")
+        received = (
+            concat(self.lib.read_batch(["r1", "r2"], lazy=True)).resample("3h").agg({"val": "sum"}).collect().data
+        )
+        combined = pl.concat([pl.from_arrow(t1), pl.from_arrow(t2)]).sort("ts")
+        expected = combined.group_by_dynamic("ts", every="3h").agg(pl.col("val").sum())
+        _assert_polars_equal(received, expected, sort_by="ts")

--- a/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
+++ b/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
@@ -800,18 +800,12 @@ class TestMixedArrowPandasConcat:
         self.lib = lmdb_library_factory(LibraryOptions())
         self.lib._nvs._set_allow_arrow_input()
 
-    def _write_arrow(self, sym, table, **kwargs):
-        self.lib.write(sym, table, **kwargs)
-
-    def _write_pandas(self, sym, df):
-        self.lib.write(sym, df)
-
     @pytest.mark.parametrize("arrow_first", [True, False])
     def test_no_index(self, arrow_first):
         arrow_table = pa.table({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
         pandas_df = pd.DataFrame({"a": [7, 8, 9], "b": [10.0, 11.0, 12.0]})
-        self._write_arrow("arrow_sym", arrow_table)
-        self._write_pandas("pandas_sym", pandas_df)
+        self.lib.write("arrow_sym", arrow_table)
+        self.lib.write("pandas_sym", pandas_df)
         symbols = ["arrow_sym", "pandas_sym"] if arrow_first else ["pandas_sym", "arrow_sym"]
         result = concat(self.lib.read_batch(symbols, lazy=True)).collect().data
         dfs = [arrow_table.to_pandas(), pandas_df] if arrow_first else [pandas_df, arrow_table.to_pandas()]
@@ -829,8 +823,8 @@ class TestMixedArrowPandasConcat:
             }
         )
         pandas_df = pd.DataFrame({"val": [4, 5, 6]}, index=pd.DatetimeIndex(dates2, name="ts"))
-        self._write_arrow("arrow_sym", arrow_table, index_column="ts")
-        self._write_pandas("pandas_sym", pandas_df)
+        self.lib.write("arrow_sym", arrow_table, index_column="ts")
+        self.lib.write("pandas_sym", pandas_df)
         symbols = ["arrow_sym", "pandas_sym"] if arrow_first else ["pandas_sym", "arrow_sym"]
         result = concat(self.lib.read_batch(symbols, lazy=True)).collect().data
         arrow_df = arrow_table.to_pandas().set_index("ts")
@@ -842,8 +836,8 @@ class TestMixedArrowPandasConcat:
     def test_different_columns(self, join):
         arrow_table = pa.table({"a": [1.0, 2.0], "b": [3.0, 4.0]})
         pandas_df = pd.DataFrame({"b": [5.0, 6.0], "c": [7.0, 8.0]})
-        self._write_arrow("arrow_sym", arrow_table)
-        self._write_pandas("pandas_sym", pandas_df)
+        self.lib.write("arrow_sym", arrow_table)
+        self.lib.write("pandas_sym", pandas_df)
         result = concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True), join).collect().data
         expected = pd.concat([arrow_table.to_pandas(), pandas_df], join=join, ignore_index=True)
         assert_frame_equal(result, expected, check_like=True)
@@ -857,8 +851,8 @@ class TestMixedArrowPandasConcat:
             }
         )
         pandas_df = pd.DataFrame({"val": [4, 5, 6]})
-        self._write_arrow("arrow_sym", arrow_table, index_column="ts")
-        self._write_pandas("pandas_sym", pandas_df)
+        self.lib.write("arrow_sym", arrow_table, index_column="ts")
+        self.lib.write("pandas_sym", pandas_df)
         with pytest.raises(SchemaException):
             concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True)).collect()
         with pytest.raises(SchemaException):
@@ -868,8 +862,8 @@ class TestMixedArrowPandasConcat:
         arrow_table = pa.table({"val": pa.array([1, 2, 3], pa.int64())})
         dates = pd.date_range("2025-01-01", periods=3, freq="h")
         pandas_df = pd.DataFrame({"val": [4, 5, 6]}, index=pd.DatetimeIndex(dates, name="ts"))
-        self._write_arrow("arrow_sym", arrow_table)
-        self._write_pandas("pandas_sym", pandas_df)
+        self.lib.write("arrow_sym", arrow_table)
+        self.lib.write("pandas_sym", pandas_df)
         with pytest.raises(SchemaException):
             concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True)).collect()
         with pytest.raises(SchemaException):
@@ -879,9 +873,33 @@ class TestMixedArrowPandasConcat:
         arrow_table = pa.table({"val": pa.array([1, 2, 3], pa.int64())})
         index = pd.MultiIndex.from_tuples([(1, "a"), (2, "b"), (3, "c")], names=["idx1", "idx2"])
         pandas_df = pd.DataFrame({"val": [4, 5, 6]}, index=index)
-        self._write_arrow("arrow_sym", arrow_table)
-        self._write_pandas("pandas_sym", pandas_df)
+        self.lib.write("arrow_sym", arrow_table)
+        self.lib.write("pandas_sym", pandas_df)
         with pytest.raises(SchemaException):
             concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True)).collect()
         with pytest.raises(SchemaException):
             concat(self.lib.read_batch(["pandas_sym", "arrow_sym"], lazy=True)).collect()
+
+    def test_arrow_arrow_concat_no_index(self):
+        t1 = pa.table({"a": pa.array([1, 2, 3], pa.int64()), "b": pa.array([4.0, 5.0, 6.0], pa.float64())})
+        t2 = pa.table({"a": pa.array([7, 8, 9], pa.int64()), "b": pa.array([10.0, 11.0, 12.0], pa.float64())})
+        self.lib.write("sym1", t1)
+        self.lib.write("sym2", t2)
+        result = concat(self.lib.read_batch(["sym1", "sym2"], lazy=True)).collect().data
+        expected = pd.concat([t1.to_pandas(), t2.to_pandas()], ignore_index=True)
+        assert_frame_equal(result, expected)
+
+    def test_arrow_arrow_concat_with_index(self):
+        dates1 = pd.date_range("2025-01-01", periods=3, freq="h")
+        dates2 = pd.date_range("2025-01-01T03:00:00", periods=3, freq="h")
+        t1 = pa.table(
+            {"ts": pa.Array.from_pandas(dates1, type=pa.timestamp("ns")), "val": pa.array([1, 2, 3], pa.int64())}
+        )
+        t2 = pa.table(
+            {"ts": pa.Array.from_pandas(dates2, type=pa.timestamp("ns")), "val": pa.array([4, 5, 6], pa.int64())}
+        )
+        self.lib.write("sym1", t1, index_column="ts")
+        self.lib.write("sym2", t2, index_column="ts")
+        result = concat(self.lib.read_batch(["sym1", "sym2"], lazy=True)).collect().data
+        expected = pd.concat([t1.to_pandas().set_index("ts"), t2.to_pandas().set_index("ts")])
+        assert_frame_equal(result, expected)

--- a/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
+++ b/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from arcticdb import col, concat, LazyDataFrame, LazyDataFrameCollection, QueryBuilder, ReadRequest
@@ -791,3 +792,96 @@ def test_symbol_concat_docstring_example(lmdb_library, any_output_format):
     lazy_df = lazy_df.resample("10min").agg({"col": "sum"})
     received = lazy_df.collect().data
     assert_frame_equal(pd.DataFrame({"col": [14]}, index=[pd.Timestamp("2025-01-01")]), received)
+
+
+class TestMixedArrowPandasConcat:
+    @pytest.fixture(autouse=True)
+    def setup(self, lmdb_library_factory):
+        self.lib = lmdb_library_factory(LibraryOptions())
+        self.lib._nvs._set_allow_arrow_input()
+
+    def _write_arrow(self, sym, table, **kwargs):
+        self.lib.write(sym, table, **kwargs)
+
+    def _write_pandas(self, sym, df):
+        self.lib.write(sym, df)
+
+    @pytest.mark.parametrize("arrow_first", [True, False])
+    def test_no_index(self, arrow_first):
+        arrow_table = pa.table({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+        pandas_df = pd.DataFrame({"a": [7, 8, 9], "b": [10.0, 11.0, 12.0]})
+        self._write_arrow("arrow_sym", arrow_table)
+        self._write_pandas("pandas_sym", pandas_df)
+        symbols = ["arrow_sym", "pandas_sym"] if arrow_first else ["pandas_sym", "arrow_sym"]
+        result = concat(self.lib.read_batch(symbols, lazy=True)).collect().data
+        dfs = [arrow_table.to_pandas(), pandas_df] if arrow_first else [pandas_df, arrow_table.to_pandas()]
+        expected = pd.concat(dfs, ignore_index=True)
+        assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("arrow_first", [True, False])
+    def test_with_timestamp_index(self, arrow_first):
+        dates1 = pd.date_range("2025-01-01", periods=3, freq="h")
+        dates2 = pd.date_range("2025-01-01T03:00:00", periods=3, freq="h")
+        arrow_table = pa.table(
+            {
+                "ts": pa.Array.from_pandas(dates1, type=pa.timestamp("ns")),
+                "val": pa.array([1, 2, 3], pa.int64()),
+            }
+        )
+        pandas_df = pd.DataFrame({"val": [4, 5, 6]}, index=pd.DatetimeIndex(dates2, name="ts"))
+        self._write_arrow("arrow_sym", arrow_table, index_column="ts")
+        self._write_pandas("pandas_sym", pandas_df)
+        symbols = ["arrow_sym", "pandas_sym"] if arrow_first else ["pandas_sym", "arrow_sym"]
+        result = concat(self.lib.read_batch(symbols, lazy=True)).collect().data
+        arrow_df = arrow_table.to_pandas().set_index("ts")
+        dfs = [arrow_df, pandas_df] if arrow_first else [pandas_df, arrow_df]
+        expected = pd.concat(dfs)
+        assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("join", ["inner", "outer"])
+    def test_different_columns(self, join):
+        arrow_table = pa.table({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        pandas_df = pd.DataFrame({"b": [5.0, 6.0], "c": [7.0, 8.0]})
+        self._write_arrow("arrow_sym", arrow_table)
+        self._write_pandas("pandas_sym", pandas_df)
+        result = concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True), join).collect().data
+        expected = pd.concat([arrow_table.to_pandas(), pandas_df], join=join, ignore_index=True)
+        assert_frame_equal(result, expected, check_like=True)
+
+    def test_arrow_indexed_with_pandas_range_index_raises(self):
+        dates = pd.date_range("2025-01-01", periods=3, freq="h")
+        arrow_table = pa.table(
+            {
+                "ts": pa.Array.from_pandas(dates, type=pa.timestamp("ns")),
+                "val": pa.array([1, 2, 3], pa.int64()),
+            }
+        )
+        pandas_df = pd.DataFrame({"val": [4, 5, 6]})
+        self._write_arrow("arrow_sym", arrow_table, index_column="ts")
+        self._write_pandas("pandas_sym", pandas_df)
+        with pytest.raises(SchemaException):
+            concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True)).collect()
+        with pytest.raises(SchemaException):
+            concat(self.lib.read_batch(["pandas_sym", "arrow_sym"], lazy=True)).collect()
+
+    def test_arrow_unindexed_with_pandas_timestamp_index_raises(self):
+        arrow_table = pa.table({"val": pa.array([1, 2, 3], pa.int64())})
+        dates = pd.date_range("2025-01-01", periods=3, freq="h")
+        pandas_df = pd.DataFrame({"val": [4, 5, 6]}, index=pd.DatetimeIndex(dates, name="ts"))
+        self._write_arrow("arrow_sym", arrow_table)
+        self._write_pandas("pandas_sym", pandas_df)
+        with pytest.raises(SchemaException):
+            concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True)).collect()
+        with pytest.raises(SchemaException):
+            concat(self.lib.read_batch(["pandas_sym", "arrow_sym"], lazy=True)).collect()
+
+    def test_arrow_with_pandas_multiindex_raises(self):
+        arrow_table = pa.table({"val": pa.array([1, 2, 3], pa.int64())})
+        index = pd.MultiIndex.from_tuples([(1, "a"), (2, "b"), (3, "c")], names=["idx1", "idx2"])
+        pandas_df = pd.DataFrame({"val": [4, 5, 6]}, index=index)
+        self._write_arrow("arrow_sym", arrow_table)
+        self._write_pandas("pandas_sym", pandas_df)
+        with pytest.raises(SchemaException):
+            concat(self.lib.read_batch(["arrow_sym", "pandas_sym"], lazy=True)).collect()
+        with pytest.raises(SchemaException):
+            concat(self.lib.read_batch(["pandas_sym", "arrow_sym"], lazy=True)).collect()


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ref: 18053022100

#### What does this implement or fix?
Concatenation is made to work with arrow written normalization metadata. Mixing arrow and pandas also works as long as `arrow.has_index() == pandas_index.is_physically_stored()`. 

This PR also adds sparse arrow testing for groupby, resampling and concat.

GroupBy and concat work as expected.

Resampling does not and is a non trivial fix. Monday ref to track: 11679866800

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
