### PR TITLE
Enhancement 11518164303: method for checking fragmentation

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -223,6 +223,7 @@ set(arcticdb_srcs
         column_store/segment_utils.hpp
         column_store/memory_segment_pretty_print.hpp
         entity/atom_key.hpp
+        entity/compact_data_info.hpp
         entity/frame_and_descriptor.hpp
         entity/index_range.hpp
         entity/key.hpp
@@ -466,6 +467,7 @@ set(arcticdb_srcs
         column_store/segment_utils.cpp
         column_store/statistics.hpp
         column_store/string_pool.cpp
+        entity/compact_data_info.cpp
         entity/data_error.cpp
         entity/field_collection.cpp
         entity/field_collection_proto.cpp

--- a/cpp/arcticdb/entity/compact_data_info.cpp
+++ b/cpp/arcticdb/entity/compact_data_info.cpp
@@ -1,0 +1,58 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/entity/compact_data_info.hpp>
+
+namespace arcticdb {
+namespace entity {
+
+CompactDataInfo::CompactDataInfo(
+        std::vector<uint64_t>&& row_slices_before, std::vector<uint64_t>&& row_slices_after,
+        VersionId version_id_before, VersionId version_id_after
+) :
+    row_slices_before_(std::move(row_slices_before)),
+    row_slices_after_(std::move(row_slices_after)),
+    version_id_before_(version_id_before),
+    version_id_after_(version_id_after) {}
+
+std::vector<uint64_t> CompactDataInfo::row_slices_before() const { return row_slices_before_; }
+
+std::vector<uint64_t> CompactDataInfo::row_slices_after() const { return row_slices_after_; }
+
+size_t CompactDataInfo::num_row_slices_before() const {
+    // By construction, row_slices_before_.size() != 1. If there is a single row-slice, the vector will look like [0, n]
+    // where n is the number of rows
+    return row_slices_before_.empty() ? 0 : row_slices_before_.size() - 1;
+}
+
+size_t CompactDataInfo::num_row_slices_after() const {
+    // By construction, row_slices_after_.size() != 1. If there is a single row-slice, the vector will look like [0, n]
+    // where n is the number of rows
+    return row_slices_after_.empty() ? 0 : row_slices_after_.size() - 1;
+}
+
+VersionId CompactDataInfo::version_id_before() const { return version_id_before_; }
+
+VersionId CompactDataInfo::version_id_after() const { return version_id_after_; }
+
+bool CompactDataInfo::will_do_work() const { return version_id_after_ != version_id_before_; }
+
+std::string CompactDataInfo::to_string() const {
+    return fmt::format(
+            "CompactDataInfo(will_do_work={}, version_id_before={}, version_id_after={}, num_row_slices_before={}, "
+            "num_row_slices_after={})",
+            will_do_work(),
+            version_id_before(),
+            version_id_after(),
+            num_row_slices_before(),
+            num_row_slices_after()
+    );
+}
+
+} // namespace entity
+} // namespace arcticdb

--- a/cpp/arcticdb/entity/compact_data_info.hpp
+++ b/cpp/arcticdb/entity/compact_data_info.hpp
@@ -1,0 +1,44 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <arcticdb/entity/types.hpp>
+
+namespace arcticdb {
+namespace entity {
+
+class CompactDataInfo {
+  public:
+    CompactDataInfo(
+            std::vector<uint64_t>&& row_slices_before, std::vector<uint64_t>&& row_slices_after,
+            VersionId version_id_before, VersionId version_id_after
+    );
+
+    ARCTICDB_MOVE_COPY_DEFAULT(CompactDataInfo);
+
+    std::vector<uint64_t> row_slices_before() const;
+    std::vector<uint64_t> row_slices_after() const;
+    size_t num_row_slices_before() const;
+    size_t num_row_slices_after() const;
+    VersionId version_id_before() const;
+    VersionId version_id_after() const;
+    bool will_do_work() const;
+    std::string to_string() const;
+
+  private:
+    std::vector<uint64_t> row_slices_before_;
+    std::vector<uint64_t> row_slices_after_;
+    VersionId version_id_before_;
+    VersionId version_id_after_;
+};
+} // namespace entity
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -1242,6 +1242,12 @@ CompactDataClause::CompactDataClause(uint64_t rows_per_segment) : rows_per_segme
     max_rows_per_segment_ = std::max((4 * rows_per_segment_) / 3, rows_per_segment_ + 1);
 }
 
+bool CompactDataClause::row_ranges_all_acceptable_lengths(const std::set<RowRange>& row_ranges) const {
+    return std::ranges::all_of(row_ranges, [this](const RowRange& row_range) {
+        return min_rows_per_segment_ <= row_range.diff() && row_range.diff() <= max_rows_per_segment_;
+    });
+}
+
 // Given the set of row ranges in the input data:
 // {[0, x1), [x1, x2), ..., [xn-1, xn), [xn, total_rows)}
 // produces a covering set of output row ranges
@@ -1308,9 +1314,7 @@ std::vector<std::vector<size_t>> CompactDataClause::structure_for_processing(std
     }
     // The greedy algorithm in structure_row_ranges can reslice data where all segments have an acceptable number of
     // rows, which is not desirable, so short-circuit out if this is the case
-    if (std::ranges::all_of(row_ranges, [this](const RowRange& row_range) {
-            return min_rows_per_segment_ <= row_range.diff() && row_range.diff() <= max_rows_per_segment_;
-        })) {
+    if (row_ranges_all_acceptable_lengths(row_ranges)) {
         log::version().info("No work to do in CompactDataClause, data is already compacted");
         ranges_and_keys.clear();
         return {};

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -969,7 +969,8 @@ struct CompactDataClause {
 
     [[nodiscard]] std::string to_string() const;
 
-    // Public only for testing purposes
+    [[nodiscard]] bool row_ranges_all_acceptable_lengths(const std::set<RowRange>& row_ranges) const;
+
     [[nodiscard]] std::set<RowRange> structure_row_ranges(const std::set<RowRange>& row_ranges) const;
 };
 } // namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1323,21 +1323,40 @@ std::variant<VersionedItem, CompactionError> LocalVersionedEngine::compact_incom
     return versioned_item;
 }
 
-VersionedItem LocalVersionedEngine::compact_data_internal(
-        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
-) {
-    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data");
-    py::gil_scoped_release release_gil;
+UpdateInfo LocalVersionedEngine::compact_data_preamble(const StreamId& stream_id) {
     UpdateInfo update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
     storage::check<ErrorCode::E_SYMBOL_NOT_FOUND>(
             update_info.previous_index_key_.has_value(), "Cannot compact data of non-existent symbol \"{}\".", stream_id
     );
     // We could make this work by compacting the leaf nodes, but it is not obviously worth the effort at this stage
+    // Leaf nodes of recursively normalized data cannot become fragmented through appends/updates, so it would only be
+    // useful for changing the slicing by an explicitly provided rows_per_segment
     schema::check<ErrorCode::E_OPERATION_NOT_SUPPORTED_WITH_RECURSIVE_NORMALIZED_DATA>(
             update_info.previous_index_key_->type() != KeyType::MULTI_KEY,
             "Cannot compact data of recursively normalized symbol {}",
             stream_id
     );
+    return update_info;
+}
+
+CompactDataInfo LocalVersionedEngine::compact_data_explain_plan_internal(
+        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
+) {
+    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data_explain_plan");
+    py::gil_scoped_release release_gil;
+    UpdateInfo update_info = compact_data_preamble(stream_id);
+    return compact_data_explain_plan_impl(
+                   store(), update_info, rows_per_segment.value_or(get_write_options().segment_row_size)
+    )
+            .get();
+}
+
+VersionedItem LocalVersionedEngine::compact_data_internal(
+        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
+) {
+    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data");
+    py::gil_scoped_release release_gil;
+    UpdateInfo update_info = compact_data_preamble(stream_id);
     auto versioned_item = compact_data_impl(
                                   store(),
                                   VersionedItem{*update_info.previous_index_key_},

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -325,6 +325,10 @@ class LocalVersionedEngine : public VersionedEngine {
             const StreamId& stream_id, const VersionQuery& version_query
     );
 
+    CompactDataInfo compact_data_explain_plan_internal(
+            const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
+    ) override;
+
     VersionedItem compact_data_internal(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
     ) override;
@@ -454,6 +458,7 @@ class LocalVersionedEngine : public VersionedEngine {
     void add_to_symbol_list_on_compaction(
             const StreamId& stream_id, const CompactIncompleteParameters& parameters, const UpdateInfo& update_info
     );
+    UpdateInfo compact_data_preamble(const StreamId& stream_id);
 
     std::shared_ptr<Store> store_;
     arcticdb::proto::storage::VersionStoreConfig cfg_;

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -337,6 +337,37 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
             .def_property_readonly("index_segment", &DescriptorItem::index_segment)
             .def_property_readonly("column_stats_segment", &DescriptorItem::column_stats_segment);
 
+    py::class_<CompactDataInfo, std::shared_ptr<CompactDataInfo>>(version, "CompactDataInfo", R"pbdoc(
+        Result returned by the compact_data_explain_plan method. Contains information about what the effect of calling
+        compact_data would be on the specified symbol.
+
+        Attributes
+        ----------
+        row_slices_before : List[int]
+            The row numbers of boundaries between row-slices in the current latest version
+        row_slices_after : List[int]
+            What the row numbers of boundaries between row-slices would be after calling compact_data
+        num_row_slices_before : int
+            The number of row-slices in the current latest version
+        num_row_slices_after : int
+            What the number of row-slices would be after calling compact_data
+        version_id_before : int
+            The version id of the current latest version
+        version_id_after : int
+            What the version id would be after calling compact_data
+        will_do_work : bool
+            Whether calling compact_data would do any compaction. If False, the current data is already suitably
+            compacted.
+)pbdoc")
+            .def_property_readonly("row_slices_before", &CompactDataInfo::row_slices_before)
+            .def_property_readonly("row_slices_after", &CompactDataInfo::row_slices_after)
+            .def_property_readonly("num_row_slices_before", &CompactDataInfo::num_row_slices_before)
+            .def_property_readonly("num_row_slices_after", &CompactDataInfo::num_row_slices_after)
+            .def_property_readonly("version_id_before", &CompactDataInfo::version_id_before)
+            .def_property_readonly("version_id_after", &CompactDataInfo::version_id_after)
+            .def_property_readonly("will_do_work", &CompactDataInfo::will_do_work)
+            .def("__repr__", &CompactDataInfo::to_string);
+
     py::class_<StageResult>(version, "StageResult", R"pbdoc(
         Result returned by the stage method containing information about staged segments.
         
@@ -697,6 +728,10 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                  &PythonVersionStore::compact_library,
                  py::call_guard<SingleThreadMutexHolder>(),
                  "Compact the whole library wherever necessary")
+            .def("_compact_data_explain_plan",
+                 &PythonVersionStore::compact_data_explain_plan,
+                 py::call_guard<SingleThreadMutexHolder>(),
+                 "Calculates what the new row-slice distribution would be after calling compact_data")
             .def("_compact_data",
                  &PythonVersionStore::compact_data,
                  py::call_guard<SingleThreadMutexHolder>(),

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -8,6 +8,7 @@
 
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/column_store/column_algorithms.hpp>
+#include <arcticdb/column_store/column_reslicer.hpp>
 #include <column_stats.pb.h>
 #include <arcticdb/stream/segment_aggregator.hpp>
 #include <arcticdb/pipeline/write_frame.hpp>
@@ -3143,6 +3144,72 @@ folly::Future<VersionedItem> merge_update_impl(
                         store
                 );
             });
+}
+
+folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, uint64_t rows_per_segment
+) {
+    VersionIdentifier resolved_version = std::make_shared<IndexInformation>(
+            read_index_key_without_column_stats(store, *update_info.previous_index_key_)
+    );
+    return async::submit_io_task(
+                   SetupPipelineContextTask{store, std::move(resolved_version), std::make_shared<ReadQuery>(), {}}
+    ).thenValueInline([update_info, rows_per_segment](auto&& pipeline_context) -> CompactDataInfo {
+        auto ranges_and_keys = generate_ranges_and_keys(*pipeline_context);
+        if (ranges_and_keys.empty()) {
+            return {{}, {}, update_info.previous_index_key_->version_id(), update_info.previous_index_key_->version_id()
+            };
+        }
+        // Extract the unique row ranges
+        std::set<RowRange> row_ranges;
+        std::vector<uint64_t> row_slices_before;
+        for (const auto& range_and_key : ranges_and_keys) {
+            const auto& row_range = range_and_key.row_range();
+            if (row_ranges.insert(row_range).second) {
+                if (row_slices_before.empty()) {
+                    util::check(row_range.first == 0, "Unexpected non-zero first row-range entry {}", row_range.first);
+                    row_slices_before.emplace_back(0);
+                } else {
+                    util::check(
+                            row_range.first == row_slices_before.back(),
+                            "Unexpected mismatch between row ranges {} != {}",
+                            row_range.first,
+                            row_slices_before.back()
+                    );
+                }
+                row_slices_before.emplace_back(row_range.second);
+            }
+        }
+        CompactDataClause clause{rows_per_segment};
+        std::vector<uint64_t> row_slices_after;
+        VersionId version_id_after;
+        // If there is only 1 segment, and it has fewer than min_rows_per_segment, then the compaction will be a no-op
+        if (clause.row_ranges_all_acceptable_lengths(row_ranges) ||
+            (row_ranges.size() == 1 && row_ranges.cbegin()->diff() < clause.min_rows_per_segment_)) {
+            version_id_after = update_info.previous_index_key_->version_id();
+            row_slices_after = row_slices_before;
+        } else {
+            version_id_after = update_info.next_version_id_;
+            auto processing_row_ranges = clause.structure_row_ranges(row_ranges);
+            row_slices_after.emplace_back(0);
+            for (const auto& row_range : processing_row_ranges) {
+                ReslicingInfo reslicing_info(row_range.diff(), clause.max_rows_per_segment_);
+                for (uint64_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+                    row_slices_after.emplace_back(row_slices_after.back() + reslicing_info.rows_in_slice(idx));
+                }
+            }
+        }
+        util::check(
+                row_slices_before.back() == row_slices_after.back(),
+                "Mismatching row counts in compact_data_explain_plan {} != {}",
+                row_slices_before.back(),
+                row_slices_after.back()
+        );
+        return {std::move(row_slices_before),
+                std::move(row_slices_after),
+                update_info.previous_index_key_->version_id(),
+                version_id_after};
+    });
 }
 
 folly::Future<std::optional<VersionedItem>> compact_data_impl(

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <arcticdb/entity/compact_data_info.hpp>
 #include <arcticdb/entity/versioned_item.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
 #include <arcticdb/pipeline/query.hpp>
@@ -199,6 +200,10 @@ folly::Future<VersionedItem> merge_update_impl(
         const std::shared_ptr<Store>& store, const VersionIdentifier& version_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
         std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source
+);
+
+folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, uint64_t rows_per_segment
 );
 
 folly::Future<std::optional<VersionedItem>> compact_data_impl(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1498,6 +1498,12 @@ VersionedItem PythonVersionStore::merge(
     );
 }
 
+CompactDataInfo PythonVersionStore::compact_data_explain_plan(
+        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
+) {
+    return compact_data_explain_plan_internal(stream_id, rows_per_segment);
+}
+
 VersionedItem PythonVersionStore::compact_data(
         const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
 ) {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -297,6 +297,8 @@ class PythonVersionStore : public LocalVersionedEngine {
             std::vector<std::string> on
     );
 
+    CompactDataInfo compact_data_explain_plan(const StreamId& stream_id, std::optional<uint64_t> rows_per_segment);
+
     VersionedItem compact_data(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
     );

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -135,6 +135,10 @@ class VersionedEngine {
 
     virtual std::set<StreamId> get_active_incomplete_refs() = 0;
 
+    virtual CompactDataInfo compact_data_explain_plan_internal(
+            const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
+    ) = 0;
+
     virtual VersionedItem compact_data_internal(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
     ) = 0;

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -34,7 +34,7 @@ import time
 from arcticdb.dependencies import pyarrow as pa
 from arcticdb.dependencies import polars as pl
 from arcticc.pb2.descriptors_pb2 import IndexDescriptor, TypeDescriptor
-from arcticdb_ext.version_store import RecordBatchData, SortedValue, StageResult
+from arcticdb_ext.version_store import CompactDataInfo, RecordBatchData, SortedValue, StageResult
 from arcticc.pb2.storage_pb2 import LibraryConfig, EnvironmentConfigsMap
 from arcticdb.preconditions import check
 from arcticdb.supported_types import DateRangeInput, ExplicitlySupportedDates
@@ -3968,6 +3968,67 @@ class NativeVersionStore:
         udm = normalize_metadata(metadata)
         v = self.version_store.write_metadata(symbol, udm, prune_previous_version)
         return self._convert_thin_cxx_item_to_python(v, metadata)
+
+    def compact_data_explain_plan_experimental(
+        self,
+        symbol: str,
+        rows_per_segment: Optional[int] = None,
+    ) -> CompactDataInfo:
+        """
+        Do a dry run of compact_data_experimental, demonstrating what the impact would be of calling
+        compact_data_experimental without actually modifying any data on disk.
+
+        Parameters
+        ----------
+        symbol : str
+            The symbol to perform the dry run on.
+        rows_per_segment : Optional[int], default=None
+            The target number of rows for each segment after the compaction. If None, uses the library configuration
+            setting.
+
+        Returns
+        -------
+        CompactDataInfo
+            Structure containing information about what the fragmentation of the symbol looks like currently, and what
+            it would look like after a call to compact_data_experimental.
+
+        Raises
+        ------
+        StorageException
+            If symbol doesn't exist
+        ArcticNativeException
+            If invalid rows_per_segment is provided
+        SchemaException
+            If the existing data is recursively normalized
+
+        Examples
+        --------
+
+        >>> df = pd.DataFrame({"col": np.arange(100_000)})
+        >>> for idx in range(100):
+        >>>     lib.append("sym", df[idx * 1_000: (idx + 1) * 1_000])
+        >>> compact_data_info = lib.compact_data_explain_plan_experimental("sym")
+        >>> compact_data_info.row_slices_before
+        [0, 1000, 2000, ..., 99000, 100000]
+        >>> compact_data_info.row_slices_after
+        [0, 100000]
+        >>> compact_data_info.num_row_slices_before
+        100
+        >>> compact_data_info.num_row_slices_after
+        1
+        >>> compact_data_info.version_id_before
+        99
+        >>> compact_data_info.version_id_after
+        100
+        >>> compact_data_info.will_do_work
+        True
+        """
+        check(
+            rows_per_segment is None or rows_per_segment > 0,
+            f"rows_per_segment must be >0, received {rows_per_segment}",
+        )
+        res = self.version_store._compact_data_explain_plan(symbol, rows_per_segment)
+        return res
 
     def compact_data_experimental(
         self,

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -35,6 +35,7 @@ from arcticdb.version_store._store import (
 )
 from arcticdb_ext.exceptions import ArcticException
 from arcticdb_ext.version_store import (
+    CompactDataInfo,
     DataError,
     StageResult,
     KeyNotFoundInStageResultInfo,
@@ -3186,6 +3187,62 @@ class Library:
             Storage lock required to compact the symbol list could not be acquired
         """
         return self._nvs.compact_symbol_list()
+
+    def compact_data_explain_plan_experimental(
+        self,
+        symbol: str,
+        rows_per_segment: Optional[int] = None,
+    ) -> CompactDataInfo:
+        """
+        Do a dry run of compact_data_experimental, demonstrating what the impact would be of calling
+        compact_data_experimental without actually modifying any data on disk.
+
+        Parameters
+        ----------
+        symbol : str
+            The symbol to perform the dry run on.
+        rows_per_segment : Optional[int], default=None
+            The target number of rows for each segment after the compaction. If None, uses the library configuration
+            setting.
+
+        Returns
+        -------
+        CompactDataInfo
+            Structure containing information about what the fragmentation of the symbol looks like currently, and what
+            it would look like after a call to compact_data_experimental.
+
+        Raises
+        ------
+        StorageException
+            If symbol doesn't exist
+        ArcticNativeException
+            If invalid rows_per_segment is provided
+        SchemaException
+            If the existing data is recursively normalized
+
+        Examples
+        --------
+
+        >>> df = pd.DataFrame({"col": np.arange(100_000)})
+        >>> for idx in range(100):
+        >>>     lib.append("sym", df[idx * 1_000: (idx + 1) * 1_000])
+        >>> compact_data_info = lib.compact_data_explain_plan_experimental("sym")
+        >>> compact_data_info.row_slices_before
+        [0, 1000, 2000, ..., 99000, 100000]
+        >>> compact_data_info.row_slices_after
+        [0, 100000]
+        >>> compact_data_info.num_row_slices_before
+        100
+        >>> compact_data_info.num_row_slices_after
+        1
+        >>> compact_data_info.version_id_before
+        99
+        >>> compact_data_info.version_id_after
+        100
+        >>> compact_data_info.will_do_work
+        True
+        """
+        return self._nvs.compact_data_explain_plan_experimental(symbol, rows_per_segment)
 
     def compact_data_experimental(
         self,

--- a/python/tests/unit/arcticdb/version_store/test_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_compact_data.py
@@ -16,6 +16,7 @@ import pytest
 
 from arcticdb_ext.exceptions import DuplicateKeyException, SchemaException, StorageException
 from arcticdb_ext.storage import KeyType
+from arcticdb_ext.version_store import CompactDataInfo
 from arcticdb.exceptions import ArcticNativeException, UserInputException
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.hypothesis import (
@@ -26,13 +27,45 @@ from tests.util.mark import MACOS, WINDOWS
 from tests.util.naughty_strings import read_big_list_of_naughty_strings
 
 
+def check_compact_data_info(
+    compact_data_info, pre_compaction_version, post_compaction_version, pre_compaction_index, post_compaction_index
+):
+    assert compact_data_info.version_id_before == pre_compaction_version
+    assert compact_data_info.version_id_after == post_compaction_version
+    assert compact_data_info.will_do_work == (pre_compaction_version != post_compaction_version)
+    row_slices_before = compact_data_info.row_slices_before
+    assert compact_data_info.num_row_slices_before == max(len(row_slices_before) - 1, 0)
+    for idx, data_key in enumerate(pre_compaction_index.itertuples()):
+        # This relies on the data keys in our index keys being ordered by column slice, and so will need changing if
+        # we switch to the (more sensible) ordering by row slice
+        idx = idx % compact_data_info.num_row_slices_before
+        assert data_key.start_row == row_slices_before[idx]
+        assert data_key.end_row == row_slices_before[idx + 1]
+
+    row_slices_after = compact_data_info.row_slices_after
+    assert compact_data_info.num_row_slices_after == max(len(row_slices_after) - 1, 0)
+    for idx, data_key in enumerate(post_compaction_index.itertuples()):
+        idx = idx % compact_data_info.num_row_slices_after
+        assert data_key.start_row == row_slices_after[idx]
+        assert data_key.end_row == row_slices_after[idx + 1]
+
+
 def generic_compact_data_test(lib, sym, method_arg=None):
     qs.reset_stats()  # Clear any leftover stats from a previous failed run
     pickled = lib.is_symbol_pickled(sym)
     # Use Polars so that sparse data checking is proper
     vit_before_compaction = lib.read(sym, output_format="POLARS")
     expected = vit_before_compaction.data
-    pre_compaction_data_keys = len(lib.read_index(sym))
+    pre_compaction_index = lib.read_index(sym)
+    pre_compaction_data_keys = len(pre_compaction_index)
+    with qs.query_stats():
+        compact_data_info = lib.compact_data_explain_plan_experimental(sym, rows_per_segment=method_arg)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    # No data keys read and no keys of any type written
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 0
+    assert "Memory_PutObject" not in stats["storage_operations"]
+
     with qs.query_stats():
         lib.compact_data_experimental(sym, rows_per_segment=method_arg)
         stats = qs.get_query_stats()
@@ -42,13 +75,14 @@ def generic_compact_data_test(lib, sym, method_arg=None):
     )
     if rows_per_segment == 0:
         rows_per_segment = 100_000
-    received = lib.read(sym, output_format="POLARS").data
+    vit_after_compaction = lib.read(sym, output_format="POLARS")
+    received = vit_after_compaction.data
     if pickled:
         assert received == expected
     else:
         assert_frame_equal_pl(expected, received)
-    index = lib.read_index(sym)
-    row_counts = index["end_row"] - index["start_row"]
+    post_compaction_index = lib.read_index(sym)
+    row_counts = post_compaction_index["end_row"] - post_compaction_index["start_row"]
     # Definitions taken from CompactDataClause constructor
     min_rows_per_segment = max((2 * rows_per_segment) // 3, 1)
     max_rows_per_segment = max((4 * rows_per_segment) // 3, rows_per_segment + 1)
@@ -58,11 +92,20 @@ def generic_compact_data_test(lib, sym, method_arg=None):
     assert row_counts.min() >= min_rows_per_segment
     assert row_counts.max() <= max_rows_per_segment
 
-    post_compaction_data_keys = len(index)
-    new_data_keys = len(index[index["version_id"] > vit_before_compaction.version])
+    post_compaction_data_keys = len(post_compaction_index)
+    new_data_keys = len(post_compaction_index[post_compaction_index["version_id"] > vit_before_compaction.version])
     compacted_data_keys = pre_compaction_data_keys - (post_compaction_data_keys - new_data_keys)
     assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == compacted_data_keys
     assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == new_data_keys
+
+    check_compact_data_info(
+        compact_data_info,
+        vit_before_compaction.version,
+        vit_after_compaction.version,
+        pre_compaction_index,
+        post_compaction_index,
+    )
+
     # Second compaction should always be a no-op
     generic_compact_data_test_noop(lib, sym, rows_per_segment)
 
@@ -73,6 +116,18 @@ def generic_compact_data_test_noop(lib, sym, rows_per_segment=None):
     vit_before_compaction = lib.read(sym, output_format="POLARS")
     expected = vit_before_compaction.data
     pre_compaction_index = lib.read_index(sym)
+    with qs.query_stats():
+        compact_data_info = lib.compact_data_explain_plan_experimental(sym, rows_per_segment=rows_per_segment)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    assert compact_data_info.num_row_slices_before == compact_data_info.num_row_slices_after
+    assert compact_data_info.row_slices_before == compact_data_info.row_slices_after
+    assert compact_data_info.version_id_before == compact_data_info.version_id_after
+    assert not compact_data_info.will_do_work
+    # No data keys read and no keys of any type written
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 0
+    assert "Memory_PutObject" not in stats["storage_operations"]
+
     with qs.query_stats():
         compacted_version = lib.compact_data_experimental(sym, rows_per_segment=rows_per_segment).version
         stats = qs.get_query_stats()
@@ -91,8 +146,59 @@ def generic_compact_data_test_noop(lib, sym, rows_per_segment=None):
     # No objects should be written at all in this case
     assert "Memory_PutObject" not in stats["storage_operations"]
 
+    check_compact_data_info(
+        compact_data_info, vit_before_compaction.version, compacted_version, pre_compaction_index, post_compaction_index
+    )
 
-def test_docstring_example_v1(lmdb_version_store_v1):
+
+def test_compact_data_explain_plan(in_memory_store_factory):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_compact_data_explain_plan"
+    lib.write(sym, pd.DataFrame({"col": [0, 1, 2, 3, 4]}))
+    lib.append(sym, pd.DataFrame({"col": [5, 6, 7, 8, 9]}))
+    # Run it twice to prove that it isn't compacting anything
+    compact_data_info = lib.compact_data_explain_plan_experimental(sym)
+    compact_data_info_again = lib.compact_data_explain_plan_experimental(sym)
+    # We don't need an equality operator for this class for any other reason, so just compare the repr for this test
+    assert str(compact_data_info) == str(compact_data_info_again)
+    assert isinstance(compact_data_info, CompactDataInfo)
+    assert compact_data_info.num_row_slices_before == 2
+    assert compact_data_info.num_row_slices_after == 1
+    assert compact_data_info.row_slices_before == [0, 5, 10]
+    assert compact_data_info.row_slices_after == [0, 10]
+    assert compact_data_info.version_id_before == 1
+    assert compact_data_info.version_id_after == 2
+    assert compact_data_info.will_do_work
+
+    # After compaction there will be no work to do
+    lib.compact_data_experimental(sym)
+    compact_data_info = lib.compact_data_explain_plan_experimental(sym)
+    assert isinstance(compact_data_info, CompactDataInfo)
+    assert compact_data_info.num_row_slices_before == 1
+    assert compact_data_info.num_row_slices_after == 1
+    assert compact_data_info.row_slices_before == [0, 10]
+    assert compact_data_info.row_slices_after == [0, 10]
+    assert compact_data_info.version_id_before == 2
+    assert compact_data_info.version_id_after == 2
+    assert not compact_data_info.will_do_work
+
+
+def test_compact_data_explain_plan_docstring_example(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    df = pd.DataFrame({"col": np.arange(100_000)})
+    for idx in range(100):
+        lib.append("sym", df[idx * 1_000 : (idx + 1) * 1_000])
+    compact_data_info = lib.compact_data_explain_plan_experimental("sym")
+    assert compact_data_info.row_slices_before == list(range(0, 101_000, 1_000))
+    assert compact_data_info.row_slices_after == [0, 100_000]
+    assert compact_data_info.num_row_slices_before == 100
+    assert compact_data_info.num_row_slices_after == 1
+    assert compact_data_info.version_id_before == 99
+    assert compact_data_info.version_id_after == 100
+    assert compact_data_info.will_do_work
+
+
+def test_compact_data_docstring_example_v1(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     df = pd.DataFrame({"col": np.arange(100_000)})
     for idx in range(100):
@@ -102,7 +208,7 @@ def test_docstring_example_v1(lmdb_version_store_v1):
     assert len(lib.read_index("sym")) == 1
 
 
-def test_docstring_example_v2(lmdb_library):
+def test_compact_data_docstring_example_v2(lmdb_library):
     lib = lmdb_library
     df = pd.DataFrame({"col": np.arange(100_000)})
     for idx in range(100):


### PR DESCRIPTION
#### Reference Issues/PRs
[11518164303](https://man312219.monday.com/boards/7852509418/pulses/11518164303)

#### What does this implement or fix?
Adds a method to check what the effect of calling `compact_data_experimental` would be. Returned information includes whether any compaction would take place, the number of row-slices before and after compaction, and the exact distribution of row-slices pre and post compaction.