### PR TITLE
Fix small performance regression reading None / NaN columns after Folly upgrade

### DIFF
--- a/cpp/arcticdb/python/python_handler_data.hpp
+++ b/cpp/arcticdb/python/python_handler_data.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-#include <folly/ThreadCachedInt.h>
 
+#include <atomic>
 #include <memory>
+
+// Python 3.12 (PEP 683) made Py_None immortal: Py_INCREF on it is a no-op, so we no longer
+// need to track how many times it was used and replay the INCREFs at end-of-read.
+#define ARCTICDB_PY_NONE_IMMORTAL_HEX 0x030C0000
 
 namespace arcticdb {
 
@@ -24,9 +28,15 @@ struct PythonHandlerData {
             PyGILState_Release(gstate);
         })) {}
 
-    void increment_none_refcount(size_t increment) { none_refcount_->increment(increment); }
+    void increment_none_refcount(size_t increment) {
+#if PY_VERSION_HEX < ARCTICDB_PY_NONE_IMMORTAL_HEX
+        none_refcount_->fetch_add(increment, std::memory_order_relaxed);
+#else
+        (void)increment;
+#endif
+    }
 
-    void increment_nan_refcount(size_t increment) { nan_refcount_->increment(increment); }
+    void increment_nan_refcount(size_t increment) { nan_refcount_->fetch_add(increment, std::memory_order_relaxed); }
 
     bool is_nan_initialized() const { return static_cast<bool>(py_nan_); }
 
@@ -35,29 +45,29 @@ struct PythonHandlerData {
     /// The GIL must be acquired when this is called as it changes the refcount of the global static None variable which
     /// can be used by other Python threads
     void apply_none_refcount() {
-        const size_t cnt = none_refcount_->readFullAndReset();
+#if PY_VERSION_HEX < ARCTICDB_PY_NONE_IMMORTAL_HEX
+        const size_t cnt = none_refcount_->exchange(0, std::memory_order_acq_rel);
         internal::check<ErrorCode::E_ASSERTION_FAILURE>(
                 PyGILState_Check(), "The thread incrementing None refcount must hold the GIL"
         );
         for (size_t i = 0; i < cnt; ++i) {
             Py_INCREF(Py_None);
         }
+#endif
     }
 
     /// There is no need to hold the GIL for this operation as this python object was created by the
     /// PythonHandlerData object on a read/read_batch/etc... operation and not handled to python yet.
     void apply_nan_refcount() {
-        const size_t count = nan_refcount_->readFullAndReset();
-        for (size_t i = 0; i < count; ++i) {
-            Py_INCREF(py_nan_->ptr());
+        const size_t count = nan_refcount_->exchange(0, std::memory_order_acq_rel);
+        if (count > 0) {
+            Py_SET_REFCNT(py_nan_->ptr(), count);
         }
     }
 
   private:
-    std::shared_ptr<folly::ThreadCachedInt<uint64_t>> none_refcount_ =
-            std::make_shared<folly::ThreadCachedInt<uint64_t>>();
-    std::shared_ptr<folly::ThreadCachedInt<uint64_t>> nan_refcount_ =
-            std::make_shared<folly::ThreadCachedInt<uint64_t>>();
+    std::shared_ptr<std::atomic<uint64_t>> none_refcount_ = std::make_shared<std::atomic<uint64_t>>(0);
+    std::shared_ptr<std::atomic<uint64_t>> nan_refcount_ = std::make_shared<std::atomic<uint64_t>>(0);
     std::shared_ptr<py::handle> py_nan_;
 };
 

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2519,6 +2519,55 @@
         "version": "eee3f8539d658de25ad38be90b670970a13fc5030a402331fbe2e1a191fe18ff",
         "warmup_time": 0
     },
