### PR TITLE
Optimize binary search methods

### DIFF
--- a/cpp/arcticdb/column_store/column_algorithms.hpp
+++ b/cpp/arcticdb/column_store/column_algorithms.hpp
@@ -398,14 +398,17 @@ ColumnData::ColumnDataIterator<TDT, IT, ID, true> bound_search(
 
     const size_t block_pos = first_block;
     const RawType* block_ptr = block_data_at(block_pos);
+    const size_t block_row_count = block_row_count_at(block_pos);
     const size_t first = (block_pos == begin_block) ? begin_in_block_offset : 0;
-    const size_t last = (block_pos == end_block) ? end_in_block_offset : block_row_count_at(block_pos);
+    const size_t last = (block_pos == end_block) ? end_in_block_offset : block_row_count;
     const RawType* found = bisect(block_ptr + first, block_ptr + last, value);
     if (found == block_ptr + last) {
         // If bisect doesn't find the result in the block, there is no result in the given [begin, end)
         return end;
     }
-    return ColumnData::ColumnDataIterator<TDT, IT, ID, true>(data, block_pos, static_cast<size_t>(found - block_ptr));
+    return ColumnData::ColumnDataIterator<TDT, IT, ID, true>(
+            data, block_pos, static_cast<size_t>(found - block_ptr), block_ptr, block_row_count
+    );
 }
 
 // Gallop forward from `begin` in steps of 2**n until an element after value is reached.
@@ -456,7 +459,22 @@ gallop_bracket(
         if (block > end_block_idx || (block == end_block_idx && offset >= end_in_block_offset)) {
             return end;
         }
-        return ColumnData::ColumnDataIterator<TDT, IT, ID, true>(data, block, offset);
+        return ColumnData::ColumnDataIterator<TDT, IT, ID, true>(
+                data, block, offset, block_data_at(block), block_row_count_at(block)
+        );
+    };
+
+    // Optimized variants for the first block
+    auto record_probe_in_first_block = [&](size_t next_offset, RawType probe_value) {
+        prev_offset = cur_offset;
+        cur_offset = next_offset;
+        return is_before(probe_value, value);
+    };
+
+    auto make_iter_in_first_block = [&](size_t offset) -> ColumnData::ColumnDataIterator<TDT, IT, ID, true> {
+        return ColumnData::ColumnDataIterator<TDT, IT, ID, true>(
+                data, first_block_idx, offset, first_block_data, first_block_row_count
+        );
     };
 
     // Probe within the first block at first_offset + 2**n
