### PR TITLE
Processing pipeline perf improvements

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -427,14 +427,16 @@ class AsyncStore : public Store {
             std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
     ) override {
         ARCTICDB_RUNTIME_DEBUG(log::version(), "Reading {} keys", ranges_and_keys.size());
-        std::vector<folly::Future<pipelines::SegmentAndSlice>> output;
-        for (auto&& ranges_and_key : ranges_and_keys) {
-            const auto key = ranges_and_key.key_;
-            output.emplace_back(read_and_continue(
-                    key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
-            ));
-        }
-        return output;
+        return folly::window(
+                std::move(ranges_and_keys),
+                [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
+                    const auto key = ranges_and_key.key_;
+                    return read_and_continue(
+                            key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+                    );
+                },
+                2 * async::TaskScheduler::instance()->io_thread_count()
+                );
     }
 
     std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override {

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -432,11 +432,14 @@ class AsyncStore : public Store {
                 [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
                     const auto key = ranges_and_key.key_;
                     return read_and_continue(
-                            key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+                            key,
+                            library_,
+                            storage::ReadKeyOpts{},
+                            DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
                     );
                 },
                 2 * async::TaskScheduler::instance()->io_thread_count()
-                );
+        );
     }
 
     std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override {

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -59,7 +59,8 @@ class AsyncStore : public Store {
     ) :
         library_(std::move(library)),
         codec_(std::make_shared<proto::encoding::VariantCodec>(codec)),
-        encoding_version_(encoding_version) {}
+        encoding_version_(encoding_version),
+        window_processing_pipeline_reads_(ConfigsMap::instance()->get_int("Storage.WindowProcessingReads", 1) == 1) {}
 
     folly::Future<entity::VariantKey> write(
             stream::KeyType key_type, VersionId version_id, const StreamId& stream_id, IndexValue start_index,
@@ -427,19 +428,36 @@ class AsyncStore : public Store {
             std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
     ) override {
         ARCTICDB_RUNTIME_DEBUG(log::version(), "Reading {} keys", ranges_and_keys.size());
-        return folly::window(
-                std::move(ranges_and_keys),
-                [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
-                    const auto key = ranges_and_key.key_;
-                    return read_and_continue(
-                            key,
-                            library_,
-                            storage::ReadKeyOpts{},
-                            DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
-                    );
-                },
-                2 * async::TaskScheduler::instance()->io_thread_count()
-        );
+        // Window the reads by default (but with a kill switch) for reasons detailed in the PR description:
+        // https://github.com/man-group/ArcticDB/pull/3086
+        // TODO 11961775873: remove this kill switch
+        if (window_processing_pipeline_reads_) {
+            return folly::window(
+                    std::move(ranges_and_keys),
+                    [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
+                        const auto key = ranges_and_key.key_;
+                        return read_and_continue(
+                                key,
+                                library_,
+                                storage::ReadKeyOpts{},
+                                DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+                        );
+                    },
+                    2 * async::TaskScheduler::instance()->io_thread_count()
+            );
+        } else {
+            std::vector<folly::Future<pipelines::SegmentAndSlice>> output;
+            for (auto&& ranges_and_key : ranges_and_keys) {
+                const auto key = ranges_and_key.key_;
+                output.emplace_back(read_and_continue(
+                        key,
+                        library_,
+                        storage::ReadKeyOpts{},
+                        DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+                ));
+            }
+            return output;
+        }
     }
 
     std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override {
@@ -513,6 +531,7 @@ class AsyncStore : public Store {
     std::shared_ptr<storage::Library> library_;
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_;
     const EncodingVersion encoding_version_;
+    const bool window_processing_pipeline_reads_;
 };
 
 } // namespace arcticdb::async

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -789,9 +789,10 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
             );
         }
 
