### PR TITLE
Use UnsortedDataException not SortingException in update

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -37,7 +37,7 @@ from arcticdb.exceptions import (
     ArcticNativeException,
     ArcticDbNotYetImplemented,
     NormalizationException,
-    SortingException,
+    UnsortedDataException,
 )
 from arcticdb.supported_types import DateRangeInput, time_types as supported_time_types
 from arcticdb.util._versions import IS_PANDAS_TWO, IS_PANDAS_ZERO
@@ -1870,7 +1870,7 @@ def restrict_data_to_date_range_only(
             # data.loc[...] and let version_core.cpp::sorted_data_check_update handle this, but that will be confusing
             # as the frame input to sorted_data_check_update WILL be sorted. Instead, we fail early here, at the cost
             # of duplicating exception messages.
-            raise SortingException("E_UNSORTED_DATA When calling update, the input data must be sorted.")
+            raise UnsortedDataException("E_UNSORTED_DATA When calling update, the input data must be sorted.")
         data = data.loc[pd.to_datetime(start) : pd.to_datetime(end)]
     elif _PYARROW_AVAILABLE and isinstance(data, pa.Table):
         check(index_column is not None, "Cannot update with pyarrow Table without specifying index column")

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4226,7 +4226,7 @@ class NativeVersionStore:
             If symbol doesn't exist and `upsert=False`
         UserInputException
             If strategy is not one of the supported strategies listed above
-        SortingException
+        UnsortedDataException
             If date-time index is used and source or target are not sorted
         SchemaException
             If dynamic schema is used or if source's schema is incompatible with target's schema

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1750,7 +1750,7 @@ class Library:
         Calling ``finalize_staged_data`` without having staged data for the symbol will throw ``UserInputException``. Use
         ``get_staged_symbols`` to check if there are staged segments for the symbol.
 
-        Calling ``finalize_staged_data`` if any of the staged segments contains NaT in its index will throw ``SortingException``.
+        Calling ``finalize_staged_data`` if any of the staged segments contains NaT in its index will throw ``UnsortedDataException``.
 
         Parameters
         ----------
@@ -1793,7 +1793,7 @@ class Library:
 
         Raises
         ------
-        SortingException
+        UnsortedDataException
 
             - If any two staged segments for a given symbol have overlapping indexes
             - If any staged segment for a given symbol is not sorted
@@ -1884,7 +1884,7 @@ class Library:
         Calling ``sort_and_finalize_staged_data`` without having staged data for the symbol will throw ``UserInputException``. Use
         ``get_staged_symbols`` to check if there are staged segments for the symbol.
 
-        Calling ``sort_and_finalize_staged_data`` if any of the staged segments contains NaT in its index will throw ``SortingException``.
+        Calling ``sort_and_finalize_staged_data`` if any of the staged segments contains NaT in its index will throw ``UnsortedDataException``.
 
         Parameters
         ----------
@@ -1923,7 +1923,7 @@ class Library:
 
         Raises
         ------
-        SortingException
+        UnsortedDataException
 
             - If the first index value of the sorted block is not greater or equal than the last index value of
                 the existing data when ``StagedDataFinalizeMethod.APPEND`` is used.
@@ -3415,7 +3415,7 @@ class Library:
             If symbol doesn't exist and `upsert=False`
         UserInputException
             If strategy is not one of the supported strategies listed above
-        SortingException
+        UnsortedDataException
             If date-time index is used and source or target are not sorted
         SchemaException
             If dynamic schema is used or if source's schema is incompatible with target's schema

--- a/python/installation_tests/test_installation.py
+++ b/python/installation_tests/test_installation.py
@@ -20,7 +20,7 @@ from arcticdb.util.test import random_floats, random_strings_of_length
 from arcticdb.version_store import VersionedItem as PythonVersionedItem
 from arcticdb.toolbox.library_tool import KeyType
 from arcticdb.version_store.library import ReadRequest, StagedDataFinalizeMethod, WritePayload
-from arcticdb_ext.exceptions import SortingException
+from arcticdb_ext.exceptions import UnsortedDataException
 from arcticdb_ext.version_store import AtomKey, RefKey
 from packaging import version
 
@@ -181,10 +181,10 @@ def test_parallel_writes_and_appends_index_validation(ac_library, finalize_metho
     lib.write(sym, df_1, staged=True)
     if validate_index is None:
         # Test default behaviour when arg isn't provided
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.finalize_staged_data(sym, finalize_method)
     elif validate_index:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.finalize_staged_data(sym, finalize_method, validate_index=True)
     else:
         lib.finalize_staged_data(sym, finalize_method, validate_index=False)

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -21,7 +21,7 @@ from enum import Enum
 import multiprocessing
 
 from arcticdb_ext import get_config_int, set_config_int
-from arcticdb_ext.exceptions import InternalException, SortingException, UserInputException
+from arcticdb_ext.exceptions import InternalException, UnsortedDataException, UserInputException
 from arcticdb_ext.storage import NoDataFoundException, KeyType, AWSAuthMethod
 from arcticdb.exceptions import ArcticDbNotYetImplemented, NoSuchVersionException
 from arcticdb.adapters.mongo_library_adapter import MongoLibraryAdapter
@@ -441,10 +441,10 @@ def test_parallel_writes_and_appends_index_validation(arctic_library, finalize_m
     lib.write(sym, df_1, staged=True)
     if validate_index is None:
         # Test default behaviour when arg isn't provided
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.finalize_staged_data(sym, finalize_method)
     elif validate_index:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.finalize_staged_data(sym, finalize_method, validate_index=True)
     else:
         lib.finalize_staged_data(sym, finalize_method, validate_index=False)
@@ -476,7 +476,7 @@ class TestAppendStagedData:
         lib.write("sym", initial_df)
         df1 = pd.DataFrame({"col": [2]}, index=pd.DatetimeIndex([np.datetime64("2023-01-02")], dtype="datetime64[ns]"))
         lib.write("sym", df1, staged=True)
-        with pytest.raises(SortingException) as exception_info:
+        with pytest.raises(UnsortedDataException) as exception_info:
             lib.finalize_staged_data("sym", mode=StagedDataFinalizeMethod.APPEND)
         assert "append" in str(exception_info.value)
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
@@ -20,7 +20,7 @@ from arcticdb.util.test_utils import DFGenerator, generate_random_series, set_se
 from arcticdb.version_store._store import NativeVersionStore, VersionedItem
 from datetime import timedelta, timezone
 
-from arcticdb.exceptions import ArcticNativeException, SortingException
+from arcticdb.exceptions import ArcticNativeException, UnsortedDataException
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb_ext.version_store import StreamDescriptorMismatch, NoSuchVersionException
 
@@ -355,9 +355,9 @@ def test_append_scenario_with_errors_and_success(version_store_and_real_s3_basic
     assert len(lib.list_versions()) == 4 if dynamic_schema else 3
 
     # Validate that validate_index works as expected
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lib.append(symbol, df_not_sorted, validate_index=True)
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lib.append(symbol, df_not_sorted, validate_index=True, incomplete=True)
     result2 = lib.append(symbol, df_not_sorted, validate_index=False)
     assert result2.version == result.version + 1

--- a/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
@@ -25,7 +25,6 @@ from arcticdb.version_store.processing import QueryBuilder
 from arcticdb_ext.version_store import StreamDescriptorMismatch, NoSuchVersionException
 
 from arcticdb_ext.exceptions import (
-    UnsortedDataException,
     InternalException,
     NormalizationException,
     UserInputException,

--- a/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
@@ -5,7 +5,7 @@ from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data
 import arcticdb
 from arcticdb.version_store import VersionedItem
 import numpy as np
-from arcticdb.exceptions import StreamDescriptorMismatch, UserInputException, SortingException, StorageException
+from arcticdb.exceptions import StreamDescriptorMismatch, UserInputException, UnsortedDataException, StorageException
 from arcticdb.version_store.library import MergeAction, MergeStrategy
 from arcticdb.version_store._store import normalize_merge_action
 from typing import List, Optional

--- a/python/tests/unit/arcticdb/test_errors.py
+++ b/python/tests/unit/arcticdb/test_errors.py
@@ -15,7 +15,6 @@ specific_exception_types = [
     SchemaException,
     StorageException,
     UnsortedDataException,
-    UnsortedDataException,
     UserInputException,
 ]
 

--- a/python/tests/unit/arcticdb/test_errors.py
+++ b/python/tests/unit/arcticdb/test_errors.py
@@ -14,7 +14,7 @@ specific_exception_types = [
     MissingDataException,
     SchemaException,
     StorageException,
-    SortingException,
+    UnsortedDataException,
     UnsortedDataException,
     UserInputException,
 ]

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -12,7 +12,7 @@ from pandas._libs.tslibs.offsets import BDay
 import arcticdb
 import arcticdb.exceptions
 from arcticdb.version_store import NativeVersionStore
-from arcticdb_ext.exceptions import InternalException, NormalizationException, SortingException, SchemaException
+from arcticdb_ext.exceptions import InternalException, NormalizationException, UnsortedDataException, SchemaException
 from arcticdb_ext import set_config_int
 from arcticdb.util.test import random_integers, assert_frame_equal
 from arcticdb.config import set_log_level
@@ -317,7 +317,7 @@ def test_append_not_sorted_exception(lmdb_version_store):
     df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
     assert df2.index.is_monotonic_increasing == False
 
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lmdb_version_store.append(symbol, df2, validate_index=True)
 
 
@@ -355,7 +355,7 @@ def test_append_existing_not_sorted_exception(lmdb_version_store):
     df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
     assert df2.index.is_monotonic_increasing == True
 
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lmdb_version_store.append(symbol, df2, validate_index=True)
 
 
@@ -409,7 +409,7 @@ def test_append_not_sorted_multi_index_exception(lmdb_version_store):
     assert df2.index.is_monotonic_increasing == False
     assert isinstance(df.index, MultiIndex) == True
 
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lmdb_version_store.append(symbol, df2, validate_index=True)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_date_range.py
+++ b/python/tests/unit/arcticdb/version_store/test_date_range.py
@@ -9,7 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import pandas as pd
 import numpy as np
 import pytest
-from arcticdb_ext.exceptions import SortingException, InternalException
+from arcticdb_ext.exceptions import UnsortedDataException, InternalException
 from arcticdb.version_store import _store as store
 
 try:
@@ -59,7 +59,7 @@ def test_read_unsorted_date_range_dataframe(lmdb_version_store):
     lmdb_version_store.write(symbol, df)
     info = lmdb_version_store.get_info(symbol)
     assert info["sorted"] == "UNSORTED"
-    with pytest.raises(SortingException) as e_info:
+    with pytest.raises(UnsortedDataException) as e_info:
         data = lmdb_version_store.read(
             symbol, date_range=(DateRange(pd.Timestamp("2019-01-03"), pd.Timestamp("2019-01-06")))
         ).data
@@ -85,7 +85,7 @@ def test_batch_read_unsorted_date_range_dataframe(lmdb_version_store):
     info2 = lmdb_version_store.get_info(symbol2)
     assert info1["sorted"] == "UNSORTED"
     assert info2["sorted"] == "UNSORTED"
-    with pytest.raises(SortingException) as e_info:
+    with pytest.raises(UnsortedDataException) as e_info:
         batch_res = lmdb_version_store.batch_read(
             [symbol1, symbol2],
             date_ranges=[
@@ -127,7 +127,7 @@ def test_read_unsorted_date_range_dataframe_multi_index(lmdb_version_store):
     lmdb_version_store.write(symbol, df)
     info = lmdb_version_store.get_info(symbol)
     assert info["sorted"] == "UNSORTED"
-    with pytest.raises(SortingException) as e_info:
+    with pytest.raises(UnsortedDataException) as e_info:
         data = lmdb_version_store.read(
             symbol, date_range=(DateRange(pd.Timestamp("2019-01-03"), pd.Timestamp("2019-01-06")))
         ).data

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -14,7 +14,7 @@ from arcticdb.version_store import VersionedItem
 from arcticdb_ext.exceptions import SchemaException
 from arcticdb_ext.storage import KeyType
 import numpy as np
-from arcticdb.exceptions import StreamDescriptorMismatch, UserInputException, SortingException, StorageException
+from arcticdb.exceptions import StreamDescriptorMismatch, UserInputException, UnsortedDataException, StorageException
 from arcticdb.version_store.library import MergeAction, MergeStrategy
 from arcticdb.version_store._store import normalize_merge_action
 from typing import Union, List, Optional
@@ -200,7 +200,7 @@ class TestMergeTimeseriesCommon:
             ),
         )
 
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.merge_experimental("sym", source, strategy=strategy)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -28,7 +28,6 @@ from arcticdb.util.test import (
 )
 from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticdb.version_store.library import Library
-from arcticdb_ext.exceptions import UnsortedDataException
 from arcticdb_ext.storage import KeyType
 
 from arcticdb import util, LibraryOptions

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -14,7 +14,7 @@ import pytest
 
 
 from arcticdb.exceptions import (
-    SortingException,
+    UnsortedDataException,
     SchemaException,
     UserInputException,
     ArcticDbNotYetImplemented,
@@ -559,7 +559,7 @@ def test_parallel_sortedness_checks_unsorted_data(lmdb_version_store, append, va
         lib.write(sym, df_0)
     df_1 = pd.DataFrame({"col": [3, 4]}, index=[pd.Timestamp("2024-01-04"), pd.Timestamp("2024-01-03")])
     if validate_index:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             if append:
                 lib.append(sym, df_1, incomplete=True, validate_index=True)
             else:
@@ -686,7 +686,7 @@ def test_parallel_overlapping_incomplete_segments(
         lib.write(sym, df_2, parallel=True)
         lib.write(sym, df_1, parallel=True)
     if validate_index:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.compact_incomplete(
                 sym,
                 append,
@@ -744,7 +744,7 @@ def test_parallel_all_incomplete_segments_same_index(
         lib.write(sym, df_2, parallel=True)
         lib.write(sym, df_1, parallel=True)
     if validate_index:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.compact_incomplete(
                 sym,
                 append,
@@ -782,7 +782,7 @@ def test_parallel_append_overlapping_with_existing(lmdb_version_store, validate_
     )
     lib.append(sym, df_1, incomplete=True)
     if validate_index:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.compact_incomplete(
                 sym,
                 True,
@@ -824,7 +824,7 @@ def test_parallel_append_existing_data_unsorted(
     df_1 = pd.DataFrame({"col": [3, 4]}, index=[pd.Timestamp("2024-01-05"), pd.Timestamp("2024-01-06")])
     lib.append(sym, df_1, incomplete=True)
     if validate_index:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.compact_incomplete(
                 sym,
                 True,

--- a/python/tests/unit/arcticdb/version_store/test_sort_merge.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort_merge.py
@@ -6,7 +6,7 @@ from arcticdb_ext.storage import KeyType
 from arcticdb.version_store.library import StagedDataFinalizeMethod
 from arcticdb.exceptions import (
     UserInputException,
-    SortingException,
+    UnsortedDataException,
     StreamDescriptorMismatch,
     InternalException,
     SchemaException,
@@ -279,7 +279,7 @@ class TestMergeSortAppend:
         lib.write("sym", initial_df)
         df1 = pd.DataFrame({"col": [2]}, index=pd.DatetimeIndex([np.datetime64("2023-01-02")], dtype="datetime64[ns]"))
         lib.write("sym", df1, staged=True)
-        with pytest.raises(SortingException) as exception_info:
+        with pytest.raises(UnsortedDataException) as exception_info:
             lib.sort_and_finalize_staged_data(
                 "sym", mode=StagedDataFinalizeMethod.APPEND, delete_staged_data_on_failure=delete_staged_data_on_failure
             )
@@ -707,7 +707,7 @@ class TestNatInIndexNotAllowed:
 
     @classmethod
     def assert_nat_not_allowed(cls, lib, symbol, mode, delete_staged_data_on_failure):
-        with pytest.raises(SortingException) as exception_info:
+        with pytest.raises(UnsortedDataException) as exception_info:
             lib.sort_and_finalize_staged_data(
                 symbol, mode=mode, delete_staged_data_on_failure=delete_staged_data_on_failure
             )

--- a/python/tests/unit/arcticdb/version_store/test_stage.py
+++ b/python/tests/unit/arcticdb/version_store/test_stage.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pytest
 
 from arcticdb import LibraryOptions
-from arcticdb_ext.exceptions import UserInputException, UnsortedDataException, SortingException
+from arcticdb_ext.exceptions import UserInputException, UnsortedDataException, UnsortedDataException
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import (
     StageResult,
@@ -649,7 +649,7 @@ def test_delete_staged_data_on_failure_with_tokens_overlap(
         keys = lib._dev_tools.library_tool().find_keys(KeyType.APPEND_DATA)
         assert len(keys) == 1
     else:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             finalize(
                 arctic_api,
                 lib,

--- a/python/tests/unit/arcticdb/version_store/test_stage.py
+++ b/python/tests/unit/arcticdb/version_store/test_stage.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pytest
 
 from arcticdb import LibraryOptions
-from arcticdb_ext.exceptions import UserInputException, UnsortedDataException, UnsortedDataException
+from arcticdb_ext.exceptions import UserInputException, UnsortedDataException
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import (
     StageResult,

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -20,7 +20,7 @@ from arcticdb.util.test import (
     random_floats,
     assert_frame_equal,
 )
-from arcticdb.exceptions import InternalException, SortingException, NormalizationException, SchemaException
+from arcticdb.exceptions import InternalException, UnsortedDataException, NormalizationException, SchemaException
 from arcticdb_ext.version_store import StreamDescriptorMismatch
 from tests.util.date import DateRange
 from pandas import MultiIndex
@@ -546,7 +546,7 @@ def test_update_sortedness_checks(
         lib.update(symbol, update_df, date_range=date_range)
         assert lib.get_info(symbol)["sorted"] == "ASCENDING"
     else:
-        with pytest.raises(SortingException):
+        with pytest.raises(UnsortedDataException):
             lib.update(symbol, update_df, date_range=date_range)
 
 
@@ -576,7 +576,7 @@ def test_update_not_sorted_input_multi_index_exception(lmdb_version_store):
     assert isinstance(df.index, MultiIndex) == True
     assert df.index.is_monotonic_increasing == False
 
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lmdb_version_store.update(symbol, df)
 
 
@@ -606,7 +606,7 @@ def test_update_not_sorted_existing_multi_index_exception(lmdb_version_store):
     assert isinstance(df.index, MultiIndex) == True
     assert df.index.is_monotonic_increasing == True
 
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lmdb_version_store.update(symbol, df)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_version_chain.py
+++ b/python/tests/unit/arcticdb/version_store/test_version_chain.py
@@ -16,7 +16,7 @@ from arcticdb.version_store import NativeVersionStore
 from arcticdb_ext.exceptions import (
     InternalException,
     NormalizationException,
-    SortingException,
+    UnsortedDataException,
 )
 
 

--- a/python/tests/unit/arcticdb/version_store/test_write.py
+++ b/python/tests/unit/arcticdb/version_store/test_write.py
@@ -9,7 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import numpy as np
 import pandas as pd
 import pytest
-from arcticdb_ext.exceptions import SortingException, ArcticException as ArcticNativeException
+from arcticdb_ext.exceptions import UnsortedDataException, ArcticException as ArcticNativeException
 from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticdb.util.test import assert_frame_equal
 from pandas import MultiIndex
@@ -81,7 +81,7 @@ def test_write_not_sorted_exception(lmdb_version_store):
     df = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
     assert df.index.is_monotonic_increasing == False
 
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lmdb_version_store.write(symbol, df, validate_index=True)
 
 
@@ -112,7 +112,7 @@ def test_write_not_sorted_multi_index_exception(lmdb_version_store):
     assert isinstance(df.index, MultiIndex) == True
     assert df.index.is_monotonic_increasing == False
 
-    with pytest.raises(SortingException):
+    with pytest.raises(UnsortedDataException):
         lmdb_version_store.write(symbol, df, validate_index=True)
 
 


### PR DESCRIPTION
Use UnsortedDataException (the specific exception type) not SortingException (the category).

This is a very minor API break. UnsortedDataException is a sub-type of SortingException so this is backwards compatible, except that users catching UnsortedDataException will now catch unsorted data from update calls too. Marked "minor" to avoid scaring users with a major version bump for something so trivial.

Also update tests to check for UnsortedDataException rather than the more general SortingException.

Customer request: https://arcticdb.slack.com/archives/C05ATNAR3PA/p1776368548164199
