### PR TITLE
Use in_memory storage for arrow tests

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -333,6 +333,14 @@ def lmdb_library_factory(lmdb_storage, lib_name):
 
 
 @pytest.fixture
+def mem_library_factory(mem_storage, lib_name):
+    def f(library_options: LibraryOptions = LibraryOptions()):
+        return mem_storage.create_arctic().create_library(lib_name, library_options=library_options)
+
+    return f
+
+
+@pytest.fixture
 def s3_library_factory(s3_storage, lib_name):
     def f(library_options: LibraryOptions = LibraryOptions()):
         return s3_storage.create_arctic().create_library(lib_name, library_options=library_options)
@@ -1672,6 +1680,30 @@ def in_memory_version_store_tiny_segment(in_memory_store_factory) -> NativeVersi
 @pytest.fixture
 def in_memory_version_store_tiny_segment_dynamic(in_memory_store_factory) -> NativeVersionStore:
     return in_memory_store_factory(column_group_size=2, segment_row_size=2, dynamic_schema=True)
+
+
+@pytest.fixture
+def in_memory_version_store_arrow(in_memory_store_factory) -> NativeVersionStore:
+    store = in_memory_store_factory(dynamic_strings=True)
+    store.set_output_format(OutputFormat.PYARROW)
+    store._set_allow_arrow_input()
+    return store
+
+
+@pytest.fixture
+def in_memory_version_store_dynamic_schema_arrow(in_memory_store_factory) -> NativeVersionStore:
+    store = in_memory_store_factory(dynamic_schema=True, dynamic_strings=True)
+    store.set_output_format(OutputFormat.PYARROW)
+    store._set_allow_arrow_input()
+    return store
+
+
+@pytest.fixture
+def in_memory_version_store_tiny_segment_arrow(in_memory_store_factory) -> NativeVersionStore:
+    store = in_memory_store_factory(column_group_size=2, segment_row_size=2, dynamic_strings=True)
+    store.set_output_format(OutputFormat.PYARROW)
+    store._set_allow_arrow_input()
+    return store
 
 
 @pytest.fixture

