### PR TITLE
Propagate SortedValue to Polars set_sorted() on index column

### DIFF
--- a/cpp/arcticdb/arrow/test/test_arrow_write.cpp
+++ b/cpp/arcticdb/arrow/test/test_arrow_write.cpp
@@ -337,7 +337,7 @@ TEST(ArrowWriteMemoryLifetime, InputFrameKeepsBufferAlive) {
 
     auto input_frame = std::make_shared<pipelines::InputFrame>();
     input_frame->norm_meta.mutable_experimental_arrow()->set_has_index(false);
-    convert::record_batches_to_frame(record_batches, *input_frame);
+    convert::record_batches_to_frame(record_batches, *input_frame, pipelines::SortednessScan::SKIP);
     input_frame->desc().set_id(symbol);
     input_frame->set_index_range();
 

--- a/cpp/arcticdb/entity/read_result.hpp
+++ b/cpp/arcticdb/entity/read_result.hpp
@@ -27,14 +27,16 @@ using OutputFrame = std::variant<pipelines::PandasOutputFrame, ArrowOutputFrame>
 struct ARCTICDB_VISIBILITY_HIDDEN NodeReadResult {
     NodeReadResult(
             const StreamId& symbol, OutputFrame&& frame_data,
-            arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta
+            arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta, SortedValue sorted = SortedValue::UNKNOWN
     ) :
         symbol_(symbol),
         frame_data_(std::move(frame_data)),
-        norm_meta_(std::move(norm_meta)) {};
+        norm_meta_(std::move(norm_meta)),
+        sorted_(sorted) {};
     StreamId symbol_;
     OutputFrame frame_data_;
     arcticdb::proto::descriptors::NormalizationMetadata norm_meta_;
+    SortedValue sorted_ = SortedValue::UNKNOWN;
 
     ARCTICDB_MOVE_ONLY_DEFAULT(NodeReadResult)
 };
@@ -47,7 +49,7 @@ struct ARCTICDB_VISIBILITY_HIDDEN ReadResult {
                     arcticdb::proto::descriptors::UserDefinedMetadata,
                     std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>>& user_meta,
             const arcticdb::proto::descriptors::UserDefinedMetadata& multi_key_meta,
-            std::vector<NodeReadResult>&& node_results = {}
+            std::vector<NodeReadResult>&& node_results = {}, SortedValue sorted = SortedValue::UNKNOWN
     ) :
         item(versioned_item),
         frame_data(std::move(frame_data)),
@@ -55,7 +57,8 @@ struct ARCTICDB_VISIBILITY_HIDDEN ReadResult {
         norm_meta(norm_meta),
         user_meta(user_meta),
         multi_key_meta(multi_key_meta),
-        node_results(std::move(node_results)) {}
+        node_results(std::move(node_results)),
+        sorted(sorted) {}
     std::variant<VersionedItem, std::vector<VersionedItem>> item;
     OutputFrame frame_data;
     OutputFormat output_format;
@@ -66,6 +69,7 @@ struct ARCTICDB_VISIBILITY_HIDDEN ReadResult {
             user_meta;
     arcticdb::proto::descriptors::UserDefinedMetadata multi_key_meta;
     std::vector<NodeReadResult> node_results;
+    SortedValue sorted = SortedValue::UNKNOWN;
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ReadResult)
 };

--- a/cpp/arcticdb/entity/read_result.hpp
+++ b/cpp/arcticdb/entity/read_result.hpp
@@ -27,7 +27,7 @@ using OutputFrame = std::variant<pipelines::PandasOutputFrame, ArrowOutputFrame>
 struct ARCTICDB_VISIBILITY_HIDDEN NodeReadResult {
     NodeReadResult(
             const StreamId& symbol, OutputFrame&& frame_data,
-            arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta, SortedValue sorted = SortedValue::UNKNOWN
+            arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta, SortedValue sorted
     ) :
         symbol_(symbol),
         frame_data_(std::move(frame_data)),
@@ -36,7 +36,7 @@ struct ARCTICDB_VISIBILITY_HIDDEN NodeReadResult {
     StreamId symbol_;
     OutputFrame frame_data_;
     arcticdb::proto::descriptors::NormalizationMetadata norm_meta_;
-    SortedValue sorted_ = SortedValue::UNKNOWN;
+    SortedValue sorted_;
 
     ARCTICDB_MOVE_ONLY_DEFAULT(NodeReadResult)
 };
@@ -49,7 +49,7 @@ struct ARCTICDB_VISIBILITY_HIDDEN ReadResult {
                     arcticdb::proto::descriptors::UserDefinedMetadata,
                     std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>>& user_meta,
             const arcticdb::proto::descriptors::UserDefinedMetadata& multi_key_meta,
-            std::vector<NodeReadResult>&& node_results = {}, SortedValue sorted = SortedValue::UNKNOWN
+            std::vector<NodeReadResult>&& node_results, SortedValue sorted
     ) :
         item(versioned_item),
         frame_data(std::move(frame_data)),
@@ -69,7 +69,7 @@ struct ARCTICDB_VISIBILITY_HIDDEN ReadResult {
             user_meta;
     arcticdb::proto::descriptors::UserDefinedMetadata multi_key_meta;
     std::vector<NodeReadResult> node_results;
-    SortedValue sorted = SortedValue::UNKNOWN;
+    SortedValue sorted;
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ReadResult)
 };

--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -16,10 +16,39 @@
 
 namespace arcticdb::pipelines {
 
+namespace {
+SortedValue compute_index_sortedness(const Column& index_column) {
+    using TimeseriesTDT = stream::TimeseriesIndex::TypeDescTag;
+    auto column_data = index_column.data();
+    auto it = column_data.cbegin<TimeseriesTDT>();
+    const auto end = column_data.cend<TimeseriesTDT>();
+    if (it == end) {
+        return SortedValue::ASCENDING;
+    }
+    bool ascending = true;
+    bool descending = true;
+    auto prev = *it;
+    for (++it; it != end; ++it) {
+        const auto curr = *it;
+        if (curr < prev) {
+            ascending = false;
+        } else if (curr > prev) {
+            descending = false;
+        }
+        if (!ascending && !descending) {
+            return SortedValue::UNSORTED;
+        }
+        prev = curr;
+    }
+    return ascending ? SortedValue::ASCENDING : SortedValue::DESCENDING;
+}
+} // namespace
+
 InputFrame::InputFrame() : index(stream::empty_index()) {}
 
 void InputFrame::set_from_columns(
-        std::vector<Column>&& cols, StreamDescriptor&& desc, std::vector<sparrow::record_batch>&& arrow_buffer_owners
+        std::vector<Column>&& cols, StreamDescriptor&& desc, std::vector<sparrow::record_batch>&& arrow_buffer_owners,
+        SortednessScan sortedness_scan
 ) {
     util::check(norm_meta.has_experimental_arrow(), "Unexpected non-Arrow norm metadata provided with Arrow data");
     desc_ = std::move(desc);
@@ -34,9 +63,11 @@ void InputFrame::set_from_columns(
         );
         desc_.set_index({IndexDescriptorImpl::Type::TIMESTAMP, 1});
         index = stream::TimeseriesIndex{std::string(desc_.field(0).name())};
-        // We do not verify monotonicity of Arrow index columns, so the sort order is UNKNOWN. This avoids the
-        // O(n) check on write; the polars read path will not claim the column is sorted as a result.
-        seg.descriptor().set_sorted(SortedValue::UNKNOWN);
+        // Arrow input does not record sortedness up front (unlike pandas), so we have to compute it when required.
+        seg.descriptor().set_sorted(
+                sortedness_scan == SortednessScan::SCAN_IF_UNKNOWN ? compute_index_sortedness(seg.column(0))
+                                                                   : SortedValue::UNKNOWN
+        );
     } else {
         desc_.set_index({IndexDescriptorImpl::Type::ROWCOUNT, 0});
         index = stream::RowCountIndex{};

--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -64,8 +64,8 @@ void InputFrame::set_from_columns(
         desc_.set_index({IndexDescriptorImpl::Type::TIMESTAMP, 1});
         index = stream::TimeseriesIndex{std::string(desc_.field(0).name())};
         // Arrow input does not record sortedness up front (unlike pandas), so we have to compute it when required.
-        seg.descriptor().set_sorted(
-                sortedness_scan == SortednessScan::SCAN_IF_UNKNOWN ? compute_index_sortedness(seg.column(0))
+        desc_.set_sorted(
+                sortedness_scan == SortednessScan::SCAN_IF_UNKNOWN ? compute_index_sortedness(cols[0])
                                                                    : SortedValue::UNKNOWN
         );
     } else {

--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -32,10 +32,11 @@ void InputFrame::set_from_columns(
                 "Specified Arrow index column has non-time type {}",
                 cols[0].type().data_type()
         );
-
         desc_.set_index({IndexDescriptorImpl::Type::TIMESTAMP, 1});
         index = stream::TimeseriesIndex{std::string(desc_.field(0).name())};
-        desc_.set_sorted(SortedValue::ASCENDING);
+        // We do not verify monotonicity of Arrow index columns, so the sort order is UNKNOWN. This avoids the
+        // O(n) check on write; the polars read path will not claim the column is sorted as a result.
+        seg.descriptor().set_sorted(SortedValue::UNKNOWN);
     } else {
         desc_.set_index({IndexDescriptorImpl::Type::ROWCOUNT, 0});
         index = stream::RowCountIndex{};

--- a/cpp/arcticdb/pipeline/input_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_frame.hpp
@@ -29,6 +29,13 @@ concept ValidIndex = util::any_of<
         std::remove_cvref_t<std::remove_pointer_t<std::decay_t<IndexT>>>, stream::TimeseriesIndex,
         stream::RowCountIndex, stream::TableIndex, stream::EmptyIndex>;
 
+// Whether to determine the sort order of a timeseries index column by walking it (an O(n) scan).
+// Only applies to Arrow input for which sortedness is not known upfront. Pandas precomputes it on construction.
+enum class SortednessScan {
+    SKIP,            // do not scan; for Arrow, leave the index sort order as UNKNOWN
+    SCAN_IF_UNKNOWN, // for Arrow, walk the index column to determine its sort order
+};
+
 // This class originally wrapped numpy data, but with the addition of Arrow as an input format it is now a thin wrapper
 // around a variant representing either numpy or Arrow input data
 struct InputFrame {
@@ -71,9 +78,11 @@ struct InputFrame {
         );
     };
 
+    // With SortednessScan::SCAN_IF_UNKNOWN we do an O(n) verification of the sortedness of a timeseries index and
+    // use it to populate SortedValue. Otherwise the sort order is left as SortedValue::UNKNOWN.
     void set_from_columns(
             std::vector<Column>&& cols, StreamDescriptor&& desc,
-            std::vector<sparrow::record_batch>&& arrow_buffer_owners
+            std::vector<sparrow::record_batch>&& arrow_buffer_owners, SortednessScan sortedness_scan
     );
     StreamDescriptor& desc();
     const StreamDescriptor& desc() const;

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -96,13 +96,19 @@ inline ReadResult create_python_read_result(
         metadata = std::move(desc_proto.user_meta());
     }
 
+    auto sorted = result.desc_.sorted();
+
     std::vector<NodeReadResult> node_results;
     for (auto& node_output : node_outputs) {
         auto& node_fd = node_output.frame_and_descriptor_;
         auto node_python_frame = get_python_frame(node_fd);
         auto node_metadata = node_fd.desc_.proto().normalization();
+        auto node_sorted = node_fd.desc_.sorted();
         node_results.emplace_back(
-                node_output.versioned_item_.symbol(), std::move(node_python_frame), std::move(node_metadata)
+                node_output.versioned_item_.symbol(),
+                std::move(node_python_frame),
+                std::move(node_metadata),
+                node_sorted
         );
     }
     return {version,
@@ -111,7 +117,8 @@ inline ReadResult create_python_read_result(
             desc_proto.normalization(),
             metadata,
             desc_proto.multi_key_meta(),
-            std::move(node_results)};
+            std::move(node_results),
+            sorted};
 }
 
 namespace detail {

--- a/cpp/arcticdb/python/adapt_read_dataframe.hpp
+++ b/cpp/arcticdb/python/adapt_read_dataframe.hpp
@@ -36,7 +36,13 @@ inline py::tuple adapt_read_df(ReadResult&& ret, std::any* const handler_data) {
     auto multi_key_meta = python_util::pb_to_python(ret.multi_key_meta);
     auto node_results = python_util::node_results_to_python_list(std::move(ret.node_results));
     return py::make_tuple(
-            ret.item, std::move(ret.frame_data), pynorm, pyuser_meta, multi_key_meta, std::move(node_results)
+            ret.item,
+            std::move(ret.frame_data),
+            pynorm,
+            pyuser_meta,
+            multi_key_meta,
+            std::move(node_results),
+            static_cast<int>(ret.sorted)
     );
 };
 

--- a/cpp/arcticdb/python/adapt_read_dataframe.hpp
+++ b/cpp/arcticdb/python/adapt_read_dataframe.hpp
@@ -42,7 +42,7 @@ inline py::tuple adapt_read_df(ReadResult&& ret, std::any* const handler_data) {
             pyuser_meta,
             multi_key_meta,
             std::move(node_results),
-            static_cast<int>(ret.sorted)
+            ret.sorted
     );
 };
 

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -335,7 +335,10 @@ void tensors_to_frame(const py::tuple& tuple, const bool empty_types, InputFrame
     frame.set_from_tensors(std::move(desc), std::move(field_tensors), std::move(opt_index_tensor));
 }
 
-void record_batches_to_frame(const std::vector<std::shared_ptr<RecordBatchData>>& record_batches, InputFrame& frame) {
+void record_batches_to_frame(
+        const std::vector<std::shared_ptr<RecordBatchData>>& record_batches, InputFrame& frame,
+        pipelines::SortednessScan sortedness_scan
+) {
     util::check(
             frame.norm_meta.has_experimental_arrow(), "Unexpected non-Arrow norm metadata provided with Arrow data"
     );
@@ -349,12 +352,14 @@ void record_batches_to_frame(const std::vector<std::shared_ptr<RecordBatchData>>
         sparrow_record_batches.emplace_back(std::move(rbd->array_), std::move(rbd->schema_));
     }
     auto [columns, descriptor] = record_batches_to_columns(sparrow_record_batches, arrow_norm_metadata.has_index());
-    frame.set_from_columns(std::move(columns), std::move(descriptor), std::move(sparrow_record_batches));
+    frame.set_from_columns(
+            std::move(columns), std::move(descriptor), std::move(sparrow_record_batches), sortedness_scan
+    );
 }
 
 std::shared_ptr<InputFrame> py_ndf_to_frame(
         const StreamId& stream_name, const InputItem& item, const py::object& norm_meta, const py::object& user_meta,
-        bool empty_types
+        bool empty_types, pipelines::SortednessScan sortedness_scan
 ) {
     ARCTICDB_SUBSAMPLE_DEFAULT(NormalizeFrame)
     auto res = std::make_shared<InputFrame>();
@@ -367,7 +372,7 @@ std::shared_ptr<InputFrame> py_ndf_to_frame(
             item,
             [&](const py::tuple& tensors) { tensors_to_frame(tensors, empty_types, *res); },
             [&](const std::vector<std::shared_ptr<RecordBatchData>>& record_batches) {
-                record_batches_to_frame(record_batches, *res);
+                record_batches_to_frame(record_batches, *res, sortedness_scan);
             }
     );
     res->set_index_range();

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -78,12 +78,13 @@ std::variant<StringEncodingError, PyStringWrapper> py_unicode_to_buffer(
 NativeTensor obj_to_tensor(PyObject* ptr, bool empty_types, std::optional<std::string_view> column_name = std::nullopt);
 
 void record_batches_to_frame(
-        const std::vector<std::shared_ptr<RecordBatchData>>& record_batches, pipelines::InputFrame& frame
+        const std::vector<std::shared_ptr<RecordBatchData>>& record_batches, pipelines::InputFrame& frame,
+        pipelines::SortednessScan sortedness_scan
 );
 
 std::shared_ptr<pipelines::InputFrame> py_ndf_to_frame(
         const StreamId& stream_name, const InputItem& item, const py::object& norm_meta, const py::object& user_meta,
-        bool empty_types
+        bool empty_types, pipelines::SortednessScan sortedness_scan
 );
 
 std::shared_ptr<pipelines::InputFrame> py_none_to_frame();

--- a/cpp/arcticdb/python/python_utils.hpp
+++ b/cpp/arcticdb/python/python_utils.hpp
@@ -240,7 +240,10 @@ inline py::list node_results_to_python_list(std::vector<NodeReadResult>&& node_r
     py::list node_results_list;
     for (auto& node_result : node_results) {
         node_results_list.append(py::make_tuple(
-                node_result.symbol_, std::move(node_result.frame_data_), pb_to_python(node_result.norm_meta_)
+                node_result.symbol_,
+                std::move(node_result.frame_data_),
+                pb_to_python(node_result.norm_meta_),
+                static_cast<int>(node_result.sorted_)
         ));
     }
     return node_results_list;
@@ -269,7 +272,8 @@ inline py::list adapt_read_dfs(std::vector<std::variant<ReadResult, DataError>>&
                             pynorm,
                             pyuser_meta,
                             multi_key_meta,
-                            std::move(node_results)
+                            std::move(node_results),
+                            static_cast<int>(read_result.sorted)
                     ));
                     util::check(
                             !output_format.has_value() || output_format.value() == read_result.output_format,

--- a/cpp/arcticdb/python/python_utils.hpp
+++ b/cpp/arcticdb/python/python_utils.hpp
@@ -243,7 +243,7 @@ inline py::list node_results_to_python_list(std::vector<NodeReadResult>&& node_r
                 node_result.symbol_,
                 std::move(node_result.frame_data_),
                 pb_to_python(node_result.norm_meta_),
-                static_cast<int>(node_result.sorted_)
+                node_result.sorted_
         ));
     }
     return node_results_list;
@@ -273,7 +273,7 @@ inline py::list adapt_read_dfs(std::vector<std::variant<ReadResult, DataError>>&
                             pyuser_meta,
                             multi_key_meta,
                             std::move(node_results),
-                            static_cast<int>(read_result.sorted)
+                            read_result.sorted
                     ));
                     util::check(
                             !output_format.has_value() || output_format.value() == read_result.output_format,

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -85,8 +85,14 @@ SegmentInMemory LibraryTool::item_to_segment_in_memory(
         const StreamId& stream_id, const py::tuple& item, const py::object& norm, const py::object& user_meta,
         std::optional<AtomKey> next_key
 ) {
-    auto frame =
-            convert::py_ndf_to_frame(stream_id, item, norm, user_meta, engine_.cfg().write_options().empty_types());
+    auto frame = convert::py_ndf_to_frame(
+            stream_id,
+            item,
+            norm,
+            user_meta,
+            engine_.cfg().write_options().empty_types(),
+            pipelines::SortednessScan::SKIP
+    );
     auto segment_in_memory = incomplete_segment_from_tensor_frame(
             frame, 0, std::move(next_key), engine_.cfg().write_options().allow_sparse()
     );

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -955,6 +955,8 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                                 tsd_proto.normalization(),
                                 tsd_proto.user_meta(),
                                 tsd_proto.multi_key_meta(),
+                                {},
+                                tsd.sorted(),
                         };
                         return adapt_read_df(std::move(res), nullptr);
                     },
@@ -1109,7 +1111,9 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                                     read_options.output_format(),
                                     tsd_proto.normalization(),
                                     tsd_proto.user_meta(),
-                                    tsd_proto.multi_key_meta()
+                                    tsd_proto.multi_key_meta(),
+                                    {},
+                                    tsd.sorted(),
                             };
                             output.emplace_back(std::move(res));
                         }

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -30,6 +30,13 @@ using namespace arcticdb::entity;
 namespace as = arcticdb::stream;
 using namespace arcticdb::storage;
 
+namespace {
+// validate_index requires a sorted index, so for Arrow input we must determine its sort order.
+pipelines::SortednessScan sortedness_scan_for(bool validate_index) {
+    return validate_index ? pipelines::SortednessScan::SCAN_IF_UNKNOWN : pipelines::SortednessScan::SKIP;
+}
+} // namespace
+
 template PythonVersionStore::PythonVersionStore(
         const std::shared_ptr<storage::Library>& library, const util::SysClock& ct
 );
@@ -55,7 +62,14 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
     auto versioned_item = write_dataframe_impl(
             store(),
             VersionId(version_id),
-            convert::py_ndf_to_frame(stream_id, item, norm, user_meta, cfg().write_options().empty_types()),
+            convert::py_ndf_to_frame(
+                    stream_id,
+                    item,
+                    norm,
+                    user_meta,
+                    cfg().write_options().empty_types(),
+                    pipelines::SortednessScan::SKIP
+            ),
             get_write_options()
     );
 
@@ -68,14 +82,15 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
 
 std::vector<std::shared_ptr<InputFrame>> create_input_tensor_frames(
         const std::vector<StreamId>& stream_ids, const std::vector<convert::InputItem>& items,
-        const std::vector<py::object>& norms, const std::vector<py::object>& user_metas, bool empty_types
+        const std::vector<py::object>& norms, const std::vector<py::object>& user_metas, bool empty_types,
+        pipelines::SortednessScan sortedness_scan
 ) {
     std::vector<std::shared_ptr<InputFrame>> output;
     output.reserve(stream_ids.size());
     for (size_t idx = 0; idx < stream_ids.size(); idx++) {
-        output.emplace_back(
-                convert::py_ndf_to_frame(stream_ids[idx], items[idx], norms[idx], user_metas[idx], empty_types)
-        );
+        output.emplace_back(convert::py_ndf_to_frame(
+                stream_ids[idx], items[idx], norms[idx], user_metas[idx], empty_types, sortedness_scan
+        ));
     }
     return output;
 }
@@ -86,7 +101,14 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_wr
         bool validate_index, bool throw_on_error
 ) {
 
-    auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas, cfg().write_options().empty_types());
+    auto frames = create_input_tensor_frames(
+            stream_ids,
+            items,
+            norms,
+            user_metas,
+            cfg().write_options().empty_types(),
+            sortedness_scan_for(validate_index)
+    );
     return batch_write_versioned_dataframe_internal(
             stream_ids, std::move(frames), prune_previous_versions, validate_index, throw_on_error
     );
@@ -97,7 +119,14 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_ap
         const std::vector<py::object>& norms, const std::vector<py::object>& user_metas, bool prune_previous_versions,
         bool validate_index, bool upsert, bool throw_on_error
 ) {
-    auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas, cfg().write_options().empty_types());
+    auto frames = create_input_tensor_frames(
+            stream_ids,
+            items,
+            norms,
+            user_metas,
+            cfg().write_options().empty_types(),
+            sortedness_scan_for(validate_index)
+    );
     return batch_append_internal(
             stream_ids, std::move(frames), prune_previous_versions, validate_index, upsert, throw_on_error
     );
@@ -680,7 +709,12 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
                 store(),
                 version_id,
                 convert::py_ndf_to_frame(
-                        subkeyname, partitioned_dfs[idx], norm_meta, py::none(), cfg().write_options().empty_types()
+                        subkeyname,
+                        partitioned_dfs[idx],
+                        norm_meta,
+                        py::none(),
+                        cfg().write_options().empty_types(),
+                        pipelines::SortednessScan::SKIP
                 ),
                 write_options,
                 de_dup_map,
@@ -743,8 +777,14 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
         de_dup_maps.emplace_back(de_dup_map);
     }
 
