### PR TITLE
Support bools with column stats

### DIFF
--- a/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
@@ -148,6 +148,32 @@ std::vector<StatsComparison> visit_binary_membership_stats(
     );
 }
 
+bool value_is_nan(const Value& val) {
+    if (is_floating_point_type(val.data_type())) {
+        return details::visit_type(val.data_type(), [&val]<typename TagType>(TagType) -> bool {
+            using RawType = TagType::raw_type;
+            if constexpr (std::is_floating_point_v<RawType>) {
+                return std::isnan(val.get<RawType>());
+            }
+            return false;
+        });
+    }
+    return false;
+}
+
+StatsComparison to_stats_comparison_for_boolean(const ColumnStatsValues& csv) {
+    return unary_boolean_stats(csv, OperationType::IDENTITY);
+}
+
+StatsComparison to_stats_comparison_for_boolean(const Value& val) {
+    util::check(
+            is_bool_type(val.data_type()),
+            "Expected bool type in to_stats_comparison_for_boolean, got {}",
+            get_user_friendly_type_string(val.descriptor())
+    );
+    return val.get<bool>() ? StatsComparison::ALL_MATCH : StatsComparison::NONE_MATCH;
+}
+
 StatsComparison binary_boolean_stats(StatsComparison left, StatsComparison right, OperationType operation) {
     switch (operation) {
     case OperationType::AND:
@@ -173,36 +199,109 @@ StatsComparison binary_boolean_stats(StatsComparison left, StatsComparison right
     }
 }
 
+namespace {
+
+std::vector<StatsComparison> pairwise_binary_boolean(
+        const std::vector<StatsComparison>& l, const std::vector<StatsComparison>& r, OperationType operation
+) {
+    util::check(
+            l.size() == r.size(), "Mismatched vector sizes in pairwise_binary_boolean: {} vs {}", l.size(), r.size()
+    );
+    std::vector<StatsComparison> result;
+    result.reserve(l.size());
+    for (size_t i = 0; i < l.size(); ++i) {
+        result.push_back(binary_boolean_stats(l[i], r[i], operation));
+    }
+    return result;
+}
+
+std::vector<StatsComparison> convert_boolean_stats_to_comparisons(const std::vector<ColumnStatsValues>& column_stats) {
+    std::vector<StatsComparison> result;
+    result.reserve(column_stats.size());
+    for (const auto& column_stat : column_stats) {
+        result.push_back(to_stats_comparison_for_boolean(column_stat));
+    }
+    return result;
+}
+
+std::vector<StatsComparison> broadcast_value(StatsComparison val, size_t size) { return std::vector(size, val); }
+
+} // namespace
+
 std::vector<StatsComparison> visit_binary_boolean_stats(
         const StatsVariantData& left, const StatsVariantData& right, OperationType operation
 ) {
-    // TODO aseaton remaining cases Monday: 11292565671
-    // StatsComparison & Value -> Only if Value is a bool
-    // StatsComparison & ColumnStatsValues -> Only if ColumnStatsValues are a bool
-    // Value & Value -> Only if Value is a bool
-    // ColumnStatsValues & ColumnStatsValues -> Only if a bool
-    // Value & ColumnStatsValues -> Only if a bool
     return std::visit(
             util::overload{
+                    // StatsComparison x StatsComparison
                     [operation](const std::vector<StatsComparison>& l, const std::vector<StatsComparison>& r)
+                            -> std::vector<StatsComparison> { return pairwise_binary_boolean(l, r, operation); },
+                    // StatsComparison x bool ColumnStatsValues
+                    [operation](const std::vector<StatsComparison>& l, const std::vector<ColumnStatsValues>& r)
                             -> std::vector<StatsComparison> {
-                        util::check(
-                                l.size() == r.size(),
-                                "Mismatched vector sizes in visit_binary_boolean_stats: {} vs {}",
-                                l.size(),
-                                r.size()
-                        );
-                        std::vector<StatsComparison> result;
-                        result.reserve(l.size());
-                        for (size_t i = 0; i < l.size(); ++i) {
-                            result.push_back(binary_boolean_stats(l.at(i), r.at(i), operation));
-                        }
-                        return result;
+                        return pairwise_binary_boolean(l, convert_boolean_stats_to_comparisons(r), operation);
                     },
-                    [&](const auto&, const auto&) -> std::vector<StatsComparison> {
-                        size_t sz = std::max(stats_variant_size(left), stats_variant_size(right));
-                        log::version().warn("Unsupported case in visit_binary_boolean_stats");
-                        return std::vector(sz, StatsComparison::UNKNOWN);
+                    // bool ColumnStatsValues x StatsComparison
+                    [operation](const std::vector<ColumnStatsValues>& l, const std::vector<StatsComparison>& r)
+                            -> std::vector<StatsComparison> {
+                        return pairwise_binary_boolean(convert_boolean_stats_to_comparisons(l), r, operation);
+                    },
+                    // bool ColumnStatsValues x bool ColumnStatsValues
+                    [operation](const std::vector<ColumnStatsValues>& l, const std::vector<ColumnStatsValues>& r)
+                            -> std::vector<StatsComparison> {
+                        return pairwise_binary_boolean(
+                                convert_boolean_stats_to_comparisons(l),
+                                convert_boolean_stats_to_comparisons(r),
+                                operation
+                        );
+                    },
+                    // StatsComparison x bool Value
+                    [operation](const std::vector<StatsComparison>& l, const std::shared_ptr<Value>& r)
+                            -> std::vector<StatsComparison> {
+                        return pairwise_binary_boolean(
+                                l, broadcast_value(to_stats_comparison_for_boolean(*r), l.size()), operation
+                        );
+                    },
+                    // bool Value x StatsComparison
+                    [operation](const std::shared_ptr<Value>& l, const std::vector<StatsComparison>& r)
+                            -> std::vector<StatsComparison> {
+                        return pairwise_binary_boolean(
+                                broadcast_value(to_stats_comparison_for_boolean(*l), r.size()), r, operation
+                        );
+                    },
+                    // ColumnStatsValues x bool Value
+                    [operation](const std::vector<ColumnStatsValues>& l, const std::shared_ptr<Value>& r)
+                            -> std::vector<StatsComparison> {
+                        auto converted_l = convert_boolean_stats_to_comparisons(l);
+                        return pairwise_binary_boolean(
+                                converted_l, broadcast_value(to_stats_comparison_for_boolean(*r), l.size()), operation
+                        );
+                    },
+                    // bool Value x ColumnStatsValues
+                    [operation](const std::shared_ptr<Value>& l, const std::vector<ColumnStatsValues>& r)
+                            -> std::vector<StatsComparison> {
+                        auto converted_r = convert_boolean_stats_to_comparisons(r);
+                        return pairwise_binary_boolean(
+                                broadcast_value(to_stats_comparison_for_boolean(*l), r.size()), converted_r, operation
+                        );
+                    },
+                    // The remaining combinations are invalid for boolean operations.
+                    // Each is listed explicitly so that adding a new type to StatsVariantData
+                    // produces a compile error rather than silently falling into a catch-all.
+                    [](const std::shared_ptr<Value>&, const std::shared_ptr<Value>&) -> std::vector<StatsComparison> {
+                        // q[True & False] fails earlier
+                        util::raise_rte("Value x Value is not valid in visit_binary_boolean_stats");
+                    },
+                    // The ValueSet cases should not fall in here, they should go to visit_binary_membership_stats
+                    [](const std::shared_ptr<ValueSet>&,
+                       const std::shared_ptr<ValueSet>&) -> std::vector<StatsComparison> {
+                        util::raise_rte("ValueSet x ValueSet is not valid in visit_binary_boolean_stats");
+                    },
+                    [](const std::shared_ptr<ValueSet>&, const auto&) -> std::vector<StatsComparison> {
+                        util::raise_rte("ValueSet x other is not valid in visit_binary_boolean_stats");
+                    },
+                    [](const auto&, const std::shared_ptr<ValueSet>&) -> std::vector<StatsComparison> {
+                        util::raise_rte("other x ValueSet is not valid in visit_binary_boolean_stats");
                     }
             },
             left,
@@ -242,7 +341,7 @@ StatsComparison unary_boolean_stats(const ColumnStatsValues& stats_values, Opera
     );
     bool min_val = stats_values.min->get<bool>();
     bool max_val = stats_values.max->get<bool>();
-    util::check(max_val >= min_val, "Should never have min_val=true and max_val=false");
+    util::check(!min_val || max_val, "Should never have min_val=true and max_val=false");
     // Cases:
     // min_val  max_val  IDENTITY   NEG
     // false    true     UNKNOWN    UNKNOWN

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
@@ -148,19 +148,6 @@ std::vector<StatsComparison> visit_binary_membership_stats(
     );
 }
 
-bool value_is_nan(const Value& val) {
-    if (is_floating_point_type(val.data_type())) {
-        return details::visit_type(val.data_type(), [&val]<typename TagType>(TagType) -> bool {
-            using RawType = TagType::raw_type;
-            if constexpr (std::is_floating_point_v<RawType>) {
-                return std::isnan(val.get<RawType>());
-            }
-            return false;
-        });
-    }
-    return false;
-}
-
 StatsComparison to_stats_comparison_for_boolean(const ColumnStatsValues& csv) {
     return unary_boolean_stats(csv, OperationType::IDENTITY);
 }
@@ -224,8 +211,6 @@ std::vector<StatsComparison> convert_boolean_stats_to_comparisons(const std::vec
     return result;
 }
 
-std::vector<StatsComparison> broadcast_value(StatsComparison val, size_t size) { return std::vector(size, val); }
-
 } // namespace
 
 std::vector<StatsComparison> visit_binary_boolean_stats(
@@ -255,36 +240,6 @@ std::vector<StatsComparison> visit_binary_boolean_stats(
                                 operation
                         );
                     },
-                    // StatsComparison x bool Value
-                    [operation](const std::vector<StatsComparison>& l, const std::shared_ptr<Value>& r)
-                            -> std::vector<StatsComparison> {
-                        return pairwise_binary_boolean(
-                                l, broadcast_value(to_stats_comparison_for_boolean(*r), l.size()), operation
-                        );
-                    },
-                    // bool Value x StatsComparison
-                    [operation](const std::shared_ptr<Value>& l, const std::vector<StatsComparison>& r)
-                            -> std::vector<StatsComparison> {
-                        return pairwise_binary_boolean(
-                                broadcast_value(to_stats_comparison_for_boolean(*l), r.size()), r, operation
-                        );
-                    },
-                    // ColumnStatsValues x bool Value
-                    [operation](const std::vector<ColumnStatsValues>& l, const std::shared_ptr<Value>& r)
-                            -> std::vector<StatsComparison> {
-                        auto converted_l = convert_boolean_stats_to_comparisons(l);
-                        return pairwise_binary_boolean(
-                                converted_l, broadcast_value(to_stats_comparison_for_boolean(*r), l.size()), operation
-                        );
-                    },
-                    // bool Value x ColumnStatsValues
-                    [operation](const std::shared_ptr<Value>& l, const std::vector<ColumnStatsValues>& r)
-                            -> std::vector<StatsComparison> {
-                        auto converted_r = convert_boolean_stats_to_comparisons(r);
-                        return pairwise_binary_boolean(
-                                broadcast_value(to_stats_comparison_for_boolean(*l), r.size()), converted_r, operation
-                        );
-                    },
                     // The remaining combinations are invalid for boolean operations.
                     // Each is listed explicitly so that adding a new type to StatsVariantData
                     // produces a compile error rather than silently falling into a catch-all.
@@ -297,12 +252,30 @@ std::vector<StatsComparison> visit_binary_boolean_stats(
                        const std::shared_ptr<ValueSet>&) -> std::vector<StatsComparison> {
                         util::raise_rte("ValueSet x ValueSet is not valid in visit_binary_boolean_stats");
                     },
+                    [](const std::shared_ptr<ValueSet>&,
+                       const std::shared_ptr<Value>&) -> std::vector<StatsComparison> {
+                        util::raise_rte("ValueSet x Value is not valid in visit_binary_boolean_stats");
+                    },
+                    [](const std::shared_ptr<Value>&,
+                       const std::shared_ptr<ValueSet>&) -> std::vector<StatsComparison> {
+                        util::raise_rte("Value x ValueSet is not valid in visit_binary_boolean_stats");
+                    },
                     [](const std::shared_ptr<ValueSet>&, const auto&) -> std::vector<StatsComparison> {
                         util::raise_rte("ValueSet x other is not valid in visit_binary_boolean_stats");
                     },
                     [](const auto&, const std::shared_ptr<ValueSet>&) -> std::vector<StatsComparison> {
                         util::raise_rte("other x ValueSet is not valid in visit_binary_boolean_stats");
-                    }
+                    },
+                    // any x bool Value
+                    [](const auto&, const std::shared_ptr<Value>&) -> std::vector<StatsComparison> {
+                        util::raise_rte("other x Value is not valid in visit_binary_boolean_stats (should have been "
+                                        "simplified in Python layer)");
+                    },
+                    // bool Value x any
+                    [](const std::shared_ptr<Value>&, const auto&) -> std::vector<StatsComparison> {
+                        util::raise_rte("Value x other is not valid in visit_binary_boolean_stats (should have been "
+                                        "simplified in Python layer)");
+                    },
             },
             left,
             right

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -14,7 +14,9 @@
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/operation_types.hpp>
 #include <arcticdb/entity/type_conversion.hpp>