+        // Switch to the CPU executor for reasons detailed in the PR description:
+        // https://github.com/man-group/ArcticDB/pull/3086
         futures->emplace_back(folly::collect(local_futs)
-                                      .via(&async::io_executor()
-                                      ) // Stay on the same executor as the read so that we can inline if possible
+                                      .via(&async::cpu_executor())
                                       .thenValueInline([component_manager,
                                                         segment_fetch_counts,
                                                         id_to_pos,

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -766,6 +766,10 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
         std::shared_ptr<ankerl::unordered_dense::map<EntityId, size_t>>&& id_to_pos,
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses
 ) {
+    // TODO 11961775873: remove this kill switch
+    static const bool process_on_cpu_executor = ConfigsMap::instance()->get_int("Storage.ProcessOnCpuExecutor", 1) == 1;
+    auto* processing_executor = process_on_cpu_executor ? dynamic_cast<folly::Executor*>(&async::cpu_executor())
+                                                        : dynamic_cast<folly::Executor*>(&async::io_executor());
     // Used to make sure each entity is only added into the component manager once
     auto slice_added_mtx = std::make_shared<std::vector<std::mutex>>(num_segments);
     auto slice_added = std::make_shared<std::vector<bool>>(num_segments, false);
@@ -789,10 +793,10 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
             );
         }
 
-        // Switch to the CPU executor for reasons detailed in the PR description:
+        // Switch to the CPU executor by default (but with a kill switch) for reasons detailed in the PR description:
         // https://github.com/man-group/ArcticDB/pull/3086
         futures->emplace_back(folly::collect(local_futs)
-                                      .via(&async::cpu_executor())
+                                      .via(processing_executor)
                                       .thenValueInline([component_manager,
                                                         segment_fetch_counts,
                                                         id_to_pos,

--- a/python/tests/unit/arcticdb/version_store/test_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_compact_data.py
@@ -26,6 +26,8 @@ from arcticdb.util.test import assert_frame_equal, config_context, query_stats_o
 from tests.util.mark import MACOS, WINDOWS
 from tests.util.naughty_strings import read_big_list_of_naughty_strings
 
+pytestmark = pytest.mark.pipeline
+
 
 def check_compact_data_info(
     compact_data_info, pre_compaction_version, post_compaction_version, pre_compaction_index, post_compaction_index


### PR DESCRIPTION
#### What does this implement or fix?
While profiling and optimising the `compact_data` API, I noticed an unusual pattern. With 1 CPU/IO thread, peak memory usage was stable and low, but with 2 or more, it jumped massively. After [much digging](https://chat-man.slack.com/archives/C02NEG3V38X/p1778148513774729) it turned out to be a vicious cycle problem.
To avoid context switching and cache-thrashing, segment decodes happen in the IO thread that read the segment. Segments that are required to be together for the first clause's `process` call are then `folly::collect`ed. The important point is that they are collected in the IO executor as well, and the following lambda which does the processing is `thenValueInline`d. In practice, this means that whichever IO thread finished reading+decoding it's segment last also then executes the processing lambda.
Prior to this, `batch_read_uncompressed` scheduled all of the IO up front. Work scheduled to the IO threadpool is just round-robinned around the available threads, and so every IO thread will receive an equal number of segments to read. However, whichever thread had to execute the processing lambda, which was already the last to finish the read+decode will finish later than the others. This then compounds, so that for the next `collect`, it will almost certainly be the same IO thread that finishes last again, as it started reading later than the others.
The result is that in an IO threadpool of size `n`, `n-1` of the threads just do read+decode tasks, and 1 does ALL of the processing (and writing in the `compact_data` case), so most of the wall clock time is the tail latency of this 1 thread.
The solution is two changes:

1. Switch to the CPU executor for the processing lambda. This will then mean there isn't a single IO thread doing all of the work.
2. `folly::window` the initial reads. This is now required, because the IO of writing back to storage for clauses like compact and merge used to be (basically) inlined when it was scheduled from an IO thread. Now we want these writes to be interleaved with the reads, otherwise they will be at the back of the IO thread's work queues, and so the flush to storage won't happen until the end.

There is one case where this could have a negative performance impact, and that is when the clause processing function needs only a single segment from storage (e.g. a filter with non column sliced data). Previously this would have been executed inline in the thread that read+decoded the data for maximal cache efficiency. It is possible there will now be a delay between the decoding and the processing, leading to the segment being evicted from the CPU cache. We will need to see if this is a problem in practice. We could use the IO executor after single-segment collects, and the CPU executor for multi-segment collects, but this seems like a recipe for deadlocks and debugging nightmares.