--- a/python/tests/unit/arcticdb/test_arrow_api.py
+++ b/python/tests/unit/arcticdb/test_arrow_api.py
@@ -47,8 +47,8 @@ def expected_output_type(arctic_output_format, library_output_format, output_for
 @pytest.mark.parametrize("arctic_output_format", no_str_output_format_args)
 @pytest.mark.parametrize("library_output_format", all_output_format_args)
 @pytest.mark.parametrize("output_format_override", all_output_format_args)
-def test_read_arctic(lmdb_storage, lib_name, arctic_output_format, library_output_format, output_format_override):
-    ac = lmdb_storage.create_arctic(output_format=arctic_output_format)
+def test_read_arctic(mem_storage, lib_name, arctic_output_format, library_output_format, output_format_override):
+    ac = mem_storage.create_arctic(output_format=arctic_output_format)
     lib = ac.create_library(lib_name, output_format=library_output_format)
     sym = "sym"
     df = sample_dataframe()
@@ -74,8 +74,8 @@ def test_head(lmdb_storage, lib_name, arctic_output_format, output_format_overri
 
 @pytest.mark.parametrize("arctic_output_format", no_str_output_format_args)
 @pytest.mark.parametrize("output_format_override", no_str_output_format_args)
-def test_tail(lmdb_storage, lib_name, arctic_output_format, output_format_override):
-    ac = lmdb_storage.create_arctic(output_format=arctic_output_format)
+def test_tail(mem_storage, lib_name, arctic_output_format, output_format_override):
+    ac = mem_storage.create_arctic(output_format=arctic_output_format)
     lib = ac.create_library(lib_name)
     sym = "sym"
     df = sample_dataframe()
@@ -88,8 +88,8 @@ def test_tail(lmdb_storage, lib_name, arctic_output_format, output_format_overri
 
 @pytest.mark.parametrize("arctic_output_format", no_str_output_format_args)
 @pytest.mark.parametrize("output_format_override", no_str_output_format_args)
-def test_lazy_read(lmdb_storage, lib_name, arctic_output_format, output_format_override):
-    ac = lmdb_storage.create_arctic(output_format=arctic_output_format)
+def test_lazy_read(mem_storage, lib_name, arctic_output_format, output_format_override):
+    ac = mem_storage.create_arctic(output_format=arctic_output_format)
     lib = ac.create_library(lib_name)
     sym = "sym"
     df = sample_dataframe()
@@ -108,8 +108,8 @@ def test_lazy_read(lmdb_storage, lib_name, arctic_output_format, output_format_o
 
 @pytest.mark.parametrize("arctic_output_format", no_str_output_format_args)
 @pytest.mark.parametrize("output_format_override", no_str_output_format_args)
-def test_read_batch(lmdb_storage, lib_name, arctic_output_format, output_format_override):
-    ac = lmdb_storage.create_arctic(output_format=arctic_output_format)
+def test_read_batch(mem_storage, lib_name, arctic_output_format, output_format_override):
+    ac = mem_storage.create_arctic(output_format=arctic_output_format)
     lib = ac.create_library(lib_name)
     syms = ["sym", "sym_1", "sym_2"]
     syms_to_read = ["sym", "missing", "sym_1", "sym_2", "other_missing"]
@@ -132,8 +132,8 @@ def test_read_batch(lmdb_storage, lib_name, arctic_output_format, output_format_
 
 @pytest.mark.parametrize("arctic_output_format", no_str_output_format_args)
 @pytest.mark.parametrize("output_format_override", no_str_output_format_args)
-def test_read_batch_and_join(lmdb_storage, lib_name, arctic_output_format, output_format_override):
-    ac = lmdb_storage.create_arctic(output_format=arctic_output_format)
+def test_read_batch_and_join(mem_storage, lib_name, arctic_output_format, output_format_override):
+    ac = mem_storage.create_arctic(output_format=arctic_output_format)
     lib = ac.create_library(lib_name)
     syms = ["sym", "sym_1", "sym_2"]
     expected_dfs = []
@@ -195,8 +195,8 @@ def test_basic_modifications(lmdb_library, allow_arrow_input):
 
 
 @pytest.mark.parametrize("allow_arrow_input", [None, False, True])
-def test_batch_modifications(lmdb_library, allow_arrow_input):
-    lib = lmdb_library
+def test_batch_modifications(mem_library, allow_arrow_input):
+    lib = mem_library
     sym = "test_batch_modifications"
     if allow_arrow_input is not None:
         lib._nvs._set_allow_arrow_input(allow_arrow_input)
@@ -241,8 +241,8 @@ def test_batch_modifications(lmdb_library, allow_arrow_input):
 
 @pytest.mark.parametrize("batch", [False, True])
 @pytest.mark.parametrize("allow_arrow_input", [None, False, True])
-def test_write_pickle(lmdb_library, batch, allow_arrow_input):
-    lib = lmdb_library
+def test_write_pickle(mem_library, batch, allow_arrow_input):
+    lib = mem_library
     sym = "test_write_pickle"
     if allow_arrow_input is not None:
         lib._nvs._set_allow_arrow_input(allow_arrow_input)
@@ -267,8 +267,8 @@ def test_write_pickle(lmdb_library, batch, allow_arrow_input):
 
 
 @pytest.mark.parametrize("allow_arrow_input", [None, False, True])
-def test_stage(lmdb_library, allow_arrow_input):
-    lib = lmdb_library
+def test_stage(mem_library, allow_arrow_input):
+    lib = mem_library
     sym = "test_stage"
     if allow_arrow_input is not None:
         lib._nvs._set_allow_arrow_input(allow_arrow_input)
@@ -310,9 +310,9 @@ arrow_string_formats_with_none = arrow_string_formats + [None]
 @pytest.mark.parametrize("read_str_format_default", arrow_string_formats_with_none)
 @pytest.mark.parametrize("read_str_format_per_column", arrow_string_formats_with_none)
 def test_read_arctic_strings(
-    lmdb_storage, lib_name, arctic_str_format, library_str_format, read_str_format_default, read_str_format_per_column
+    mem_storage, lib_name, arctic_str_format, library_str_format, read_str_format_default, read_str_format_per_column
 ):
-    ac = lmdb_storage.create_arctic(output_format=OutputFormat.PYARROW, arrow_string_format_default=arctic_str_format)
+    ac = mem_storage.create_arctic(output_format=OutputFormat.PYARROW, arrow_string_format_default=arctic_str_format)
     lib = ac.create_library(lib_name, arrow_string_format_default=library_str_format)
     sym = "sym"
     df = pd.DataFrame({"col": ["some", "strings", "in", "this", "column"]})
@@ -342,8 +342,8 @@ def test_read_arctic_strings(
 
 @pytest.mark.parametrize("lazy", [True, False])
 @pytest.mark.parametrize("batch_default", [ArrowOutputStringFormat.SMALL_STRING, None])
-def test_read_batch_strings(lmdb_storage, lib_name, lazy, batch_default):
-    ac = lmdb_storage.create_arctic(output_format=OutputFormat.PYARROW)
+def test_read_batch_strings(mem_storage, lib_name, lazy, batch_default):
+    ac = mem_storage.create_arctic(output_format=OutputFormat.PYARROW)
     lib = ac.create_library(lib_name)
     sym_1, sym_2 = "sym_1", "sym_2"
     df_1 = pd.DataFrame({"col_1": ["a", "a", "bb"], "col_2": ["x", "y", "z"]})
@@ -377,8 +377,8 @@ def test_read_batch_strings(lmdb_storage, lib_name, lazy, batch_default):
 
 @pytest.mark.parametrize("default", [None, ArrowOutputStringFormat.SMALL_STRING])
 @pytest.mark.parametrize("per_column", [None, ArrowOutputStringFormat.CATEGORICAL])
-def test_read_batch_and_join_strings(lmdb_storage, lib_name, default, per_column):
-    ac = lmdb_storage.create_arctic(output_format=OutputFormat.PYARROW)
+def test_read_batch_and_join_strings(mem_storage, lib_name, default, per_column):
+    ac = mem_storage.create_arctic(output_format=OutputFormat.PYARROW)
     lib = ac.create_library(lib_name, library_options=LibraryOptions(dynamic_schema=True))
     sym_1, sym_2 = "sym_1", "sym_2"
     df_1 = pd.DataFrame({"col_1": ["a", "a", "bb"], "col_2": ["x", "y", "z"]})

--- a/python/tests/unit/arcticdb/version_store/test_arrow_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_normalization.py
@@ -37,22 +37,22 @@ def test_range_index(lmdb_version_store_arrow, index, index_name, col_name):
 
 @pytest.mark.parametrize("col_name", ["col", None, 5, ""])
 @pytest.mark.parametrize("duplicate", [True, False])
-def test_duplicate_and_special_col_names(lmdb_version_store_arrow, col_name, duplicate):
+def test_duplicate_and_special_col_names(in_memory_version_store_arrow, col_name, duplicate):
     columns = [col_name, "y"]
     expected_columns = [f"{col_name}", "y"]
     if duplicate:
         columns.append(col_name)
         expected_columns.append(f"_{col_name}_")
     df = pd.DataFrame(np.zeros((1, len(columns))), columns=columns)
-    generic_arrow_norm_test(lmdb_version_store_arrow, "test_duplicate_and_special_col_names", df, expected_columns)
+    generic_arrow_norm_test(in_memory_version_store_arrow, "test_duplicate_and_special_col_names", df, expected_columns)
 
 
 @pytest.mark.parametrize("col_name", [None, 5])
-def test_special_col_names_clash_with_string_col_name(lmdb_version_store_arrow, col_name):
+def test_special_col_names_clash_with_string_col_name(in_memory_version_store_arrow, col_name):
     columns = [col_name, str(col_name), col_name]
     df = pd.DataFrame(np.zeros((1, len(columns))), columns=columns)
     generic_arrow_norm_test(
-        lmdb_version_store_arrow,
+        in_memory_version_store_arrow,
         "test_special_col_names_clash_with_string_col_name",
         df,
         [f"{col_name}", f"_{col_name}_", f"__{col_name}__"],
@@ -60,7 +60,7 @@ def test_special_col_names_clash_with_string_col_name(lmdb_version_store_arrow, 
 
 
 @pytest.mark.parametrize("columns", [["col"], ["index"], ["index", "index"], ["__index__"], ["__index__", "__index__"]])
-def test_unnamed_timeseries_index(lmdb_version_store_arrow, columns):
+def test_unnamed_timeseries_index(in_memory_version_store_arrow, columns):
     df = pd.DataFrame(np.zeros((1, len(columns))), columns=columns, index=[pd.Timestamp(0)])
     index_column_name = "__index__" if "__index__" not in columns else "___index___"
     expected_columns = [index_column_name]
@@ -70,36 +70,36 @@ def test_unnamed_timeseries_index(lmdb_version_store_arrow, columns):
             column = f"_{column}_"
         taken_column_names.add(column)
         expected_columns.append(column)
-    generic_arrow_norm_test(lmdb_version_store_arrow, "test_unnamed_timeseries_index", df, expected_columns)
+    generic_arrow_norm_test(in_memory_version_store_arrow, "test_unnamed_timeseries_index", df, expected_columns)
 
 
 @pytest.mark.parametrize("index_name", ["index", "__index__", "ts"])
-def test_named_timeseries_index_no_clash(lmdb_version_store_arrow, index_name):
+def test_named_timeseries_index_no_clash(in_memory_version_store_arrow, index_name):
     columns = ["col"]
     df = pd.DataFrame(np.zeros((1, len(columns))), columns=columns, index=[pd.Timestamp(0)])
     df.index.name = index_name
     expected_columns = [index_name] + columns
-    generic_arrow_norm_test(lmdb_version_store_arrow, "test_named_timeseries_index_no_clash", df, expected_columns)
+    generic_arrow_norm_test(in_memory_version_store_arrow, "test_named_timeseries_index_no_clash", df, expected_columns)
 
 
 @pytest.mark.parametrize("index_name", ["index", "__index__", "ts"])
-def test_named_timeseries_index_clash(lmdb_version_store_arrow, index_name):
+def test_named_timeseries_index_clash(in_memory_version_store_arrow, index_name):
     columns = [index_name, index_name, f"_{index_name}_"]
     df = pd.DataFrame(np.zeros((1, len(columns))), columns=columns, index=[pd.Timestamp(0)])
     df.index.name = index_name
     expected_columns = [index_name, f"_{columns[0]}_", f"__{columns[1]}__", f"__{columns[2]}__"]
-    generic_arrow_norm_test(lmdb_version_store_arrow, "test_named_timeseries_index_clash", df, expected_columns)
+    generic_arrow_norm_test(in_memory_version_store_arrow, "test_named_timeseries_index_clash", df, expected_columns)
 
 
 @pytest.mark.parametrize("col_name", ["", None, 5])
-def test_named_timeseries_index_clash_special_col_names(lmdb_version_store_arrow, col_name):
+def test_named_timeseries_index_clash_special_col_names(in_memory_version_store_arrow, col_name):
     index_name = str(col_name)
     columns = [col_name, col_name]
     df = pd.DataFrame(np.zeros((1, len(columns))), columns=columns, index=[pd.Timestamp(0)])
     df.index.name = index_name
     expected_columns = [index_name, f"_{columns[0]}_", f"__{columns[1]}__"]
     generic_arrow_norm_test(
-        lmdb_version_store_arrow, "test_named_timeseries_index_clash_special_col_names", df, expected_columns
+        in_memory_version_store_arrow, "test_named_timeseries_index_clash_special_col_names", df, expected_columns
     )
 
 
@@ -113,7 +113,7 @@ def test_named_timeseries_index_clash_special_col_names(lmdb_version_store_arrow
         ["__index_level_0__", "__index_level_1__"],
     ],
 )
-def test_unnamed_multiindex(lmdb_version_store_arrow, columns):
+def test_unnamed_multiindex(in_memory_version_store_arrow, columns):
     df = pd.DataFrame(
         np.zeros((1, len(columns))), columns=columns, index=pd.MultiIndex.from_product([[pd.Timestamp(0)], ["id"]])
     )
@@ -125,7 +125,7 @@ def test_unnamed_multiindex(lmdb_version_store_arrow, columns):
     if columns == ["__index_level_0__", "__index_level_0__"]:
         columns[-1] = f"__{columns[-1]}__"
     expected_columns = index_column_names + columns
-    generic_arrow_norm_test(lmdb_version_store_arrow, "test_unnamed_multiindex", df, expected_columns)
+    generic_arrow_norm_test(in_memory_version_store_arrow, "test_unnamed_multiindex", df, expected_columns)
 
 
 @pytest.mark.parametrize(
@@ -145,7 +145,7 @@ def test_unnamed_multiindex(lmdb_version_store_arrow, columns):
         ["__index_level_0__", "__index_level_1__"],
     ],
 )
-def test_partially_named_multiindex(lmdb_version_store_arrow, index_column_names, columns):
+def test_partially_named_multiindex(in_memory_version_store_arrow, index_column_names, columns):
     df = pd.DataFrame(
         np.zeros((1, len(columns))),
         columns=columns,
@@ -163,21 +163,21 @@ def test_partially_named_multiindex(lmdb_version_store_arrow, index_column_names
         expected_columns[-1] = f"_{expected_columns[-1]}_"
     if expected_columns[0] == "___index_level_0___" and columns == ["__index_level_0__", "__index_level_0__"]:
         expected_columns[-1] = f"_{expected_columns[-1]}_"
-    generic_arrow_norm_test(lmdb_version_store_arrow, "test_partially_named_multiindex", df, expected_columns)
+    generic_arrow_norm_test(in_memory_version_store_arrow, "test_partially_named_multiindex", df, expected_columns)
 
 
 @pytest.mark.parametrize("index_names", [["level 1", "level 2"], ["index", "__index__"], ["__index__", "index"]])
-def test_named_multiindex_no_clash(lmdb_version_store_arrow, index_names):
+def test_named_multiindex_no_clash(in_memory_version_store_arrow, index_names):
     columns = ["col"]
     df = pd.DataFrame(
         np.zeros((1, len(columns))),
         columns=columns,
         index=pd.MultiIndex.from_product([[pd.Timestamp(0)], ["id"]], names=index_names),
     )
-    generic_arrow_norm_test(lmdb_version_store_arrow, "test_named_multiindex_no_clash", df, index_names + columns)
+    generic_arrow_norm_test(in_memory_version_store_arrow, "test_named_multiindex_no_clash", df, index_names + columns)
 
 
-def test_named_multiindex_duplicates_in_level_names(lmdb_version_store_arrow):
+def test_named_multiindex_duplicates_in_level_names(in_memory_version_store_arrow):
     index_names = ["level", "level"]
     columns = ["col"]
     df = pd.DataFrame(
@@ -186,12 +186,15 @@ def test_named_multiindex_duplicates_in_level_names(lmdb_version_store_arrow):
         index=pd.MultiIndex.from_product([[pd.Timestamp(0)], ["id"]], names=index_names),
     )
     generic_arrow_norm_test(
-        lmdb_version_store_arrow, "test_named_multiindex_duplicates_in_level_names", df, ["level", "_level_", "col"]
+        in_memory_version_store_arrow,
+        "test_named_multiindex_duplicates_in_level_names",
+        df,
+        ["level", "_level_", "col"],
     )
 
 
 @pytest.mark.parametrize("columns", [["level 1"], ["level 2"], ["level 1", "level 2"], ["level 1", "level 1"]])
-def test_named_multiindex_duplicates_in_columns(lmdb_version_store_arrow, columns):
+def test_named_multiindex_duplicates_in_columns(in_memory_version_store_arrow, columns):
     index_names = ["level 1", "level 2"]
     df = pd.DataFrame(
         np.zeros((1, len(columns))),
@@ -206,13 +209,13 @@ def test_named_multiindex_duplicates_in_columns(lmdb_version_store_arrow, column
         expected_columns.append(col)
         taken_column_names.add(col)
     generic_arrow_norm_test(
-        lmdb_version_store_arrow, "test_named_multiindex_duplicates_in_columns", df, expected_columns
+        in_memory_version_store_arrow, "test_named_multiindex_duplicates_in_columns", df, expected_columns
     )
 
 
 @pytest.mark.parametrize("clash_level", [0, 1])
 @pytest.mark.parametrize("col_name", ["", None, 5])
-def test_named_multiindex_clash_special_col_names(lmdb_version_store_arrow, clash_level, col_name):
+def test_named_multiindex_clash_special_col_names(in_memory_version_store_arrow, clash_level, col_name):
     index_names = ["level 1", "level 2"]
     index_names[clash_level] = str(col_name)
     df = pd.DataFrame(
@@ -222,17 +225,17 @@ def test_named_multiindex_clash_special_col_names(lmdb_version_store_arrow, clas
     )
     expected_columns = index_names + [f"_{col_name}_"]
     generic_arrow_norm_test(
-        lmdb_version_store_arrow, "test_named_multiindex_clash_special_col_names", df, expected_columns
+        in_memory_version_store_arrow, "test_named_multiindex_clash_special_col_names", df, expected_columns
     )
 
 
-def test_index_with_timezone(lmdb_version_store_arrow):
+def test_index_with_timezone(in_memory_version_store_arrow):
     df = pd.DataFrame(
         {"col": np.arange(10, dtype=np.int64)},
         index=pd.date_range(pd.Timestamp(year=2025, month=1, day=1, tz="America/New_York"), periods=10),
     )
     generic_arrow_norm_test(
-        lmdb_version_store_arrow,
+        in_memory_version_store_arrow,
         "test_index_with_timezone",
         df,
         ["__index__", "col"],
@@ -240,7 +243,7 @@ def test_index_with_timezone(lmdb_version_store_arrow):
     )
 
 
-def test_multi_index_with_tz(lmdb_version_store_arrow):
+def test_multi_index_with_tz(in_memory_version_store_arrow):
     df = pd.DataFrame(
         {"col": np.arange(10, dtype=np.int64())},
         index=[
@@ -250,7 +253,7 @@ def test_multi_index_with_tz(lmdb_version_store_arrow):
     )
     df.index.names = ["index1", "index2"]
     generic_arrow_norm_test(
-        lmdb_version_store_arrow,
+        in_memory_version_store_arrow,
         "test_multi_index_with_tz",
         df,
         ["index1", "index2", "col"],
@@ -258,7 +261,7 @@ def test_multi_index_with_tz(lmdb_version_store_arrow):
     )
 
 
-def test_multi_index_no_name_multiple_tz(lmdb_version_store_arrow):
+def test_multi_index_no_name_multiple_tz(in_memory_version_store_arrow):
     df = pd.DataFrame(
         {"col": np.arange(10, dtype=np.int64)},
         index=[
@@ -267,7 +270,7 @@ def test_multi_index_no_name_multiple_tz(lmdb_version_store_arrow):
         ],
     )
     generic_arrow_norm_test(
-        lmdb_version_store_arrow,
+        in_memory_version_store_arrow,
         "test_multi_index_no_name_multiple_tz",
         df,
         ["__index_level_0__", "__index_level_1__", "col"],
@@ -282,14 +285,14 @@ def test_series_basic(lmdb_version_store_arrow):
     generic_arrow_norm_test(lmdb_version_store_arrow, "test_series_basic", series, ["my series"])
 
 
-def test_series_with_index(lmdb_version_store_arrow):
+def test_series_with_index(in_memory_version_store_arrow):
     series = pd.Series(
         np.arange(10, dtype=np.int64),
         name="my series",
         index=pd.date_range(pd.Timestamp(year=2025, month=1, day=1, tz="Europe/London"), periods=10),
     )
     generic_arrow_norm_test(
-        lmdb_version_store_arrow,
+        in_memory_version_store_arrow,
         "test_series_with_index",
         series,
         ["__index__", "my series"],
@@ -297,8 +300,8 @@ def test_series_with_index(lmdb_version_store_arrow):
     )
 
 
-def test_read_pickled(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_read_pickled(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_read_pickled"
     obj = {"a": ["b", "c"], "x": 122.3}
     lib.write(sym, obj)
@@ -306,8 +309,8 @@ def test_read_pickled(lmdb_version_store_arrow):
     assert obj == result
 
 
-def test_custom_normalizer(custom_thing_with_registered_normalizer, lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_custom_normalizer(custom_thing_with_registered_normalizer, in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_custom_normalizer"
     obj = custom_thing_with_registered_normalizer
     lib.write(sym, obj)

--- a/python/tests/unit/arcticdb/version_store/test_arrow_read.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_read.py
@@ -43,7 +43,6 @@ def test_basic_with_index(lmdb_version_store_arrow):
 
 def test_basic_small_slices(in_memory_version_store_tiny_segment_arrow):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame({"x": np.arange(10)})
     lib.write("arrow", df)
     table = lib.read("arrow").data
@@ -52,7 +51,6 @@ def test_basic_small_slices(in_memory_version_store_tiny_segment_arrow):
 
 def test_basic_small_slices_with_index(in_memory_version_store_tiny_segment_arrow):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame({"x": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))
     lib.write("arrow", df)
     table = lib.read("arrow").data
@@ -149,7 +147,6 @@ def test_strings_basic(in_memory_version_store_arrow, dynamic_strings, any_arrow
 @pytest.mark.parametrize("row_range", [None, (2, 3), (2, 4), (2, 5), (2, 6), (3, 4), (3, 5), (3, 6)])
 def test_strings_with_nones_and_nans(in_memory_version_store_tiny_segment_arrow, row_range, any_arrow_string_format):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     lib.set_arrow_string_format_default(any_arrow_string_format)
     # in_memory_version_store_tiny_segment_arrow has 2 rows per segment
     # This column is constructed so that every 2-element permutation of strings, Nones, and NaNs are tested
@@ -186,7 +183,6 @@ def test_strings_with_nones_and_nans(in_memory_version_store_tiny_segment_arrow,
 @pytest.mark.xfail(reason="NaT values in datetime columns are not converted to Arrow nulls (monday ref: 11525537906)")
 def test_datetime_col_with_nats(in_memory_version_store_tiny_segment_arrow):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame(
         {
             "x": pd.to_datetime(
@@ -264,7 +260,6 @@ def test_strings_multiple_segments_and_columns(
     in_memory_version_store_tiny_segment_arrow, dynamic_strings, any_arrow_string_format
 ):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     lib.set_arrow_string_format_default(any_arrow_string_format)
     df = pd.DataFrame(
         {
@@ -332,7 +327,6 @@ def test_date_range_corner_cases(in_memory_store_factory, date_range_start, date
 )
 def test_date_range_between_index_values(in_memory_version_store_tiny_segment_arrow):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame(
         data={
             "col1": np.arange(2),
@@ -674,7 +668,6 @@ def test_with_querybuilder(in_memory_version_store_arrow):
 
 def test_arrow_layout(in_memory_version_store_tiny_segment_arrow):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     lib_tool = lib.library_tool()
     num_rows = 100
     df = pd.DataFrame(
@@ -1027,7 +1020,6 @@ def test_arrow_dynamic_schema_filtered_column(in_memory_version_store_dynamic_sc
 
 def test_project_dynamic_schema(in_memory_version_store_dynamic_schema_arrow):
     lib = in_memory_version_store_dynamic_schema_arrow
-    lib.set_output_format(OutputFormat.PYARROW)
     sym = "sym"
     table_1 = pa.table({"a": pa.array([1, 2])})
     table_2 = pa.table({"a": pa.array([3, 4]), "b": pa.array([1, 2])})

--- a/python/tests/unit/arcticdb/version_store/test_arrow_read.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_read.py
@@ -41,8 +41,8 @@ def test_basic_with_index(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow(table, df)
 
 
-def test_basic_small_slices(lmdb_version_store_tiny_segment):
-    lib = lmdb_version_store_tiny_segment
+def test_basic_small_slices(in_memory_version_store_tiny_segment_arrow):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame({"x": np.arange(10)})
     lib.write("arrow", df)
@@ -50,8 +50,8 @@ def test_basic_small_slices(lmdb_version_store_tiny_segment):
     assert_frame_equal_with_arrow(table, df)
 
 
-def test_basic_small_slices_with_index(lmdb_version_store_tiny_segment):
-    lib = lmdb_version_store_tiny_segment
+def test_basic_small_slices_with_index(in_memory_version_store_tiny_segment_arrow):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame({"x": np.arange(10)}, index=pd.date_range(pd.Timestamp(0), periods=10))
     lib.write("arrow", df)
@@ -59,24 +59,24 @@ def test_basic_small_slices_with_index(lmdb_version_store_tiny_segment):
     assert_frame_equal_with_arrow(table, df)
 
 
-def test_double_columns(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_double_columns(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     df = pd.DataFrame({"x": np.arange(10), "y": np.arange(10.0, 20.0)})
     lib.write("arrow", df)
     table = lib.read("arrow").data
     assert_frame_equal_with_arrow(table, df)
 
 
-def test_bool_columns(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_bool_columns(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     df = pd.DataFrame({"x": [i % 3 == 0 for i in range(10)], "y": [i % 2 == 0 for i in range(10)]})
     lib.write("arrow", df)
     table = lib.read("arrow").data
     assert_frame_equal_with_arrow(table, df)
 
 
-def test_read_empty(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_read_empty(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "sym"
     df = pd.DataFrame()
     lib.write(sym, df)
@@ -92,8 +92,8 @@ def test_read_empty(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_read_empty_column_filter(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_read_empty_column_filter(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "sym"
     df = pd.DataFrame({"col": [1, 2, 3]})
     lib.write(sym, df)
@@ -107,8 +107,8 @@ def test_read_empty_column_filter(lmdb_version_store_arrow):
 
 
 @pytest.mark.skipif(IS_PANDAS_ONE, reason="Different empty frame handling in pandas 1.x")
-def test_read_empty_with_columns(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_read_empty_with_columns(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "sym"
     df = pd.DataFrame({"col_int": np.zeros(0, dtype=np.int32), "col_float": np.zeros(0, dtype=np.float64)})
     lib.write(sym, df)
@@ -119,8 +119,8 @@ def test_read_empty_with_columns(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_column_filtering(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_column_filtering(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     df = pd.DataFrame({"x": np.arange(10), "y": np.arange(10.0, 20.0)})
     lib.write("arrow", df)
     table = lib.read("arrow", columns=["y"]).data
@@ -137,8 +137,8 @@ def test_column_filtering(lmdb_version_store_arrow):
         ),
     ],
 )
-def test_strings_basic(lmdb_version_store_arrow, dynamic_strings, any_arrow_string_format):
-    lib = lmdb_version_store_arrow
+def test_strings_basic(in_memory_version_store_arrow, dynamic_strings, any_arrow_string_format):
+    lib = in_memory_version_store_arrow
     lib.set_arrow_string_format_default(any_arrow_string_format)
     df = pd.DataFrame({"x": ["mene", "mene", "tekel", "upharsin", ""]})
     lib.write("arrow", df, dynamic_strings=dynamic_strings)
@@ -147,11 +147,11 @@ def test_strings_basic(lmdb_version_store_arrow, dynamic_strings, any_arrow_stri
 
 
 @pytest.mark.parametrize("row_range", [None, (2, 3), (2, 4), (2, 5), (2, 6), (3, 4), (3, 5), (3, 6)])
-def test_strings_with_nones_and_nans(lmdb_version_store_tiny_segment, row_range, any_arrow_string_format):
-    lib = lmdb_version_store_tiny_segment
+def test_strings_with_nones_and_nans(in_memory_version_store_tiny_segment_arrow, row_range, any_arrow_string_format):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     lib.set_arrow_string_format_default(any_arrow_string_format)
-    # lmdb_version_store_tiny_segment has 2 rows per segment
+    # in_memory_version_store_tiny_segment_arrow has 2 rows per segment
     # This column is constructed so that every 2-element permutation of strings, Nones, and NaNs are tested
     df = pd.DataFrame(
         {
@@ -184,8 +184,8 @@ def test_strings_with_nones_and_nans(lmdb_version_store_tiny_segment, row_range,
 
 
 @pytest.mark.xfail(reason="NaT values in datetime columns are not converted to Arrow nulls (monday ref: 11525537906)")
-def test_datetime_col_with_nats(lmdb_version_store_tiny_segment):
-    lib = lmdb_version_store_tiny_segment
+def test_datetime_col_with_nats(in_memory_version_store_tiny_segment_arrow):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame(
         {
@@ -210,8 +210,8 @@ def test_datetime_col_with_nats(lmdb_version_store_tiny_segment):
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_strings_in_multi_index(lmdb_version_store_arrow, any_arrow_string_format):
-    lib = lmdb_version_store_arrow
+def test_strings_in_multi_index(in_memory_version_store_arrow, any_arrow_string_format):
+    lib = in_memory_version_store_arrow
     df = pd.DataFrame(
         {"x": ["hello", "world", "!"]},
         index=[
@@ -240,8 +240,8 @@ def test_strings_in_multi_index(lmdb_version_store_arrow, any_arrow_string_forma
 
 
 @pytest.mark.xfail(reason="Monday issue 10679807500")
-def test_explicit_string_format__idx__prefix(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_explicit_string_format__idx__prefix(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_explicit_string_format__idx__prefix"
     df = pd.DataFrame({"__idx__blah": ["hello"], "blah": ["goodbye"]})
     lib.write(sym, df)
@@ -261,9 +261,9 @@ def test_explicit_string_format__idx__prefix(lmdb_version_store_arrow):
     ],
 )
 def test_strings_multiple_segments_and_columns(
-    lmdb_version_store_tiny_segment, dynamic_strings, any_arrow_string_format
+    in_memory_version_store_tiny_segment_arrow, dynamic_strings, any_arrow_string_format
 ):
-    lib = lmdb_version_store_tiny_segment
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     lib.set_arrow_string_format_default(any_arrow_string_format)
     df = pd.DataFrame(
@@ -279,8 +279,8 @@ def test_strings_multiple_segments_and_columns(
     assert_frame_equal_with_arrow(table, df)
 
 
-def test_all_types(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_all_types(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     # sample dataframe contains all dtypes + unicode strings
     df = get_sample_dataframe()
     lib.write("arrow", df)
@@ -291,8 +291,8 @@ def test_all_types(lmdb_version_store_arrow):
 @pytest.mark.parametrize("date_range_start", [0, 1, 2, 3, 4, 5, 6])
 @pytest.mark.parametrize("date_range_width", [0, 1, 2, 3])
 @pytest.mark.parametrize("dynamic_schema", [True, False])
-def test_date_range_corner_cases(version_store_factory, date_range_start, date_range_width, dynamic_schema):
-    lib = version_store_factory(
+def test_date_range_corner_cases(in_memory_store_factory, date_range_start, date_range_width, dynamic_schema):
+    lib = in_memory_store_factory(
         segment_row_size=2, column_group_size=2, dynamic_schema=dynamic_schema, dynamic_strings=True
     )
     lib.set_output_format(OutputFormat.PYARROW)
@@ -330,8 +330,8 @@ def test_date_range_corner_cases(version_store_factory, date_range_start, date_r
 @pytest.mark.skipif(
     IS_PANDAS_ONE, reason="For pandas 1.x with OutputFormat.PANDAS we return empty string columns as float64"
 )
-def test_date_range_between_index_values(lmdb_version_store_tiny_segment):
-    lib = lmdb_version_store_tiny_segment
+def test_date_range_between_index_values(in_memory_version_store_tiny_segment_arrow):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     df = pd.DataFrame(
         data={
@@ -363,8 +363,8 @@ def test_date_range_between_index_values(lmdb_version_store_tiny_segment):
 @pytest.mark.skipif(
     IS_PANDAS_ONE, reason="For pandas 1.x with OutputFormat.PANDAS we return empty string columns as float64"
 )
-def test_date_range_empty_result(version_store_factory, date_range_start, dynamic_schema):
-    lib = version_store_factory(
+def test_date_range_empty_result(in_memory_store_factory, date_range_start, dynamic_schema):
+    lib = in_memory_store_factory(
         segment_row_size=2, column_group_size=2, dynamic_schema=dynamic_schema, dynamic_strings=True
     )
     lib.set_output_format(OutputFormat.PYARROW)
@@ -430,9 +430,9 @@ def test_date_range_empty_result(version_store_factory, date_range_start, dynami
     ],
 )
 def test_date_range(
-    version_store_factory, segment_row_size, start_offset, end_offset, use_query_builder, output_format
+    in_memory_store_factory, segment_row_size, start_offset, end_offset, use_query_builder, output_format
 ):
-    lib = version_store_factory(segment_row_size=segment_row_size, dynamic_strings=True)
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_strings=True)
     lib.set_output_format(output_format)
     initial_timestamp = pd.Timestamp("2019-01-01")
     df = pd.DataFrame(
@@ -487,9 +487,9 @@ def test_date_range(
     ],
 )
 def test_date_range_with_duplicates(
-    version_store_factory, segment_row_size, start_date, end_date, use_query_builder, any_output_format
+    in_memory_store_factory, segment_row_size, start_date, end_date, use_query_builder, any_output_format
 ):
-    lib = version_store_factory(segment_row_size=segment_row_size)
+    lib = in_memory_store_factory(segment_row_size=segment_row_size)
     lib.set_output_format(any_output_format)
     index_with_duplicates = (
         [pd.Timestamp(2025, 1, 1)] * 10
@@ -520,8 +520,8 @@ def test_date_range_with_duplicates(
 @pytest.mark.parametrize("row_range_width", [0, 1, 2, 3])
 @pytest.mark.parametrize("dynamic_schema", [True, False])
 @pytest.mark.parametrize("index", [None, pd.date_range(pd.Timestamp(0), freq="ns", periods=7)])
-def test_row_range_corner_cases(version_store_factory, row_range_start, row_range_width, dynamic_schema, index):
-    lib = version_store_factory(
+def test_row_range_corner_cases(in_memory_store_factory, row_range_start, row_range_width, dynamic_schema, index):
+    lib = in_memory_store_factory(
         segment_row_size=2, column_group_size=2, dynamic_schema=dynamic_schema, dynamic_strings=True
     )
     lib.set_output_format(OutputFormat.PYARROW)
@@ -559,8 +559,8 @@ def test_row_range_corner_cases(version_store_factory, row_range_start, row_rang
 @pytest.mark.skipif(
     IS_PANDAS_ONE, reason="For pandas 1.x with OutputFormat.PANDAS we return empty string columns as float64"
 )
-def test_row_range_empty_result(version_store_factory, row_range_start, dynamic_schema, index):
-    lib = version_store_factory(
+def test_row_range_empty_result(in_memory_store_factory, row_range_start, dynamic_schema, index):
+    lib = in_memory_store_factory(
         segment_row_size=2, column_group_size=2, dynamic_schema=dynamic_schema, dynamic_strings=True
     )
     lib.set_output_format(OutputFormat.PYARROW)
@@ -626,8 +626,10 @@ def test_row_range_empty_result(version_store_factory, row_range_start, dynamic_
         (-21, -17),
     ],
 )
-def test_row_range(version_store_factory, segment_row_size, start_offset, end_offset, use_query_builder, output_format):
-    lib = version_store_factory(segment_row_size=segment_row_size, dynamic_strings=True)
+def test_row_range(
+    in_memory_store_factory, segment_row_size, start_offset, end_offset, use_query_builder, output_format
+):
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_strings=True)
     lib.set_output_format(output_format)
     initial_timestamp = pd.Timestamp("2019-01-01")
     df = pd.DataFrame(
@@ -659,8 +661,8 @@ def test_row_range(version_store_factory, segment_row_size, start_offset, end_of
     assert_frame_equal_with_arrow(expected_df, result)
 
 
-def test_with_querybuilder(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_with_querybuilder(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     df = pd.DataFrame({"x": np.arange(10), "y": np.arange(10.0, 20.0)})
     q = QueryBuilder()
     q = q[q["x"] < 5]
@@ -670,8 +672,8 @@ def test_with_querybuilder(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_arrow_layout(lmdb_version_store_tiny_segment):
-    lib = lmdb_version_store_tiny_segment
+def test_arrow_layout(in_memory_version_store_tiny_segment_arrow):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     lib_tool = lib.library_tool()
     num_rows = 100
@@ -713,9 +715,9 @@ def test_arrow_layout(lmdb_version_store_tiny_segment):
         ((10, 20), [10]),  # Aligned to segment boundaries
     ],
 )
-def test_arrow_string_layout_after_truncation(version_store_factory, row_range_and_expected_segment_sizes):
+def test_arrow_string_layout_after_truncation(in_memory_store_factory, row_range_and_expected_segment_sizes):
     row_range, expected_segment_sizes = row_range_and_expected_segment_sizes
-    lib = version_store_factory(segment_row_size=10, dynamic_strings=True)
+    lib = in_memory_store_factory(segment_row_size=10, dynamic_strings=True)
     lib.set_output_format(OutputFormat.PYARROW)
     sym = "test_arrow_string_layout_after_truncation"
     # Each string is of the same width for easier calculation of buffer sizes
@@ -781,12 +783,12 @@ def test_arrow_string_layout_after_truncation(version_store_factory, row_range_a
         pa.float64(),
     ],
 )
-def test_arrow_dynamic_schema_changing_types(lmdb_version_store_dynamic_schema_arrow, first_type, second_type):
+def test_arrow_dynamic_schema_changing_types(in_memory_version_store_dynamic_schema_arrow, first_type, second_type):
     if (pa.types.is_uint64(first_type) and pa.types.is_signed_integer(second_type)) or (
         pa.types.is_uint64(second_type) and pa.types.is_signed_integer(first_type)
     ):
         pytest.skip("Unsupported ArcticDB type combination")
-    lib = lmdb_version_store_dynamic_schema_arrow
+    lib = in_memory_version_store_dynamic_schema_arrow
     sym = "test_arrow_dynamic_schema_changing_types"
     write_table = pa.table({"col": pa.array([0], first_type)})
     append_table = pa.table({"col": pa.array([1], second_type)})
@@ -800,10 +802,10 @@ def test_arrow_dynamic_schema_changing_types(lmdb_version_store_dynamic_schema_a
 
 @pytest.mark.parametrize("rows_per_column", [1, 7, 8, 9, 100_000])
 @pytest.mark.parametrize("segment_row_size", [1, 2, 100_000])
-def test_arrow_dynamic_schema_missing_columns_numeric(version_store_factory, rows_per_column, segment_row_size):
+def test_arrow_dynamic_schema_missing_columns_numeric(in_memory_store_factory, rows_per_column, segment_row_size):
     if rows_per_column == 100_000 and segment_row_size != 100_000:
         pytest.skip("Slow to write and doesn't tell us anything the other variants do not")
-    lib = version_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
     lib.set_output_format(OutputFormat.PYARROW)
     sym = "test_arrow_dynamic_schema_missing_columns_numeric"
     write_table = pa.table({"col1": pa.array([1] * rows_per_column, pa.int64())})
@@ -818,9 +820,9 @@ def test_arrow_dynamic_schema_missing_columns_numeric(version_store_factory, row
 
 @pytest.mark.parametrize("rows_per_column", [1, 7, 8, 9, 100_000])
 def test_arrow_dynamic_schema_missing_columns_strings(
-    lmdb_version_store_dynamic_schema_arrow, rows_per_column, any_arrow_string_format
+    in_memory_version_store_dynamic_schema_arrow, rows_per_column, any_arrow_string_format
 ):
-    lib = lmdb_version_store_dynamic_schema_arrow
+    lib = in_memory_version_store_dynamic_schema_arrow
     lib.set_arrow_string_format_default(any_arrow_string_format)
     sym = "test_arrow_dynamic_schema_missing_columns_strings"
     write_table = pa.table({"col1": pa.array(["hello"] * rows_per_column, pa.string())})
@@ -887,10 +889,10 @@ def combinable_numeric_dtypes(draw):
     ),
 )
 def test_arrow_dynamic_schema_missing_columns_hypothesis(
-    lmdb_version_store_dynamic_schema_arrow, df_0, df_1, df_2, columns_0, columns_1, columns_2
+    in_memory_version_store_dynamic_schema_arrow, df_0, df_1, df_2, columns_0, columns_1, columns_2
 ):
     assume(len(df_0) and len(df_1) and len(df_2))
-    lib = lmdb_version_store_dynamic_schema_arrow
+    lib = in_memory_version_store_dynamic_schema_arrow
     sym = "test_arrow_dynamic_schema_missing_columns_hypothesis"
     df_0 = df_0[columns_0]
     df_1 = df_1[columns_1]
@@ -911,9 +913,9 @@ def test_arrow_dynamic_schema_missing_columns_hypothesis(
 @pytest.mark.parametrize("row_range_width", [0, 1, 2, 5])
 @pytest.mark.parametrize("use_query_builder", [True, False])
 def test_arrow_dynamic_schema_row_range(
-    version_store_factory, row_range_start, row_range_width, use_query_builder, any_arrow_string_format
+    in_memory_store_factory, row_range_start, row_range_width, use_query_builder, any_arrow_string_format
 ):
-    lib = version_store_factory(segment_row_size=3, dynamic_schema=True, dynamic_strings=True)
+    lib = in_memory_store_factory(segment_row_size=3, dynamic_schema=True, dynamic_strings=True)
     lib.set_output_format(OutputFormat.PYARROW)
     lib.set_arrow_string_format_default(any_arrow_string_format)
     sym = "test_arrow_dynamic_schema_row_range"
@@ -958,9 +960,9 @@ def test_arrow_dynamic_schema_row_range(
 @pytest.mark.parametrize("date_range_width", [0, 1, 2, 5])
 @pytest.mark.parametrize("use_query_builder", [True, False])
 def test_arrow_dynamic_schema_date_range(
-    version_store_factory, date_range_start, date_range_width, use_query_builder, any_arrow_string_format
+    in_memory_store_factory, date_range_start, date_range_width, use_query_builder, any_arrow_string_format
 ):
-    lib = version_store_factory(segment_row_size=3, dynamic_schema=True, dynamic_strings=True)
+    lib = in_memory_store_factory(segment_row_size=3, dynamic_schema=True, dynamic_strings=True)
     lib.set_output_format(OutputFormat.PYARROW)
     lib.set_arrow_string_format_default(any_arrow_string_format)
     sym = "test_arrow_dynamic_schema_date_range"
@@ -1002,8 +1004,8 @@ def test_arrow_dynamic_schema_date_range(
 
 
 @pytest.mark.parametrize("type_to_drop", [pa.int64(), pa.float64(), pa.large_string()])
-def test_arrow_dynamic_schema_filtered_column(lmdb_version_store_dynamic_schema_arrow, type_to_drop):
-    lib = lmdb_version_store_dynamic_schema_arrow
+def test_arrow_dynamic_schema_filtered_column(in_memory_version_store_dynamic_schema_arrow, type_to_drop):
+    lib = in_memory_version_store_dynamic_schema_arrow
     sym = "sym"
     column_to_drop = (
         pa.array(["a", "b"], type_to_drop) if type_to_drop == pa.large_string() else pa.array([1, 2], type_to_drop)
@@ -1023,8 +1025,8 @@ def test_arrow_dynamic_schema_filtered_column(lmdb_version_store_dynamic_schema_
     assert expected.equals(received)
 
 
-def test_project_dynamic_schema(lmdb_version_store_dynamic_schema_arrow):
-    lib = lmdb_version_store_dynamic_schema_arrow
+def test_project_dynamic_schema(in_memory_version_store_dynamic_schema_arrow):
+    lib = in_memory_version_store_dynamic_schema_arrow
     lib.set_output_format(OutputFormat.PYARROW)
     sym = "sym"
     table_1 = pa.table({"a": pa.array([1, 2])})
@@ -1042,8 +1044,8 @@ def test_project_dynamic_schema(lmdb_version_store_dynamic_schema_arrow):
     assert expected.equals(received)
 
 
-def test_project_dynamic_schema_complex(lmdb_version_store_dynamic_schema_arrow):
-    lib = lmdb_version_store_dynamic_schema_arrow
+def test_project_dynamic_schema_complex(in_memory_version_store_dynamic_schema_arrow):
+    lib = in_memory_version_store_dynamic_schema_arrow
     sym = "sym"
     df = pd.DataFrame(
         {
@@ -1065,8 +1067,8 @@ def test_project_dynamic_schema_complex(lmdb_version_store_dynamic_schema_arrow)
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_aggregation_empty_slices(lmdb_version_store_dynamic_schema_arrow):
-    lib = lmdb_version_store_dynamic_schema_arrow
+def test_aggregation_empty_slices(in_memory_version_store_dynamic_schema_arrow):
+    lib = in_memory_version_store_dynamic_schema_arrow
     sym = "sym"
     df_1 = pd.DataFrame(
         {
@@ -1108,8 +1110,8 @@ def test_aggregation_empty_slices(lmdb_version_store_dynamic_schema_arrow):
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_resample_empty_slices(lmdb_version_store_dynamic_schema_arrow):
-    lib = lmdb_version_store_dynamic_schema_arrow
+def test_resample_empty_slices(in_memory_version_store_dynamic_schema_arrow):
+    lib = in_memory_version_store_dynamic_schema_arrow
     sym = "sym"
 
     def gen_df(start, num_rows, with_columns=True):
@@ -1161,8 +1163,8 @@ def test_resample_empty_slices(lmdb_version_store_dynamic_schema_arrow):
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_sparse_strings_from_processing_pipeline(lmdb_version_store_dynamic_schema_arrow, any_arrow_string_format):
-    lib = lmdb_version_store_dynamic_schema_arrow
+def test_sparse_strings_from_processing_pipeline(in_memory_version_store_dynamic_schema_arrow, any_arrow_string_format):
+    lib = in_memory_version_store_dynamic_schema_arrow
     lib.set_arrow_string_format_default(any_arrow_string_format)
     sym = "test_sparse_strings_from_processing_pipeline"
     df_1 = pd.DataFrame(
@@ -1198,8 +1200,8 @@ def test_sparse_strings_from_processing_pipeline(lmdb_version_store_dynamic_sche
     assert_frame_equal_with_arrow(table, expected)
 
 
-def test_arrow_read_batch_with_strings(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_arrow_read_batch_with_strings(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym_1, sym_2 = "sym_1", "sym_2"
     df_1 = pd.DataFrame({"col_1": ["a", "a", "bb"], "col_2": ["x", "y", "z"]})
     df_2 = pd.DataFrame({"col_1": ["a", "aa", "aaa"], "col_2": ["a", "a", "a"]})
@@ -1229,8 +1231,8 @@ def test_arrow_read_batch_with_strings(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow(table_2, df_2)
 
 
-def test_polars_basic(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_polars_basic(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     lib.set_output_format(OutputFormat.POLARS)
     sym = "polars"
     df = pd.DataFrame(
@@ -1254,8 +1256,8 @@ def test_polars_basic(lmdb_version_store_arrow):
     assert result.equals(expected)
 
 
-def test_polars_unsupported_small_string(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_polars_unsupported_small_string(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     lib.set_output_format(OutputFormat.POLARS)
     sym = "polars"
     df = pd.DataFrame({"col": ["a", "bb"]})
@@ -1268,8 +1270,8 @@ def test_polars_unsupported_small_string(lmdb_version_store_arrow):
         lib.read(sym, arrow_string_format_per_column={"col": ArrowOutputStringFormat.SMALL_STRING}).data
 
 
-def test_arrow_read_all_empty_strings(lmdb_version_store_arrow, any_arrow_string_format):
-    lib = lmdb_version_store_arrow
+def test_arrow_read_all_empty_strings(in_memory_version_store_arrow, any_arrow_string_format):
+    lib = in_memory_version_store_arrow
     sym = "test_arrow_read_all_empty_strings"
 
     df = pd.DataFrame({"empty_string_col": [""] * 10})

--- a/python/tests/unit/arcticdb/version_store/test_arrow_sparse.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_sparse.py
@@ -39,9 +39,9 @@ STRING_FORMAT_PER_COLUMN = {
 @pytest.mark.parametrize("row_range_start", list(range(15)))
 @pytest.mark.parametrize("row_range_width", [0, 1, 2, 5, 7, 10, 14, 15])
 def test_sparse_arrow_row_range(
-    version_store_factory, dynamic_schema, use_query_builder, row_range_start, row_range_width
+    in_memory_store_factory, dynamic_schema, use_query_builder, row_range_start, row_range_width
 ):
-    lib = version_store_factory(segment_row_size=5, dynamic_schema=dynamic_schema)
+    lib = in_memory_store_factory(segment_row_size=5, dynamic_schema=dynamic_schema)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_sparse_arrow_row_range"
@@ -82,9 +82,9 @@ def test_sparse_arrow_row_range(
 @pytest.mark.parametrize("date_range_start", list(pd.date_range("2025-01-01", periods=15)))
 @pytest.mark.parametrize("date_range_width", [0, 1, 2, 5, 7, 10, 14, 15])
 def test_sparse_arrow_date_range(
-    version_store_factory, dynamic_schema, use_query_builder, date_range_start, date_range_width
+    in_memory_store_factory, dynamic_schema, use_query_builder, date_range_start, date_range_width
 ):
-    lib = version_store_factory(segment_row_size=5, dynamic_schema=dynamic_schema)
+    lib = in_memory_store_factory(segment_row_size=5, dynamic_schema=dynamic_schema)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_sparse_arrow_date_range"
@@ -132,10 +132,10 @@ def test_sparse_arrow_date_range(
     rows_per_slice=st.integers(2, 10),
     use_row_range=st.booleans(),
 )
-def test_sparse_arrow_hypothesis(lmdb_version_store_arrow, df, rows_per_slice, use_row_range):
+def test_sparse_arrow_hypothesis(in_memory_version_store_arrow, df, rows_per_slice, use_row_range):
     row_count = len(df)
     assume(row_count > 0)
-    lib = lmdb_version_store_arrow
+    lib = in_memory_version_store_arrow
     lib._cfg.write_options.segment_row_size = rows_per_slice
     sym = "test_sparse_arrow_hypothesis"
     float_array = pa.Array.from_pandas(df["float_col"])
@@ -181,8 +181,8 @@ def test_sparse_arrow_hypothesis(lmdb_version_store_arrow, df, rows_per_slice, u
         ["b"],
     ],
 )
-def test_sparse_column_selection(version_store_factory, column_group_size, use_row_range, index_column, columns):
-    lib = version_store_factory(column_group_size=column_group_size)
+def test_sparse_column_selection(in_memory_store_factory, column_group_size, use_row_range, index_column, columns):
+    lib = in_memory_store_factory(column_group_size=column_group_size)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_sparse_col_selection"
@@ -222,8 +222,8 @@ class TestSparseArrowQueryBuilder:
     sym = "TestSparseArrowQueryBuilder"
 
     @pytest.fixture(autouse=True)
-    def setup(self, lmdb_version_store_arrow):
-        lib = lmdb_version_store_arrow
+    def setup(self, in_memory_version_store_arrow):
+        lib = in_memory_version_store_arrow
         self.table = pa.table(
             {
                 "ts": pa.Array.from_pandas(pd.date_range("2025-01-01", periods=8), type=pa.timestamp("ns")),
@@ -233,50 +233,50 @@ class TestSparseArrowQueryBuilder:
         )
         lib.write(self.sym, self.table, index_column=True)
 
-    def test_filter_isnull(self, lmdb_version_store_arrow):
+    def test_filter_isnull(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[q["int_col"].isnull()]
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         mask = pc.is_null(self.table.column("int_col"))
         expected = self.table.filter(mask)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym, query_builder=q, output_format="PANDAS"
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
-    def test_filter_notnull(self, lmdb_version_store_arrow):
+    def test_filter_notnull(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[q["int_col"].notnull()]
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         mask = pc.is_valid(self.table.column("int_col"))
         expected = self.table.filter(mask)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym, query_builder=q, output_format="PANDAS"
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
-    def test_filter_equals(self, lmdb_version_store_arrow):
+    def test_filter_equals(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[q["int_col"] == 3]
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         mask = pc.equal(self.table.column("int_col"), 3)
         expected = self.table.filter(mask)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym, query_builder=q, output_format="PANDAS"
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
-    def test_filter_greater_than(self, lmdb_version_store_arrow):
+    def test_filter_greater_than(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[q["int_col"] > 3]
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         mask = pc.greater(self.table.column("int_col"), 3)
         expected = self.table.filter(mask)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym, query_builder=q, output_format="PANDAS"
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
@@ -295,60 +295,60 @@ class TestSparseArrowQueryBuilder:
             ),
         ],
     )
-    def test_filter_isin(self, lmdb_version_store_arrow, values):
+    def test_filter_isin(self, in_memory_version_store_arrow, values):
         q = QueryBuilder()
         q = q[q["int_col"].isin(values)]
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         mask = pc.is_in(self.table.column("int_col"), pa.array(values, pa.int64()))
         expected = self.table.filter(mask)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym, query_builder=q, output_format="PANDAS"
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
-    def test_filter_combined_columns(self, lmdb_version_store_arrow):
+    def test_filter_combined_columns(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[(q["int_col"].notnull()) & (q["float_col"].notnull())]
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         assert len(received) == 0
-        received_pandas = lmdb_version_store_arrow.read(self.sym, query_builder=q, output_format="PANDAS").data
+        received_pandas = in_memory_version_store_arrow.read(self.sym, query_builder=q, output_format="PANDAS").data
         assert len(received_pandas) == 0
 
-    def test_project_multiple_cols(self, lmdb_version_store_arrow):
+    def test_project_multiple_cols(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q.apply("sum", q["int_col"] + 10)
         q = q.apply("product", q["int_col"] * q["float_col"])
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         sum = pc.add(self.table.column("int_col"), 10)
         product = pc.multiply(self.table.column("int_col"), self.table.column("float_col"))
         expected = self.table.append_column("sum", sum)
         expected = expected.append_column("product", product)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym, query_builder=q, output_format="PANDAS"
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
-    def test_filter_then_project(self, lmdb_version_store_arrow):
+    def test_filter_then_project(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[q["float_col"].notnull()]
         q = q.apply("doubled", q["float_col"] * 2)
-        received = lmdb_version_store_arrow.read(self.sym, query_builder=q).data
+        received = in_memory_version_store_arrow.read(self.sym, query_builder=q).data
         mask = pc.is_valid(self.table.column("float_col"))
         filtered = self.table.filter(mask)
         doubled = pc.multiply(filtered.column("float_col"), 2)
         expected = filtered.append_column("doubled", doubled)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym, query_builder=q, output_format="PANDAS"
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
-    def test_date_range_with_filter(self, lmdb_version_store_arrow):
+    def test_date_range_with_filter(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[q["int_col"].notnull()]
-        received = lmdb_version_store_arrow.read(
+        received = in_memory_version_store_arrow.read(
             self.sym,
             date_range=(pd.Timestamp("2025-01-02"), pd.Timestamp("2025-01-06")),
             query_builder=q,
@@ -357,7 +357,7 @@ class TestSparseArrowQueryBuilder:
         mask = pc.is_valid(sliced.column("int_col"))
         expected = sliced.filter(mask)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym,
             date_range=(pd.Timestamp("2025-01-02"), pd.Timestamp("2025-01-06")),
             query_builder=q,
@@ -365,10 +365,10 @@ class TestSparseArrowQueryBuilder:
         ).data.reset_index()
         assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
-    def test_row_range_with_filter(self, lmdb_version_store_arrow):
+    def test_row_range_with_filter(self, in_memory_version_store_arrow):
         q = QueryBuilder()
         q = q[q["float_col"].notnull()]
-        received = lmdb_version_store_arrow.read(
+        received = in_memory_version_store_arrow.read(
             self.sym,
             row_range=(2, 6),
             query_builder=q,
@@ -377,7 +377,7 @@ class TestSparseArrowQueryBuilder:
         mask = pc.is_valid(sliced.column("float_col"))
         expected = sliced.filter(mask)
         assert expected.equals(received)
-        received_pandas = lmdb_version_store_arrow.read(
+        received_pandas = in_memory_version_store_arrow.read(
             self.sym,
             row_range=(2, 6),
             query_builder=q,
@@ -388,8 +388,8 @@ class TestSparseArrowQueryBuilder:
 
 @pytest.mark.parametrize("write_sparse", [True, False])
 @pytest.mark.parametrize("append_sparse", [True, False])
-def test_sparse_append_roundtrip(lmdb_version_store_arrow, write_sparse, append_sparse, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_sparse_append_roundtrip(in_memory_version_store_arrow, write_sparse, append_sparse, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_append_roundtrip"
     if write_sparse:
         str_data_1 = [None, "b", None]
@@ -480,9 +480,9 @@ def test_sparse_append_all_nulls(lmdb_version_store_arrow):
     ],
 )
 def test_sparse_update_roundtrip(
-    lmdb_version_store_arrow, write_sparse, update_sparse, date_range, arrow_output_format
+    in_memory_version_store_arrow, write_sparse, update_sparse, date_range, arrow_output_format
 ):
-    lib = lmdb_version_store_arrow
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_update_roundtrip"
     dates = pd.date_range("2025-01-01", periods=6)
     update_dates = pd.date_range("2025-01-03", periods=2)  # replaces rows 2 and 3
@@ -561,8 +561,8 @@ def test_sparse_update_roundtrip(
     assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
 
-def test_sparse_update_all_nulls(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_sparse_update_all_nulls(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_update_all_nulls"
     dates = pd.date_range("2025-01-01", periods=4)
     write_table = pa.table(
@@ -592,8 +592,8 @@ def test_sparse_update_all_nulls(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow_for_sparse(expected, received_pandas)
 
 
-def test_sparse_dynamic_schema_combined(version_store_factory):
-    lib = version_store_factory(dynamic_schema=True, dynamic_strings=True)
+def test_sparse_dynamic_schema_combined(in_memory_store_factory):
+    lib = in_memory_store_factory(dynamic_schema=True, dynamic_strings=True)
     lib.set_output_format(OutputFormat.PYARROW)
     lib._set_allow_arrow_input()
     sym = "test_sparse_dynschema_combined"
@@ -658,9 +658,9 @@ def test_sparse_dynamic_schema_combined(version_store_factory):
 )
 @pytest.mark.parametrize("row_range", [None, (2, 6)])
 def test_sparse_dynamic_schema_type_upgrade(
-    version_store_factory, write_type, append_type, result_type, row_range, arrow_output_format
+    in_memory_store_factory, write_type, append_type, result_type, row_range, arrow_output_format
 ):
-    lib = version_store_factory(dynamic_schema=True)
+    lib = in_memory_store_factory(dynamic_schema=True)
     lib.set_output_format(OutputFormat.PYARROW)
     lib._set_allow_arrow_input()
     sym = "test_sparse_type_upgrade"
@@ -727,8 +727,8 @@ class TestSparseArrowGroupBy:
     sym = "test_sparse_groupby"
 
     @pytest.fixture(autouse=True)
-    def setup(self, version_store_factory):
-        self.lib = version_store_factory(segment_row_size=3)
+    def setup(self, in_memory_store_factory):
+        self.lib = in_memory_store_factory(segment_row_size=3)
         self.lib.set_output_format(OutputFormat.POLARS)
         self.lib._set_allow_arrow_input()
         self.pldf = pl.DataFrame(
@@ -778,8 +778,8 @@ class TestSparseArrowResample:
     # - Other resampling kwargs like offset, origin
 
     @pytest.fixture(autouse=True)
-    def setup(self, version_store_factory):
-        self.lib = version_store_factory(segment_row_size=4)
+    def setup(self, in_memory_store_factory):
+        self.lib = in_memory_store_factory(segment_row_size=4)
         self.lib.set_output_format(OutputFormat.POLARS)
         self.lib._set_allow_arrow_input()
         # Bucket 2 (hours 6-8) is fully null for both columns when resampled at 3h
@@ -831,8 +831,8 @@ class TestSparseArrowResample:
 
 class TestSparseArrowConcat:
     @pytest.fixture(autouse=True)
-    def setup(self, lmdb_library_factory):
-        self.lib = lmdb_library_factory(LibraryOptions())
+    def setup(self, mem_library_factory):
+        self.lib = mem_library_factory(LibraryOptions())
         self.lib._nvs.set_output_format(OutputFormat.POLARS)
         self.lib._nvs._set_allow_arrow_input()
 

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -199,8 +199,6 @@ def test_write_multiple_record_batches_indexed(in_memory_version_store_arrow):
 @pytest.mark.parametrize("num_cols", [1, 2, 3, 4, 5])
 def test_write_sliced(in_memory_version_store_tiny_segment_arrow, num_rows, num_cols, arrow_output_format):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format("pyarrow")
-    lib._set_allow_arrow_input()
     sym = "test_write_sliced"
     table = pa.table(
         {
@@ -235,8 +233,6 @@ def test_write_sliced(in_memory_version_store_tiny_segment_arrow, num_rows, num_
 )
 def test_write_bools_sliced(in_memory_version_store_tiny_segment_arrow, data):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format("pyarrow")
-    lib._set_allow_arrow_input()
     sym = "test_write_bools_sliced"
     table = pa.table({"col": pa.array(data)})
     lib.write(sym, table)
@@ -248,8 +244,6 @@ def test_write_bools_sliced(in_memory_version_store_tiny_segment_arrow, data):
 @pytest.mark.parametrize("num_cols", [1, 2, 3, 4, 5])
 def test_write_sliced_with_index(in_memory_version_store_tiny_segment_arrow, num_rows, num_cols):
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format("pyarrow")
-    lib._set_allow_arrow_input()
     lib_tool = lib.library_tool()
     sym = "test_write_sliced_with_index"
     df = pd.DataFrame(
@@ -376,8 +370,6 @@ def test_write_view_strings(in_memory_version_store_arrow, type):
 def test_write_owned_and_non_owned_buffers(in_memory_version_store_tiny_segment_arrow):
     # This test is about our ChunkedBuffer holding mixes of owned and non-owned blocks, not Arrow views
     lib = in_memory_version_store_tiny_segment_arrow
-    lib.set_output_format("pyarrow")
-    lib._set_allow_arrow_input()
     sym = "test_write_owned_and_non_owned_buffers"
     rb0 = pa.RecordBatch.from_arrays([pa.array([0, 1, 2], pa.int32())], names=["col"])
     rb1 = pa.RecordBatch.from_arrays([pa.array([3, 4, 5], pa.int32())], names=["col"])

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -60,8 +60,8 @@ def test_write_zero_row_table(lmdb_version_store_arrow):
     assert table.equals(received)
 
 
-def test_write_zero_row_table_view(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_write_zero_row_table_view(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_write_zero_row_table_view"
     arr0 = pa.array([0, 1], pa.int64())
     arr1 = pa.array([2, 3, 4], pa.int64())
@@ -78,8 +78,8 @@ def test_write_zero_row_table_view(lmdb_version_store_arrow):
 
 # Arrow stores bools as packed bitsets so worth testing separately even in scenarios as basic as this
 @pytest.mark.parametrize("type", [pa.int64(), pa.bool_()])
-def test_basic_write(lmdb_version_store_arrow, type, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_basic_write(in_memory_version_store_arrow, type, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_basic_write"
     table = pa.table({"col": pa.array([0, 1] if type == pa.int64() else [True, False], type)})
     metadata = {"hello", "there"}
@@ -90,8 +90,8 @@ def test_basic_write(lmdb_version_store_arrow, type, arrow_output_format):
 
 
 @pytest.mark.parametrize("type", [pa.string(), pa.large_string()])
-def test_basic_write_strings(lmdb_version_store_arrow, type):
-    lib = lmdb_version_store_arrow
+def test_basic_write_strings(in_memory_version_store_arrow, type):
+    lib = in_memory_version_store_arrow
     sym = "test_basic_write_strings"
     table = pa.table({"col": pa.array(["hello", "bonjour", "gutentag", "nihao", "konnichiwa"], type)})
     lib.write(sym, table)
@@ -102,8 +102,8 @@ def test_basic_write_strings(lmdb_version_store_arrow, type):
 @pytest.mark.skip(reason="Not implemented yet 9951777416")
 @pytest.mark.parametrize("type", [pa.timestamp("us"), pa.timestamp("ms"), pa.timestamp("s")])
 @pytest.mark.parametrize("index_column", [False, True])
-def test_write_with_non_nanosecond_time_types(lmdb_version_store_arrow, type, index_column):
-    lib = lmdb_version_store_arrow
+def test_write_with_non_nanosecond_time_types(in_memory_version_store_arrow, type, index_column):
+    lib = in_memory_version_store_arrow
     sym = "test_write_with_non_nanosecond_time_types"
     table = pa.table(
         {
@@ -117,8 +117,8 @@ def test_write_with_non_nanosecond_time_types(lmdb_version_store_arrow, type, in
 
 
 @pytest.mark.parametrize("type", [pa.int64(), pa.bool_(), pa.string(), pa.large_string()])
-def test_write_multiple_record_batches(lmdb_version_store_arrow, type):
-    lib = lmdb_version_store_arrow
+def test_write_multiple_record_batches(in_memory_version_store_arrow, type):
+    lib = in_memory_version_store_arrow
     sym = "test_write_multiple_record_batches"
     if type == pa.int64():
         arr0 = pa.array([0, 1], type)
@@ -143,8 +143,8 @@ def test_write_multiple_record_batches(lmdb_version_store_arrow, type):
     assert table.equals(received)
 
 
-def test_write_with_index(lmdb_version_store_arrow, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_write_with_index(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_write_with_index"
     table = pa.table(
         {
@@ -162,8 +162,8 @@ def test_write_with_index(lmdb_version_store_arrow, arrow_output_format):
     assert_arrow_equal(table, received)
 
 
-def test_write_multiple_record_batches_indexed(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_write_multiple_record_batches_indexed(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_write_multiple_record_batches_indexed"
     rb0 = pa.RecordBatch.from_arrays(
         [
@@ -197,8 +197,8 @@ def test_write_multiple_record_batches_indexed(lmdb_version_store_arrow):
 
 @pytest.mark.parametrize("num_rows", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("num_cols", [1, 2, 3, 4, 5])
-def test_write_sliced(lmdb_version_store_tiny_segment, num_rows, num_cols, arrow_output_format):
-    lib = lmdb_version_store_tiny_segment
+def test_write_sliced(in_memory_version_store_tiny_segment_arrow, num_rows, num_cols, arrow_output_format):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_write_sliced"
@@ -233,8 +233,8 @@ def test_write_sliced(lmdb_version_store_tiny_segment, num_rows, num_cols, arrow
         [False, True, True, False, True],
     ],
 )
-def test_write_bools_sliced(lmdb_version_store_tiny_segment, data):
-    lib = lmdb_version_store_tiny_segment
+def test_write_bools_sliced(in_memory_version_store_tiny_segment_arrow, data):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_write_bools_sliced"
@@ -246,8 +246,8 @@ def test_write_bools_sliced(lmdb_version_store_tiny_segment, data):
 
 @pytest.mark.parametrize("num_rows", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("num_cols", [1, 2, 3, 4, 5])
-def test_write_sliced_with_index(lmdb_version_store_tiny_segment, num_rows, num_cols):
-    lib = lmdb_version_store_tiny_segment
+def test_write_sliced_with_index(in_memory_version_store_tiny_segment_arrow, num_rows, num_cols):
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     lib_tool = lib.library_tool()
@@ -285,9 +285,9 @@ def test_write_sliced_with_index(lmdb_version_store_tiny_segment, num_rows, num_
 
 
 @pytest.mark.parametrize("rows_per_slice", [1, 2, 10, 100_000])
-def test_many_record_batches_many_slices(version_store_factory, rows_per_slice):
+def test_many_record_batches_many_slices(in_memory_store_factory, rows_per_slice):
     rng = np.random.default_rng()
-    lib = version_store_factory(segment_row_size=rows_per_slice)
+    lib = in_memory_store_factory(segment_row_size=rows_per_slice)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_many_record_batches_many_slices"
@@ -312,9 +312,9 @@ def test_many_record_batches_many_slices(version_store_factory, rows_per_slice):
 
 @pytest.mark.parametrize("rows_per_slice", [1, 2, 3, 5, 7])
 @pytest.mark.parametrize("rows_per_record_batch", [1, 2, 3, 5, 7])
-def test_many_record_batches_edge_cases(version_store_factory, rows_per_slice, rows_per_record_batch):
+def test_many_record_batches_edge_cases(in_memory_store_factory, rows_per_slice, rows_per_record_batch):
     rng = np.random.default_rng()
-    lib = version_store_factory(segment_row_size=rows_per_slice)
+    lib = in_memory_store_factory(segment_row_size=rows_per_slice)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_many_record_batches_same_size"
@@ -337,8 +337,8 @@ def test_many_record_batches_edge_cases(version_store_factory, rows_per_slice, r
     assert table.equals(received)
 
 
-def test_write_view(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_write_view(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_write_view"
     table = pa.table(
         {
@@ -361,8 +361,8 @@ def test_write_view(lmdb_version_store_arrow):
 
 
 @pytest.mark.parametrize("type", [pa.string(), pa.large_string()])
-def test_write_view_strings(lmdb_version_store_arrow, type):
-    lib = lmdb_version_store_arrow
+def test_write_view_strings(in_memory_version_store_arrow, type):
+    lib = in_memory_version_store_arrow
     sym = "test_write_view_strings"
     table_0 = pa.table({"col": pa.array(["hello", "bonjour", "gutentag"], type)})
     table_1 = pa.table({"col": pa.array(["dog", "bats", "on"], type)})
@@ -373,9 +373,9 @@ def test_write_view_strings(lmdb_version_store_arrow, type):
     assert view.equals(received)
 
 
-def test_write_owned_and_non_owned_buffers(lmdb_version_store_tiny_segment):
+def test_write_owned_and_non_owned_buffers(in_memory_version_store_tiny_segment_arrow):
     # This test is about our ChunkedBuffer holding mixes of owned and non-owned blocks, not Arrow views
-    lib = lmdb_version_store_tiny_segment
+    lib = in_memory_version_store_tiny_segment_arrow
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_write_owned_and_non_owned_buffers"
@@ -388,8 +388,8 @@ def test_write_owned_and_non_owned_buffers(lmdb_version_store_tiny_segment):
 
 
 @pytest.mark.xfail(reason="Not implemented yet, issue number 9929831600")
-def test_write_with_timezone(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_write_with_timezone(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_write_with_timezone"
     table = pa.table(
         {
@@ -408,8 +408,8 @@ def test_write_with_timezone(lmdb_version_store_arrow):
     assert table.equals(received)
 
 
-def test_write_with_index_and_read_with_column_slicing(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_write_with_index_and_read_with_column_slicing(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_write_with_index_and_read_with_column_slicing"
     table = pa.table(
         {
@@ -424,16 +424,16 @@ def test_write_with_index_and_read_with_column_slicing(lmdb_version_store_arrow)
     assert expected.equals(received)
 
 
-def test_write_index_column_on_empty_table(lmdb_version_store_arrow, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_write_index_column_on_empty_table(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_write_index_column_on_empty_table"
     table = pa.table({})
     with pytest.raises(SchemaException, match="Cannot use index_column=True on a table with no columns"):
         lib.write(sym, to_format(table, arrow_output_format), index_column=True)
 
 
-def test_write_non_timestamp_index_column(lmdb_version_store_arrow, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_write_non_timestamp_index_column(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_write_non_timestamp_index_column"
     table = pa.table({"non-ts": pa.array([0, 1], pa.int64()), "col": pa.array([2, 3], pa.int64())})
     with pytest.raises(UserInputException) as e:
@@ -441,8 +441,8 @@ def test_write_non_timestamp_index_column(lmdb_version_store_arrow, arrow_output
     assert "int64" in str(e.value).lower()
 
 
-def test_write_unsupported_types(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_write_unsupported_types(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_write_unsupported_types"
     table = pa.table({"col": pa.array(np.arange(2, dtype=np.float16), pa.float16())})
     with pytest.raises(SchemaException) as e:
@@ -457,8 +457,8 @@ def test_write_unsupported_types(lmdb_version_store_arrow):
 
 
 # Reinstate if bounds check is re-added in WriteToSegmentTask::slice_column when 9951777416 is implemented
-# def test_write_with_out_of_range_timestamps(lmdb_version_store_arrow):
-#     lib = lmdb_version_store_arrow
+# def test_write_with_out_of_range_timestamps(in_memory_version_store_arrow):
+#     lib = in_memory_version_store_arrow
 #     sym = "test_write_with_out_of_range_timestamps"
 #     table = pa.table(
 #         {
@@ -474,8 +474,8 @@ def test_write_unsupported_types(lmdb_version_store_arrow):
 
 
 @pytest.mark.parametrize("existing_data", [True, False])
-def test_append(lmdb_version_store_arrow, existing_data, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_append(in_memory_version_store_arrow, existing_data, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_append"
     if existing_data:
         write_table = pa.table({"col0": pa.array([0, 1], pa.int64()), "col1": pa.array(["a", "bb"], pa.string())})
@@ -493,8 +493,8 @@ def test_append(lmdb_version_store_arrow, existing_data, arrow_output_format):
 
 
 @pytest.mark.parametrize("first_type", [pa.string(), pa.large_string()])
-def test_append_mix_strings_and_large_strings(lmdb_version_store_arrow, first_type):
-    lib = lmdb_version_store_arrow
+def test_append_mix_strings_and_large_strings(in_memory_version_store_arrow, first_type):
+    lib = in_memory_version_store_arrow
     sym = "test_append_mix_strings_and_large_strings"
     write_table = pa.table({"col": pa.array(["a", "bb"], first_type)})
     lib.write(sym, write_table)
@@ -508,8 +508,8 @@ def test_append_mix_strings_and_large_strings(lmdb_version_store_arrow, first_ty
 
 
 @pytest.mark.parametrize("existing_data", [True, False])
-def test_append_with_index(lmdb_version_store_arrow, existing_data):
-    lib = lmdb_version_store_arrow
+def test_append_with_index(in_memory_version_store_arrow, existing_data):
+    lib = in_memory_version_store_arrow
     sym = "test_append_with_index"
     if existing_data:
         write_table = pa.table(
@@ -533,8 +533,8 @@ def test_append_with_index(lmdb_version_store_arrow, existing_data):
 
 
 @pytest.mark.parametrize("method", ["append", "update"])
-def test_wrong_index_name(lmdb_version_store_arrow, method, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_wrong_index_name(in_memory_version_store_arrow, method, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_wrong_index_name"
     table_0 = pa.table(
         {
@@ -554,8 +554,8 @@ def test_wrong_index_name(lmdb_version_store_arrow, method, arrow_output_format)
 
 
 @pytest.mark.parametrize("existing_data", [True, False])
-def test_update(lmdb_version_store_arrow, existing_data, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_update(in_memory_version_store_arrow, existing_data, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_update"
     if existing_data:
         write_table = pa.table(
@@ -594,8 +594,8 @@ def test_update(lmdb_version_store_arrow, existing_data, arrow_output_format):
 
 
 @pytest.mark.parametrize("first_type", [pa.string(), pa.large_string()])
-def test_update_mix_strings_and_large_strings(lmdb_version_store_arrow, first_type):
-    lib = lmdb_version_store_arrow
+def test_update_mix_strings_and_large_strings(in_memory_version_store_arrow, first_type):
+    lib = in_memory_version_store_arrow
     sym = "test_update_mix_strings_and_large_strings"
     write_table = pa.table(
         {
@@ -630,8 +630,8 @@ def test_update_mix_strings_and_large_strings(lmdb_version_store_arrow, first_ty
         (pd.Timestamp("2025-01-03"), pd.Timestamp("2025-01-04")),
     ],
 )
-def test_update_with_date_range_wider_than_data(lmdb_version_store_arrow, date_range, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_update_with_date_range_wider_than_data(in_memory_version_store_arrow, date_range, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_update_with_date_range_wider_than_data"
     reference_sym = "test_update_with_date_range_wider_than_data_reference"
     write_table = pa.table(
@@ -692,8 +692,10 @@ def test_update_with_date_range_wider_than_data(lmdb_version_store_arrow, date_r
         ),
     ],
 )
-def test_update_with_date_range_narrower_than_data(lmdb_version_store_arrow, date_range, index_tz, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_update_with_date_range_narrower_than_data(
+    in_memory_version_store_arrow, date_range, index_tz, arrow_output_format
+):
+    lib = in_memory_version_store_arrow
     sym = "test_update_with_date_range_narrower_than_data"
     reference_sym = "test_update_with_date_range_narrower_than_data_reference"
     ts_type = pa.timestamp("ns", tz=index_tz)
@@ -723,8 +725,8 @@ def test_update_with_date_range_narrower_than_data(lmdb_version_store_arrow, dat
 
 
 @pytest.mark.parametrize("method", ["write_parallel", "write_incomplete", "append", "stage"])
-def test_staging_without_sorting(version_store_factory, method):
-    lib = version_store_factory(segment_row_size=2, dynamic_schema=True)
+def test_staging_without_sorting(in_memory_store_factory, method):
+    lib = in_memory_store_factory(segment_row_size=2, dynamic_schema=True)
     lib_tool = lib.library_tool()
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
@@ -767,8 +769,8 @@ def test_staging_without_sorting(version_store_factory, method):
     assert expected.equals(received)
 
 
-def test_staging_with_sorting(version_store_factory, arrow_output_format):
-    lib = version_store_factory(segment_row_size=2, dynamic_schema=True)
+def test_staging_with_sorting(in_memory_store_factory, arrow_output_format):
+    lib = in_memory_store_factory(segment_row_size=2, dynamic_schema=True)
     lib_tool = lib.library_tool()
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
@@ -801,8 +803,8 @@ def test_staging_with_sorting(version_store_factory, arrow_output_format):
 
 # Merge with test_staging_with_sorting when 18190648152 is done
 @pytest.mark.xfail(reason="Not implemented yet, see issue 18190648152")
-def test_staging_with_sorting_strings(version_store_factory):
-    lib = version_store_factory(segment_row_size=2, dynamic_schema=True)
+def test_staging_with_sorting_strings(in_memory_store_factory):
+    lib = in_memory_store_factory(segment_row_size=2, dynamic_schema=True)
     lib_tool = lib.library_tool()
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
@@ -829,8 +831,8 @@ def test_staging_with_sorting_strings(version_store_factory):
     assert expected.equals(received)
 
 
-def test_recursive_normalizers(lmdb_version_store_arrow, all_recursive_metastructure_versions):
-    lib = lmdb_version_store_arrow
+def test_recursive_normalizers(in_memory_version_store_arrow, all_recursive_metastructure_versions):
+    lib = in_memory_version_store_arrow
     sym = "test_recursive_normalizers"
     table_0 = pa.table({"col0": pa.array(["hello", "there"], pa.string())})
     df_1 = pd.DataFrame({"col1": [2, 3, 4]})
@@ -870,8 +872,10 @@ def test_recursive_normalizers(lmdb_version_store_arrow, all_recursive_metastruc
     assert table_2.equals(cast_string_columns(received["b"]["d"], pa.large_string()))
 
 
-def test_recursive_normalizers_mixed_polars_pyarrow(lmdb_version_store_arrow, all_recursive_metastructure_versions):
-    lib = lmdb_version_store_arrow
+def test_recursive_normalizers_mixed_polars_pyarrow(
+    in_memory_version_store_arrow, all_recursive_metastructure_versions
+):
+    lib = in_memory_version_store_arrow
     sym = "test_recursive_normalizers_mixed"
     pa_table = pa.table({"col0": pa.array(["hello", "there"], pa.large_string())})
     pl_frame = pl.DataFrame({"col1": [2, 3, 4]})
@@ -896,8 +900,8 @@ def test_recursive_normalizers_mixed_polars_pyarrow(lmdb_version_store_arrow, al
     assert_frame_equal_with_arrow(df, received["b"]["d"])
 
 
-def test_batch_write(lmdb_version_store_arrow, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_batch_write(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
     table_0 = pa.table({"col0": pa.array([0, 1], pa.int16())})
     df_1 = pd.DataFrame({"col1": np.arange(2, 5, dtype=np.int32)})
     table_2 = pa.table(
@@ -919,8 +923,8 @@ def test_batch_write(lmdb_version_store_arrow, arrow_output_format):
     assert_arrow_equal(table_2, received_2)
 
 
-def test_batch_append(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_batch_append(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     table_0 = pa.table({"col0": pa.array([0, 1], pa.int16())})
     df_1 = pd.DataFrame({"col1": np.arange(2, 5, dtype=np.int32)})
     table_2 = pa.table(
@@ -983,7 +987,7 @@ num_supported_types = len(supported_types)
     null_percentage=st.integers(0, 100),
 )
 def test_arrow_writes_hypothesis(
-    lmdb_version_store_big_map,
+    in_memory_store_factory,
     df_length,
     max_record_batches,
     max_row_slices,
@@ -991,9 +995,9 @@ def test_arrow_writes_hypothesis(
     null_percentage,
 ):
     rng = np.random.default_rng()
-    lib = lmdb_version_store_big_map
+    lib = in_memory_store_factory(name="_unique_")
     sym = "test_arrow_writes_hypothesis"
-    # version_store_factory doesn't play nicely with hypothesis, so set these values manually
+    # in_memory_store_factory doesn't play nicely with hypothesis, so set these values manually
     rows_per_slice = max(df_length // max_row_slices, 1)
     cols_per_slice = num_supported_types // max_col_slices
     lib.lib_cfg().lib_desc.version.write_options.segment_row_size = rows_per_slice
@@ -1038,8 +1042,8 @@ def test_arrow_writes_hypothesis(
 
 
 @pytest.mark.xfail(reason="Monday ref: 11325694339")
-def test_write_arrow_read_arrow_convert_to_pandas(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_write_arrow_read_arrow_convert_to_pandas(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_write_arrow_read_arrow_convert_to_pandas"
     table = pa.table(
         {
@@ -1053,8 +1057,8 @@ def test_write_arrow_read_arrow_convert_to_pandas(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow(arrow_received, pandas_received)
 
 
-def test_basic_sparse_write(lmdb_version_store_arrow, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_basic_sparse_write(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_basic_sparse_write"
     table = pa.table({"col": pa.array([1, None, 3, None, 5], pa.int64())})
     lib.write(sym, to_format(table, arrow_output_format))
@@ -1064,8 +1068,8 @@ def test_basic_sparse_write(lmdb_version_store_arrow, arrow_output_format):
     assert_frame_equal_with_arrow_for_sparse(table, pandas_received)
 
 
-def test_sparse_write_all_nulls_column(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_sparse_write_all_nulls_column(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_write_all_nulls"
     table = pa.table(
         {
@@ -1091,8 +1095,8 @@ def test_sparse_write_all_nulls_column(lmdb_version_store_arrow):
         pytest.param(["hello", None, "world", None, "!"], pa.large_string(), id="large_string"),
     ],
 )
-def test_sparse_write_different_types(lmdb_version_store_arrow, data, arrow_type):
-    lib = lmdb_version_store_arrow
+def test_sparse_write_different_types(in_memory_version_store_arrow, data, arrow_type):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_write_different_types"
     table = pa.table({"col": pa.array(data, arrow_type)})
     lib.write(sym, table)
@@ -1105,8 +1109,8 @@ def test_sparse_write_different_types(lmdb_version_store_arrow, data, arrow_type
 
 @pytest.mark.parametrize("rows_per_slice", [1, 2, 3, 5])
 @pytest.mark.parametrize("cols_per_slice", [1, 2, 3, 5])
-def test_sparse_write_multiple_columns_different_types(version_store_factory, rows_per_slice, cols_per_slice):
-    lib = version_store_factory(segment_row_size=rows_per_slice, column_group_size=cols_per_slice)
+def test_sparse_write_multiple_columns_different_types(in_memory_store_factory, rows_per_slice, cols_per_slice):
+    lib = in_memory_store_factory(segment_row_size=rows_per_slice, column_group_size=cols_per_slice)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_sparse_write_multiple_columns"
@@ -1141,8 +1145,8 @@ def test_sparse_write_multiple_columns_different_types(version_store_factory, ro
         pytest.param("hello", pa.large_string(), id="large_string"),
     ],
 )
-def test_sparse_many_different_size_batches(version_store_factory, rows_per_slice, value, arrow_type):
-    lib = version_store_factory(segment_row_size=rows_per_slice)
+def test_sparse_many_different_size_batches(in_memory_store_factory, rows_per_slice, value, arrow_type):
+    lib = in_memory_store_factory(segment_row_size=rows_per_slice)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_sparse_many_different_size_batches"
@@ -1166,9 +1170,9 @@ def test_sparse_many_different_size_batches(version_store_factory, rows_per_slic
 
 @pytest.mark.parametrize("rows_per_slice", [1, 2, 3, 5, 7])
 @pytest.mark.parametrize("rows_per_record_batch", [1, 2, 3, 5, 7])
-def test_sparse_write_many_batches_many_slices(version_store_factory, rows_per_slice, rows_per_record_batch):
+def test_sparse_write_many_batches_many_slices(in_memory_store_factory, rows_per_slice, rows_per_record_batch):
     rng = np.random.default_rng(42)
-    lib = version_store_factory(segment_row_size=rows_per_slice)
+    lib = in_memory_store_factory(segment_row_size=rows_per_slice)
     lib.set_output_format("pyarrow")
     lib._set_allow_arrow_input()
     sym = "test_sparse_write_many_batches_many_slices"
@@ -1237,8 +1241,8 @@ def test_sparse_write_many_batches_many_slices(version_store_factory, rows_per_s
         pytest.param(3, 0, id="empty_slice"),
     ],
 )
-def test_sparse_write_view(lmdb_version_store_arrow, offset, length):
-    lib = lmdb_version_store_arrow
+def test_sparse_write_view(in_memory_version_store_arrow, offset, length):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_write_view"
     table = pa.table(
         {
@@ -1254,8 +1258,8 @@ def test_sparse_write_view(lmdb_version_store_arrow, offset, length):
     assert view.equals(received)
 
 
-def test_sparse_index_column_raises(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_sparse_index_column_raises(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_index_column_raises"
     # Create a table with a timestamp index column that has null values
     table = pa.table(
@@ -1275,8 +1279,8 @@ def test_sparse_index_column_raises(lmdb_version_store_arrow):
         lib.write(sym, table, index_column=True)
 
 
-def test_sparse_write_with_index(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_sparse_write_with_index(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_write_with_index"
     table = pa.table(
         {
@@ -1296,8 +1300,8 @@ def test_sparse_write_with_index(lmdb_version_store_arrow):
     assert_frame_equal_with_arrow_for_sparse(table, pandas_received)
 
 
-def test_sparse_append(lmdb_version_store_arrow, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_sparse_append(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_append"
     write_table = pa.table({"col": pa.array([1, None, 3], pa.int64())})
     lib.write(sym, to_format(write_table, arrow_output_format))
@@ -1311,8 +1315,8 @@ def test_sparse_append(lmdb_version_store_arrow, arrow_output_format):
     assert_frame_equal_with_arrow_for_sparse(expected, pandas_received)
 
 
-def test_sparse_update(lmdb_version_store_arrow, arrow_output_format):
-    lib = lmdb_version_store_arrow
+def test_sparse_update(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
     sym = "test_sparse_update"
     write_table = pa.table(
         {
@@ -1341,11 +1345,8 @@ def test_sparse_update(lmdb_version_store_arrow, arrow_output_format):
     assert_frame_equal_with_arrow_for_sparse(expected, pandas_received)
 
 
-@pytest.mark.xfail(
-    reason="Column selection for Arrow-written data always includes the first column even when not requested (monday: 11432991054)"
-)
-def test_arrow_column_selection_excludes_first_column(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_arrow_column_selection_excludes_first_column(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     table = pa.table(
         {
             "a": pa.array([1, 2, 3], pa.int64()),
@@ -1358,8 +1359,8 @@ def test_arrow_column_selection_excludes_first_column(lmdb_version_store_arrow):
     assert expected.equals(received)
 
 
-def test_arrow_buffer_released_after_write(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_arrow_buffer_released_after_write(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     sym = "lifetime_test"
     released = []
 


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ref: 11795831799

#### What does this implement or fix?
All arrow tests don't really care about the storage backend. Arrow differences are on a higher level than the storage backend.

For performance this moves almost all arrow tests to in memory storage (leaves just 1-2 basic tests per file on lmdb).

#### Any other comments?

Comparison between the previous PR and current unit test timings:

| Job | Before (PR 3037) | After (PR 3051) | Δ |                                                                                                                                                                                                  
  |---|---|---|---|                                                                                                                                                                                                                                 
  | **Linux** | | | |                                                                                                                                                                                                                               
  | 3.9 / unit-DefaultCache | 12m 35s | 18m 50s | +6m 15s |
  | 3.10 / unit-DefaultCache | 12m 04s | 13m 03s | +0m 59s |                                                                                                                                                                                        
  | 3.11 / unit-NoCache | 13m 21s | 11m 36s | −1m 45s |                                                                                                                                                                                             
  | 3.11 / unit-DefaultCache | 12m 59s | 11m 58s | −1m 01s |                                                                                                                                                                                        
  | 3.11 / unit-compat311-NoCache | 12m 21s | 15m 20s | +2m 59s |                                                                                                                                                                                   
  | 3.11 / unit-compat311-DefaultCache | 13m 30s | 11m 30s | −2m 00s | 
  | 3.12 / unit-DefaultCache | 9m 57s | 10m 59s | +1m 02s |                                                                                                                                                                                         
  | 3.13 / unit-DefaultCache | 11m 39s | 10m 42s | −0m 57s |                                                                                                                                                                                        
  | 3.14 / unit-DefaultCache | 11m 24s | 11m 21s | −0m 03s |                                                                                                                                                                                        
  | **Linux avg** | **12m 12s** | **12m 49s** | **+0m 37s** |                                                                                                                                                                                       
  | **Windows** | | | |                                                
  | 3.9 / unit-DefaultCache | 54m 38s | 73m 25s | +18m 47s |                                                                                                                                                                                        
  | 3.10 / unit-DefaultCache | 71m 18s | 47m 17s | −24m 01s |          
  | 3.11 / unit-NoCache | 56m 13s | 46m 23s | −9m 50s |                                                                                                                                                                                             
  | 3.11 / unit-DefaultCache | 71m 48s | 53m 13s | −18m 35s |          
  | 3.12 / unit-DefaultCache | 63m 03s | 44m 36s | −18m 27s |                                                                                                                                                                                       
  | 3.13 / unit-DefaultCache | 66m 17s | 50m 14s | −16m 03s |                                                                                                                                                                                       
  | 3.14 / unit-DefaultCache | 57m 55s | 57m 01s | −0m 54s |                                                                                                                                                                                        
  | **Windows avg** | **63m 02s** | **53m 10s** | **−9m 52s (−16%)** |

This speeds up the slowest test run (windows unit) by on average 10 minutes. Linux results are a bit noisier.

There is a big variance in unit test runtimes but results are still somewhat representative.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
