### PR TITLE
Configure logging on duplicate LMDB libraries via config map

### DIFF
--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -128,8 +128,8 @@ jobs:
             fi
             echo "FINAL selection to execute SUITE=$SUITE"
             echo "SUITE=$SUITE" >> $GITHUB_ENV
-            # Now lets reduce logging
             echo "ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0" >> $GITHUB_ENV
+            echo "ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all" >> $GITHUB_ENV
 
       - name: Benchmark given commit
         if: github.event_name != 'pull_request' || inputs.benchmark_all_tags == true

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -649,8 +649,6 @@ jobs:
           openssl version -d 
           # list file descriptors and other limits of the runner
           ulimit -a
-          export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
-          export ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all
           if [[ "$(echo "$ARCTICDB_PYTEST_ARGS" | xargs)" == pytest* ]]; then
             python -m pip  install pytest-repeat setuptools wheel
             python setup.py protoc --build-lib python
@@ -669,6 +667,8 @@ jobs:
           STORAGE_TYPE: ${{ env.real_tests_storage_type }}
           # Testing with 0(no version cache) and -1(will use default timeout)
           VERSION_MAP_RELOAD_INTERVAL: ${{matrix.version_cache_timeout == 'NoCache' && 0 || -1}}
+          ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME: 0
+          ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR: all
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -650,6 +650,7 @@ jobs:
           # list file descriptors and other limits of the runner
           ulimit -a
           export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
+          export ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all
           if [[ "$(echo "$ARCTICDB_PYTEST_ARGS" | xargs)" == pytest* ]]; then
             python -m pip  install pytest-repeat setuptools wheel
             python setup.py protoc --build-lib python

--- a/.github/workflows/compile_and_test_with_conda.yml
+++ b/.github/workflows/compile_and_test_with_conda.yml
@@ -308,8 +308,6 @@ jobs:
           echo "Run commandline: $COMMANDLINE"
           eval "$COMMANDLINE"
           export ARCTICDB_RAND_SEED=$RANDOM
-          export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
-          export ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all
           python setup.py protoc --build-lib python
           if [[ "$(echo "$ARCTICDB_PYTEST_ARGS" | xargs)" == pytest* ]]; then
             echo "Run custom pytest command: $ARCTICDB_PYTEST_ARGS"
@@ -333,3 +331,5 @@ jobs:
           ARCTICDB_PYTEST_ARGS: ${{inputs.run_custom_pytest_command}}
           STORAGE_TYPE: ${{inputs.persistent_storage == 'no' && 'LMDB' || inputs.persistent_storage}}
           NODE_OPTIONS: --openssl-legacy-provider
+          ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME: 0
+          ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR: all

--- a/.github/workflows/compile_and_test_with_conda.yml
+++ b/.github/workflows/compile_and_test_with_conda.yml
@@ -309,6 +309,7 @@ jobs:
           eval "$COMMANDLINE"
           export ARCTICDB_RAND_SEED=$RANDOM
           export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
+          export ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all
           python setup.py protoc --build-lib python
           if [[ "$(echo "$ARCTICDB_PYTEST_ARGS" | xargs)" == pytest* ]]; then
             echo "Run custom pytest command: $ARCTICDB_PYTEST_ARGS"

--- a/.github/workflows/installation_tests.yml
+++ b/.github/workflows/installation_tests.yml
@@ -263,6 +263,7 @@ jobs:
         echo "ARCTICDB_STORAGE_GCP=${{ env.real_gcp }}" >> $GITHUB_ENV        
         echo "ARCTICDB_PERSISTENT_STORAGE_TESTS=1" >> $GITHUB_ENV
         echo "ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0" >> $GITHUB_ENV
+        echo "ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all" >> $GITHUB_ENV
     
     - name: Set environment variables based on arcticdb version for GCP
       if: ${{ env.SKIP_JOB != 'true' }}

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -22,6 +22,7 @@ if [ "$VERSION_MAP_RELOAD_INTERVAL" != "-1" ]; then
 fi
 
 export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
+export ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all
 # Enable faulthandler so SIGSEGV/SIGBUS dump tracebacks to stderr
 export PYTHONFAULTHANDLER=1
 # Arm a C-level per-test watchdog that dumps tracebacks and kills the worker

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -21,8 +21,6 @@ if [ "$VERSION_MAP_RELOAD_INTERVAL" != "-1" ]; then
     export ARCTICDB_VersionMap_ReloadInterval_int=$VERSION_MAP_RELOAD_INTERVAL
 fi
 
-export ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME=0
-export ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR=all
 # Enable faulthandler so SIGSEGV/SIGBUS dump tracebacks to stderr
 export PYTHONFAULTHANDLER=1
 # Arm a C-level per-test watchdog that dumps tracebacks and kills the worker

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -469,23 +469,33 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
     );
 }
 