+    "nonreg_random_read.NonRegRandomRead.peakmem_read": {
+        "code": "class NonRegRandomRead:\n    def peakmem_read(self, libs_for_storage, rows, storage):\n        self.lib.read(self.symbol).data\n\n    def setup(self, libs_for_storage, rows, storage):\n        self.lib = libs_for_storage[storage][_lib_name(rows)]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol(rows)\n\n    def setup_cache(self):\n        start = time.time()\n        libs_for_storage = {}\n        library_names = [_lib_name(self.num_rows)]\n        df = _generate_random(self.num_rows)\n        for storage in STORAGES:\n            libs = create_libraries(storage, library_names)\n            libs_for_storage[storage] = dict(zip(library_names, libs))\n            lib = libs_for_storage[storage][library_names[0]]\n            if lib is None:\n                continue\n            lib.write(_symbol(self.num_rows), df)\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return libs_for_storage",
+        "name": "nonreg_random_read.NonRegRandomRead.peakmem_read",
+        "param_names": [
+            "rows",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "setup_cache_key": "nonreg_random_read:91",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "69353e7df39440ffe03bf80d85c4752a1f1db28aca80f47928408b8dc9b45451"
+    },
+    "nonreg_random_read.NonRegRandomRead.time_read": {
+        "code": "class NonRegRandomRead:\n    def time_read(self, libs_for_storage, rows, storage):\n        self.lib.read(self.symbol).data\n\n    def setup(self, libs_for_storage, rows, storage):\n        self.lib = libs_for_storage[storage][_lib_name(rows)]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol(rows)\n\n    def setup_cache(self):\n        start = time.time()\n        libs_for_storage = {}\n        library_names = [_lib_name(self.num_rows)]\n        df = _generate_random(self.num_rows)\n        for storage in STORAGES:\n            libs = create_libraries(storage, library_names)\n            libs_for_storage[storage] = dict(zip(library_names, libs))\n            lib = libs_for_storage[storage][library_names[0]]\n            if lib is None:\n                continue\n            lib.write(_symbol(self.num_rows), df)\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")\n        return libs_for_storage",
+        "min_run_count": 2,
+        "name": "nonreg_random_read.NonRegRandomRead.time_read",
+        "number": 0,
+        "param_names": [
+            "rows",
+            "storage"
+        ],
+        "params": [
+            [
+                "1000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 2,
+        "sample_time": 2,
+        "setup_cache_key": "nonreg_random_read:91",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "54d190c55702975510edf47cdb800becc58916ede08d29d59d38870213dabcae",
+        "warmup_time": 0.2
+    },
     "query_builder.QueryBuilderFunctions.peakmem_filtering_numeric": {
         "code": "class QueryBuilderFunctions:\n    def peakmem_filtering_numeric(self, *args):\n        self._filtering_numeric()\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n        self.null_symbol = _null_symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n    \n            df_with_nulls = df.copy()\n    \n            # Null out 90% of the id1 column, but make sure the first row has non-null id001 so the\n            # equality benchmark does return something\n            df_with_nulls.iloc[0, df_with_nulls.columns.get_loc(\"id1\")] = \"id001\"\n            null_mask = np.random.random(len(df_with_nulls)) < 0.9\n            null_mask[0] = False\n            df_with_nulls.loc[null_mask, \"id1\"] = None\n            null_sym = _null_symbol_name(rows)\n    \n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n                self.logger.info(f\"writing {df_with_nulls.shape} under {null_sym}\")\n                lib.write(null_sym, df_with_nulls)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "name": "query_builder.QueryBuilderFunctions.peakmem_filtering_numeric",

--- a/python/benchmarks/nonreg_random_read.py
+++ b/python/benchmarks/nonreg_random_read.py
@@ -57,7 +57,7 @@ def _generate_random(n):
             "col_float4": rng.standard_normal(n),
             "col_string": _make_strings(n, rng),
             "col_string_sparse": _make_sparse_strings(n, rng),
-            "col_none": np.full(n, np.nan, dtype=np.float64),
+            "col_nan": np.full(n, np.nan, dtype=np.float64),
         },
         index=pd.date_range("2026-01-01", periods=n, freq="s"),
     )

--- a/python/benchmarks/nonreg_random_read.py
+++ b/python/benchmarks/nonreg_random_read.py
@@ -1,0 +1,116 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+# Reproduces the read-time regression introduced by the folly upgrade in commit 38909e54a
+# between ArcticDB 5.10.0 and 6.1.0.
+#
+#   ┌─────────┬─────────────┐
+#   │ version │ time_read   │
+#   ├─────────┼─────────────┤
+#   │ 5.10.0  │ 44.6 ± 1 ms │
+#   ├─────────┼─────────────┤
+#   │ 6.13.0  │ 59.3 ± 1 ms │
+#   └─────────┴─────────────┘
+
+import string
+import time
+
+import numpy as np
+import pandas as pd
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
+from arcticdb.util.logger import get_logger
+from benchmarks.environment_setup import Storage, create_libraries
+
+SEED = 20260421
+STORAGES = [Storage.LMDB, Storage.AMAZON]
+
+
+def _make_strings(n, rng, length=8):
+    alphabet = np.array(list(string.ascii_lowercase), dtype="<U1")
+    chars = rng.choice(alphabet, size=(n, length))
+    return chars.view(f"<U{length}").reshape(n)
+
+
+def _make_sparse_strings(n, rng, none_fraction=0.99, length=8):
+    arr = np.full(n, None, dtype=object)
+    num_strings = n - int(n * none_fraction)
+    if num_strings > 0:
+        idx = rng.choice(n, size=num_strings, replace=False)
+        arr[idx] = _make_strings(num_strings, rng, length=length)
+    return arr
+
+
+def _generate_random(n):
+    rng = np.random.default_rng(SEED)
+    df = pd.DataFrame(
+        {
+            "col_int": rng.integers(0, 1_000_000, size=n, dtype=np.int64),
+            "col_float1": rng.standard_normal(n),
+            "col_float2": rng.standard_normal(n),
+            "col_float3": rng.standard_normal(n),
+            "col_float4": rng.standard_normal(n),
+            "col_string": _make_strings(n, rng),
+            "col_string_sparse": _make_sparse_strings(n, rng),
+            "col_none": np.full(n, np.nan, dtype=np.float64),
+        },
+        index=pd.date_range("2026-01-01", periods=n, freq="s"),
+    )
+    df.index.name = "col_datetime"
+    return df
+
+
+def _lib_name(rows):
+    return f"nonreg_random_{rows}"
+
+
+def _symbol(rows):
+    return f"sym_{rows}"
+
+
+class NonRegRandomRead:
+    timeout = 600
+    sample_time = 2
+    rounds = 2
+    repeat = (1, 10, 20.0)
+    warmup_time = 0.2
+
+    num_rows = 1_000_000
+
+    params = [[num_rows], STORAGES]
+    param_names = ["rows", "storage"]
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        start = time.time()
+        libs_for_storage = {}
+        library_names = [_lib_name(self.num_rows)]
+        df = _generate_random(self.num_rows)
+        for storage in STORAGES:
+            libs = create_libraries(storage, library_names)
+            libs_for_storage[storage] = dict(zip(library_names, libs))
+            lib = libs_for_storage[storage][library_names[0]]
+            if lib is None:
+                continue
+            lib.write(_symbol(self.num_rows), df)
+        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+        return libs_for_storage
+
+    def setup(self, libs_for_storage, rows, storage):
+        self.lib = libs_for_storage[storage][_lib_name(rows)]
+        if self.lib is None:
+            raise SkipNotImplemented
+        self.symbol = _symbol(rows)
+
+    def time_read(self, libs_for_storage, rows, storage):
+        self.lib.read(self.symbol).data
+
+    def peakmem_read(self, libs_for_storage, rows, storage):
+        self.lib.read(self.symbol).data


### PR DESCRIPTION
This fixes a small performance regression when reading columns with None or NaN values. We expect the change to only be measurable on very fast storage backends like LMDB or in-memory.

We could alternatively (mostly) fix this by just moving up to latest Folly - I'm hesitant to do that here as this saga has shown we are quite sensitive to Folly changes and it needs to be done carefully.

## Background

A user reported a slowdown between ArcticDB 5.10.0 and latest ArcticDB running reads like those in the `nonreg_random_read.py` benchmark. Their numbers were:

```
| version | 1M mean | 10M mean |
|---------|---------|----------|
| 5.10    | 0.060s  | 0.631s   |
| 6.12.1  | 0.077s  | 0.870s   |
```

A git bisect pinned the regression down to:

```
    38909e54a  Upgrade folly (#2502)      — folly 2023.09.25.00 → 2025.04.14.00
```

he issue only repro'd with the string and `col_none` columns. This narrowed the problem down to our `none_refcount_` and `nan_refcount_` handling in `python_handler_data.cpp`.

I then did another bisect within those Folly versions which pinned down the regression to [this change](https://github.com/facebook/folly/commit/2a3bd4c9b617cb6ff1f1331e6751f8b21d621193) in Folly which added extra synchronisation in `folly::ThreadLocal`. We acquire this new `forkHandlerLock_` whenever:
- A worker thread touches the None or NaN counts for the first time
- Three times when the `PythonHandlerData` is torn down

On my machine I got the following numbers, upgrading to latest Folly also helps us recover from the problem:

```
| build                                     | 1M mean (s) | 10M mean (s) |
|-------------------------------------------|-------------|--------------|
| 5.10.0 (folly 2023.09.25.00)              | 0.0484      | 0.447        |
| 6.13.0 (folly 2025.04.14.00)              | 0.0646      | 0.606        |
| master @ tree-two + folly 2026.02.23.00   | 0.0550      | 0.520        |
```

## Fix

I first added the `nonreg_random_read.py` ASV benchmark that repros the user's problem.

I also ran tests with a dataframe of 100k rows and 10k columns, with half the columns full of NaN and half full of None. These are the ones with `100kx10k` in the snippets below.

I simply changed the Folly thread locals for `std::atomic<uint64_t>` and this recovered the performance.

Without the fix:

```
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_1M
symbol: sym_1M  size: 1M
threads: cpu=16 io=24  warmup=2  iterations=20
mean=0.0635s  stdev=0.0034s  p50=0.0630s  min=0.0593s  max=0.0747s  n=20
```

```
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_100kx10k
symbol: sym_100kx10k  size-tag: 100kx10k
threads: cpu=16 io=24  warmup=2  iterations=20
mean=1.4774s  stdev=0.2175s  p50=1.5144s  min=0.9064s  max=1.7331s  n=20
```

With the move to `std::atomic`:

```
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_1M
symbol: sym_1M  size: 1M
threads: cpu=16 io=24  warmup=2  iterations=20
mean=0.0511s  stdev=0.0039s  p50=0.0504s  min=0.0451s  max=0.0633s  n=20
```

```
$ python ./bench_nan_none_read.py 
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_100kx10k
symbol: sym_100kx10k  size-tag: 100kx10k
threads: cpu=16 io=24  warmup=2  iterations=20
mean=1.3767s  stdev=0.2342s  p50=1.4399s  min=0.6685s  max=1.7649s  n=20
```

so we see in the narrow cases an improvement, and in the wide case the same results within stddev.

With a move to latest Folly instead:

```
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_1M
symbol: sym_1M  size: 1M
threads: cpu=16 io=24  warmup=2  iterations=20
mean=0.0497s  stdev=0.0029s  p50=0.0491s  min=0.0458s  max=0.0578s  n=20

python ./bench_nan_none_read.py 
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_100kx10k
symbol: sym_100kx10k  size-tag: 100kx10k
threads: cpu=16 io=24  warmup=2  iterations=20
mean=1.3818s  stdev=0.2577s  p50=1.3941s  min=0.4492s  max=1.6414s  n=20
```

With the old Folly version:

```
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_1M
symbol: sym_1M  size: 1M
threads: cpu=16 io=24  warmup=2  iterations=20
mean=0.0517s  stdev=0.0039s  p50=0.0513s  min=0.0473s  max=0.0634s  n=20
```

```
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_100kx10k
symbol: sym_100kx10k  size-tag: 100kx10k
threads: cpu=16 io=24  warmup=2  iterations=20
mean=1.4966 ...
```

*With 5.10.0+man4 we were still faster - this is due to the malloc_trim issues we discussed recently*

```
arcticdb version: 5.10.0+man4
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_100kx10k
symbol: sym_100kx10k  size-tag: 100kx10k
threads: cpu=16 io=24  warmup=2  iterations=20
mean=0.3864s  stdev=0.2791s  p50=0.3042s  min=0.2522s  max=1.2016s  n=20
```

We could fix this by just moving up to latest Folly - I'm hesitant to do that here as this saga has shown we are quite sensitive to Folly changes and it needs to be done carefully.

## Other Changes

https://peps.python.org/pep-0683/ introduces "immortal objects" (including `None`) from Python 3.12. Since we have shown here that the ref counting can be expensive, I've gotten rid of the `None` ref-counting when running on these Python versions.

We could set the `nan` as immortal too - but there is no public API in Python to do this so I chose not to.

I also made a small change to set the `NaN` refcount with one API call rather than repeated increments. This made no measurable difference to performance.

With Python 3.14 (so picking up the None change), with a dataframe of 50% None cols and 50% NaN cols:

```
(tree-two-py314) aseaton@dlonapatcs502:~/source/ArcticDB-worktree/tree-two/python DEV $ python ./bench_nan_none_read.py 
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_100kx10k
symbol: sym_100kx10k  size-tag: 100kx10k
threads: cpu=16 io=24  warmup=2  iterations=20
mean=1.5837s  stdev=0.2243s  p50=1.6384s  min=0.9165s  max=1.8272s  n=20
```

whereas without these changes we had the same within stddev:

```
$ python ./bench_nan_none_read.py 
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_100kx10k
symbol: sym_100kx10k  size-tag: 100kx10k
threads: cpu=16 io=24  warmup=2  iterations=20
mean=1.4971s  stdev=0.2179s  p50=1.5409s  min=0.7825s  max=1.8207s  n=20
```

on the normal data:

```
python ./bench_read.py 
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_1M
symbol: sym_1M  size: 1M
threads: cpu=16 io=24  warmup=2  iterations=20
mean=0.0545s  stdev=0.0040s  p50=0.0537s  min=0.0503s  max=0.0644s  n=20
```

whereas without these changes we had:

```
$ python ./bench_bbg_read.py 
arcticdb version: dev
lmdb: /data/team/data/arctic_native/aseaton/bbg_random_20260421/lmdb_dev_1M
symbol: sym_1M  size: 1M
threads: cpu=16 io=24  warmup=2  iterations=20
mean=0.0634s  stdev=0.0046s  p50=0.0617s  min=0.0580s  max=0.0737s  n=20
```