+#include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/entity/types.hpp>
+#include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/variant.hpp>
 
 #include <memory>
@@ -49,6 +51,27 @@ StatsVariantData compute_stats(
 namespace column_stats_detail {
 
 size_t stats_variant_size(const StatsVariantData& v);
+
+bool value_is_nan(const Value& val);
+
+template<DataType StatsType, DataType ValType>
+void check_no_mixed_bool_comparison(const Value& stats_val, const Value& query_val) {
+    constexpr bool stats_is_bool = is_bool_type(StatsType);
+    constexpr bool val_is_bool = is_bool_type(ValType);
+    if constexpr (stats_is_bool && !val_is_bool) {
+        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                "Invalid comparison: cannot compare bool column ({}) with non-bool value ({})",
+                get_user_friendly_type_string(stats_val.descriptor()),
+                get_user_friendly_type_string(query_val.descriptor())
+        );
+    } else if constexpr (!stats_is_bool && val_is_bool) {
+        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                "Invalid comparison: cannot compare non-bool column ({}) with bool value ({})",
+                get_user_friendly_type_string(stats_val.descriptor()),
+                get_user_friendly_type_string(query_val.descriptor())
+        );
+    }
+}
 
 template<typename Func>
 struct FlippedComparator;
@@ -90,11 +113,14 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Value
         return details::visit_type(val_rhs.data_type(), [&](auto val_tag) -> StatsComparison {
             using ValTag = std::remove_reference_t<decltype(val_tag)>;
 
-            // bools are disabled in this part of the grammar at the moment, Monday: 11292565671
             // Monday: 8065794446 we should disallow comparing time types to non-time numeric types
             // This is also wrong downstream in the rest of the processing pipeline
-            if constexpr ((is_numeric_type(StatsTag::data_type) || is_time_type(StatsTag::data_type)) &&
-                          (is_numeric_type(ValTag::data_type) || is_time_type(ValTag::data_type))) {
+            constexpr bool stats_supported = is_numeric_type(StatsTag::data_type) ||
+                                             is_time_type(StatsTag::data_type) || is_bool_type(StatsTag::data_type);
+            constexpr bool val_supported = is_numeric_type(ValTag::data_type) || is_time_type(ValTag::data_type) ||
+                                           is_bool_type(ValTag::data_type);
+            check_no_mixed_bool_comparison<StatsTag::data_type, ValTag::data_type>(*stats_lhs.min, val_rhs);
+            if constexpr (stats_supported && val_supported) {
                 using StatsRawType = StatsTag::raw_type;
                 using ValRawType = ValTag::raw_type;
                 using comp = Comparable<StatsRawType, ValRawType>;
@@ -144,6 +170,9 @@ std::vector<StatsComparison> visit_binary_comparator_stats(
             right
     );
 }
+
+StatsComparison to_stats_comparison_for_boolean(const ColumnStatsValues& csv);
+StatsComparison to_stats_comparison_for_boolean(const Value& val);
 
 StatsComparison stats_membership_comparator(const ColumnStatsValues& stats, ValueSet& value_set, OperationType op);
 

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -52,8 +52,6 @@ namespace column_stats_detail {
 
 size_t stats_variant_size(const StatsVariantData& v);
 
-bool value_is_nan(const Value& val);
-
 template<DataType StatsType, DataType ValType>
 void check_no_mixed_bool_comparison(const Value& stats_val, const Value& query_val) {
     constexpr bool stats_is_bool = is_bool_type(StatsType);

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -117,8 +117,11 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Value
                                              is_time_type(StatsTag::data_type) || is_bool_type(StatsTag::data_type);
             constexpr bool val_supported = is_numeric_type(ValTag::data_type) || is_time_type(ValTag::data_type) ||
                                            is_bool_type(ValTag::data_type);
+            // Mixed bool/non-bool comparisons are rejected at runtime by check_no_mixed_bool_comparison.
+            // MSVC C4804 treats `numeric > bool` as an error.
+            constexpr bool bool_compatible = is_bool_type(StatsTag::data_type) == is_bool_type(ValTag::data_type);
             check_no_mixed_bool_comparison<StatsTag::data_type, ValTag::data_type>(*stats_lhs.min, val_rhs);
-            if constexpr (stats_supported && val_supported) {
+            if constexpr (stats_supported && val_supported && bool_compatible) {
                 using StatsRawType = StatsTag::raw_type;
                 using ValRawType = ValTag::raw_type;
                 using comp = Comparable<StatsRawType, ValRawType>;

--- a/cpp/arcticdb/pipeline/test/test_column_stats_dispatch.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_dispatch.cpp
@@ -1462,3 +1462,191 @@ INSTANTIATE_TEST_SUITE_P(
                 std::make_tuple(OperationType::NE, StatsComparison::ALL_MATCH)
         )
 );
+
+// Parameters: (min, max, query_value, op, expected)
+class BoolValueRangeComparisonTest
+    : public ::testing::TestWithParam<std::tuple<bool, bool, bool, OperationType, StatsComparison>> {};
+
+TEST_P(BoolValueRangeComparisonTest, AllCases) {
+    auto [min, max, value, op, expected] = GetParam();
+    std::vector<ColumnStatsValues> stats{{construct_value(min), construct_value(max)}};
+    auto query = std::make_shared<Value>(construct_value(value));
+    auto result = std::get<std::vector<StatsComparison>>(dispatch_binary_stats(stats, query, op));
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_EQ(result.at(0), expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        LessThan, BoolValueRangeComparisonTest,
+        ::testing::Values(
+                // [false, false] < false -> NONE_MATCH (min=false >= false)
+                std::make_tuple(false, false, false, OperationType::LT, StatsComparison::NONE_MATCH),
+                // [false, false] < true -> ALL_MATCH (max=false < true)
+                std::make_tuple(false, false, true, OperationType::LT, StatsComparison::ALL_MATCH),
+                // [false, true] < false -> NONE_MATCH (min=false >= false)
+                std::make_tuple(false, true, false, OperationType::LT, StatsComparison::NONE_MATCH),
+                // [false, true] < true -> UNKNOWN (min=false < true but max=true >= true)
+                std::make_tuple(false, true, true, OperationType::LT, StatsComparison::UNKNOWN),
+                // [true, true] < false -> NONE_MATCH (min=true >= false)
+                std::make_tuple(true, true, false, OperationType::LT, StatsComparison::NONE_MATCH),
+                // [true, true] < true -> NONE_MATCH (min=true >= true)
+                std::make_tuple(true, true, true, OperationType::LT, StatsComparison::NONE_MATCH)
+        )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        LessThanEquals, BoolValueRangeComparisonTest,
+        ::testing::Values(
+                // [false, false] <= false -> ALL_MATCH
+                std::make_tuple(false, false, false, OperationType::LE, StatsComparison::ALL_MATCH),
+                // [false, false] <= true -> ALL_MATCH
+                std::make_tuple(false, false, true, OperationType::LE, StatsComparison::ALL_MATCH),
+                // [false, true] <= false -> UNKNOWN
+                std::make_tuple(false, true, false, OperationType::LE, StatsComparison::UNKNOWN),
+                // [false, true] <= true -> ALL_MATCH
+                std::make_tuple(false, true, true, OperationType::LE, StatsComparison::ALL_MATCH),
+                // [true, true] <= false -> NONE_MATCH
+                std::make_tuple(true, true, false, OperationType::LE, StatsComparison::NONE_MATCH),
+                // [true, true] <= true -> ALL_MATCH
+                std::make_tuple(true, true, true, OperationType::LE, StatsComparison::ALL_MATCH)
+        )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        GreaterThan, BoolValueRangeComparisonTest,
+        ::testing::Values(
+                // [false, false] > false -> NONE_MATCH
+                std::make_tuple(false, false, false, OperationType::GT, StatsComparison::NONE_MATCH),
+                // [false, false] > true -> NONE_MATCH
+                std::make_tuple(false, false, true, OperationType::GT, StatsComparison::NONE_MATCH),
+                // [false, true] > false -> UNKNOWN
+                std::make_tuple(false, true, false, OperationType::GT, StatsComparison::UNKNOWN),
+                // [false, true] > true -> NONE_MATCH
+                std::make_tuple(false, true, true, OperationType::GT, StatsComparison::NONE_MATCH),
+                // [true, true] > false -> ALL_MATCH
+                std::make_tuple(true, true, false, OperationType::GT, StatsComparison::ALL_MATCH),
+                // [true, true] > true -> NONE_MATCH
+                std::make_tuple(true, true, true, OperationType::GT, StatsComparison::NONE_MATCH)
+        )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        GreaterThanEquals, BoolValueRangeComparisonTest,
+        ::testing::Values(
+                // [false, false] >= false -> ALL_MATCH
+                std::make_tuple(false, false, false, OperationType::GE, StatsComparison::ALL_MATCH),
+                // [false, false] >= true -> NONE_MATCH
+                std::make_tuple(false, false, true, OperationType::GE, StatsComparison::NONE_MATCH),
+                // [false, true] >= false -> ALL_MATCH
+                std::make_tuple(false, true, false, OperationType::GE, StatsComparison::ALL_MATCH),
+                // [false, true] >= true -> UNKNOWN
+                std::make_tuple(false, true, true, OperationType::GE, StatsComparison::UNKNOWN),
+                // [true, true] >= false -> ALL_MATCH
+                std::make_tuple(true, true, false, OperationType::GE, StatsComparison::ALL_MATCH),
+                // [true, true] >= true -> ALL_MATCH
+                std::make_tuple(true, true, true, OperationType::GE, StatsComparison::ALL_MATCH)
+        )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        Equals, BoolValueRangeComparisonTest,
+        ::testing::Values(
+                // [false, false] == false -> ALL_MATCH
+                std::make_tuple(false, false, false, OperationType::EQ, StatsComparison::ALL_MATCH),
+                // [false, false] == true -> NONE_MATCH
+                std::make_tuple(false, false, true, OperationType::EQ, StatsComparison::NONE_MATCH),
+                // [false, true] == false -> UNKNOWN
+                std::make_tuple(false, true, false, OperationType::EQ, StatsComparison::UNKNOWN),
+                // [false, true] == true -> UNKNOWN
+                std::make_tuple(false, true, true, OperationType::EQ, StatsComparison::UNKNOWN),
+                // [true, true] == false -> NONE_MATCH
+                std::make_tuple(true, true, false, OperationType::EQ, StatsComparison::NONE_MATCH),
+                // [true, true] == true -> ALL_MATCH
+                std::make_tuple(true, true, true, OperationType::EQ, StatsComparison::ALL_MATCH)
+        )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        NotEquals, BoolValueRangeComparisonTest,
+        ::testing::Values(
+                // [false, false] != false -> NONE_MATCH
+                std::make_tuple(false, false, false, OperationType::NE, StatsComparison::NONE_MATCH),
+                // [false, false] != true -> ALL_MATCH
+                std::make_tuple(false, false, true, OperationType::NE, StatsComparison::ALL_MATCH),
+                // [false, true] != false -> UNKNOWN
+                std::make_tuple(false, true, false, OperationType::NE, StatsComparison::UNKNOWN),
+                // [false, true] != true -> UNKNOWN
+                std::make_tuple(false, true, true, OperationType::NE, StatsComparison::UNKNOWN),
+                // [true, true] != false -> ALL_MATCH
+                std::make_tuple(true, true, false, OperationType::NE, StatsComparison::ALL_MATCH),
+                // [true, true] != true -> NONE_MATCH
+                std::make_tuple(true, true, true, OperationType::NE, StatsComparison::NONE_MATCH)
+        )
+);
+
+// Parameters: (min_opt, max_opt, query_val, op, expected)
+class BoolStatsComparatorTest
+    : public ::testing::TestWithParam<
+              std::tuple<std::optional<bool>, std::optional<bool>, bool, OperationType, StatsComparison>> {};
+
+TEST_P(BoolStatsComparatorTest, AllCases) {
+    auto [min_opt, max_opt, query_val, op, expected] = GetParam();
+    std::optional<Value> min_val = min_opt.has_value() ? std::optional{construct_value(*min_opt)} : std::nullopt;
+    std::optional<Value> max_val = max_opt.has_value() ? std::optional{construct_value(*max_opt)} : std::nullopt;
+    std::vector<ColumnStatsValues> stats{{min_val, max_val}};
+    auto query = std::make_shared<Value>(construct_value(query_val));
+    auto result = std::get<std::vector<StatsComparison>>(dispatch_binary_stats(stats, query, op));
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_EQ(result.at(0), expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        MissingStats, BoolStatsComparatorTest,
+        ::testing::Values(
+                // Both missing -> UNKNOWN
+                std::make_tuple(
+                        std::optional<bool>{}, std::optional<bool>{}, true, OperationType::EQ, StatsComparison::UNKNOWN
+                ),
+                std::make_tuple(
+                        std::optional<bool>{}, std::optional<bool>{}, false, OperationType::GT, StatsComparison::UNKNOWN
+                )
+        )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        BoolVsBool, BoolStatsComparatorTest,
+        ::testing::Values(
+                // [false, false] == false -> ALL_MATCH
+                std::make_tuple(
+                        std::optional{false}, std::optional{false}, false, OperationType::EQ, StatsComparison::ALL_MATCH
+                ),
+                // [false, false] == true -> NONE_MATCH
+                std::make_tuple(
+                        std::optional{false}, std::optional{false}, true, OperationType::EQ, StatsComparison::NONE_MATCH
+                ),
+                // [true, true] == true -> ALL_MATCH
+                std::make_tuple(
+                        std::optional{true}, std::optional{true}, true, OperationType::EQ, StatsComparison::ALL_MATCH
+                ),
+                // [true, true] > false -> ALL_MATCH
+                std::make_tuple(
+                        std::optional{true}, std::optional{true}, false, OperationType::GT, StatsComparison::ALL_MATCH
+                ),
+                // [false, true] < true -> UNKNOWN
+                std::make_tuple(
+                        std::optional{false}, std::optional{true}, true, OperationType::LT, StatsComparison::UNKNOWN
+                ),
+                // [false, false] != true -> ALL_MATCH
+                std::make_tuple(
+                        std::optional{false}, std::optional{false}, true, OperationType::NE, StatsComparison::ALL_MATCH
+                ),
+                // [false, true] >= true -> UNKNOWN
+                std::make_tuple(
+                        std::optional{false}, std::optional{true}, true, OperationType::GE, StatsComparison::UNKNOWN
+                ),
+                // [false, false] < true -> ALL_MATCH
+                std::make_tuple(
+                        std::optional{false}, std::optional{false}, true, OperationType::LT, StatsComparison::ALL_MATCH
+                )
+        )
+);

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -378,6 +378,8 @@ struct LessThanOperator {
     bool operator()(T t, U u) const {
         return t < u;
     }
+    // MSVC warns about using < on bool (C4804). Cast to int to suppress.
+    bool operator()(bool t, bool u) const { return static_cast<int>(t) < static_cast<int>(u); }
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Less than operator not supported with strings");
@@ -404,6 +406,7 @@ struct LessThanEqualsOperator {
     bool operator()(T t, U u) const {
         return t <= u;
     }
+    bool operator()(bool t, bool u) const { return static_cast<int>(t) <= static_cast<int>(u); }
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Less than equals operator not supported with strings");
@@ -430,6 +433,7 @@ struct GreaterThanOperator {
     bool operator()(T t, U u) const {
         return t > u;
     }
+    bool operator()(bool t, bool u) const { return static_cast<int>(t) > static_cast<int>(u); }
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Greater than operator not supported with strings");
@@ -456,6 +460,7 @@ struct GreaterThanEqualsOperator {
     bool operator()(T t, U u) const {
         return t >= u;
     }
+    bool operator()(bool t, bool u) const { return static_cast<int>(t) >= static_cast<int>(u); }
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Greater than equals operator not supported with strings");
@@ -482,6 +487,7 @@ struct EqualsOperator {
     bool operator()(T t, U u) const {
         return t == u;
     }
+    bool operator()(bool t, bool u) const { return static_cast<int>(t) == static_cast<int>(u); }
     template<typename T>
     bool operator()(T t, std::optional<T> u) const {
         if (u.has_value())
@@ -536,6 +542,7 @@ struct NotEqualsOperator {
     bool operator()(T t, U u) const {
         return t != u;
     }
+    bool operator()(bool t, bool u) const { return static_cast<int>(t) != static_cast<int>(u); }
     template<typename T>
     bool operator()(T t, std::optional<T> u) const {
         if (u.has_value())

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -378,8 +378,8 @@ struct LessThanOperator {
     bool operator()(T t, U u) const {
         return t < u;
     }
-    // MSVC warns about using < on bool (C4804). Cast to int to suppress.
-    bool operator()(bool t, bool u) const { return static_cast<int>(t) < static_cast<int>(u); }
+    // MSVC warns about using < on bool (C4804).
+    bool operator()(bool t, bool u) const { return !t && u; }
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Less than operator not supported with strings");
@@ -406,7 +406,10 @@ struct LessThanEqualsOperator {
     bool operator()(T t, U u) const {
         return t <= u;
     }
-    bool operator()(bool t, bool u) const { return static_cast<int>(t) <= static_cast<int>(u); }
+
+    // MSVC warns about using comparisons on bool (C4804).
+    bool operator()(bool t, bool u) const { return !t || (t && u); }
+
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Less than equals operator not supported with strings");
@@ -433,7 +436,10 @@ struct GreaterThanOperator {
     bool operator()(T t, U u) const {
         return t > u;
     }
-    bool operator()(bool t, bool u) const { return static_cast<int>(t) > static_cast<int>(u); }
+
+    // MSVC warns about using comparisons on bool (C4804).
+    bool operator()(bool t, bool u) const { return t && !u; }
+
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Greater than operator not supported with strings");
@@ -460,7 +466,10 @@ struct GreaterThanEqualsOperator {
     bool operator()(T t, U u) const {
         return t >= u;
     }
-    bool operator()(bool t, bool u) const { return static_cast<int>(t) >= static_cast<int>(u); }
+
+    // MSVC warns about using comparisons on bool (C4804).
+    bool operator()(bool t, bool u) const { return t || !u; }
+
     template<typename T>
     bool operator()(std::optional<T>, T) const {
         util::raise_rte("Greater than equals operator not supported with strings");
@@ -487,7 +496,7 @@ struct EqualsOperator {
     bool operator()(T t, U u) const {
         return t == u;
     }
-    bool operator()(bool t, bool u) const { return static_cast<int>(t) == static_cast<int>(u); }
+
     template<typename T>
     bool operator()(T t, std::optional<T> u) const {
         if (u.has_value())
@@ -542,7 +551,6 @@ struct NotEqualsOperator {
     bool operator()(T t, U u) const {
         return t != u;
     }
-    bool operator()(bool t, bool u) const { return static_cast<int>(t) != static_cast<int>(u); }
     template<typename T>
     bool operator()(T t, std::optional<T> u) const {
         if (u.has_value())

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -9,6 +9,8 @@ from arcticdb.version_store.processing import QueryBuilder
 import arcticdb.toolbox.query_stats as qs
 import pandas as pd
 
+from arcticdb_ext.exceptions import UserInputException
+
 
 def get_table_data_read_count():
     """Get the number of TABLE_DATA keys read from query stats."""
@@ -1386,3 +1388,190 @@ def test_column_stats_empty_stats(in_memory_version_store, column_stats_filterin
     q = q[q["col"] > 0]
     result = lib.read(sym, query_builder=q).data
     assert len(result) == 3
+
+
+@pytest.mark.parametrize(
+    "query_expr,expected_reads",
+    [
+        pytest.param(lambda q: q["bool_col"] == True, 2, id="eq_true"),  # noqa: E712
+        pytest.param(lambda q: q["bool_col"] == False, 2, id="eq_false"),  # noqa: E712
+        pytest.param(lambda q: q["bool_col"] != True, 2, id="ne_true"),  # noqa: E712
+        pytest.param(lambda q: q["bool_col"] != False, 2, id="ne_false"),  # noqa: E712
+        pytest.param(lambda q: True == q["bool_col"], 2, id="true_eq"),  # noqa: E712
+        pytest.param(lambda q: False == q["bool_col"], 2, id="false_eq"),  # noqa: E712
+    ],
+)
+def test_column_stats_bool_comparison_operators(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, expected_reads
+):
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"bool_col": [True, True]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"bool_col": [False, True]}, index=pd.date_range("2000-01-03", periods=2))
+    df2 = pd.DataFrame({"bool_col": [False, False]}, index=pd.date_range("2000-01-05", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.append(sym, df2)
+
+    lib.create_column_stats(sym, {"bool_col": {"MINMAX"}})
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    full_df = pd.concat([df0, df1, df2])
+    expected = full_df[query_expr(full_df)]
+    assert_frame_equal(expected, result)
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA reads, got {table_data_reads}"
+
+
+@pytest.mark.parametrize(
+    "query_expr,expected_reads",
+    [
+        pytest.param(lambda q: (q["int_col"] > 4) & q["bool_col"], 1, id="comparison_and_bool_col"),
+        pytest.param(lambda q: q["bool_col"] & (q["int_col"] > 4), 1, id="bool_col_and_comparison"),
+        pytest.param(lambda q: (q["int_col"] > 4) & q["bool_col"], 1, id="bool_col_and_comparison_flipped"),
+        pytest.param(lambda q: (q["int_col"] > 4) | q["bool_col"], 1, id="comparison_or_bool_col"),
+    ],
+)
+def test_column_stats_bool_col_combined_with_comparison(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, expected_reads
+):
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"int_col": [1, 2], "bool_col": [False, False]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"int_col": [5, 6], "bool_col": [True, True]}, index=pd.date_range("2000-01-03", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+
+    lib.create_column_stats(sym, {"int_col": {"MINMAX"}, "bool_col": {"MINMAX"}})
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    full_df = pd.concat([df0, df1])
+    expected = full_df[query_expr(full_df)]
+    assert_frame_equal(expected, result)
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA reads, got {table_data_reads}"
+
+
+@pytest.mark.parametrize(
+    "query_expr",
+    [
+        lambda q: q["b"] & True,
+        lambda q: q["b"] | False,
+        lambda q: True & q["b"],
+        lambda q: False | q["b"],
+    ],
+    ids=["and_true", "or_false", "true_and", "false_or"],
+)
+def test_column_stats_bool_col_and_bool_value(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr
+):
+    """Test expressions like `q["b"] & True`"""
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"b": [False, False]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"b": [True, True]}, index=pd.date_range("2000-01-03", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.create_column_stats(sym, {"b": {"MINMAX"}})
+
+    qs.enable()
+
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+    assert_frame_equal(result, df1)
+    assert table_data_reads == 1, f"Expected 1 read, got {table_data_reads}"
+
+
+def test_column_stats_two_bool_cols(in_memory_version_store, clear_query_stats, column_stats_filtering_enabled):
+    """Test binary boolean operation between two bool columns"""
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"b1": [True, True], "b2": [False, False]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"b1": [True, True], "b2": [True, True]}, index=pd.date_range("2000-01-03", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.create_column_stats(sym, {"b1": {"MINMAX"}, "b2": {"MINMAX"}})
+
+    qs.enable()
+
+    q = QueryBuilder()
+    q = q[q["b1"] & q["b2"]]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+    assert_frame_equal(result, df1)
+    assert table_data_reads == 1, f"Expected 1 read, got {table_data_reads}"
+
+
+@pytest.mark.xfail("Needs support for col-col comparisons")
+def test_column_stats_two_bool_cols_comparison(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
+):
+    """Test binary boolean operation between two bool columns"""
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"b1": [True, True], "b2": [False, False]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"b1": [True, True], "b2": [True, True]}, index=pd.date_range("2000-01-03", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.create_column_stats(sym, {"b1": {"MINMAX"}, "b2": {"MINMAX"}})
+
+    qs.enable()
+
+    q = QueryBuilder()
+    q = q[q["b1"] > q["b2"]]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+    assert_frame_equal(result, df0)
+    assert table_data_reads == 1, f"Expected 1 read, got {table_data_reads}"
+
+
+def test_column_stats_bool_vs_int_cross_type(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
+):
+    """Cross-type bool-vs-int comparisons (e.g. bool_col > 0) are rejected by the
+    processing layer."""
+    lib = in_memory_version_store
+
+    # seg0: all-true, seg1: all-false
+    df0 = pd.DataFrame({"bool_col": [True, True]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"bool_col": [False, False]}, index=pd.date_range("2000-01-03", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.create_column_stats(sym, {"bool_col": {"MINMAX"}})
+
+    # When a surviving segment is processed, the cross-type comparison is rejected
+    q = QueryBuilder()
+    q = q[q["bool_col"] > 0]
+    with pytest.raises(UserInputException):
+        lib.read(sym, query_builder=q)
+
+    # When column stats prune ALL segments, schema validation still rejects it
+    df_only_false = pd.DataFrame({"bool_col": [False, False]}, index=pd.date_range("2000-01-01", periods=2))
+    lib.write(sym, df_only_false)
+    lib.create_column_stats(sym, {"bool_col": {"MINMAX"}})
+
+    q = QueryBuilder()
+    q = q[q["bool_col"] > 0]
+    with pytest.raises(UserInputException):
+        lib.read(sym, query_builder=q)

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -1432,10 +1432,10 @@ def test_column_stats_bool_comparison_operators(
 @pytest.mark.parametrize(
     "query_expr,expected_reads",
     [
-        pytest.param(lambda q: (q["int_col"] > 4) & q["bool_col"], 1, id="comparison_and_bool_col"),
-        pytest.param(lambda q: q["bool_col"] & (q["int_col"] > 4), 1, id="bool_col_and_comparison"),
-        pytest.param(lambda q: (q["int_col"] > 4) & q["bool_col"], 1, id="bool_col_and_comparison_flipped"),
-        pytest.param(lambda q: (q["int_col"] > 4) | q["bool_col"], 1, id="comparison_or_bool_col"),
+        pytest.param(lambda q: (q["int_col"] > 4) & q["bool_col"], 1, id="int_col_and_bool_col"),
+        pytest.param(lambda q: q["bool_col"] & (q["int_col"] > 4), 1, id="bool_col_and_int_col"),
+        pytest.param(lambda q: (q["int_col"] > 4) | q["bool_col"], 1, id="int_col_or_bool_col"),
+        pytest.param(lambda q: q["bool_col"] | (q["int_col"] > 4), 1, id="bool_col_or_int_col"),
     ],
 )
 def test_column_stats_bool_col_combined_with_comparison(
@@ -1520,7 +1520,7 @@ def test_column_stats_two_bool_cols(in_memory_version_store, clear_query_stats, 
     assert table_data_reads == 1, f"Expected 1 read, got {table_data_reads}"
 
 
-@pytest.mark.xfail("Needs support for col-col comparisons")
+@pytest.mark.xfail(reason="Needs support for col-col comparisons")
 def test_column_stats_two_bool_cols_comparison(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
 ):


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 11292569665

#### What does this implement or fix?

Use column stats for comparisons against bool columns, like:

```
q["int_col"] > 4) & q["bool_col"]
```

This may be useful if a block is full of True or False values only, although it is unclear how often it will help in practice. You can imagine a flag that might be set to False on old data and True on newer data to see that this might actually be quite useful.

This also supports more verbose forms like:

```
False == q["bool_col"]
```