-void LmdbStorage::warn_if_lmdb_already_open() {
-    uint64_t& count_for_pid = ++times_path_opened[lib_dir_.string()];
-    // Only warn for the "base" config library to avoid spamming users with more warnings if they decide to ignore it
-    // and continue
-    if (count_for_pid != 1 && lib_dir_.string().find(CONFIG_LIBRARY_NAME) != std::string::npos) {
-        std::filesystem::path user_facing_path = lib_dir_;
-        // Strip magic name from warning as it will confuse users
-        user_facing_path.remove_filename();
-        log::storage().warn(fmt::format(
-                "LMDB path at {} has already been opened in this process which is not supported by LMDB. "
-                "You should only open a single Arctic instance over a given LMDB path. "
-                "To continue safely, you should delete this Arctic instance and any others over the LMDB path in this "
-                "process and then try again. Current process ID=[{}]",
-                user_facing_path.string(),
-                getpid()
-        ));
+void LmdbStorage::warn_if_lmdb_already_open() const {
+    const std::string warn_setting =
+            util::to_lower(ConfigsMap::instance()->get_string("LMDBStorage.WarnIfOpened", "config"));
+    const uint64_t& count_for_pid = ++times_path_opened[lib_dir_.string()];
+    if (warn_setting == "none") {
+        return;
     }
+    if (count_for_pid != 1) {
+        if (warn_setting == "all" ||
+            (warn_setting == "config" && lib_dir_.string().find(CONFIG_LIBRARY_NAME) != std::string::npos)) {
+            print_warning_if_lmdb_already_open();
+        }
+    }
+}
+
+void LmdbStorage::print_warning_if_lmdb_already_open() const {
+    std::filesystem::path user_facing_path = lib_dir_;
+    // Strip magic name from warning as it will confuse users
+    user_facing_path.remove_filename();
+    log::storage().warn(fmt::format(
+            "LMDB path at {} has already been opened in this process which is not supported by LMDB. "
+            "You should only open a single Arctic instance over a given LMDB path. "
+            "To continue safely, you should delete this Arctic instance and any others over the LMDB path in this "
+            "process and then try again. Current process ID=[{}]",
+            user_facing_path.string(),
+            getpid()
+    ));
 }
 
 LmdbStorage::LmdbStorage(LmdbStorage&& other) noexcept :

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -477,9 +477,22 @@ void LmdbStorage::warn_if_lmdb_already_open() const {
         return;
     }
     if (count_for_pid != 1) {
-        if (warn_setting == "all" ||
-            (warn_setting == "config" && lib_dir_.string().find(CONFIG_LIBRARY_NAME) != std::string::npos)) {
+        if (warn_setting == "all") {
             print_warning_if_lmdb_already_open();
+        } else if (warn_setting == "config") {
+            if (lib_dir_.string().find(CONFIG_LIBRARY_NAME) != std::string::npos) {
+                print_warning_if_lmdb_already_open();
+            }
+        } else {
+            static bool wrong_env_warned = false;
+            if (!wrong_env_warned) {
+                log::storage().warn(fmt::format(
+                        "Wrong config map setting: LMDBStorage.WarnIfOpened is set to '{}'. Allowed values are: "
+                        "\"none\", \"config\", \"all\"",
+                        warn_setting
+                ));
+                wrong_env_warned = true;
+            }
         }
     }
 }

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -73,7 +73,12 @@ class LmdbStorage final : public Storage {
 
     std::string do_key_path(const VariantKey&) const final { return {}; };
 
-    void warn_if_lmdb_already_open();
+    /// Checks the config map for LMDBStorage.WarnIfOpened and warns if the same LMDB path is opened more than once
+    /// by the same process based on it. LMDBStorage.WarnIfOpened has three values: none - don't warn, config (default)
+    /// warn only for the "base" config library to avoid spamming users, all - warn for any lmdb library opened more
+    /// than once.
+    void warn_if_lmdb_already_open() const;
+    void print_warning_if_lmdb_already_open() const;
 
     // _internal methods assume the write mutex is already held
     void do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn);


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 10535827729

#### What does this implement or fix?

This does not fix the 10535827729. I suspect that the python fixture allows us to open two LMDB databases from the same process which is not supported. This adds warnings in the logs so that the next time this happens in the CI we can check if there's a warning.

It adds three ways to configure the warning:

1. none - no warnings at all
2. config - default level keeps the current behavior and warns only if the config library is opened twice in the same process
3. all - warns if any LMDB library is opened twice in the same process

The CI is configured to `all`
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
