### PR TITLE
Enhancement 11590368094: Fully support compact_data and deprecate old methods

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -9,6 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import copy
 from dataclasses import dataclass
 import datetime
+import inspect
 import os
 import sys
 from warnings import warn
@@ -896,10 +897,11 @@ class NativeVersionStore:
         )
         if self._valid_item_type(item):
             if parallel or incomplete:
+                stacklevel = 3 if inspect.stack()[1].filename.endswith("arcticdb/version_store/library.py") else 2
                 warn(
                     "Staging data with write() is deprecated. Use stage() instead.",
                     DeprecationWarning,
-                    stacklevel=2,
+                    stacklevel=stacklevel,
                 )
                 self.version_store.write_parallel(symbol, item, norm_meta, validate_index, False, None)
                 return None
@@ -1047,6 +1049,8 @@ class NativeVersionStore:
         if self._valid_item_type(item):
             with _diff_long_stream_descriptor_mismatch(self):
                 if incomplete:
+                    # Note that the V2 API has never called append with the incomplete kwarg, so we don't need the
+                    # stacklevel switching behaviour
                     warn(
                         "Staging data with append() is deprecated. Use stage() instead.",
                         DeprecationWarning,
@@ -4109,6 +4113,9 @@ class NativeVersionStore:
 
     def is_symbol_fragmented(self, symbol: str, segment_size: Optional[int] = None) -> bool:
         """
+        This method has been deprecated and will be removed in a future release. Please use compact_data_explain_plan
+        instead.
+
         Check whether the number of segments that would be reduced by compaction is more than or equal to the
         value specified by the configuration option "SymbolDataCompact.SegmentCount" (defaults to 100).
 
@@ -4129,8 +4136,11 @@ class NativeVersionStore:
         -------
         bool
         """
-        log.warning(
-            "is_symbol_fragmented is deprecated and will be removed in a future release. Please use compact_data_explain_plan instead."
+        stacklevel = 3 if inspect.stack()[1].filename.endswith("arcticdb/version_store/library.py") else 2
+        warn(
+            "is_symbol_fragmented is deprecated and will be removed in a future release. Please use compact_data_explain_plan instead.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
         )
         return self.version_store.is_symbol_fragmented(symbol, segment_size)
 
@@ -4142,6 +4152,8 @@ class NativeVersionStore:
         **kwargs,
     ) -> VersionedItem:
         """
+        This method has been deprecated and will be removed in a future release. Please use compact_data instead.
+
         Compacts fragmented segments by merging row-sliced segments (https://docs.arcticdb.io/technical/on_disk_storage/#data-layer).
         This method calls `is_symbol_fragmented` to determine whether to proceed with the defragmentation operation.
 
@@ -4199,8 +4211,11 @@ class NativeVersionStore:
         Config map setting - SymbolDataCompact.SegmentCount will be replaced by a library setting
         in the future. This API will allow overriding the setting as well.
         """
-        log.warning(
-            "defragment_symbol_data is deprecated and will be removed in a future release. Please use compact_data instead."
+        stacklevel = 3 if inspect.stack()[1].filename.endswith("arcticdb/version_store/library.py") else 2
+        warn(
+            "defragment_symbol_data is deprecated and will be removed in a future release. Please use compact_data instead.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
         )
         self._validate_kwargs("defragment_symbol_data", {"prune_previous_version"}, kwargs)
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -3974,14 +3974,14 @@ class NativeVersionStore:
         v = self.version_store.write_metadata(symbol, udm, prune_previous_version)
         return self._convert_thin_cxx_item_to_python(v, metadata)
 
-    def compact_data_explain_plan_experimental(
+    def compact_data_explain_plan(
         self,
         symbol: str,
         rows_per_segment: Optional[int] = None,
     ) -> CompactDataInfo:
         """
-        Do a dry run of compact_data_experimental, demonstrating what the impact would be of calling
-        compact_data_experimental without actually modifying any data on disk.
+        Do a dry run of compact_data, demonstrating what the impact would be of calling compact_data without actually
+        modifying any data on disk.
 
         Parameters
         ----------
@@ -3995,7 +3995,7 @@ class NativeVersionStore:
         -------
         CompactDataInfo
             Structure containing information about what the fragmentation of the symbol looks like currently, and what
-            it would look like after a call to compact_data_experimental.
+            it would look like after a call to compact_data.
 
         Raises
         ------
@@ -4012,7 +4012,7 @@ class NativeVersionStore:
         >>> df = pd.DataFrame({"col": np.arange(100_000)})
         >>> for idx in range(100):
         >>>     lib.append("sym", df[idx * 1_000: (idx + 1) * 1_000])
-        >>> compact_data_info = lib.compact_data_explain_plan_experimental("sym")
+        >>> compact_data_info = lib.compact_data_explain_plan("sym")
         >>> compact_data_info.row_slices_before
         [0, 1000, 2000, ..., 99000, 100000]
         >>> compact_data_info.row_slices_after
@@ -4035,7 +4035,7 @@ class NativeVersionStore:
         res = self.version_store._compact_data_explain_plan(symbol, rows_per_segment)
         return res
 
-    def compact_data_experimental(
+    def compact_data(
         self,
         symbol: str,
         rows_per_segment: Optional[int] = None,
@@ -4053,11 +4053,8 @@ class NativeVersionStore:
         Note that any fixed-width string columns that are compacted by this method will be coerced to dynamic UTF-8.
 
         !!! warning
-            This API is under development and is subject to change. The API is not subject to semver and can change in
-            minor or patch releases.
-
-            Note that compacting dynamic schema data can produce sparse data, even if the input data was dense, and
-            resampling does not yet support sparse data.
+            Compacting dynamic schema data can produce sparse data, even if the input data was dense, and resampling
+            does not yet support sparse data.
 
         Parameters
         ----------
@@ -4093,7 +4090,7 @@ class NativeVersionStore:
         >>>     lib.append("sym", df[idx * 1_000: (idx + 1) * 1_000])
         >>> len(lib.read_index("sym"))
         100
-        >>> lib.compact_data_experimental("sym")
+        >>> lib.compact_data("sym")
         >>> len(lib.read_index("sym"))
         1
         """
@@ -4110,7 +4107,6 @@ class NativeVersionStore:
         cxx_versioned_item = self.version_store._compact_data(symbol, rows_per_segment, prune_previous_version)
         return self._convert_thin_cxx_item_to_python(cxx_versioned_item, None)
 
-    # TODO: Mark these and Library methods as deprecated
     def is_symbol_fragmented(self, symbol: str, segment_size: Optional[int] = None) -> bool:
         """
         Check whether the number of segments that would be reduced by compaction is more than or equal to the
@@ -4133,6 +4129,9 @@ class NativeVersionStore:
         -------
         bool
         """
+        log.warning(
+            "is_symbol_fragmented is deprecated and will be removed in a future release. Please use compact_data_explain_plan instead."
+        )
         return self.version_store.is_symbol_fragmented(symbol, segment_size)
 
     def defragment_symbol_data(
@@ -4200,6 +4199,9 @@ class NativeVersionStore:
         Config map setting - SymbolDataCompact.SegmentCount will be replaced by a library setting
         in the future. This API will allow overriding the setting as well.
         """
+        log.warning(
+            "defragment_symbol_data is deprecated and will be removed in a future release. Please use compact_data instead."
+        )
         self._validate_kwargs("defragment_symbol_data", {"prune_previous_version"}, kwargs)
 
         proto_cfg = self._lib_cfg.lib_desc.version.write_options

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3307,6 +3307,9 @@ class Library:
 
     def is_symbol_fragmented(self, symbol: str, segment_size: Optional[int] = None) -> bool:
         """
+        This method has been deprecated and will be removed in a future release. Please use compact_data_explain_plan
+        instead.
+
         Check whether the number of segments that would be reduced by compaction is more than or equal to the
         value specified by the configuration option "SymbolDataCompact.SegmentCount" (defaults to 100).
 
@@ -3336,6 +3339,8 @@ class Library:
         prune_previous_versions: bool = False,
     ) -> VersionedItem:
         """
+        This method has been deprecated and will be removed in a future release. Please use compact_data instead.
+
         Compacts fragmented segments by merging row-sliced segments (https://docs.arcticdb.io/technical/on_disk_storage/#data-layer).
         This method calls `is_symbol_fragmented` to determine whether to proceed with the defragmentation operation.
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3188,14 +3188,14 @@ class Library:
         """
         return self._nvs.compact_symbol_list()
 
-    def compact_data_explain_plan_experimental(
+    def compact_data_explain_plan(
         self,
         symbol: str,
         rows_per_segment: Optional[int] = None,
     ) -> CompactDataInfo:
         """
-        Do a dry run of compact_data_experimental, demonstrating what the impact would be of calling
-        compact_data_experimental without actually modifying any data on disk.
+        Do a dry run of compact_data, demonstrating what the impact would be of calling compact_data without actually
+        modifying any data on disk.
 
         Parameters
         ----------
@@ -3209,7 +3209,7 @@ class Library:
         -------
         CompactDataInfo
             Structure containing information about what the fragmentation of the symbol looks like currently, and what
-            it would look like after a call to compact_data_experimental.
+            it would look like after a call to compact_data.
 
         Raises
         ------
@@ -3226,7 +3226,7 @@ class Library:
         >>> df = pd.DataFrame({"col": np.arange(100_000)})
         >>> for idx in range(100):
         >>>     lib.append("sym", df[idx * 1_000: (idx + 1) * 1_000])
-        >>> compact_data_info = lib.compact_data_explain_plan_experimental("sym")
+        >>> compact_data_info = lib.compact_data_explain_plan("sym")
         >>> compact_data_info.row_slices_before
         [0, 1000, 2000, ..., 99000, 100000]
         >>> compact_data_info.row_slices_after
@@ -3242,9 +3242,9 @@ class Library:
         >>> compact_data_info.will_do_work
         True
         """
-        return self._nvs.compact_data_explain_plan_experimental(symbol, rows_per_segment)
+        return self._nvs.compact_data_explain_plan(symbol, rows_per_segment)
 
-    def compact_data_experimental(
+    def compact_data(
         self,
         symbol: str,
         rows_per_segment: Optional[int] = None,
@@ -3260,11 +3260,8 @@ class Library:
         The metadata from the version being compacted is maintained with the newly created version.
 
         !!! warning
-            This API is under development and is subject to change. The API is not subject to semver and can change in
-            minor or patch releases.
-
-            Note that compacting dynamic schema data can produce sparse data, even if the input data was dense, and
-            resampling does not yet support sparse data.
+            Compacting dynamic schema data can produce sparse data, even if the input data was dense, and resampling
+            does not yet support sparse data.
 
         Parameters
         ----------
@@ -3302,11 +3299,11 @@ class Library:
         >>> lib_tool = lib._dev_tools.library_tool()
         >>> len(lib_tool.read_index("sym"))
         100
-        >>> lib.compact_data_experimental("sym")
+        >>> lib.compact_data("sym")
         >>> len(lib_tool.read_index("sym"))
         1
         """
-        return self._nvs.compact_data_experimental(symbol, rows_per_segment, prune_previous_versions)
+        return self._nvs.compact_data(symbol, rows_per_segment, prune_previous_versions)
 
     def is_symbol_fragmented(self, symbol: str, segment_size: Optional[int] = None) -> bool:
         """

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -1621,7 +1621,7 @@ def test_compact_data(lmdb_library, rows_per_segment, prune_previous_versions):
     df = pd.DataFrame({"col": np.arange(100)})
     for i in range(10):
         lib.append(sym, df[i * 10 : (i + 1) * 10])
-    lib.compact_data_experimental(sym, rows_per_segment, prune_previous_versions)
+    lib.compact_data(sym, rows_per_segment, prune_previous_versions)
     assert_frame_equal(df, lib.read(sym).data)
     rows_per_segment = 100_000 if rows_per_segment is None else rows_per_segment
     assert len(lib._dev_tools.library_tool().read_index(sym)) == max(len(df) // rows_per_segment, 1)

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -324,7 +324,7 @@ def test_date_range_multi_index(lmdb_version_store):
         "append",
         "update",
         "write_metadata",
-        "compact_data_experimental",
+        "compact_data",
         "batch_write",
         "batch_append",
         "batch_write_metadata",
@@ -351,7 +351,7 @@ def test_prune_previous_general(version_store_factory, monkeypatch, method, lib_
     arg_0 = [sym] if method.startswith("batch") else sym
     if method.startswith("batch"):
         arg_1 = [df_1]
-    elif method == "compact_data_experimental":
+    elif method == "compact_data":
         # Prune previous on this call so that we start with 1 index key for the method under test
         lib.append(sym, df_1, prune_previous_version=True)
         arg_1 = 100_000  # rows_per_segment

--- a/python/tests/unit/arcticdb/version_store/test_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_compact_data.py
@@ -61,7 +61,7 @@ def generic_compact_data_test(lib, sym, method_arg=None):
     pre_compaction_index = lib.read_index(sym)
     pre_compaction_data_keys = len(pre_compaction_index)
     with qs.query_stats():
-        compact_data_info = lib.compact_data_explain_plan_experimental(sym, rows_per_segment=method_arg)
+        compact_data_info = lib.compact_data_explain_plan(sym, rows_per_segment=method_arg)
         stats = qs.get_query_stats()
     qs.reset_stats()
     # No data keys read and no keys of any type written
@@ -69,7 +69,7 @@ def generic_compact_data_test(lib, sym, method_arg=None):
     assert "Memory_PutObject" not in stats["storage_operations"]
 
     with qs.query_stats():
-        lib.compact_data_experimental(sym, rows_per_segment=method_arg)
+        lib.compact_data(sym, rows_per_segment=method_arg)
         stats = qs.get_query_stats()
     qs.reset_stats()
     rows_per_segment = (
@@ -119,7 +119,7 @@ def generic_compact_data_test_noop(lib, sym, rows_per_segment=None):
     expected = vit_before_compaction.data
     pre_compaction_index = lib.read_index(sym)
     with qs.query_stats():
-        compact_data_info = lib.compact_data_explain_plan_experimental(sym, rows_per_segment=rows_per_segment)
+        compact_data_info = lib.compact_data_explain_plan(sym, rows_per_segment=rows_per_segment)
         stats = qs.get_query_stats()
     qs.reset_stats()
     assert compact_data_info.num_row_slices_before == compact_data_info.num_row_slices_after
@@ -131,7 +131,7 @@ def generic_compact_data_test_noop(lib, sym, rows_per_segment=None):
     assert "Memory_PutObject" not in stats["storage_operations"]
 
     with qs.query_stats():
-        compacted_version = lib.compact_data_experimental(sym, rows_per_segment=rows_per_segment).version
+        compacted_version = lib.compact_data(sym, rows_per_segment=rows_per_segment).version
         stats = qs.get_query_stats()
     qs.reset_stats()
     assert vit_before_compaction.version == compacted_version
@@ -159,8 +159,8 @@ def test_compact_data_explain_plan(in_memory_store_factory):
     lib.write(sym, pd.DataFrame({"col": [0, 1, 2, 3, 4]}))
     lib.append(sym, pd.DataFrame({"col": [5, 6, 7, 8, 9]}))
     # Run it twice to prove that it isn't compacting anything
-    compact_data_info = lib.compact_data_explain_plan_experimental(sym)
-    compact_data_info_again = lib.compact_data_explain_plan_experimental(sym)
+    compact_data_info = lib.compact_data_explain_plan(sym)
+    compact_data_info_again = lib.compact_data_explain_plan(sym)
     # We don't need an equality operator for this class for any other reason, so just compare the repr for this test
     assert str(compact_data_info) == str(compact_data_info_again)
     assert isinstance(compact_data_info, CompactDataInfo)
@@ -173,8 +173,8 @@ def test_compact_data_explain_plan(in_memory_store_factory):
     assert compact_data_info.will_do_work
 
     # After compaction there will be no work to do
-    lib.compact_data_experimental(sym)
-    compact_data_info = lib.compact_data_explain_plan_experimental(sym)
+    lib.compact_data(sym)
+    compact_data_info = lib.compact_data_explain_plan(sym)
     assert isinstance(compact_data_info, CompactDataInfo)
     assert compact_data_info.num_row_slices_before == 1
     assert compact_data_info.num_row_slices_after == 1
@@ -190,7 +190,7 @@ def test_compact_data_explain_plan_docstring_example(lmdb_version_store_v1):
     df = pd.DataFrame({"col": np.arange(100_000)})
     for idx in range(100):
         lib.append("sym", df[idx * 1_000 : (idx + 1) * 1_000])
-    compact_data_info = lib.compact_data_explain_plan_experimental("sym")
+    compact_data_info = lib.compact_data_explain_plan("sym")
     assert compact_data_info.row_slices_before == list(range(0, 101_000, 1_000))
     assert compact_data_info.row_slices_after == [0, 100_000]
     assert compact_data_info.num_row_slices_before == 100
@@ -206,7 +206,7 @@ def test_compact_data_docstring_example_v1(lmdb_version_store_v1):
     for idx in range(100):
         lib.append("sym", df[idx * 1_000 : (idx + 1) * 1_000])
     assert len(lib.read_index("sym")) == 100
-    lib.compact_data_experimental("sym")
+    lib.compact_data("sym")
     assert len(lib.read_index("sym")) == 1
 
 
@@ -217,7 +217,7 @@ def test_compact_data_docstring_example_v2(lmdb_library):
         lib.append("sym", df[idx * 1_000 : (idx + 1) * 1_000])
     lib_tool = lib._dev_tools.library_tool()
     assert len(lib_tool.read_index("sym")) == 100
-    lib.compact_data_experimental("sym")
+    lib.compact_data("sym")
     assert len(lib_tool.read_index("sym")) == 1
 
 
@@ -225,7 +225,7 @@ def test_compact_data_symbol_doesnt_exist(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_compact_data_symbol_doesnt_exist"
     with pytest.raises(StorageException) as e:
-        lib.compact_data_experimental(sym)
+        lib.compact_data(sym)
     assert sym in str(e.value)
 
 
@@ -234,7 +234,7 @@ def test_compact_data_invalid_rows_per_segment(lmdb_version_store_v1, rows_per_s
     lib = lmdb_version_store_v1
     sym = "test_compact_data_invalid_rows_per_segment"
     with pytest.raises(ArcticNativeException):
-        lib.compact_data_experimental(sym, rows_per_segment=rows_per_segment)
+        lib.compact_data(sym, rows_per_segment=rows_per_segment)
 
 
 def test_compact_data_maintain_metadata(lmdb_version_store_v1):
@@ -245,7 +245,7 @@ def test_compact_data_maintain_metadata(lmdb_version_store_v1):
     metadata = {"hello": "world"}
     lib.append(sym, df, metadata=metadata)
     assert lib.read_metadata(sym).metadata == metadata
-    lib.compact_data_experimental(sym)
+    lib.compact_data(sym)
     assert len(lib.read_index(sym)) == 1
     assert lib.read_metadata(sym).metadata == metadata
 
@@ -456,7 +456,7 @@ def test_compact_data_read_previous_version(in_memory_store_factory):
     df = pd.DataFrame({"col": np.arange(10)})
     lib.write(sym, df[:5])  # v0
     lib.append(sym, df[5:])  # v1
-    lib.compact_data_experimental(sym)  # v2
+    lib.compact_data(sym)  # v2
     assert_frame_equal(df[:5], lib.read(sym, as_of=0).data)
     assert_frame_equal(df, lib.read(sym, as_of=1).data)
     assert_frame_equal(df, lib.read(sym).data)
@@ -476,7 +476,7 @@ def test_compact_data_date_range_read(in_memory_store_factory, rows_per_segment)
     mid = index[num_rows // 2]
     expected_first_half = lib.read(sym, date_range=(index[0], mid)).data
     expected_second_half = lib.read(sym, date_range=(mid, index[-1])).data
-    lib.compact_data_experimental(sym)
+    lib.compact_data(sym)
     assert_frame_equal(expected_first_half, lib.read(sym, date_range=(index[0], mid)).data)
     assert_frame_equal(expected_second_half, lib.read(sym, date_range=(mid, index[-1])).data)
 
@@ -587,7 +587,7 @@ def test_compact_recursively_normalized_data(lmdb_version_store_v1):
     lib.write(sym, data, recursive_normalizers=True)
     assert len(lt.find_keys(KeyType.MULTI_KEY)) == 1
     with pytest.raises(SchemaException) as e:
-        lib.compact_data_experimental(sym)
+        lib.compact_data(sym)
     assert "recursive" in str(e.value) and sym in str(e.value)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
[11590368094](https://man312219.monday.com/boards/7852509418/pulses/11590368094)

#### What does this implement or fix?
Removes the `_experimental` suffix from `compact_data` and `compact_data_explain_plan`, and logs deprecation messages when using the old `is_symbol_fragmented` and `defragment_symbol_data` methods.