### PR TITLE
ASV benchmarks for column stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,5 +151,5 @@ install-editable: ## Install arcticdb in editable mode
 	$(PROXY_CMD) $(_VENV_PIP) install -e . --no-deps
 
 # ── bench-py ─────────────────────────────────────────────────────────────────
-bench-py: install-editable ## Run ASV Python benchmarks (BENCH= for --bench filter)
-	$(_VENV_PYTHON) -m asv run --python=same -v --show-stderr $(if $(BENCH),--bench $(BENCH))
+bench-py: install-editable ## Run ASV Python benchmarks (BENCH= for --bench filter, QUICK=1 for single iteration)
+	$(_VENV_PYTHON) -m asv run --python=same -v --show-stderr $(if $(QUICK),--quick) $(if $(BENCH),--bench $(BENCH))

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -1556,6 +1556,502 @@
         "version": "3cd2c7d90725498da459157638eb15b5a3fcc68aa91684951717ed5ab1c8ca63",
         "warmup_time": 0
     },
+    "column_stats.ColumnStatsCreate.time_create_column_stats": {
+        "code": "class ColumnStatsCreate:\n    def time_create_column_stats(self, *args):\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        # Drop stats so time_ measures creation from scratch\n        self.nvs.drop_column_stats(self.symbol)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsCreate.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsCreate.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsCreate.time_create_column_stats",
+        "number": 1,
+        "param_names": [
+            "num_rows",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "repeat": 0,
+        "rounds": 2,
+        "sample_time": 0.01,
+        "setup_cache_key": "column_stats:243",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "37ae3b0b362b4403bf5cc8e055a098712609664f344542f69e603a6be2c38fe6",
+        "warmup_time": 0
+    },
+    "column_stats.ColumnStatsManagement.time_drop_column_stats": {
+        "code": "class ColumnStatsManagement:\n    def time_drop_column_stats(self, *args):\n        self.nvs.drop_column_stats(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsManagement.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsManagement.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsManagement.time_drop_column_stats",
+        "number": 1,
+        "param_names": [
+            "num_rows",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "repeat": 0,
+        "rounds": 2,
+        "sample_time": 0.01,
+        "setup_cache_key": "column_stats:287",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "e8ac44df433a44200b6a538db48dde33d8144c219306d284051d70b5c8c1ca2d",
+        "warmup_time": 0
+    },
+    "column_stats.ColumnStatsManagement.time_get_column_stats_info": {
+        "code": "class ColumnStatsManagement:\n    def time_get_column_stats_info(self, *args):\n        self.nvs.get_column_stats_info(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsManagement.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsManagement.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsManagement.time_get_column_stats_info",
+        "number": 1,
+        "param_names": [
+            "num_rows",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "repeat": 0,
+        "rounds": 2,
+        "sample_time": 0.01,
+        "setup_cache_key": "column_stats:287",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "b7c703433b5d5997475127cf3a4bf3ac6d58cd6cc3fb8172a2b9abef9cb3ff2a",
+        "warmup_time": 0
+    },
+    "column_stats.ColumnStatsManagement.time_read_column_stats": {
+        "code": "class ColumnStatsManagement:\n    def time_read_column_stats(self, *args):\n        self.nvs.read_column_stats(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsManagement.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsManagement.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsManagement.time_read_column_stats",
+        "number": 1,
+        "param_names": [
+            "num_rows",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "repeat": 0,
+        "rounds": 2,
+        "sample_time": 0.01,
+        "setup_cache_key": "column_stats:287",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "18e6e8c2283903300366c1c8b824045b5d14e4c7594dd43e2a092b177aa99f41",
+        "warmup_time": 0
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_bool": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_bool(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"bool_col\"] == True]\n        self.lib.read(self.symbol, columns=[\"bool_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_bool",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "1f230dcdaedf7f0e949f21f7e6cce17975354ced56811633820cc0837ec6b0f1",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_combined_and": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_combined_and(self, *args):\n        q = QueryBuilder()\n        q = q[(q[\"uint64_col\"] > self.uint64_high) & (q[\"float_col\"] > 900.0)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\", \"float_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_combined_and",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "9ace40d640224399bf0c06ea47efe1717ffb90512ec8080e26fc02f1cfe1785d",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_combined_or": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_combined_or(self, *args):\n        q = QueryBuilder()\n        q = q[(q[\"uint64_col\"] < self.uint64_low) | (q[\"float_col\"] > 900.0)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\", \"float_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_combined_or",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "a5b267335062002eea45cede70d4f06c67ec639fa89eaef50fa0ac0b4e233184",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_datetime": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_datetime(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"datetime_col\"] > self.datetime_high]\n        self.lib.read(self.symbol, columns=[\"datetime_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_datetime",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "9bb3361e680d29ee14395c5eab579b8a0e039bc84fdc22f5cee81c44094ae0cb",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_float": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_float(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"float_col\"] > 900.0]\n        self.lib.read(self.symbol, columns=[\"float_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_float",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "a8429bc6881f84f4e06f9df428d74c5acc2ac3e25575f4004f5757521e082a34",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_uint64": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_uint64(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] < self.uint64_low]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_uint64",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "7de9e9a56f47cc6ea6e25484679a94cbf5fe40bad50425079123664cef71f9a3",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_with_date_range": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_with_date_range(self, *args):\n        \"\"\"date_range narrows to 50% of rows, then filter selects the top 10% of uint64 values.\n    \n        Tests whether stats provide additional pruning on top of index-based date range filtering.\n        \"\"\"\n        if not self.data_ordered:\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] > self.uint64_high]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], date_range=self.date_range_half, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_with_date_range",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "38d1ac195a18e232fcf4a11e91b1da26b94658ccb16943b8cff246aa381b9c0c",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_filter_zero_match": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_zero_match(self, *args):\n        \"\"\"Filter that matches no rows, best case for column stats.\"\"\"\n        if not self.data_ordered:\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] > self.zero_match_threshold]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_filter_zero_match",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "e843c513aa00f199b3e699843faf7731a68967bf1c7d09b77b8f08ff9fefd2bc",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_isin_uint64": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_isin_uint64(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"].isin(self.isin_values)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_isin_uint64",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "402a43b46203bb6c9acce4a0a739269b8904131ef57c8187457954c325641feb",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsQueryPerformance.time_isnotin_uint64": {
+        "code": "class ColumnStatsQueryPerformance:\n    def time_isnotin_uint64(self, *args):\n        if not self.data_ordered:\n            # Not that interesting - we already run isin in the unordered case\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"].isnotin(self.isin_values)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsQueryPerformance.time_isnotin_uint64",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "column_stats_enabled",
+            "data_ordered",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:118",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "6c04e95306c5b47791ccd53cfc61d690925e768fb3da3b59a1ccd53917a5a29a",
+        "warmup_time": 0.5
+    },
     "finalize_staged_data.FinalizeStagedData.peakmem_finalize_staged_data": {
         "code": "class FinalizeStagedData:\n    def peakmem_finalize_staged_data(self, *args):\n        staged_symbols = self.lib.get_staged_symbols()\n        assert self.symbol + \"-mem\" in staged_symbols\n        self.lib.finalize_staged_data(self.symbol + \"-mem\", mode=StagedDataFinalizeMethod.WRITE)\n\n    def setup(self, lib_for_storage, num_chunks, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n    \n        assert len(self.lib.list_symbols()) == 0  # check we are in a clean state\n        initial_timestamp = TimestampNumber(0, self.df_generator.TIME_UNIT)\n    \n        list_of_chunks = [10_000] * num_chunks\n    \n        for suffix in (\"-time\", \"-mem\"):\n            symbol = _symbol_name(num_chunks) + suffix\n            stage_chunks(self.lib, symbol, self.df_generator, initial_timestamp, list_of_chunks)\n            self.logger.info(f\"Created Symbol: {symbol}\")\n        self.symbol = _symbol_name(num_chunks)\n\n    def setup_cache(self):\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        return lib_for_storage",
         "name": "finalize_staged_data.FinalizeStagedData.peakmem_finalize_staged_data",

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -1557,7 +1557,7 @@
         "warmup_time": 0
     },
     "column_stats.ColumnStatsCreate.time_create_column_stats": {
-        "code": "class ColumnStatsCreate:\n    def time_create_column_stats(self, *args):\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        # Drop stats so time_ measures creation from scratch\n        self.nvs.drop_column_stats(self.symbol)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsCreate.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsCreate.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsCreate:\n    def time_create_column_stats(self, *args):\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        # Drop stats so time_ measures creation from scratch\n        self.nvs.drop_column_stats(self.symbol)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for storage in ColumnStatsCreate.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsCreate.num_rows:\n                df = _generate_column_stats_dataframe(rows)\n                sym = _symbol_name(rows, ordered=True)\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsCreate.time_create_column_stats",
         "number": 1,
@@ -1567,7 +1567,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1578,15 +1577,43 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "column_stats:243",
+        "setup_cache_key": "column_stats:369",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "37ae3b0b362b4403bf5cc8e055a098712609664f344542f69e603a6be2c38fe6",
+        "version": "c51e2ca01ec0f6d1877864ce47df2839c806106a3f0008eb023ef306fc5859ef",
         "warmup_time": 0
     },
+    "column_stats.ColumnStatsDynamicSchema.time_filter_sometimes_missing_column": {
+        "code": "class ColumnStatsDynamicSchema:\n    def time_filter_sometimes_missing_column(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"sometimes_missing_col\"] < self.sometimes_missing_low]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS + [\"sometimes_missing_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, column_stats_enabled, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = \"dynamic_schema\"\n    \n        # sometimes_missing_col has values 0..(5*ROWS_PER_CHUNK - 1) across the 5 odd chunks\n        total_sometimes_missing_rows = self.NUM_ROWS // 2\n        self.sometimes_missing_low = total_sometimes_missing_rows // 10\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = {}\n        for storage in self.storages:\n            if not is_storage_enabled(storage):\n                lib_for_storage[storage] = None\n                continue\n            lib = create_library(storage, LibraryOptions(dynamic_schema=True))\n            lib_for_storage[storage] = lib\n    \n            sym = \"dynamic_schema\"\n            rows_per_chunk = self.ROWS_PER_CHUNK\n            sometimes_missing_counter = 0\n    \n            for chunk_idx in range(self.NUM_CHUNKS):\n                offset = chunk_idx * rows_per_chunk\n                timestamps = pd.date_range(\n                    start=pd.Timestamp(\"2020-01-01\") + pd.Timedelta(seconds=offset),\n                    periods=rows_per_chunk,\n                    freq=\"s\",\n                )\n                datetime_start = pd.Timestamp(\"2000-01-01\")\n                data = {\n                    \"uint64_col\": np.arange(offset, offset + rows_per_chunk, dtype=np.uint64),\n                    \"float_col\": np.linspace(chunk_idx * 100.0, (chunk_idx + 1) * 100.0, rows_per_chunk),\n                    \"bool_col\": np.zeros(rows_per_chunk, dtype=bool),\n                    \"datetime_col\": pd.date_range(\n                        start=datetime_start + pd.Timedelta(seconds=offset),\n                        periods=rows_per_chunk,\n                        freq=\"s\",\n                    ),\n                }\n                # Odd-numbered chunks include sometimes_missing_col with monotonically increasing values\n                if chunk_idx % 2 == 1:\n                    data[\"sometimes_missing_col\"] = np.arange(\n                        sometimes_missing_counter, sometimes_missing_counter + rows_per_chunk, dtype=np.uint64\n                    )\n                    sometimes_missing_counter += rows_per_chunk\n    \n                df = pd.DataFrame(data)\n                _add_extra_columns(df, rows_per_chunk, ordered=True)\n                df.index = timestamps\n                df.index.name = \"ts\"\n    \n                lib.append(sym, df)\n                self.logger.info(f\"Wrote chunk {chunk_idx} for {sym}\")\n    \n            lib._nvs.create_column_stats(sym, {\"sometimes_missing_col\": {\"MINMAX\"}, **COLUMN_STATS})\n            self.logger.info(f\"Created column stats for {sym}\")\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsDynamicSchema.time_filter_sometimes_missing_column",
+        "number": 0,
+        "param_names": [
+            "column_stats_enabled",
+            "storage"
+        ],
+        "params": [
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:278",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "e0bd464c72351dcd285e0786572502d94664b47b402a8e95b9f340a32ab3e0c3",
+        "warmup_time": 0.5
+    },
     "column_stats.ColumnStatsManagement.time_drop_column_stats": {
-        "code": "class ColumnStatsManagement:\n    def time_drop_column_stats(self, *args):\n        self.nvs.drop_column_stats(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsManagement.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsManagement.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsManagement:\n    def time_drop_column_stats(self, *args):\n        self.nvs.drop_column_stats(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for storage in ColumnStatsManagement.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsManagement.num_rows:\n                df = _generate_column_stats_dataframe(rows)\n                sym = _symbol_name(rows, ordered=True)\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsManagement.time_drop_column_stats",
         "number": 1,
@@ -1596,7 +1623,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1607,15 +1633,15 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "column_stats:287",
+        "setup_cache_key": "column_stats:413",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "e8ac44df433a44200b6a538db48dde33d8144c219306d284051d70b5c8c1ca2d",
+        "version": "f7b8086b0d2fab81473eca52142c0cd835608f3888f51f851ccb69fdce77bbc1",
         "warmup_time": 0
     },
     "column_stats.ColumnStatsManagement.time_get_column_stats_info": {
-        "code": "class ColumnStatsManagement:\n    def time_get_column_stats_info(self, *args):\n        self.nvs.get_column_stats_info(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsManagement.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsManagement.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsManagement:\n    def time_get_column_stats_info(self, *args):\n        self.nvs.get_column_stats_info(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for storage in ColumnStatsManagement.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsManagement.num_rows:\n                df = _generate_column_stats_dataframe(rows)\n                sym = _symbol_name(rows, ordered=True)\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsManagement.time_get_column_stats_info",
         "number": 1,
@@ -1625,7 +1651,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1636,15 +1661,15 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "column_stats:287",
+        "setup_cache_key": "column_stats:413",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "b7c703433b5d5997475127cf3a4bf3ac6d58cd6cc3fb8172a2b9abef9cb3ff2a",
+        "version": "44a4a1153711f89d882106fc441a74b6863335873662091f49e8594995b34f54",
         "warmup_time": 0
     },
     "column_stats.ColumnStatsManagement.time_read_column_stats": {
-        "code": "class ColumnStatsManagement:\n    def time_read_column_stats(self, *args):\n        self.nvs.read_column_stats(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsManagement.num_rows:\n            df = _generate_column_stats_dataframe(rows)\n            sym = _symbol_name(rows, ordered=True)\n            for storage in ColumnStatsManagement.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsManagement:\n    def time_read_column_stats(self, *args):\n        self.nvs.read_column_stats(self.symbol)\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.nvs = self.lib._nvs\n        self.symbol = _symbol_name(num_rows, ordered=True)\n        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for storage in ColumnStatsManagement.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsManagement.num_rows:\n                df = _generate_column_stats_dataframe(rows)\n                sym = _symbol_name(rows, ordered=True)\n                self.logger.info(f\"Writing {sym} with {rows} rows\")\n                lib.write(sym, df)\n                lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsManagement.time_read_column_stats",
         "number": 1,
@@ -1654,7 +1679,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1665,15 +1689,15 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "column_stats:287",
+        "setup_cache_key": "column_stats:413",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "18e6e8c2283903300366c1c8b824045b5d14e4c7594dd43e2a092b177aa99f41",
+        "version": "9caa2c6bf8e784be62da33ef74b0296b37b7980e99494920dd8b61643fdab7fa",
         "warmup_time": 0
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_bool": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_bool(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"bool_col\"] == True]\n        self.lib.read(self.symbol, columns=[\"bool_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_bool(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"bool_col\"]]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_bool",
         "number": 0,
@@ -1685,7 +1709,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1703,15 +1726,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "1f230dcdaedf7f0e949f21f7e6cce17975354ced56811633820cc0837ec6b0f1",
+        "version": "191f87da766de9c93e59f255863048c358389c34a8a0e0ea31c53dfd898a4188",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_combined_and": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_combined_and(self, *args):\n        q = QueryBuilder()\n        q = q[(q[\"uint64_col\"] > self.uint64_high) & (q[\"float_col\"] > 900.0)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\", \"float_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_combined_and(self, *args):\n        q = QueryBuilder()\n        q = q[(q[\"uint64_col\"] > self.uint64_high) & (q[\"float_col\"] > 900.0)]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_combined_and",
         "number": 0,
@@ -1723,7 +1746,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1741,15 +1763,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "9ace40d640224399bf0c06ea47efe1717ffb90512ec8080e26fc02f1cfe1785d",
+        "version": "fa1fc5ea4db837cb23331754ee26d89ec6610b0b91c1c650408295b8d91505e3",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_combined_or": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_combined_or(self, *args):\n        q = QueryBuilder()\n        q = q[(q[\"uint64_col\"] < self.uint64_low) | (q[\"float_col\"] > 900.0)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\", \"float_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_combined_or(self, *args):\n        q = QueryBuilder()\n        q = q[(q[\"uint64_col\"] < self.uint64_low) | (q[\"float_col\"] > 900.0)]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_combined_or",
         "number": 0,
@@ -1761,7 +1783,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1779,15 +1800,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "a5b267335062002eea45cede70d4f06c67ec639fa89eaef50fa0ac0b4e233184",
+        "version": "9c1111a849bc8dd29844dc604fb3a3b6d55fde0a1b2cc9af368e0f40a14a8260",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_datetime": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_datetime(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"datetime_col\"] > self.datetime_high]\n        self.lib.read(self.symbol, columns=[\"datetime_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_datetime(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"datetime_col\"] > self.datetime_high]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_datetime",
         "number": 0,
@@ -1799,7 +1820,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1817,15 +1837,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "9bb3361e680d29ee14395c5eab579b8a0e039bc84fdc22f5cee81c44094ae0cb",
+        "version": "b7cf502b8f91d478e6c064cbbef084f3c2e41313959de803995addfdccb7ec4e",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_float": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_float(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"float_col\"] > 900.0]\n        self.lib.read(self.symbol, columns=[\"float_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_float(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"float_col\"] > 900.0]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_float",
         "number": 0,
@@ -1837,7 +1857,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1855,15 +1874,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "a8429bc6881f84f4e06f9df428d74c5acc2ac3e25575f4004f5757521e082a34",
+        "version": "22eb19847216c619598f6f2fb2cf0bf75c90c56167f9f886eb6ca72aeacb2ef2",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_uint64": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_uint64(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] < self.uint64_low]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_uint64(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] < self.uint64_low]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_uint64",
         "number": 0,
@@ -1875,7 +1894,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1893,15 +1911,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "7de9e9a56f47cc6ea6e25484679a94cbf5fe40bad50425079123664cef71f9a3",
+        "version": "ed8244e1ca94ddceb188e53cd13478f446b7d003ad460671129f7187e9ccfcb1",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_with_date_range": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_with_date_range(self, *args):\n        \"\"\"date_range narrows to 50% of rows, then filter selects the top 10% of uint64 values.\n    \n        Tests whether stats provide additional pruning on top of index-based date range filtering.\n        \"\"\"\n        if not self.data_ordered:\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] > self.uint64_high]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], date_range=self.date_range_half, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_with_date_range(self, *args):\n        \"\"\"date_range narrows to 50% of rows, then filter selects the top 10% of uint64 values.\n    \n        Tests whether stats provide additional pruning on top of index-based date range filtering.\n        \"\"\"\n        if not self.data_ordered:\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] > self.uint64_high]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, date_range=self.date_range_half, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_with_date_range",
         "number": 0,
@@ -1913,7 +1931,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1931,15 +1948,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "38d1ac195a18e232fcf4a11e91b1da26b94658ccb16943b8cff246aa381b9c0c",
+        "version": "de545c49bc16d23a1283821fc14babda3bbb1f1a31efe0aa04b928f44c53bd51",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_filter_zero_match": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_zero_match(self, *args):\n        \"\"\"Filter that matches no rows, best case for column stats.\"\"\"\n        if not self.data_ordered:\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] > self.zero_match_threshold]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_filter_zero_match(self, *args):\n        \"\"\"Filter that matches no rows, best case for column stats.\"\"\"\n        if not self.data_ordered:\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"] > self.zero_match_threshold]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_filter_zero_match",
         "number": 0,
@@ -1951,7 +1968,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -1969,15 +1985,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "e843c513aa00f199b3e699843faf7731a68967bf1c7d09b77b8f08ff9fefd2bc",
+        "version": "7f9b9b54b4df4043d99211995d4be46b8167f8305d8b4b3fa57b59f3e13c2d5a",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_isin_uint64": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_isin_uint64(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"].isin(self.isin_values)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_isin_uint64(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"].isin(self.isin_values)]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_isin_uint64",
         "number": 0,
@@ -1989,7 +2005,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -2007,15 +2022,15 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "402a43b46203bb6c9acce4a0a739269b8904131ef57c8187457954c325641feb",
+        "version": "c496d3b5d577ed288d82bbfe2408e02b240af32b61820abfcea2ca2f2d759ba8",
         "warmup_time": 0.5
     },
     "column_stats.ColumnStatsQueryPerformance.time_isnotin_uint64": {
-        "code": "class ColumnStatsQueryPerformance:\n    def time_isnotin_uint64(self, *args):\n        if not self.data_ordered:\n            # Not that interesting - we already run isin in the unordered case\n            raise SkipNotImplemented\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"].isnotin(self.isin_values)]\n        self.lib.read(self.symbol, columns=[\"uint64_col\"], query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for rows in ColumnStatsQueryPerformance.num_rows:\n            for ordered in ColumnStatsQueryPerformance.data_ordered:\n                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                sym = _symbol_name(rows, ordered)\n                for storage in ColumnStatsQueryPerformance.storages:\n                    if not is_storage_enabled(storage):\n                        continue\n                    lib = lib_for_storage[storage]\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "code": "class ColumnStatsQueryPerformance:\n    def time_isnotin_uint64(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"uint64_col\"].isnotin(self.isin_values)]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,
         "name": "column_stats.ColumnStatsQueryPerformance.time_isnotin_uint64",
         "number": 0,
@@ -2027,7 +2042,6 @@
         ],
         "params": [
             [
-                "1000000",
                 "10000000"
             ],
             [
@@ -2045,11 +2059,39 @@
         ],
         "rounds": 1,
         "sample_time": 0.5,
-        "setup_cache_key": "column_stats:118",
+        "setup_cache_key": "column_stats:137",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "6c04e95306c5b47791ccd53cfc61d690925e768fb3da3b59a1ccd53917a5a29a",
+        "version": "118060e82bbb522a9ec88311f72527e89fac5f019147e02ec8e0fd0fd938d9c6",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsWideFilter.time_filter_wide": {
+        "code": "class ColumnStatsWideFilter:\n    def time_filter_wide(self, *args):\n        \"\"\"Filter with 1001 OR'd conditions forcing decode of 1000 extra columns.\"\"\"\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=self.query)\n\n    def setup(self, lib_for_storage, column_stats_enabled, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = \"wide_filter\"\n    \n        n_int = self.NUM_EXTRA // 2\n        n_float = self.NUM_EXTRA - n_int\n    \n        # Build the QueryBuilder with 1001 OR'd conditions as a balanced tree.\n        # A left-leaning chain would exceed Python's recursion limit in the\n        # recursive expression visitor in processing.py.\n        q = QueryBuilder()\n        uint64_low = self.NUM_ROWS // 10\n        conditions = [q[\"uint64_col\"] < uint64_low]\n        for i in range(n_int):\n            conditions.append(q[f\"extra_int64_{i}\"] < np.int64(0))\n        for i in range(n_float):\n            conditions.append(q[f\"extra_float_{i}\"] < 0.0)\n        while len(conditions) > 1:\n            next_level = []\n            for j in range(0, len(conditions), 2):\n                if j + 1 < len(conditions):\n                    next_level.append(conditions[j] | conditions[j + 1])\n                else:\n                    next_level.append(conditions[j])\n            conditions = next_level\n        q = q[conditions[0]]\n        self.query = q\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        for storage in self.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            sym = \"wide_filter\"\n            n_int = self.NUM_EXTRA // 2\n            n_float = self.NUM_EXTRA - n_int\n    \n            for chunk_idx in range(self.NUM_ROWS // self.ROWS_PER_CHUNK):\n                n = self.ROWS_PER_CHUNK\n                offset = chunk_idx * n\n                timestamps = pd.date_range(\n                    start=pd.Timestamp(\"2020-01-01\") + pd.Timedelta(seconds=offset),\n                    periods=n,\n                    freq=\"s\",\n                )\n                datetime_start = pd.Timestamp(\"2000-01-01\")\n                data = {\n                    \"uint64_col\": np.arange(offset, offset + n, dtype=np.uint64),\n                    \"float_col\": np.linspace(\n                        offset * 1000.0 / self.NUM_ROWS,\n                        (offset + n) * 1000.0 / self.NUM_ROWS,\n                        n,\n                    ),\n                    \"bool_col\": np.array([i + offset >= self.NUM_ROWS // 2 for i in range(n)], dtype=bool),\n                    \"datetime_col\": pd.date_range(\n                        start=datetime_start + pd.Timedelta(seconds=offset),\n                        periods=n,\n                        freq=\"s\",\n                    ),\n                }\n                base_int = np.arange(offset + 1, offset + n + 1, dtype=np.int64)\n                base_float = np.linspace(1.0, 1000.0, n)\n                for i in range(n_int):\n                    data[f\"extra_int64_{i}\"] = base_int + i\n                for i in range(n_float):\n                    data[f\"extra_float_{i}\"] = base_float + i * 0.1\n    \n                df = pd.DataFrame(data)\n                df.index = timestamps\n                df.index.name = \"ts\"\n    \n                lib.append(sym, df)\n                self.logger.info(f\"Wrote chunk {chunk_idx} for {sym}\")\n    \n            # Create stats on all columns (benchmark + extra) so column stats can prune\n            all_stats = dict(COLUMN_STATS)\n            for i in range(n_int):\n                all_stats[f\"extra_int64_{i}\"] = {\"MINMAX\"}\n            for i in range(n_float):\n                all_stats[f\"extra_float_{i}\"] = {\"MINMAX\"}\n            lib._nvs.create_column_stats(sym, all_stats)\n            self.logger.info(f\"Created column stats for {sym}\")\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsWideFilter.time_filter_wide",
+        "number": 0,
+        "param_names": [
+            "column_stats_enabled",
+            "storage"
+        ],
+        "params": [
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:475",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "8164e364b520bda248fbd8afe5bbd4995e2f929fa2f2bf8524ee3c65e0ea3c4b",
         "warmup_time": 0.5
     },
     "finalize_staged_data.FinalizeStagedData.peakmem_finalize_staged_data": {

--- a/python/benchmarks/column_stats.py
+++ b/python/benchmarks/column_stats.py
@@ -1,0 +1,318 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import time
+
+import numpy as np
+import pandas as pd
+from arcticdb import QueryBuilder
+from arcticdb_ext import set_config_int, unset_config_int
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
+from benchmarks.common import *
+from arcticdb.util.logger import get_logger
+from benchmarks.environment_setup import (
+    Storage,
+    create_libraries_across_storages,
+    is_storage_enabled,
+)
+
+STORAGES = [Storage.LMDB, Storage.AMAZON]
+
+COLUMN_STATS = {
+    "uint64_col": {"MINMAX"},
+    "float_col": {"MINMAX"},
+    "bool_col": {"MINMAX"},
+    "datetime_col": {"MINMAX"},
+}
+
+
+def _symbol_name(rows, ordered):
+    suffix = "ordered" if ordered else "random"
+    return f"col_stats_{rows}_{suffix}"
+
+
+def _generate_column_stats_dataframe(n):
+    """Generate a DataFrame with ordered data suitable for column stats benchmarking.
+
+    Data is monotonically ordered so that each storage segment has a tight min/max range,
+    allowing column stats to effectively prune segments during filtered reads.
+    """
+    timestamps = pd.date_range(end="1/1/2023", periods=n, freq="s")
+    # Monotonically increasing datetime column spanning a separate range from the index
+    datetime_start = pd.Timestamp("2000-01-01")
+    datetime_col = pd.date_range(start=datetime_start, periods=n, freq="s")
+    df = pd.DataFrame(
+        {
+            "uint64_col": np.arange(n, dtype=np.uint64),
+            "float_col": np.linspace(0.0, 1000.0, n),
+            "bool_col": np.array([i >= n // 2 for i in range(n)], dtype=bool),
+            "datetime_col": datetime_col,
+        }
+    )
+    df.index = timestamps
+    df.index.name = "ts"
+    return df
+
+
+def _generate_random_dataframe(n):
+    """Generate a DataFrame with random data that will not benefit from column stats.
+
+    Every segment will span the full value range for each column, so MINMAX stats
+    cannot prune any segments. Uses the same value ranges as the ordered generator
+    so the same filter thresholds select a similar fraction of rows.
+    """
+    rng = np.random.default_rng(42)
+    timestamps = pd.date_range(end="1/1/2023", periods=n, freq="s")
+    datetime_start = pd.Timestamp("2000-01-01")
+    datetime_offsets = rng.integers(0, n, size=n)
+    datetime_col = datetime_start + pd.to_timedelta(datetime_offsets, unit="s")
+    df = pd.DataFrame(
+        {
+            "uint64_col": rng.integers(0, n, size=n).astype(np.uint64),
+            "float_col": rng.uniform(0.0, 1000.0, size=n),
+            "bool_col": rng.choice([True, False], size=n),
+            "datetime_col": datetime_col,
+        }
+    )
+    df.index = timestamps
+    df.index.name = "ts"
+    return df
+
+
+class ColumnStatsQueryPerformance:
+    """Benchmark query filtering performance with and without column stats enabled.
+
+    Runs against two data distributions:
+    - ordered: monotonically sorted so segment-level min/max stats allow effective pruning.
+    - random: uniformly distributed so every segment spans the full range and stats cannot prune.
+
+    Filters target ~10% of the data range (or 50% for bool). With ordered data ~90% of segments can be skipped.
+    With random data no segments can be skipped, measuring the overhead of stats when they cannot help.
+    """
+
+    sample_time = 0.5
+    rounds = 1
+    repeat = (2, 3, 5.0)
+    warmup_time = 0.5
+    timeout = 600
+
+    num_rows = [1_000_000, 10_000_000]
+    column_stats_enabled = [True, False]
+    data_ordered = [True, False]
+    storages = STORAGES
+
+    params = [num_rows, column_stats_enabled, data_ordered, storages]
+    param_names = ["num_rows", "column_stats_enabled", "data_ordered", "storage"]
+
+    def __init__(self):
+        self.logger = get_logger()
+        self.lib = None
+        self.symbol = None
+
+    def setup_cache(self):
+        start = time.time()
+        lib_for_storage = create_libraries_across_storages(self.storages)
+        for rows in ColumnStatsQueryPerformance.num_rows:
+            for ordered in ColumnStatsQueryPerformance.data_ordered:
+                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)
+                sym = _symbol_name(rows, ordered)
+                for storage in ColumnStatsQueryPerformance.storages:
+                    if not is_storage_enabled(storage):
+                        continue
+                    lib = lib_for_storage[storage]
+                    self.logger.info(f"Writing {sym} with {rows} rows")
+                    lib.write(sym, df)
+                    lib._nvs.create_column_stats(sym, COLUMN_STATS)
+        self.logger.info(f"setup_cache time: {time.time() - start}")
+        return lib_for_storage
+
+    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):
+        self.lib = lib_for_storage[storage]
+        if self.lib is None:
+            raise SkipNotImplemented
+        self.symbol = _symbol_name(num_rows, data_ordered)
+        self.data_ordered = data_ordered
+
+        # Compute filter thresholds targeting ~10% of the value range
+        self.uint64_low = num_rows // 10
+        self.uint64_high = num_rows * 9 // 10
+        # ~100 values from the first 10% of the uint64 range
+        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))
+        # Datetime threshold: last 10% of the datetime_col range
+        datetime_start = pd.Timestamp("2000-01-01")
+        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)
+        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing
+        self.zero_match_threshold = num_rows
+        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks
+        index_end = pd.Timestamp("2023-01-01")
+        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)
+
+        if column_stats_enabled:
+            set_config_int("ColumnStats.UseForQueries", 1)
+        else:
+            unset_config_int("ColumnStats.UseForQueries")
+
+    def teardown(self, *args):
+        unset_config_int("ColumnStats.UseForQueries")
+
+    def time_filter_uint64(self, *args):
+        q = QueryBuilder()
+        q = q[q["uint64_col"] < self.uint64_low]
+        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+
+    def time_filter_float(self, *args):
+        q = QueryBuilder()
+        q = q[q["float_col"] > 900.0]
+        self.lib.read(self.symbol, columns=["float_col"], query_builder=q)
+
+    def time_filter_bool(self, *args):
+        q = QueryBuilder()
+        q = q[q["bool_col"] == True]
+        self.lib.read(self.symbol, columns=["bool_col"], query_builder=q)
+
+    def time_filter_combined_and(self, *args):
+        q = QueryBuilder()
+        q = q[(q["uint64_col"] > self.uint64_high) & (q["float_col"] > 900.0)]
+        self.lib.read(self.symbol, columns=["uint64_col", "float_col"], query_builder=q)
+
+    def time_filter_combined_or(self, *args):
+        q = QueryBuilder()
+        q = q[(q["uint64_col"] < self.uint64_low) | (q["float_col"] > 900.0)]
+        self.lib.read(self.symbol, columns=["uint64_col", "float_col"], query_builder=q)
+
+    def time_filter_datetime(self, *args):
+        q = QueryBuilder()
+        q = q[q["datetime_col"] > self.datetime_high]
+        self.lib.read(self.symbol, columns=["datetime_col"], query_builder=q)
+
+    def time_isin_uint64(self, *args):
+        q = QueryBuilder()
+        q = q[q["uint64_col"].isin(self.isin_values)]
+        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+
+    def time_filter_zero_match(self, *args):
+        """Filter that matches no rows, best case for column stats."""
+        if not self.data_ordered:
+            raise SkipNotImplemented
+        q = QueryBuilder()
+        q = q[q["uint64_col"] > self.zero_match_threshold]
+        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+
+    def time_filter_with_date_range(self, *args):
+        """date_range narrows to 50% of rows, then filter selects the top 10% of uint64 values.
+
+        Tests whether stats provide additional pruning on top of index-based date range filtering.
+        """
+        if not self.data_ordered:
+            raise SkipNotImplemented
+        q = QueryBuilder()
+        q = q[q["uint64_col"] > self.uint64_high]
+        self.lib.read(self.symbol, columns=["uint64_col"], date_range=self.date_range_half, query_builder=q)
+
+    def time_isnotin_uint64(self, *args):
+        if not self.data_ordered:
+            # Not that interesting - we already run isin in the unordered case
+            raise SkipNotImplemented
+        q = QueryBuilder()
+        q = q[q["uint64_col"].isnotin(self.isin_values)]
+        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+
+
+class ColumnStatsCreate:
+    """Benchmark column stats creation. Setup drops stats so time_ measures pure creation."""
+
+    number = 1
+    warmup_time = 0
+    timeout = 600
+
+    num_rows = [1_000_000, 10_000_000]
+    storages = STORAGES
+
+    params = [num_rows, storages]
+    param_names = ["num_rows", "storage"]
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        start = time.time()
+        lib_for_storage = create_libraries_across_storages(self.storages)
+        for rows in ColumnStatsCreate.num_rows:
+            df = _generate_column_stats_dataframe(rows)
+            sym = _symbol_name(rows, ordered=True)
+            for storage in ColumnStatsCreate.storages:
+                if not is_storage_enabled(storage):
+                    continue
+                lib = lib_for_storage[storage]
+                self.logger.info(f"Writing {sym} with {rows} rows")
+                lib.write(sym, df)
+        self.logger.info(f"setup_cache time: {time.time() - start}")
+        return lib_for_storage
+
+    def setup(self, lib_for_storage, num_rows, storage):
+        self.lib = lib_for_storage[storage]
+        if self.lib is None:
+            raise SkipNotImplemented
+        self.nvs = self.lib._nvs
+        self.symbol = _symbol_name(num_rows, ordered=True)
+        # Drop stats so time_ measures creation from scratch
+        self.nvs.drop_column_stats(self.symbol)
+
+    def time_create_column_stats(self, *args):
+        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)
+
+
+class ColumnStatsManagement:
+    """Benchmark column stats operations: drop, get_info, read."""
+
+    number = 1
+    warmup_time = 0
+    timeout = 600
+
+    num_rows = [1_000_000, 10_000_000]
+    storages = STORAGES
+
+    params = [num_rows, storages]
+    param_names = ["num_rows", "storage"]
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        start = time.time()
+        lib_for_storage = create_libraries_across_storages(self.storages)
+        for rows in ColumnStatsManagement.num_rows:
+            df = _generate_column_stats_dataframe(rows)
+            sym = _symbol_name(rows, ordered=True)
+            for storage in ColumnStatsManagement.storages:
+                if not is_storage_enabled(storage):
+                    continue
+                lib = lib_for_storage[storage]
+                self.logger.info(f"Writing {sym} with {rows} rows")
+                lib.write(sym, df)
+                lib._nvs.create_column_stats(sym, COLUMN_STATS)
+        self.logger.info(f"setup_cache time: {time.time() - start}")
+        return lib_for_storage
+
+    def setup(self, lib_for_storage, num_rows, storage):
+        self.lib = lib_for_storage[storage]
+        if self.lib is None:
+            raise SkipNotImplemented
+        self.nvs = self.lib._nvs
+        self.symbol = _symbol_name(num_rows, ordered=True)
+        self.nvs.create_column_stats(self.symbol, COLUMN_STATS)
+
+    def time_drop_column_stats(self, *args):
+        self.nvs.drop_column_stats(self.symbol)
+
+    def time_get_column_stats_info(self, *args):
+        self.nvs.get_column_stats_info(self.symbol)
+
+    def time_read_column_stats(self, *args):
+        self.nvs.read_column_stats(self.symbol)

