### PR TITLE
Test 11710066367: Use query_stats_operation_count where applicable in all tests

### DIFF
--- a/python/tests/integration/arcticdb/version_store/test_num_storage_operations_with_filtering.py
+++ b/python/tests/integration/arcticdb/version_store/test_num_storage_operations_with_filtering.py
@@ -5,7 +5,7 @@ from arcticdb_ext.storage import KeyType
 import arcticdb.toolbox.query_stats as qs
 import pandas as pd
 
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, query_stats_operation_count
 
 # We create more data keys for rowcount and string indexes because these are just written like normal columns,
 # in a TABLE_DATA key.
@@ -52,15 +52,12 @@ def test_column_slicing(
     lib.write("sym", df)
     check_n_data_keys(lib, "sym", expected_total_data_keys)
 
-    qs.enable()
-
-    lib.read("sym", columns=["a"])
-
-    res = qs.get_query_stats()["storage_operations"]["Memory_GetObject"]
-
-    assert res["TABLE_INDEX"]["count"] == 1
-    # We prune off 3 keys by excluding "b"
-    assert res["TABLE_DATA"]["count"] == expected_total_data_keys - 3
+    with qs.query_stats():
+        lib.read("sym", columns=["a"])
+    stats = qs.get_query_stats()
+    qs.reset_stats()
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == expected_total_data_keys - 3
 
 
 @pytest.mark.parametrize("index_and_expected_data_keys", INDEXES_AND_EXPECTED_DATA_KEYS, ids=INDEX_IDS)
@@ -72,14 +69,12 @@ def test_row_slicing(in_memory_version_store_single_element_segment, index_and_e
     lib.write("sym", df)
     check_n_data_keys(lib, "sym", expected_total_data_keys)
 
-    qs.enable()
-
-    lib.read("sym", row_range=(2, 3))
-
-    res = qs.get_query_stats()["storage_operations"]["Memory_GetObject"]
-
-    assert res["TABLE_INDEX"]["count"] == 1
-    assert res["TABLE_DATA"]["count"] == expected_total_data_keys / 3
+    with qs.query_stats():
+        lib.read("sym", row_range=(2, 3))
+    stats = qs.get_query_stats()
+    qs.reset_stats()
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == expected_total_data_keys / 3
 
 
 @pytest.mark.parametrize("index_and_expected_data_keys", INDEXES_AND_EXPECTED_DATA_KEYS, ids=INDEX_IDS)

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -24,6 +24,7 @@ from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.conftest import Marks
 from tests.util.date import DateRange
 from tests.util.marking import marks
+from arcticdb.util.test import query_stats_operation_count
 
 
 @pytest.mark.storage
@@ -518,15 +519,14 @@ def test_use_norm_failure_handler_known_types(lmdb_version_store_allows_pickling
     Library("dummy", nvs)
 
 
-def test_all_snapshots_not_loaded_for_tombstoned_as_of(s3_version_store_v1, tiny_thread_pool):
+def test_all_snapshots_not_loaded_for_tombstoned_as_of(in_memory_store_factory, tiny_thread_pool):
     # Prior to https://github.com/man-group/ArcticDB/pull/2699 if a version was requested as_of a version number that
     # had been tombstoned, we would load all of the snapshots into memory, and then search for the specified index key.
     # The new implementation:
     # 1. Loads snapshots in parallel (windowed on the number of IO threads)
     # 2. Short-circuits and stops reading snapshot keys when the required index key has been found
-    lib = s3_version_store_v1
+    lib = in_memory_store_factory()
     sym = "test_all_snapshots_not_loaded_for_tombstoned_as_of_sym"
-
     lib.write(sym, 1)
     for idx in range(10):
         lib.snapshot(f"snap_{idx}")
@@ -540,6 +540,6 @@ def test_all_snapshots_not_loaded_for_tombstoned_as_of(s3_version_store_v1, tiny
     assert received == 1
     # There should be exactly 1 listing of snapshot ref keys, 1 listing of the legacy snapshot keys, and 1 GET
     # of a snapshot ref key
-    assert stats["storage_operations"]["S3_ListObjectsV2"]["SNAPSHOT_REF"]["count"] == 1
-    assert stats["storage_operations"]["S3_ListObjectsV2"]["SNAPSHOT"]["count"] == 1
-    assert stats["storage_operations"]["S3_GetObject"]["SNAPSHOT_REF"]["count"] == 1
+    assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT_REF") == 1
+    assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT") == 1
+    assert query_stats_operation_count(stats, "Memory_GetObject", "SNAPSHOT_REF") == 1

--- a/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 import random
-from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data, merge
+from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data, merge, query_stats_operation_count
 import arcticdb
 from arcticdb.version_store import VersionedItem
 import numpy as np
@@ -85,9 +85,8 @@ class TestStressTimeseriesMergeUpdate:
         "segments_to_update",
         [[0], [9], [5], [8, 9], [0, 1, 2], [2, 3, 4, 5], [0, 2, 4, 6, 8], [1, 3, 5, 7, 9], [1, 4, 5, 6, 9]],
     )
-    def test_merge_update(self, s3_version_store_v1, segments_to_update):
-        qs.reset_stats()
-        lib = s3_version_store_v1
+    def test_merge_update(self, in_memory_store_factory, segments_to_update, clear_query_stats):
+        lib = in_memory_store_factory()
         lib.write("sym", self.__class__.data)
         source = make_matching_source(self.__class__.data, segments_to_update, self.__class__.rows_per_segment)
         strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
@@ -95,10 +94,10 @@ class TestStressTimeseriesMergeUpdate:
             lib.merge_experimental("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         expected_table_data_read_count = len(segments_to_update) * self.__class__.col_slices
-        assert stats["storage_operations"]["S3_GetObject"]["TABLE_DATA"]["count"] == expected_table_data_read_count
-        assert stats["storage_operations"]["S3_PutObject"]["TABLE_DATA"]["count"] == expected_table_data_read_count
-        assert stats["storage_operations"]["S3_GetObject"]["TABLE_INDEX"]["count"] == 1
-        assert stats["storage_operations"]["S3_PutObject"]["TABLE_INDEX"]["count"] == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == expected_table_data_read_count
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_table_data_read_count
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
 
         result = lib.read("sym").data
         expected = merge(self.__class__.data, source, strategy=strategy)

--- a/python/tests/unit/arcticdb/test_append_and_defrag.py
+++ b/python/tests/unit/arcticdb/test_append_and_defrag.py
@@ -10,7 +10,7 @@ import pandas as pd
 from arcticdb import LibraryOptions
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.append_and_defrag import _generate_levels, _generate_date_to_read_from, _append_and_defrag_idempotent
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, query_stats_operation_count
 
 
 def test_generate_levels():
@@ -272,16 +272,8 @@ def test_multi_symbol_idempotency(lmdb_library_factory):
 
 
 def assert_data_key_ios(stats, expected_reads, expected_writes):
-    try:
-        read_count = stats["S3_GetObject"]["TABLE_DATA"]["count"]
-    except KeyError:
-        read_count = 0
-    try:
-        write_count = stats["S3_PutObject"]["TABLE_DATA"]["count"]
-    except KeyError:
-        write_count = 0
-    assert read_count == expected_reads
-    assert write_count == expected_writes
+    assert query_stats_operation_count(stats, "S3_GetObject", "TABLE_DATA") == expected_reads
+    assert query_stats_operation_count(stats, "S3_PutObject", "TABLE_DATA") == expected_writes
 
 
 def test_io_count_basic(s3_library_factory):
@@ -299,13 +291,13 @@ def test_io_count_basic(s3_library_factory):
     # sym_1: 0-4
     with qs.query_stats():
         _append_and_defrag_idempotent(lib, [(sym_0, df_0), (sym_1, df_1)], factor, 1)
-        stats = qs.get_query_stats()["storage_operations"]
+        stats = qs.get_query_stats()
     qs.reset_stats()
     assert_data_key_ios(stats, 0, 2)
     # Make the same call again - idempotent so no data keys written the second time
     with qs.query_stats():
         _append_and_defrag_idempotent(lib, [(sym_0, df_0), (sym_1, df_1)], factor, 1)
-        stats = qs.get_query_stats()["storage_operations"]
+        stats = qs.get_query_stats()
     qs.reset_stats()
     assert_data_key_ios(stats, 0, 0)
     # Second call
@@ -316,7 +308,7 @@ def test_io_count_basic(s3_library_factory):
     df_1 = pd.DataFrame({"col": np.arange(rows_per_df_1)}, index=rows_per_df_1 * [ts])
     with qs.query_stats():
         _append_and_defrag_idempotent(lib, [(sym_0, df_0), (sym_1, df_1)], factor, 1)
-        stats = qs.get_query_stats()["storage_operations"]
+        stats = qs.get_query_stats()
     qs.reset_stats()
     # sym_0 will have to read the existing data key to combine it with the new data
     assert_data_key_ios(stats, 1, 2)
@@ -328,7 +320,7 @@ def test_io_count_basic(s3_library_factory):
     df_1 = pd.DataFrame({"col": np.arange(rows_per_df_1)}, index=rows_per_df_1 * [ts])
     with qs.query_stats():
         _append_and_defrag_idempotent(lib, [(sym_0, df_0), (sym_1, df_1)], factor, 1)
-        stats = qs.get_query_stats()["storage_operations"]
+        stats = qs.get_query_stats()
     qs.reset_stats()
     # No defrag happening so no data keys will be read
     assert_data_key_ios(stats, 0, 2)
@@ -340,7 +332,7 @@ def test_io_count_basic(s3_library_factory):
     df_1 = pd.DataFrame({"col": np.arange(rows_per_df_1)}, index=rows_per_df_1 * [ts])
     with qs.query_stats():
         _append_and_defrag_idempotent(lib, [(sym_0, df_0), (sym_1, df_1)], factor, 1)
-        stats = qs.get_query_stats()["storage_operations"]
+        stats = qs.get_query_stats()
     qs.reset_stats()
     # sym_0 will read 1 data key to defrag
     # sym_1 will read all 3 data keys to defrag
@@ -360,7 +352,7 @@ def test_io_count_many_iterations(s3_library_factory):
             _append_and_defrag_idempotent(lib, [(sym, df)], factor, 1)
             ts += pd.Timedelta(1, unit="days")
             df = pd.DataFrame({"col": np.arange(rows_per_df)}, index=rows_per_df * [ts])
-        stats = qs.get_query_stats()["storage_operations"]
+        stats = qs.get_query_stats()
     qs.reset_stats()
     # Iterations:
     # 0:    read 0 data keys, write 1 data key 0-4

--- a/python/tests/unit/arcticdb/version_store/test_collect_schema.py
+++ b/python/tests/unit/arcticdb/version_store/test_collect_schema.py
@@ -16,7 +16,7 @@ from arcticdb_ext.exceptions import KeyNotFoundException
 from arcticdb.exceptions import SchemaException
 from arcticdb.options import ArrowOutputStringFormat, OutputFormat
 import arcticdb.toolbox.query_stats as qs
-from arcticdb.util.test import assert_frame_equal_with_arrow, config_context
+from arcticdb.util.test import assert_frame_equal_with_arrow, config_context, query_stats_operation_count
 
 
 @pytest.mark.parametrize("num_rows", [0, 1])
@@ -246,26 +246,26 @@ def test_collect_schema_and_collect_multiple_times(mem_library):
             stats = qs.get_query_stats()
         qs.reset_stats()
         # Read the vref and index key to get the schema, but no data keys yet
-        assert stats["storage_operations"]["Memory_GetObject"]["VERSION_REF"]["count"] == 1
-        assert stats["storage_operations"]["Memory_GetObject"]["TABLE_INDEX"]["count"] == 1
-        assert "TABLE_DATA" not in stats["storage_operations"]["Memory_GetObject"]
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 0
         with qs.query_stats():
             lazy_df._collect_schema()
             stats = qs.get_query_stats()
         qs.reset_stats()
         # Read the same keys again, see comment in _collect_schema() impl for explanation of why
-        assert stats["storage_operations"]["Memory_GetObject"]["VERSION_REF"]["count"] == 1
-        assert stats["storage_operations"]["Memory_GetObject"]["TABLE_INDEX"]["count"] == 1
-        assert "TABLE_DATA" not in stats["storage_operations"]["Memory_GetObject"]
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 0
         with qs.query_stats():
             received_df = lazy_df.collect().data
             stats = qs.get_query_stats()
         qs.reset_stats()
         # Read the data key, but no vref, version, or index keys
-        assert stats["storage_operations"]["Memory_GetObject"]["TABLE_DATA"]["count"] == 1
-        assert "VERSION_REF" not in stats["storage_operations"]["Memory_GetObject"]
-        assert "VERSION" not in stats["storage_operations"]["Memory_GetObject"]
-        assert "TABLE_INDEX" not in stats["storage_operations"]["Memory_GetObject"]
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF") == 0
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION") == 0
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 0
         assert_frame_equal_with_arrow(df, received_df)
 
         # Change the query
@@ -314,12 +314,12 @@ def test_collect_schema_and_collect_version_deleted(mem_library):
             stats = qs.get_query_stats()
         qs.reset_stats()
         # Attempted to read the data key but failed (hence 0 bytes)
-        assert stats["storage_operations"]["Memory_GetObject"]["TABLE_DATA"]["count"] == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
         assert stats["storage_operations"]["Memory_GetObject"]["TABLE_DATA"]["size_bytes"] == 0
         # Did not attempt to read from the version chain again
-        assert "VERSION_REF" not in stats["storage_operations"]["Memory_GetObject"]
-        assert "VERSION" not in stats["storage_operations"]["Memory_GetObject"]
-        assert "TABLE_INDEX" not in stats["storage_operations"]["Memory_GetObject"]
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF") == 0
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION") == 0
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 0
 
 
 def test_collect_schema_recursive_normalizers(lmdb_library):

--- a/python/tests/unit/arcticdb/version_store/test_list_versions.py
+++ b/python/tests/unit/arcticdb/version_store/test_list_versions.py
@@ -9,6 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import pytest
 
 import arcticdb.toolbox.query_stats as qs
+from arcticdb.util.test import query_stats_operation_count
 from arcticdb_ext.exceptions import KeyNotFoundException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 
@@ -137,24 +138,20 @@ def test_list_versions_deleted_symbols_alive_in_snapshot(lmdb_version_store_v1):
 # 1 argument
 
 
-def test_list_versions_deleted_symbols_alive_in_snapshot_skip_snapshots(s3_version_store_v1, clear_query_stats):
+def test_list_versions_deleted_symbols_alive_in_snapshot_skip_snapshots(in_memory_store_factory, clear_query_stats):
     """Should not look in snapshots at all, even if the symbol is deleted."""
-    lib = s3_version_store_v1
+    lib = in_memory_store_factory()
     lib.write("sym", 1)
     lib.snapshot("snap")
     lib.delete("sym")
 
-    qs.enable()
+    with qs.query_stats():
+        res = lib.list_versions(skip_snapshots=True)
+        stats = qs.get_query_stats()
     qs.reset_stats()
-    res = lib.list_versions(skip_snapshots=True)
-
     assert res == []
-
-    stats = qs.get_query_stats()
-    storage_ops = stats["storage_operations"]
-
-    assert "SNAPSHOT_REF" not in storage_ops["S3_ListObjectsV2"]
-    assert "SNAPSHOT_REF" not in storage_ops["S3_GetObject"]
+    assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT_REF") == 0
+    assert query_stats_operation_count(stats, "Memory_GetObject", "SNAPSHOT_REF") == 0
 
 
 @pytest.mark.parametrize("symbol", [None, "sym"])
@@ -396,8 +393,8 @@ def test_broken_version_chain(lmdb_version_store_v1, latest_only):
     assert broken_sym in str(e.value)
 
 
-def test_list_versions_specific_snapshot_should_not_list_snapshots(s3_version_store_v1, clear_query_stats):
-    lib = s3_version_store_v1
+def test_list_versions_specific_snapshot_should_not_list_snapshots(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
     num_snapshots = 5
 
     for i in range(num_snapshots):
@@ -411,18 +408,15 @@ def test_list_versions_specific_snapshot_should_not_list_snapshots(s3_version_st
     lib.list_versions(snapshot="snap0", skip_snapshots=True)
 
     stats = qs.get_query_stats()
-    storage_ops = stats["storage_operations"]
 
     # Should not list snapshots when user specifies a particular snapshot
-    assert "S3_ListObjectsV2" not in storage_ops
-    snapshot_read_count = storage_ops["S3_GetObject"]["SNAPSHOT_REF"]["count"]
-    assert snapshot_read_count == 1
+    assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT_REF") == 0
+    assert query_stats_operation_count(stats, "Memory_GetObject", "SNAPSHOT_REF") == 1
 
-    # Reasonableness check that "S3_ListObjectsV2" can be in the output
+    # Reasonableness check that "Memory_ListObjects" can be in the output
     lib.list_snapshots()
     stats = qs.get_query_stats()
-    storage_ops = stats["storage_operations"]
-    assert "S3_ListObjectsV2" in storage_ops
+    assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT_REF") == 1
 
 
 def test_list_versions_specific_snapshot_all_symbols(lmdb_version_store_v1):

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -17,7 +17,7 @@ import dateutil
 
 from arcticdb import OutputFormat
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, query_stats_operation_count
 import arcticdb.toolbox.query_stats as qs
 
 pytestmark = pytest.mark.pipeline
@@ -1260,8 +1260,8 @@ def test_to_strings():
 
 
 @pytest.mark.parametrize("dynamic_schema", [True, False])
-def test_column_select_projected_column(s3_store_factory, dynamic_schema, any_output_format):
-    lib = s3_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
+def test_column_select_projected_column(in_memory_store_factory, dynamic_schema, any_output_format):
+    lib = in_memory_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "sym_0"
     lib.write(sym, pd.DataFrame({"a": [1, 2], "b": ["a", "b"], "c": [5, 6]}))
@@ -1273,12 +1273,12 @@ def test_column_select_projected_column(s3_store_factory, dynamic_schema, any_ou
     qs.reset_stats()
     expected = pd.DataFrame({"new_column": [3, 4]})
     assert_frame_equal(expected, result)
-    assert stats["storage_operations"]["S3_GetObject"]["TABLE_DATA"]["count"] == 1
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
 
 
 @pytest.mark.parametrize("dynamic_schema", [True, False])
-def test_column_select_projected_column_and_filter_it(s3_store_factory, dynamic_schema, any_output_format):
-    lib = s3_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
+def test_column_select_projected_column_and_filter_it(in_memory_store_factory, dynamic_schema, any_output_format):
+    lib = in_memory_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "sym_0"
     lib.write(sym, pd.DataFrame({"b": ["a", "b"], "c": [5, 6], "a": [1, 2]}))
@@ -1291,15 +1291,15 @@ def test_column_select_projected_column_and_filter_it(s3_store_factory, dynamic_
     qs.reset_stats()
     expected = pd.DataFrame({"new_column": [4]})
     assert_frame_equal(expected, result)
-    assert stats["storage_operations"]["S3_GetObject"]["TABLE_DATA"]["count"] == 1
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
 
 
 @pytest.mark.parametrize("dynamic_schema", [True, False])
 @pytest.mark.parametrize("column_to_read", ["b", "c"])
 def test_filter_synthetic_column_and_select_on_disk_column(
-    s3_store_factory, dynamic_schema, column_to_read, any_output_format
+    in_memory_store_factory, dynamic_schema, column_to_read, any_output_format
 ):
-    lib = s3_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
+    lib = in_memory_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "sym_0"
     df = pd.DataFrame({"a": [1, 2], "b": [7, 8], "c": [5, 6]})
@@ -1319,4 +1319,4 @@ def test_filter_synthetic_column_and_select_on_disk_column(
         # Column c is in the second column slice. This means that we must read the first column slice to perform the
         # filter and then read the second column slice to return the requested column
         data_keys_count = 2
-    assert stats["storage_operations"]["S3_GetObject"]["TABLE_DATA"]["count"] == data_keys_count
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == data_keys_count

--- a/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
+++ b/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
@@ -59,9 +59,7 @@ class AlmostAListNormalizer(CustomNormalizer):
 @pytest.mark.parametrize("staged", (True, False, None))
 @pytest.mark.parametrize("lib_option", (True, False, None))
 @pytest.mark.parametrize("recursive_normalizers", (True, False, None))
-def test_v2_api(
-    arctic_client_lmdb_v1_only, sym, recursive_normalizers, clear_query_stats, lib_name, lib_option, staged
-):
+def test_v2_api(arctic_client_lmdb_v1_only, sym, recursive_normalizers, lib_name, lib_option, staged):
     if lib_option is None:
         lib = arctic_client_lmdb_v1_only.create_library(lib_name)
     else:


### PR DESCRIPTION
#### Reference Issues/PRs
[11710066367](https://man312219.monday.com/boards/7852509418/pulses/11710066367)

#### What does this implement or fix?
Uses `query_stats_operation_count` in all applicable tests. Also swaps some S3 fixxtures for in-memory now that we have stats for this storage backend as well, as it is a lot faster.