-    auto frames =
-            create_input_tensor_frames(sub_keys, items, norm_metas, user_metas, cfg().write_options().empty_types());
+    auto frames = create_input_tensor_frames(
+            sub_keys,
+            items,
+            norm_metas,
+            user_metas,
+            cfg().write_options().empty_types(),
+            pipelines::SortednessScan::SKIP
+    );
     // Need to hold the GIL up to this point as we will call pb_from_python
     auto release_gil = std::make_unique<py::gil_scoped_release>();
     auto index_keys =
@@ -766,7 +806,9 @@ VersionedItem PythonVersionStore::write_versioned_dataframe(
         bool prune_previous_versions, bool sparsify_floats, bool validate_index
 ) {
     ARCTICDB_SAMPLE(WriteVersionedDataframe, 0)
-    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, cfg().write_options().empty_types());
+    auto frame = convert::py_ndf_to_frame(
+            stream_id, item, norm, user_meta, cfg().write_options().empty_types(), sortedness_scan_for(validate_index)
+    );
     auto versioned_item = write_versioned_dataframe_internal(
             stream_id, frame, prune_previous_versions, sparsify_floats, validate_index
     );
@@ -790,7 +832,14 @@ VersionedItem PythonVersionStore::append(
 ) {
     return append_internal(
             stream_id,
-            convert::py_ndf_to_frame(stream_id, item, norm, user_meta, cfg().write_options().empty_types()),
+            convert::py_ndf_to_frame(
+                    stream_id,
+                    item,
+                    norm,
+                    user_meta,
+                    cfg().write_options().empty_types(),
+                    sortedness_scan_for(validate_index)
+            ),
             upsert,
             prune_previous_versions,
             validate_index
@@ -804,7 +853,16 @@ VersionedItem PythonVersionStore::update(
     return update_internal(
             stream_id,
             query,
-            convert::py_ndf_to_frame(stream_id, item, norm, user_meta, cfg().write_options().empty_types()),
+            // update always requires a sorted index (both the upsert-to-write path and updating existing data),
+            // so always determine the Arrow index sort order.
+            convert::py_ndf_to_frame(
+                    stream_id,
+                    item,
+                    norm,
+                    user_meta,
+                    cfg().write_options().empty_types(),
+                    pipelines::SortednessScan::SCAN_IF_UNKNOWN
+            ),
             upsert,
             dynamic_schema,
             prune_previous_versions
@@ -827,7 +885,9 @@ void PythonVersionStore::append_incomplete(
     using namespace arcticdb::pipelines;
 
     // Turn the input into a standardised frame object
-    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, cfg().write_options().empty_types());
+    auto frame = convert::py_ndf_to_frame(
+            stream_id, item, norm, user_meta, cfg().write_options().empty_types(), SortednessScan::SKIP
+    );
     append_incomplete_frame(stream_id, frame, validate_index);
 }
 
@@ -949,7 +1009,12 @@ StageResult PythonVersionStore::write_parallel(
         const StreamId& stream_id, const convert::InputItem& item, const py::object& norm, bool validate_index,
         bool sort_on_index, std::optional<std::vector<std::string>> sort_columns
 ) const {
-    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, py::none(), cfg().write_options().empty_types());
+    // When the data will be sorted for us (sort_on_index or sort_columns) the input order is irrelevant, so only
+    // determine the Arrow index sort order when the unsorted input itself must be validated.
+    const bool verify = validate_index && !sort_on_index && (!sort_columns || sort_columns->empty());
+    auto frame = convert::py_ndf_to_frame(
+            stream_id, item, norm, py::none(), cfg().write_options().empty_types(), sortedness_scan_for(verify)
+    );
     return write_parallel_frame(stream_id, frame, validate_index, sort_on_index, sort_columns);
 }
 
@@ -989,7 +1054,15 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_up
         const std::vector<py::object>& norms, const std::vector<py::object>& user_metas,
         const std::vector<UpdateQuery>& update_qeries, bool prune_previous_versions, bool upsert
 ) {
-    auto frames = create_input_tensor_frames(stream_ids, items, norms, user_metas, cfg().write_options().empty_types());
+    // Like single update, batch update always requires a sorted index, so determine the Arrow index sort order.
+    auto frames = create_input_tensor_frames(
+            stream_ids,
+            items,
+            norms,
+            user_metas,
+            cfg().write_options().empty_types(),
+            pipelines::SortednessScan::SCAN_IF_UNKNOWN
+    );
     return batch_update_internal(stream_ids, std::move(frames), update_qeries, prune_previous_versions, upsert);
 }
 
@@ -1462,7 +1535,7 @@ void write_dataframe_to_file(
         const py::object& user_meta
 ) {
     ARCTICDB_SAMPLE(WriteDataframeToFile, 0)
-    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, false);
+    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, false, pipelines::SortednessScan::SKIP);
     write_dataframe_to_file_internal(
             stream_id, frame, path, WriteOptions{}, codec::default_lz4_codec(), EncodingVersion::V2
     );
