### PR TITLE
Change metadata size limit to 16MB

### DIFF
--- a/docs/mkdocs/docs/tutorials/metadata.md
+++ b/docs/mkdocs/docs/tutorials/metadata.md
@@ -60,7 +60,7 @@ variable `ARCTICDB_PickledMetadata_loglevel_str` to `DEBUG`. The log message loo
 Pickling metadata - may not be readable by other clients
 ```
 
-The metadata may be up to 4GB in size.
+The metadata may be up to 16MB in size.
 
 ### Practical example - using metadata to track vendor timelines
 


### PR DESCRIPTION
Updated the maximum size of metadata from 4GB to 16MB.

#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
