### PR TITLE
Remove unused libiconv (lgpl) dependency

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -103,11 +103,7 @@ add_library(xxHash STATIC IMPORTED)
 set_target_properties(xxHash PROPERTIES IMPORTED_LOCATION ${xxHash_LIBRARY})
 set_target_properties(xxHash PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${xxHash_INCLUDE_DIR})
 
-# Libraries baked into the internal and external Linux images are found by searching various paths
-# On Windows, vcpkg will provide a "Config" which takes precedence
-if (WIN32)
-    find_package(Iconv)
-else ()
+if (NOT WIN32)
     find_library(Sasl2_LIBRARY NAMES sasl2 libsasl2 PATHS /usr/local/lib/libsasl2.a REQUIRED)
 endif ()
 
@@ -809,11 +805,7 @@ else()
     endif()
 endif()
 
-if (WIN32)
-    list (APPEND arcticdb_core_libraries
-            Iconv::Iconv
-            )
-else ()
+if (NOT WIN32)
 
     if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list (APPEND arcticdb_core_libraries stdc++fs)

--- a/cpp/arcticdb/util/encoding_conversion.hpp
+++ b/cpp/arcticdb/util/encoding_conversion.hpp
@@ -8,29 +8,9 @@
 
 #pragma once
 
-#include <iconv.h>
-#include <arcticdb/util/preconditions.hpp>
+#include <cstring>
 
 namespace arcticdb {
-
-class EncodingConversion {
-    iconv_t iconv_;
-
-  public:
-    EncodingConversion(const char* to, const char* from) : iconv_(iconv_open(to, from)) {
-        if (iconv_t(-1) == iconv_)
-            util::raise_rte("error from iconv_open()");
-    }
-
-    ~EncodingConversion() {
-        if (iconv_t(-1) != iconv_)
-            iconv_close(iconv_);
-    }
-
-    bool convert(const char* input, size_t input_size, uint8_t* output, size_t& output_size) {
-        return iconv(iconv_, (char**)&input, &input_size, (char**)&output, &output_size) != size_t(-1);
-    }
-};
 
 class PortableEncodingConversion {
   public:

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -51,10 +51,6 @@
     "boost-optional",
     "boost-multiprecision",
     "bitmagic",
-    {
-      "name": "libiconv",
-      "platform": "!linux"
-    },
     "openssl",
     "double-conversion",
     "libevent",
@@ -114,7 +110,6 @@
     { "name": "gtest", "version": "1.12.1" },
     { "name": "libbson", "version": "1.30.3" },
     { "name": "libevent", "version": "2.1.12#7" },
-    { "name": "libiconv", "version": "1.17#0" },
     { "name": "lz4", "version": "1.9.3#4" },
     { "name": "mongo-c-driver", "version": "1.28.0" },
     { "name": "mongo-cxx-driver", "version": "3.10.2#1" },

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -57,7 +57,6 @@ dependencies:
   # Matches the version of lmdb as vendored in its submodule.
   - lmdb==0.9.22
   - lmdbxx
-  - libiconv
   - aws-c-s3
   # Build dependencies for tests
   - libarrow


### PR DESCRIPTION
The EncodingConversion class wrapping iconv() was never instantiated — only PortableEncodingConversion is used (in string_reducers.hpp), which does manual UTF-8 to UTF-32 widening without calling iconv.

Remove the dead class, the #include <iconv.h>, and the libiconv vcpkg dependency and version override.