@@ -1500,7 +1573,14 @@ VersionedItem PythonVersionStore::merge(
     };
     return merge_internal(
             stream_id,
-            convert::py_ndf_to_frame(stream_id, source, norm, user_meta, cfg().write_options().empty_types()),
+            convert::py_ndf_to_frame(
+                    stream_id,
+                    source,
+                    norm,
+                    user_meta,
+                    cfg().write_options().empty_types(),
+                    pipelines::SortednessScan::SKIP
+            ),
             prune_previous_versions,
             upsert,
             strategy,

--- a/docs/claude/python/NATIVE_VERSION_STORE.md
+++ b/docs/claude/python/NATIVE_VERSION_STORE.md
@@ -86,6 +86,12 @@ versions = nvs.list_versions("symbol")
 - `read_metadata(symbol, as_of)` - Read only metadata
 - `get_info(symbol, as_of)` - Get symbol info without reading data
 
+#### Sort Order Propagation
+
+`ReadResult` and `NodeReadResult` (`version_store/read_result.py`) carry a `sort_order` field (`SortedValue` enum: `UNKNOWN`, `UNSORTED`, `ASCENDING`, `DESCENDING`) populated from the C++ `StreamDescriptor.sorted` field.
+
+When `output_format="polars"`, `NativeVersionStore._apply_polars_sorted_flag_to_index` calls `pl.col().set_sorted()` on the index column if `sort_order` is `ASCENDING` or `DESCENDING`. The index column name is resolved via `_get_index_col_from_norm(norm)`, which supports single-level indexes only (`multi_index` is excluded).
+
 ### Version Operations
 
 - `list_versions(symbol, snapshot, skip_snapshots)` - List versions
@@ -162,6 +168,7 @@ result = nvs.read("symbol", row_range=(0, 1000))
 | File | Purpose |
 |------|---------|
 | `version_store/_store.py` | NativeVersionStore class |
+| `version_store/read_result.py` | ReadResult / NodeReadResult (includes `sort_order`) |
 | `version_store/_normalization.py` | Data normalization |
 | `cpp/arcticdb/version/version_store_api.cpp` | C++ implementation |
 

--- a/python/arcticdb/options.py
+++ b/python/arcticdb/options.py
@@ -185,6 +185,10 @@ class OutputFormat(str, Enum):
         Dataframes are returned as `polars.DataFrame` objects using Apache Arrow's columnar memory format.
         Provides better performance than `PANDAS`, especially for dataframes containing many string columns.
         String format can be customized via `ArrowOutputStringFormat`.
+        If ArcticDB has verified the index column is monotonic (ascending or descending), its Polars sorted
+        flag is set automatically, enabling Polars sort-aware optimizations such as fast joins and group-bys.
+        Symbols whose sort order was never verified (Arrow writes, or symbols written by ArcticDB versions
+        before sortedness was tracked) keep the default unsorted flag.
     """
 
     PANDAS = "PANDAS"

--- a/python/arcticdb/options.py
+++ b/python/arcticdb/options.py
@@ -187,8 +187,8 @@ class OutputFormat(str, Enum):
         String format can be customized via `ArrowOutputStringFormat`.
         If ArcticDB has verified the index column is monotonic (ascending or descending), its Polars sorted
         flag is set automatically, enabling Polars sort-aware optimizations such as fast joins and group-bys.
-        Symbols whose sort order was never verified (Arrow writes, or symbols written by ArcticDB versions
-        before sortedness was tracked) keep the default unsorted flag.
+        Symbols whose sort order was never verified (e.g. Arrow writes without index validation) keep the default
+        unsorted flag.
     """
 
     PANDAS = "PANDAS"

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -352,21 +352,18 @@ def _assume_false(name, kwargs):
         return True
 
 
-def _get_index_col_from_norm(norm):
-    """Get the name of the index column from normalization metadata, or None if no physically stored index."""
+def _has_physically_stored_index(norm):
     input_type = norm.WhichOneof("input_type")
     if input_type == "experimental_arrow":
-        if norm.experimental_arrow.has_index:
-            return norm.experimental_arrow.index_column_name
-    elif input_type in ("df", "series"):
+        return norm.experimental_arrow.has_index
+    if input_type in ("df", "series"):
         common = norm.df.common if input_type == "df" else norm.series.common
         index_type = common.WhichOneof("index_type")
-        # multi_index intentionally excluded: multi-level sorting semantics are more complex
-        if index_type == "index" and common.index.is_physically_stored:
-            if common.index.fake_name:
-                return "__index__"
-            return common.index.name
-    return None
+        if index_type == "index":
+            return common.index.is_physically_stored
+        if index_type == "multi_index":
+            return True
+    return False
 
 
 class NativeVersionStore:
@@ -2670,7 +2667,7 @@ class NativeVersionStore:
         if len(read_result.node_read_results) > 0:
             meta_struct = denormalize_user_metadata(read_result.mmeta)
             key_map = {
-                v.sym: self._adapt_frame_data(v.frame_data, v.norm, output_format)
+                v.sym: self._adapt_frame_data(v.frame_data, v.norm, output_format, v.sort_order)
                 for v in read_result.node_read_results
             }
             original_data = Flattener().create_original_obj_from_metastruct(meta_struct, key_map)
@@ -2918,7 +2915,7 @@ class NativeVersionStore:
             return pa.Table.from_arrays([])
         return pa.Table.from_batches(record_batches)
 
-    def _adapt_frame_data(self, frame_data, norm, output_format):
+    def _adapt_frame_data(self, frame_data, norm, output_format, sort_order):
         if isinstance(frame_data, ArrowOutputFrame):
             table = self._arrow_output_frame_to_table(frame_data)
             data = self._normalizer.denormalize(table, norm)
@@ -2933,6 +2930,7 @@ class NativeVersionStore:
                 and not norm.WhichOneof("input_type") == "msg_pack_frame"
             ):
                 data = pl.from_arrow(data, rechunk=False)
