### PR TITLE
Stability improvement for QueryBuilder ASV benchmarks

### DIFF
--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2329,14 +2329,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "9c9e9cd8492f587c0ffc69bc7367905281a11229bea0b1f7042214de7895f436",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_filtering_string_isin": {
         "code": "class QueryBuilderFunctions:\n    def time_filtering_string_isin(self, lib_for_storage, num_rows, storage):\n        # Selects about 1% of the rows\n        k = num_rows // 1000\n        string_set = [f\"id{str(i).zfill(3)}\" for i in range(1, k + 1)]\n        q = QueryBuilder()\n        q = q[q[\"id1\"].isin(string_set)]\n        self.lib.read(self.symbol, columns=[\"v3\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
@@ -2357,14 +2357,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "e3264e4f0b655d3b381488fe3d0906362671d2e640b3ca0c729a644d237e0bb1",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_filtering_string_regex_match": {
         "code": "class QueryBuilderFunctions:\n    def time_filtering_string_regex_match(self, *args):\n        pattern = r\"^id\\d\\d\\d$\"\n        q = QueryBuilder()\n        q = q[q[\"id1\"].regex_match(pattern)]\n        self.lib.read(self.symbol, columns=[\"v3\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
@@ -2385,14 +2385,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "57afa0ac498853e31288aced64f87c946d84a2db67af6058f77bc8bd6cd6ec32",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_projection": {
         "code": "class QueryBuilderFunctions:\n    def time_projection(self, *args):\n        q = QueryBuilder()\n        q = q.apply(\"new_col\", q[\"v2\"] * q[\"v3\"])\n        self.lib.read(self.symbol, columns=[\"new_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
@@ -2413,14 +2413,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "60d5bdab793a5bfc17913dd4f0af6224f86247b49afc9a064384b640c66f460f",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_query_1": {
         "code": "class QueryBuilderFunctions:\n    def time_query_1(self, *args):\n        q = QueryBuilder()\n        q = q.groupby(\"id1\").agg({\"v1\": \"sum\"})\n        self.lib.read(self.symbol, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
@@ -2441,14 +2441,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "ba8983e5c8df1cc9b61131f42ac04147af2bbca98b230f208b048dd1a6a80070",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_query_3": {
         "code": "class QueryBuilderFunctions:\n    def time_query_3(self, *args):\n        q = QueryBuilder()\n        q = q.groupby(\"id3\").agg({\"v1\": \"sum\", \"v3\": \"sum\"})\n        self.lib.read(self.symbol, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
@@ -2469,14 +2469,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "90510c3d0cf383bd728b23b90b4c30ed14423d81d410c8ebb477e52793733fde",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_query_4": {
         "code": "class QueryBuilderFunctions:\n    def time_query_4(self, *args):\n        q = QueryBuilder()\n        q = q.groupby(\"id6\").agg({\"v1\": \"sum\", \"v2\": \"sum\"})\n        self.lib.read(self.symbol, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
@@ -2497,14 +2497,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "32c12c7f850640e929401b67cc7be03231a37994a4dffdea7dc228e8765c7293",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_query_adv_query_2": {
         "code": "class QueryBuilderFunctions:\n    def time_query_adv_query_2(self, *args):\n        q = QueryBuilder()\n        q = q.groupby(\"id3\").agg({\"v1\": \"max\", \"v2\": \"min\"})\n        self.lib.read(self.symbol, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
@@ -2525,14 +2525,14 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "rounds": 2,
+        "rounds": 3,
         "sample_time": 2,
         "setup_cache_key": "query_builder:42",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "8f0f2114a5f0bb59e2c5857dfa305d134a8464c4270722fff6758ed44488a257",
-        "warmup_time": 0.2
+        "warmup_time": 1.0
     },
     "recursive_normalizer.LMDBRecursiveNormalizerRead.peakmem_read_batch_nested_dict": {
         "code": "class LMDBRecursiveNormalizerRead:\n    def peakmem_read_batch_nested_dict(self, num_dict_entry, num_symbols):\n        self.lib.read_batch([get_symbol_name(num_dict_entry, i) for i in range(num_symbols)])\n\n    def setup(self, num_dict_entry, num_symbols):\n        self.lib = Arctic(LMDBRecursiveNormalizerRead.ARCTIC_URI).get_library(\"lib\")\n\n    def setup_cache(self):\n        ac = Arctic(LMDBRecursiveNormalizerRead.ARCTIC_URI)\n        if \"lib\" in ac:\n            ac.delete_library(\"lib\")\n    \n        lib = ac.create_library(\"lib\")\n    \n        max_num_symbols = max(self.params[1])\n        for num_dict_entry in self.params[0]:\n            data = get_data(num_dict_entry)\n            for symbol_idx in range(max_num_symbols):\n                symbol_name = get_symbol_name(num_dict_entry, symbol_idx)\n                lib._nvs.write(symbol_name, data, recursive_normalizers=True)",

--- a/python/benchmarks/query_builder.py
+++ b/python/benchmarks/query_builder.py
@@ -23,9 +23,9 @@ def _symbol_name(rows):
 
 class QueryBuilderFunctions:
     sample_time = 2
-    rounds = 2
+    rounds = 3
     repeat = (1, 10, 20.0)
-    warmup_time = 0.2
+    warmup_time = 1.0
     timeout = 600
 
     num_rows = [1_000_000, 10_000_000]


### PR DESCRIPTION
Claude thinks that the warmup time of 200ms is too short for the 10M row benchmark, which takes about 500ms in the CI so it itsn't managing a single warmup. This theory is also compatible with the issue affecting the first benchmark in the file particularly badly.

Results from repeated runs on my machine after this fix, showing <5% difference in the mean across runs.

```
  ┌─────┬──────────┬──────────┐
  │ Run      │ 1M rows  │ 10M rows │
  ├─────┼──────────┼──────────┤
  │ 1          │ 97.7±3ms │ 737±70ms │
  ├─────┼──────────┼──────────┤
  │ 2          │ 98.1±2ms │ 764±60ms │
  ├─────┼──────────┼──────────┤
  │ 3          │ 99.7±3ms │ 759±60ms │
  └─────┴──────────┴──────────┘

```
  Previous failures:

```
  Benchmarks that have got worse:

  | Change   | Before [6c5d6df9]    | After [f4197dbf]    |   Ratio | Benchmark (Parameter)                                                         |
  |----------|----------------------|---------------------|---------|-------------------------------------------------------------------------------|
  | +        | 436±7ms              | 508±4ms             |    1.17 | query_builder.QueryBuilderFunctions.time_query_1(10000000, <Storage.LMDB: 2>) |
  There were no ASV execution failures to report.
  Benchmarks that have got worse:

  | Change   | Before [c6748f3c]    | After [55d8e77f]    |   Ratio | Benchmark (Parameter)                                                         |
  |----------|----------------------|---------------------|---------|-------------------------------------------------------------------------------|
  | +        | 456±20ms             | 529±6ms             |    1.16 | query_builder.QueryBuilderFunctions.time_query_1(10000000, <Storage.LMDB: 2>) |
```