--- a/python/benchmarks/column_stats.py
+++ b/python/benchmarks/column_stats.py
@@ -11,6 +11,7 @@ import time
 import numpy as np
 import pandas as pd
 from arcticdb import QueryBuilder
+from arcticdb.options import LibraryOptions
 from arcticdb_ext import set_config_int, unset_config_int
 from asv_runner.benchmarks.mark import SkipNotImplemented
 
@@ -18,11 +19,14 @@ from benchmarks.common import *
 from arcticdb.util.logger import get_logger
 from benchmarks.environment_setup import (
     Storage,
+    create_library,
     create_libraries_across_storages,
     is_storage_enabled,
 )
 
 STORAGES = [Storage.LMDB, Storage.AMAZON]
+
+BENCHMARK_COLUMNS = ["uint64_col", "float_col", "bool_col", "datetime_col"]
 
 COLUMN_STATS = {
     "uint64_col": {"MINMAX"},
@@ -37,12 +41,27 @@ def _symbol_name(rows, ordered):
     return f"col_stats_{rows}_{suffix}"
 
 
-def _generate_column_stats_dataframe(n):
-    """Generate a DataFrame with ordered data suitable for column stats benchmarking.
+def _add_extra_columns(df, n, num_cols=100, ordered=True):
+    """Add extra filler columns: half int64, half float64, all positive values."""
+    n_int = num_cols // 2
+    n_float = num_cols - n_int
+    if ordered:
+        base_int = np.arange(1, n + 1, dtype=np.int64)
+        base_float = np.linspace(1.0, 1000.0, n)
+        for i in range(n_int):
+            df[f"extra_int64_{i}"] = base_int + i
+        for i in range(n_float):
+            df[f"extra_float_{i}"] = base_float + i * 0.1
+    else:
+        rng = np.random.default_rng(123)
+        for i in range(n_int):
+            df[f"extra_int64_{i}"] = rng.integers(1, n, size=n, dtype=np.int64)
+        for i in range(n_float):
+            df[f"extra_float_{i}"] = rng.uniform(1.0, 1000.0, size=n)
 
-    Data is monotonically ordered so that each storage segment has a tight min/max range,
-    allowing column stats to effectively prune segments during filtered reads.
-    """
+
+def _generate_column_stats_dataframe(n):
+    """Generate a DataFrame with ordered data suitable for column stats benchmarking."""
     timestamps = pd.date_range(end="1/1/2023", periods=n, freq="s")
     # Monotonically increasing datetime column spanning a separate range from the index
     datetime_start = pd.Timestamp("2000-01-01")
@@ -55,18 +74,14 @@ def _generate_column_stats_dataframe(n):
             "datetime_col": datetime_col,
         }
     )