+                data = self._apply_polars_sorted_flag_to_index(data, sort_order, norm)
         else:
             data = self._normalizer.denormalize(frame_data, norm)
             if norm.HasField("custom"):
@@ -2941,22 +2939,20 @@ class NativeVersionStore:
         return data
 
     @staticmethod
-    def _apply_polars_sorted_flag_to_index(data, read_result):
-        if pl is None or not isinstance(data, pl.DataFrame):
+    def _apply_polars_sorted_flag_to_index(data, sort_order, norm):
+        # Only ASCENDING / DESCENDING are verified. UNKNOWN covers symbols written by paths that do not check
+        # monotonicity (e.g. Arrow writes) or by ArcticDB versions before sortedness was tracked, so we cannot
+        # safely tell Polars the column is sorted.
+        if sort_order not in (SortedValue.ASCENDING, SortedValue.DESCENDING):
             return data
-
-        sorted_val = read_result.sort_order
-        if sorted_val not in (SortedValue.ASCENDING, SortedValue.DESCENDING):
+        if not _has_physically_stored_index(norm) or len(data.columns) == 0:
             return data
-
-        index_col = _get_index_col_from_norm(read_result.norm)
-        if index_col is not None and index_col in data.columns:
-            data = data.with_columns(pl.col(index_col).set_sorted(descending=(sorted_val == SortedValue.DESCENDING)))
-        return data
+        # The index column is always the first column.
+        index_col = data.columns[0]
+        return data.with_columns(pl.col(index_col).set_sorted(descending=(sort_order == SortedValue.DESCENDING)))
 
     def _adapt_read_res(self, read_result: ReadResult, output_format: OutputFormat) -> VersionedItem:
-        data = self._adapt_frame_data(read_result.frame_data, read_result.norm, output_format)
-        data = self._apply_polars_sorted_flag_to_index(data, read_result)
+        data = self._adapt_frame_data(read_result.frame_data, read_result.norm, output_format, read_result.sort_order)
 
         if isinstance(read_result.version, list):
             versions = []

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -352,6 +352,22 @@ def _assume_false(name, kwargs):
         return True
 
 
