### PR TITLE
Fix intermittent hang in test_overwrite_append_data

### DIFF
--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -28,7 +28,7 @@ export PYTHONFAULTHANDLER=1
 # if a test hangs with the GIL held (where pytest-timeout's thread method can't fire).
 # Crash tracebacks are written to per-PID files in ARCTICDB_FAULTHANDLER_DIR
 # (xdist worker stderr is piped through execnet and never reaches CI logs).
-export ARCTICDB_FAULTHANDLER_TIMEOUT=3300
+export ARCTICDB_FAULTHANDLER_TIMEOUT=1600
 export ARCTICDB_FAULTHANDLER_DIR="$TEST_OUTPUT_DIR/faulthandler"
 
 print_faulthandler_crashes() {

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -28,7 +28,7 @@ export PYTHONFAULTHANDLER=1
 # if a test hangs with the GIL held (where pytest-timeout's thread method can't fire).
 # Crash tracebacks are written to per-PID files in ARCTICDB_FAULTHANDLER_DIR
 # (xdist worker stderr is piped through execnet and never reaches CI logs).
-export ARCTICDB_FAULTHANDLER_TIMEOUT=1600
+export ARCTICDB_FAULTHANDLER_TIMEOUT=3300
 export ARCTICDB_FAULTHANDLER_DIR="$TEST_OUTPUT_DIR/faulthandler"
 
 print_faulthandler_crashes() {

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -338,6 +338,13 @@ class AsyncStore : public Store {
         return read_and_continue(key, library_, opts, DecodeTimeseriesDescriptorTask{});
     }
 
+    std::pair<VariantKey, TimeseriesDescriptor> read_timeseries_descriptor_sync(
+            const entity::VariantKey& key, storage::ReadKeyOpts opts
+    ) override {
+        auto key_seg = read_sync_dispatch(key, library_, opts);
+        return DecodeTimeseriesDescriptorTask{}(std::move(key_seg));
+    }
+
     folly::Future<bool> key_exists(entity::VariantKey&& key) {
         return async::submit_io_task(KeyExistsTask{std::move(key), library_});
     }

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -141,4 +141,25 @@ inline ReadResult read_result_from_single_frame(
     return create_python_read_result(VersionedItem{key}, output_format, std::move(frame_and_desc));
 }
 
+inline ReadResult read_result_from_single_frame_sync(
+        FrameAndDescriptor& frame_and_desc, const AtomKey& key, std::any& handler_data, OutputFormat output_format
+) {
+    auto pipeline_context = std::make_shared<PipelineContext>(frame_and_desc.frame_.descriptor());
+    SliceAndKey sk{FrameSlice{frame_and_desc.frame_}, key};
+    pipeline_context->slice_and_keys_.emplace_back(std::move(sk));
+    util::BitSet bitset(1);
+    bitset.flip();
+    pipeline_context->fetch_index_ = std::move(bitset);
+    pipeline_context->ensure_vectors();
+
+    generate_filtered_field_descriptors(pipeline_context, {});
+    pipeline_context->begin()->set_string_pool(frame_and_desc.frame_.string_pool_ptr());
+    auto descriptor = std::make_shared<StreamDescriptor>(frame_and_desc.frame_.descriptor());
+    pipeline_context->begin()->set_descriptor(std::move(descriptor));
+    std::shared_ptr<std::any> handler_data_ptr(std::shared_ptr<std::any>{}, &handler_data);
+    reduce_and_fix_columns_sync(pipeline_context, frame_and_desc.frame_, ReadOptions{}, handler_data_ptr);
+    apply_type_handlers(frame_and_desc.frame_, handler_data, output_format);
+    return create_python_read_result(VersionedItem{key}, output_format, std::move(frame_and_desc));
+}
+
 } // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -120,8 +120,9 @@ inline ReadResult create_python_read_result(
             std::move(node_results)};
 }
 
