### PR TITLE
Performance 10762751693: reduce malloc trim frequency

### DIFF
--- a/cpp/arcticdb/arrow/arrow_c_interface.cpp
+++ b/cpp/arcticdb/arrow/arrow_c_interface.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <arcticdb/arrow/arrow_c_interface.hpp>
+#include <arcticdb/util/allocator.hpp>
 
 #include <vector>
 
@@ -16,30 +17,21 @@ namespace arcticdb {
 
 RecordBatchData::RecordBatchData(ArrowArray array, ArrowSchema schema) : array_(array), schema_(schema) {}
 
-ArrowOutputFrame::ArrowOutputFrame(std::shared_ptr<std::vector<sparrow::record_batch>>&& data) :
-    data_(std::move(data)) {}
+ArrowOutputFrame::ArrowOutputFrame(std::vector<sparrow::record_batch>&& data) : data_(std::move(data)) {}
 
-size_t ArrowOutputFrame::num_blocks() const {
-    if (!data_ || data_->empty())
-        return 0;
-
-    return data_->size();
-}
+size_t ArrowOutputFrame::num_blocks() const { return data_.size(); }
 
 std::vector<RecordBatchData> ArrowOutputFrame::extract_record_batches() {
     std::vector<RecordBatchData> output;
-    if (!data_) {
-        return output;
-    }
-    output.reserve(data_->size());
+    output.reserve(data_.size());
 
-    for (auto& batch : *data_) {
+    for (auto& batch : data_) {
         auto struct_array = sparrow::array{batch.extract_struct_array()};
         auto [arr, schema] = sparrow::extract_arrow_structures(std::move(struct_array));
 
         output.emplace_back(arr, schema);
     }
-
+    data_.clear();
     return output;
 }
 

--- a/cpp/arcticdb/arrow/arrow_c_interface.hpp
+++ b/cpp/arcticdb/arrow/arrow_c_interface.hpp
@@ -7,17 +7,11 @@
  */
 #pragma once
 
-#include <memory>
 #include <vector>
 
 #include <sparrow/c_interface.hpp>
+#include <sparrow/record_batch.hpp>
 #include <arcticdb/util/constructors.hpp>
-
-// Anything that transitively includes sparrow.array.hpp takes ages to build the (unused by us) std::format impl
-// So avoid including sparrow in headers where possible until this is resolved
-namespace sparrow {
-class record_batch;
-}
 
 namespace arcticdb {
 
@@ -60,9 +54,11 @@ struct RecordBatchData {
 struct ArrowOutputFrame {
     ArrowOutputFrame() = default;
 
-    ArrowOutputFrame(std::shared_ptr<std::vector<sparrow::record_batch>>&& data);
+    ARCTICDB_MOVE_ONLY_DEFAULT(ArrowOutputFrame);
 
-    std::shared_ptr<std::vector<sparrow::record_batch>> data_;
+    ArrowOutputFrame(std::vector<sparrow::record_batch>&& data);
+
+    std::vector<sparrow::record_batch> data_;
 
     std::vector<RecordBatchData> extract_record_batches();
 

--- a/cpp/arcticdb/arrow/arrow_utils.cpp
+++ b/cpp/arcticdb/arrow/arrow_utils.cpp
@@ -338,22 +338,20 @@ std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::
     return vec;
 }
 
-std::shared_ptr<std::vector<sparrow::record_batch>> segment_to_arrow_data(SegmentInMemory& segment) {
+std::vector<sparrow::record_batch> segment_to_arrow_data(SegmentInMemory& segment) {
     const auto total_blocks = segment.num_blocks();
     const auto num_columns = segment.num_columns();
     if (num_columns == 0) {
         // We can't construct a record batch with no columns, so in this case we return an empty list of record batches,
         // which needs special handling in python.
-        return std::make_shared<std::vector<sparrow::record_batch>>();
+        return std::vector<sparrow::record_batch>();
     }
     const auto column_blocks = segment.column(0).num_blocks();
     util::check(total_blocks == column_blocks * num_columns, "Expected regular block size");
 
     // column_blocks == 0 is a special case where we are returning a zero-row structure (e.g. if date_range is
     // provided outside of the time range covered by the symbol)
-    auto output = std::make_shared<std::vector<sparrow::record_batch>>(
-            column_blocks == 0 ? 1 : column_blocks, sparrow::record_batch{}
-    );
+    std::vector<sparrow::record_batch> output{column_blocks == 0 ? 1 : column_blocks, sparrow::record_batch{}};
     for (auto i = 0UL; i < num_columns; ++i) {
         auto& column = segment.column(static_cast<position_t>(i));
         util::check(
@@ -365,15 +363,15 @@ std::shared_ptr<std::vector<sparrow::record_batch>> segment_to_arrow_data(Segmen
 
         auto column_arrays = arrow_arrays_from_column(column, segment.field(i).name());
         util::check(
-                column_arrays.size() == output->size(),
+                column_arrays.size() == output.size(),
                 "Unexpected number of arrow arrays returned: {} != {}",
                 column_arrays.size(),
-                output->size()
+                output.size()
         );
 
         for (auto block_idx = 0UL; block_idx < column_arrays.size(); ++block_idx) {
-            util::check(block_idx < output->size(), "Block index overflow {} > {}", block_idx, output->size());
-            (*output)[block_idx].add_column(
+            util::check(block_idx < output.size(), "Block index overflow {} > {}", block_idx, output.size());
+            output[block_idx].add_column(
                     static_cast<std::string>(segment.field(i).name()), std::move(column_arrays[block_idx])
             );
         }

--- a/cpp/arcticdb/arrow/arrow_utils.hpp
+++ b/cpp/arcticdb/arrow/arrow_utils.hpp
@@ -35,7 +35,7 @@ struct RecordBatchData;
 
 std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::string_view name);
 
-std::shared_ptr<std::vector<sparrow::record_batch>> segment_to_arrow_data(SegmentInMemory& segment);
+std::vector<sparrow::record_batch> segment_to_arrow_data(SegmentInMemory& segment);
 
 // It would be cleaner if the index column position finding happened in the Python layer. However, finding a column by
 // name is O(n), and we have to iterate through the columns here anyway

--- a/cpp/arcticdb/arrow/test/test_arrow_read.cpp
+++ b/cpp/arcticdb/arrow/test/test_arrow_read.cpp
@@ -274,8 +274,8 @@ TEST(ArrowRead, ConvertSegmentBasic) {
 
     auto arrow_data = segment_to_arrow_data(segment);
     // We expect to see num_chunks record batches
-    EXPECT_EQ(arrow_data->size(), num_chunks);
-    for (const auto& record_batch : *arrow_data) {
+    EXPECT_EQ(arrow_data.size(), num_chunks);
+    for (const auto& record_batch : arrow_data) {
         auto names = record_batch.names();
         auto columns = record_batch.columns();
         // Each record batch should have all columns for the row range (including the index)
@@ -338,10 +338,10 @@ TEST(ArrowRead, ConvertSegmentMultipleStringColumns) {
 
     // Convert to arrow
     auto arrow_data = segment_to_arrow_data(segment);
-    EXPECT_EQ(arrow_data->size(), num_chunks);
+    EXPECT_EQ(arrow_data.size(), num_chunks);
     for (auto i = 0u; i < num_chunks; ++i) {
         auto row_count = std::min(chunk_size, num_rows - i * chunk_size);
-        const auto& record_batch = (*arrow_data)[i];
+        const auto& record_batch = (arrow_data)[i];
         auto names = record_batch.names();
         auto columns = record_batch.columns();
         // Each record batch should have all columns for the row range (including the index)

--- a/cpp/arcticdb/util/allocator.cpp
+++ b/cpp/arcticdb/util/allocator.cpp
@@ -13,7 +13,6 @@
 #include <arcticdb/util/memory_tracing.hpp>
 #include <arcticdb/util/clock.hpp>
 #include <arcticdb/util/configs_map.hpp>
-#include <arcticdb/util/thread_cached_int.hpp>
 #include <folly/concurrency/ConcurrentHashMap.h>
 
 #if defined(__linux__) && defined(__GLIBC__)
@@ -142,19 +141,36 @@ bool InMemoryTracingPolicy::deallocated() {
 
 void InMemoryTracingPolicy::clear() { data().clear(); }
 
-namespace {
-template<typename TracingPolicy, typename ClockType>
-auto& free_count_of() {
-    static ThreadCachedInt<uint32_t> free_count;
-    return free_count;
-};
-} // namespace
-
 template<typename TracingPolicy, typename ClockType>
 std::shared_ptr<AllocatorImpl<TracingPolicy, ClockType>> AllocatorImpl<TracingPolicy, ClockType>::instance_;
 
 template<typename TracingPolicy, typename ClockType>
 std::once_flag AllocatorImpl<TracingPolicy, ClockType>::init_flag_;
+
+#if defined(__linux__) && defined(__GLIBC__)
+template<typename TracingPolicy, typename ClockType>
+ThreadCachedInt<uint32_t> AllocatorImpl<TracingPolicy, ClockType>::free_count_;
+
+template<typename TracingPolicy, typename ClockType>
+std::atomic<entity::timestamp> AllocatorImpl<TracingPolicy, ClockType>::last_trim_time_ms_ = 0;
+
+template<class TracingPolicy, class ClockType>
+void AllocatorImpl<TracingPolicy, ClockType>::maybe_trim() {
+    // Moving this to a static member of AllocatorImpl would subtly change the initialisation time in a way that could
+    // break existing usage. Initalise trim_min_interval_ms at the same time for consistency.
+    static const uint32_t trim_count = ConfigsMap::instance()->get_int("Allocator.TrimCount", 250);
+    static const entity::timestamp trim_min_interval_ms =
+            ConfigsMap::instance()->get_int("Allocator.TrimMinIntervalMs", 10'000);
+    if (free_count_.readFast() > trim_count && free_count_.readFastAndReset() > trim_count) {
+        auto last_trim_time_ms = last_trim_time_ms_.load();
+        auto now_ms = util::SysClock::coarse_nanos_since_epoch() / 1'000'000;
+        if (now_ms - last_trim_time_ms > trim_min_interval_ms &&
+            last_trim_time_ms_.compare_exchange_strong(last_trim_time_ms, now_ms, std::memory_order_relaxed)) {
+            trim();
+        }
+    }
+}
+#endif
 
 template<class TracingPolicy, class ClockType>
 uint8_t* AllocatorImpl<TracingPolicy, ClockType>::get_alignment(size_t size) {
@@ -202,8 +218,10 @@ void AllocatorImpl<TracingPolicy, ClockType>::internal_free(uint8_t* p) {
     }
 #else
     std::free(p);
-    free_count_of<TracingPolicy, ClockType>().increment(1);
+#if defined(__linux__) && defined(__GLIBC__)
+    free_count_.increment(1);
     maybe_trim();
+#endif
 #endif
 }
 
@@ -274,14 +292,6 @@ void AllocatorImpl<TracingPolicy, ClockType>::trim() {
 #if defined(__linux__) && defined(__GLIBC__)
     malloc_trim(0);
 #endif
-}
-
-template<class TracingPolicy, class ClockType>
-void AllocatorImpl<TracingPolicy, ClockType>::maybe_trim() {
-    static const uint32_t trim_count = ConfigsMap::instance()->get_int("Allocator.TrimCount", 250);
-    if (free_count_of<TracingPolicy, ClockType>().readFast() > trim_count &&
-        free_count_of<TracingPolicy, ClockType>().readFastAndReset() > trim_count)
-        trim();
 }
 
 template<typename TracingPolicy, typename ClockType>

--- a/cpp/arcticdb/util/allocator.hpp
+++ b/cpp/arcticdb/util/allocator.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <arcticdb/util/clock.hpp>
+#include <arcticdb/util/thread_cached_int.hpp>
 #include <memory>
 
 #if USE_SLAB_ALLOCATOR
@@ -141,6 +142,12 @@ class AllocatorImpl {
     static void internal_free(uint8_t* p);
     static uint8_t* internal_realloc(uint8_t* p, std::size_t size);
 
+#if defined(__linux__) && defined(__GLIBC__)
+    static ThreadCachedInt<uint32_t> free_count_;
+    static std::atomic<entity::timestamp> last_trim_time_ms_;
+    static void maybe_trim();
+#endif
+
   public:
     static std::shared_ptr<AllocatorImpl> instance_;
     static std::once_flag init_flag_;
@@ -150,7 +157,6 @@ class AllocatorImpl {
     static void destroy_instance();
     static std::pair<uint8_t*, entity::timestamp> alloc(size_t size, bool no_realloc ARCTICDB_UNUSED = false);
     static void trim();
-    static void maybe_trim();
     static std::pair<uint8_t*, entity::timestamp> aligned_alloc(size_t size, bool no_realloc = false);
     static std::pair<uint8_t*, entity::timestamp> realloc(std::pair<uint8_t*, entity::timestamp> ptr, size_t size);
     static void free(std::pair<uint8_t*, entity::timestamp> ptr);

--- a/cpp/arcticdb/version/python_bindings_common.cpp
+++ b/cpp/arcticdb/version/python_bindings_common.cpp
@@ -27,7 +27,9 @@ void register_version_store_common_bindings(py::module& version, BindingScope sc
             .def("extract_numpy_arrays",
                  [](PandasOutputFrame& self) { return python_util::extract_numpy_arrays(self); });
 
-    py::class_<ArrowOutputFrame>(version, "ArrowOutputFrame", py::module_local(local_bindings))
+    py::class_<ArrowOutputFrame, std::shared_ptr<ArrowOutputFrame>>(
+            version, "ArrowOutputFrame", py::module_local(local_bindings)
+    )
             .def("extract_record_batches", &ArrowOutputFrame::extract_record_batches);
 }
 


### PR DESCRIPTION
#### Reference Issues/PRs
[10762751693](https://man312219.monday.com/boards/7852509418/pulses/10762751693)

#### What does this implement or fix?
Previously `malloc_trim` was called every 250 times a `Buffer`, or a `MemBlock` within a `ChunkedBuffer` was freed. This is problematic with wide dataframes in general, and particularly in `read_batch`, where `malloc_trim` is then called 100s or 1000s of times in quick succession, with the performance of the trim call degrading over time.

This change rate limits the calls, by default to no more often than once every 10s. The previous behaviour can be recovered if desired by setting this minimum period to zero.

Timings for checked in test (this will be removed before merge, only present to illustrate):
```
Master
	serial 20.95
	batch  34.76
Branch
	serial 17.48
	batch  14.96
```