+def _get_index_col_from_norm(norm):
+    """Get the name of the index column from normalization metadata, or None if no physically stored index."""
+    input_type = norm.WhichOneof("input_type")
+    if input_type == "experimental_arrow":
+        if norm.experimental_arrow.has_index:
+            return norm.experimental_arrow.index_column_name
+    elif input_type in ("df", "series"):
+        common = norm.df.common if input_type == "df" else norm.series.common
+        index_type = common.WhichOneof("index_type")
+        if index_type == "index" and common.index.is_physically_stored:
+            if common.index.fake_name:
+                return "__index__"
+            return common.index.name
+    return None
+
+
 class NativeVersionStore:
     """
     NativeVersionStore objects provide access to ArcticDB libraries, enabling fundamental library operations
@@ -2923,8 +2939,24 @@ class NativeVersionStore:
 
         return data
 
+    @staticmethod
+    def _apply_polars_sorted_flag_to_index(data, read_result):
+        if pl is None or not isinstance(data, pl.DataFrame):
+            return data
+
+        sorted_val = read_result.sorted
+        if sorted_val not in (SortedValue.ASCENDING, SortedValue.DESCENDING):
+            return data
+
+        index_col = _get_index_col_from_norm(read_result.norm)
+        if index_col is not None and index_col in data.columns:
+            data = data.with_columns(pl.col(index_col).set_sorted(descending=(sorted_val == SortedValue.DESCENDING)))
+        return data
+
     def _adapt_read_res(self, read_result: ReadResult, output_format: OutputFormat) -> VersionedItem:
         data = self._adapt_frame_data(read_result.frame_data, read_result.norm, output_format)
+        # Currently, the sorted flag applies only to the index
+        data = self._apply_polars_sorted_flag_to_index(data, read_result)
 
         if isinstance(read_result.version, list):
             versions = []

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -807,7 +807,7 @@ class NativeVersionStore:
         validate_index: bool, default=False
             If True, will verify that the index of `data` supports date range searches and update operations. This in effect tests that the data is sorted in ascending order.
             ArcticDB relies on Pandas to detect if data is sorted - you can call DataFrame.index.is_monotonic_increasing on your input DataFrame to see if Pandas believes the
-            data to be sorted. Note that no checks are performed for Arrow input data.
+            data to be sorted. For Arrow input data, ArcticDB checks the index column directly.
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
@@ -981,7 +981,7 @@ class NativeVersionStore:
         validate_index: bool, default=False
             If True, will verify that resulting symbol will support date range searches and update operations. This in effect tests that the previous version of the
             data and `data` are both sorted in ascending order. ArcticDB relies on Pandas to detect if data is sorted - you can call DataFrame.index.is_monotonic_increasing
-            on your input DataFrame to see if Pandas believes the data to be sorted.  Note that no checks are performed for Arrow input data.
+            on your input DataFrame to see if Pandas believes the data to be sorted.  For Arrow input data, ArcticDB checks the index column directly.
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
@@ -1819,7 +1819,7 @@ class NativeVersionStore:
             If set to True, it will verify for each entry in the batch whether the index of the data supports date range searches and update operations.
             This in effect tests that the data is sorted in ascending order. ArcticDB relies on Pandas to detect if data is sorted -
             you can call DataFrame.index.is_monotonic_increasing on your input DataFrame to see if Pandas believes the data to be sorted.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
         index_column_vector: Optional[List[bool]], default=None
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True for a given entry,
             the first column is treated as the timeseries index.
@@ -2034,7 +2034,7 @@ class NativeVersionStore:
             If set to True, it will verify for each entry in the batch whether the index of the data supports date range searches and update operations.
             This in effect tests that the data is sorted in ascending order. ArcticDB relies on Pandas to detect if data is sorted -
             you can call DataFrame.index.is_monotonic_increasing on your input DataFrame to see if Pandas believes the data to be sorted.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
         index_column_vector: Optional[List[bool]], default=None
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True for a given entry,
             the first column is treated as the timeseries index.
@@ -2834,7 +2834,7 @@ class NativeVersionStore:
             If True, will verify that the index of the symbol after this operation supports date range searches and
             update operations. This requires that the indexes of the incomplete segments are non-overlapping with each
             other, and, in the case of append=True, fall after the last index value in the previous version.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
         delete_staged_data_on_failure : bool, default=False
             Determines the handling of staged data when an exception occurs during the execution of the
             ``compact_incomplete`` function.

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -361,6 +361,7 @@ def _get_index_col_from_norm(norm):
     elif input_type in ("df", "series"):
         common = norm.df.common if input_type == "df" else norm.series.common
         index_type = common.WhichOneof("index_type")
+        # multi_index intentionally excluded: multi-level sorting semantics are more complex
         if index_type == "index" and common.index.is_physically_stored:
             if common.index.fake_name:
                 return "__index__"
@@ -2944,7 +2945,7 @@ class NativeVersionStore:
         if pl is None or not isinstance(data, pl.DataFrame):
             return data
 
-        sorted_val = read_result.sorted
+        sorted_val = read_result.sort_order
         if sorted_val not in (SortedValue.ASCENDING, SortedValue.DESCENDING):
             return data
 
@@ -2955,7 +2956,6 @@ class NativeVersionStore:
 
     def _adapt_read_res(self, read_result: ReadResult, output_format: OutputFormat) -> VersionedItem:
         data = self._adapt_frame_data(read_result.frame_data, read_result.norm, output_format)
-        # Currently, the sorted flag applies only to the index
         data = self._apply_polars_sorted_flag_to_index(data, read_result)
 
         if isinstance(read_result.version, list):

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -2077,9 +2077,6 @@ class Library:
             Output format for the returned dataframe.
             If `None`, uses the output format from the `Library` instance.
             See `OutputFormat` documentation for details on available formats.
-            When using ``POLARS`` output format, the index column (if physically stored) will automatically have
-            its Polars sorted flag set based on the sort order tracked by ArcticDB, enabling Polars sort-aware
-            optimizations such as fast joins and group-bys.
 
         arrow_string_format_default: Optional[Union[ArrowOutputStringFormat, "pa.DataType"]], default=None
             String column format when using `PYARROW` or `POLARS` output formats.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -2077,6 +2077,9 @@ class Library:
             Output format for the returned dataframe.
             If `None`, uses the output format from the `Library` instance.
             See `OutputFormat` documentation for details on available formats.
+            When using ``POLARS`` output format, the index column (if physically stored) will automatically have
+            its Polars sorted flag set based on the sort order tracked by ArcticDB, enabling Polars sort-aware
+            optimizations such as fast joins and group-bys.
 
         arrow_string_format_default: Optional[Union[ArrowOutputStringFormat, "pa.DataType"]], default=None
             String column format when using `PYARROW` or `POLARS` output formats.
@@ -2178,6 +2181,8 @@ class Library:
             Output format for the returned dataframes.
             If `None`, uses the output format from the `Library` instance.
             See `OutputFormat` documentation for details on available formats.
+            When using ``POLARS`` output format, the index column (if physically stored) will automatically have
+            its Polars sorted flag set based on the sort order tracked by ArcticDB.
 
         arrow_string_format_default: Optional[Union[ArrowOutputStringFormat, "pa.DataType"]], default=None
             String column format when using `PYARROW` or `POLARS` output formats.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -975,7 +975,7 @@ class Library:
             Data to be written. Staged data must be normalizable.
         validate_index:
             Check that the index is sorted prior to writing. In the case of unsorted data, throw an UnsortedDataException.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
         sort_on_index:
             If an appropriate index is present, sort the data on it. In combination with sort_columns the
             index will be used as the primary sort column, and the others as secondaries.
@@ -1064,7 +1064,7 @@ class Library:
         validate_index: bool, default=True
             If True, verify that the index of `data` supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
@@ -1253,7 +1253,7 @@ class Library:
         validate_index: bool, default=True
             Verify that each entry in the batch has an index that supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
 
         Returns
         -------
@@ -1395,7 +1395,7 @@ class Library:
         validate_index
             If True, verify that the index of `data` supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
@@ -1476,7 +1476,7 @@ class Library:
         validate_index: bool, default=True
             Verify that each entry in the batch has an index that supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
-            Note that no checks are performed for Arrow input data.
+            For Arrow input data, ArcticDB checks the index column directly.
 
         Returns
         -------
@@ -1774,7 +1774,7 @@ class Library:
             If True, and staged segments are timeseries, will verify that the index of the symbol after this operation
             supports date range searches and update operations. This requires that the indexes of the staged segments
             are non-overlapping with each other, and, in the case of `StagedDataFinalizeMethod.APPEND`, fall after the
-            last index value in the previous version.  Note that no checks are performed for Arrow input data.
+            last index value in the previous version.  For Arrow input data, ArcticDB checks the index column directly.
         delete_staged_data_on_failure : bool, default=False
             Determines the handling of staged data when an exception occurs during the execution of the
             ``finalize_staged_data`` function.

--- a/python/arcticdb/version_store/read_result.py
+++ b/python/arcticdb/version_store/read_result.py
@@ -6,21 +6,22 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
-from arcticdb_ext.version_store import PandasOutputFrame
+from arcticdb_ext.version_store import PandasOutputFrame, SortedValue
 from arcticdb.version_store._normalization import FrameData
 
 
 class NodeReadResult:
-    def __init__(self, sym, frame_data, norm):
+    def __init__(self, sym, frame_data, norm, sorted=SortedValue.UNKNOWN):
         self.sym = sym
         self.frame_data = (
             FrameData(*frame_data.extract_numpy_arrays()) if isinstance(frame_data, PandasOutputFrame) else frame_data
         )
         self.norm = norm
+        self.sorted = SortedValue(sorted) if isinstance(sorted, int) else sorted
 
 
 class ReadResult:
-    def __init__(self, version, frame_data, norm, udm, mmeta, node_read_results):
+    def __init__(self, version, frame_data, norm, udm, mmeta, node_read_results, sorted=SortedValue.UNKNOWN):
         self.version = version
         self.frame_data = (
             FrameData(*frame_data.extract_numpy_arrays()) if isinstance(frame_data, PandasOutputFrame) else frame_data
@@ -28,6 +29,7 @@ class ReadResult:
         self.norm = norm
         self.udm = udm
         self.mmeta = mmeta
+        self.sorted = SortedValue(sorted) if isinstance(sorted, int) else sorted
         self.node_read_results = (
             [NodeReadResult(*node_read_result) for node_read_result in node_read_results]
             if node_read_results is not None

--- a/python/arcticdb/version_store/read_result.py
+++ b/python/arcticdb/version_store/read_result.py
@@ -11,17 +11,17 @@ from arcticdb.version_store._normalization import FrameData
 
 
 class NodeReadResult:
-    def __init__(self, sym, frame_data, norm, sorted=SortedValue.UNKNOWN):
+    def __init__(self, sym, frame_data, norm, sort_order=SortedValue.UNKNOWN):
         self.sym = sym
         self.frame_data = (
             FrameData(*frame_data.extract_numpy_arrays()) if isinstance(frame_data, PandasOutputFrame) else frame_data
         )
         self.norm = norm
-        self.sorted = SortedValue(sorted) if isinstance(sorted, int) else sorted
+        self.sort_order = SortedValue(sort_order) if isinstance(sort_order, int) else sort_order
 
 
 class ReadResult:
-    def __init__(self, version, frame_data, norm, udm, mmeta, node_read_results, sorted=SortedValue.UNKNOWN):
+    def __init__(self, version, frame_data, norm, udm, mmeta, node_read_results, sort_order=SortedValue.UNKNOWN):
         self.version = version
         self.frame_data = (
             FrameData(*frame_data.extract_numpy_arrays()) if isinstance(frame_data, PandasOutputFrame) else frame_data
@@ -29,7 +29,7 @@ class ReadResult:
         self.norm = norm
         self.udm = udm
         self.mmeta = mmeta
-        self.sorted = SortedValue(sorted) if isinstance(sorted, int) else sorted
+        self.sort_order = SortedValue(sort_order) if isinstance(sort_order, int) else sort_order
         self.node_read_results = (
             [NodeReadResult(*node_read_result) for node_read_result in node_read_results]
             if node_read_results is not None

--- a/python/arcticdb/version_store/read_result.py
+++ b/python/arcticdb/version_store/read_result.py
@@ -11,17 +11,17 @@ from arcticdb.version_store._normalization import FrameData
 
 
 class NodeReadResult:
-    def __init__(self, sym, frame_data, norm, sort_order=SortedValue.UNKNOWN):
+    def __init__(self, sym, frame_data, norm, sort_order):
         self.sym = sym
         self.frame_data = (
             FrameData(*frame_data.extract_numpy_arrays()) if isinstance(frame_data, PandasOutputFrame) else frame_data
         )
         self.norm = norm
-        self.sort_order = SortedValue(sort_order) if isinstance(sort_order, int) else sort_order
+        self.sort_order = sort_order
 
 
 class ReadResult:
-    def __init__(self, version, frame_data, norm, udm, mmeta, node_read_results, sort_order=SortedValue.UNKNOWN):
+    def __init__(self, version, frame_data, norm, udm, mmeta, node_read_results, sort_order):
         self.version = version
         self.frame_data = (
             FrameData(*frame_data.extract_numpy_arrays()) if isinstance(frame_data, PandasOutputFrame) else frame_data
@@ -29,7 +29,7 @@ class ReadResult:
         self.norm = norm
         self.udm = udm
         self.mmeta = mmeta
-        self.sort_order = SortedValue(sort_order) if isinstance(sort_order, int) else sort_order
+        self.sort_order = sort_order
         self.node_read_results = (
             [NodeReadResult(*node_read_result) for node_read_result in node_read_results]
             if node_read_results is not None

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -499,7 +499,7 @@ def test_segment_in_memory_to_read_result(lmdb_version_store_v1, sym):
     read_result = lib_tool.segment_in_memory_to_read_result(segment_in_memory)
 
     assert isinstance(read_result, tuple)
-    assert len(read_result) == 6
+    assert len(read_result) == 7
 
     expected_df = lib_tool.read_to_dataframe(tdata_key)
     assert_frame_equal(expected_df, denormalize_dataframe(read_result))

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -14,7 +14,9 @@ import pandas as pd
 import pyarrow as pa
 import polars as pl
 import pytest
+from arcticdb import DataError
 from arcticdb.exceptions import SchemaException, StreamDescriptorMismatch, UserInputException
+from arcticdb_ext.exceptions import UnsortedDataException
 from arcticdb.options import ArrowOutputStringFormat
 from arcticdb.util.arrow import cast_string_columns
 from arcticdb.util.test import (
@@ -1383,3 +1385,80 @@ def test_arrow_buffer_released_after_write(in_memory_version_store_arrow):
     del tables, t
     gc.collect()
     assert sorted(released) == [0, 1, 2, 3, 4]
+
+
+def _ts_arrow_table(days):
+    return pa.table(
+        {
+            "ts": pa.array([pd.Timestamp(d) for d in days], pa.timestamp("ns")),
+            "col": pa.array(list(range(len(days))), pa.int64()),
+        }
+    )
+
+
+_SORTED_DAYS = ["2024-01-01", "2024-01-02", "2024-01-03"]
+_UNSORTED_DAYS = ["2024-01-03", "2024-01-01", "2024-01-02"]
+
+
+@pytest.mark.parametrize("method", ["write", "append", "update", "stage"])
+@pytest.mark.parametrize("validate_index", [True, False])
+@pytest.mark.parametrize("sorted_data", [True, False])
+def test_validate_index_arrow(lmdb_version_store_arrow, method, validate_index, sorted_data):
+    lib = lmdb_version_store_arrow
+    sym = "test_validate_index_arrow"
+    table = _ts_arrow_table(_SORTED_DAYS if sorted_data else _UNSORTED_DAYS)
+    if method == "append":
+        lib.write(sym, _ts_arrow_table(["2023-12-01", "2023-12-02"]), index_column=True, validate_index=True)
+    elif method == "update":
+        lib.write(sym, _ts_arrow_table(_SORTED_DAYS), index_column=True, validate_index=True)
+
+    ops = {
+        "write": lambda: lib.write(sym, table, validate_index=validate_index, index_column=True),
+        "append": lambda: lib.append(sym, table, validate_index=validate_index, index_column=True),
+        "update": lambda: lib.update(sym, table, index_column=True),
+        "stage": lambda: lib.stage(sym, table, validate_index=validate_index, index_column=True),
+    }
+    # update always validates the index; the other methods only when validate_index is set
+    if not sorted_data and (validate_index or method == "update"):
+        with pytest.raises(UnsortedDataException):
+            ops[method]()
+    else:
+        ops[method]()
+
+
+def _batch_rejected_as_unsorted(fn):
+    # batch_write/batch_append raise; batch_update surfaces per-symbol failures as DataError entries
+    try:
+        result = fn()
+    except UnsortedDataException:
+        return True
+    return any(isinstance(r, DataError) for r in result)
+
+
+@pytest.mark.parametrize("method", ["batch_write", "batch_append", "batch_update"])
+@pytest.mark.parametrize("validate_index", [True, False])
+@pytest.mark.parametrize("sorted_data", [True, False])
+def test_validate_index_arrow_batch(lmdb_version_store_arrow, method, validate_index, sorted_data):
+    lib = lmdb_version_store_arrow
+    sym = "test_validate_index_arrow_batch"
+    table = _ts_arrow_table(_SORTED_DAYS if sorted_data else _UNSORTED_DAYS)
+    if method == "batch_append":
+        lib.write(sym, _ts_arrow_table(["2023-12-01", "2023-12-02"]), index_column=True, validate_index=True)
+    elif method == "batch_update":
+        lib.write(sym, _ts_arrow_table(_SORTED_DAYS), index_column=True, validate_index=True)
+
+    ops = {
+        "batch_write": lambda: lib.batch_write(
+            [sym], [table], validate_index=validate_index, index_column_vector=[True]
+        ),
+        "batch_append": lambda: lib.batch_append(
+            [sym], [table], validate_index=validate_index, index_column_vector=[True]
+        ),
+        "batch_update": lambda: lib._batch_update_internal([sym], [table], [None], [None], index_column_vector=[True]),
+    }
+    # batch_update always validates the index; the others only when validate_index is set
+    if not sorted_data and (validate_index or method == "batch_update"):
+        assert _batch_rejected_as_unsorted(ops[method])
+    else:
+        result = ops[method]()
+        assert all(not isinstance(r, DataError) for r in result)

--- a/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
+++ b/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
@@ -121,7 +121,7 @@ def _make_mock_read_result(sort_order, index_name="__index__", fake_name=True, i
 
 def test_descending_sort_order_sets_sorted_desc():
     """When sort_order is DESCENDING the Polars column should have SORTED_DESC."""
-    data = pl.DataFrame({"__index__": pl.date_range(pd.Timestamp("2024-01-01"), periods=5, interval="1h", eager=True)})
+    data = pl.DataFrame({"__index__": pd.date_range("2024-01-01", periods=5, freq="h")})
     read_result = _make_mock_read_result(SortedValue.DESCENDING)
 
     result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, read_result)
@@ -132,7 +132,7 @@ def test_descending_sort_order_sets_sorted_desc():
 
 def test_unknown_sort_order_does_not_set_sorted_flag():
     """When sort_order is UNKNOWN no sorted flag should be applied even with a physical index."""
-    data = pl.DataFrame({"__index__": pl.date_range(pd.Timestamp("2024-01-01"), periods=5, interval="1h", eager=True)})
+    data = pl.DataFrame({"__index__": pd.date_range("2024-01-01", periods=5, freq="h")})
     read_result = _make_mock_read_result(SortedValue.UNKNOWN)
 
     result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, read_result)

--- a/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
+++ b/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
@@ -1,0 +1,105 @@
+"""
+Tests for the Polars set_sorted() flag on the index column during ArcticDB reads.
+
+Verifies that when data is read back with output_format="polars", the index column
+has the SORTED_ASC flag set (based on SortedValue from the C++ StreamDescriptor).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import polars as pl
+
+
+def test_sorted_flag_on_datetime_index(lmdb_library):
+    """Unnamed DatetimeIndex -> column '__index__' should have SORTED_ASC."""
+    lib = lmdb_library
+    df = pd.DataFrame(
+        {"val": np.arange(10)},
+        index=pd.date_range("2024-01-01", periods=10, freq="h"),
+    )
+    lib.write("sym", df)
+    result = lib.read("sym", output_format="polars").data
+
+    assert isinstance(result, pl.DataFrame)
+    assert result["__index__"].flags["SORTED_ASC"] is True
+    assert result["__index__"].flags["SORTED_DESC"] is False
+
+
+def test_sorted_flag_on_named_datetime_index(lmdb_library):
+    """Named DatetimeIndex -> column with that name should have SORTED_ASC."""
+    lib = lmdb_library
+    df = pd.DataFrame(
+        {"val": np.arange(10)},
+        index=pd.date_range("2024-01-01", periods=10, freq="h", name="timestamp"),
+    )
+    lib.write("sym", df)
+    result = lib.read("sym", output_format="polars").data
+
+    assert isinstance(result, pl.DataFrame)
+    assert "timestamp" in result.columns
+    assert result["timestamp"].flags["SORTED_ASC"] is True
+
+
+def test_no_sorted_flag_on_range_index(lmdb_library):
+    """RangeIndex is not physically stored — no column should carry a sorted flag."""
+    lib = lmdb_library
+    df = pd.DataFrame({"val": np.arange(10)})
+    lib.write("sym", df)
+    result = lib.read("sym", output_format="polars").data
+
+    assert isinstance(result, pl.DataFrame)
+    for col in result.columns:
+        assert result[col].flags["SORTED_ASC"] is False, f"Column {col} should not have SORTED_ASC"
+
+
+def test_sorted_flag_not_set_for_pandas_output(lmdb_library):
+    """Reading as pandas (default) should not crash and returns a regular DataFrame."""
+    lib = lmdb_library
+    df = pd.DataFrame(
+        {"val": np.arange(10)},
+        index=pd.date_range("2024-01-01", periods=10, freq="h"),
+    )
+    lib.write("sym", df)
+    result = lib.read("sym").data
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 10
+
+
+@pytest.mark.storage
+def test_sorted_flag_with_stage_finalize(arctic_library):
+    """Stage shuffled data with sort_on_index=True, finalize, read as Polars -> SORTED_ASC."""
+    lib = arctic_library
+    symbol = "staged"
+
+    df = pd.DataFrame(
+        {"val": np.arange(50)},
+        index=pd.date_range("2024-01-01", periods=50, freq="h"),
+    )
+    shuffled = df.sample(frac=1, random_state=42)
+
+    lib.stage(symbol, shuffled, validate_index=False, sort_on_index=True)
+    lib.finalize_staged_data(symbol)
+
+    result = lib.read(symbol, output_format="polars").data
+
+    assert isinstance(result, pl.DataFrame)
+    assert result["__index__"].flags["SORTED_ASC"] is True
+
+
+def test_value_columns_not_sorted(lmdb_library):
+    """Only the index column should get the sorted flag, not value columns."""
+    lib = lmdb_library
+    # Both index and value columns are actually sorted in the data
+    df = pd.DataFrame(
+        {"sorted_val": np.arange(10), "another": np.arange(10)},
+        index=pd.date_range("2024-01-01", periods=10, freq="h"),
+    )
+    lib.write("sym", df)
+    result = lib.read("sym", output_format="polars").data
+
+    assert isinstance(result, pl.DataFrame)
+    assert result["__index__"].flags["SORTED_ASC"] is True
+    assert result["sorted_val"].flags["SORTED_ASC"] is False
+    assert result["another"].flags["SORTED_ASC"] is False

