### PR TITLE
Use the s3_version_store_v1 fixture for merge_update hypothesis tests

### DIFF
--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -111,17 +111,9 @@ def merge_arguments(
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @given(merge_args=merge_arguments(COL_NAMES, DTYPES))
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
-@pytest.mark.skipif(
-    WINDOWS or MACOS,
-    reason="""
-        On macOS/Windows the low timestamp resolution can cause duplicate keys when
-        successive operations land within the same clock tick.
-        TODO: Fix the underlying issue and remove this workaround (monday ticket ref 11777175142)
-""",
-)
-def test_timeseries_merge_update(lmdb_version_store_v1, merge_args):
+def test_timeseries_merge_update(s3_version_store_v1, merge_args):
     target_list, source, on = merge_args
-    lib = lmdb_version_store_v1
+    lib = s3_version_store_v1
     symbol = "test_merge_update"
     lib.version_store.force_delete_symbol(symbol)
     strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
@@ -146,12 +138,12 @@ def test_timeseries_merge_update(lmdb_version_store_v1, merge_args):
     cols_to_promote=st.lists(st.sampled_from(COL_NAMES), unique=True, min_size=1),
 )
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
-def test_multiindex_merge_update(lmdb_version_store_v1, merge_args, cols_to_promote):
+def test_multiindex_merge_update(s3_version_store_v1, merge_args, cols_to_promote):
     target_list, source, on = merge_args
     target_list = [df.set_index(cols_to_promote, append=True) for df in target_list]
     source = source.set_index(cols_to_promote, append=True)
 
-    lib = lmdb_version_store_v1
+    lib = s3_version_store_v1
     symbol = "test_multiindex_merge_update"
     lib.version_store.force_delete_symbol(symbol)
     for df in target_list:
@@ -173,18 +165,10 @@ def test_multiindex_merge_update(lmdb_version_store_v1, merge_args, cols_to_prom
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @given(merge_args=merge_arguments(COL_NAMES, DTYPES, index_type=DataframeStrategyIndexType.ROWRANGE))
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
-@pytest.mark.skipif(
-    WINDOWS or MACOS,
-    reason="""
-        On macOS/Windows the low timestamp resolution can cause duplicate keys when
-        successive operations land within the same clock tick.
-        TODO: Fix the underlying issue and remove this workaround (monday ticket ref 11777175142)
-""",
-)
-def test_rowrange_merge_update(lmdb_version_store_v1, merge_args):
+def test_rowrange_merge_update(s3_version_store_v1, merge_args):
     target, source, on = merge_args
     assert len(target) == 1
-    lib = lmdb_version_store_v1
+    lib = s3_version_store_v1
     symbol = "test_merge_update"
     lib.version_store.force_delete_symbol(symbol)
     strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 11912122297

#### What does this implement or fix?

Merge update is susceptible to creating keys with the same name. We can often end up with keys having the same start/end index and the same content, because we use read modify write the keys are written in parallel which also means that the timestamp part of the key can also be the same. If S3 is used the second write will rewrite the key with LMDB however we throw exception, thus the tests occasionally fail. Changing the S3 backend fixes the issues.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
