### PR TITLE
Refactor component manager

### DIFF
--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -940,7 +940,7 @@ std::vector<std::vector<EntityId>> RowRangeClause::structure_for_processing(
         new_row_ranges.emplace_back(std::move(new_row_range));
     }
 
-    component_manager_->replace_entities<std::shared_ptr<RowRange>>(entity_ids, new_row_ranges);
+    component_manager_->replace_entities_zip(entity_ids, std::move(new_row_ranges));
 
     auto new_structure_offsets = structure_by_row_slice(ranges_and_entities);
     return offsets_to_entity_ids(new_structure_offsets, ranges_and_entities);
@@ -1130,8 +1130,8 @@ std::vector<std::vector<EntityId>> ConcatClause::structure_for_processing(
             new_row_ranges.emplace_back(std::move(new_row_range));
         }
     }
-    component_manager_->replace_entities<std::shared_ptr<RowRange>>(
-            util::flatten_vectors(std::move(entity_ids_vec)), new_row_ranges
+    component_manager_->replace_entities_zip(
+            util::flatten_vectors(std::move(entity_ids_vec)), std::move(new_row_ranges)
     );
     auto new_structure_offsets = structure_by_row_slice(ranges_and_entities);
     return offsets_to_entity_ids(new_structure_offsets, ranges_and_entities);

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -35,18 +35,19 @@ class ComponentManager {
 
     // Add a single entity with the components defined by args
     template<class... Args>
-    void add_entity(EntityId id, Args... args) {
+    void add_entity(EntityId id, Args&&... args) {
         std::unique_lock lock(mtx_);
         (
                 [&] {
-                    registry_.emplace<Args>(id, args);
                     // Store the initial entity fetch count component as a "first-class" entity, accessible by
                     // registry_.get<EntityFetchCount>(id), as this is external facing (used by resample)
                     // The remaining entity fetch count below will be decremented each time an entity is fetched, but is
                     // never accessed externally. Stored as an atomic to minimise the requirement to take the
                     // shared_mutex with a unique_lock.
-                    if constexpr (std::is_same_v<Args, EntityFetchCount>) {
-                        registry_.emplace<std::atomic<EntityFetchCount>>(id, args);
+                    if constexpr (std::same_as<std::decay_t<Args>, EntityFetchCount>) {
+                        registry_.emplace<std::atomic<EntityFetchCount>>(id, std::forward<decltype(args)>(args));
+                    } else {
+                        registry_.emplace<Args>(id, std::forward<decltype(args)>(args));
                     }
                 }(),
                 ...
@@ -56,7 +57,7 @@ class ComponentManager {
     // Add a collection of entities. Each element of args should be a collection of components, all of which have the
     // same number of elements
     template<class... Args>
-    std::vector<EntityId> add_entities(Args... args) {
+    std::vector<EntityId> add_entities(Args&&... args) {
         std::vector<EntityId> ids;
         size_t entity_count{0};
         ARCTICDB_SAMPLE_DEFAULT(AddEntities)
@@ -74,11 +75,15 @@ class ComponentManager {
                                 "ComponentManager::add_entities received collections of differing lengths"
                         );
                     }
-                    registry_.insert<typename Args::value_type>(ids.cbegin(), ids.cend(), args.begin());
-                    if constexpr (std::is_same_v<typename Args::value_type, EntityFetchCount>) {
+                    using T = std::decay_t<typename Args::value_type>;
+                    if constexpr (std::same_as<T, EntityFetchCount>) {
                         for (auto&& [idx, id] : folly::enumerate(ids)) {
-                            registry_.emplace<std::atomic<EntityFetchCount>>(id, args[idx]);
+                            registry_.emplace<std::atomic<EntityFetchCount>>(
+                                    id, std::forward<EntityFetchCount>(args[idx])
+                            );
                         }
+                    } else {
+                        registry_.insert<T>(ids.cbegin(), ids.cend(), std::make_move_iterator(args.begin()));
                     }
                 }(),
                 ...
@@ -87,29 +92,32 @@ class ComponentManager {
     }
 
     template<typename T>
-    void replace_entities(const std::vector<EntityId>& ids, T value) {
+    void replace_entities(std::span<const EntityId> ids, const T& value) {
         ARCTICDB_SAMPLE_DEFAULT(ReplaceEntities)
         std::unique_lock lock(mtx_);
         for (auto id : ids) {
-            registry_.replace<T>(id, value);
-            if constexpr (std::is_same_v<T, EntityFetchCount>) {
+            if constexpr (std::same_as<std::decay_t<T>, EntityFetchCount>) {
                 update_entity_fetch_count(id, value);
+            } else {
+                registry_.replace<T>(id, value);
             }
         }
     }
 
-    template<typename T>
-    void replace_entities(const std::vector<EntityId>& ids, const std::vector<T>& values) {
+    template<std::ranges::random_access_range R>
+    void replace_entities_zip(std::span<const EntityId> ids, R&& values) {
         ARCTICDB_SAMPLE_DEFAULT(ReplaceEntityValues)
         internal::check<ErrorCode::E_ASSERTION_FAILURE>(
                 ids.size() == values.size(),
                 "Received vectors of differing lengths in ComponentManager::replace_entities"
         );
+        using T = std::ranges::range_value_t<R>;
         std::unique_lock lock(mtx_);
         for (auto [idx, id] : folly::enumerate(ids)) {
-            registry_.replace<T>(id, values[idx]);
-            if constexpr (std::is_same_v<T, EntityFetchCount>) {
-                update_entity_fetch_count(id, values[idx]);
+            if constexpr (std::same_as<T, EntityFetchCount>) {
+                update_entity_fetch_count(id, std::forward<R>(values)[idx]);
+            } else {
+                registry_.replace<T>(id, std::forward<R>(values)[idx]);
             }
         }
     }
@@ -118,13 +126,13 @@ class ComponentManager {
 
     // Get a collection of entities. Returns a tuple of vectors, one for each component requested via Args
     template<class... Args>
-    std::tuple<std::vector<Args>...> get_entities_and_decrement_refcount(const std::vector<EntityId>& ids) {
+    std::tuple<std::vector<Args>...> get_entities_and_decrement_refcount(std::span<const EntityId> ids) {
         return get_entities_impl<Args...>(ids, true);
     }
 
     // Get a collection of entities. Returns a tuple of vectors, one for each component requested via Args
     template<class... Args>
-    std::tuple<std::vector<Args>...> get_entities(const std::vector<EntityId>& ids) {
+    std::tuple<std::vector<Args>...> get_entities(std::span<const EntityId> ids) {
         return get_entities_impl<Args...>(ids, false);
     }
 
@@ -133,7 +141,7 @@ class ComponentManager {
     void update_entity_fetch_count(EntityId id, EntityFetchCount count);
 
     template<class... Args>
-    std::tuple<std::vector<Args>...> get_entities_impl(const std::vector<EntityId>& ids, bool decrement_ref_count) {
+    std::tuple<std::vector<Args>...> get_entities_impl(std::span<const EntityId> ids, bool decrement_ref_count) {
         std::vector<std::tuple<Args...>> tuple_res;
         ARCTICDB_SAMPLE_DEFAULT(GetEntities)
         tuple_res.reserve(ids.size());

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -39,6 +39,7 @@ class ComponentManager {
         std::unique_lock lock(mtx_);
         (
                 [&] {
+                    registry_.emplace<Args>(id, std::forward<decltype(args)>(args));
                     // Store the initial entity fetch count component as a "first-class" entity, accessible by
                     // registry_.get<EntityFetchCount>(id), as this is external facing (used by resample)
                     // The remaining entity fetch count below will be decremented each time an entity is fetched, but is
@@ -46,8 +47,6 @@ class ComponentManager {
                     // shared_mutex with a unique_lock.
                     if constexpr (std::same_as<std::decay_t<Args>, EntityFetchCount>) {
                         registry_.emplace<std::atomic<EntityFetchCount>>(id, std::forward<decltype(args)>(args));
-                    } else {
-                        registry_.emplace<Args>(id, std::forward<decltype(args)>(args));
                     }
                 }(),
                 ...
@@ -76,14 +75,13 @@ class ComponentManager {
                         );
                     }
                     using T = std::decay_t<typename Args::value_type>;
+                    registry_.insert<T>(ids.cbegin(), ids.cend(), std::make_move_iterator(args.begin()));
                     if constexpr (std::same_as<T, EntityFetchCount>) {
                         for (auto&& [idx, id] : folly::enumerate(ids)) {
                             registry_.emplace<std::atomic<EntityFetchCount>>(
                                     id, std::forward<EntityFetchCount>(args[idx])
                             );
                         }
-                    } else {
-                        registry_.insert<T>(ids.cbegin(), ids.cend(), std::make_move_iterator(args.begin()));
                     }
                 }(),
                 ...
@@ -96,10 +94,9 @@ class ComponentManager {
         ARCTICDB_SAMPLE_DEFAULT(ReplaceEntities)
         std::unique_lock lock(mtx_);
         for (auto id : ids) {
+            registry_.replace<T>(id, value);
             if constexpr (std::same_as<std::decay_t<T>, EntityFetchCount>) {
                 update_entity_fetch_count(id, value);
-            } else {
-                registry_.replace<T>(id, value);
             }
         }
     }
@@ -114,10 +111,9 @@ class ComponentManager {
         using T = std::ranges::range_value_t<R>;
         std::unique_lock lock(mtx_);
         for (auto [idx, id] : folly::enumerate(ids)) {
+            registry_.replace<T>(id, std::forward<R>(values)[idx]);
             if constexpr (std::same_as<T, EntityFetchCount>) {
                 update_entity_fetch_count(id, std::forward<R>(values)[idx]);
-            } else {
-                registry_.replace<T>(id, std::forward<R>(values)[idx]);
             }
         }
     }


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?

* Implement perfect forwarding. All entities were passed by value.
* There were two implementations of replace_entities one taking vector and one taking template parameter. There are two issues with this. First we cannot use this to place the same vector in all of the entities because the type deduction will pick up the more specific implementation. Second parameters were passed by value. The function taking vector is now `replace_entities_zip` and moves the elements of the vector. The function taking a single parameter and placing it in all entities is `replace_entities` and takes a const ref. We cannot move in this case
* Cosmetic changes: some const std::vector were changed to std::span so that it can accept wider range of types (e.g. std::array)

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
