### PR TITLE
Performance improvements for reading column stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,8 @@ When working on a feature branch, maintain a work log in `docs/claude/plans/<bra
 
 Code style is enforced by `make lint` **Always run `make lint` after making code changes.**
 
+Prefer `vec.at(i)` over `vec[i]` for `std::vector` and `std::array` access.
+
 ### Git Commits
 
 - Do not add "Generated with AI" or "Co-Authored-By" lines to commit messages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,8 +190,6 @@ When working on a feature branch, maintain a work log in `docs/claude/plans/<bra
 
 Code style is enforced by `make lint` **Always run `make lint` after making code changes.**
 
-Prefer `vec.at(i)` over `vec[i]` for `std::vector` and `std::array` access.
-
 ### Git Commits
 
 - Do not add "Generated with AI" or "Co-Authored-By" lines to commit messages

--- a/cpp/arcticdb/codec/python_bindings.cpp
+++ b/cpp/arcticdb/codec/python_bindings.cpp
@@ -166,7 +166,7 @@ void register_codec(py::module& m) {
                 };
             });
 
-    py::class_<Segment>(m, "Segment")
+    py::class_<Segment, std::shared_ptr<Segment>>(m, "Segment")
             .def(py::init<>())
             .def("fields_size", &Segment::fields_size)
             .def("fields", &Segment::fields_vector)

--- a/cpp/arcticdb/entity/descriptor_item.hpp
+++ b/cpp/arcticdb/entity/descriptor_item.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <arcticdb/entity/atom_key.hpp>
+#include <arcticdb/storage/key_segment_pair.hpp>
 #include <fmt/format.h>
 #include <string>
 
@@ -31,7 +32,7 @@ struct DescriptorItem {
     std::optional<timestamp> end_index_;
     std::optional<TimeseriesDescriptor> timeseries_descriptor_;
     std::optional<SegmentInMemory> index_segment_;
-    std::optional<SegmentInMemory> column_stats_segment_;
+    std::optional<storage::KeySegmentPair> column_stats_segment_;
 
     std::string symbol() const { return fmt::format("{}", key_.id()); }
     uint64_t version() const { return key_.version_id(); }
@@ -41,6 +42,6 @@ struct DescriptorItem {
     std::optional<TimeseriesDescriptor> timeseries_descriptor() const { return timeseries_descriptor_; }
     entity::AtomKey key() const { return key_; }
     std::optional<SegmentInMemory> index_segment() const { return index_segment_; }
-    std::optional<SegmentInMemory> column_stats_segment() const { return column_stats_segment_; }
+    std::optional<storage::KeySegmentPair> column_stats_segment() const { return column_stats_segment_; }
 };
 } // namespace arcticdb

--- a/cpp/arcticdb/entity/descriptor_item.hpp
+++ b/cpp/arcticdb/entity/descriptor_item.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
+#include <arcticdb/codec/segment.hpp>
 #include <arcticdb/entity/atom_key.hpp>
-#include <arcticdb/storage/key_segment_pair.hpp>
 #include <fmt/format.h>
 #include <string>
 
