### PR TITLE
Enhancement/11746871478/kwargs validation take 12

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -106,7 +106,6 @@ from packaging.version import Version
 import arcticdb_ext as ae
 
 from arcticdb.util.arrow import convert_arrow_to_pandas_for_tests
-from arcticdb.util.utils import strtobool
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -693,20 +692,11 @@ class NativeVersionStore:
                 invalid_args.append(arg)
         if invalid_args:
             # Log formatting gets confused by curly braces in input string, hence the conversion to a list
-            base_msg = (
-                f"{method} received unrecognized keyword argument(s) {invalid_args}. "
-                f"Supported keyword arguments are {sorted(list(valid_kwargs))}. "
-                f"If you want to explicitly opt out of the validation exception, set the environment variable ARCTICDB_DISABLE_KWARG_VALIDATION to a truthy value (e.g. '1'). "
-            )
-            if strtobool(os.environ.get("ARCTICDB_DISABLE_KWARG_VALIDATION", "1")):
-                msg = (
-                    base_msg
-                    + "This warning will be changed to an exception in a future version of ArcticDB. "
-                    + "If you want to preview the future behavior, set the environment variable ARCTICDB_DISABLE_KWARG_VALIDATION to 0. "
-                )
+            msg = f"{method} received invalid kwargs {invalid_args}. Supported kwargs are {sorted(list(valid_kwargs))}"
+            if os.environ.get("ARCTICDB_DISABLE_KWARG_VALIDATION", None) == "1":
                 log.warning(msg)
             else:
-                raise ArcticNativeException(base_msg)
+                raise ArcticNativeException(msg)
 
     def stage(
         self,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2457,7 +2457,12 @@ class NativeVersionStore:
         -------
         VersionedItem
         """
-        self._validate_kwargs("read", self._valid_read_kwargs.union({"implement_read_index"}), kwargs)
+        # allow_secondary does not do anything with arcticdb (and never has), but it was a valid argument to read with
+        # Arctic Python. Some users have code that is agnostic to whether ArcticDB or Arctic Python is the backend, so
+        # do not raise/log for this specific kwarg
+        self._validate_kwargs(
+            "read", self._valid_read_kwargs.union({"implement_read_index", "allow_secondary"}), kwargs
+        )
 
         implement_read_index = kwargs.get("implement_read_index", False)
         columns = self._resolve_empty_columns(columns, implement_read_index)

--- a/python/tests/unit/arcticdb/version_store/test_kwarg_validation.py
+++ b/python/tests/unit/arcticdb/version_store/test_kwarg_validation.py
@@ -13,25 +13,12 @@ from arcticdb.exceptions import ArcticNativeException
 from arcticdb.util.test import config_context
 from arcticdb.version_store.processing import QueryBuilder
 
-# "warn" = env var set to "1" (explicit opt-in to warning)
-# "warn_default" = env var not set (default is now "1", so warns)
-# "error" = env var set to "0" (opt-in to error)
-VALIDATION_MODES = ["warn", "warn_default", "error"]
-
-
-def _setup_env_var(monkeypatch, mode):
-    if mode == "warn":
-        monkeypatch.setenv("ARCTICDB_DISABLE_KWARG_VALIDATION", "1")
-    elif mode == "warn_default":
-        monkeypatch.delenv("ARCTICDB_DISABLE_KWARG_VALIDATION", raising=False)
-    elif mode == "error":
-        monkeypatch.setenv("ARCTICDB_DISABLE_KWARG_VALIDATION", "0")
-
 
 @pytest.mark.parametrize("method", ["stage", "write", "append", "update", "batch_write", "batch_append"])
-@pytest.mark.parametrize("mode", VALIDATION_MODES)
-def test_modification_methods(lmdb_version_store_v1, monkeypatch, method, mode):
-    _setup_env_var(monkeypatch, mode)
+@pytest.mark.parametrize("env_var_set", [True, False])
+def test_modification_methods(lmdb_version_store_v1, monkeypatch, method, env_var_set):
+    if env_var_set:
+        monkeypatch.setenv("ARCTICDB_DISABLE_KWARG_VALIDATION", "1")
     lib = lmdb_version_store_v1
     sym = "test_modification_methods"
     df = pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)])
@@ -40,13 +27,13 @@ def test_modification_methods(lmdb_version_store_v1, monkeypatch, method, mode):
     f = getattr(lib, method)
     arg_0 = [sym] if method.startswith("batch_") else sym
     arg_1 = [df] if method.startswith("batch_") else df
-    if mode == "error":
+    if env_var_set:
+        f(arg_0, arg_1, not_a_kwarg=True)
+    else:
         with pytest.raises(ArcticNativeException) as e:
             f(arg_0, arg_1, not_a_kwarg=True)
         msg = str(e.value)
         assert method in msg and "not_a_kwarg" in msg
-    else:
-        f(arg_0, arg_1, not_a_kwarg=True)
 
 
 @pytest.mark.parametrize(
@@ -70,9 +57,10 @@ def test_modification_methods(lmdb_version_store_v1, monkeypatch, method, mode):
         "batch_restore_version",
     ],
 )
-@pytest.mark.parametrize("mode", VALIDATION_MODES)
-def test_single_argument_methods(lmdb_version_store_v1, monkeypatch, method, mode):
-    _setup_env_var(monkeypatch, mode)
+@pytest.mark.parametrize("env_var_set", [True, False])
+def test_single_argument_methods(lmdb_version_store_v1, monkeypatch, method, env_var_set):
+    if env_var_set:
+        monkeypatch.setenv("ARCTICDB_DISABLE_KWARG_VALIDATION", "1")
     lib = lmdb_version_store_v1
     sym = "test_read_methods"
     df = pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)])
@@ -82,33 +70,35 @@ def test_single_argument_methods(lmdb_version_store_v1, monkeypatch, method, mod
     f = getattr(lib, method)
     arg_0 = [sym] if method.startswith("batch_") else sym
     with config_context("SymbolDataCompact.SegmentCount", 1):
-        if mode == "error":
+        if env_var_set:
+            f(arg_0, not_a_kwarg=True)
+        else:
             with pytest.raises(ArcticNativeException) as e:
                 f(arg_0, not_a_kwarg=True)
             msg = str(e.value)
             assert method in msg and "not_a_kwarg" in msg
-        else:
-            f(arg_0, not_a_kwarg=True)
 
 
-@pytest.mark.parametrize("mode", VALIDATION_MODES)
-def test_batch_read_and_join(lmdb_version_store_v1, monkeypatch, mode):
-    _setup_env_var(monkeypatch, mode)
+@pytest.mark.parametrize("env_var_set", [True, False])
+def test_batch_read_and_join(lmdb_version_store_v1, monkeypatch, env_var_set):
+    if env_var_set:
+        monkeypatch.setenv("ARCTICDB_DISABLE_KWARG_VALIDATION", "1")
     lib = lmdb_version_store_v1
     sym = "test_batch_read_and_join"
     lib.write(sym, pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)]))
-    if mode == "error":
+    if env_var_set:
+        lib.batch_read_and_join([sym], query_builder=QueryBuilder().concat(), not_a_kwarg=True)
+    else:
         with pytest.raises(ArcticNativeException) as e:
             lib.batch_read_and_join([sym], query_builder=QueryBuilder().concat(), not_a_kwarg=True)
         msg = str(e.value)
         assert "batch_read_and_join" in msg and "not_a_kwarg" in msg
-    else:
-        lib.batch_read_and_join([sym], query_builder=QueryBuilder().concat(), not_a_kwarg=True)
 
 
-@pytest.mark.parametrize("mode", VALIDATION_MODES)
-def test_add_to_snapshot(lmdb_version_store_v1, monkeypatch, mode):
-    _setup_env_var(monkeypatch, mode)
+@pytest.mark.parametrize("env_var_set", [True, False])
+def test_add_to_snapshot(lmdb_version_store_v1, monkeypatch, env_var_set):
+    if env_var_set:
+        monkeypatch.setenv("ARCTICDB_DISABLE_KWARG_VALIDATION", "1")
     lib = lmdb_version_store_v1
     sym_0 = "test_add_to_snapshot_0"
     lib.write(sym_0, pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)]))
@@ -116,10 +106,10 @@ def test_add_to_snapshot(lmdb_version_store_v1, monkeypatch, mode):
     lib.snapshot(snap)
     sym_1 = "test_add_to_snapshot_1"
     lib.write(sym_1, pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)]))
-    if mode == "error":
+    if env_var_set:
+        lib.add_to_snapshot(snap, [sym_1], not_a_kwarg=True)
+    else:
         with pytest.raises(ArcticNativeException) as e:
             lib.add_to_snapshot(snap, [sym_1], not_a_kwarg=True)
         msg = str(e.value)
         assert "add_to_snapshot" in msg and "not_a_kwarg" in msg
-    else:
-        lib.add_to_snapshot(snap, [sym_1], not_a_kwarg=True)

--- a/python/tests/unit/arcticdb/version_store/test_kwarg_validation.py
+++ b/python/tests/unit/arcticdb/version_store/test_kwarg_validation.py
@@ -113,3 +113,14 @@ def test_add_to_snapshot(lmdb_version_store_v1, monkeypatch, env_var_set):
             lib.add_to_snapshot(snap, [sym_1], not_a_kwarg=True)
         msg = str(e.value)
         assert "add_to_snapshot" in msg and "not_a_kwarg" in msg
+
+
+@pytest.mark.parametrize("env_var_set", [True, False])
+def test_read_with_allow_secondary(lmdb_version_store_v1, monkeypatch, env_var_set):
+    # This was a valid argument with Arctic Python, so should always succeed
+    if env_var_set:
+        monkeypatch.setenv("ARCTICDB_DISABLE_KWARG_VALIDATION", "1")
+    lib = lmdb_version_store_v1
+    sym = "test_read_with_allow_secondary"
+    lib.write(sym, pd.DataFrame({"col": [0]}))
+    lib.read(sym, allow_secondary=True)


### PR DESCRIPTION
#### Reference Issues/PRs
[11746871478](https://man312219.monday.com/boards/7852509418/pulses/11746871478)

#### What does this implement or fix?
Changes the default behaviour of kwargs validation back to throwing again.
Also adds `allow_secondary` as a kwarg to `read` (even though it does nothing) so that users who are agnostic to whether their library is ArcticDB or Arctic Python can have this continue to work.