+    _add_extra_columns(df, n, ordered=True)
     df.index = timestamps
     df.index.name = "ts"
     return df
 
 
 def _generate_random_dataframe(n):
-    """Generate a DataFrame with random data that will not benefit from column stats.
-
-    Every segment will span the full value range for each column, so MINMAX stats
-    cannot prune any segments. Uses the same value ranges as the ordered generator
-    so the same filter thresholds select a similar fraction of rows.
-    """
+    """Generate a DataFrame with random data that will not benefit from column stats."""
     rng = np.random.default_rng(42)
     timestamps = pd.date_range(end="1/1/2023", periods=n, freq="s")
     datetime_start = pd.Timestamp("2000-01-01")
@@ -80,6 +95,7 @@ def _generate_random_dataframe(n):
             "datetime_col": datetime_col,
         }
     )
+    _add_extra_columns(df, n, ordered=False)
     df.index = timestamps
     df.index.name = "ts"
     return df
@@ -89,11 +105,14 @@ class ColumnStatsQueryPerformance:
     """Benchmark query filtering performance with and without column stats enabled.
 
     Runs against two data distributions:
-    - ordered: monotonically sorted so segment-level min/max stats allow effective pruning.
-    - random: uniformly distributed so every segment spans the full range and stats cannot prune.
+    - ordered: sorted so segment-level min/max stats allow pruning
+    - random: uniformly distributed so every segment spans the full range and stats cannot prune
 
-    Filters target ~10% of the data range (or 50% for bool). With ordered data ~90% of segments can be skipped.
-    With random data no segments can be skipped, measuring the overhead of stats when they cannot help.
+    Filters target ~10% of the data range (or 50% for bool). With ordered data ~90% of segments
+    can be skipped. With random data no segments can be skipped, measuring the overhead of stats
+    when they cannot help.
+
+    Data includes 100 extra filler columns; reads use columns= to restrict to the 4 benchmark columns.
     """
 
     sample_time = 0.5