--- a/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
+++ b/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
@@ -9,6 +9,10 @@ import numpy as np
 import pandas as pd
 import pytest
 import polars as pl
+from types import SimpleNamespace
+
+from arcticdb_ext.version_store import SortedValue
+from arcticdb.version_store._store import NativeVersionStore
 
 
 def test_sorted_flag_on_datetime_index(lmdb_library):
@@ -103,3 +107,35 @@ def test_value_columns_not_sorted(lmdb_library):
     assert result["__index__"].flags["SORTED_ASC"] is True
     assert result["sorted_val"].flags["SORTED_ASC"] is False
     assert result["another"].flags["SORTED_ASC"] is False
+
+
+def _make_mock_read_result(sort_order, index_name="__index__", fake_name=True, is_physically_stored=True):
+    """Build a minimal mock ReadResult with the given sort_order and index normalization metadata."""
+    index = SimpleNamespace(name=index_name, fake_name=fake_name, is_physically_stored=is_physically_stored)
+    common = SimpleNamespace(_index_type="index", index=index)
+    common.WhichOneof = lambda field: "index" if field == "index_type" else None
+    norm = SimpleNamespace(df=SimpleNamespace(common=common))
+    norm.WhichOneof = lambda field: "df" if field == "input_type" else None
+    return SimpleNamespace(sort_order=sort_order, norm=norm)
+
+
+def test_descending_sort_order_sets_sorted_desc():
+    """When sort_order is DESCENDING the Polars column should have SORTED_DESC."""
+    data = pl.DataFrame({"__index__": pl.date_range(pd.Timestamp("2024-01-01"), periods=5, interval="1h", eager=True)})
+    read_result = _make_mock_read_result(SortedValue.DESCENDING)
+
+    result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, read_result)
+
+    assert result["__index__"].flags["SORTED_DESC"] is True
+    assert result["__index__"].flags["SORTED_ASC"] is False
+
+
+def test_unknown_sort_order_does_not_set_sorted_flag():
+    """When sort_order is UNKNOWN no sorted flag should be applied even with a physical index."""
+    data = pl.DataFrame({"__index__": pl.date_range(pd.Timestamp("2024-01-01"), periods=5, interval="1h", eager=True)})
+    read_result = _make_mock_read_result(SortedValue.UNKNOWN)
+
+    result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, read_result)
+
+    assert result["__index__"].flags["SORTED_ASC"] is False
+    assert result["__index__"].flags["SORTED_DESC"] is False