-inline ReadResult read_result_from_single_frame(
-        FrameAndDescriptor& frame_and_desc, const AtomKey& key, std::any& handler_data, OutputFormat output_format
+namespace detail {
+inline std::pair<std::shared_ptr<PipelineContext>, std::shared_ptr<std::any>> prepare_single_frame_context(
+        FrameAndDescriptor& frame_and_desc, const AtomKey& key, std::any& handler_data
 ) {
     auto pipeline_context = std::make_shared<PipelineContext>(frame_and_desc.frame_.descriptor());
     SliceAndKey sk{FrameSlice{frame_and_desc.frame_}, key};
@@ -136,6 +137,14 @@ inline ReadResult read_result_from_single_frame(
     auto descriptor = std::make_shared<StreamDescriptor>(frame_and_desc.frame_.descriptor());
     pipeline_context->begin()->set_descriptor(std::move(descriptor));
     std::shared_ptr<std::any> handler_data_ptr(std::shared_ptr<std::any>{}, &handler_data);
+    return {std::move(pipeline_context), std::move(handler_data_ptr)};
+}
+} // namespace detail
+
+inline ReadResult read_result_from_single_frame(
+        FrameAndDescriptor& frame_and_desc, const AtomKey& key, std::any& handler_data, OutputFormat output_format
+) {
+    auto [pipeline_context, handler_data_ptr] = detail::prepare_single_frame_context(frame_and_desc, key, handler_data);
     reduce_and_fix_columns(pipeline_context, frame_and_desc.frame_, ReadOptions{}, handler_data_ptr).get();
     apply_type_handlers(frame_and_desc.frame_, handler_data, output_format);
     return create_python_read_result(VersionedItem{key}, output_format, std::move(frame_and_desc));
@@ -144,19 +153,7 @@ inline ReadResult read_result_from_single_frame(
 inline ReadResult read_result_from_single_frame_sync(
         FrameAndDescriptor& frame_and_desc, const AtomKey& key, std::any& handler_data, OutputFormat output_format
 ) {
-    auto pipeline_context = std::make_shared<PipelineContext>(frame_and_desc.frame_.descriptor());
-    SliceAndKey sk{FrameSlice{frame_and_desc.frame_}, key};
-    pipeline_context->slice_and_keys_.emplace_back(std::move(sk));
-    util::BitSet bitset(1);
-    bitset.flip();
-    pipeline_context->fetch_index_ = std::move(bitset);
-    pipeline_context->ensure_vectors();
-
-    generate_filtered_field_descriptors(pipeline_context, {});
-    pipeline_context->begin()->set_string_pool(frame_and_desc.frame_.string_pool_ptr());
-    auto descriptor = std::make_shared<StreamDescriptor>(frame_and_desc.frame_.descriptor());
-    pipeline_context->begin()->set_descriptor(std::move(descriptor));
-    std::shared_ptr<std::any> handler_data_ptr(std::shared_ptr<std::any>{}, &handler_data);
+    auto [pipeline_context, handler_data_ptr] = detail::prepare_single_frame_context(frame_and_desc, key, handler_data);
     reduce_and_fix_columns_sync(pipeline_context, frame_and_desc.frame_, ReadOptions{}, handler_data_ptr);
     apply_type_handlers(frame_and_desc.frame_, handler_data, output_format);
     return create_python_read_result(VersionedItem{key}, output_format, std::move(frame_and_desc));

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -1048,6 +1048,27 @@ struct ReduceColumnTask : async::BaseTask {
     }
 };
 
+void reduce_and_fix_columns_sync(
+        std::shared_ptr<PipelineContext>& context, SegmentInMemory& frame, const ReadOptions& read_options,
+        std::shared_ptr<std::any> handler_data
+) {
+    ARCTICDB_SAMPLE_DEFAULT(ReduceAndFixStringCol)
+    ARCTICDB_DEBUG(log::version(), "Reduce and fix columns (sync)");
+    if (frame.empty())
+        return;
+
+    auto slice_map = std::make_shared<FrameSliceMap>(context, read_options.dynamic_schema().value_or(false));
+
+    DecodePathData shared_data;
+    for (size_t idx = 0; idx < frame.descriptor().fields().size(); ++idx) {
+        const auto& frame_field = frame.field(idx);
+        if (read_options.dynamic_schema().value_or(false) ||
+            (slice_map->columns_.contains(frame_field.name()) && is_sequence_type(frame_field.type().data_type()))) {
+            ReduceColumnTask(frame, idx, slice_map, context, shared_data, handler_data, read_options)();
+        }
+    }
+}
+
 folly::Future<folly::Unit> reduce_and_fix_columns(
         std::shared_ptr<PipelineContext>& context, SegmentInMemory& frame, const ReadOptions& read_options,
         std::shared_ptr<std::any> handler_data

--- a/cpp/arcticdb/pipeline/read_frame.hpp
+++ b/cpp/arcticdb/pipeline/read_frame.hpp
@@ -89,6 +89,11 @@ folly::Future<folly::Unit> reduce_and_fix_columns(
         std::shared_ptr<std::any> handler_data
 );
 
+void reduce_and_fix_columns_sync(
+        std::shared_ptr<PipelineContext>& context, SegmentInMemory& frame, const ReadOptions& read_options,
+        std::shared_ptr<std::any> handler_data
+);
+
 StreamDescriptor get_filtered_descriptor(
         const StreamDescriptor& desc, const ReadOptions& read_options,
         const std::shared_ptr<FieldCollection>& filter_columns

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -527,8 +527,8 @@ class InMemoryStore : public Store {
         return folly::makeFuture(std::move(components));
     }
 
-    folly::Future<std::pair<VariantKey, arcticdb::TimeseriesDescriptor>>
-    read_timeseries_descriptor(const entity::VariantKey& key, storage::ReadKeyOpts /*opts*/) override {
+    std::pair<VariantKey, arcticdb::TimeseriesDescriptor>
+    read_timeseries_descriptor_sync(const entity::VariantKey& key, storage::ReadKeyOpts /*opts*/) override {
         auto failure_sim = StorageFailureSimulator::instance();
         failure_sim->go(FailureType::READ);
         return util::variant_match(
@@ -550,10 +550,9 @@ class InMemoryStore : public Store {
         );
     }
 
-    std::pair<VariantKey, arcticdb::TimeseriesDescriptor> read_timeseries_descriptor_sync(
-            const entity::VariantKey& key, storage::ReadKeyOpts opts
-    ) override {
-        return read_timeseries_descriptor(key, opts).get();
+    folly::Future<std::pair<VariantKey, arcticdb::TimeseriesDescriptor>>
+    read_timeseries_descriptor(const entity::VariantKey& key, storage::ReadKeyOpts opts) override {
+        return folly::makeFuture(read_timeseries_descriptor_sync(key, opts));
     }
 
     void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator&) override {}

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -550,8 +550,9 @@ class InMemoryStore : public Store {
         );
     }
 
-    folly::Future<std::pair<VariantKey, arcticdb::TimeseriesDescriptor>>
-    read_timeseries_descriptor(const entity::VariantKey& key, storage::ReadKeyOpts opts) override {
+    folly::Future<std::pair<VariantKey, arcticdb::TimeseriesDescriptor>> read_timeseries_descriptor(
+            const entity::VariantKey& key, storage::ReadKeyOpts opts
+    ) override {
         return folly::makeFuture(read_timeseries_descriptor_sync(key, opts));
     }
 

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -550,6 +550,11 @@ class InMemoryStore : public Store {
         );
     }
 
+    std::pair<VariantKey, arcticdb::TimeseriesDescriptor>
+    read_timeseries_descriptor_sync(const entity::VariantKey& key, storage::ReadKeyOpts opts) override {
+        return read_timeseries_descriptor(key, opts).get();
+    }
+
     void set_failure_sim(const arcticdb::proto::storage::VersionStoreConfig::StorageFailureSimulator&) override {}
 
     std::string name() const override { return "InMemoryStore"; }

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -550,8 +550,9 @@ class InMemoryStore : public Store {
         );
     }
 
-    std::pair<VariantKey, arcticdb::TimeseriesDescriptor>
-    read_timeseries_descriptor_sync(const entity::VariantKey& key, storage::ReadKeyOpts opts) override {
+    std::pair<VariantKey, arcticdb::TimeseriesDescriptor> read_timeseries_descriptor_sync(
+            const entity::VariantKey& key, storage::ReadKeyOpts opts
+    ) override {
         return read_timeseries_descriptor(key, opts).get();
     }
 

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -84,6 +84,10 @@ struct StreamSource {
             const entity::VariantKey& key, storage::ReadKeyOpts opts = storage::ReadKeyOpts{}
     ) = 0;
 
+    virtual std::pair<VariantKey, TimeseriesDescriptor> read_timeseries_descriptor_sync(
+            const entity::VariantKey& key, storage::ReadKeyOpts opts = storage::ReadKeyOpts{}
+    ) = 0;
+
     virtual void read_ignoring_key_not_found(KeySizeCalculators&& calculators) {
         if (calculators.empty()) {
             return;

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -9,6 +9,7 @@
 #include <arcticdb/toolbox/library_tool.hpp>
 
 #include <arcticdb/async/async_store.hpp>
+#include <arcticdb/async/tasks.hpp>
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/pipeline/pipeline_utils.hpp>
@@ -53,16 +54,18 @@ Segment LibraryTool::read_to_segment(const VariantKey& key) {
 }
 
 std::optional<google::protobuf::Any> LibraryTool::read_metadata(const VariantKey& key) {
-    return store()->read_metadata(key, storage::ReadKeyOpts{}).get().second;
+    auto kv = store()->read_compressed_sync(key);
+    return DecodeMetadataTask{}(std::move(kv)).second;
 }
 
 StreamDescriptor LibraryTool::read_descriptor(const VariantKey& key) {
-    auto metadata_and_descriptor = store()->read_metadata_and_descriptor(key, storage::ReadKeyOpts{}).get();
-    return std::get<StreamDescriptor>(metadata_and_descriptor);
+    auto kv = store()->read_compressed_sync(key);
+    return std::get<StreamDescriptor>(DecodeMetadataAndDescriptorTask{}(std::move(kv)));
 }
 
 TimeseriesDescriptor LibraryTool::read_timeseries_descriptor(const VariantKey& key) {
-    return store()->read_timeseries_descriptor_sync(key).second;
+    auto kv = store()->read_compressed_sync(key);
+    return DecodeTimeseriesDescriptorTask{}(std::move(kv)).second;
 }
 
 void LibraryTool::write(VariantKey key, const Segment& segment) {

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -41,38 +41,8 @@ py::tuple LibraryTool::segment_in_memory_to_read_result(SegmentInMemory& segment
     const auto& atom_key = AtomKeyBuilder().build<KeyType::VERSION_REF>(segment.descriptor().id());
     auto frame_and_descriptor = frame_and_descriptor_from_segment(std::move(segment));
 
-    auto& frame = frame_and_descriptor.frame_;
-    if (!frame.empty()) {
-        auto pipeline_context = std::make_shared<pipelines::PipelineContext>(frame.descriptor());
-        pipelines::SliceAndKey sk{pipelines::FrameSlice{frame}, atom_key};
-        pipeline_context->slice_and_keys_.emplace_back(std::move(sk));
-        util::BitSet bitset(1);
-        bitset.flip();
-        pipeline_context->fetch_index_ = std::move(bitset);
-        pipeline_context->ensure_vectors();
-        pipelines::generate_filtered_field_descriptors(pipeline_context, {});
-        pipeline_context->begin()->set_string_pool(frame.string_pool_ptr());
-        auto descriptor = std::make_shared<StreamDescriptor>(frame.descriptor());
-        pipeline_context->begin()->set_descriptor(std::move(descriptor));
-
-        auto slice_map = std::make_shared<pipelines::FrameSliceMap>(pipeline_context, false);
-        DecodePathData shared_data;
-        std::shared_ptr<std::any> handler_data_ptr(std::shared_ptr<std::any>{}, &handler_data);
-        for (size_t idx = 0; idx < frame.descriptor().fields().size(); ++idx) {
-            const auto& frame_field = frame.field(idx);
-            if (slice_map->columns_.contains(frame_field.name()) && is_sequence_type(frame_field.type().data_type())) {
-                pipelines::
-                        ReduceColumnTask(frame, idx, slice_map, pipeline_context, shared_data, handler_data_ptr, ReadOptions{})(
-                        );
-            }
-        }
-        pipelines::apply_type_handlers(frame, handler_data, output_format);
-    }
-
     return adapt_read_df(
-            pipelines::create_python_read_result(
-                    VersionedItem{atom_key}, output_format, std::move(frame_and_descriptor)
-            ),
+            pipelines::read_result_from_single_frame_sync(frame_and_descriptor, atom_key, handler_data, output_format),
             &handler_data
     );
 }

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -62,7 +62,7 @@ StreamDescriptor LibraryTool::read_descriptor(const VariantKey& key) {
 }
 
 TimeseriesDescriptor LibraryTool::read_timeseries_descriptor(const VariantKey& key) {
-    return store()->read_timeseries_descriptor(key).get().second;
+    return store()->read_timeseries_descriptor_sync(key).second;
 }
 
 void LibraryTool::write(VariantKey key, const Segment& segment) {

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -55,17 +55,17 @@ Segment LibraryTool::read_to_segment(const VariantKey& key) {
 
 std::optional<google::protobuf::Any> LibraryTool::read_metadata(const VariantKey& key) {
     auto kv = store()->read_compressed_sync(key);
-    return DecodeMetadataTask{}(std::move(kv)).second;
+    return async::DecodeMetadataTask{}(std::move(kv)).second;
 }
 
 StreamDescriptor LibraryTool::read_descriptor(const VariantKey& key) {
     auto kv = store()->read_compressed_sync(key);
-    return std::get<StreamDescriptor>(DecodeMetadataAndDescriptorTask{}(std::move(kv)));
+    return std::get<StreamDescriptor>(async::DecodeMetadataAndDescriptorTask{}(std::move(kv)));
 }
 
 TimeseriesDescriptor LibraryTool::read_timeseries_descriptor(const VariantKey& key) {
     auto kv = store()->read_compressed_sync(key);
-    return DecodeTimeseriesDescriptorTask{}(std::move(kv)).second;
+    return async::DecodeTimeseriesDescriptorTask{}(std::move(kv)).second;
 }
 
 void LibraryTool::write(VariantKey key, const Segment& segment) {

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -41,8 +41,38 @@ py::tuple LibraryTool::segment_in_memory_to_read_result(SegmentInMemory& segment
     const auto& atom_key = AtomKeyBuilder().build<KeyType::VERSION_REF>(segment.descriptor().id());
     auto frame_and_descriptor = frame_and_descriptor_from_segment(std::move(segment));
 
+    auto& frame = frame_and_descriptor.frame_;
+    if (!frame.empty()) {
+        auto pipeline_context = std::make_shared<pipelines::PipelineContext>(frame.descriptor());
+        pipelines::SliceAndKey sk{pipelines::FrameSlice{frame}, atom_key};
+        pipeline_context->slice_and_keys_.emplace_back(std::move(sk));
+        util::BitSet bitset(1);
+        bitset.flip();
+        pipeline_context->fetch_index_ = std::move(bitset);
+        pipeline_context->ensure_vectors();
+        pipelines::generate_filtered_field_descriptors(pipeline_context, {});
+        pipeline_context->begin()->set_string_pool(frame.string_pool_ptr());
+        auto descriptor = std::make_shared<StreamDescriptor>(frame.descriptor());
+        pipeline_context->begin()->set_descriptor(std::move(descriptor));
+
+        auto slice_map = std::make_shared<pipelines::FrameSliceMap>(pipeline_context, false);
+        DecodePathData shared_data;
+        std::shared_ptr<std::any> handler_data_ptr(std::shared_ptr<std::any>{}, &handler_data);
+        for (size_t idx = 0; idx < frame.descriptor().fields().size(); ++idx) {
+            const auto& frame_field = frame.field(idx);
+            if (slice_map->columns_.contains(frame_field.name()) && is_sequence_type(frame_field.type().data_type())) {
+                pipelines::
+                        ReduceColumnTask(frame, idx, slice_map, pipeline_context, shared_data, handler_data_ptr, ReadOptions{})(
+                        );
+            }
+        }
+        pipelines::apply_type_handlers(frame, handler_data, output_format);
+    }
+
     return adapt_read_df(
-            pipelines::read_result_from_single_frame(frame_and_descriptor, atom_key, handler_data, output_format),
+            pipelines::create_python_read_result(
+                    VersionedItem{atom_key}, output_format, std::move(frame_and_descriptor)
+            ),
             &handler_data
     );
 }

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -279,8 +279,12 @@ def test_overwrite_append_data(lmdb_version_store_v1):
     def read_append_data_keys_from_ref(symbol):
         append_ref = lib_tool.find_keys_for_symbol(KeyType.APPEND_REF, symbol)[0]
         append_data_keys = []
+        seen_keys = set()
         next_key = lib_tool.read_timeseries_descriptor(append_ref).next_key
         while next_key is not None and lib_tool.key_exists(next_key):
+            key_str = str(next_key)
+            assert key_str not in seen_keys, f"Cycle detected in append data linked list: {key_str} already visited. Chain so far: {[str(k) for k in append_data_keys]}"
+            seen_keys.add(key_str)
             append_data_keys.append(next_key)
             next_key = lib_tool.read_timeseries_descriptor(next_key).next_key
         return append_data_keys

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -283,7 +283,9 @@ def test_overwrite_append_data(lmdb_version_store_v1):
         next_key = lib_tool.read_timeseries_descriptor(append_ref).next_key
         while next_key is not None and lib_tool.key_exists(next_key):
             key_str = str(next_key)
-            assert key_str not in seen_keys, f"Cycle detected in append data linked list: {key_str} already visited. Chain so far: {[str(k) for k in append_data_keys]}"
+            assert (
+                key_str not in seen_keys
+            ), f"Cycle detected in append data linked list: {key_str} already visited. Chain so far: {[str(k) for k in append_data_keys]}"
             seen_keys.add(key_str)
             append_data_keys.append(next_key)
             next_key = lib_tool.read_timeseries_descriptor(next_key).next_key


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ticket ref: 11803660445

#### What does this implement or fix?
`test_overwrite_append_data` intermittently hangs in CI, causing the pytest-xdist worker to crash. The faulthandler trace shows the main thread blocked inside various `LibraryTool` C++ calls. The hang point changes between runs — it has been observed in `read_timeseries_descriptor`, `read_descriptor`, and `segment_in_memory_to_read_result`.

This reproduces across multiple branches and Python versions (3.9, 3.10, 3.11) but only in CI environments.

### Root Cause

`LibraryTool` methods used the async pipeline machinery — submitting tasks to the IO and CPU thread pools via `submit_io_task`/`submit_cpu_task` and then blocking the calling thread on `.get()`. In CI containers, the thread pools intermittently fail to process submitted tasks, causing `.get()` to block forever.
The suspected root cause is that the `LibraryTool` is not releasing the GIL properly.
This will be addressed by Monday ticket 10841098589

The affected code paths were:
- `read_metadata` — `read_and_continue` → IO pool → `.get()`
- `read_descriptor` — `read_and_continue` → IO pool → `.get()`
- `read_timeseries_descriptor` — `read_and_continue` → IO pool → `.get()`
- `segment_in_memory_to_read_result` → `read_result_from_single_frame` → `reduce_and_fix_columns` → CPU pool → `.get()`

### Fix

Make all `LibraryTool` operations fully synchronous — no thread pool submissions:

1. **Read methods** (`read_metadata`, `read_descriptor`, `read_timeseries_descriptor`): Use `read_compressed_sync` + inline decode tasks instead of async `read_and_continue` + `.get()`.

2. **`segment_in_memory_to_read_result`**: Use new `read_result_from_single_frame_sync` which calls `reduce_and_fix_columns_sync` — runs `ReduceColumnTask` directly on the calling thread instead of submitting to the CPU pool.

Existing `PythonVersionStore` callers of `read_result_from_single_frame` are unchanged and continue using the async path. Common pipeline setup logic is extracted into `detail::prepare_single_frame_context` to avoid duplication between the async and sync variants.

The `LibraryTool` only processes single segments and doesn't benefit from parallelism, so there's no performance downside.