@@ -466,19 +484,19 @@ gallop_bracket(
     size_t step = 1;
     for (; first_offset + step + 1 < up_to; step *= 2) {
         const size_t probe_offset = first_offset + step;
-        if (!record_probe(first_block_idx, probe_offset + 1, first_block_data[probe_offset])) {
-            return {make_iter(prev_block, prev_offset), make_iter(cur_block, cur_offset)};
+        if (!record_probe_in_first_block(probe_offset + 1, first_block_data[probe_offset])) {
+            return {make_iter_in_first_block(prev_offset), make_iter_in_first_block(cur_offset)};
         }
     }
 
     if (end_block_idx == first_block_idx) {
         // End lies in the first block; resulting range is [cur, end).
-        return {make_iter(cur_block, cur_offset), end};
+        return {make_iter_in_first_block(cur_offset), end};
     }
 
     // Probe the last element of the first block. Post-probe position is (first_block_idx + 1, 0).
     if (!record_probe(first_block_idx + 1, 0, first_block_data[first_block_row_count - 1])) {
-        return {make_iter(prev_block, prev_offset), make_iter(cur_block, cur_offset)};
+        return {make_iter_in_first_block(prev_offset), make_iter(cur_block, cur_offset)};
     }
 
     // Answer is after the first block — probe the last elements of blocks at first_idx + 2**n
@@ -609,7 +627,7 @@ size_t lower_bound_idx(
                        ? column_data.template citerator_at<TDT, IteratorType::ENUMERATED>(*to)
                        : column_data.template cend<TDT, IteratorType::ENUMERATED, IteratorDensity::DENSE>();
     auto result = lower_bound<TDT, IteratorType::ENUMERATED, IteratorDensity::DENSE>(begin, end, value);
-    if (!result.current_block().has_value()) {
+    if (result.current_block_data() == nullptr) {
         // Iterator to end doesn't have `->idx()`
         return column.row_count();
     }
@@ -637,7 +655,7 @@ size_t upper_bound_idx(
                        ? column_data.template citerator_at<TDT, IteratorType::ENUMERATED>(*to)
                        : column_data.template cend<TDT, IteratorType::ENUMERATED, IteratorDensity::DENSE>();
     auto result = upper_bound<TDT, IteratorType::ENUMERATED, IteratorDensity::DENSE>(begin, end, value);
-    if (!result.current_block().has_value()) {
+    if (result.current_block_data() == nullptr) {
         // Iterator to end doesn't have `->idx()`
         return column.row_count();
     }

--- a/cpp/arcticdb/column_store/column_data.hpp
+++ b/cpp/arcticdb/column_store/column_data.hpp
@@ -206,28 +206,36 @@ struct ColumnData {
             block_pos_(block_pos) {
             load_current_block();
             in_block_offset_ = in_block_offset;
-            if constexpr (iterator_type == IteratorType::ENUMERATED) {
-                if constexpr (iterator_density == IteratorDensity::SPARSE) {
-                    util::raise_rte("ColumnDataIterator at-position constructor not supported for SPARSE iteration");
-                } else {
-                    const size_t block_start_idx = parent_->buffer().block_byte_offset(block_pos) / sizeof(RawType);
-                    data_.idx_ = static_cast<ssize_t>(block_start_idx + in_block_offset);
-                }
-            }
+            recalculate_enumeration();
+        }
+
+        // Optimized constructor that can skip `load_current_block` if caller already has `block_data` and
+        // `block_row_count` Frequently used in search methods.
+        ColumnDataIterator(
+                const ColumnData* parent, size_t block_pos, size_t in_block_offset, const RawType* block_data,
+                size_t block_row_count
+        ) :
+            parent_(parent),
+            block_pos_(block_pos),
+            block_begin_(block_data),
+            in_block_offset_(in_block_offset),
+            block_size_(block_row_count) {
+            recalculate_enumeration();
         }
 
         template<bool OtherConst>
         explicit ColumnDataIterator(const ColumnDataIterator<TDT, iterator_type, iterator_density, OtherConst>& other) :
             parent_(other.parent_),
             block_pos_(other.block_pos_),
-            opt_block_(other.opt_block_),
+            block_begin_(other.block_begin_),
             in_block_offset_(other.in_block_offset_),
             block_size_(other.block_size_),
             data_(other.data_) {}
 
         // Minimal accessors used by the search algorithms in column_algorithms.hpp.
         [[nodiscard]] const ColumnData* parent() const { return parent_; }
-        [[nodiscard]] const std::optional<TypedBlockData<TDT>>& current_block() const { return opt_block_; }
+        // nullptr when the iterator is at end (no current block).
+        [[nodiscard]] const RawType* current_block_data() const { return block_begin_; }
         // Index of the block this iterator currently points into. For end iterators this is num_blocks.
         [[nodiscard]] size_t current_block_index() const { return block_pos_; }
         [[nodiscard]] size_t current_in_block_offset() const { return in_block_offset_; }
@@ -253,21 +261,38 @@ struct ColumnData {
         }
 
         void load_current_block() {
-            opt_block_ = parent_->template typed_block_at_position<TDT>(block_pos_);
-            block_size_ = opt_block_.has_value() ? opt_block_->row_count() : 0;
-            // It is possible for arrow sparse data to have blocks with zero set rows.
-            // We need to skip all blocks with zero rows to get to the next iterator position.
-            while (ARCTICDB_UNLIKELY(opt_block_.has_value() && block_size_ == 0)) {
-                ++block_pos_;
-                opt_block_ = parent_->template typed_block_at_position<TDT>(block_pos_);
-                block_size_ = opt_block_.has_value() ? opt_block_->row_count() : 0;
-            }
+            const size_t num_blocks = parent_->num_blocks();
+            const auto& blocks = parent_->buffer().blocks();
             in_block_offset_ = 0;
+            // It is possible for arrow sparse data to have blocks with zero set rows.
+            // Skip all such blocks to get to the next iterator position.
+            while (block_pos_ < num_blocks) {
+                IMemBlock* block = blocks[block_pos_];
+                block_begin_ = reinterpret_cast<const RawType*>(block->data());
+                block_size_ = block->logical_size() / sizeof(RawType);
+                if (ARCTICDB_LIKELY(block_size_ != 0)) {
+                    return;
+                }
+                ++block_pos_;
+            }
+            block_begin_ = nullptr;
+            block_size_ = 0;
         }
 
         void advance_block() {
             ++block_pos_;
             load_current_block();
+        }
+
+        void recalculate_enumeration() {
+            if constexpr (iterator_type == IteratorType::ENUMERATED) {
+                if constexpr (iterator_density == IteratorDensity::SPARSE) {
+                    util::raise_rte("ColumnDataIterator at-position constructor not supported for SPARSE iteration");
+                } else {
+                    const size_t block_start_idx = parent_->buffer().block_byte_offset(block_pos_) / sizeof(RawType);
+                    data_.idx_ = static_cast<ssize_t>(block_start_idx + in_block_offset_);
+                }
+            }
         }
 
         template<bool OtherConst>
@@ -285,14 +310,14 @@ struct ColumnData {
         {
             ARCTICDB_DEBUG_CHECK(
                     ErrorCode::E_ASSERTION_FAILURE,
-                    opt_block_.has_value(),
+                    block_begin_ != nullptr,
                     "Dereferencing end iterator in ColumnDataIterator"
             );
             if constexpr (iterator_type == IteratorType::ENUMERATED) {
-                data_.ptr_ = const_cast<RawType*>(opt_block_->data() + in_block_offset_);
+                data_.ptr_ = const_cast<RawType*>(block_begin_ + in_block_offset_);
                 return data_;
             } else {
-                return *(opt_block_->data() + in_block_offset_);
+                return *(block_begin_ + in_block_offset_);
             }
         }
 
@@ -301,20 +326,21 @@ struct ColumnData {
         {
             ARCTICDB_DEBUG_CHECK(
                     ErrorCode::E_ASSERTION_FAILURE,
-                    opt_block_.has_value(),
+                    block_begin_ != nullptr,
                     "Dereferencing end iterator in ColumnDataIterator"
             );
             if constexpr (iterator_type == IteratorType::ENUMERATED) {
-                data_.ptr_ = const_cast<RawType*>(opt_block_->data() + in_block_offset_);
+                data_.ptr_ = const_cast<RawType*>(block_begin_ + in_block_offset_);
                 return *const_cast<typename base_type::value_type*>(&data_);
             } else {
-                return *const_cast<RawType*>(opt_block_->data() + in_block_offset_);
+                return *const_cast<RawType*>(block_begin_ + in_block_offset_);
             }
         }
 
         const ColumnData* parent_{nullptr};
         size_t block_pos_{0};
-        std::optional<TypedBlockData<TDT>> opt_block_{std::nullopt};
+        // Raw pointer to the start of the current block's data, nullptr at end.
+        const RawType* block_begin_{nullptr};
         size_t in_block_offset_{0};
         size_t block_size_{0};
         // Mutable is to allow assigning `ptr_` lazily on dereference for ENUMERATED

--- a/cpp/arcticdb/column_store/test/test_column.cpp
+++ b/cpp/arcticdb/column_store/test/test_column.cpp
@@ -541,7 +541,7 @@ void check_search_on_column(
                                   : column_data.cbegin<SearchTDT, IteratorType::ENUMERATED, IteratorDensity::DENSE>();
     auto end = to.has_value() ? column_data.citerator_at<SearchTDT, IteratorType::ENUMERATED>(*to)
                               : column_data.cend<SearchTDT, IteratorType::ENUMERATED, IteratorDensity::DENSE>();
-    auto res_idx = [&](auto& it) { return it.current_block().has_value() ? it->idx() : total; };
+    auto res_idx = [&](auto& it) { return it.current_block_data() != nullptr ? it->idx() : total; };
     const auto std_begin = values.begin() + from.value_or(0);
     const auto std_end = values.begin() + to.value_or(values.size());
     for (auto v : probes) {


### PR DESCRIPTION
#### Reference Issues/PRs
Optimizations on top of #3091
Used in #3062 

#### What does this implement or fix?
Some micro optimizations on binary search methods:
- Don't keep `TypedBlockData` in `ColumnDataIterator`. Instead only keep `block_data_` and `block_size_`
- Don't recalculate block pointer and size when we already know them during gallop

#### Any other comments?
Benchmarks for all search and iteration methods:

  | Benchmark | Before (ns) | After (ns) | Delta |
  |---|---:|---:|---:|
  | iterate_irregular_blocks_1 (one row per block) | 478,496 | 311,163 | −35.0% |
  | iterate_with_iterator (100 rows) | 798 | 719 | −9.9% |
  | exponential_lb_single_block (in first 100) | 356 | 323 | −9.2% |
  | exponential_lb_single_block (full gallop) | 458 | 424 | −7.4% |
  | exponential_lb_regular (in first 100) | 364 | 339 | −6.7% |
  | exponential_lb_irregular_1000 (in first 100) | 360 | 335 | −6.7% |
  | exponential_lb_irregular_1000 (full gallop) | 496 | 476 | −3.9% |
  | exponential_lb_regular (full gallop) | 504 | 489 | −2.9% |
  | exponential_lb_irregular_1 (in first 100) | 464 | 455 | −2.0% |
  | exponential_lb_irregular_1 (full gallop) | 687 | 679 | −1.3% |
  | lower_bound_single_block | 411 | 394 | −4.1% |
  | lower_bound_irregular_1000 | 444 | 431 | −3.0% |
  | lower_bound_irregular_1 | 595 | 579 | −2.8% |
  | lower_bound_regular_blocks | 443 | 436 | −1.4% |
  | iterate_single_block | 27,305 | 27,247 | −0.2% |
  | iterate_regular_blocks | 29,051 | 28,734 | −1.1% |
  | iterate_irregular_blocks_1000 | 28,136 | 27,893 | −0.9% |
  | iterate_with_scalar_at (100 rows) | 182,183,122 | 182,088,026 | −0.1% |

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