@@ -102,7 +121,7 @@ class ColumnStatsQueryPerformance:
     warmup_time = 0.5
     timeout = 600
 
-    num_rows = [1_000_000, 10_000_000]
+    num_rows = [10_000_000]
     column_stats_enabled = [True, False]
     data_ordered = [True, False]
     storages = STORAGES
@@ -118,14 +137,20 @@ class ColumnStatsQueryPerformance:
     def setup_cache(self):
         start = time.time()
         lib_for_storage = create_libraries_across_storages(self.storages)
-        for rows in ColumnStatsQueryPerformance.num_rows:
-            for ordered in ColumnStatsQueryPerformance.data_ordered:
-                df = _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)
-                sym = _symbol_name(rows, ordered)
-                for storage in ColumnStatsQueryPerformance.storages:
-                    if not is_storage_enabled(storage):
-                        continue
-                    lib = lib_for_storage[storage]
+        dfs = {}
+        for storage in ColumnStatsQueryPerformance.storages:
+            if not is_storage_enabled(storage):
+                continue
+            lib = lib_for_storage[storage]
+            for rows in ColumnStatsQueryPerformance.num_rows:
+                for ordered in ColumnStatsQueryPerformance.data_ordered:
+                    key = (rows, ordered)
+                    if key not in dfs:
+                        dfs[key] = (
+                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)
+                        )
+                    df = dfs[key]
+                    sym = _symbol_name(rows, ordered)
                     self.logger.info(f"Writing {sym} with {rows} rows")
                     lib.write(sym, df)
                     lib._nvs.create_column_stats(sym, COLUMN_STATS)