--- a/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
+++ b/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
@@ -99,6 +99,24 @@ def test_unsorted_arrow_write_does_not_get_polars_sorted_flag(lmdb_version_store
     assert result["ts"].flags["SORTED_DESC"] is False
 
 
+@pytest.mark.parametrize("validate_index", [True, False])
+def test_arrow_write_sets_polars_sorted_flag_only_when_validated(lmdb_version_store_arrow, validate_index):
+    """Polars writes only carry the sorted flag on read when validate_index requested the sortedness check."""
+    lib = lmdb_version_store_arrow
+    df = pl.DataFrame(
+        {
+            "ts": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03")],
+            "val": [1, 2, 3],
+        },
+        schema={"ts": pl.Datetime("ns"), "val": pl.Int64},
+    )
+    lib.write("sym", df, index_column=True, validate_index=validate_index)
+    result = lib.read("sym", output_format="polars").data
+
+    assert result["ts"].flags["SORTED_ASC"] is validate_index
+    assert result["ts"].flags["SORTED_DESC"] is False
+
+
 def test_value_columns_not_sorted(lmdb_library):
     """Only the index column should get the sorted flag, not value columns."""
     lib = lmdb_library

--- a/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
+++ b/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
@@ -57,20 +57,6 @@ def test_no_sorted_flag_on_range_index(lmdb_library):
         assert result[col].flags["SORTED_ASC"] is False, f"Column {col} should not have SORTED_ASC"
 
 
-def test_sorted_flag_not_set_for_pandas_output(lmdb_library):
-    """Reading as pandas (default) should not crash and returns a regular DataFrame."""
-    lib = lmdb_library
-    df = pd.DataFrame(
-        {"val": np.arange(10)},
-        index=pd.date_range("2024-01-01", periods=10, freq="h"),
-    )
-    lib.write("sym", df)
-    result = lib.read("sym").data
-
-    assert isinstance(result, pd.DataFrame)
-    assert len(result) == 10
-
-
 @pytest.mark.storage
 def test_sorted_flag_with_stage_finalize(arctic_library):
     """Stage shuffled data with sort_on_index=True, finalize, read as Polars -> SORTED_ASC."""
@@ -92,10 +78,30 @@ def test_sorted_flag_with_stage_finalize(arctic_library):
     assert result["__index__"].flags["SORTED_ASC"] is True
 
 
+def test_unsorted_arrow_write_does_not_get_polars_sorted_flag(lmdb_version_store_arrow):
+    """Polars writes with a non-monotonic index column must not carry SORTED_ASC on read."""
+    lib = lmdb_version_store_arrow
+    df = pl.DataFrame(
+        {
+            "ts": [
+                pd.Timestamp("2024-01-03"),
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-02"),
+            ],
+            "val": [1, 2, 3],
+        },
+        schema={"ts": pl.Datetime("ns"), "val": pl.Int64},
+    )
+    lib.write("sym", df, index_column=True)
+    result = lib.read("sym", output_format="polars").data
+
+    assert result["ts"].flags["SORTED_ASC"] is False
+    assert result["ts"].flags["SORTED_DESC"] is False
+
+
 def test_value_columns_not_sorted(lmdb_library):
     """Only the index column should get the sorted flag, not value columns."""
     lib = lmdb_library
-    # Both index and value columns are actually sorted in the data
     df = pd.DataFrame(
         {"sorted_val": np.arange(10), "another": np.arange(10)},
         index=pd.date_range("2024-01-01", periods=10, freq="h"),
@@ -109,33 +115,58 @@ def test_value_columns_not_sorted(lmdb_library):
     assert result["another"].flags["SORTED_ASC"] is False
 
 
-def _make_mock_read_result(sort_order, index_name="__index__", fake_name=True, is_physically_stored=True):
-    """Build a minimal mock ReadResult with the given sort_order and index normalization metadata."""
-    index = SimpleNamespace(name=index_name, fake_name=fake_name, is_physically_stored=is_physically_stored)
-    common = SimpleNamespace(_index_type="index", index=index)
-    common.WhichOneof = lambda field: "index" if field == "index_type" else None
+def _make_norm_meta(input_type="df", index_type="index", is_physically_stored=True):
+    """Build a minimal mock normalization metadata object."""
+    index = SimpleNamespace(is_physically_stored=is_physically_stored)
+    common = SimpleNamespace(index=index)
+    common.WhichOneof = lambda field: index_type if field == "index_type" else None
     norm = SimpleNamespace(df=SimpleNamespace(common=common))
-    norm.WhichOneof = lambda field: "df" if field == "input_type" else None
-    return SimpleNamespace(sort_order=sort_order, norm=norm)
+    norm.WhichOneof = lambda field: input_type if field == "input_type" else None
+    return norm
 
 
 def test_descending_sort_order_sets_sorted_desc():
     """When sort_order is DESCENDING the Polars column should have SORTED_DESC."""
     data = pl.DataFrame({"__index__": pd.date_range("2024-01-01", periods=5, freq="h")})
-    read_result = _make_mock_read_result(SortedValue.DESCENDING)
 
-    result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, read_result)
+    result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, SortedValue.DESCENDING, _make_norm_meta())
 
     assert result["__index__"].flags["SORTED_DESC"] is True
     assert result["__index__"].flags["SORTED_ASC"] is False
 
 
 def test_unknown_sort_order_does_not_set_sorted_flag():
