### PR TITLE
Performance 11900115518: use atom key packed in version map cache

### DIFF
--- a/cpp/arcticdb/column_store/column.cpp
+++ b/cpp/arcticdb/column_store/column.cpp
@@ -326,7 +326,9 @@ void Column::allocate_and_advance_by(std::size_t bytes) {
     advance_data(bytes);
 }
 
-[[nodiscard]] ChunkedBuffer& Column::buffer() { return data_.buffer(); }
+ChunkedBuffer& Column::buffer() { return data_.buffer(); }
+
+const ChunkedBuffer& Column::buffer() const { return data_.buffer(); }
 
 uint8_t* Column::bytes_at(size_t bytes, size_t required) {
     ARCTICDB_TRACE(log::inmem(), "Column returning {} bytes at position {}", required, bytes);

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -564,6 +564,8 @@ class Column {
 
     [[nodiscard]] ChunkedBuffer& buffer();
 
+    [[nodiscard]] const ChunkedBuffer& buffer() const;
+
     uint8_t* bytes_at(size_t bytes, size_t required);
 
     const uint8_t* bytes_at(size_t bytes, size_t required) const;

--- a/cpp/arcticdb/entity/atom_key.hpp
+++ b/cpp/arcticdb/entity/atom_key.hpp
@@ -89,12 +89,16 @@ class AtomKeyImpl {
     friend bool operator!=(const AtomKeyImpl& l, const AtomKeyImpl& r) { return !(l == r); }
 
     friend bool operator<(const AtomKeyImpl& l, const AtomKeyImpl& r) {
-        const auto lt = std::tie(l.id_, l.version_id_, l.index_start_, l.index_end_, l.creation_ts_);
-        const auto rt = std::tie(r.id_, r.version_id_, r.index_start_, r.index_end_, r.creation_ts_);
+        const auto lt = std::tie(
+                l.id_, l.version_id_, l.index_start_, l.index_end_, l.creation_ts_, l.key_type_, l.content_hash_
+        );
+        const auto rt = std::tie(
+                r.id_, r.version_id_, r.index_start_, r.index_end_, r.creation_ts_, r.key_type_, r.content_hash_
+        );
         return lt < rt;
     }
 
-    friend bool operator>(const AtomKeyImpl& l, const AtomKeyImpl& r) { return !(l < r) && (l != r); }
+    friend bool operator>(const AtomKeyImpl& l, const AtomKeyImpl& r) { return r < l; }
 
     size_t get_cached_hash() const {
         if (!hash_) {
@@ -236,6 +240,7 @@ struct AtomKeyPacked {
     AtomKeyPacked(const AtomKey& atom_key) :
         version_id_(atom_key.version_id()),
         creation_ts_(atom_key.creation_ts()),
+        content_hash_(atom_key.content_hash()),
         key_type_(atom_key.type()),
         index_start_(atom_key.start_time()),
         index_end_(atom_key.end_time()) {}
@@ -243,6 +248,13 @@ struct AtomKeyPacked {
     AtomKey to_atom_key(const StreamId& stream_id) const {
         return AtomKey(stream_id, version_id_, creation_ts_, content_hash_, index_start_, index_end_, key_type_);
     }
+
+    const auto& version_id() const { return version_id_; }
+    const auto& creation_ts() const { return creation_ts_; }
+    const auto& content_hash() const { return content_hash_; }
+    const auto& type() const { return key_type_; }
+    const auto& start_index() const { return index_start_; }
+    const auto& end_index() const { return index_end_; }
 
     VersionId version_id_ = 0;
     timestamp creation_ts_ = 0;
@@ -252,14 +264,29 @@ struct AtomKeyPacked {
     timestamp index_end_;
 
     friend bool operator==(const AtomKeyPacked& l, const AtomKeyPacked& r) {
-        return l.version_id_ == r.version_id_ && l.creation_ts_ == r.creation_ts_ &&
-               l.content_hash_ == r.content_hash_ && l.key_type_ == r.key_type_ && l.index_start_ == r.index_start_ &&
-               l.index_end_ == r.index_end_;
+        return l.version_id() == r.version_id() && l.creation_ts() == r.creation_ts() &&
+               l.content_hash() == r.content_hash() && l.start_index() == r.start_index() &&
+               l.end_index() == r.end_index() && l.type() == r.type();
     }
+
+    friend bool operator!=(const AtomKeyPacked& l, const AtomKeyPacked& r) { return !(l == r); }
+
+    friend bool operator<(const AtomKeyPacked& l, const AtomKeyPacked& r) {
+        const auto lt =
+                std::tie(l.version_id_, l.index_start_, l.index_end_, l.creation_ts_, l.key_type_, l.content_hash_);
+        const auto rt =
+                std::tie(r.version_id_, r.index_start_, r.index_end_, r.creation_ts_, r.key_type_, r.content_hash_);
+        return lt < rt;
+    }
+
+    friend bool operator>(const AtomKeyPacked& l, const AtomKeyPacked& r) { return r < l; }
 };
 constexpr size_t AtomKeyPackedSize = 40 + sizeof(int);
 static_assert(sizeof(AtomKeyPacked) == AtomKeyPackedSize);
 #pragma pack(pop)
+
+template<typename T>
+concept AtomKeyType = std::is_same_v<T, AtomKey> || std::is_same_v<T, AtomKeyPacked>;
 
 } // namespace arcticdb::entity
 
@@ -316,6 +343,29 @@ struct formatter<AtomKey> {
         return f.format(formattable, ctx);
     }
 };
+
+template<>
+struct formatter<arcticdb::entity::AtomKeyPacked> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const arcticdb::entity::AtomKeyPacked& k, FormatContext& ctx) const {
+        return fmt::format_to(
+                ctx.out(),
+                "{} v{} {}-{} ts{} hash{}",
+                k.key_type_,
+                k.version_id_,
+                k.index_start_,
+                k.index_end_,
+                k.creation_ts_,
+                k.content_hash_
+        );
+    }
+};
+
 } // namespace fmt
 
 namespace std {

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -92,7 +92,7 @@ struct ArrowInputContiguousSlice {
 
 std::vector<ArrowInputContiguousSlice> arrow_contiguous_slices_in_range(const Column& col, size_t from, size_t to) {
     auto slices = std::vector<ArrowInputContiguousSlice>();
-    const auto& buffer = col.data().buffer();
+    const auto& buffer = col.buffer();
     const auto type_size = get_type_size(col.type().data_type());
     const auto from_byte = from * type_size;
     const auto to_byte = to * type_size;

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1148,16 +1148,16 @@ folly::Future<DeleteTreesStats> delete_trees_responsibly(
             get_matching_prev_and_next_versions(
                     entry,
                     key.version_id(), // Check 2)
-                    [](const AtomKey&) {},
-                    [&check, &not_to_delete](auto& prev) {
+                    [](const AtomKeyPacked&) {},
+                    [&check, &not_to_delete, &entry](auto& prev) {
                         if (check.prev_version)
-                            not_to_delete.insert(prev);
+                            not_to_delete.insert(prev.to_atom_key(entry->stream_id_));
                     },
-                    [&check, &not_to_delete](auto& next) {
+                    [&check, &not_to_delete, &entry](auto& next) {
                         if (check.next_version)
-                            not_to_delete.insert(next);
+                            not_to_delete.insert(next.to_atom_key(entry->stream_id_));
                     },
-                    [v = key.version_id()](const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry) {
+                    [v = key.version_id()](const AtomKeyPacked& key, const std::shared_ptr<VersionMapEntry>& entry) {
                         // Can't use is_live_index_type_key() because the target version's index key might have
                         // already been tombstoned, so will miss it and thus not able to find the prev/next key.
                         return is_index_key_type(key.type()) && (key.version_id() == v || !entry->is_tombstoned(key));

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -973,13 +973,11 @@ struct CheckSymbolsTask {
 TEST_F(SymbolListSuite, AddAndCompact) {
     log::version().set_pattern("%Y%m%d %H:%M:%S.%f %t %L %n | %v");
     std::vector<Future<Unit>> futures;
-    std::optional<AtomKey> previous_key;
     for (auto x = 0; x < 1000; ++x) {
         auto symbol = fmt::format("symbol_{}", x);
         SymbolList::add_symbol(store_, symbol, 0);
         auto key = atom_key_builder().build(symbol, KeyType::TABLE_INDEX);
-        version_map_->write_version(store_, key, previous_key);
-        previous_key = key;
+        version_map_->write_version(store_, key, std::nullopt);
     }
     (void)symbol_list_->get_symbol_set(store_);
     auto versions = std::make_shared<ReferenceVersionMap>();

--- a/cpp/arcticdb/version/test/test_version_map.cpp
+++ b/cpp/arcticdb/version/test/test_version_map.cpp
@@ -95,7 +95,7 @@ TEST(VersionMap, WithPredecessors) {
     ASSERT_EQ(latest.value(), key2);
     version_map->write_version(store, key3, key2);
 
-    std::vector<AtomKey> expected{key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3, key2, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 }
@@ -134,7 +134,7 @@ TEST(VersionMap, TombstoneDelete) {
     ASSERT_EQ(del_res.keys_to_delete.front(), key2);
     ASSERT_THAT(del_res.could_share_data, UnorderedElementsAre(key1, key3));
 
-    std::vector<AtomKey> expected{key4, key3, key1};
+    std::vector<AtomKeyPacked> expected{key4, key3, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 
@@ -190,7 +190,7 @@ TEST(VersionMap, PingPong) {
 
     left->write_version(store, key3, key2);
 
-    std::vector<AtomKey> expected{key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3, key2, key1};
     auto left_result = get_all_versions(store, left, id);
     ASSERT_EQ(left_result, expected);
     auto right_result = get_all_versions(store, right, id);
@@ -232,14 +232,14 @@ TEST(VersionMap, TestLoadsRefAndIteration) {
 
     ScopedConfig reload_interval("VersionMap.ReloadInterval", 0); // always reload
 
-    std::vector<AtomKey> expected{key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3, key2, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 
-    auto entry_iteration = std::make_shared<VersionMapEntry>();
+    auto entry_iteration = std::make_shared<VersionMapEntry>(id);
     version_map->load_via_iteration(store, id, entry_iteration);
 
-    auto entry_ref = std::make_shared<VersionMapEntry>();
+    auto entry_ref = std::make_shared<VersionMapEntry>(id);
     version_map->load_via_ref_key(store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, entry_ref);
 
     ASSERT_EQ(entry_iteration->head_, entry_ref->head_);
@@ -272,7 +272,7 @@ TEST(VersionMap, TestCompact) {
     ASSERT_EQ(store->num_atom_keys(), 2);
     ASSERT_EQ(store->num_ref_keys(), 1);
 
-    std::vector<AtomKey> expected{key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3, key2, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 }
@@ -296,7 +296,7 @@ TEST(VersionMap, TestCompactWithDelete) {
     ASSERT_EQ(store->num_atom_keys(), 2);
     ASSERT_EQ(store->num_ref_keys(), 1);
 
-    std::vector<AtomKey> expected{key3, key1};
+    std::vector<AtomKeyPacked> expected{key3, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 }
@@ -334,7 +334,7 @@ TEST(VersionMap, TestCompactWithDeleteTombstones) {
     ScopedConfig reload_interval("VersionMap.ReloadInterval", 0); // always reload
     version_map->compact(store, id);
 
-    std::vector<AtomKey> expected{key3, key1};
+    std::vector<AtomKeyPacked> expected{key3, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 }
@@ -371,7 +371,7 @@ void write_old_style_journal_entry(const AtomKey& key, std::shared_ptr<StreamSin
 TEST(VersionMap, GetNextVersionInEntry) {
     using namespace arcticdb;
 
-    auto entry = std::make_shared<VersionMapEntry>();
+    auto entry = std::make_shared<VersionMapEntry>("");
 
     ASSERT_FALSE(get_next_version_in_entry(entry, 5));
     ASSERT_FALSE(get_prev_version_in_entry(entry, 0));
@@ -446,11 +446,11 @@ TEST(VersionMap, ForceRewriteVersion) {
     const bool prevent_non_increasing_version_id = false;
     version_map->write_version(store, key3_new, key2, prevent_non_increasing_version_id);
 
-    std::vector<AtomKey> expected{key3_new, key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3_new, key3, key2, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 
-    auto entry_ref = std::make_shared<VersionMapEntry>();
+    auto entry_ref = std::make_shared<VersionMapEntry>(id);
     version_map->load_via_ref_key(store, id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, entry_ref);
     ASSERT_EQ(get_prev_version_in_entry(entry_ref, 3).value(), 2);
 }
@@ -503,7 +503,7 @@ TEST(VersionMap, FixRefKey) {
     version_map->fix_ref_key(store, id);
     ASSERT_TRUE(version_map->check_ref_key(store, id));
 
-    std::vector<AtomKey> expected{key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3, key2, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 }
@@ -604,7 +604,7 @@ TEST(VersionMap, RewriteVersionKeys) {
     ASSERT_TRUE(final_index_key1.has_value());
     ASSERT_TRUE(final_index_key2.has_value());
 
-    std::vector<AtomKey> expected{key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3, key2, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 }
@@ -632,7 +632,7 @@ TEST(VersionMap, RecoverDeleted) {
     ASSERT_THROW({ get_all_versions(store, version_map, id); }, std::runtime_error);
     version_map->recover_deleted(store, id);
 
-    std::vector<AtomKey> expected{key3, key2, key1};
+    std::vector<AtomKeyPacked> expected{key3, key2, key1};
     auto result = get_all_versions(store, version_map, id);
     ASSERT_EQ(result, expected);
 }
@@ -748,9 +748,9 @@ TEST(VersionMap, FollowingVersionChain) {
     write_alternating_deleted_undeleted(store, version_map, id);
 
     auto check_strategy_loads_to = [&](LoadStrategy load_strategy, VersionId should_load_to) {
-        auto ref_entry = VersionMapEntry{};
+        auto ref_entry = VersionMapEntry{id};
         read_symbol_ref(store, id, ref_entry);
-        auto follow_result = std::make_shared<VersionMapEntry>();
+        auto follow_result = std::make_shared<VersionMapEntry>(id);
 
         version_map->follow_version_chain(store, ref_entry, follow_result, load_strategy);
         ASSERT_EQ(follow_result->load_progress_.oldest_loaded_index_version_, VersionId{should_load_to});
@@ -877,9 +877,9 @@ TEST(VersionMap, FollowingVersionChainEndEarlyOnTombstoneAll) {
     // Deleting should add a TOMBSTONE_ALL which should end searching for undeleted versions early.
     version_map->delete_all_versions(store, id);
 
-    auto ref_entry = VersionMapEntry{};
+    auto ref_entry = VersionMapEntry{id};
     read_symbol_ref(store, id, ref_entry);
-    auto follow_result = std::make_shared<VersionMapEntry>();
+    auto follow_result = std::make_shared<VersionMapEntry>(id);
 
     for (auto load_strategy :
          {LoadStrategy{LoadType::DOWNTO, LoadObjective::UNDELETED_ONLY, static_cast<SignedVersionId>(0)},
@@ -922,9 +922,9 @@ TEST(VersionMap, FollowingVersionChainWithWriteAndPrunePrevious) {
     auto key2 = atom_key_with_version(id, 3, 3);
     version_map->write_and_prune_previous(store, key2, key);
 
-    auto ref_entry = VersionMapEntry{};
+    auto ref_entry = VersionMapEntry{id};
     read_symbol_ref(store, id, ref_entry);
-    auto follow_result = std::make_shared<VersionMapEntry>();
+    auto follow_result = std::make_shared<VersionMapEntry>(id);
 
     // LATEST should load only the latest version
     for (auto load_strategy :
@@ -1361,7 +1361,7 @@ TEST(VersionMap, TombstoneAllFromEntry) {
     StreamId id{"test"};
     auto store = std::make_shared<InMemoryStore>();
     auto version_map = std::make_shared<VersionMap>();
-    auto entry = std::make_shared<VersionMapEntry>();
+    auto entry = std::make_shared<VersionMapEntry>(id);
 
     auto key1 = atom_key_with_version(id, 0, 0);
     version_map->do_write(store, key1, entry);

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -130,25 +130,25 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
     auto k2 = write_version_frame(stream_id, 1, version_store, 1000000, true, 1, k1);
     write_version_frame(stream_id, 2, version_store, 1000000, true, 2, k2);
 
-    auto iter_entry = std::make_shared<VersionMapEntry>();
-    auto ref_entry = std::make_shared<VersionMapEntry>();
+    auto iter_entry = std::make_shared<VersionMapEntry>(stream_id);
+    auto ref_entry = std::make_shared<VersionMapEntry>(stream_id);
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry);
     version_map->load_via_ref_key(
             mock_store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, ref_entry
     );
 
-    EXPECT_EQ(std::string(iter_entry->head_.value().view()), std::string(ref_entry->head_.value().view()));
+    EXPECT_EQ(iter_entry->head_.value(), ref_entry->head_.value());
     ASSERT_EQ(iter_entry->keys_.size(), ref_entry->keys_.size());
     for (size_t idx = 0; idx != iter_entry->keys_.size(); idx++) {
-        EXPECT_EQ(std::string(iter_entry->keys_[idx].view()), std::string(ref_entry->keys_[idx].view()));
+        EXPECT_EQ(iter_entry->keys_[idx], ref_entry->keys_[idx]);
     }
 
     // Testing the method after compaction
     version_map->compact(mock_store, stream_id);
 
-    auto iter_entry_compact = std::make_shared<VersionMapEntry>();
-    auto ref_entry_compact = std::make_shared<VersionMapEntry>();
+    auto iter_entry_compact = std::make_shared<VersionMapEntry>(stream_id);
+    auto ref_entry_compact = std::make_shared<VersionMapEntry>(stream_id);
 
     version_map->load_via_iteration(mock_store, stream_id, iter_entry_compact);
     version_map->load_via_ref_key(
@@ -158,14 +158,10 @@ TEST(PythonVersionStore, IterationVsRefWrite) {
             ref_entry_compact
     );
 
-    EXPECT_EQ(
-            std::string(iter_entry_compact->head_.value().view()), std::string(ref_entry_compact->head_.value().view())
-    );
+    EXPECT_EQ(iter_entry_compact->head_.value(), ref_entry_compact->head_.value());
     ASSERT_EQ(iter_entry_compact->keys_.size(), ref_entry_compact->keys_.size());
     for (size_t idx = 0; idx != iter_entry_compact->keys_.size(); idx++) {
-        EXPECT_EQ(
-                std::string(iter_entry_compact->keys_[idx].view()), std::string(ref_entry_compact->keys_[idx].view())
-        );
+        EXPECT_EQ(iter_entry_compact->keys_[idx], ref_entry_compact->keys_[idx]);
     }
 }
 
@@ -667,7 +663,7 @@ TEST(VersionStore, AppendRefKeyOptimisation) {
 
     uint64_t version_id = 1;
     // Test that v1 is visible when deleted versions are included
-    auto entry_deleted = std::make_shared<VersionMapEntry>();
+    auto entry_deleted = std::make_shared<VersionMapEntry>(symbol);
     version_map->load_via_ref_key(
             store,
             symbol,
@@ -682,7 +678,7 @@ TEST(VersionStore, AppendRefKeyOptimisation) {
     ASSERT_TRUE(it != std::end(all_index_keys));
 
     // Test that v1 is not visible when only undeleted versions are queried
-    auto entry_undeleted = std::make_shared<VersionMapEntry>();
+    auto entry_undeleted = std::make_shared<VersionMapEntry>(symbol);
     version_map->load_via_ref_key(
             store,
             symbol,

--- a/cpp/arcticdb/version/test/version_backwards_compat.hpp
+++ b/cpp/arcticdb/version/test/version_backwards_compat.hpp
@@ -32,7 +32,7 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
     auto entry = version_map->check_reload(
             store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
     );
-    auto indexes = entry->get_indexes(false);
+    auto indexes = entry->template get_indexes<AtomKey>(false);
     output.assign(std::begin(indexes), std::end(indexes));
 
     if (auto ref_key = get_symbol_ref_key(store, stream_id); ref_key) {
@@ -46,22 +46,21 @@ std::deque<AtomKey> backwards_compat_delete_all_versions(
 std::vector<AtomKey> backwards_compat_write_and_prune_previous(
         std::shared_ptr<Store>& store, std::shared_ptr<VersionMap>& version_map, const AtomKey& key
 ) {
+    const auto& sym = key.id();
     log::version().debug("Version map pruning previous versions for stream {}", key.id());
-
-    std::vector<AtomKey> output;
     auto entry = version_map->check_reload(
-            store, key.id(), LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
+            store, sym, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
     );
 
     auto old_entry = *entry;
     entry->clear();
     version_map->do_write(store, key, entry);
     write_symbol_ref(store, key, std::nullopt, entry->head_.value());
-    version_map->remove_entry_version_keys(store, old_entry, key.id());
-    output = old_entry.get_indexes(false);
+    version_map->remove_entry_version_keys(store, old_entry, sym);
+    auto output = old_entry.template get_indexes<AtomKey>(false);
 
     if (version_map->log_changes())
-        log_write(store, key.id(), key.version_id());
+        log_write(store, sym, key.version_id());
 
     return output;
 }

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -50,13 +50,14 @@ inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_i
     return {latest_undeleted_version, next_version_id};
 }
 
-inline std::vector<AtomKey> get_all_versions(
+template<AtomKeyType T = AtomKeyPacked>
+std::vector<T> get_all_versions(
         const std::shared_ptr<Store>& store, const std::shared_ptr<VersionMap>& version_map, const StreamId& stream_id
 ) {
     ARCTICDB_SAMPLE(GetAllVersions, 0)
     LoadStrategy load_strategy{LoadType::ALL, LoadObjective::UNDELETED_ONLY};
     auto entry = version_map->check_reload(store, stream_id, load_strategy, __FUNCTION__);
-    return entry->get_indexes(false);
+    return entry->template get_indexes<T>(false);
 }
 
 inline std::optional<AtomKey> get_specific_version(
@@ -79,7 +80,7 @@ bool get_matching_prev_and_next_versions(
         PrevAcceptor prev_acceptor, NextAcceptor next_acceptor, KeyFilter key_filter
 ) {
     bool found_version = false;
-    const IndexTypeKey* last = nullptr;
+    const AtomKeyPacked* last = nullptr;
 
     for (const auto& item : entry->keys_) {
         if (key_filter(item, entry)) {
@@ -131,7 +132,7 @@ inline std::unordered_map<VersionId, bool> get_all_tombstoned_versions(
     LoadStrategy load_strategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED};
     auto entry = version_map->check_reload(store, stream_id, load_strategy, __FUNCTION__);
     std::unordered_map<VersionId, bool> result;
-    for (auto key : entry->get_tombstoned_indexes())
+    for (const auto& key : entry->template get_tombstoned_indexes<AtomKey>())
         result[key.version_id()] = store->key_exists(key).get();
 
     return result;
@@ -149,12 +150,12 @@ inline version_store::TombstoneVersionResult populate_tombstone_result(
         get_matching_prev_and_next_versions(
                 entry,
                 version_id,
-                [&res, &found](auto& matching) {
-                    res.keys_to_delete.push_back(matching);
+                [&res, &found, &entry](auto& matching) {
+                    res.keys_to_delete.push_back(matching.to_atom_key(entry->stream_id_));
                     found = true;
                 },
-                [&res](auto& prev) { res.could_share_data.emplace(prev); },
-                [&res](auto& next) { res.could_share_data.emplace(next); },
+                [&res, &entry](auto& prev) { res.could_share_data.emplace(prev.to_atom_key(entry->stream_id_)); },
+                [&res, &entry](auto& next) { res.could_share_data.emplace(next.to_atom_key(entry->stream_id_)); },
                 is_live_index_type_key // Entry could be cached with deleted keys even if LOAD_UNDELETED
         );
 
@@ -222,7 +223,7 @@ inline folly::Future<version_store::TombstoneVersionResult> finalize_tombstone_a
     if (version_map->validate())
         entry->validate();
 
-    version_store::TombstoneVersionResult res{true, entry->head_->id()};
+    version_store::TombstoneVersionResult res{true, entry->stream_id_};
     res.keys_to_delete = std::move(tombstone_result.second);
 
     res.no_undeleted_left = true;
@@ -294,11 +295,11 @@ inline version_store::TombstoneVersionResult tombstone_versions(
     return tombstone_versions_async(store, version_map, stream_id, version_ids).get();
 }
 
-inline std::optional<AtomKey> get_index_key_from_time(timestamp from_time, const std::vector<AtomKey>& keys) {
-    auto at_or_after =
-            std::lower_bound(std::begin(keys), std::end(keys), from_time, [](const AtomKey& v_key, timestamp cmp) {
-                return v_key.creation_ts() > cmp;
-            });
+template<AtomKeyType T>
+inline std::optional<T> get_index_key_from_time(timestamp from_time, const std::vector<T>& keys) {
+    auto at_or_after = std::lower_bound(std::begin(keys), std::end(keys), from_time, [](const T& v_key, timestamp cmp) {
+        return v_key.creation_ts() > cmp;
+    });
     // If iterator points to the last element, we didn't have any versions before that
     if (at_or_after == keys.end()) {
         return std::nullopt;
@@ -313,19 +314,29 @@ inline std::optional<AtomKey> load_index_key_from_time(
     LoadStrategy load_strategy{LoadType::FROM_TIME, LoadObjective::UNDELETED_ONLY, from_time};
     auto entry = version_map->check_reload(store, stream_id, load_strategy, __FUNCTION__);
     auto indexes = entry->get_indexes(false);
-    return get_index_key_from_time(from_time, indexes);
+    if (auto opt_index_key = get_index_key_from_time(from_time, indexes); opt_index_key.has_value()) {
+        return opt_index_key->to_atom_key(stream_id);
+    } else {
+        return std::nullopt;
+    }
 }
 
-inline std::vector<AtomKey> get_index_and_tombstone_keys(
+template<AtomKeyType T>
+std::vector<T> get_index_and_tombstone_keys(
         const std::shared_ptr<Store>& store, const std::shared_ptr<VersionMap>& version_map, const StreamId& stream_id
 ) {
     LoadStrategy load_strategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED};
     const auto entry = version_map->check_reload(store, stream_id, load_strategy, __FUNCTION__);
-    std::vector<AtomKey> res;
-    std::copy_if(std::begin(entry->keys_), std::end(entry->keys_), std::back_inserter(res), [&](const auto& key) {
-        return is_index_or_tombstone(key);
-    });
-
+    std::vector<T> res;
+    for (const auto& key : entry->keys_) {
+        if (is_index_or_tombstone(key.type())) {
+            if constexpr (std::is_same_v<T, AtomKey>) {
+                res.emplace_back(key.to_atom_key(entry->stream_id_));
+            } else { // AtomKeyPacked
+                res.emplace_back(key);
+            }
+        }
+    }
     return res;
 }
 

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -30,6 +30,7 @@
 #include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/storage/store.hpp>
 #include <arcticdb/storage/storage.hpp>
+#include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/util/constants.hpp>
 #include <arcticdb/util/key_utils.hpp>
 #include <arcticdb/version/version_map_entry.hpp>
@@ -135,6 +136,12 @@ class VersionMapImpl {
             const std::shared_ptr<Store>& store, const VersionMapEntry& ref_entry,
             const std::shared_ptr<VersionMapEntry>& entry, const LoadStrategy& load_strategy
     ) const {
+        util::check(
+                ref_entry.stream_id_ == entry->stream_id_,
+                "follow_version_chain called with mismatching stream ids {} != {}",
+                ref_entry.stream_id_,
+                entry->stream_id_
+        );
         auto next_key = ref_entry.head_;
         entry->head_ = ref_entry.head_;
 
@@ -144,11 +151,10 @@ class VersionMapImpl {
         std::optional<AtomKey> cached_penultimate_index;
         if (ref_entry.keys_.size() == 3) {
             util::check(
-                    is_index_or_tombstone(ref_entry.keys_[1]),
-                    "Expected index key in as second item in 3-item ref key, got {}",
-                    ref_entry.keys_[1]
+                    is_index_or_tombstone(ref_entry.keys_[1].type()),
+                    "Expected index key in as second item in 3-item ref key"
             );
-            cached_penultimate_index = ref_entry.keys_[1];
+            cached_penultimate_index = ref_entry.keys_[1].to_atom_key(ref_entry.stream_id_);
         }
 
         if (key_exists_in_ref_entry(load_strategy, ref_entry, cached_penultimate_index)) {
@@ -179,7 +185,7 @@ class VersionMapImpl {
         auto max_trials = max_trial_config;
         while (true) {
             try {
-                VersionMapEntry ref_entry;
+                VersionMapEntry ref_entry(stream_id);
                 read_symbol_ref(store, stream_id, ref_entry);
                 if (ref_entry.empty())
                     return;
@@ -257,7 +263,7 @@ class VersionMapImpl {
             std::optional<AtomKey> first_key_to_tombstone = std::nullopt,
             std::optional<std::shared_ptr<VersionMapEntry>> cached_entry = std::nullopt
     ) {
-        std::shared_ptr<VersionMapEntry> entry;
+        auto entry = std::make_shared<VersionMapEntry>(stream_id);
         if (cached_entry) {
             entry = cached_entry.value();
         } else {
@@ -271,7 +277,9 @@ class VersionMapImpl {
             entry->validate();
 
         if (entry->head_)
-            write_symbol_ref(store, *entry->keys_.cbegin(), std::nullopt, entry->head_.value());
+            write_symbol_ref(
+                    store, entry->keys_.cbegin()->to_atom_key(entry->stream_id_), std::nullopt, entry->head_.value()
+            );
 
         return output;
     }
@@ -302,7 +310,9 @@ class VersionMapImpl {
         }
 
         auto previous_index = do_write(store, key.version_id(), key.id(), std::span{keys_to_write}, entry);
-        write_symbol_ref(store, *entry->keys_.cbegin(), previous_index, entry->head_.value());
+        write_symbol_ref(
+                store, entry->keys_.cbegin()->to_atom_key(entry->stream_id_), previous_index, entry->head_.value()
+        );
 
         maybe_invalidate_cached_undeleted(*entry);
         if (log_changes_) {
@@ -325,7 +335,7 @@ class VersionMapImpl {
     }
 
     bool requires_compaction(const std::shared_ptr<VersionMapEntry>& entry) const {
-        int64_t num_blocks = std::count_if(entry->keys_.cbegin(), entry->keys_.cend(), [](const AtomKey& key) {
+        int64_t num_blocks = std::count_if(entry->keys_.cbegin(), entry->keys_.cend(), [](const AtomKeyPacked& key) {
             return key.type() == KeyType::VERSION;
         });
 
@@ -358,7 +368,7 @@ class VersionMapImpl {
         });
         const auto new_version_id = latest_version->version_id();
 
-        auto new_entry = std::make_shared<VersionMapEntry>();
+        auto new_entry = std::make_shared<VersionMapEntry>(stream_id);
         new_entry->keys_.push_front(*latest_version);
 
         if (const auto first_is_tombstone = entry->get_tombstone(new_version_id); first_is_tombstone)
@@ -375,8 +385,15 @@ class VersionMapImpl {
                     else {
                         if (tombstone->type() == KeyType::TOMBSTONE_ALL)
                             new_entry->try_set_tombstone_all(*tombstone);
-                        else
-                            new_entry->tombstones_.insert(std::make_pair(key.version_id(), *tombstone));
+                        else {
+                            util::check(
+                                    key.id() == new_entry->stream_id_,
+                                    "compact_and_remove_deleted_indexes found mismatching stream ids {} != {}",
+                                    key.id(),
+                                    new_entry->stream_id_
+                            );
+                            new_entry->try_set_tombstone(*tombstone);
+                        }
 
                         new_entry->keys_.push_back(key);
                     }
@@ -495,9 +512,9 @@ class VersionMapImpl {
     }
 
     void overwrite_symbol_tree(
-            std::shared_ptr<Store> store, const StreamId& stream_id, const std::vector<AtomKey>& index_keys
+            std::shared_ptr<Store> store, const StreamId& stream_id, const std::vector<AtomKeyPacked>& index_keys
     ) {
-        auto entry = std::make_shared<VersionMapEntry>();
+        auto entry = std::make_shared<VersionMapEntry>(stream_id);
         try {
             entry = check_reload(
                     store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, __FUNCTION__
@@ -666,7 +683,7 @@ class VersionMapImpl {
         auto tombstone_version_id = tombstones.front().version_id();
         do_write(store, tombstone_version_id, stream_id, std::span{tombstones}, entry);
         for (const auto& key : tombstones) {
-            entry->tombstones_.try_emplace(key.version_id(), key);
+            entry->try_set_tombstone(key);
         }
         maybe_invalidate_cached_undeleted(*entry);
 
@@ -694,9 +711,8 @@ class VersionMapImpl {
         }
         std::vector<folly::Future<Store::RemoveKeyResultType>> key_futs;
         for (const auto& key : entry.keys_) {
-            util::check(key.id() == stream_id, "Id mismatch for entry {} vs symbol {}", key.id(), stream_id);
             if (key.type() == KeyType::VERSION)
-                key_futs.emplace_back(store->remove_key(key));
+                key_futs.emplace_back(store->remove_key(key.to_atom_key(entry.stream_id_)));
         }
         folly::collect(key_futs).get();
     }
@@ -789,23 +805,21 @@ class VersionMapImpl {
 
         // Copy version keys to be removed
         std::vector<VariantKey> version_keys_compacted;
-        std::copy_if(
-                parent + 1,
-                std::end(new_entry->keys_),
-                std::back_inserter(version_keys_compacted),
-                [](const auto& k) { return k.type() == KeyType::VERSION; }
-        );
+        for (auto key = parent + 1; key != std::end(new_entry->keys_); ++key) {
+            if (key->type() == KeyType::VERSION) {
+                version_keys_compacted.emplace_back(key->to_atom_key(new_entry->stream_id_));
+            }
+        }
 
         // Copy index keys to be compacted
         std::vector<AtomKey> index_keys_compacted;
-        std::copy_if(
-                parent + 1,
-                std::end(new_entry->keys_),
-                std::back_inserter(index_keys_compacted),
-                [](const auto& k) { return is_index_or_tombstone(k); }
-        );
+        for (auto key = parent + 1; key != std::end(new_entry->keys_); ++key) {
+            if (is_index_or_tombstone(key->type())) {
+                index_keys_compacted.emplace_back(key->to_atom_key(new_entry->stream_id_));
+            }
+        }
 
-        update_version_key(store, *parent, index_keys_compacted, stream_id);
+        update_version_key(store, parent->to_atom_key(stream_id), index_keys_compacted, stream_id);
         store->remove_keys(version_keys_compacted).get();
 
         new_entry->keys_.erase(
@@ -888,7 +902,7 @@ class VersionMapImpl {
         if (auto result = map_.find(stream_id); result != std::end(map_))
             return result->second;
 
-        return map_.try_emplace(stream_id, std::make_shared<VersionMapEntry>()).first->second;
+        return map_.try_emplace(stream_id, std::make_shared<VersionMapEntry>(stream_id)).first->second;
     }
 
     AtomKey write_entry_to_storage(
@@ -914,12 +928,12 @@ class VersionMapImpl {
         );
 
         for (const auto& key : entry->keys_) {
-            version_agg.add_key(key);
+            version_agg.add_key(key.to_atom_key(entry->stream_id_));
         }
 
         version_agg.commit();
         auto previous_index = entry->get_second_undeleted_index();
-        write_symbol_ref(store, *entry->keys_.cbegin(), previous_index, journal_key);
+        write_symbol_ref(store, entry->keys_.cbegin()->to_atom_key(entry->stream_id_), previous_index, journal_key);
         return journal_key;
     }
 
@@ -954,12 +968,12 @@ class VersionMapImpl {
     std::shared_ptr<VersionMapEntry> rewrite_entry(
             std::shared_ptr<Store> store, const StreamId& stream_id, const std::shared_ptr<VersionMapEntry>& entry
     ) {
-        auto new_entry = std::make_shared<VersionMapEntry>();
+        auto new_entry = std::make_shared<VersionMapEntry>(stream_id);
         std::copy_if(
                 std::begin(entry->keys_),
                 std::end(entry->keys_),
                 std::back_inserter(new_entry->keys_),
-                [](const auto& key) { return is_index_or_tombstone(key); }
+                [](const auto& key) { return is_index_or_tombstone(key.type()); }
         );
         const auto first_index = new_entry->get_first_index(true).first;
         util::check(static_cast<bool>(first_index), "No index exists in rewrite entry");
@@ -975,7 +989,7 @@ class VersionMapImpl {
 
   public:
     bool check_ref_key(std::shared_ptr<Store> store, const StreamId& stream_id) {
-        auto entry_iteration = std::make_shared<VersionMapEntry>();
+        auto entry_iteration = std::make_shared<VersionMapEntry>(stream_id);
         load_via_iteration(store, stream_id, entry_iteration);
         auto maybe_latest_pair = get_latest_key_pair(entry_iteration);
         if (!maybe_latest_pair) {
@@ -983,7 +997,7 @@ class VersionMapImpl {
             return false;
         }
 
-        VersionMapEntry ref_entry;
+        VersionMapEntry ref_entry(stream_id);
         read_symbol_ref(store, stream_id, ref_entry);
 
         if (ref_entry.empty() || ref_entry.keys_.size() < 2) {
@@ -992,7 +1006,8 @@ class VersionMapImpl {
         }
 
         util::check(static_cast<bool>(ref_entry.head_), "Expected head to be set");
-        if (maybe_latest_pair->first != ref_entry.keys_[0] || maybe_latest_pair->second != *ref_entry.head_) {
+        if (maybe_latest_pair->first != ref_entry.keys_[0].to_atom_key(ref_entry.stream_id_) ||
+            maybe_latest_pair->second != *ref_entry.head_) {
             log::version().warn(
                     "Ref entry is incorrect for stream {}, either {} != {} or {} != {}",
                     stream_id,
@@ -1005,7 +1020,7 @@ class VersionMapImpl {
         }
 
         try {
-            auto entry_ref = std::make_shared<VersionMapEntry>();
+            auto entry_ref = std::make_shared<VersionMapEntry>(stream_id);
             load_via_ref_key(store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, entry_ref);
             entry_ref->validate();
         } catch (const std::exception& err) {
@@ -1020,7 +1035,7 @@ class VersionMapImpl {
     }
 
     bool indexes_sorted(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
-        auto entry_ref = std::make_shared<VersionMapEntry>();
+        auto entry_ref = std::make_shared<VersionMapEntry>(stream_id);
         load_via_ref_key(store, stream_id, LoadStrategy{LoadType::ALL, LoadObjective::INCLUDE_DELETED}, entry_ref);
         auto indexes = entry_ref->get_indexes(true);
         return std::is_sorted(std::cbegin(indexes), std::cend(indexes), [](const auto& l, const auto& r) {
@@ -1073,7 +1088,7 @@ class VersionMapImpl {
                             std::find_if(std::begin(entry->keys_), std::end(entry->keys_), [&](const auto& entry_key) {
                                 return entry_key.type() == KeyType::VERSION &&
                                        std::tie(key.id(), key.version_id()) ==
-                                               std::tie(entry_key.id(), entry_key.version_id());
+                                               std::tie(entry->stream_id_, entry_key.version_id());
                             });
                     if (it == std::end(entry->keys_)) {
                         util::check(
@@ -1091,7 +1106,7 @@ class VersionMapImpl {
     }
 
     std::vector<AtomKey> find_deleted_version_keys(std::shared_ptr<Store> store, const StreamId& stream_id) {
-        auto entry = std::make_shared<VersionMapEntry>();
+        auto entry = std::make_shared<VersionMapEntry>(stream_id);
         load_via_iteration(store, stream_id, entry);
         return find_deleted_version_keys_for_entry(store, stream_id, entry);
     }
@@ -1132,7 +1147,7 @@ class VersionMapImpl {
         for (const auto& key : entry->keys_) {
             if (is_index_key_type(key.type()) && !entry->is_tombstoned(key) &&
                 key.version_id() <= first_key_to_tombstone->version_id()) {
-                output.emplace_back(key);
+                output.emplace_back(key.to_atom_key(entry->stream_id_));
             }
         }
 

--- a/cpp/arcticdb/version/version_map_entry.hpp
+++ b/cpp/arcticdb/version/version_map_entry.hpp
@@ -162,16 +162,17 @@ bool deque_is_unique(std::deque<T> vec) {
     return it == vec.end();
 }
 
-inline bool is_tombstone_key_type(const AtomKey& key) {
-    return key.type() == KeyType::TOMBSTONE || key.type() == KeyType::TOMBSTONE_ALL;
+inline bool is_tombstone_key_type(KeyType key_type) {
+    return key_type == KeyType::TOMBSTONE || key_type == KeyType::TOMBSTONE_ALL;
 }
 
-inline bool is_index_or_tombstone(const AtomKey& key) {
-    return is_index_key_type(key.type()) || is_tombstone_key_type(key);
+inline bool is_index_or_tombstone(KeyType key_type) {
+    return is_index_key_type(key_type) || is_tombstone_key_type(key_type);
 }
 
-inline void check_is_index_or_tombstone(const AtomKey& key) {
-    util::check(is_index_or_tombstone(key), "Expected index or tombstone key type but got {}", key);
+template<AtomKeyType T>
+void check_is_index_or_tombstone(const T& key) {
+    util::check(is_index_or_tombstone(key.type()), "Expected index or tombstone key type but got {}", key);
 }
 
 inline AtomKey index_to_tombstone(const AtomKey& index_key, const StreamId& stream_id, timestamp creation_ts) {
@@ -225,7 +226,7 @@ struct VersionMapEntry {
       It also contains a map of version_ids and the tombstone key corresponding to it iff it has been pruned or
       explicitly deleted.
      */
-    VersionMapEntry() = default;
+    VersionMapEntry(const StreamId& stream_id) : stream_id_(stream_id) {}
 
     ARCTICDB_MOVE_COPY_DEFAULT(VersionMapEntry)
 
@@ -236,7 +237,7 @@ struct VersionMapEntry {
             return;
 
         // Sorting by creation_ts is safe from clock skew because we don't support parallel writes to the same symbol.
-        std::sort(std::begin(keys_), std::end(keys_), [](const AtomKey& l, const AtomKey& r) {
+        std::sort(std::begin(keys_), std::end(keys_), [](const AtomKeyPacked& l, const AtomKeyPacked& r) {
             return l.creation_ts() > r.creation_ts();
         });
     }
@@ -257,6 +258,7 @@ struct VersionMapEntry {
         left.validate();
         right.validate();
 
+        swap(left.stream_id_, right.stream_id_);
         swap(left.keys_, right.keys_);
         swap(left.tombstones_, right.tombstones_);
         swap(left.last_reload_time_, right.last_reload_time_);
@@ -273,8 +275,9 @@ struct VersionMapEntry {
         return tombstone_all_ && tombstone_all_->version_id() >= version_id;
     }
 
-    bool is_tombstoned(const AtomKey& key) const {
-        return is_tombstoned_via_tombstone_all(key.version_id()) || has_individual_tombstone(key.version_id());
+    template<AtomKeyType T>
+    bool is_tombstoned(const T& key) const {
+        return is_tombstoned(key.version_id());
     }
 
     bool is_tombstoned(VersionId version_id) const {
@@ -286,11 +289,12 @@ struct VersionMapEntry {
             return tombstone_all_;
         }
         auto it = tombstones_.find(version_id);
-        return it != tombstones_.end() ? std::make_optional<AtomKey>(it->second) : std::nullopt;
+        return it != tombstones_.end() ? std::make_optional<AtomKey>(it->second.to_atom_key(stream_id_)) : std::nullopt;
     }
 
     std::string dump() const {
         std::ostringstream strm;
+        strm << fmt::format("\n Symbol: {}\n", stream_id_);
         strm << fmt::format("\nLast reload time: {}\n", last_reload_time_);
 
         if (head_)
@@ -310,22 +314,42 @@ struct VersionMapEntry {
         return strm.str();
     }
 
-    void unshift_key(const AtomKey& key) { keys_.push_front(key); }
+    void unshift_key(const AtomKey& key) {
+        util::check(
+                key.id() == stream_id_,
+                "VersionMapEntry::unshift_key called with key with stream id {} != {}",
+                key.id(),
+                stream_id_
+        );
+        keys_.push_front(key);
+    }
 
-    std::vector<IndexTypeKey> get_indexes(bool include_deleted) const {
-        std::vector<AtomKey> output;
+    template<AtomKeyType T = AtomKeyPacked>
+    std::vector<T> get_indexes(bool include_deleted) const {
+        std::vector<T> output;
         for (const auto& key : keys_) {
-            if (is_index_key_type(key.type()) && (include_deleted || !is_tombstoned(key)))
-                output.emplace_back(key);
+            if (is_index_key_type(key.type()) && (include_deleted || !is_tombstoned(key))) {
+                if constexpr (std::is_same_v<T, AtomKey>) {
+                    output.emplace_back(key.to_atom_key(stream_id_));
+                } else {
+                    output.emplace_back(key);
+                }
+            }
         }
         return output;
     }
 
-    std::vector<IndexTypeKey> get_tombstoned_indexes() const {
-        std::vector<AtomKey> output;
+    template<AtomKeyType T = AtomKeyPacked>
+    std::vector<T> get_tombstoned_indexes() const {
+        std::vector<T> output;
         for (const auto& key : keys_) {
-            if (is_index_key_type(key.type()) && is_tombstoned(key))
-                output.emplace_back(key);
+            if (is_index_key_type(key.type()) && is_tombstoned(key)) {
+                if constexpr (std::is_same_v<T, AtomKey>) {
+                    output.emplace_back(key.to_atom_key(stream_id_));
+                } else {
+                    output.emplace_back(key);
+                }
+            }
         }
         return output;
     }
@@ -335,7 +359,7 @@ struct VersionMapEntry {
             if (is_index_key_type(key.type())) {
                 const auto tombstoned = is_tombstoned(key);
                 if (!tombstoned || include_deleted)
-                    return {key, tombstoned};
+                    return {key.to_atom_key(stream_id_), tombstoned};
             }
         }
         return {std::nullopt, false};
@@ -349,7 +373,7 @@ struct VersionMapEntry {
                 if (!found_first) {
                     found_first = true;
                 } else {
-                    output = key;
+                    output = key.to_atom_key(stream_id_);
                     break;
                 }
             }
@@ -364,7 +388,7 @@ struct VersionMapEntry {
         auto first_index = std::find_if(std::begin(keys_), std::end(keys_), [](const auto& key) {
             return is_index_key_type(key.type());
         });
-        if (keys_.size() == 2 && is_tombstone_key_type(keys_[0]))
+        if (keys_.size() == 2 && is_tombstone_key_type(keys_[0].type()))
             return;
         util::check(first_index != std::end(keys_), "Didn't find any index keys");
         auto version_id = first_index->version_id();
@@ -411,18 +435,31 @@ struct VersionMapEntry {
     void check_stream_id() const {
         if (empty())
             return;
+        util::check_rte(head_->id() == stream_id_, "Multiple symbols in keys: {} != {}", head_->id(), stream_id_);
+    }
 
-        std::unordered_map<StreamId, std::vector<VersionId>> id_to_version_id;
-        if (head_)
-            id_to_version_id[head_->id()].push_back(head_->version_id());
-        for (const auto& k : keys_)
-            id_to_version_id[k.id()].push_back(k.version_id());
-        util::check_rte(
-                id_to_version_id.size() == 1, "Multiple symbols in keys: {}", fmt::format("{}", id_to_version_id)
+    void try_set_tombstone(const AtomKey& key) {
+        util::check(
+                key.id() == stream_id_,
+                "VersionMapEntry::try_set_tombstone called with key with stream id {} != {}",
+                key.id(),
+                stream_id_
         );
+        util::check(
+                key.type() == KeyType::TOMBSTONE,
+                "VersionMapEntry::try_set_tombstone called with key with type {}, should be TOMBSTONE",
+                key.type()
+        );
+        tombstones_.try_emplace(key.version_id(), key);
     }
 
     void try_set_tombstone_all(const AtomKey& key) {
+        util::check(
+                key.id() == stream_id_,
+                "VersionMapEntry::try_set_tombstone_all called with key with stream id {} != {}",
+                key.id(),
+                stream_id_
+        );
         util::check(key.type() == KeyType::TOMBSTONE_ALL, "Can't set tombstone all key with key {}", key);
         if (!tombstone_all_ || tombstone_all_->version_id() < key.version_id())
             tombstone_all_ = key;
@@ -443,24 +480,27 @@ struct VersionMapEntry {
                 std::all_of(
                         keys_.begin(),
                         keys_.end(),
-                        [](const AtomKey& key) {
+                        [](const AtomKeyPacked& key) {
                             return is_index_key_type(key.type()) || key.type() == KeyType::VERSION ||
-                                   is_tombstone_key_type(key);
+                                   is_tombstone_key_type(key.type());
                         }
                 ),
                 "Unexpected key types in write entry"
         );
     }
 
+    StreamId stream_id_;
     std::optional<AtomKey> head_;
     timestamp last_reload_time_ = 0;
     LoadProgress load_progress_;
-    std::deque<AtomKey> keys_;
-    std::unordered_map<VersionId, AtomKey> tombstones_;
+    std::deque<AtomKeyPacked> keys_;
     std::optional<AtomKey> tombstone_all_;
+
+  private:
+    ankerl::unordered_dense::map<VersionId, AtomKeyPacked> tombstones_;
 };
 
-inline bool is_live_index_type_key(const AtomKeyImpl& key, const std::shared_ptr<VersionMapEntry>& entry) {
+inline bool is_live_index_type_key(const AtomKeyPacked& key, const std::shared_ptr<VersionMapEntry>& entry) {
     return is_index_key_type(key.type()) && !entry->is_tombstoned(key);
 }
 
@@ -476,7 +516,7 @@ inline std::optional<VersionId> get_prev_version_in_entry(
                 std::begin(index_keys),
                 std::end(index_keys),
                 version_id,
-                [&](VersionId v_id, const AtomKey& key) { return key.version_id() < v_id; }
+                [&](VersionId v_id, const AtomKeyPacked& key) { return key.version_id() < v_id; }
         );
         iterator_lt != index_keys.end()) {
         return {iterator_lt->version_id()};
@@ -496,7 +536,7 @@ inline std::optional<VersionId> get_next_version_in_entry(
                 std::begin(index_keys),
                 std::end(index_keys),
                 version_id,
-                [&](const AtomKey& key, VersionId v_id) { return key.version_id() > v_id; }
+                [&](const AtomKeyPacked& key, VersionId v_id) { return key.version_id() > v_id; }
         );
         iterator_gt != index_keys.begin()) {
         iterator_gt--;
@@ -513,7 +553,10 @@ inline VersionDetails find_index_key_for_version_id_and_tombstone_status(
     });
     if (key == std::end(entry->keys_))
         return VersionDetails{std::nullopt, VersionStatus::NEVER_EXISTED};
-    return VersionDetails{*key, entry->is_tombstoned(*key) ? VersionStatus::TOMBSTONED : VersionStatus::LIVE};
+    return VersionDetails{
+            key->to_atom_key(entry->stream_id_),
+            entry->is_tombstoned(*key) ? VersionStatus::TOMBSTONED : VersionStatus::LIVE
+    };
 }
 
 inline std::optional<AtomKey> find_index_key_for_version_id(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1399,7 +1399,7 @@ ReadResult PythonVersionStore::read_index(
 }
 
 std::vector<AtomKey> PythonVersionStore::get_version_history(const StreamId& stream_id) {
-    return get_index_and_tombstone_keys(store(), version_map(), stream_id);
+    return get_index_and_tombstone_keys<AtomKey>(store(), version_map(), stream_id);
 }
 
 void PythonVersionStore::_compact_version_map(const StreamId& id) { version_map()->compact(store(), id); }

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -39,7 +39,12 @@ inline std::optional<AtomKey> read_segment_with_keys(
     for (; row < ssize_t(seg.row_count()); ++row) {
         auto key = read_key_row(seg, row);
         ARCTICDB_TRACE(log::version(), "Reading key {}", key);
-
+        util::check(
+                key.id() == entry.stream_id_,
+                "read_segment_with_keys found mismatching stream ids {} != {}",
+                key.id(),
+                entry.stream_id_
+        );
         if (is_index_key_type(key.type())) {
             entry.keys_.push_back(key);
             oldest_loaded_index = std::min(oldest_loaded_index, key.version_id());
@@ -51,7 +56,7 @@ inline std::optional<AtomKey> read_segment_with_keys(
             }
 
         } else if (key.type() == KeyType::TOMBSTONE) {
-            entry.tombstones_.try_emplace(key.version_id(), key);
+            entry.try_set_tombstone(key);
             entry.keys_.push_back(key);
         } else if (key.type() == KeyType::TOMBSTONE_ALL) {
             entry.try_set_tombstone_all(key);
@@ -91,16 +96,22 @@ std::shared_ptr<VersionMapEntry> build_version_map_entry_with_predicate_iteratio
 ) {
 
     auto prefix = std::holds_alternative<StringId>(stream_id) ? std::get<StringId>(stream_id) : std::string();
-    auto output = std::make_shared<VersionMapEntry>();
+    auto output = std::make_shared<VersionMapEntry>(stream_id);
     std::vector<AtomKey> read_keys;
     for (auto key_type : key_types) {
         store->iterate_type(
                 key_type,
-                [&predicate, &read_keys, &store, &output, &perform_read_segment_with_keys](VariantKey&& vk) {
+                [&stream_id, &predicate, &read_keys, &store, &output, &perform_read_segment_with_keys](VariantKey&& vk
+                ) {
                     const auto& key = to_atom(std::move(vk));
                     if (!predicate(key))
                         return;
-
+                    util::check(
+                            key.id() == stream_id,
+                            "build_version_map_entry_with_predicate_iteration found mismatching stream ids {} != {}",
+                            key.id(),
+                            stream_id
+                    );
                     read_keys.push_back(key);
                     ARCTICDB_DEBUG(log::storage(), "Version map iterating key {}", key);
                     if (perform_read_segment_with_keys) {

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -103,6 +103,7 @@ def test_special_chars(object_version_store):
             object_version_store.write(sym, df)
             vitem = object_version_store.read(sym)
             assert_equal(vitem.data, df)
+            object_version_store.version_store.clear()
         except AssertionError as e:
             errors.append(f"Failed for character {special_char}: {str(e)}")
     assert not errors, "errors occurred:\n" + "\n".join(errors)


### PR DESCRIPTION
#### Reference Issues/PRs
[11900115518](https://man312219.monday.com/boards/7852509418/pulses/11900115518)

#### What does this implement or fix?
Uses `AtomKeyPacked` instead of `AtomKey` in the two collections inside `VersionMapEntry` in order to reduce the memory footprint of the version map cache. Also uses `ankerl::unordered_dense::map` over `std::unordered_map` for the same reason. Full `AtomKey`s are only materialised when necessary.