@@ -164,37 +189,37 @@ class ColumnStatsQueryPerformance:
     def time_filter_uint64(self, *args):
         q = QueryBuilder()
         q = q[q["uint64_col"] < self.uint64_low]
-        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_filter_float(self, *args):
         q = QueryBuilder()
         q = q[q["float_col"] > 900.0]
-        self.lib.read(self.symbol, columns=["float_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_filter_bool(self, *args):
         q = QueryBuilder()
-        q = q[q["bool_col"] == True]
-        self.lib.read(self.symbol, columns=["bool_col"], query_builder=q)
+        q = q[q["bool_col"]]
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_filter_combined_and(self, *args):
         q = QueryBuilder()
         q = q[(q["uint64_col"] > self.uint64_high) & (q["float_col"] > 900.0)]
-        self.lib.read(self.symbol, columns=["uint64_col", "float_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_filter_combined_or(self, *args):
         q = QueryBuilder()
         q = q[(q["uint64_col"] < self.uint64_low) | (q["float_col"] > 900.0)]
-        self.lib.read(self.symbol, columns=["uint64_col", "float_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_filter_datetime(self, *args):
         q = QueryBuilder()
         q = q[q["datetime_col"] > self.datetime_high]
-        self.lib.read(self.symbol, columns=["datetime_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_isin_uint64(self, *args):
         q = QueryBuilder()
         q = q[q["uint64_col"].isin(self.isin_values)]
-        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_filter_zero_match(self, *args):
         """Filter that matches no rows, best case for column stats."""
@@ -202,7 +227,7 @@ class ColumnStatsQueryPerformance:
             raise SkipNotImplemented
         q = QueryBuilder()
         q = q[q["uint64_col"] > self.zero_match_threshold]
-        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
 
     def time_filter_with_date_range(self, *args):
         """date_range narrows to 50% of rows, then filter selects the top 10% of uint64 values.
@@ -213,25 +238,126 @@ class ColumnStatsQueryPerformance:
             raise SkipNotImplemented
         q = QueryBuilder()
         q = q[q["uint64_col"] > self.uint64_high]
-        self.lib.read(self.symbol, columns=["uint64_col"], date_range=self.date_range_half, query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, date_range=self.date_range_half, query_builder=q)
 
     def time_isnotin_uint64(self, *args):
-        if not self.data_ordered:
-            # Not that interesting - we already run isin in the unordered case
-            raise SkipNotImplemented
         q = QueryBuilder()
         q = q[q["uint64_col"].isnotin(self.isin_values)]
-        self.lib.read(self.symbol, columns=["uint64_col"], query_builder=q)
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)
+
+
+class ColumnStatsDynamicSchema:
+    """Benchmark column stats filtering when the filter column exists in some segments but not others.
+
+    Uses dynamic schema to write data in alternating chunks: odd-numbered chunks include
+    sometimes_missing_col (uint64), even-numbered chunks do not.
+
+    Data includes 100 extra filler columns; reads use columns= to restrict to the benchmark
+    columns plus sometimes_missing_col.
+    """
+
+    sample_time = 0.5
+    rounds = 1
+    repeat = (2, 3, 5.0)
+    warmup_time = 0.5
+    timeout = 600
+
+    column_stats_enabled = [True, False]
+    storages = STORAGES
+
+    params = [column_stats_enabled, storages]
+    param_names = ["column_stats_enabled", "storage"]
+
+    NUM_ROWS = 10_000_000
+    NUM_CHUNKS = 10
+    ROWS_PER_CHUNK = NUM_ROWS // NUM_CHUNKS
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        start = time.time()
+        lib_for_storage = {}
+        for storage in self.storages:
+            if not is_storage_enabled(storage):
+                lib_for_storage[storage] = None
+                continue
+            lib = create_library(storage, LibraryOptions(dynamic_schema=True))
+            lib_for_storage[storage] = lib
+
+            sym = "dynamic_schema"
+            rows_per_chunk = self.ROWS_PER_CHUNK
+            sometimes_missing_counter = 0
+
+            for chunk_idx in range(self.NUM_CHUNKS):
+                offset = chunk_idx * rows_per_chunk
+                timestamps = pd.date_range(
+                    start=pd.Timestamp("2020-01-01") + pd.Timedelta(seconds=offset),
+                    periods=rows_per_chunk,
+                    freq="s",
+                )
+                datetime_start = pd.Timestamp("2000-01-01")
+                data = {
+                    "uint64_col": np.arange(offset, offset + rows_per_chunk, dtype=np.uint64),
+                    "float_col": np.linspace(chunk_idx * 100.0, (chunk_idx + 1) * 100.0, rows_per_chunk),
+                    "bool_col": np.zeros(rows_per_chunk, dtype=bool),
+                    "datetime_col": pd.date_range(
+                        start=datetime_start + pd.Timedelta(seconds=offset),
+                        periods=rows_per_chunk,
+                        freq="s",
+                    ),
+                }
+                # Odd-numbered chunks include sometimes_missing_col with monotonically increasing values
+                if chunk_idx % 2 == 1:
+                    data["sometimes_missing_col"] = np.arange(
+                        sometimes_missing_counter, sometimes_missing_counter + rows_per_chunk, dtype=np.uint64
+                    )
+                    sometimes_missing_counter += rows_per_chunk
+
+                df = pd.DataFrame(data)
+                _add_extra_columns(df, rows_per_chunk, ordered=True)
+                df.index = timestamps
+                df.index.name = "ts"
+
+                lib.append(sym, df)
+                self.logger.info(f"Wrote chunk {chunk_idx} for {sym}")
+
+            lib._nvs.create_column_stats(sym, {"sometimes_missing_col": {"MINMAX"}, **COLUMN_STATS})
+            self.logger.info(f"Created column stats for {sym}")
+
+        self.logger.info(f"setup_cache time: {time.time() - start}")
+        return lib_for_storage
+
+    def setup(self, lib_for_storage, column_stats_enabled, storage):
+        self.lib = lib_for_storage[storage]
+        if self.lib is None:
+            raise SkipNotImplemented
+        self.symbol = "dynamic_schema"
+
+        # sometimes_missing_col has values 0..(5*ROWS_PER_CHUNK - 1) across the 5 odd chunks
+        total_sometimes_missing_rows = self.NUM_ROWS // 2
+        self.sometimes_missing_low = total_sometimes_missing_rows // 10
+
+        if column_stats_enabled:
+            set_config_int("ColumnStats.UseForQueries", 1)
+        else:
+            unset_config_int("ColumnStats.UseForQueries")
+
+    def teardown(self, *args):
+        unset_config_int("ColumnStats.UseForQueries")
+
+    def time_filter_sometimes_missing_column(self, *args):
+        q = QueryBuilder()
+        q = q[q["sometimes_missing_col"] < self.sometimes_missing_low]
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS + ["sometimes_missing_col"], query_builder=q)
 
 
 class ColumnStatsCreate:
-    """Benchmark column stats creation. Setup drops stats so time_ measures pure creation."""
-
     number = 1
     warmup_time = 0
     timeout = 600
 
-    num_rows = [1_000_000, 10_000_000]
+    num_rows = [10_000_000]
     storages = STORAGES
 
     params = [num_rows, storages]
@@ -243,13 +369,13 @@ class ColumnStatsCreate:
     def setup_cache(self):
         start = time.time()
         lib_for_storage = create_libraries_across_storages(self.storages)
-        for rows in ColumnStatsCreate.num_rows:
-            df = _generate_column_stats_dataframe(rows)
-            sym = _symbol_name(rows, ordered=True)
-            for storage in ColumnStatsCreate.storages:
-                if not is_storage_enabled(storage):
-                    continue
-                lib = lib_for_storage[storage]
+        for storage in ColumnStatsCreate.storages:
+            if not is_storage_enabled(storage):
+                continue
+            lib = lib_for_storage[storage]
+            for rows in ColumnStatsCreate.num_rows:
+                df = _generate_column_stats_dataframe(rows)
+                sym = _symbol_name(rows, ordered=True)
                 self.logger.info(f"Writing {sym} with {rows} rows")
                 lib.write(sym, df)
         self.logger.info(f"setup_cache time: {time.time() - start}")
@@ -275,7 +401,7 @@ class ColumnStatsManagement:
     warmup_time = 0
     timeout = 600
 
-    num_rows = [1_000_000, 10_000_000]
+    num_rows = [10_000_000]
     storages = STORAGES
 
     params = [num_rows, storages]
@@ -287,13 +413,13 @@ class ColumnStatsManagement:
     def setup_cache(self):
         start = time.time()
         lib_for_storage = create_libraries_across_storages(self.storages)
-        for rows in ColumnStatsManagement.num_rows:
-            df = _generate_column_stats_dataframe(rows)
-            sym = _symbol_name(rows, ordered=True)
-            for storage in ColumnStatsManagement.storages:
-                if not is_storage_enabled(storage):
-                    continue
-                lib = lib_for_storage[storage]
+        for storage in ColumnStatsManagement.storages:
+            if not is_storage_enabled(storage):
+                continue
+            lib = lib_for_storage[storage]
+            for rows in ColumnStatsManagement.num_rows:
+                df = _generate_column_stats_dataframe(rows)
+                sym = _symbol_name(rows, ordered=True)
                 self.logger.info(f"Writing {sym} with {rows} rows")
                 lib.write(sym, df)
                 lib._nvs.create_column_stats(sym, COLUMN_STATS)
@@ -316,3 +442,134 @@ class ColumnStatsManagement:
 
     def time_read_column_stats(self, *args):
         self.nvs.read_column_stats(self.symbol)
+
+
+class ColumnStatsWideFilter:
+    """Benchmark the overhead of query builder filters that force decoding many extra columns.
+
+    Writes 10M rows with 1004 columns (4 benchmark + 500 int64 + 500 float) and create column stats on everything.
+    The query builder ORs the main uint64 filter with a ``< 0`` condition on every extra column
+    (all values are positive, so these never match). Without column stats, this forces a full table scan
+    through all these columns.
+    """
+
+    sample_time = 0.5
+    rounds = 1
+    repeat = (2, 3, 5.0)
+    warmup_time = 0.5
+    timeout = 600
+
+    column_stats_enabled = [True, False]
+    storages = STORAGES
+
+    params = [column_stats_enabled, storages]
+    param_names = ["column_stats_enabled", "storage"]
+
+    NUM_ROWS = 10_000_000
+    NUM_EXTRA = 1000
+    ROWS_PER_CHUNK = 1_000_000
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        start = time.time()
+        lib_for_storage = create_libraries_across_storages(self.storages)
+        for storage in self.storages:
+            if not is_storage_enabled(storage):
+                continue
+            lib = lib_for_storage[storage]
+            sym = "wide_filter"
+            n_int = self.NUM_EXTRA // 2
+            n_float = self.NUM_EXTRA - n_int
+
+            for chunk_idx in range(self.NUM_ROWS // self.ROWS_PER_CHUNK):
+                n = self.ROWS_PER_CHUNK
+                offset = chunk_idx * n
+                timestamps = pd.date_range(
+                    start=pd.Timestamp("2020-01-01") + pd.Timedelta(seconds=offset),
+                    periods=n,
+                    freq="s",
+                )
+                datetime_start = pd.Timestamp("2000-01-01")
+                data = {
+                    "uint64_col": np.arange(offset, offset + n, dtype=np.uint64),
+                    "float_col": np.linspace(
+                        offset * 1000.0 / self.NUM_ROWS,
+                        (offset + n) * 1000.0 / self.NUM_ROWS,
+                        n,
+                    ),
+                    "bool_col": np.array([i + offset >= self.NUM_ROWS // 2 for i in range(n)], dtype=bool),
+                    "datetime_col": pd.date_range(
+                        start=datetime_start + pd.Timedelta(seconds=offset),
+                        periods=n,
+                        freq="s",
+                    ),
+                }
+                base_int = np.arange(offset + 1, offset + n + 1, dtype=np.int64)
+                base_float = np.linspace(1.0, 1000.0, n)
+                for i in range(n_int):
+                    data[f"extra_int64_{i}"] = base_int + i
+                for i in range(n_float):
+                    data[f"extra_float_{i}"] = base_float + i * 0.1
+
+                df = pd.DataFrame(data)
+                df.index = timestamps
+                df.index.name = "ts"
+
+                lib.append(sym, df)
+                self.logger.info(f"Wrote chunk {chunk_idx} for {sym}")
+
+            # Create stats on all columns (benchmark + extra) so column stats can prune
+            all_stats = dict(COLUMN_STATS)
+            for i in range(n_int):
+                all_stats[f"extra_int64_{i}"] = {"MINMAX"}
+            for i in range(n_float):
+                all_stats[f"extra_float_{i}"] = {"MINMAX"}
+            lib._nvs.create_column_stats(sym, all_stats)
+            self.logger.info(f"Created column stats for {sym}")
+
+        self.logger.info(f"setup_cache time: {time.time() - start}")
+        return lib_for_storage
+
+    def setup(self, lib_for_storage, column_stats_enabled, storage):
+        self.lib = lib_for_storage[storage]
+        if self.lib is None:
+            raise SkipNotImplemented
+        self.symbol = "wide_filter"
+
+        n_int = self.NUM_EXTRA // 2
+        n_float = self.NUM_EXTRA - n_int
+
+        # Build the QueryBuilder with 1001 OR'd conditions as a balanced tree.
+        # A left-leaning chain would exceed Python's recursion limit in the
+        # recursive expression visitor in processing.py.
+        q = QueryBuilder()
+        uint64_low = self.NUM_ROWS // 10
+        conditions = [q["uint64_col"] < uint64_low]
+        for i in range(n_int):
+            conditions.append(q[f"extra_int64_{i}"] < np.int64(0))
+        for i in range(n_float):
+            conditions.append(q[f"extra_float_{i}"] < 0.0)
+        while len(conditions) > 1:
+            next_level = []
+            for j in range(0, len(conditions), 2):
+                if j + 1 < len(conditions):
+                    next_level.append(conditions[j] | conditions[j + 1])
+                else:
+                    next_level.append(conditions[j])
+            conditions = next_level
+        q = q[conditions[0]]
+        self.query = q
+
+        if column_stats_enabled:
+            set_config_int("ColumnStats.UseForQueries", 1)
+        else:
+            unset_config_int("ColumnStats.UseForQueries")
+
+    def teardown(self, *args):
+        unset_config_int("ColumnStats.UseForQueries")
+
+    def time_filter_wide(self, *args):
+        """Filter with 1001 OR'd conditions forcing decode of 1000 extra columns."""
+        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=self.query)


### PR DESCRIPTION
Add benchmarks that run with and without column stats, on both ordered data (that should benefit a lot) and unordered data (that should not benefit). The unordered data helps us to measure the overhead of evaluating column stats when it cannot provide any benefit.

Since we're still waiting to merge #2958 the runs with and without column stats should be identical to start with. This will also help give us some nice evidence when we rebase and merge #2958.

Evidence of stability from 3 runs:

```
  | Case                              | Run 1   | Run 2   | Run 3   |   CV |
  |-----------------------------------|---------|---------|---------|------|
  | uint64 1M stats=T ordered=T      | 5.97ms  | 5.37ms  | 5.37ms  | 6.2% |
  | uint64 1M stats=F random=F       | 3.67ms  | 3.71ms  | 3.97ms  | 4.3% |
  | uint64 10M stats=T ordered=T     | 13.2ms  | 11.9ms  | 12.4ms  | 5.2% |
  | uint64 10M stats=F random=F      | 16.8ms  | 16.0ms  | 17.2ms  | 3.7% |
  | combined_or 1M stats=T ordered=T | 7.93ms  | 7.38ms  | 8.35ms  | 6.2% |
  | combined_or 10M stats=T ordered=T| 23.5ms  | 22.7ms  | 24.0ms  | 2.8% |
  | combined_or 10M stats=F random=F | 22.7ms  | 22.3ms  | 24.0ms  | 3.9% |
```