@@ -32,7 +32,7 @@ struct DescriptorItem {
     std::optional<timestamp> end_index_;
     std::optional<TimeseriesDescriptor> timeseries_descriptor_;
     std::optional<SegmentInMemory> index_segment_;
-    std::optional<storage::KeySegmentPair> column_stats_segment_;
+    std::shared_ptr<Segment> column_stats_segment_;
 
     std::string symbol() const { return fmt::format("{}", key_.id()); }
     uint64_t version() const { return key_.version_id(); }
@@ -42,6 +42,6 @@ struct DescriptorItem {
     std::optional<TimeseriesDescriptor> timeseries_descriptor() const { return timeseries_descriptor_; }
     entity::AtomKey key() const { return key_; }
     std::optional<SegmentInMemory> index_segment() const { return index_segment_; }
-    std::optional<storage::KeySegmentPair> column_stats_segment() const { return column_stats_segment_; }
+    std::shared_ptr<Segment> column_stats_segment() const { return column_stats_segment_; }
 };
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -36,6 +36,8 @@ struct NameAndStatTypes {
 
 void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header);
 
+std::string to_segment_column_name(const std::string& column, ColumnStatTypeInternal type);
+
 class ColumnStats {
   public:
     explicit ColumnStats(const std::unordered_map<std::string, std::unordered_set<std::string>>& column_stats);

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -34,10 +34,14 @@ using StatsVariantData = std::variant<
         // A value set from an isin/isnotin expression
         std::shared_ptr<ValueSet>>;
 
-using StatsRowVector = std::vector<const ColumnStatsRow*>;
+// One entry per index segment row: the matching ColumnStatsData row index, or nullopt when no
+// stats row matches (or when the row is already pruned). Materialisation of stats values happens
+// downstream via ColumnStatsData::materialize_slot.
+using StatsRowIndices = std::vector<std::optional<size_t>>;
 
 StatsVariantData evaluate_ast_node_against_stats(
-        const VariantNode& node, const ExpressionContext& expression_context, const StatsRowVector& stats_rows
+        const VariantNode& node, const ExpressionContext& expression_context, const StatsRowIndices& row_indices,
+        const ColumnStatsData& column_stats
 );
 
 StatsVariantData dispatch_binary_stats(
@@ -45,7 +49,8 @@ StatsVariantData dispatch_binary_stats(
 );
 
 StatsVariantData compute_stats(
-        const ExpressionContext& expression_context, const ExpressionNode& node, const StatsRowVector& stats_rows
+        const ExpressionContext& expression_context, const ExpressionNode& node, const StatsRowIndices& row_indices,
+        const ColumnStatsData& column_stats
 );
 
 namespace column_stats_detail {

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -35,8 +35,8 @@ using StatsVariantData = std::variant<
         std::shared_ptr<ValueSet>>;
 
 // One entry per index segment row: the matching ColumnStatsData row index, or nullopt when no
-// stats row matches (or when the row is already pruned). Materialisation of stats values happens
-// downstream via ColumnStatsData::materialize_slot.
+// stats row matches (or when the row is already pruned). Stats values are read out
+// downstream via ColumnStatsData::values_at_slot.
 using StatsRowIndices = std::vector<std::optional<size_t>>;
 
 StatsVariantData evaluate_ast_node_against_stats(

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -36,7 +36,7 @@ using StatsVariantData = std::variant<
 
 // One entry per index segment row: the matching ColumnStatsData row index, or nullopt when no
 // stats row matches (or when the row is already pruned). Stats values are read out
-// downstream via ColumnStatsData::values_at_slot.
+// downstream via ColumnStatsData::values_for_column.
 using StatsRowIndices = std::vector<std::optional<size_t>>;
 
 StatsVariantData evaluate_ast_node_against_stats(

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -9,6 +9,8 @@
 #include <arcticdb/pipeline/column_stats_filter.hpp>
 #include <arcticdb/pipeline/column_stats_dispatch.hpp>
 
+#include <arcticdb/codec/codec.hpp>
+#include <arcticdb/entity/stream_descriptor.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/pipeline/value.hpp>
@@ -16,86 +18,40 @@
 #include <arcticdb/stream/stream_utils.hpp>
 #include <arcticdb/processing/query_planner.hpp>
 
+#include <iterator>
+#include <unordered_set>
+
 namespace arcticdb {
-
-namespace {
-
-std::optional<Value> extract_value_from_column(
-        const SegmentInMemory::iterator& it, size_t col_idx, DataType data_type
-) {
-    return details::visit_type(data_type, [&it, col_idx](auto tag) -> std::optional<Value> {
-        using type_info = ScalarTypeInfo<decltype(tag)>;
-        // Only numeric types are supported at the moment.
-        if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
-                      is_bool_type(type_info::data_type)) {
-            auto opt_val = it->scalar_at<typename type_info::RawType>(col_idx);
-            if (opt_val.has_value()) {
-                return Value{*opt_val, type_info::data_type};
-            }
-        }
-        return std::nullopt;
-    });
-}
-
-} // anonymous namespace
 
 bool is_column_stats_enabled() { return ConfigsMap::instance()->get_int("ColumnStats.UseForQueries", 0) == 1; }
 
-bool should_try_column_stats_read(const ReadQuery& read_query) {
-    if (!is_column_stats_enabled()) {
-        return false;
-    }
-    if (read_query.clauses_.empty()) {
-        return false;
-    }
-    for (const auto& clause : read_query.clauses_) {
-        auto& clause_type = folly::poly_type(*clause);
-        if (clause_type == typeid(DateRangeClause) || clause_type == typeid(RowRangeClause)) {
-            continue;
-        }
-        if (clause_type == typeid(FilterClause)) {
-            return true;
-        }
-        break;
-    }
-    return false;
+bool ColumnStatsQueryMetadata::should_try_column_stats_read() const {
+    return is_column_stats_enabled() && !filter_expressions.empty();
 }
 
 StatsVariantData evaluate_ast_node_against_stats(
-        const VariantNode& node, const ExpressionContext& expression_context, const StatsRowVector& stats_rows
+        const VariantNode& node, const ExpressionContext& expression_context, const StatsRowIndices& row_indices,
+        const ColumnStatsData& column_stats
 ) {
     return util::variant_match(
             node,
             [&](const ColumnName& column_name) -> StatsVariantData {
-                std::vector<ColumnStatsValues> result;
-                result.reserve(stats_rows.size());
-                for (const auto& row : stats_rows) {
-                    if (!row) {
-                        result.emplace_back(std::nullopt, std::nullopt);
-                        continue;
-                    }
-                    if (auto it = row->stats_for_column.find(column_name.value); it != row->stats_for_column.end()) {
-                        result.push_back(it->second);
-                    } else {
-                        result.emplace_back(std::nullopt, std::nullopt);
-                    }
+                if (auto slot = column_stats.slot_for_column(column_name.value); slot.has_value()) {
+                    return column_stats.materialize_slot(*slot, row_indices);
                 }
-                util::check(
-                        result.size() == stats_rows.size(), "Expected the result to have the same size as stats_rows"
-                );
-                return result;
+                return std::vector<ColumnStatsValues>(row_indices.size());
             },
             [&](const ValueName& value_name) -> StatsVariantData {
                 return expression_context.values_.get_value(value_name.value);
             },
             [&](const ExpressionName& expression_name) -> StatsVariantData {
                 auto expr = expression_context.expression_nodes_.get_value(expression_name.value);
-                return compute_stats(expression_context, *expr, stats_rows);
+                return compute_stats(expression_context, *expr, row_indices, column_stats);
             },
             [&](const ValueSetName& value_set_name) -> StatsVariantData {
                 return expression_context.value_sets_.get_value(value_set_name.value);
             },
-            [&](const auto&) -> StatsVariantData { return std::vector(stats_rows.size(), StatsComparison::UNKNOWN); }
+            [&](const auto&) -> StatsVariantData { return std::vector(row_indices.size(), StatsComparison::UNKNOWN); }
     );
 }
 
@@ -157,27 +113,30 @@ StatsVariantData dispatch_unary_stats(const StatsVariantData& left, OperationTyp
 }
 
 StatsVariantData compute_stats(
-        const ExpressionContext& expression_context, const ExpressionNode& node, const StatsRowVector& stats_rows
+        const ExpressionContext& expression_context, const ExpressionNode& node, const StatsRowIndices& row_indices,
+        const ColumnStatsData& column_stats
 ) {
     if (is_binary_operation(node.operation_type_)) {
-        auto left = evaluate_ast_node_against_stats(node.left_, expression_context, stats_rows);
-        auto right = evaluate_ast_node_against_stats(node.right_, expression_context, stats_rows);
+        auto left = evaluate_ast_node_against_stats(node.left_, expression_context, row_indices, column_stats);
+        auto right = evaluate_ast_node_against_stats(node.right_, expression_context, row_indices, column_stats);
         return dispatch_binary_stats(left, right, node.operation_type_);
     }
     if (is_unary_operation(node.operation_type_)) {
-        auto left = evaluate_ast_node_against_stats(node.left_, expression_context, stats_rows);
+        auto left = evaluate_ast_node_against_stats(node.left_, expression_context, row_indices, column_stats);
         return dispatch_unary_stats(left, node.operation_type_);
     }
-    return std::vector(stats_rows.size(), StatsComparison::UNKNOWN);
+    return std::vector(row_indices.size(), StatsComparison::UNKNOWN);
 }
 
-ColumnStatsData::ColumnStatsData(SegmentInMemory&& segment, const TimeseriesDescriptor& tsd) {
+ColumnStatsData::ColumnStatsData(
+        SegmentInMemory&& segment, const TimeseriesDescriptor& tsd,
+        std::optional<std::pair<timestamp, timestamp>> date_range
+) {
     using namespace arcticc::pb2::column_stats_pb2;
     if (segment.row_count() == 0) {
         return;
     }
 
-    // Build reverse lookup: stats_seg_offset -> (column_name, stat_type)
     ColumnStatsHeader header;
     auto* metadata = segment.metadata();
     util::check(metadata != nullptr, "Column stats segment has no metadata");
@@ -185,95 +144,231 @@ ColumnStatsData::ColumnStatsData(SegmentInMemory&& segment, const TimeseriesDesc
     util::check(unpacked, "Could not unpack ColumnStatsHeader from column stats segment metadata");
     validate_column_stats_header_version(header);
 
-    std::unordered_map<size_t, std::pair<std::string, ColumnStatsType>> stats_at_column_index;
-    for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
-        std::string col_name{tsd.fields().at(data_col_offset).name()};
-        for (const auto& entry : entry_list.entries()) {
-            stats_at_column_index.emplace(entry.stats_seg_offset(), std::make_pair(col_name, entry.type()));
-        }
+    segment.init_column_map();
+    const auto& fields = segment.descriptor().fields();
+    const auto segment_row_count = segment.row_count();
+
+    const auto& start_index_col = segment.column(start_index_column_offset);
+    const auto& end_index_col = segment.column(end_index_column_offset);
+    if (start_index_col.is_sparse() || end_index_col.is_sparse() ||
+        static_cast<size_t>(start_index_col.row_count()) != segment_row_count ||
+        static_cast<size_t>(end_index_col.row_count()) != segment_row_count) {
+        log::version().warn("Saw column stats row without start_index or end_index, discarding all column stats");
+        return;
     }
 
-    // Future aseaton consider iterating column-wise rather than row-wise?
-    const auto& fields = segment.descriptor().fields();
-    rows_.reserve(segment.row_count());
-    for (auto it = segment.begin(); it != segment.end(); ++it) {
-        ColumnStatsRow stats_row;
-
-        // The index values in the column stats segment are just rowcounts if the symbol is string-indexed
-        auto start_index = it->scalar_at<timestamp>(start_index_column_offset);
-        auto end_index = it->scalar_at<timestamp>(end_index_column_offset);
-
-        if (!start_index || !end_index) {
-            log::version().warn("Saw column stats row without start_index or end_index, discarding all column stats");
-            rows_.clear();
-            index_to_row_.clear();
-            return;
-        }
-
-        stats_row.start_index = *start_index;
-        stats_row.end_index = *end_index;
-
-        for (size_t col_idx = end_index_column_offset + 1; col_idx < fields.size(); ++col_idx) {
-            const auto& field = fields[col_idx];
-            auto lookup_it = stats_at_column_index.find(col_idx);
-            if (lookup_it == stats_at_column_index.end()) {
+    // For each column in the read query with any stats we register a slot and remember the segment column indices to
+    // read from.
+    std::vector<StatsMetadataForColumn> stats_metadata;
+    stats_metadata.reserve(header.stats_by_column().size());
+    for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
+        StatsMetadataForColumn stats_metadata_for_column;
+        stats_metadata_for_column.col_name = std::string{tsd.fields().at(data_col_offset).name()};
+        for (const auto& entry : entry_list.entries()) {
+            if (entry.type() != MIN_V1 && entry.type() != MAX_V1) {
+                log::version().warn(
+                        "Unknown column stats type {} for column {}, skipping",
+                        static_cast<int>(entry.type()),
+                        stats_metadata_for_column.col_name
+                );
                 continue;
             }
-            const auto& [col_name, stat_type] = lookup_it->second;
-            auto value = extract_value_from_column(it, col_idx, field.type().data_type());
-
-            auto& stats = stats_row.stats_for_column[col_name];
-            switch (stat_type) {
-            case MIN_V1:
-                stats.min = value;
-                break;
-            case MAX_V1:
-                stats.max = value;
-                break;
-            default:
-                log::version().warn(
-                        "Unknown column stats type {} at offset {}, skipping", static_cast<int>(stat_type), col_idx
+            const auto field_name = to_segment_column_name(stats_metadata_for_column.col_name, entry.type());
+            const auto col_index = segment.column_index(field_name);
+            if (!col_index.has_value()) {
+                // Column was filtered out at decode time, or never present in this segment.
+                continue;
+            }
+            const auto entry_data_type = fields.at(*col_index).type().data_type();
+            if (stats_metadata_for_column.data_type == DataType::UNKNOWN) {
+                stats_metadata_for_column.data_type = entry_data_type;
+            } else {
+                util::check(
+                        stats_metadata_for_column.data_type == entry_data_type,
+                        "MIN/MAX stats columns for {} disagree on data type",
+                        stats_metadata_for_column.col_name
                 );
-                break;
             }
+            stats_metadata_for_column.entries.push_back({*col_index, entry.type()});
         }
-
-        // If a column's min and max are both absent (sparse bitmap), the column was not present
-        // in the data segment.
-        for (auto& [col_name, stats] : stats_row.stats_for_column) {
-            util::check(
-                    stats.min.has_value() == stats.max.has_value(),
-                    "MIN and MAX should both be present or both be absent, col_name={}",
-                    col_name
-            );
-            if (!stats.min) {
-                stats.column_absent = true;
-            }
+        if (!stats_metadata_for_column.entries.empty()) {
+            stats_metadata.emplace_back(std::move(stats_metadata_for_column));
         }
-
-        auto key = std::make_pair(stats_row.start_index, stats_row.end_index);
-        if (auto [_, inserted] = index_to_row_.emplace(key, rows_.size()); !inserted) {
-            // Duplicate (start_index, end_index). This can happen with timestamp indices where
-            // multiple segments span the same time range.
-            duplicate_keys_.insert(key);
-        }
-        rows_.push_back(std::move(stats_row));
     }
 
-    for (const auto& key : duplicate_keys_) {
+    // Construct start_indices and end_indices with date range pruning.
+    // Also construct the interval [first_kept, last_kept_excl) to quickly skip stats for row ranges
+    // we are not interested in when we read the statistics themselves.
+    size_t first_kept = segment_row_count;
+    size_t last_kept_excl = 0;
+    start_indices_.reserve(segment_row_count);
+    end_indices_.reserve(segment_row_count);
+    using TsTDT = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
+    auto start_it = start_index_col.begin<TsTDT>();
+    auto end_it = end_index_col.begin<TsTDT>();
+    timestamp prev_start = 0;
+    timestamp prev_end = 0;
+    for (size_t r = 0; r < segment_row_count; ++r, ++start_it, ++end_it) {
+        const timestamp start_index_ts = *start_it;
+        const timestamp end_index_ts = *end_it;
+        if (r > 0) {
+            util::check(
+                    start_index_ts >= prev_start && end_index_ts >= prev_end,
+                    "Column stats segment start_index/end_index must be monotonically increasing "
+                    "(violated at row {})",
+                    r
+            );
+        }
+        prev_start = start_index_ts;
+        prev_end = end_index_ts;
+        if (date_range.has_value()) {
+            if (start_index_ts > date_range->second) {
+                break;
+            }
+            if (end_index_ts < date_range->first) {
+                continue;
+            }
+        }
+        if (first_kept == segment_row_count) {
+            first_kept = r;
+        }
+        last_kept_excl = r + 1;
+        start_indices_.push_back(start_index_ts);
+        end_indices_.push_back(end_index_ts);
+    }
+    num_rows_ = start_indices_.size();
+    if (num_rows_ == 0) {
+        return;
+    }
+
+    // Write the statistics to the flat buffers
+    num_slots_ = stats_metadata.size();
+    slots_.resize(num_slots_);
+    min_data_.assign(num_slots_ * num_rows_ * BYTES_PER_CELL, 0);
+    max_data_.assign(num_slots_ * num_rows_ * BYTES_PER_CELL, 0);
+
+    for (size_t slot = 0; slot < num_slots_; ++slot) {
+        auto& stats_metadata_for_column = stats_metadata.at(slot);
+        col_name_to_slot_.emplace(stats_metadata_for_column.col_name, slot);
+        auto& slot_info = slots_.at(slot);
+        slot_info.data_type = stats_metadata_for_column.data_type;
+
+        details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
+            using type_info = ScalarTypeInfo<T>;
+            if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
+                          is_bool_type(type_info::data_type)) {
+                using RawType = type_info::RawType;
+                static_assert(sizeof(RawType) <= BYTES_PER_CELL, "RawType wider than per-cell slot");
+
+                for (const auto& entry : stats_metadata_for_column.entries) {
+                    const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
+                    const bool is_min = entry.stat_type == MIN_V1;
+                    uint8_t* dest = (is_min ? min_data_.data() : max_data_.data()) + slot * num_rows_ * BYTES_PER_CELL;
+                    auto& set_bits = is_min ? slot_info.min_set : slot_info.max_set;
+
+                    if (!column.is_sparse() && static_cast<size_t>(column.row_count()) == segment_row_count) {
+                        // Dense
+                        auto it = column.begin<typename type_info::TDT>();
+                        std::advance(it, static_cast<ssize_t>(first_kept));
+                        for (size_t r = first_kept; r < last_kept_excl; ++r, ++it) {
+                            const size_t kept = r - first_kept; // index in to the output buffer dest
+                            // Write *it in to the dest buffer
+                            *reinterpret_cast<RawType*>(dest + kept * BYTES_PER_CELL) = *it;
+                        }
+                    } else {
+                        // Sparse
+                        set_bits.emplace(static_cast<util::BitSetSizeType>(num_rows_));
+                        for (size_t r = first_kept; r < last_kept_excl; ++r) {
+                            if (auto opt_val = column.scalar_at<RawType>(static_cast<position_t>(r));
+                                opt_val.has_value()) {
+                                const size_t kept = r - first_kept;
+                                *reinterpret_cast<RawType*>(dest + kept * BYTES_PER_CELL) = *opt_val;
+                                set_bits->set(static_cast<util::BitSetSizeType>(kept));
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    index_to_row_.reserve(num_rows_);
+    std::unordered_set<std::pair<timestamp, timestamp>, util::PairHasher> duplicate_keys;
+    for (size_t r = 0; r < num_rows_; ++r) {
+        auto key = std::make_pair(start_indices_.at(r), end_indices_.at(r));
+        if (auto [_, inserted] = index_to_row_.emplace(key, r); !inserted) {
+            // Duplicate (start_index, end_index) — can happen with timestamp indices when multiple
+            // segments span the same time range.
+            duplicate_keys.insert(key);
+        }
+    }
+    for (const auto& key : duplicate_keys) {
         log::version().debug("Duplicate key detected in column stats - dropping {}", key);
         index_to_row_.erase(key);
     }
 }
 
-const ColumnStatsRow* ColumnStatsData::find_stats(timestamp start_index, timestamp end_index) const {
+std::optional<size_t> ColumnStatsData::find_row(timestamp start_index, timestamp end_index) const {
     if (auto it = index_to_row_.find({start_index, end_index}); it != index_to_row_.end()) {
-        return &rows_[it->second];
+        return it->second;
     }
-    return nullptr;
+    return std::nullopt;
 }
 
-bool ColumnStatsData::empty() const { return rows_.empty(); }
+std::optional<size_t> ColumnStatsData::slot_for_column(const std::string& col_name) const {
+    if (auto it = col_name_to_slot_.find(col_name); it != col_name_to_slot_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::vector<ColumnStatsValues> ColumnStatsData::materialize_slot(
+        size_t slot, const std::vector<std::optional<size_t>>& row_indices
+) const {
+    std::vector<ColumnStatsValues> result(row_indices.size());
+    if (slot >= num_slots_ || num_rows_ == 0) {
+        return result;
+    }
+
+    const auto& info = slots_[slot];
+    const uint8_t* min_buf = min_data_.data() + slot * num_rows_ * BYTES_PER_CELL;
+    const uint8_t* max_buf = max_data_.data() + slot * num_rows_ * BYTES_PER_CELL;
+
+    details::visit_type(info.data_type, [&](auto tag) {
+        using type_info = ScalarTypeInfo<decltype(tag)>;
+        if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
+                      is_bool_type(type_info::data_type)) {
+            using RawType = type_info::RawType;
+            const bool min_dense = !info.min_set.has_value();
+            const bool max_dense = !info.max_set.has_value();
+            for (size_t i = 0; i < row_indices.size(); ++i) {
+                const auto& maybe_row = row_indices.at(i);
+                if (!maybe_row.has_value()) {
+                    continue;
+                }
+                const size_t r = *maybe_row;
+                const bool min_set = min_dense || info.min_set->test(static_cast<util::BitSetSizeType>(r));
+                const bool max_set = max_dense || info.max_set->test(static_cast<util::BitSetSizeType>(r));
+                util::check(min_set == max_set, "MIN and MAX should both be present or both be absent");
+                auto& result_entry = result.at(i);
+                if (min_set) {
+                    RawType raw_min = *reinterpret_cast<const RawType*>(min_buf + r * BYTES_PER_CELL);
+                    result_entry.min = Value{raw_min, type_info::data_type};
+                    RawType raw_max = *reinterpret_cast<const RawType*>(max_buf + r * BYTES_PER_CELL);
+                    result_entry.max = Value{raw_max, type_info::data_type};
+                } else {
+                    result_entry.column_absent = true;
+                }
+            }
+        }
+    });
+    return result;
+}
+
+ColumnStatsValues ColumnStatsData::stats_for(size_t slot, size_t row) const {
+    auto v = materialize_slot(slot, {std::optional<size_t>{row}});
+    return v.empty() ? ColumnStatsValues{} : std::move(v[0]);
+}
 
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         ColumnStatsData&& column_stats_data, ExpressionContext&& expression_context
@@ -294,29 +389,26 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         auto start_index_col = isr.column(Fields::start_index).begin<stream::TimeseriesIndex::TypeDescTag>();
         auto end_index_col = isr.column(Fields::end_index).begin<stream::TimeseriesIndex::TypeDescTag>();
 
-        StatsRowVector stats_rows;
-        stats_rows.reserve(isr.size());
+        StatsRowIndices row_indices;
+        row_indices.reserve(isr.size());
         [[maybe_unused]] size_t total_count = 0; // for debug logging only, unused in release build
         for (size_t row = 0; row < isr.size(); ++row) {
             if (!res->get_bit(row)) {
                 // Don't bother - we already know we don't need to look at the segment
-                stats_rows.push_back(nullptr);
+                row_indices.emplace_back(std::nullopt);
                 continue;
             }
             total_count++;
             timestamp start_idx = *(start_index_col + row);
             timestamp end_idx = *(end_index_col + row);
-            if (const ColumnStatsRow* stats = column_stats_data.find_stats(start_idx, end_idx)) {
-                stats_rows.push_back(stats);
-            } else {
-                stats_rows.push_back(nullptr);
-            }
+            row_indices.emplace_back(column_stats_data.find_row(start_idx, end_idx));
         }
-        util::check(stats_rows.size() == isr.size(), "Expected stats_rows.size() == isr.size()");
+        util::check(row_indices.size() == isr.size(), "Expected row_indices.size() == isr.size()");
 
         // Evaluate the AST
-        StatsVariantData result =
-                evaluate_ast_node_against_stats(expression_context.root_node_name_, expression_context, stats_rows);
+        StatsVariantData result = evaluate_ast_node_against_stats(
+                expression_context.root_node_name_, expression_context, row_indices, column_stats_data
+        );
         util::check(
                 std::holds_alternative<std::vector<StatsComparison>>(result),
                 "evaluate_ast_node_against_stats should evaluate to a vector<StatsComparison>"
@@ -338,38 +430,124 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
     };
 }
 
-FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
-        SegmentInMemory&& column_stats_segment, const TimeseriesDescriptor& tsd,
-        const std::vector<std::shared_ptr<Clause>>& clauses
-) {
-    std::vector<std::shared_ptr<ExpressionContext>> filter_expressions;
-
+ColumnStatsQueryMetadata column_stats_query_metadata(const std::vector<std::shared_ptr<Clause>>& clauses) {
+    // The clauses eligible for column stats use:
+    // - FilterClauses contribute filter expressions and columns of interest
+    // - DateRangeClauses contribute their range
+    // - RowRangeClauses are skipped
+    // - Anything else (Resample / GroupBy / Project) ends the prefix because those clauses
+    // transform the data so stats computed on the original segments are no longer valid.
+    ColumnStatsQueryMetadata result;
     for (const auto& clause : clauses) {
         auto& clause_type = folly::poly_type(*clause);
-
-        if (clause_type == typeid(DateRangeClause) || clause_type == typeid(RowRangeClause)) {
+        if (clause_type == typeid(DateRangeClause)) {
+            const auto& date_range_clause = folly::poly_cast<DateRangeClause>(*clause);
+            if (!result.date_range.has_value()) {
+                result.date_range = std::make_pair(date_range_clause.start(), date_range_clause.end());
+            } else {
+                result.date_range->first = std::max(result.date_range->first, date_range_clause.start());
+                result.date_range->second = std::min(result.date_range->second, date_range_clause.end());
+            }
             continue;
         }
-
-        // Resample, GroupBy, and Projection clauses transform the data so column stats
-        // computed on the original segments are no longer valid for any subsequent filters.
+        if (clause_type == typeid(RowRangeClause)) {
+            continue;
+        }
         if (clause_type != typeid(FilterClause)) {
             break;
         }
+        const auto& filter = folly::poly_cast<FilterClause>(*clause);
+        result.filter_expressions.emplace_back(filter.expression_context_);
+        util::check(
+                filter.clause_info().input_columns_.has_value(),
+                "FilterClause is missing input_columns_ — Python bindings should always populate this"
+        );
+        for (const auto& col : *filter.clause_info().input_columns_) {
+            result.columns_of_interest.insert(col);
+        }
+    }
+    return result;
+}
 
-        FilterClause& filter = folly::poly_cast<FilterClause>(*clause);
-        filter_expressions.emplace_back(filter.expression_context_);
+SegmentInMemory partial_decode_column_stats_segment(
+        Segment& column_stats_segment, const TimeseriesDescriptor& tsd,
+        const std::unordered_set<std::string>& columns_of_interest
+) {
+    using namespace arcticc::pb2::column_stats_pb2;
+
+    auto maybe_metadata = decode_metadata_from_segment(column_stats_segment);
+    util::check(maybe_metadata.has_value(), "Column stats segment has no metadata");
+    ColumnStatsHeader header;
+    bool unpacked = maybe_metadata->UnpackTo(&header);
+    util::check(unpacked, "Could not unpack ColumnStatsHeader from column stats segment metadata");
+    validate_column_stats_header_version(header);
+
+    std::unordered_set<std::string> retain_field_names;
+    retain_field_names.insert(start_index_column_name);
+    retain_field_names.insert(end_index_column_name);
+    for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
+        std::string col_name{tsd.fields().at(data_col_offset).name()};
+        if (!columns_of_interest.contains(col_name)) {
+            continue;
+        }
+        for (const auto& entry : entry_list.entries()) {
+            retain_field_names.insert(to_segment_column_name(col_name, entry.type()));
+        }
     }
 
+    // Preserve the order so start_index lands at offset 0 and end_index at offset 1, matching the
+    // start_index_column_offset / end_index_column_offset constants used downstream.
+    StreamDescriptor partial_desc;
+    partial_desc.set_index(column_stats_segment.descriptor().index());
+    for (const auto& field : column_stats_segment.descriptor().fields()) {
+        if (retain_field_names.contains(std::string{field.name()})) {
+            partial_desc.add_field(field);
+        }
+    }
+    util::check(
+            partial_desc.fields().size() >= 2 && partial_desc.fields(0).name() == start_index_column_name &&
+                    partial_desc.fields(1).name() == end_index_column_name,
+            "Expected start_index/end_index at the front of the column stats segment"
+    );
+
+    SegmentInMemory partial(std::move(partial_desc), 0, AllocationType::DYNAMIC);
+    decode_into_memory_segment(
+            column_stats_segment, column_stats_segment.header(), partial, column_stats_segment.descriptor()
+    );
+    return partial;
+}
+
+namespace {
+
+FilterQuery<index::IndexSegmentReader> build_filter_from_column_stats_data(
+        ColumnStatsData&& column_stats, std::vector<std::shared_ptr<ExpressionContext>>&& filter_expressions
+) {
     util::check(!filter_expressions.empty(), "Expected at least one filter expression");
-
-    ColumnStatsData column_stats{std::move(column_stats_segment), tsd};
-
     ARCTICDB_DEBUG(log::version(), "AND-ing expression contexts from filters");
     ExpressionContext overall_context = and_filter_expression_contexts(filter_expressions);
-
     ARCTICDB_DEBUG(log::version(), "Creating column stats filter");
     return create_column_stats_filter(std::move(column_stats), std::move(overall_context));
+}
+
+} // namespace
+
+FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
+        storage::KeySegmentPair&& column_stats_compressed, const TimeseriesDescriptor& tsd,
+        ColumnStatsQueryMetadata&& query_metadata
+) {
+    SegmentInMemory partial_segment = partial_decode_column_stats_segment(
+            *column_stats_compressed.segment_ptr(), tsd, query_metadata.columns_of_interest
+    );
+    ColumnStatsData column_stats{std::move(partial_segment), tsd, query_metadata.date_range};
+    return build_filter_from_column_stats_data(std::move(column_stats), std::move(query_metadata.filter_expressions));
+}
+
+FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
+        SegmentInMemory&& column_stats_segment, const TimeseriesDescriptor& tsd,
+        ColumnStatsQueryMetadata&& query_metadata
+) {
+    ColumnStatsData column_stats{std::move(column_stats_segment), tsd, query_metadata.date_range};
+    return build_filter_from_column_stats_data(std::move(column_stats), std::move(query_metadata.filter_expressions));
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -37,7 +37,7 @@ StatsVariantData evaluate_ast_node_against_stats(
             node,
             [&](const ColumnName& column_name) -> StatsVariantData {
                 if (auto slot = column_stats.slot_for_column(column_name.value); slot.has_value()) {
-                    return column_stats.materialize_slot(*slot, row_indices);
+                    return column_stats.values_at_slot(*slot, row_indices);
                 }
                 return std::vector<ColumnStatsValues>(row_indices.size());
             },
@@ -241,49 +241,44 @@ ColumnStatsData::ColumnStatsData(
         return;
     }
 
-    // Write the statistics to the flat buffers
     num_slots_ = stats_metadata.size();
     slots_.resize(num_slots_);
-    min_data_.assign(num_slots_ * num_rows_ * BYTES_PER_CELL, 0);
-    max_data_.assign(num_slots_ * num_rows_ * BYTES_PER_CELL, 0);
+    for (auto& slot_data : slots_) {
+        slot_data.mins.resize(num_rows_);
+        slot_data.maxes.resize(num_rows_);
+    }
 
     for (size_t slot = 0; slot < num_slots_; ++slot) {
         auto& stats_metadata_for_column = stats_metadata.at(slot);
         col_name_to_slot_.emplace(stats_metadata_for_column.col_name, slot);
-        auto& slot_info = slots_.at(slot);
-        slot_info.data_type = stats_metadata_for_column.data_type;
+        auto& slot_data = slots_.at(slot);
 
         details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
             using type_info = ScalarTypeInfo<T>;
             if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
                           is_bool_type(type_info::data_type)) {
                 using RawType = type_info::RawType;
-                static_assert(sizeof(RawType) <= BYTES_PER_CELL, "RawType wider than per-cell slot");
 
                 for (const auto& entry : stats_metadata_for_column.entries) {
                     const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
                     const bool is_min = entry.stat_type == MIN_V1;
-                    uint8_t* dest = (is_min ? min_data_.data() : max_data_.data()) + slot * num_rows_ * BYTES_PER_CELL;
-                    auto& set_bits = is_min ? slot_info.min_set : slot_info.max_set;
+                    auto& dest = is_min ? slot_data.mins : slot_data.maxes;
 
                     if (!column.is_sparse() && static_cast<size_t>(column.row_count()) == segment_row_count) {
                         // Dense
                         auto it = column.begin<typename type_info::TDT>();
                         std::advance(it, static_cast<ssize_t>(first_kept));
                         for (size_t r = first_kept; r < last_kept_excl; ++r, ++it) {
-                            const size_t kept = r - first_kept; // index in to the output buffer dest
-                            // Write *it in to the dest buffer
-                            *reinterpret_cast<RawType*>(dest + kept * BYTES_PER_CELL) = *it;
+                            const size_t kept = r - first_kept;
+                            dest.at(kept) = Value{*it, type_info::data_type};
                         }
                     } else {
                         // Sparse
-                        set_bits.emplace(static_cast<util::BitSetSizeType>(num_rows_));
                         for (size_t r = first_kept; r < last_kept_excl; ++r) {
                             if (auto opt_val = column.scalar_at<RawType>(static_cast<position_t>(r));
                                 opt_val.has_value()) {
                                 const size_t kept = r - first_kept;
-                                *reinterpret_cast<RawType*>(dest + kept * BYTES_PER_CELL) = *opt_val;
-                                set_bits->set(static_cast<util::BitSetSizeType>(kept));
+                                dest.at(kept) = Value{*opt_val, type_info::data_type};
                             }
                         }
                     }
@@ -322,7 +317,7 @@ std::optional<size_t> ColumnStatsData::slot_for_column(const std::string& col_na
     return std::nullopt;
 }
 
-std::vector<ColumnStatsValues> ColumnStatsData::materialize_slot(
+std::vector<ColumnStatsValues> ColumnStatsData::values_at_slot(
         size_t slot, const std::vector<std::optional<size_t>>& row_indices
 ) const {
     std::vector<ColumnStatsValues> result(row_indices.size());
@@ -330,44 +325,30 @@ std::vector<ColumnStatsValues> ColumnStatsData::materialize_slot(
         return result;
     }
 
-    const auto& info = slots_[slot];
-    const uint8_t* min_buf = min_data_.data() + slot * num_rows_ * BYTES_PER_CELL;
-    const uint8_t* max_buf = max_data_.data() + slot * num_rows_ * BYTES_PER_CELL;
-
-    details::visit_type(info.data_type, [&](auto tag) {
-        using type_info = ScalarTypeInfo<decltype(tag)>;
-        if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
-                      is_bool_type(type_info::data_type)) {
-            using RawType = type_info::RawType;
-            const bool min_dense = !info.min_set.has_value();
-            const bool max_dense = !info.max_set.has_value();
-            for (size_t i = 0; i < row_indices.size(); ++i) {
-                const auto& maybe_row = row_indices.at(i);
-                if (!maybe_row.has_value()) {
-                    continue;
-                }
-                const size_t r = *maybe_row;
-                const bool min_set = min_dense || info.min_set->test(static_cast<util::BitSetSizeType>(r));
-                const bool max_set = max_dense || info.max_set->test(static_cast<util::BitSetSizeType>(r));
-                util::check(min_set == max_set, "MIN and MAX should both be present or both be absent");
-                auto& result_entry = result.at(i);
-                if (min_set) {
-                    RawType raw_min = *reinterpret_cast<const RawType*>(min_buf + r * BYTES_PER_CELL);
-                    result_entry.min = Value{raw_min, type_info::data_type};
-                    RawType raw_max = *reinterpret_cast<const RawType*>(max_buf + r * BYTES_PER_CELL);
-                    result_entry.max = Value{raw_max, type_info::data_type};
-                } else {
-                    result_entry.column_absent = true;
-                }
-            }
+    const auto& slot_data = slots_.at(slot);
+    for (size_t i = 0; i < row_indices.size(); ++i) {
+        const auto& maybe_row = row_indices.at(i);
+        if (!maybe_row.has_value()) {
+            continue;
         }
-    });
+        const size_t r = *maybe_row;
+        const bool min_set = slot_data.mins.at(r).has_value();
+        const bool max_set = slot_data.maxes.at(r).has_value();
+        util::check(min_set == max_set, "MIN and MAX should both be present or both be absent");
+        auto& result_entry = result.at(i);
+        if (min_set) {
+            result_entry.min = slot_data.mins.at(r);
+            result_entry.max = slot_data.maxes.at(r);
+        } else {
+            result_entry.column_absent = true;
+        }
+    }
     return result;
 }
 
 ColumnStatsValues ColumnStatsData::stats_for(size_t slot, size_t row) const {
-    auto v = materialize_slot(slot, {std::optional<size_t>{row}});
-    return v.empty() ? ColumnStatsValues{} : std::move(v[0]);
+    auto v = values_at_slot(slot, {std::optional<size_t>{row}});
+    return v.empty() ? ColumnStatsValues{} : std::move(v.at(0));
 }
 
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -125,43 +125,26 @@ StatsVariantData compute_stats(
     return std::vector(row_indices.size(), StatsComparison::UNKNOWN);
 }
 
-ColumnStatsData::ColumnStatsData(
-        SegmentInMemory&& segment, const TimeseriesDescriptor& tsd,
-        std::optional<std::pair<timestamp, timestamp>> date_range
+namespace {
+std::vector<StatsMetadataForColumn> calculate_stats_metadata(
+        const SegmentInMemory& segment, const TimeseriesDescriptor& tsd,
+        arcticc::pb2::column_stats_pb2::ColumnStatsHeader header, const FieldCollection& fields
 ) {
-    using namespace arcticc::pb2::column_stats_pb2;
-    if (segment.row_count() == 0) {
-        return;
-    }
-
-    ColumnStatsHeader header;
-    auto* metadata = segment.metadata();
-    util::check(metadata != nullptr, "Column stats segment has no metadata");
-    bool unpacked = metadata->UnpackTo(&header);
-    util::check(unpacked, "Could not unpack ColumnStatsHeader from column stats segment metadata");
-    validate_column_stats_header_version(header);
-
-    segment.init_column_map();
-    const auto& fields = segment.descriptor().fields();
-    const auto segment_row_count = segment.row_count();
-
-    const auto& start_index_col = segment.column(start_index_column_offset);
-    const auto& end_index_col = segment.column(end_index_column_offset);
-    if (start_index_col.is_sparse() || end_index_col.is_sparse() ||
-        static_cast<size_t>(start_index_col.row_count()) != segment_row_count ||
-        static_cast<size_t>(end_index_col.row_count()) != segment_row_count) {
-        log::version().warn("Saw column stats row without start_index or end_index, discarding all column stats");
-        return;
-    }
-
     // Gather metadata about the statistics we're interested in
     std::vector<StatsMetadataForColumn> stats_metadata;
     stats_metadata.reserve(header.stats_by_column().size());
     for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
         StatsMetadataForColumn stats_metadata_for_column;
+        util::check(
+                data_col_offset < tsd.fields().size(),
+                "Expected data_col_offset < tsd.fields().size() but saw data_col_offset=[{}] tsd.fields().size()=[{}]",
+                data_col_offset,
+                tsd.fields().size()
+        );
         stats_metadata_for_column.col_name = std::string{tsd.fields().at(data_col_offset).name()};
         for (const auto& entry : entry_list.entries()) {
-            if (entry.type() != MIN_V1 && entry.type() != MAX_V1) {
+            if (entry.type() != arcticc::pb2::column_stats_pb2::MIN_V1 &&
+                entry.type() != arcticc::pb2::column_stats_pb2::MAX_V1) {
                 log::version().warn(
                         "Unknown column stats type {} for column {}, skipping",
                         static_cast<int>(entry.type()),
@@ -191,7 +174,51 @@ ColumnStatsData::ColumnStatsData(
             stats_metadata.emplace_back(std::move(stats_metadata_for_column));
         }
     }
+    return stats_metadata;
+}
 
+std::unordered_map<std::string, StatsForColumn> load_stats_by_column(
+        const SegmentInMemory& segment, std::vector<StatsMetadataForColumn> stats_metadata, size_t first_kept,
+        size_t last_kept_excl, size_t num_rows
+) {
+    std::unordered_map<std::string, StatsForColumn> stats_by_column;
+    for (auto& stats_metadata_for_column : stats_metadata) {
+        StatsForColumn stats_for_column;
+        stats_for_column.mins.resize(num_rows);
+        stats_for_column.maxes.resize(num_rows);
+
+        details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
+            using type_info = ScalarTypeInfo<T>;
+            if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
+                          is_bool_type(type_info::data_type)) {
+                for (const auto& entry : stats_metadata_for_column.entries) {
+                    const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
+                    const bool is_min = entry.stat_type == arcticc::pb2::column_stats_pb2::MIN_V1;
+                    auto& dest = is_min ? stats_for_column.mins : stats_for_column.maxes;
+                    for_each_enumerated<typename type_info::TDT>(
+                            column,
+                            [&](const ColumnData::Enumeration<typename type_info::RawType>& enumerating_it) {
+                                auto idx = static_cast<size_t>(enumerating_it.idx());
+                                if (idx >= first_kept && idx < last_kept_excl) {
+                                    dest.at(idx - first_kept) = Value{enumerating_it.value(), type_info::data_type};
+                                }
+                            }
+                    );
+                }
+            }
+        });
+
+        stats_by_column.emplace(std::move(stats_metadata_for_column.col_name), std::move(stats_for_column));
+    }
+    return stats_by_column;
+}
+
+} // anonymous namespace
+
+std::pair<size_t, size_t> ColumnStatsData::calculate_start_and_end_indices(
+        const std::optional<std::pair<timestamp, timestamp>>& date_range, const size_t segment_row_count,
+        const Column& start_index_col, const Column& end_index_col
+) {
     // Construct start_indices and end_indices with date range pruning.
     // Also construct the interval [first_kept, last_kept_excl) to quickly skip stats for row ranges
     // we are not interested in when we read the statistics themselves.
@@ -200,23 +227,23 @@ ColumnStatsData::ColumnStatsData(
     start_indices_.reserve(segment_row_count);
     end_indices_.reserve(segment_row_count);
     using TsTDT = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    auto start_it = start_index_col.begin<TsTDT>();
-    auto end_it = end_index_col.begin<TsTDT>();
+    auto start_data = start_index_col.data();
+    auto end_data = end_index_col.data();
+    auto start_it = start_data.begin<TsTDT>();
+    auto end_it = end_data.begin<TsTDT>();
     timestamp prev_start = 0;
-    timestamp prev_end = 0;
     for (size_t r = 0; r < segment_row_count; ++r, ++start_it, ++end_it) {
         const timestamp start_index_ts = *start_it;
         const timestamp end_index_ts = *end_it;
         if (r > 0) {
             util::check(
-                    start_index_ts >= prev_start && end_index_ts >= prev_end,
-                    "Column stats segment start_index/end_index must be monotonically increasing "
+                    start_index_ts >= prev_start,
+                    "Column stats segment start_index must be monotonically increasing "
                     "(violated at row {})",
                     r
             );
         }
         prev_start = start_index_ts;
-        prev_end = end_index_ts;
         if (date_range.has_value()) {
             if (start_index_ts > date_range->second) {
                 break;
@@ -232,53 +259,10 @@ ColumnStatsData::ColumnStatsData(
         start_indices_.push_back(start_index_ts);
         end_indices_.push_back(end_index_ts);
     }
-    num_rows_ = start_indices_.size();
-    if (num_rows_ == 0) {
-        return;
-    }
+    return std::make_pair(first_kept, last_kept_excl);
+}
 
-    // Store statistics in the stats_by_column_ map
-    for (auto& stats_metadata_for_column : stats_metadata) {
-        StatsForColumn stats_for_column;
-        stats_for_column.mins.resize(num_rows_);
-        stats_for_column.maxes.resize(num_rows_);
-
-        details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
-            using type_info = ScalarTypeInfo<T>;
-            if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
-                          is_bool_type(type_info::data_type)) {
-                using RawType = type_info::RawType;
-
-                for (const auto& entry : stats_metadata_for_column.entries) {
-                    const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
-                    const bool is_min = entry.stat_type == MIN_V1;
-                    auto& dest = is_min ? stats_for_column.mins : stats_for_column.maxes;
-
-                    if (!column.is_sparse() && static_cast<size_t>(column.row_count()) == segment_row_count) {
-                        // Dense
-                        auto it = column.begin<typename type_info::TDT>();
-                        std::advance(it, static_cast<ssize_t>(first_kept));
-                        for (size_t r = first_kept; r < last_kept_excl; ++r, ++it) {
-                            const size_t kept = r - first_kept;
-                            dest.at(kept) = Value{*it, type_info::data_type};
-                        }
-                    } else {
-                        // Sparse
-                        for (size_t r = first_kept; r < last_kept_excl; ++r) {
-                            if (auto opt_val = column.scalar_at<RawType>(static_cast<position_t>(r));
-                                opt_val.has_value()) {
-                                const size_t kept = r - first_kept;
-                                dest.at(kept) = Value{*opt_val, type_info::data_type};
-                            }
-                        }
-                    }
-                }
-            }
-        });
-
-        stats_by_column_.emplace(std::move(stats_metadata_for_column.col_name), std::move(stats_for_column));
-    }
-
+void ColumnStatsData::drop_duplicate_rows() {
     index_to_row_.reserve(num_rows_);
     std::unordered_set<std::pair<timestamp, timestamp>, util::PairHasher> duplicate_keys;
     for (size_t r = 0; r < num_rows_; ++r) {
@@ -293,6 +277,48 @@ ColumnStatsData::ColumnStatsData(
         log::version().debug("Duplicate key detected in column stats - dropping {}", key);
         index_to_row_.erase(key);
     }
+}
+
+ColumnStatsData::ColumnStatsData(
+        SegmentInMemory&& segment, const TimeseriesDescriptor& tsd,
+        std::optional<std::pair<timestamp, timestamp>> date_range
+) {
+    using namespace arcticc::pb2::column_stats_pb2;
+    if (segment.row_count() == 0) {
+        return;
+    }
+
+    ColumnStatsHeader header;
+    auto* metadata = segment.metadata();
+    util::check(metadata != nullptr, "Column stats segment has no metadata");
+    bool unpacked = metadata->UnpackTo(&header);
+    util::check(unpacked, "Could not unpack ColumnStatsHeader from column stats segment metadata");
+    validate_column_stats_header_version(header);
+
+    segment.init_column_map();
+    const auto& fields = segment.descriptor().fields();
+    const auto segment_row_count = segment.row_count();
+
+    const auto& start_index_col = segment.column(start_index_column_offset);
+    const auto& end_index_col = segment.column(end_index_column_offset);
+    if (start_index_col.is_sparse() || end_index_col.is_sparse() ||
+        static_cast<size_t>(start_index_col.row_count()) != segment_row_count ||
+        static_cast<size_t>(end_index_col.row_count()) != segment_row_count) {
+        log::version().warn("Saw column stats row without start_index or end_index, discarding all column stats");
+        return;
+    }
+
+    std::vector<StatsMetadataForColumn> stats_metadata = calculate_stats_metadata(segment, tsd, header, fields);
+
+    auto [first_kept, last_kept_excl] =
+            calculate_start_and_end_indices(date_range, segment_row_count, start_index_col, end_index_col);
+    num_rows_ = start_indices_.size();
+    if (num_rows_ == 0) {
+        return;
+    }
+
+    stats_by_column_ = load_stats_by_column(segment, stats_metadata, first_kept, last_kept_excl, num_rows_);
+    drop_duplicate_rows();
 }
 
 std::optional<size_t> ColumnStatsData::find_row(timestamp start_index, timestamp end_index) const {
@@ -332,11 +358,6 @@ std::vector<ColumnStatsValues> ColumnStatsData::values_for_column(
         }
     }
     return result;
-}
-
-ColumnStatsValues ColumnStatsData::stats_for(const std::string& col_name, size_t row) const {
-    auto v = values_for_column(col_name, {std::optional<size_t>{row}});
-    return v.empty() ? ColumnStatsValues{} : std::move(v.at(0));
 }
 
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
@@ -399,23 +420,22 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
     };
 }
 
-ColumnStatsQueryMetadata column_stats_query_metadata(const std::vector<std::shared_ptr<Clause>>& clauses) {
+ColumnStatsQueryMetadata::ColumnStatsQueryMetadata(const std::vector<std::shared_ptr<Clause>>& clauses) {
     // The clauses eligible for column stats use:
     // - FilterClauses contribute filter expressions and columns of interest
     // - DateRangeClauses contribute their range
     // - RowRangeClauses are skipped
     // - Anything else (Resample / GroupBy / Project) ends the prefix because those clauses
     // transform the data so stats computed on the original segments are no longer valid.
-    ColumnStatsQueryMetadata result;
     for (const auto& clause : clauses) {
         auto& clause_type = folly::poly_type(*clause);
         if (clause_type == typeid(DateRangeClause)) {
             const auto& date_range_clause = folly::poly_cast<DateRangeClause>(*clause);
-            if (!result.date_range.has_value()) {
-                result.date_range = std::make_pair(date_range_clause.start(), date_range_clause.end());
+            if (date_range.has_value()) {
+                date_range->first = std::max(date_range->first, date_range_clause.start());
+                date_range->second = std::min(date_range->second, date_range_clause.end());
             } else {
-                result.date_range->first = std::max(result.date_range->first, date_range_clause.start());
-                result.date_range->second = std::min(result.date_range->second, date_range_clause.end());
+                date_range = std::make_pair(date_range_clause.start(), date_range_clause.end());
             }
             continue;
         }
@@ -426,16 +446,15 @@ ColumnStatsQueryMetadata column_stats_query_metadata(const std::vector<std::shar
             break;
         }
         const auto& filter = folly::poly_cast<FilterClause>(*clause);
-        result.filter_expressions.emplace_back(filter.expression_context_);
+        filter_expressions.emplace_back(filter.expression_context_);
         util::check(
                 filter.clause_info().input_columns_.has_value(),
                 "FilterClause is missing input_columns_ — Python bindings should always populate this"
         );
         for (const auto& col : *filter.clause_info().input_columns_) {
-            result.columns_of_interest.insert(col);
+            columns_of_interest.insert(col);
         }
     }
-    return result;
 }
 
 SegmentInMemory partial_decode_column_stats_segment(
@@ -504,18 +523,14 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         storage::KeySegmentPair&& column_stats_compressed, const TimeseriesDescriptor& tsd,
         ColumnStatsQueryMetadata&& query_metadata
 ) {
+    util::check(
+            query_metadata.should_try_column_stats_read(),
+            "Should not try to create column stats filter if !should_try_column_stats_read()"
+    );
     SegmentInMemory partial_segment = partial_decode_column_stats_segment(
             *column_stats_compressed.segment_ptr(), tsd, query_metadata.columns_of_interest
     );
     ColumnStatsData column_stats{std::move(partial_segment), tsd, query_metadata.date_range};
-    return build_filter_from_column_stats_data(std::move(column_stats), std::move(query_metadata.filter_expressions));
-}
-
-FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
-        SegmentInMemory&& column_stats_segment, const TimeseriesDescriptor& tsd,
-        ColumnStatsQueryMetadata&& query_metadata
-) {
-    ColumnStatsData column_stats{std::move(column_stats_segment), tsd, query_metadata.date_range};
     return build_filter_from_column_stats_data(std::move(column_stats), std::move(query_metadata.filter_expressions));
 }
 

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -36,10 +36,7 @@ StatsVariantData evaluate_ast_node_against_stats(
     return util::variant_match(
             node,
             [&](const ColumnName& column_name) -> StatsVariantData {
-                if (auto slot = column_stats.slot_for_column(column_name.value); slot.has_value()) {
-                    return column_stats.values_at_slot(*slot, row_indices);
-                }
-                return std::vector<ColumnStatsValues>(row_indices.size());
+                return column_stats.values_for_column(column_name.value, row_indices);
             },
             [&](const ValueName& value_name) -> StatsVariantData {
                 return expression_context.values_.get_value(value_name.value);
@@ -157,8 +154,7 @@ ColumnStatsData::ColumnStatsData(
         return;
     }
 
-    // For each column in the read query with any stats we register a slot and remember the segment column indices to
-    // read from.
+    // Gather metadata about the statistics we're interested in
     std::vector<StatsMetadataForColumn> stats_metadata;
     stats_metadata.reserve(header.stats_by_column().size());
     for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
@@ -241,17 +237,11 @@ ColumnStatsData::ColumnStatsData(
         return;
     }
 
-    num_slots_ = stats_metadata.size();
-    slots_.resize(num_slots_);
-    for (auto& slot_data : slots_) {
-        slot_data.mins.resize(num_rows_);
-        slot_data.maxes.resize(num_rows_);
-    }
-
-    for (size_t slot = 0; slot < num_slots_; ++slot) {
-        auto& stats_metadata_for_column = stats_metadata.at(slot);
-        col_name_to_slot_.emplace(stats_metadata_for_column.col_name, slot);
-        auto& slot_data = slots_.at(slot);
+    // Store statistics in the stats_by_column_ map
+    for (auto& stats_metadata_for_column : stats_metadata) {
+        StatsForColumn stats_for_column;
+        stats_for_column.mins.resize(num_rows_);
+        stats_for_column.maxes.resize(num_rows_);
 
         details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
             using type_info = ScalarTypeInfo<T>;
@@ -262,7 +252,7 @@ ColumnStatsData::ColumnStatsData(
                 for (const auto& entry : stats_metadata_for_column.entries) {
                     const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
                     const bool is_min = entry.stat_type == MIN_V1;
-                    auto& dest = is_min ? slot_data.mins : slot_data.maxes;
+                    auto& dest = is_min ? stats_for_column.mins : stats_for_column.maxes;
 
                     if (!column.is_sparse() && static_cast<size_t>(column.row_count()) == segment_row_count) {
                         // Dense
@@ -285,6 +275,8 @@ ColumnStatsData::ColumnStatsData(
                 }
             }
         });
+
+        stats_by_column_.emplace(std::move(stats_metadata_for_column.col_name), std::move(stats_for_column));
     }
 
     index_to_row_.reserve(num_rows_);
@@ -310,35 +302,31 @@ std::optional<size_t> ColumnStatsData::find_row(timestamp start_index, timestamp
     return std::nullopt;
 }
 
-std::optional<size_t> ColumnStatsData::slot_for_column(const std::string& col_name) const {
-    if (auto it = col_name_to_slot_.find(col_name); it != col_name_to_slot_.end()) {
-        return it->second;
-    }
-    return std::nullopt;
-}
-
-std::vector<ColumnStatsValues> ColumnStatsData::values_at_slot(
-        size_t slot, const std::vector<std::optional<size_t>>& row_indices
+std::vector<ColumnStatsValues> ColumnStatsData::values_for_column(
+        const std::string& col_name, const std::vector<std::optional<size_t>>& row_indices
 ) const {
     std::vector<ColumnStatsValues> result(row_indices.size());
-    if (slot >= num_slots_ || num_rows_ == 0) {
+    if (num_rows_ == 0) {
         return result;
     }
-
-    const auto& slot_data = slots_.at(slot);
+    auto it = stats_by_column_.find(col_name);
+    if (it == stats_by_column_.end()) {
+        return result;
+    }
+    const auto& stats = it->second;
     for (size_t i = 0; i < row_indices.size(); ++i) {
         const auto& maybe_row = row_indices.at(i);
         if (!maybe_row.has_value()) {
             continue;
         }
         const size_t r = *maybe_row;
-        const bool min_set = slot_data.mins.at(r).has_value();
-        const bool max_set = slot_data.maxes.at(r).has_value();
+        const bool min_set = stats.mins.at(r).has_value();
+        const bool max_set = stats.maxes.at(r).has_value();
         util::check(min_set == max_set, "MIN and MAX should both be present or both be absent");
         auto& result_entry = result.at(i);
         if (min_set) {
-            result_entry.min = slot_data.mins.at(r);
-            result_entry.max = slot_data.maxes.at(r);
+            result_entry.min = stats.mins.at(r);
+            result_entry.max = stats.maxes.at(r);
         } else {
             result_entry.column_absent = true;
         }
@@ -346,8 +334,8 @@ std::vector<ColumnStatsValues> ColumnStatsData::values_at_slot(
     return result;
 }
 
-ColumnStatsValues ColumnStatsData::stats_for(size_t slot, size_t row) const {
-    auto v = values_at_slot(slot, {std::optional<size_t>{row}});
+ColumnStatsValues ColumnStatsData::stats_for(const std::string& col_name, size_t row) const {
+    auto v = values_for_column(col_name, {std::optional<size_t>{row}});
     return v.empty() ? ColumnStatsValues{} : std::move(v.at(0));
 }
 

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -520,16 +520,15 @@ FilterQuery<index::IndexSegmentReader> build_filter_from_column_stats_data(
 } // namespace
 
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
-        storage::KeySegmentPair&& column_stats_compressed, const TimeseriesDescriptor& tsd,
+        std::shared_ptr<Segment> column_stats_compressed, const TimeseriesDescriptor& tsd,
         ColumnStatsQueryMetadata&& query_metadata
 ) {
     util::check(
             query_metadata.should_try_column_stats_read(),
             "Should not try to create column stats filter if !should_try_column_stats_read()"
     );
-    SegmentInMemory partial_segment = partial_decode_column_stats_segment(
-            *column_stats_compressed.segment_ptr(), tsd, query_metadata.columns_of_interest
-    );
+    SegmentInMemory partial_segment =
+            partial_decode_column_stats_segment(*column_stats_compressed, tsd, query_metadata.columns_of_interest);
     ColumnStatsData column_stats{std::move(partial_segment), tsd, query_metadata.date_range};
     return build_filter_from_column_stats_data(std::move(column_stats), std::move(query_metadata.filter_expressions));
 }

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -21,7 +21,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <gtest/gtest_prod.h>
 #include <column_stats.pb.h>
 
 namespace arcticdb {
@@ -60,6 +59,11 @@ struct StatsMetadataForColumn {
     std::vector<StatsIndexAndType> entries;
 };
 
+struct StatsForColumn {
+    std::vector<std::optional<Value>> mins;  // size == num_rows_
+    std::vector<std::optional<Value>> maxes; // size == num_rows_
+};
+
 /**
  * Parsed column statistics from a column stats segment.
  */
@@ -95,17 +99,12 @@ class ColumnStatsData {
     ) const;
 
   private:
-    FRIEND_TEST(ColumnStatsDataTest, FindStatsAllRowsPresent);
-    FRIEND_TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows);
-    FRIEND_TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows);
-    FRIEND_TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly);
+    std::pair<size_t, size_t> calculate_start_and_end_indices(
+            const std::optional<std::pair<timestamp, timestamp>>& date_range, size_t segment_row_count,
+            const Column& start_index_col, const Column& end_index_col
+    );
 
-    ColumnStatsValues stats_for(const std::string& col_name, size_t row) const;
-
-    struct StatsForColumn {
-        std::vector<std::optional<Value>> mins;  // size == num_rows_
-        std::vector<std::optional<Value>> maxes; // size == num_rows_
-    };
+    void drop_duplicate_rows();
 
     size_t num_rows_{0};
     std::vector<timestamp> start_indices_; // size = num_rows_
@@ -122,6 +121,9 @@ struct ColumnStatsQueryMetadata {
     // Columns referenced in the user's query.
     std::unordered_set<std::string> columns_of_interest;
     std::optional<std::pair<timestamp, timestamp>> date_range;
+
+    ColumnStatsQueryMetadata() = default;
+    explicit ColumnStatsQueryMetadata(const std::vector<std::shared_ptr<Clause>>& clauses);
 
     /**
      * True iff column stats are feature-flagged on and the query has at least one filter
@@ -154,25 +156,6 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         storage::KeySegmentPair&& column_stats_compressed, const TimeseriesDescriptor& tsd,
         ColumnStatsQueryMetadata&& query_metadata
 );
-
-/**
- * Create a column stats filter from an already-decoded column stats segment.
- *
- * Used when the column stats segment has been pre-loaded (e.g. via PreloadedIndexQuery) and the
- * compressed bytes are no longer available. Date-range row pruning still applies, but column-set
- * filtering does not — the caller has already paid the full decode cost.
- *
- * Precondition: query_metadata.should_try_column_stats_read() == true.
- */
-FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
-        SegmentInMemory&& column_stats_segment, const TimeseriesDescriptor& tsd,
-        ColumnStatsQueryMetadata&& query_metadata
-);
-
-/**
- * Metadata about the part of the user's query to which we can apply column stats.
- */
-ColumnStatsQueryMetadata column_stats_query_metadata(const std::vector<std::shared_ptr<Clause>>& clauses);
 
 /**
  * Decode a column stats segment, only considering fields referenced by columns_of_interest.

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -89,13 +89,12 @@ class ColumnStatsData {
     std::optional<size_t> slot_for_column(const std::string& col_name) const;
 
     /**
-     * Materialize ColumnStatsValues for the requested slot at each row index in row_indices.
+     * Return the min/max ColumnStatsValues for the requested slot at each row index in row_indices.
      */
-    std::vector<ColumnStatsValues> materialize_slot(size_t slot, const std::vector<std::optional<size_t>>& row_indices)
+    std::vector<ColumnStatsValues> values_at_slot(size_t slot, const std::vector<std::optional<size_t>>& row_indices)
             const;
 
   private:
-    static constexpr size_t BYTES_PER_CELL = 8;
     FRIEND_TEST(ColumnStatsDataTest, FindStatsAllRowsPresent);
     FRIEND_TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows);
     FRIEND_TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows);
@@ -103,26 +102,16 @@ class ColumnStatsData {
 
     ColumnStatsValues stats_for(size_t slot, size_t row) const;
 
-    /**
-     * Storage layout is flat columnar: we keep a typed raw buffer for min and max.
-     * This gives us a single big allocation rather than one vector per row, and
-     * avoids the per-cell Value wrapper construction when constructing this object.
-     */
-    struct SlotInfo {
-        DataType data_type;
-        // Bit per row indicating whether that row has a value for the statistic.
-        // nullopt means the source column was dense and every row has a value.
-        std::optional<util::BitSet> min_set;
-        std::optional<util::BitSet> max_set;
+    struct SlotData {
+        std::vector<std::optional<Value>> mins;  // size == num_rows_
+        std::vector<std::optional<Value>> maxes; // size == num_rows_
     };
 
     size_t num_rows_{0};
     size_t num_slots_{0};
     std::vector<timestamp> start_indices_; // size = num_rows_
     std::vector<timestamp> end_indices_;   // size = num_rows_
-    std::vector<SlotInfo> slots_;          // size = num_slots_
-    std::vector<uint8_t> min_data_;        // size = num_slots_ * num_rows_ * BYTES_PER_CELL
-    std::vector<uint8_t> max_data_;        // size = num_slots_ * num_rows_ * BYTES_PER_CELL
+    std::vector<SlotData> slots_;          // size = num_slots_
 
     // (start_index, end_index) -> row index. The index values are rowcounts for string-indexed symbols.
     std::unordered_map<std::pair<timestamp, timestamp>, size_t, util::PairHasher> index_to_row_;

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -12,12 +12,17 @@
 #include <arcticdb/pipeline/query.hpp>
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/storage/key_segment_pair.hpp>
+#include <arcticdb/util/bitset.hpp>
 
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <gtest/gtest_prod.h>
+#include <column_stats.pb.h>
 
 namespace arcticdb {
 
@@ -44,14 +49,15 @@ struct ColumnStatsValues {
     };
 };
 
-/**
- * Represents column statistics for a single row-slice.
- */
-struct ColumnStatsRow {
-    timestamp start_index;
-    timestamp end_index;
-    // Map from column name to its stats
-    std::unordered_map<std::string, ColumnStatsValues> stats_for_column;
+struct StatsIndexAndType {
+    size_t segment_col_idx;
+    arcticc::pb2::column_stats_pb2::ColumnStatsType stat_type;
+};
+
+struct StatsMetadataForColumn {
+    std::string col_name;
+    DataType data_type{DataType::UNKNOWN};
+    std::vector<StatsIndexAndType> entries;
 };
 
 /**
@@ -59,26 +65,82 @@ struct ColumnStatsRow {
  */
 class ColumnStatsData {
   public:
-    explicit ColumnStatsData(SegmentInMemory&& segment, const TimeseriesDescriptor& tsd);
+    /**
+     * @param segment The column stats segment.
+     * @param tsd     The original symbol's TSD, used to resolve data_col_offsets in the column stats
+     *                header back to user column names.
+     * @param date_range Date range to load stats for.
+     */
+    explicit ColumnStatsData(
+            SegmentInMemory&& segment, const TimeseriesDescriptor& tsd,
+            std::optional<std::pair<timestamp, timestamp>> date_range = std::nullopt
+    );
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ColumnStatsData)
 
     /**
-     * Find the column stats for a given row-slice identified by start_index and end_index.
-     * Returns nullptr if no matching stats found.
+     * Find the row index for a given row-slice identified by start_index and end_index.
+     * Returns nullopt if no matching stats found.
      */
-    const ColumnStatsRow* find_stats(timestamp start_index, timestamp end_index) const;
+    std::optional<size_t> find_row(timestamp start_index, timestamp end_index) const;
 
-    bool empty() const;
+    bool empty() const { return num_rows_ == 0; }
+
+    std::optional<size_t> slot_for_column(const std::string& col_name) const;
+
+    /**
+     * Materialize ColumnStatsValues for the requested slot at each row index in row_indices.
+     */
+    std::vector<ColumnStatsValues> materialize_slot(size_t slot, const std::vector<std::optional<size_t>>& row_indices)
+            const;
 
   private:
-    std::vector<ColumnStatsRow> rows_;
-    // (start_index, end_index) -> row index
-    // The index values in the column stats segment are just rowcounts if the symbol is string-indexed
+    static constexpr size_t BYTES_PER_CELL = 8;
+    FRIEND_TEST(ColumnStatsDataTest, FindStatsAllRowsPresent);
+    FRIEND_TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows);
+    FRIEND_TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows);
+    FRIEND_TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly);
+
+    ColumnStatsValues stats_for(size_t slot, size_t row) const;
+
+    /**
+     * Storage layout is flat columnar: we keep a typed raw buffer for min and max.
+     * This gives us a single big allocation rather than one vector per row, and
+     * avoids the per-cell Value wrapper construction when constructing this object.
+     */
+    struct SlotInfo {
+        DataType data_type;
+        // Bit per row indicating whether that row has a value for the statistic.
+        // nullopt means the source column was dense and every row has a value.
+        std::optional<util::BitSet> min_set;
+        std::optional<util::BitSet> max_set;
+    };
+
+    size_t num_rows_{0};
+    size_t num_slots_{0};
+    std::vector<timestamp> start_indices_; // size = num_rows_
+    std::vector<timestamp> end_indices_;   // size = num_rows_
+    std::vector<SlotInfo> slots_;          // size = num_slots_
+    std::vector<uint8_t> min_data_;        // size = num_slots_ * num_rows_ * BYTES_PER_CELL
+    std::vector<uint8_t> max_data_;        // size = num_slots_ * num_rows_ * BYTES_PER_CELL
+
+    // (start_index, end_index) -> row index. The index values are rowcounts for string-indexed symbols.
     std::unordered_map<std::pair<timestamp, timestamp>, size_t, util::PairHasher> index_to_row_;
-    // Keys that appeared more than once in the stats segment. Entries for these keys are removed, forcing the segments
-    // to be read without pruning.
-    std::unordered_set<std::pair<timestamp, timestamp>, util::PairHasher> duplicate_keys_;
+    std::unordered_map<std::string, size_t> col_name_to_slot_;
+};
+
+struct ColumnStatsQueryMetadata {
+    // Filter expressions we can apply column stats to.
+    std::vector<std::shared_ptr<ExpressionContext>> filter_expressions;
+    // Columns referenced in the user's query.
+    std::unordered_set<std::string> columns_of_interest;
+    std::optional<std::pair<timestamp, timestamp>> date_range;
+
+    /**
+     * True iff column stats are feature-flagged on and the query has at least one filter
+     * expression in the column-stats-eligible prefix.
+     */
+    bool should_try_column_stats_read() const;
 };
 
 /**
@@ -94,21 +156,43 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
 );
 
 /**
- * Is column stats feature flagged on?
+ * Create a column stats filter from compressed column stats bytes.
  *
- * Does the query have a filter query before any resample, group by or projection clauses, so that it
- * might be able to benefit from using the column stats?
+ * Partially decodes the column stats segment so only the stats columns referenced by the query's
+ * filter clauses are loaded; rows outside the intersection of any DateRangeClause are pruned.
+ *
+ * Precondition: query_metadata.should_try_column_stats_read() == true.
  */
-bool should_try_column_stats_read(const ReadQuery& read_query);
+FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
+        storage::KeySegmentPair&& column_stats_compressed, const TimeseriesDescriptor& tsd,
+        ColumnStatsQueryMetadata&& query_metadata
+);
 
 /**
- * Create a column stats filter from an already-read column stats segment and query clauses.
+ * Create a column stats filter from an already-decoded column stats segment.
  *
- * Precondition: should_try_column_stats_read(clauses) == true
+ * Used when the column stats segment has been pre-loaded (e.g. via PreloadedIndexQuery) and the
+ * compressed bytes are no longer available. Date-range row pruning still applies, but column-set
+ * filtering does not — the caller has already paid the full decode cost.
+ *
+ * Precondition: query_metadata.should_try_column_stats_read() == true.
  */
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         SegmentInMemory&& column_stats_segment, const TimeseriesDescriptor& tsd,
-        const std::vector<std::shared_ptr<Clause>>& clauses
+        ColumnStatsQueryMetadata&& query_metadata
+);
+
+/**
+ * Metadata about the part of the user's query to which we can apply column stats.
+ */
+ColumnStatsQueryMetadata column_stats_query_metadata(const std::vector<std::shared_ptr<Clause>>& clauses);
+
+/**
+ * Decode a column stats segment, only considering fields referenced by columns_of_interest.
+ */
+SegmentInMemory partial_decode_column_stats_segment(
+        Segment& column_stats_segment, const TimeseriesDescriptor& tsd,
+        const std::unordered_set<std::string>& columns_of_interest
 );
 
 /**

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -86,13 +86,13 @@ class ColumnStatsData {
 
     bool empty() const { return num_rows_ == 0; }
 
-    std::optional<size_t> slot_for_column(const std::string& col_name) const;
-
     /**
-     * Return the min/max ColumnStatsValues for the requested slot at each row index in row_indices.
+     * Return the min/max ColumnStatsValues for the requested column at each row index in row_indices.
+     * Returns a vector of default-constructed (absent) entries if the column has no stats.
      */
-    std::vector<ColumnStatsValues> values_at_slot(size_t slot, const std::vector<std::optional<size_t>>& row_indices)
-            const;
+    std::vector<ColumnStatsValues> values_for_column(
+            const std::string& col_name, const std::vector<std::optional<size_t>>& row_indices
+    ) const;
 
   private:
     FRIEND_TEST(ColumnStatsDataTest, FindStatsAllRowsPresent);
@@ -100,22 +100,20 @@ class ColumnStatsData {
     FRIEND_TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows);
     FRIEND_TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly);
 
-    ColumnStatsValues stats_for(size_t slot, size_t row) const;
+    ColumnStatsValues stats_for(const std::string& col_name, size_t row) const;
 
-    struct SlotData {
+    struct StatsForColumn {
         std::vector<std::optional<Value>> mins;  // size == num_rows_
         std::vector<std::optional<Value>> maxes; // size == num_rows_
     };
 
     size_t num_rows_{0};
-    size_t num_slots_{0};
     std::vector<timestamp> start_indices_; // size = num_rows_
     std::vector<timestamp> end_indices_;   // size = num_rows_
-    std::vector<SlotData> slots_;          // size = num_slots_
+    std::unordered_map<std::string, StatsForColumn> stats_by_column_;
 
     // (start_index, end_index) -> row index. The index values are rowcounts for string-indexed symbols.
     std::unordered_map<std::pair<timestamp, timestamp>, size_t, util::PairHasher> index_to_row_;
-    std::unordered_map<std::string, size_t> col_name_to_slot_;
 };
 
 struct ColumnStatsQueryMetadata {

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -153,7 +153,7 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
  * Precondition: query_metadata.should_try_column_stats_read() == true.
  */
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
-        storage::KeySegmentPair&& column_stats_compressed, const TimeseriesDescriptor& tsd,
+        std::shared_ptr<Segment> column_stats_compressed, const TimeseriesDescriptor& tsd,
         ColumnStatsQueryMetadata&& query_metadata
 );
 

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -12,8 +12,8 @@
 #include <arcticdb/entity/index_range.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/variant.hpp>
+#include <arcticdb/codec/segment.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
-#include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/stream/stream_utils.hpp>
 #include <arcticdb/util/simple_string_hash.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
@@ -42,10 +42,7 @@ struct SpecificVersionQuery {
 
 // Similar to IndexInformation. See comment on IndexInformation for why both are useful.
 struct PreloadedIndexQuery {
-    PreloadedIndexQuery(
-            AtomKey index_key, SegmentInMemory index_seg,
-            std::optional<storage::KeySegmentPair> column_stats_seg = std::nullopt
-    ) :
+    PreloadedIndexQuery(AtomKey index_key, SegmentInMemory index_seg, std::shared_ptr<Segment> column_stats_seg = {}) :
         index_key_(std::move(index_key)),
         index_seg_(std::move(index_seg)),
         column_stats_seg_(std::move(column_stats_seg)) {}
@@ -53,7 +50,7 @@ struct PreloadedIndexQuery {
     // Key is just needed for constructing the VersionedItem to return
     const AtomKey index_key_;
     const SegmentInMemory index_seg_;
-    const std::optional<storage::KeySegmentPair> column_stats_seg_;
+    const std::shared_ptr<Segment> column_stats_seg_;
 };
 
 using VersionQueryType = std::variant<

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -13,6 +13,7 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/pipeline/index_segment_reader.hpp>
+#include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/stream/stream_utils.hpp>
 #include <arcticdb/util/simple_string_hash.hpp>
 #include <arcticdb/pipeline/pipeline_context.hpp>
@@ -42,7 +43,8 @@ struct SpecificVersionQuery {
 // Similar to IndexInformation. See comment on IndexInformation for why both are useful.
 struct PreloadedIndexQuery {
     PreloadedIndexQuery(
-            AtomKey index_key, SegmentInMemory index_seg, std::optional<SegmentInMemory> column_stats_seg = std::nullopt
+            AtomKey index_key, SegmentInMemory index_seg,
+            std::optional<storage::KeySegmentPair> column_stats_seg = std::nullopt
     ) :
         index_key_(std::move(index_key)),
         index_seg_(std::move(index_seg)),
@@ -51,7 +53,7 @@ struct PreloadedIndexQuery {
     // Key is just needed for constructing the VersionedItem to return
     const AtomKey index_key_;
     const SegmentInMemory index_seg_;
-    const std::optional<SegmentInMemory> column_stats_seg_;
+    const std::optional<storage::KeySegmentPair> column_stats_seg_;
 };
 
 using VersionQueryType = std::variant<

--- a/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
@@ -4,8 +4,7 @@
 #include <arcticdb/util/constants.hpp>
 #include <google/protobuf/any.pb.h>
 
-using namespace arcticdb;
-
+namespace arcticdb {
 // Helper to build a column stats SegmentInMemory with the expected schema:
 //   col 0: "start_index" (NANOSECONDS_UTC64)
 //   col 1: "end_index"   (NANOSECONDS_UTC64)
@@ -86,8 +85,8 @@ SegmentInMemory build_stats_segment(const std::vector<StatsSegmentRow>& rows) {
     return seg;
 }
 
-// When all rows have valid index values, find_stats should return the correct stats for each row.
-TEST(ColumnStatsData, FindStatsAllRowsPresent) {
+// When all rows have valid index values, find_row should return the correct stats for each row.
+TEST(ColumnStatsDataTest, FindStatsAllRowsPresent) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20},
             {300, 400, 30, 40},
@@ -98,24 +97,25 @@ TEST(ColumnStatsData, FindStatsAllRowsPresent) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    auto* row0 = data.find_stats(100, 200);
-    ASSERT_NE(row0, nullptr);
-    auto it0 = row0->stats_for_column.find("price");
-    ASSERT_NE(it0, row0->stats_for_column.end());
-    ASSERT_EQ(it0->second.min->get<int64_t>(), 10);
-    ASSERT_EQ(it0->second.max->get<int64_t>(), 20);
+    auto slot = data.slot_for_column("price");
+    ASSERT_TRUE(slot.has_value());
 
-    auto* row2 = data.find_stats(500, 600);
-    ASSERT_NE(row2, nullptr);
-    auto it2 = row2->stats_for_column.find("price");
-    ASSERT_NE(it2, row2->stats_for_column.end());
-    ASSERT_EQ(it2->second.min->get<int64_t>(), 50);
-    ASSERT_EQ(it2->second.max->get<int64_t>(), 60);
+    auto row0 = data.find_row(100, 200);
+    ASSERT_TRUE(row0.has_value());
+    auto v0 = data.stats_for(*slot, *row0);
+    ASSERT_EQ(v0.min->get<int64_t>(), 10);
+    ASSERT_EQ(v0.max->get<int64_t>(), 20);
+
+    auto row2 = data.find_row(500, 600);
+    ASSERT_TRUE(row2.has_value());
+    auto v2 = data.stats_for(*slot, *row2);
+    ASSERT_EQ(v2.min->get<int64_t>(), 50);
+    ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
 
 // A malformed row (absent start_index) causes the entire ColumnStatsData to be discarded,
 // even if valid rows were already parsed.
-TEST(ColumnStatsData, MalformedMiddleRowDiscardsAll) {
+TEST(ColumnStatsDataTest, MalformedMiddleRowDiscardsAll) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20},          // valid
             {std::nullopt, 400, 30, 40}, // malformed — absent start_index
@@ -125,12 +125,12 @@ TEST(ColumnStatsData, MalformedMiddleRowDiscardsAll) {
     auto tsd = build_test_tsd();
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_TRUE(data.empty());
-    ASSERT_EQ(data.find_stats(100, 200), nullptr);
-    ASSERT_EQ(data.find_stats(500, 600), nullptr);
+    ASSERT_FALSE(data.find_row(100, 200).has_value());
+    ASSERT_FALSE(data.find_row(500, 600).has_value());
 }
 
 // Absent end_index also triggers discard.
-TEST(ColumnStatsData, MalformedEndIndexDiscardsAll) {
+TEST(ColumnStatsDataTest, MalformedEndIndexDiscardsAll) {
     auto seg = build_stats_segment({
             {100, std::nullopt, 10, 20},
     });
@@ -140,33 +140,33 @@ TEST(ColumnStatsData, MalformedEndIndexDiscardsAll) {
     ASSERT_TRUE(data.empty());
 }
 
-// Lookup with non-existent indices returns nullptr.
-TEST(ColumnStatsData, FindStatsNonExistentIndex) {
+// Lookup with non-existent indices returns nullopt.
+TEST(ColumnStatsDataTest, FindStatsNonExistentIndex) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20},
     });
 
     auto tsd = build_test_tsd();
     ColumnStatsData data(std::move(seg), tsd);
-    ASSERT_EQ(data.find_stats(999, 888), nullptr);
+    ASSERT_FALSE(data.find_row(999, 888).has_value());
 }
 
 // An empty segment produces empty ColumnStatsData.
-TEST(ColumnStatsData, EmptySegment) {
+TEST(ColumnStatsDataTest, EmptySegment) {
     auto seg = build_stats_segment({});
 
     auto tsd = build_test_tsd();
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_TRUE(data.empty());
-    ASSERT_EQ(data.find_stats(0, 0), nullptr);
+    ASSERT_FALSE(data.find_row(0, 0).has_value());
 }
 
 // Two row-slices with the same (start_index, end_index) but different min/max stats.
 // This can happen with timestamp-indexed symbols when two segments span identical timestamp ranges
 // (e.g. segments where all rows share the same timestamp).
-// Both entries are dropped from the lookup so that find_stats returns nullptr, forcing the
+// Both entries are dropped from the lookup so that find_row returns nullopt, forcing the
 // segments to be read without pruning rather than using the wrong stats.
-TEST(ColumnStatsData, DuplicateIndexPairDropsBothRows) {
+TEST(ColumnStatsDataTest, DuplicateIndexPairDropsBothRows) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20}, // row 0: price in [10, 20]
             {100, 200, 50, 60}, // row 1: same index range, price in [50, 60]
@@ -176,12 +176,61 @@ TEST(ColumnStatsData, DuplicateIndexPairDropsBothRows) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    // Neither row is reachable via find_stats because the key is ambiguous.
-    ASSERT_EQ(data.find_stats(100, 200), nullptr);
+    // Neither row is reachable via find_row because the key is ambiguous.
+    ASSERT_FALSE(data.find_row(100, 200).has_value());
+}
+
+TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows) {
+    auto seg = build_stats_segment({
+            {100, 200, 10, 20},
+            {300, 400, 30, 40},
+            {500, 600, 50, 60},
+            {700, 800, 70, 80},
+    });
+
+    auto tsd = build_test_tsd();
+    ColumnStatsData data(std::move(seg), tsd, std::make_pair<timestamp, timestamp>(250, 650));
+    ASSERT_FALSE(data.empty());
+
+    auto slot = data.slot_for_column("price");
+    ASSERT_TRUE(slot.has_value());
+
+    ASSERT_FALSE(data.find_row(100, 200).has_value());
+    ASSERT_FALSE(data.find_row(700, 800).has_value());
+
+    auto row1 = data.find_row(300, 400);
+    ASSERT_TRUE(row1.has_value());
+    auto v1 = data.stats_for(*slot, *row1);
+    ASSERT_EQ(v1.min->get<int64_t>(), 30);
+    ASSERT_EQ(v1.max->get<int64_t>(), 40);
+
+    auto row2 = data.find_row(500, 600);
+    ASSERT_TRUE(row2.has_value());
+    auto v2 = data.stats_for(*slot, *row2);
+    ASSERT_EQ(v2.min->get<int64_t>(), 50);
+    ASSERT_EQ(v2.max->get<int64_t>(), 60);
+}
+
+TEST(ColumnStatsDataTest, DateRangeBoundariesAreInclusive) {
+    auto seg = build_stats_segment({
+            {100, 200, 10, 20},
+            {300, 400, 30, 40},
+            {500, 600, 50, 60},
+            {700, 800, 70, 80},
+    });
+
+    auto tsd = build_test_tsd();
+    ColumnStatsData data(std::move(seg), tsd, std::make_pair<timestamp, timestamp>(200, 500));
+    ASSERT_FALSE(data.empty());
+
+    ASSERT_TRUE(data.find_row(100, 200).has_value());
+    ASSERT_TRUE(data.find_row(300, 400).has_value());
+    ASSERT_TRUE(data.find_row(500, 600).has_value());
+    ASSERT_FALSE(data.find_row(700, 800).has_value());
 }
 
 // Duplicate keys are dropped but non-duplicate keys in the same segment are unaffected.
-TEST(ColumnStatsData, DuplicateIndexPairDoesNotAffectOtherRows) {
+TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows) {
     auto seg = build_stats_segment({
             {100, 300, 10, 20}, // row 0: unique key
             {300, 400, 30, 40}, // row 1: duplicate key (first)
@@ -193,24 +242,29 @@ TEST(ColumnStatsData, DuplicateIndexPairDoesNotAffectOtherRows) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    // Unique rows are still reachable.
-    auto* row0 = data.find_stats(100, 300);
-    ASSERT_NE(row0, nullptr);
-    ASSERT_EQ(row0->stats_for_column.at("price").min->get<int64_t>(), 10);
-    ASSERT_EQ(row0->stats_for_column.at("price").max->get<int64_t>(), 20);
+    auto slot = data.slot_for_column("price");
+    ASSERT_TRUE(slot.has_value());
 
-    auto* row3 = data.find_stats(400, 600);
-    ASSERT_NE(row3, nullptr);
-    ASSERT_EQ(row3->stats_for_column.at("price").min->get<int64_t>(), 70);
-    ASSERT_EQ(row3->stats_for_column.at("price").max->get<int64_t>(), 80);
+    // Unique rows are still reachable.
+    auto row0 = data.find_row(100, 300);
+    ASSERT_TRUE(row0.has_value());
+    auto v0 = data.stats_for(*slot, *row0);
+    ASSERT_EQ(v0.min->get<int64_t>(), 10);
+    ASSERT_EQ(v0.max->get<int64_t>(), 20);
+
+    auto row3 = data.find_row(400, 600);
+    ASSERT_TRUE(row3.has_value());
+    auto v3 = data.stats_for(*slot, *row3);
+    ASSERT_EQ(v3.min->get<int64_t>(), 70);
+    ASSERT_EQ(v3.max->get<int64_t>(), 80);
 
     // Duplicate key is not reachable.
-    ASSERT_EQ(data.find_stats(300, 400), nullptr);
+    ASSERT_FALSE(data.find_row(300, 400).has_value());
 }
 
 // Build a two-column stats segment where "volume" is absent (sparse) for certain rows.
-// Verify that ColumnStatsData marks those entries as column_absent = true.
-TEST(ColumnStatsData, SparseColumnAbsentMarkedCorrectly) {
+// Verify that materialize_slot reports column_absent = true for those entries.
+TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     using namespace arcticc::pb2::column_stats_pb2;
 
     // Two data columns: price (offset 1) and volume (offset 2) in the TSD.
@@ -293,33 +347,33 @@ TEST(ColumnStatsData, SparseColumnAbsentMarkedCorrectly) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    // Row 0: both columns present, neither absent
-    auto* row0 = data.find_stats(100, 200);
-    ASSERT_NE(row0, nullptr);
-    auto price0_it = row0->stats_for_column.find("price");
-    ASSERT_NE(price0_it, row0->stats_for_column.end());
-    ASSERT_TRUE(price0_it->second.min.has_value());
-    ASSERT_EQ(price0_it->second.min->get<int64_t>(), 10);
-    ASSERT_FALSE(price0_it->second.column_absent);
+    auto price_slot = data.slot_for_column("price");
+    auto vol_slot = data.slot_for_column("volume");
+    ASSERT_TRUE(price_slot.has_value());
+    ASSERT_TRUE(vol_slot.has_value());
 
-    auto vol0_it = row0->stats_for_column.find("volume");
-    ASSERT_NE(vol0_it, row0->stats_for_column.end());
-    ASSERT_TRUE(vol0_it->second.min.has_value());
-    ASSERT_EQ(vol0_it->second.min->get<int64_t>(), 100);
-    ASSERT_FALSE(vol0_it->second.column_absent);
+    auto row0 = data.find_row(100, 200);
+    ASSERT_TRUE(row0.has_value());
+    auto p0 = data.stats_for(*price_slot, *row0);
+    ASSERT_TRUE(p0.min.has_value());
+    ASSERT_EQ(p0.min->get<int64_t>(), 10);
+    ASSERT_FALSE(p0.column_absent);
 
-    // Row 1: price present, volume absent
-    auto* row1 = data.find_stats(300, 400);
-    ASSERT_NE(row1, nullptr);
-    auto price1_it = row1->stats_for_column.find("price");
-    ASSERT_NE(price1_it, row1->stats_for_column.end());
-    ASSERT_TRUE(price1_it->second.min.has_value());
-    ASSERT_EQ(price1_it->second.min->get<int64_t>(), 30);
-    ASSERT_FALSE(price1_it->second.column_absent);
+    auto v0 = data.stats_for(*vol_slot, *row0);
+    ASSERT_TRUE(v0.min.has_value());
+    ASSERT_EQ(v0.min->get<int64_t>(), 100);
+    ASSERT_FALSE(v0.column_absent);
 
-    auto vol1_it = row1->stats_for_column.find("volume");
-    ASSERT_NE(vol1_it, row1->stats_for_column.end());
-    ASSERT_FALSE(vol1_it->second.min.has_value());
-    ASSERT_FALSE(vol1_it->second.max.has_value());
-    ASSERT_TRUE(vol1_it->second.column_absent);
+    auto row1 = data.find_row(300, 400);
+    ASSERT_TRUE(row1.has_value());
+    auto p1 = data.stats_for(*price_slot, *row1);
+    ASSERT_TRUE(p1.min.has_value());
+    ASSERT_EQ(p1.min->get<int64_t>(), 30);
+    ASSERT_FALSE(p1.column_absent);
+
+    auto v1 = data.stats_for(*vol_slot, *row1);
+    ASSERT_FALSE(v1.min.has_value());
+    ASSERT_FALSE(v1.max.has_value());
+    ASSERT_TRUE(v1.column_absent);
 }
+} // namespace arcticdb

--- a/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
@@ -97,18 +97,15 @@ TEST(ColumnStatsDataTest, FindStatsAllRowsPresent) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    auto slot = data.slot_for_column("price");
-    ASSERT_TRUE(slot.has_value());
-
     auto row0 = data.find_row(100, 200);
     ASSERT_TRUE(row0.has_value());
-    auto v0 = data.stats_for(*slot, *row0);
+    auto v0 = data.stats_for("price", *row0);
     ASSERT_EQ(v0.min->get<int64_t>(), 10);
     ASSERT_EQ(v0.max->get<int64_t>(), 20);
 
     auto row2 = data.find_row(500, 600);
     ASSERT_TRUE(row2.has_value());
-    auto v2 = data.stats_for(*slot, *row2);
+    auto v2 = data.stats_for("price", *row2);
     ASSERT_EQ(v2.min->get<int64_t>(), 50);
     ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
@@ -192,21 +189,18 @@ TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows) {
     ColumnStatsData data(std::move(seg), tsd, std::make_pair<timestamp, timestamp>(250, 650));
     ASSERT_FALSE(data.empty());
 
-    auto slot = data.slot_for_column("price");
-    ASSERT_TRUE(slot.has_value());
-
     ASSERT_FALSE(data.find_row(100, 200).has_value());
     ASSERT_FALSE(data.find_row(700, 800).has_value());
 
     auto row1 = data.find_row(300, 400);
     ASSERT_TRUE(row1.has_value());
-    auto v1 = data.stats_for(*slot, *row1);
+    auto v1 = data.stats_for("price", *row1);
     ASSERT_EQ(v1.min->get<int64_t>(), 30);
     ASSERT_EQ(v1.max->get<int64_t>(), 40);
 
     auto row2 = data.find_row(500, 600);
     ASSERT_TRUE(row2.has_value());
-    auto v2 = data.stats_for(*slot, *row2);
+    auto v2 = data.stats_for("price", *row2);
     ASSERT_EQ(v2.min->get<int64_t>(), 50);
     ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
@@ -242,19 +236,16 @@ TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    auto slot = data.slot_for_column("price");
-    ASSERT_TRUE(slot.has_value());
-
     // Unique rows are still reachable.
     auto row0 = data.find_row(100, 300);
     ASSERT_TRUE(row0.has_value());
-    auto v0 = data.stats_for(*slot, *row0);
+    auto v0 = data.stats_for("price", *row0);
     ASSERT_EQ(v0.min->get<int64_t>(), 10);
     ASSERT_EQ(v0.max->get<int64_t>(), 20);
 
     auto row3 = data.find_row(400, 600);
     ASSERT_TRUE(row3.has_value());
-    auto v3 = data.stats_for(*slot, *row3);
+    auto v3 = data.stats_for("price", *row3);
     ASSERT_EQ(v3.min->get<int64_t>(), 70);
     ASSERT_EQ(v3.max->get<int64_t>(), 80);
 
@@ -263,7 +254,7 @@ TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows) {
 }
 
 // Build a two-column stats segment where "volume" is absent (sparse) for certain rows.
-// Verify that values_at_slot reports column_absent = true for those entries.
+// Verify that values_for_column reports column_absent = true for those entries.
 TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     using namespace arcticc::pb2::column_stats_pb2;
 
@@ -347,31 +338,26 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    auto price_slot = data.slot_for_column("price");
-    auto vol_slot = data.slot_for_column("volume");
-    ASSERT_TRUE(price_slot.has_value());
-    ASSERT_TRUE(vol_slot.has_value());
-
     auto row0 = data.find_row(100, 200);
     ASSERT_TRUE(row0.has_value());
-    auto p0 = data.stats_for(*price_slot, *row0);
+    auto p0 = data.stats_for("price", *row0);
     ASSERT_TRUE(p0.min.has_value());
     ASSERT_EQ(p0.min->get<int64_t>(), 10);
     ASSERT_FALSE(p0.column_absent);
 
-    auto v0 = data.stats_for(*vol_slot, *row0);
+    auto v0 = data.stats_for("volume", *row0);
     ASSERT_TRUE(v0.min.has_value());
     ASSERT_EQ(v0.min->get<int64_t>(), 100);
     ASSERT_FALSE(v0.column_absent);
 
     auto row1 = data.find_row(300, 400);
     ASSERT_TRUE(row1.has_value());
-    auto p1 = data.stats_for(*price_slot, *row1);
+    auto p1 = data.stats_for("price", *row1);
     ASSERT_TRUE(p1.min.has_value());
     ASSERT_EQ(p1.min->get<int64_t>(), 30);
     ASSERT_FALSE(p1.column_absent);
 
-    auto v1 = data.stats_for(*vol_slot, *row1);
+    auto v1 = data.stats_for("volume", *row1);
     ASSERT_FALSE(v1.min.has_value());
     ASSERT_FALSE(v1.max.has_value());
     ASSERT_TRUE(v1.column_absent);

--- a/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
@@ -263,7 +263,7 @@ TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows) {
 }
 
 // Build a two-column stats segment where "volume" is absent (sparse) for certain rows.
-// Verify that materialize_slot reports column_absent = true for those entries.
+// Verify that values_at_slot reports column_absent = true for those entries.
 TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     using namespace arcticc::pb2::column_stats_pb2;
 

--- a/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
@@ -23,6 +23,11 @@ struct StatsSegmentRow {
 // "price" is at data_col_offset=1 in the TSD (offset 0 is the timestamp index)
 static constexpr uint32_t price_data_col_offset = 1;
 
+ColumnStatsValues stats_for(const ColumnStatsData& data, const std::string& col_name, size_t row) {
+    auto v = data.values_for_column(col_name, {std::optional<size_t>{row}});
+    return v.empty() ? ColumnStatsValues{} : std::move(v.at(0));
+}
+
 TimeseriesDescriptor build_test_tsd() {
     TimeseriesDescriptor tsd;
     tsd.mutable_fields().add_field(scalar_field(DataType::NANOSECONDS_UTC64, "timestamp"));
@@ -99,13 +104,13 @@ TEST(ColumnStatsDataTest, FindStatsAllRowsPresent) {
 
     auto row0 = data.find_row(100, 200);
     ASSERT_TRUE(row0.has_value());
-    auto v0 = data.stats_for("price", *row0);
+    auto v0 = stats_for(data, "price", *row0);
     ASSERT_EQ(v0.min->get<int64_t>(), 10);
     ASSERT_EQ(v0.max->get<int64_t>(), 20);
 
     auto row2 = data.find_row(500, 600);
     ASSERT_TRUE(row2.has_value());
-    auto v2 = data.stats_for("price", *row2);
+    auto v2 = stats_for(data, "price", *row2);
     ASSERT_EQ(v2.min->get<int64_t>(), 50);
     ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
@@ -194,13 +199,13 @@ TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows) {
 
     auto row1 = data.find_row(300, 400);
     ASSERT_TRUE(row1.has_value());
-    auto v1 = data.stats_for("price", *row1);
+    auto v1 = stats_for(data, "price", *row1);
     ASSERT_EQ(v1.min->get<int64_t>(), 30);
     ASSERT_EQ(v1.max->get<int64_t>(), 40);
 
     auto row2 = data.find_row(500, 600);
     ASSERT_TRUE(row2.has_value());
-    auto v2 = data.stats_for("price", *row2);
+    auto v2 = stats_for(data, "price", *row2);
     ASSERT_EQ(v2.min->get<int64_t>(), 50);
     ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
@@ -239,18 +244,62 @@ TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows) {
     // Unique rows are still reachable.
     auto row0 = data.find_row(100, 300);
     ASSERT_TRUE(row0.has_value());
-    auto v0 = data.stats_for("price", *row0);
+    auto v0 = stats_for(data, "price", *row0);
     ASSERT_EQ(v0.min->get<int64_t>(), 10);
     ASSERT_EQ(v0.max->get<int64_t>(), 20);
 
     auto row3 = data.find_row(400, 600);
     ASSERT_TRUE(row3.has_value());
-    auto v3 = data.stats_for("price", *row3);
+    auto v3 = stats_for(data, "price", *row3);
     ASSERT_EQ(v3.min->get<int64_t>(), 70);
     ASSERT_EQ(v3.max->get<int64_t>(), 80);
 
     // Duplicate key is not reachable.
     ASSERT_FALSE(data.find_row(300, 400).has_value());
+}
+
+TEST(ColumnStatsDataTest, NonMonotonicStartIndexThrows) {
+    auto seg = build_stats_segment({
+            {100, 200, 10, 20},
+            {300, 400, 30, 40},
+            {200, 500, 50, 60},
+    });
+
+    auto tsd = build_test_tsd();
+    ASSERT_THROW(ColumnStatsData(std::move(seg), tsd), InternalException);
+}
+
+// Writers only sort on start_index, so when two rows share a start_index their end_indexes
+// can appear in any order. Like normal reads, ColumnStatsData must accept this rather than throwing,
+// even though this suggests an out of order index.
+TEST(ColumnStatsDataTest, NonMonotonicEndIndexesAllowed) {
+    auto seg = build_stats_segment({
+            {100, 300, 10, 20},
+            {100, 200, 30, 40},
+            {200, 400, 50, 60},
+    });
+
+    auto tsd = build_test_tsd();
+    ColumnStatsData data(std::move(seg), tsd);
+    ASSERT_FALSE(data.empty());
+
+    auto row0 = data.find_row(100, 300);
+    ASSERT_TRUE(row0.has_value());
+    auto v0 = stats_for(data, "price", *row0);
+    ASSERT_EQ(v0.min->get<int64_t>(), 10);
+    ASSERT_EQ(v0.max->get<int64_t>(), 20);
+
+    auto row1 = data.find_row(100, 200);
+    ASSERT_TRUE(row1.has_value());
+    auto v1 = stats_for(data, "price", *row1);
+    ASSERT_EQ(v1.min->get<int64_t>(), 30);
+    ASSERT_EQ(v1.max->get<int64_t>(), 40);
+
+    auto row2 = data.find_row(200, 400);
+    ASSERT_TRUE(row2.has_value());
+    auto v2 = stats_for(data, "price", *row2);
+    ASSERT_EQ(v2.min->get<int64_t>(), 50);
+    ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
 
 // Build a two-column stats segment where "volume" is absent (sparse) for certain rows.
@@ -340,24 +389,24 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
 
     auto row0 = data.find_row(100, 200);
     ASSERT_TRUE(row0.has_value());
-    auto p0 = data.stats_for("price", *row0);
+    auto p0 = stats_for(data, "price", *row0);
     ASSERT_TRUE(p0.min.has_value());
     ASSERT_EQ(p0.min->get<int64_t>(), 10);
     ASSERT_FALSE(p0.column_absent);
 
-    auto v0 = data.stats_for("volume", *row0);
+    auto v0 = stats_for(data, "volume", *row0);
     ASSERT_TRUE(v0.min.has_value());
     ASSERT_EQ(v0.min->get<int64_t>(), 100);
     ASSERT_FALSE(v0.column_absent);
 
     auto row1 = data.find_row(300, 400);
     ASSERT_TRUE(row1.has_value());
-    auto p1 = data.stats_for("price", *row1);
+    auto p1 = stats_for(data, "price", *row1);
     ASSERT_TRUE(p1.min.has_value());
     ASSERT_EQ(p1.min->get<int64_t>(), 30);
     ASSERT_FALSE(p1.column_absent);
 
-    auto v1 = data.stats_for("volume", *row1);
+    auto v1 = stats_for(data, "volume", *row1);
     ASSERT_FALSE(v1.min.has_value());
     ASSERT_FALSE(v1.max.has_value());
     ASSERT_TRUE(v1.column_absent);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -441,9 +441,13 @@ ReadVersionWithNodesOutput LocalVersionedEngine::read_dataframe_version_internal
             version_query.content_,
             [&](const std::shared_ptr<PreloadedIndexQuery>& preloaded_index_query) -> VersionIdentifier {
                 // Clone because Python holds the PreloadedIndexQuery across multiple collect() calls.
-                auto column_stats = preloaded_index_query->column_stats_seg_.has_value()
-                                            ? std::optional{preloaded_index_query->column_stats_seg_->clone()}
-                                            : std::nullopt;
+                std::optional<ColumnStatsSource> column_stats;
+                if (preloaded_index_query->column_stats_seg_) {
+                    column_stats = ColumnStatsSource{
+                            preloaded_index_query->column_stats_seg_->clone(),
+                            column_stats_query_metadata(read_query->clauses_)
+                    };
+                }
                 return std::make_shared<IndexInformation>(
                         std::pair{preloaded_index_query->index_key_, preloaded_index_query->index_seg_.clone()},
                         std::move(column_stats)

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -443,10 +443,11 @@ ReadVersionWithNodesOutput LocalVersionedEngine::read_dataframe_version_internal
                 // Clone because Python holds the PreloadedIndexQuery across multiple collect() calls.
                 std::optional<ColumnStatsSource> column_stats;
                 if (preloaded_index_query->column_stats_seg_) {
-                    column_stats = ColumnStatsSource{
-                            preloaded_index_query->column_stats_seg_->clone(),
-                            column_stats_query_metadata(read_query->clauses_)
-                    };
+                    const auto& key_seg = *preloaded_index_query->column_stats_seg_;
+                    column_stats.emplace(ColumnStatsSource{
+                            storage::KeySegmentPair{VariantKey{key_seg.variant_key()}, key_seg.segment().clone()},
+                            ColumnStatsQueryMetadata(read_query->clauses_)
+                    });
                 }
                 return std::make_shared<IndexInformation>(
                         std::pair{preloaded_index_query->index_key_, preloaded_index_query->index_seg_.clone()},
@@ -525,14 +526,14 @@ folly::Future<DescriptorItem> LocalVersionedEngine::get_descriptor(AtomKey&& k, 
     const auto key = std::move(k);
     auto index_future = store()->read(key);
 
-    auto column_stats_future = folly::makeFuture<std::optional<SegmentInMemory>>(std::nullopt);
+    auto column_stats_future = folly::makeFuture<std::optional<storage::KeySegmentPair>>(std::nullopt);
     if (include_index_segment && is_column_stats_enabled()) {
         auto column_stats_key = index_key_to_column_stats_key(key);
         storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
-        column_stats_future = store()->read(column_stats_key, stats_read_opts)
-                                      .thenValue(
-                                              [](std::pair<VariantKey, SegmentInMemory>&& key_seg
-                                              ) -> std::optional<SegmentInMemory> { return std::move(key_seg.second); }
+        column_stats_future = store()->read_compressed(column_stats_key, stats_read_opts)
+                                      .thenValueInline(
+                                              [](storage::KeySegmentPair&& key_seg
+                                              ) -> std::optional<storage::KeySegmentPair> { return std::move(key_seg); }
                                       );
     }
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -440,13 +440,10 @@ ReadVersionWithNodesOutput LocalVersionedEngine::read_dataframe_version_internal
     const auto identifier = util::variant_match(
             version_query.content_,
             [&](const std::shared_ptr<PreloadedIndexQuery>& preloaded_index_query) -> VersionIdentifier {
-                // Clone because Python holds the PreloadedIndexQuery across multiple collect() calls.
                 std::optional<ColumnStatsSource> column_stats;
                 if (preloaded_index_query->column_stats_seg_) {
-                    const auto& key_seg = *preloaded_index_query->column_stats_seg_;
                     column_stats.emplace(ColumnStatsSource{
-                            storage::KeySegmentPair{VariantKey{key_seg.variant_key()}, key_seg.segment().clone()},
-                            ColumnStatsQueryMetadata(read_query->clauses_)
+                            preloaded_index_query->column_stats_seg_, ColumnStatsQueryMetadata(read_query->clauses_)
                     });
                 }
                 return std::make_shared<IndexInformation>(
@@ -526,15 +523,15 @@ folly::Future<DescriptorItem> LocalVersionedEngine::get_descriptor(AtomKey&& k, 
     const auto key = std::move(k);
     auto index_future = store()->read(key);
 
-    auto column_stats_future = folly::makeFuture<std::optional<storage::KeySegmentPair>>(std::nullopt);
+    auto column_stats_future = folly::makeFuture<std::shared_ptr<Segment>>(std::shared_ptr<Segment>{});
     if (include_index_segment && is_column_stats_enabled()) {
         auto column_stats_key = index_key_to_column_stats_key(key);
         storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
-        column_stats_future = store()->read_compressed(column_stats_key, stats_read_opts)
-                                      .thenValueInline(
-                                              [](storage::KeySegmentPair&& key_seg
-                                              ) -> std::optional<storage::KeySegmentPair> { return std::move(key_seg); }
-                                      );
+        column_stats_future =
+                store()->read_compressed(column_stats_key, stats_read_opts)
+                        .thenValueInline([](storage::KeySegmentPair&& key_seg) -> std::shared_ptr<Segment> {
+                            return key_seg.segment_ptr();
+                        });
     }
 
     return folly::collectAll(std::move(index_future), std::move(column_stats_future))

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -27,6 +27,7 @@
 #include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
 #include <arcticdb/storage/storage_exceptions.hpp>
+#include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/entity/python_bindings_common.hpp>
 
 namespace arcticdb::version_store {
@@ -187,8 +188,10 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
             }))
             .def(py::init([](py::array value_list) { return std::make_shared<ValueSet>(value_list); }));
 
+    py::class_<storage::KeySegmentPair>(version, "KeySegmentPair").def(py::init<>());
+
     py::class_<PreloadedIndexQuery, std::shared_ptr<PreloadedIndexQuery>>(version, "PreloadedIndexQuery")
-            .def(py::init<AtomKey, SegmentInMemory, std::optional<SegmentInMemory>>(),
+            .def(py::init<AtomKey, SegmentInMemory, std::optional<storage::KeySegmentPair>>(),
                  py::arg("index_key"),
                  py::arg("index_seg"),
                  py::arg("column_stats_seg") = std::nullopt);

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -191,10 +191,10 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
     py::class_<storage::KeySegmentPair>(version, "KeySegmentPair").def(py::init<>());
 
     py::class_<PreloadedIndexQuery, std::shared_ptr<PreloadedIndexQuery>>(version, "PreloadedIndexQuery")
-            .def(py::init<AtomKey, SegmentInMemory, std::optional<storage::KeySegmentPair>>(),
+            .def(py::init<AtomKey, SegmentInMemory, std::shared_ptr<Segment>>(),
                  py::arg("index_key"),
                  py::arg("index_seg"),
-                 py::arg("column_stats_seg") = std::nullopt);
+                 py::arg("column_stats_seg") = nullptr);
 
     py::class_<VersionQuery>(version, "PythonVersionStoreVersionQuery")
             .def(py::init())

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1369,13 +1369,7 @@ static void read_indexed_keys_to_pipeline(
 
     if (index_information.column_stats_.has_value()) {
         auto& [data, query_metadata] = *index_information.column_stats_;
-        auto column_stats_filter = std::visit(
-                [&]<typename T>(T&& source) {
-                    return create_column_stats_filter(std::forward<T>(source), tsd, std::move(query_metadata));
-                },
-                std::move(data)
-        );
-        queries.push_back(std::move(column_stats_filter));
+        queries.push_back(create_column_stats_filter(std::move(data), tsd, std::move(query_metadata)));
     }
 
     pipeline_context->slice_and_keys_ = filter_index(index_segment_reader, combine_filter_functions(queries));
@@ -2806,19 +2800,18 @@ static folly::Future<VersionIdentifier> fetch_index_and_column_stats(
     auto index_future = store->read(versioned_item.key_);
 
     using OptionalColumnStatsSource = std::optional<ColumnStatsSource>;
-    auto query_metadata = column_stats_query_metadata(read_query.clauses_);
+    ColumnStatsQueryMetadata query_metadata(read_query.clauses_);
     folly::Future<OptionalColumnStatsSource> column_stats_future =
             folly::makeFuture<OptionalColumnStatsSource>(std::nullopt);
     if (query_metadata.should_try_column_stats_read()) {
         auto column_stats_key = index_key_to_column_stats_key(versioned_item.key_);
         storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
-        column_stats_future = store->read_compressed(column_stats_key, stats_read_opts)
-                                      .thenValue(
-                                              [qm = std::move(query_metadata)](storage::KeySegmentPair&& key_seg
-                                              ) -> OptionalColumnStatsSource {
-                                                  return ColumnStatsSource{std::move(key_seg), std::move(qm)};
-                                              }
-                                      );
+        column_stats_future =
+                store->read_compressed(column_stats_key, stats_read_opts)
+                        .thenValueInline(
+                                [qm = std::move(query_metadata)](storage::KeySegmentPair&& key_seg
+                                ) -> OptionalColumnStatsSource { return ColumnStatsSource{std::move(key_seg), qm}; }
+                        );
     }
 
     return folly::collectAll(std::move(index_future), std::move(column_stats_future))

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2810,7 +2810,7 @@ static folly::Future<VersionIdentifier> fetch_index_and_column_stats(
                 store->read_compressed(column_stats_key, stats_read_opts)
                         .thenValueInline(
                                 [qm = std::move(query_metadata)](storage::KeySegmentPair&& key_seg
-                                ) -> OptionalColumnStatsSource { return ColumnStatsSource{std::move(key_seg), qm}; }
+                                ) -> OptionalColumnStatsSource { return ColumnStatsSource{key_seg.segment_ptr(), qm}; }
                         );
     }
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1368,8 +1368,13 @@ static void read_indexed_keys_to_pipeline(
     );
 
     if (index_information.column_stats_.has_value()) {
-        auto column_stats_filter =
-                create_column_stats_filter(std::move(*index_information.column_stats_), tsd, read_query.clauses_);
+        auto& [data, query_metadata] = *index_information.column_stats_;
+        auto column_stats_filter = std::visit(
+                [&]<typename T>(T&& source) {
+                    return create_column_stats_filter(std::forward<T>(source), tsd, std::move(query_metadata));
+                },
+                std::move(data)
+        );
         queries.push_back(std::move(column_stats_filter));
     }
 
@@ -2800,17 +2805,20 @@ static folly::Future<VersionIdentifier> fetch_index_and_column_stats(
 ) {
     auto index_future = store->read(versioned_item.key_);
 
-    using OptionalKeySeg = std::optional<SegmentInMemory>;
-    const bool need_column_stats = should_try_column_stats_read(read_query);
-    folly::Future<OptionalKeySeg> column_stats_future = folly::makeFuture<OptionalKeySeg>(std::nullopt);
-    if (need_column_stats) {
+    using OptionalColumnStatsSource = std::optional<ColumnStatsSource>;
+    auto query_metadata = column_stats_query_metadata(read_query.clauses_);
+    folly::Future<OptionalColumnStatsSource> column_stats_future =
+            folly::makeFuture<OptionalColumnStatsSource>(std::nullopt);
+    if (query_metadata.should_try_column_stats_read()) {
         auto column_stats_key = index_key_to_column_stats_key(versioned_item.key_);
         storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
-        column_stats_future =
-                store->read(column_stats_key, stats_read_opts)
-                        .thenValue([](std::pair<VariantKey, SegmentInMemory>&& key_seg) -> OptionalKeySeg {
-                            return std::move(key_seg.second);
-                        });
+        column_stats_future = store->read_compressed(column_stats_key, stats_read_opts)
+                                      .thenValue(
+                                              [qm = std::move(query_metadata)](storage::KeySegmentPair&& key_seg
+                                              ) -> OptionalColumnStatsSource {
+                                                  return ColumnStatsSource{std::move(key_seg), std::move(qm)};
+                                              }
+                                      );
     }
 
     return folly::collectAll(std::move(index_future), std::move(column_stats_future))

--- a/cpp/arcticdb/version/version_tasks.cpp
+++ b/cpp/arcticdb/version/version_tasks.cpp
@@ -7,7 +7,7 @@ std::shared_ptr<pipelines::PipelineContext> SetupPipelineContextTask::operator()
 }
 
 IndexInformation::IndexInformation(
-        std::pair<VariantKey, SegmentInMemory>&& index, std::optional<SegmentInMemory>&& column_stats
+        std::pair<VariantKey, SegmentInMemory>&& index, std::optional<ColumnStatsSource>&& column_stats
 ) :
     index_(std::move(index)),
     column_stats_(std::move(column_stats)) {}

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -9,14 +9,25 @@
 #pragma once
 
 #include <arcticdb/async/base_task.hpp>
+#include <arcticdb/pipeline/column_stats_filter.hpp>
 #include <arcticdb/pipeline/read_frame.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/pipeline/query.hpp>
+#include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
 #include <arcticdb/version/version_map.hpp>
 #include <arcticdb/util/key_utils.hpp>
 
 namespace arcticdb {
+
+/**
+ * Column stats data read from storage, and metadata about the user's query.
+ * `data` is either compressed bytes or an already-decoded SegmentInMemory.
+ */
+struct ColumnStatsSource {
+    std::variant<storage::KeySegmentPair, SegmentInMemory> data;
+    ColumnStatsQueryMetadata query_metadata;
+};
 
 // Similar to PreloadedIndexQuery, but without const fields. Also forces developers to convert a PreloadedIndexQuery
 // to an IndexInformation when it is submitted to our processing engine, so that the query can be safely re-used later.
@@ -24,9 +35,9 @@ namespace arcticdb {
 struct IndexInformation {
     ARCTICDB_MOVE_ONLY_DEFAULT(IndexInformation)
     IndexInformation() = default;
-    IndexInformation(std::pair<VariantKey, SegmentInMemory>&& index, std::optional<SegmentInMemory>&& column_stats);
+    IndexInformation(std::pair<VariantKey, SegmentInMemory>&& index, std::optional<ColumnStatsSource>&& column_stats);
     std::pair<VariantKey, SegmentInMemory> index_;
-    std::optional<SegmentInMemory> column_stats_;
+    std::optional<ColumnStatsSource> column_stats_;
 };
 
 // Uniquely identifies the version to read:

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -12,8 +12,8 @@
 #include <arcticdb/pipeline/column_stats_filter.hpp>
 #include <arcticdb/pipeline/read_frame.hpp>
 #include <arcticdb/pipeline/index_utils.hpp>
+#include <arcticdb/codec/segment.hpp>
 #include <arcticdb/pipeline/query.hpp>
-#include <arcticdb/storage/key_segment_pair.hpp>
 #include <arcticdb/version/version_store_objects.hpp>
 #include <arcticdb/version/version_map.hpp>
 #include <arcticdb/util/key_utils.hpp>
@@ -24,7 +24,7 @@ namespace arcticdb {
  * Column stats data read from storage, and metadata about the user's query.
  */
 struct ColumnStatsSource {
-    storage::KeySegmentPair data;
+    std::shared_ptr<Segment> data;
     ColumnStatsQueryMetadata query_metadata;
 };
 

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -22,10 +22,9 @@ namespace arcticdb {
 
 /**
  * Column stats data read from storage, and metadata about the user's query.
- * `data` is either compressed bytes or an already-decoded SegmentInMemory.
  */
 struct ColumnStatsSource {
-    std::variant<storage::KeySegmentPair, SegmentInMemory> data;
+    storage::KeySegmentPair data;
     ColumnStatsQueryMetadata query_metadata;
 };
 

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -1582,6 +1582,62 @@
         "version": "e0bd464c72351dcd285e0786572502d94664b47b402a8e95b9f340a32ab3e0c3",
         "warmup_time": 0.5
     },
+    "column_stats.ColumnStatsManySegmentsZeroMatch.time_filter_10_columns_zero_match": {
+        "code": "class ColumnStatsManySegmentsZeroMatch:\n    def time_filter_10_columns_zero_match(self, *args):\n        self.lib.read(self.symbol, columns=self.read_columns, query_builder=self.query)\n\n    def setup(self, lib_for_storage, column_stats_enabled, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = \"many_segments_zero_match\"\n        self.read_columns = [f\"float_{i}\" for i in range(self.NUM_COLS)]\n    \n        # Every float column has positive values, so < 0 prunes everything.\n        q = QueryBuilder()\n        expr = q[\"float_0\"] < 0.0\n        for i in range(1, self.NUM_FILTER_COLS):\n            expr = expr | (q[f\"float_{i}\"] < 0.0)\n        self.query = q[expr]\n    \n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=self.NUM_ROWS // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = {}\n        for storage in self.storages:\n            if not is_storage_enabled(storage):\n                lib_for_storage[storage] = None\n                continue\n            lib = create_library(storage, LibraryOptions(rows_per_segment=self.ROWS_PER_SEGMENT))\n            lib_for_storage[storage] = lib\n    \n            sym = \"many_segments_zero_match\"\n            n = self.NUM_ROWS\n            timestamps = pd.date_range(end=\"1/1/2023\", periods=n, freq=\"s\")\n            data = {f\"float_{i}\": np.linspace(1.0 + i, 1000.0 + i, n) for i in range(self.NUM_COLS)}\n            df = pd.DataFrame(data)\n            df.index = timestamps\n            df.index.name = \"ts\"\n    \n            lib.write(sym, df)\n            stats = {f\"float_{i}\": {\"MINMAX\"} for i in range(self.NUM_COLS)}\n            lib._nvs.create_column_stats(sym, stats)\n            self.logger.info(f\"Wrote {sym} with {n} rows and created column stats\")\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsManySegmentsZeroMatch.time_filter_10_columns_zero_match",
+        "number": 0,
+        "param_names": [
+            "column_stats_enabled",
+            "storage"
+        ],
+        "params": [
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:569",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "0dab43b360a0d2e6d8b8693587dd4feb8d2af516a069a1ca2dd62c10b76e8418",
+        "warmup_time": 0.5
+    },
+    "column_stats.ColumnStatsManySegmentsZeroMatch.time_filter_10_columns_zero_match_with_date_range": {
+        "code": "class ColumnStatsManySegmentsZeroMatch:\n    def time_filter_10_columns_zero_match_with_date_range(self, *args):\n        self.lib.read(\n            self.symbol,\n            columns=self.read_columns,\n            date_range=self.date_range_half,\n            query_builder=self.query,\n        )\n\n    def setup(self, lib_for_storage, column_stats_enabled, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = \"many_segments_zero_match\"\n        self.read_columns = [f\"float_{i}\" for i in range(self.NUM_COLS)]\n    \n        # Every float column has positive values, so < 0 prunes everything.\n        q = QueryBuilder()\n        expr = q[\"float_0\"] < 0.0\n        for i in range(1, self.NUM_FILTER_COLS):\n            expr = expr | (q[f\"float_{i}\"] < 0.0)\n        self.query = q[expr]\n    \n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=self.NUM_ROWS // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = {}\n        for storage in self.storages:\n            if not is_storage_enabled(storage):\n                lib_for_storage[storage] = None\n                continue\n            lib = create_library(storage, LibraryOptions(rows_per_segment=self.ROWS_PER_SEGMENT))\n            lib_for_storage[storage] = lib\n    \n            sym = \"many_segments_zero_match\"\n            n = self.NUM_ROWS\n            timestamps = pd.date_range(end=\"1/1/2023\", periods=n, freq=\"s\")\n            data = {f\"float_{i}\": np.linspace(1.0 + i, 1000.0 + i, n) for i in range(self.NUM_COLS)}\n            df = pd.DataFrame(data)\n            df.index = timestamps\n            df.index.name = \"ts\"\n    \n            lib.write(sym, df)\n            stats = {f\"float_{i}\": {\"MINMAX\"} for i in range(self.NUM_COLS)}\n            lib._nvs.create_column_stats(sym, stats)\n            self.logger.info(f\"Wrote {sym} with {n} rows and created column stats\")\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "column_stats.ColumnStatsManySegmentsZeroMatch.time_filter_10_columns_zero_match_with_date_range",
+        "number": 0,
+        "param_names": [
+            "column_stats_enabled",
+            "storage"
+        ],
+        "params": [
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 1,
+        "sample_time": 0.5,
+        "setup_cache_key": "column_stats:569",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "f96c974959264959b732eaccaac1322d391f2d3b0422ad7af0af2256fc8aa04c",
+        "warmup_time": 0.5
+    },
     "column_stats.ColumnStatsQueryPerformance.time_filter_bool": {
         "code": "class ColumnStatsQueryPerformance:\n    def time_filter_bool(self, *args):\n        q = QueryBuilder()\n        q = q[q[\"bool_col\"]]\n        self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=q)\n\n    def setup(self, lib_for_storage, num_rows, column_stats_enabled, data_ordered, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows, data_ordered)\n        self.data_ordered = data_ordered\n    \n        # Compute filter thresholds targeting ~10% of the value range\n        self.uint64_low = num_rows // 10\n        self.uint64_high = num_rows * 9 // 10\n        # ~100 values from the first 10% of the uint64 range\n        self.isin_values = list(range(0, num_rows // 10, max(1, num_rows // 1000)))\n        # Datetime threshold: last 10% of the datetime_col range\n        datetime_start = pd.Timestamp(\"2000-01-01\")\n        self.datetime_high = datetime_start + pd.Timedelta(seconds=num_rows * 9 // 10)\n        # Zero-match threshold: max uint64 value is num_rows - 1, so > num_rows matches nothing\n        self.zero_match_threshold = num_rows\n        # Date range covering the last 50% of the index, for combined date_range + filter benchmarks\n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=num_rows // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n        dfs = {}\n        for storage in ColumnStatsQueryPerformance.storages:\n            if not is_storage_enabled(storage):\n                continue\n            lib = lib_for_storage[storage]\n            for rows in ColumnStatsQueryPerformance.num_rows:\n                for ordered in ColumnStatsQueryPerformance.data_ordered:\n                    key = (rows, ordered)\n                    if key not in dfs:\n                        dfs[key] = (\n                            _generate_column_stats_dataframe(rows) if ordered else _generate_random_dataframe(rows)\n                        )\n                    df = dfs[key]\n                    sym = _symbol_name(rows, ordered)\n                    self.logger.info(f\"Writing {sym} with {rows} rows\")\n                    lib.write(sym, df)\n                    lib._nvs.create_column_stats(sym, COLUMN_STATS)\n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -1582,6 +1582,52 @@
         "version": "e0bd464c72351dcd285e0786572502d94664b47b402a8e95b9f340a32ab3e0c3",
         "warmup_time": 0.5
     },
+    "column_stats.ColumnStatsManySegmentsZeroMatch.peakmem_filter_10_columns_zero_match": {
+        "code": "class ColumnStatsManySegmentsZeroMatch:\n    def peakmem_filter_10_columns_zero_match(self, *args):\n        self.lib.read(self.symbol, columns=self.read_columns, query_builder=self.query)\n\n    def setup(self, lib_for_storage, column_stats_enabled, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = \"many_segments_zero_match\"\n        self.read_columns = [f\"float_{i}\" for i in range(self.NUM_COLS)]\n    \n        # Every float column has positive values, so < 0 prunes everything.\n        q = QueryBuilder()\n        expr = q[\"float_0\"] < 0.0\n        for i in range(1, self.NUM_FILTER_COLS):\n            expr = expr | (q[f\"float_{i}\"] < 0.0)\n        self.query = q[expr]\n    \n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=self.NUM_ROWS // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = {}\n        for storage in self.storages:\n            if not is_storage_enabled(storage):\n                lib_for_storage[storage] = None\n                continue\n            lib = create_library(storage, LibraryOptions(rows_per_segment=self.ROWS_PER_SEGMENT))\n            lib_for_storage[storage] = lib\n    \n            sym = \"many_segments_zero_match\"\n            n = self.NUM_ROWS\n            timestamps = pd.date_range(end=\"1/1/2023\", periods=n, freq=\"s\")\n            data = {f\"float_{i}\": np.linspace(1.0 + i, 1000.0 + i, n) for i in range(self.NUM_COLS)}\n            df = pd.DataFrame(data)\n            df.index = timestamps\n            df.index.name = \"ts\"\n    \n            lib.write(sym, df)\n            stats = {f\"float_{i}\": {\"MINMAX\"} for i in range(self.NUM_COLS)}\n            lib._nvs.create_column_stats(sym, stats)\n            self.logger.info(f\"Wrote {sym} with {n} rows and created column stats\")\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "name": "column_stats.ColumnStatsManySegmentsZeroMatch.peakmem_filter_10_columns_zero_match",
+        "param_names": [
+            "column_stats_enabled",
+            "storage"
+        ],
+        "params": [
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "setup_cache_key": "column_stats:569",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "5405d27a051287dad962230360e06874df7b8d7f976104f22ec4e356fc6eb8ca"
+    },
+    "column_stats.ColumnStatsManySegmentsZeroMatch.peakmem_filter_10_columns_zero_match_with_date_range": {
+        "code": "class ColumnStatsManySegmentsZeroMatch:\n    def peakmem_filter_10_columns_zero_match_with_date_range(self, *args):\n        self.lib.read(\n            self.symbol,\n            columns=self.read_columns,\n            date_range=self.date_range_half,\n            query_builder=self.query,\n        )\n\n    def setup(self, lib_for_storage, column_stats_enabled, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = \"many_segments_zero_match\"\n        self.read_columns = [f\"float_{i}\" for i in range(self.NUM_COLS)]\n    \n        # Every float column has positive values, so < 0 prunes everything.\n        q = QueryBuilder()\n        expr = q[\"float_0\"] < 0.0\n        for i in range(1, self.NUM_FILTER_COLS):\n            expr = expr | (q[f\"float_{i}\"] < 0.0)\n        self.query = q[expr]\n    \n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=self.NUM_ROWS // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = {}\n        for storage in self.storages:\n            if not is_storage_enabled(storage):\n                lib_for_storage[storage] = None\n                continue\n            lib = create_library(storage, LibraryOptions(rows_per_segment=self.ROWS_PER_SEGMENT))\n            lib_for_storage[storage] = lib\n    \n            sym = \"many_segments_zero_match\"\n            n = self.NUM_ROWS\n            timestamps = pd.date_range(end=\"1/1/2023\", periods=n, freq=\"s\")\n            data = {f\"float_{i}\": np.linspace(1.0 + i, 1000.0 + i, n) for i in range(self.NUM_COLS)}\n            df = pd.DataFrame(data)\n            df.index = timestamps\n            df.index.name = \"ts\"\n    \n            lib.write(sym, df)\n            stats = {f\"float_{i}\": {\"MINMAX\"} for i in range(self.NUM_COLS)}\n            lib._nvs.create_column_stats(sym, stats)\n            self.logger.info(f\"Wrote {sym} with {n} rows and created column stats\")\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "name": "column_stats.ColumnStatsManySegmentsZeroMatch.peakmem_filter_10_columns_zero_match_with_date_range",
+        "param_names": [
+            "column_stats_enabled",
+            "storage"
+        ],
+        "params": [
+            [
+                "True",
+                "False"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "setup_cache_key": "column_stats:569",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "cc3533349f581e8f8259121fb379b3063200ef3156ffd1187e3fd77e2bd3549e"
+    },
     "column_stats.ColumnStatsManySegmentsZeroMatch.time_filter_10_columns_zero_match": {
         "code": "class ColumnStatsManySegmentsZeroMatch:\n    def time_filter_10_columns_zero_match(self, *args):\n        self.lib.read(self.symbol, columns=self.read_columns, query_builder=self.query)\n\n    def setup(self, lib_for_storage, column_stats_enabled, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = \"many_segments_zero_match\"\n        self.read_columns = [f\"float_{i}\" for i in range(self.NUM_COLS)]\n    \n        # Every float column has positive values, so < 0 prunes everything.\n        q = QueryBuilder()\n        expr = q[\"float_0\"] < 0.0\n        for i in range(1, self.NUM_FILTER_COLS):\n            expr = expr | (q[f\"float_{i}\"] < 0.0)\n        self.query = q[expr]\n    \n        index_end = pd.Timestamp(\"2023-01-01\")\n        self.date_range_half = (index_end - pd.Timedelta(seconds=self.NUM_ROWS // 2), index_end)\n    \n        if column_stats_enabled:\n            set_config_int(\"ColumnStats.UseForQueries\", 1)\n        else:\n            unset_config_int(\"ColumnStats.UseForQueries\")\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = {}\n        for storage in self.storages:\n            if not is_storage_enabled(storage):\n                lib_for_storage[storage] = None\n                continue\n            lib = create_library(storage, LibraryOptions(rows_per_segment=self.ROWS_PER_SEGMENT))\n            lib_for_storage[storage] = lib\n    \n            sym = \"many_segments_zero_match\"\n            n = self.NUM_ROWS\n            timestamps = pd.date_range(end=\"1/1/2023\", periods=n, freq=\"s\")\n            data = {f\"float_{i}\": np.linspace(1.0 + i, 1000.0 + i, n) for i in range(self.NUM_COLS)}\n            df = pd.DataFrame(data)\n            df.index = timestamps\n            df.index.name = \"ts\"\n    \n            lib.write(sym, df)\n            stats = {f\"float_{i}\": {\"MINMAX\"} for i in range(self.NUM_COLS)}\n            lib._nvs.create_column_stats(sym, stats)\n            self.logger.info(f\"Wrote {sym} with {n} rows and created column stats\")\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "min_run_count": 2,

--- a/python/benchmarks/column_stats.py
+++ b/python/benchmarks/column_stats.py
@@ -537,3 +537,93 @@ class ColumnStatsWideFilter:
     def time_filter_wide(self, *args):
         """Filter with 201 OR'd conditions forcing decode of 200 extra columns."""
         self.lib.read(self.symbol, columns=BENCHMARK_COLUMNS, query_builder=self.query)
+
+
+class ColumnStatsManySegmentsZeroMatch:
+    """Benchmark stats pruning with a large column stats key and where we can prune every data block.
+
+    Writes 10k rows with rows_per_segment=2 so the symbol has ~5k segments and the column
+    stats key holds one row per segment.
+    """
+
+    sample_time = 0.5
+    rounds = 1
+    repeat = (2, 3, 5.0)
+    warmup_time = 0.5
+    timeout = 600
+
+    column_stats_enabled = [True, False]
+    storages = STORAGES
+
+    params = [column_stats_enabled, storages]
+    param_names = ["column_stats_enabled", "storage"]
+
+    NUM_ROWS = 10_000
+    ROWS_PER_SEGMENT = 2
+    NUM_COLS = 100
+    NUM_FILTER_COLS = 10
+
+    def __init__(self):
+        self.logger = get_logger()
+
+    def setup_cache(self):
+        start = time.time()
+        lib_for_storage = {}
+        for storage in self.storages:
+            if not is_storage_enabled(storage):
+                lib_for_storage[storage] = None
+                continue
+            lib = create_library(storage, LibraryOptions(rows_per_segment=self.ROWS_PER_SEGMENT))
+            lib_for_storage[storage] = lib
+
+            sym = "many_segments_zero_match"
+            n = self.NUM_ROWS
+            timestamps = pd.date_range(end="1/1/2023", periods=n, freq="s")
+            data = {f"float_{i}": np.linspace(1.0 + i, 1000.0 + i, n) for i in range(self.NUM_COLS)}
+            df = pd.DataFrame(data)
+            df.index = timestamps
+            df.index.name = "ts"
+
+            lib.write(sym, df)
+            stats = {f"float_{i}": {"MINMAX"} for i in range(self.NUM_COLS)}
+            lib._nvs.create_column_stats(sym, stats)
+            self.logger.info(f"Wrote {sym} with {n} rows and created column stats")
+
+        self.logger.info(f"setup_cache time: {time.time() - start}")
+        return lib_for_storage
+
+    def setup(self, lib_for_storage, column_stats_enabled, storage):
+        self.lib = lib_for_storage[storage]
+        if self.lib is None:
+            raise SkipNotImplemented
+        self.symbol = "many_segments_zero_match"
+        self.read_columns = [f"float_{i}" for i in range(self.NUM_COLS)]
+
+        # Every float column has positive values, so < 0 prunes everything.
+        q = QueryBuilder()
+        expr = q["float_0"] < 0.0
+        for i in range(1, self.NUM_FILTER_COLS):
+            expr = expr | (q[f"float_{i}"] < 0.0)
+        self.query = q[expr]
+
+        index_end = pd.Timestamp("2023-01-01")
+        self.date_range_half = (index_end - pd.Timedelta(seconds=self.NUM_ROWS // 2), index_end)
+
+        if column_stats_enabled:
+            set_config_int("ColumnStats.UseForQueries", 1)
+        else:
+            unset_config_int("ColumnStats.UseForQueries")
+
+    def teardown(self, *args):
+        unset_config_int("ColumnStats.UseForQueries")
+
+    def time_filter_10_columns_zero_match(self, *args):
+        self.lib.read(self.symbol, columns=self.read_columns, query_builder=self.query)
+
+    def time_filter_10_columns_zero_match_with_date_range(self, *args):
+        self.lib.read(
+            self.symbol,
+            columns=self.read_columns,
+            date_range=self.date_range_half,
+            query_builder=self.query,
+        )

--- a/python/benchmarks/column_stats.py
+++ b/python/benchmarks/column_stats.py
@@ -627,3 +627,14 @@ class ColumnStatsManySegmentsZeroMatch:
             date_range=self.date_range_half,
             query_builder=self.query,
         )
+
+    def peakmem_filter_10_columns_zero_match(self, *args):
+        self.lib.read(self.symbol, columns=self.read_columns, query_builder=self.query)
+
+    def peakmem_filter_10_columns_zero_match_with_date_range(self, *args):
+        self.lib.read(
+            self.symbol,
+            columns=self.read_columns,
+            date_range=self.date_range_half,
+            query_builder=self.query,
+        )

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -751,33 +751,6 @@ def test_column_stats_with_row_range(
     assert_frame_equal(result, expected)
 
 
-def test_column_stats_with_date_range(in_memory_version_store, clear_query_stats, column_stats_filtering_enabled):
-    lib = in_memory_version_store
-
-    df0 = pd.DataFrame({"col_1": [1, 2]}, index=pd.date_range("2000-01-01", periods=2), dtype=np.int64)
-    df1 = pd.DataFrame({"col_1": [3, 4]}, index=pd.date_range("2000-01-03", periods=2), dtype=np.int64)
-    df2 = pd.DataFrame({"col_1": [5, 6]}, index=pd.date_range("2000-01-05", periods=2), dtype=np.int64)
-
-    lib.write(sym, df0)
-    lib.append(sym, df1)
-    lib.append(sym, df2)
-
-    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
-
-    q = QueryBuilder()
-    q = q[q["col_1"] > 2]
-
-    date_range = (pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-04"))
-
-    qs.enable()
-    qs.reset_stats()
-    result = lib.read(sym, query_builder=q, date_range=date_range).data
-    table_data_reads = get_table_data_read_count()
-    assert table_data_reads == 1, f"Expected 1 TABLE_DATA read, got {table_data_reads}"
-
-    assert_frame_equal(result, df1)
-
-
 @pytest.mark.parametrize("negated", (True, False))
 def test_column_stats_bool_column_filters(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, negated


### PR DESCRIPTION
In this PR we:

- Only decompress and load statistics for columns that are in the user's query builder filters
- Only load statistics within the user specified `date_range`
- Iterate over the column stats segment column-wise rather than row-wise
- Load the column stats in to a column-oriented layout in memory

The profiling script,
[bench.py](https://github.com/user-attachments/files/27394513/bench.py) writes a column stats segment with ~200 columns and 100k rows, which corresponds to a 10B row symbol with our normal row slicing. It then times a read query for which column stats can prune everything, filtering on 10 of the 100 columns in the dataframe.

After all changes:

```
lib.read zero-match (rows=20000, num_cols=100, rows_per_segment=2, filter_cols=10, iters=20, column_stats=on):
  total block      = 197.2 ms
  mean             = 9.86 ms
  median           = 9.91 ms
  min              = 9.41 ms
  max              = 10.51 ms
```


Master:

```
(tree-two-venv) aseaton@dlonapatcs502:~/source/ArcticDB-worktree/tree-two/python DEV $ python ../scripts/profiling/profile_many_columns.py --rows 20000 --num-cols 100 --rows-per-segment 2
warmup x2
timed x20

lib.read zero-match (rows=20000, num_cols=100, rows_per_segment=2, filter_cols=10, iters=20, column_stats=on):
  total block      = 5281.3 ms
  mean             = 264.06 ms
  median           = 258.79 ms
  min              = 253.26 ms
  max              = 288.51 ms
```

Without the "flattened structure" in ColumnStatsData we get these results, so it seems worth keeping, although it will make things more complex when we add strings and Bloom filters:

```
lib.read zero-match (rows=20000, num_cols=100, rows_per_segment=2, filter_cols=10, iters=20, column_stats=on):
  total block      = 505.4 ms
  mean             = 25.27 ms
  median           = 23.28 ms
  min              = 21.86 ms
  max              = 42.47 ms
```

I also tried a more complex approach with type erased uint8_t buffers for the stats, with these results. The improvement does not seem worth the complexity here (it will make strings and bloom filters harder).

```
lib.read zero-match (rows=20000, num_cols=100, rows_per_segment=2, filter_cols=10, iters=20, column_stats=on):
  total block      = 171.2 ms
  mean             = 8.56 ms
  median           = 8.51 ms
  min              = 8.04 ms
  max              = 9.30 ms
```

I've also added an ASV benchmark to regression-test the improvement, which had these results:

  | Benchmark | `column_stats_enabled` | Master `668b267d` | HEAD `45dacae7` | Ratio |                                                                                                                                                                                                                              
  | --- | :---: | ---: | ---: | :---: |
  | `time_filter_10_columns_zero_match` | `True`  | 157 ± 1 ms   | **6.15 ± 0.1 ms**  | **0.04** |                                                                                                                                                                                                                  
  | `time_filter_10_columns_zero_match_with_date_range` | `True`  | 154 ± 2 ms   | **5.30 ± 0.05 ms** | **0.03** |                                                                                                                                                                                                  
  | `time_filter_10_columns_zero_match` | `False` | 161 ± 9 ms   | 166 ± 10 ms        | 1.03 |                                                                                                                                                                                                                      
  | `time_filter_10_columns_zero_match_with_date_range` | `False` | 92.8 ± 3 ms  | 82.8 ± 3 ms        | 0.89 |                                                                                                                                                                                                      