-    """When sort_order is UNKNOWN no sorted flag should be applied even with a physical index."""
+    """UNKNOWN means sortedness was not verified (e.g. Arrow writes), so no flag should be applied."""
     data = pl.DataFrame({"__index__": pd.date_range("2024-01-01", periods=5, freq="h")})
-    read_result = _make_mock_read_result(SortedValue.UNKNOWN)
 
-    result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, read_result)
+    result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, SortedValue.UNKNOWN, _make_norm_meta())
 
     assert result["__index__"].flags["SORTED_ASC"] is False
     assert result["__index__"].flags["SORTED_DESC"] is False
+
+
+def test_unsorted_sort_order_does_not_set_sorted_flag():
+    """When sort_order is UNSORTED no sorted flag should be applied."""
+    data = pl.DataFrame({"__index__": pd.date_range("2024-01-01", periods=5, freq="h")})
+
+    result = NativeVersionStore._apply_polars_sorted_flag_to_index(data, SortedValue.UNSORTED, _make_norm_meta())
+
+    assert result["__index__"].flags["SORTED_ASC"] is False
+    assert result["__index__"].flags["SORTED_DESC"] is False
+
+
+def test_multi_index_first_level_gets_sorted_flag():
+    """For MultiIndex symbols, the first index column is marked sorted when the symbol is sorted."""
+    data = pl.DataFrame(
+        {
+            "__index__": pd.date_range("2024-01-01", periods=5, freq="h"),
+            "level_1": np.arange(5),
+        }
+    )
+
+    result = NativeVersionStore._apply_polars_sorted_flag_to_index(
+        data, SortedValue.ASCENDING, _make_norm_meta(index_type="multi_index")
+    )
+
+    assert result["__index__"].flags["SORTED_ASC"] is True
+    assert result["level_1"].flags["SORTED_ASC"] is False

--- a/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
+++ b/python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py
@@ -133,6 +133,28 @@ def test_value_columns_not_sorted(lmdb_library):
     assert result["another"].flags["SORTED_ASC"] is False
 
 
+@pytest.mark.parametrize("first_level_is_timeseries", [True, False])
+def test_multiindex_sorted_only_if_timeseries(lmdb_library, first_level_is_timeseries):
+    """A sorted MultiIndex carries the Polars sorted flag on its first level only when that level is a
+    timeseries; ArcticDB does not track sortedness for non-datetime index levels."""
+    lib = lmdb_library
+    if first_level_is_timeseries:
+        first_level = pd.date_range("2024-01-01", periods=3, freq="h").repeat(2)
+    else:
+        first_level = np.repeat(np.arange(3), 2)
+    index = pd.MultiIndex.from_arrays([first_level, np.tile([0, 1], 3)], names=["l0", "l1"])
+    df = pd.DataFrame({"val": np.arange(6)}, index=index).sort_index()
+
+    lib.write("sym", df)
+    result = lib.read("sym", output_format="polars").data
+
+    assert isinstance(result, pl.DataFrame)
+    # The first index level is the first column; it is flagged sorted only for a timeseries first level.
+    first_level_col = result[result.columns[0]]
+    assert first_level_col.flags["SORTED_ASC"] is first_level_is_timeseries
+    assert first_level_col.flags["SORTED_DESC"] is False
+
+
 def _make_norm_meta(input_type="df", index_type="index", is_physically_stored=True):
     """Build a minimal mock normalization metadata object."""
     index = SimpleNamespace(is_physically_stored=is_physically_stored)


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ticket ref: 10659398340

#### What does this implement or fix?
When reading data from ArcticDB with `output_format="polars"`, the resulting Polars DataFrame had no sorted flag set on the index column, even though ArcticDB tracks sort order internally via `SortedValue` in the C++ `StreamDescriptor`. This means Polars couldn't take advantage of optimized operations (e.g., fast joins, binary search filtering) that rely on knowing a column is sorted.

### Changes

**C++ layer — propagate `SortedValue` through the read path:**

- `cpp/arcticdb/entity/read_result.hpp` — Added a `SortedValue sorted` field to both `NodeReadResult` and `ReadResult`, defaulting to `UNKNOWN`.
- `cpp/arcticdb/pipeline/pipeline_utils.hpp` — In `create_python_read_result`, extracts the sorted value from the stream descriptor and passes it into `NodeReadResult` and the top-level `ReadResult`.
- `cpp/arcticdb/python/adapt_read_dataframe.hpp` — Includes `sorted` (cast to `int`) in the tuple returned to Python from `adapt_read_df`.
- `cpp/arcticdb/python/python_utils.hpp` — Includes `sorted` in the tuples produced by `node_results_to_python_list` and `adapt_read_dfs`.

**Python layer — receive sorted value and apply Polars flag:**

- `python/arcticdb/version_store/read_result.py` — `ReadResult` and `NodeReadResult` now accept and store a `sorted` parameter (converted from int to `SortedValue` enum).
- `python/arcticdb/version_store/_store.py`:
  - Added `_get_index_col_from_norm()` helper to extract the index column name from normalization metadata (handles pandas DataFrames, Series, and experimental Arrow formats).
  - Added `_apply_polars_sorted_flag_to_index()` static method that calls `polars.col(...).set_sorted()` on the index column when the stored sort order is `ASCENDING` or `DESCENDING`.
  - Integrated the flag application into `_adapt_read_res()` so it runs automatically on every read.

**Tests:**

- `python/tests/unit/arcticdb/version_store/test_polars_set_sorted.py` — New test file with 6 tests covering:
  - Unnamed `DatetimeIndex` → `__index__` column gets `SORTED_ASC`
  - Named `DatetimeIndex` → named column gets `SORTED_ASC`
  - `RangeIndex` (not physically stored) → no sorted flag set
  - Pandas output path still works without issues
  - Stage + finalize workflow preserves sorted flag
  - Value columns do not get the sorted flag (only the index does)
  
## Benchmark Results

### Before vs After (stock ArcticDB 6.13.0 vs branch dev build)

The benchmark script reads 1M rows as Polars and measures various operations. On stock ArcticDB, the index has no sorted flag (`SORTED_ASC: False`). With the branch's dev build, the sorted flag is automatically applied (`SORTED_ASC: True`).

**Comparing stock (6.13.0) vs branch (dev) on key index operations:**

| Benchmark | Stock 6.13.0 (ms) | Branch dev (ms) | Speedup |
|---|--:|--:|--:|
| sort_by_index | 18.90 | 3.06 | **6.18x** |
| unique_index | 3.71 | 0.69 | **5.38x** |
| upsample | 25.20 | 8.32 | **3.03x** |
| filter_range | 1.93 | 1.89 | 1.02x |
| filter_after | 1.30 | 1.27 | 1.02x |
| group_by_dynamic | 9.40 | 8.83 | 1.06x |
| rolling_mean | 25.59 | 24.87 | 1.03x |

The branch delivers significant speedups on `sort_by_index` (6.2x), `unique_index` (5.4x), and `upsample` (3x). These are operations where Polars can skip work entirely when it knows the column is sorted.

### Branch dev build: detailed benchmark (Polars 1.35.2, 1M rows, 10 iters)

Note: In the branch build, "Current (no flag)" already has `SORTED_ASC: True` on the index (the branch's feature), so applying `set_sorted()` again is a no-op. This confirms the feature is working automatically.

#### Part 2: Value Columns — Future Work

These measure the *potential* benefit of also setting `set_sorted()` on value columns, which would require populating `FieldStats.sorted_` in C++. **Not implemented in this branch.**

| Benchmark | Current/branch (ms) | + index + values (ms) | Speedup | Notes |
|---|--:|--:|--:|---|
| sort_by_price | 22.71 | 3.42 | **6.63x** | Big win |
| filter_price_range | 0.91 | 0.79 | 1.14x | |
| unique_price | 4.07 | 0.70 | **5.82x** | Big win |
| search_sorted_price | 0.11 | 0.10 | 1.10x | |
| join_asof_on_price | 5.81 | 6.42 | 0.90x | |
| sort_by_volume | 20.77 | 4.19 | **4.96x** | Big win |
| unique_volume | 3.31 | 0.64 | **5.14x** | Big win |

### Overhead

The `set_sorted()` call adds negligible overhead (~0.3 ms) relative to the read cost (~399 ms debug build):

| Operation | Time (ms) |
|---|--:|
| `set_sorted` (index only) | 0.28 |
| `set_sorted` (index + 2 cols) | 0.65 |