### PR TITLE
Fix clean up when moto has already terminated

### DIFF
--- a/.github/scripts/parse_ci_failures.py
+++ b/.github/scripts/parse_ci_failures.py
@@ -75,15 +75,30 @@ def parse_gtest_failures(log_text: str) -> set[str]:
     return results
 
 
+def strip_parametrize(test_id: str) -> str:
+    """Strip pytest parametrize suffix ``[...]`` from a test node ID.
+
+    ``tests/test_foo.py::test_bar[nfs_backed_s3--prefix]``
+    → ``tests/test_foo.py::test_bar``
+
+    This groups all parametrizations of the same test into a single
+    tracking issue.
+    """
+    return re.sub(r"\[.*\]$", "", test_id)
+
+
 def parse_pytest_failures(log_text: str) -> set[str]:
     """Extract pytest failures and errors from the summary section.
 
     Matches both:
       FAILED path/to/test.py::TestClass::test_method
       ERROR  path/to/test.py::test_name - FixtureError: ...
+
+    Parametrize suffixes (``[...]``) are stripped so that all
+    parametrizations of the same test are grouped together.
     """
     pattern = r"(?:FAILED|ERROR)\s+(\S+::\S+)"
-    return {m.group(1) for m in re.finditer(pattern, log_text)}
+    return {strip_parametrize(m.group(1)) for m in re.finditer(pattern, log_text)}
 
 
 def filter_infra_steps(all_steps: list[str]) -> list[str]:

--- a/.github/scripts/tests/test_parse_ci_failures.py
+++ b/.github/scripts/tests/test_parse_ci_failures.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from parse_ci_failures import (
     parse_gtest_failures,
     parse_pytest_failures,
+    strip_parametrize,
     filter_infra_steps,
 )
 
@@ -89,10 +90,21 @@ class TestParsePytestFailures:
         log = "PASSED tests/test_foo.py::test_method\n3 passed in 1.5s"
         assert parse_pytest_failures(log) == set()
 
-    def test_parametrized(self):
+    def test_parametrized_suffix_stripped(self):
         log = "FAILED tests/test_foo.py::test_method[param1-param2]"
         assert parse_pytest_failures(log) == {
-            "tests/test_foo.py::test_method[param1-param2]"
+            "tests/test_foo.py::test_method"
+        }
+
+    def test_multiple_parametrizations_deduplicated(self):
+        """Different parametrizations of the same test should produce one entry."""
+        log = (
+            "FAILED tests/test_foo.py::test_method[s3--prefix]\n"
+            "FAILED tests/test_foo.py::test_method[nfs_backed_s3--prefix]\n"
+            "FAILED tests/test_foo.py::test_method[gcp-suffix-prefix]\n"
+        )
+        assert parse_pytest_failures(log) == {
+            "tests/test_foo.py::test_method"
         }
 
     def test_error_lines(self):
@@ -157,3 +169,29 @@ class TestFilterInfraSteps:
     def test_case_insensitive(self):
         steps = ["Run Tests", "Install"]
         assert filter_infra_steps(steps) == ["Install"]
+
+
+# ---------------------------------------------------------------------------
+# strip_parametrize
+# ---------------------------------------------------------------------------
+class TestStripParametrize:
+    def test_strips_simple_params(self):
+        assert strip_parametrize("tests/test_foo.py::test_bar[param1]") == \
+            "tests/test_foo.py::test_bar"
+
+    def test_strips_complex_params(self):
+        assert strip_parametrize(
+            "tests/compat/arcticdb/test_lib_naming.py::test_create_library_with_all_chars[nfs_backed_s3--prefix]"
+        ) == "tests/compat/arcticdb/test_lib_naming.py::test_create_library_with_all_chars"
+
+    def test_no_params_unchanged(self):
+        assert strip_parametrize("tests/test_foo.py::test_bar") == \
+            "tests/test_foo.py::test_bar"
+
+    def test_nested_brackets(self):
+        assert strip_parametrize("tests/test_foo.py::test_bar[a[b]-c]") == \
+            "tests/test_foo.py::test_bar"
+
+    def test_empty_params(self):
+        assert strip_parametrize("tests/test_foo.py::test_bar[]") == \
+            "tests/test_foo.py::test_bar"

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -987,6 +987,14 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
                 f"Moto server process (port {self.port}) died before bucket cleanup — skipping cleanup of {b.bucket}"
             )
             return
+        try:
+            self._cleanup_bucket_inner(b)
+        except botocore.exceptions.EndpointConnectionError:
+            logger.warning(
+                f"Moto server process (port {self.port}) died during bucket cleanup — skipping cleanup of {b.bucket}"
+            )
+
+    def _cleanup_bucket_inner(self, b: S3Bucket):
         if len(self._live_buckets):
             if not self.use_mock_storage_for_testing:
                 # We are not writing to buckets in this case

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -982,6 +982,11 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
 
     def cleanup_bucket(self, b: S3Bucket):
         self._live_buckets.remove(b)
+        if not self._p.is_alive():
+            logger.warning(
+                f"Moto server process (port {self.port}) died before bucket cleanup — skipping cleanup of {b.bucket}"
+            )
+            return
         if len(self._live_buckets):
             if not self.use_mock_storage_for_testing:
                 # We are not writing to buckets in this case


### PR DESCRIPTION
### Related Issues
Fixes #3066

### Problem

The test `test_create_library_with_all_chars[nfs_backed_s3--prefix]` intermittently fails on macOS CI with:

```
ERROR at teardown of test_create_library_with_all_chars[nfs_backed_s3--prefix]
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://localhost:13734/test-nfs-bucket-1777894506-1"
```

The test itself passes — the error occurs during **session fixture teardown** when `cleanup_bucket` tries to delete the bucket from the moto S3 server. By that point the moto server process has already died (likely crashed or OOM-killed under memory pressure on the macOS runner after processing hundreds of library operations with special characters 0-255).

### Root cause

`MotoS3StorageFixtureFactory.cleanup_bucket()` unconditionally attempts S3 operations against the moto server without checking whether the server process is still alive. When the process has died, boto retries 5 times against a closed port, then raises `EndpointConnectionError`, which fails the entire test run.

### Fix

Two-layer guard in `cleanup_bucket`:

1. **`self._p.is_alive()` check** — fast path that skips cleanup immediately when the process is already known dead, avoiding 5 boto retry attempts against a closed port.
2. **`except EndpointConnectionError`** — catches the race condition where the moto process dies between the liveness check and the actual S3 operations.

In both cases, log a warning and skip cleanup. The cleanup is best-effort anyway — the moto server is ephemeral and all its state is lost when the process dies.

---

## Deduplicate flaky test issues across parametrizations

### Problem

The failure notification workflow (`failure_notification.yaml`) creates separate GitHub issues for each parametrization of the same test. For example, `test_create_library_with_all_chars[nfs_backed_s3--prefix]` and `test_create_library_with_all_chars[s3--prefix]` would create two issues even though they are the same test function.

### Fix

Strip pytest parametrize suffixes (`[...]`) from test node IDs in `parse_pytest_failures()`, so all parametrizations of the same test are grouped into a single tracking issue. This matches the existing behaviour of `parse_gtest_failures()` which already strips `/0`, `/1` suffixes.

Added `strip_parametrize()` helper with regex `\[.*\]$` applied to each parsed test ID before set deduplication.