### PR TITLE
Bug: `read(as_of=<timestamp>)` ignores snapshot-protected deleted versions when any live version exists

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -337,15 +337,27 @@ std::optional<VersionedItem> LocalVersionedEngine::get_specific_version(
 std::optional<VersionedItem> LocalVersionedEngine::get_version_at_time(
         const StreamId& stream_id, timestamp as_of, const VersionQuery& version_query
 ) {
+    LoadStrategy load_strategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, as_of};
+    auto entry = version_map()->check_reload(store(), stream_id, load_strategy, __FUNCTION__);
 
-    auto index_key = load_index_key_from_time(store(), version_map(), stream_id, as_of);
-    if (!index_key && std::get<TimestampVersionQuery>(version_query.content_).iterate_snapshots_if_tombstoned) {
-        auto index_keys = get_index_keys_in_snapshots(store(), stream_id);
-        auto vector_index_keys = std::vector<AtomKey>(index_keys.begin(), index_keys.end());
-        std::sort(std::begin(vector_index_keys), std::end(vector_index_keys), [](auto& k1, auto& k2) {
-            return k1.creation_ts() > k2.creation_ts();
-        });
-        index_key = get_index_key_from_time(as_of, vector_index_keys);
+    auto live_key = get_index_key_from_time(as_of, entry->get_indexes(false));
+    auto index_key = live_key;
+
+    if (std::get<TimestampVersionQuery>(version_query.content_).iterate_snapshots_if_tombstoned &&
+        (!entry->tombstones_.empty() || entry->tombstone_all_.has_value())) {
+        // A deleted version may be more recent than the live one at this timestamp.
+        // get_indexes(true) reuses the already-loaded entry — no extra I/O.
+        auto best_key = get_index_key_from_time(as_of, entry->get_indexes(true));
+        if (!live_key || (best_key && best_key->version_id() > live_key->version_id())) {
+            auto index_keys = get_index_keys_in_snapshots(store(), stream_id);
+            auto vector_index_keys = std::vector<AtomKey>(index_keys.begin(), index_keys.end());
+            std::sort(std::begin(vector_index_keys), std::end(vector_index_keys), [](auto& k1, auto& k2) {
+                return k1.creation_ts() > k2.creation_ts();
+            });
+            auto snap_key = get_index_key_from_time(as_of, vector_index_keys);
+            if (snap_key && (!live_key || snap_key->version_id() > live_key->version_id()))
+                index_key = snap_key;
+        }
     }
 
     if (!index_key) {

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1991,7 +1991,7 @@ def test_find_version(lmdb_version_store_v1):
         lib.write(sym, 0)
     lib.snapshot("snap_0")
 
-    # Version 1 is only available in snap_1
+    # Version 1 is in snap_1 and accessible via timestamp reads (it was current when written)
     with distinct_timestamps(lmdb_version_store_v1) as v1_time:
         lib.write(sym, 1)
     lib.snapshot("snap_1")
@@ -2027,8 +2027,10 @@ def test_find_version(lmdb_version_store_v1):
         lib._find_version(sym, as_of="snap_1000")
     # By timestamp
     assert lib._find_version(sym, as_of=v0_time.after).version == 0
-    assert lib._find_version(sym, as_of=v1_time.after).version == 0
-    assert lib._find_version(sym, as_of=v2_time.after).version == 0
+    assert lib._find_version(sym, as_of=v1_time.after).version == 1  # V1 was current; snapshot-protected
+    assert (
+        lib._find_version(sym, as_of=v2_time.after).version == 1
+    )  # V2 unprotected; V1 is most recent snapshot-protected
     assert lib._find_version(sym, as_of=v3_time.after).version == 3
 
 

--- a/python/tests/integration/arcticdb/version_store/test_snapshot.py
+++ b/python/tests/integration/arcticdb/version_store/test_snapshot.py
@@ -297,6 +297,149 @@ def test_read_symbol_with_ts_in_snapshot(store, request, sym):
     assert lib.read(sym, as_of=third_write_timestamps.after).version == 2
 
 
+def test_read_by_timestamp_finds_snapshot_protected_version_when_live_version_exists(lmdb_version_store_v1, sym):
+    """
+    Regression test for a pre-existing bug in get_version_at_time.
+
+    The snapshot fallback in get_version_at_time (local_versioned_engine.cpp) only fires when
+    load_index_key_from_time returns nullopt, i.e. when NO undeleted version exists before the
+    requested timestamp.  If an earlier live version exists it is returned instead of a newer
+    snapshot-protected-but-deleted version, violating time-travel semantics.
+
+    Scenario:
+      V0 written (alive)
+      V1 written, snapshot "snap" captures it
+      V1 deleted  -> V1 tombstoned, snap protects its data keys
+      read(as_of=ts_after_V1_write) should return V1 (was current at that time, in snapshot)
+      but currently returns V0 (the latest alive version before the timestamp).
+    """
+    lib = lmdb_version_store_v1
+
+    lib.write(sym, 0)  # V0 — remains alive throughout
+
+    with distinct_timestamps(lib) as ts_v1:
+        lib.write(sym, 1)  # V1
+
+    lib.snapshot("snap")
+    lib.delete_version(sym, 1)  # soft-delete V1; snap protects it
+
+    # V0 is alive; V1 is deleted but snapshot-protected.
+    versions = lib.list_versions(sym)
+    assert len(versions) == 2
+    assert versions[0]["deleted"] is True   # V1 deleted
+    assert versions[1]["deleted"] is False  # V0 alive
+
+    # Reading by version_id still works (snapshot protection).
+    assert lib.read(sym, as_of=1).data == 1
+
+    # Reading by timestamp at V1's creation time should return V1 (it was current then,
+    # and snap protects it).  Currently returns V0 because get_version_at_time only
+    # falls back to snapshot search when no live version is found at all.
+    assert lib.read(sym, as_of=ts_v1.after).data == 1  # BUG: currently returns V0 (data==0)
+
+
+def test_read_by_timestamp_returns_most_recent_snapshot_protected_version_when_newer_deleted_unprotected_exists(
+        lmdb_version_store_v1, sym
+):
+    """
+    Variant of test_read_by_timestamp_finds_snapshot_protected_version_when_live_version_exists.
+
+    When multiple deleted versions exist between the live version and the requested timestamp,
+    get_version_at_time must return the most recent *snapshot-protected* version, not the most
+    recent deleted one (which may carry no snapshot protection and whose data may be GC'd).
+
+    Scenario:
+      V0 written (alive)
+      V1 written, snapshot "snap" captures it, then V1 deleted  -> snap protects V1
+      V2 written (no snapshot), then V2 deleted                 -> V2 unprotected, data may be GC'd
+      read(as_of=ts_after_V2_write) should return V1 (most recent snapshot-protected version)
+      but currently returns V0 (the only live version).
+    """
+    lib = lmdb_version_store_v1
+
+    lib.write(sym, 0)  # V0 — remains alive throughout
+
+    with distinct_timestamps(lib) as ts_v1:
+        lib.write(sym, 1)  # V1
+
+    lib.snapshot("snap")
+    lib.delete_version(sym, 1)  # soft-delete V1; snap protects it
+
+    with distinct_timestamps(lib) as ts_v2:
+        lib.write(sym, 2)  # V2 — no snapshot protection
+
+    lib.delete_version(sym, 2)  # soft-delete V2; no snapshot, data may be GC'd
+
+    # V0 alive; V2 is tombstoned and unprotected (not in list_versions);
+    # V1 is tombstoned but snapshot-protected (appears as deleted=True).
+    versions = lib.list_versions(sym)
+    assert len(versions) == 2
+    assert versions[0]["deleted"] is True   # V1 deleted, snapshot-protected
+    assert versions[1]["deleted"] is False  # V0 alive
+
+    # V1 still accessible by version_id via snapshot.
+    assert lib.read(sym, as_of=1).data == 1
+
+    # At ts_v2.after, V2 was the current version but it is unprotected.
+    # V1 is the most recent snapshot-protected version at/before that timestamp.
+    # Currently returns V0 because get_version_at_time stops at the first live version found.
+    assert lib.read(sym, as_of=ts_v2.after).data == 1  # BUG: currently returns V0 (data==0)
+
+
+def test_read_by_timestamp_between_two_snapshots_returns_earlier_snapshot_version(lmdb_version_store_v1, sym):
+    """
+    Two snapshots s1 and s2 each protect a deleted version; an unprotected deleted version
+    sits between them.  A timestamp read between s1 and s2 should return s1's version.
+
+    The snapshot search calls get_index_key_from_time over keys from *all* snapshots sorted
+    descending by creation_ts.  s2's version (creation_ts > as_of) is skipped by the binary
+    search; s1's version (creation_ts <= as_of) is returned.  This test verifies that both
+    snapshot keys are present in the search and that the sort produces the correct result.
+
+    Scenario:
+      V0 written (alive)
+      V1 written -> s1 taken -> V1 deleted  (s1 protects V1)
+      V2 written -> V2 deleted              (no snapshot, V2 unprotected)
+      V3 written -> s2 taken -> V3 deleted  (s2 protects V3)
+      read(as_of=ts_after_V2) should return V1 (most recent snapshot-protected version <= ts)
+    """
+    lib = lmdb_version_store_v1
+
+    lib.write(sym, 0)  # V0 — remains alive throughout
+
+    lib.write(sym, 1)  # V1
+    lib.snapshot("s1")
+    lib.delete_version(sym, 1)  # s1 protects V1
+
+    with distinct_timestamps(lib) as ts_v2:
+        lib.write(sym, 2)  # V2 — no snapshot
+
+    lib.delete_version(sym, 2)  # V2 unprotected
+
+    lib.write(sym, 3)  # V3
+    lib.snapshot("s2")
+    lib.delete_version(sym, 3)  # s2 protects V3
+
+    # V0 alive; V1 and V3 deleted but snapshot-protected; V2 deleted and not visible.
+    versions = lib.list_versions(sym)
+    assert len(versions) == 3
+    assert versions[0]["version"] == 3  # V3 deleted, in s2
+    assert versions[0]["deleted"] is True
+    assert versions[1]["version"] == 1  # V1 deleted, in s1
+    assert versions[1]["deleted"] is True
+    assert versions[2]["version"] == 0  # V0 alive
+    assert versions[2]["deleted"] is False
+
+    # Version-id reads still work via snapshots.
+    assert lib.read(sym, as_of=1).data == 1
+    assert lib.read(sym, as_of=3).data == 3
+
+    # ts_v2.after is between V2 and V3.  V2 was current then but is unprotected.
+    # The snapshot search over {V1(s1), V3(s2)} sorted desc by creation_ts skips V3
+    # (creation_ts > ts_v2.after) and returns V1.
+    assert lib.read(sym, as_of=ts_v2.after).data == 1  # BUG: currently returns V0 (data==0)
+
+
 @pytest.mark.storage
 def test_add_to_snapshot_simple(basic_store_tombstone_and_pruning):
     lib = basic_store_tombstone_and_pruning

--- a/python/tests/integration/arcticdb/version_store/test_snapshot.py
+++ b/python/tests/integration/arcticdb/version_store/test_snapshot.py
@@ -326,7 +326,7 @@ def test_read_by_timestamp_finds_snapshot_protected_version_when_live_version_ex
     # V0 is alive; V1 is deleted but snapshot-protected.
     versions = lib.list_versions(sym)
     assert len(versions) == 2
-    assert versions[0]["deleted"] is True   # V1 deleted
+    assert versions[0]["deleted"] is True  # V1 deleted
     assert versions[1]["deleted"] is False  # V0 alive
 
     # Reading by version_id still works (snapshot protection).
@@ -339,7 +339,7 @@ def test_read_by_timestamp_finds_snapshot_protected_version_when_live_version_ex
 
 
 def test_read_by_timestamp_returns_most_recent_snapshot_protected_version_when_newer_deleted_unprotected_exists(
-        lmdb_version_store_v1, sym
+    lmdb_version_store_v1, sym
 ):
     """
     Variant of test_read_by_timestamp_finds_snapshot_protected_version_when_live_version_exists.
@@ -374,7 +374,7 @@ def test_read_by_timestamp_returns_most_recent_snapshot_protected_version_when_n
     # V1 is tombstoned but snapshot-protected (appears as deleted=True).
     versions = lib.list_versions(sym)
     assert len(versions) == 2
-    assert versions[0]["deleted"] is True   # V1 deleted, snapshot-protected
+    assert versions[0]["deleted"] is True  # V1 deleted, snapshot-protected
     assert versions[1]["deleted"] is False  # V0 alive
 
     # V1 still accessible by version_id via snapshot.


### PR DESCRIPTION
## Bug: `read(as_of=<timestamp>)` ignores snapshot-protected deleted versions when any live version exists   


This is an interesting edge-case, and I can see the argument both ways:                

 ### Minimal reproduction

```
  write(sym, 0)          # V0 — remains alive
  write(sym, 1)          # V1, timestamp captured                                                                                           
  snapshot("snap")       # snap protects V1
  delete_version(sym, 1) # V1 tombstoned; snap keeps its data keys alive                                                                    
                                                                             
  read(sym, as_of=1).data            == 1  # OK   — version-id path searches snapshots                                                      
  read(sym, as_of=ts_after_V1).data  == 1  # FAIL — returns V0 (data=0) instead
```

* Version is available via snapshot, but isn't via timestamp read as it's been 'deleted'
* However prune_previous_versions would automatically be expected to clean up non-snapshotted versions

... and versions which exist under snapshot shouldn't really be considered as deleted... Certainly from the point of view reads with timestamp.
                                                          
  ### Root cause                                                             

  The snapshot fallback only fires when `load_index_key_from_time` returns `nullopt` — i.e. when
  *no* undeleted version exists before the requested timestamp. If an older live version is present,
  it is returned silently, even if a newer version was current at that time and is protected by a                                           
  snapshot:
                                                                                                                                            
  ```cpp                                                                     
  auto index_key = load_index_key_from_time(store(), version_map(), stream_id, as_of);
  if (!index_key && ...iterate_snapshots_if_tombstoned) {                                                                                   
      // snapshot search — never reached if any live version exists
  }                                                                                                                                         
 ```                                                                            
                                                                                                                                            
###  Additional finding                                                         
                                                                                                                                            
  The V2 Library API hardcodes iterate_snapshots_if_tombstoned=False at every call site in
  library.py, so the snapshot fallback is disabled entirely for V2 users — both for timestamp and
  version-id reads. No comments explain this choice.                                                                                        
   
###  Coverage                                                                                                                                  
                                                                             
  This behaviour doesn't appear to be documented, or noted anywhere in the codebase. 