### PR TITLE
Switch to using /Zi format for MSVC. Allow generation of PDB per TU. Add cache variables for configuring compiler cache.

### DIFF
--- a/cpp/CMake/compiler_cache.cmake
+++ b/cpp/CMake/compiler_cache.cmake
@@ -1,0 +1,121 @@
+# Sets compiler cache by prepending to CMAKE_CXX_COMPILER_LAUNCHER and CMAKE_C_COMPILER_LAUNCHER based on the value of
+# the ARCTICDB_COMPILER_CACHE cache variable. Allowed values for the variable are AUTO|SCCACHE|CCACHE|OFF|CUSTOM
+# * OFF does nothing
+# * SCCACHE|CCACHE the executables for the specified caches are sought. If they are not found the script fails.
+# * CUSTOM prepends CMAKE_C(XX)_COMPILER_LAUNCHER with the value of ARCTICDB_COMPILER_CACHE_PATH. If
+#   ARCTICDB_COMPILER_CACHE_PATH is not set the script fails
+# * AUTO tries to find a compiler cache in the order sccache|ccache. If nothing is found the script exits (but does
+#   not fail). If the executable is found but CMAKE_C(XX)_COMPILER_LAUNCHER is empty the script will not change anything.
+function(set_arcticdb_compiler_cache)
+    
+    validate_compiler_cache_value()
+    if("${ARCTICDB_COMPILER_CACHE}" STREQUAL "OFF")
+        return()
+    endif()
+
+    unset(CACHE_PROGRAM_PATH CACHE)
+
+    if("${ARCTICDB_COMPILER_CACHE}" STREQUAL "CUSTOM")
+        set(CACHE_PROGRAM_PATH ${ARCTICDB_COMPILER_CACHE_PATH})
+        get_filename_component(CACHE_PROGRAM_NAME ${ARCTICDB_COMPILER_CACHE_PATH} NAME_WE)
+    elseif("${ARCTICDB_COMPILER_CACHE}" STREQUAL "AUTO")
+        set(CACHES_TO_TRY sccache ccache)
+        foreach(CACHE_CANDIDATE ${CACHES_TO_TRY})
+            find_program(CACHE_PROGRAM_PATH ${CACHE_CANDIDATE})
+            if(CACHE_PROGRAM_PATH)
+                set(CACHE_PROGRAM_NAME ${CACHE_CANDIDATE})
+                break()
+            else()
+                unset(CACHE_PROGRAM_PATH CACHE)
+            endif()
+        endforeach()
+
+        if(NOT CACHE_PROGRAM_PATH)
+            message("ArcticDB could not find any compiler cache as a result of setting ARCTICDB_COMPILER_CACHE to AUTO")
+            return()
+        endif()
+    else()
+        string(TOLOWER ${ARCTICDB_COMPILER_CACHE} CACHE_PROGRAM_NAME)
+        find_program(CACHE_PROGRAM_PATH ${CACHE_PROGRAM_NAME})
+        if(NOT CACHE_PROGRAM_PATH)
+            message(FATAL_ERROR
+                "ARCTICDB_COMPILER_CACHE set to ${ARCTICDB_COMPILER_CACHE} but ${ARCTICDB_COMPILER_CACHE} cannot be "
+                "found. Consider setting ARCTICDB_COMPILER_CACHE to CUSTOM and using ARCTICDB_COMPILER_CACHE_PATH"
+            )
+        endif()
+    endif()
+
+    if(MSVC AND CACHE_PROGRAM_PATH AND NOT "${ARCTICDB_PDB_GENERATION_MODE}" STREQUAL "TU")
+        if(${ARCTICDB_COMPILER_CACHE} STREQUAL "AUTO")
+            return()
+        endif()
+        message(FATAL_ERROR
+            "In order to use a compiler cache with MSVC a .pdb must be generated per each TU. Consider setting "
+            "ARCTICDB_PDB_GENERATION_MODE to TU."
+        )
+    endif()
+    
+    prepend_cache_if_not_existing("${CACHE_PROGRAM_PATH}" "${CACHE_PROGRAM_NAME}")
+endfunction()
+
+# Check if the value of the cache variable ARCTICDB_COMPILER_CACHE is correct. Fail if not.
+function(validate_compiler_cache_value)
+    string(TOUPPER ${ARCTICDB_COMPILER_CACHE} CACHE_UPPER)
+    set(ALLOWED_VALUES "CCACHE" "SCCACHE" "OFF" "CUSTOM" "AUTO")
+    if(NOT CACHE_UPPER IN_LIST ALLOWED_VALUES)
+        message(FATAL_ERROR "Unknown value of the ARCTICDB_COMPILER_CACHE variable: ${ARCTICDB_COMPILER_CACHE}")
+    endif()
+
+    if("${ARCTICDB_COMPILER_CACHE}" STREQUAL "CUSTOM" AND NOT ARCTICDB_COMPILER_CACHE_PATH)
+        message(FATAL_ERROR
+            "ARCTICDB_COMPILER_CACHE set to ${ARCTICDB_COMPILER_CACHE} but ARCTICDB_COMPILER_CACHE_PATH was not set"
+        )
+    endif()
+endfunction()
+
+# Set the compiler cache by prepending to CMAKE_CXX_COMPILER_LAUNCHER and CMAKE_C_COMPILER_LAUNCHER
+# CACHE_PROGRAM_PATH - full path to the compiler cache executable
+# CACHE_NAME - short name of the executable (filename with not extension)
+# * If the CMAKE_C(XX)_COMPILER_LAUNCHER already contains CACHE_PROGRAM_PATH does prints a status and does nothing
+# * If the CMAKE_C(XX)_COMPILER_LAUNCHER already contains CACHE_NAME it replaces the existing entry with CACHE_PROGRAM_PATH
+# * Otherwise prepends the compiler cache to CMAKE_C(XX)_COMPILER_LAUNCHER
+function(prepend_cache_if_not_existing CACHE_PROGRAM_PATH CACHE_NAME)
+    set(LAUNCHER_LISTS CMAKE_CXX_COMPILER_LAUNCHER CMAKE_C_COMPILER_LAUNCHER)
+    foreach(LAUNCHER_LIST ${LAUNCHER_LISTS})
+        set(CACHE_ALREADY_SET FALSE)
+        foreach(LAUNCHER_PATH ${${LAUNCHER_LIST}})
+            get_filename_component(LAUNCHER ${LAUNCHER_PATH} NAME_WE)
+            if("${CACHE_PROGRAM_PATH}" STREQUAL "${LAUNCHER_PATH}")
+                message(STATUS "Compiler cache ${CACHE_NAME}: ${CACHE_PROGRAM_PATH} already set.")
+                set(CACHE_ALREADY_SET TRUE)
+                break()
+            elseif("${LAUNCHER}" STREQUAL "${CACHE_NAME}")
+                if(NOT "${ARCTICDB_COMPILER_CACHE}" STREQUAL "AUTO")
+                    message(
+                        "Compiler cache ${CACHE_NAME} already set in ${LAUNCHER_LIST} with different path. Existing path: "
+                        "${LAUNCHER}, required path: ${CACHE_PROGRAM_PATH}. Replacing the existing path with required path."
+                    )
+                    list(FIND ${LAUNCHER_LIST} "${LAUNCHER_PATH}" idx)
+                    list(REMOVE_AT ${LAUNCHER_LIST} ${idx})
+                    list(INSERT ${LAUNCHER_LIST} ${idx} "${CACHE_PROGRAM_PATH}")
+                    set(${LAUNCHER_LIST} ${${LAUNCHER_LIST}} CACHE STRING "" FORCE)
+                endif()
+                set(CACHE_ALREADY_SET TRUE)
+                break()
+            endif()
+        endforeach()
+        if(NOT CACHE_ALREADY_SET)
+            if(${LAUNCHER_LIST})
+                message(
+                    WARNING
+                    "Setting compiler cache ${CACHE_PROGRAM_PATH} on top of non-empty ${LAUNCHER_LIST}:"
+                    "${${LAUNCHER_LIST}}"
+                )
+            else()
+                message("ArcticDB setting compiler cache ${CACHE_NAME}: ${CACHE_PROGRAM_PATH}")
+            endif()
+            list(PREPEND ${LAUNCHER_LIST} ${CACHE_PROGRAM_PATH})
+            set(${LAUNCHER_LIST} ${${LAUNCHER_LIST}} CACHE STRING "" FORCE)
+        endif()
+    endforeach()
+endfunction()

--- a/cpp/CMake/pdb_generation.cmake
+++ b/cpp/CMake/pdb_generation.cmake
@@ -1,0 +1,86 @@
+set(_ARCTICDB_PDB_GENERATION_MODE_WARNED OFF CACHE INTERNAL "")
+# In case ARCTICDB_PDB_GENERATION_MODE is TU and MSVC is used this will set a custom PDB path for each translation
+# unit. All translation units will produce unique PDB. All PDBs are automatically linked by the linker at the end (no
+# action required). The name of the PDB is the name of the cpp file_<MD5 hash of the path to the file>.pdb because by
+# default all PDBs are stored in the same folder and we need to distinguish files with the same name but from different
+# folders e.g. (a/b.cpp and c/b.cpp) will both be placed in the same folder with name b.cpp and this will confuse the
+# linker and the debugger. Attaching the path as MD5 hash will make files named the same way unique as long as they have
+# different path. If ARCTICDB_PDB_GENERATION_MODE is TARGET (which is both the default for ArcticDB and MSVC) there will
+# be one PDB per target and in case of parallel builds each compiler invocation will try taking a lock and appending in
+# the PDB file this makes the output of .cl nondeterministic and compiler caches as sccache or ccache will not work.
+
+# While in theory ARCTICDB_PDB_GENERATION_MODE=TU should make parallel builds faster it forces MSBuild to run
+# single-threaded builds even if \MP is set. This is because it batches building of TUs based on compiler parameters
+# as each TU now has unique PDB all TUs will have different flags resulting of no batches. Note: Ninja does not have
+# this problem.
+
+# Pre-compiled headers cannot work with ARCTICDB_PDB_GENERATION_MODE=TU
+
+# ARCTICDB_PDB_GENERATION_MODE=TU makes sense only when CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=ProgramDatabase which is
+# the same as setting the /Zi (or /ZI) compiler flag.
+
+# The function takes the path to each translation unit. The path can be relative or absolute. All paths must be unique.
+function(set_pdb_name_per_translation_unit)
+    if(MSVC AND "${ARCTICDB_PDB_GENERATION_MODE}" STREQUAL "TU")
+        if(NOT "${CMAKE_MSVC_DEBUG_INFORMATION_FORMAT}" STREQUAL "ProgramDatabase")
+            message(WARNING
+                "ARCTICDB_PDB_GENERATION_MODE set to ${ARCTICDB_PDB_GENERATION_MODE}, but "
+                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT is ${CMAKE_MSVC_DEBUG_INFORMATION_FORMAT} (not ProgramDatabase). "
+                "Generation of PDBs per TU makes sense only if debug format is ProgramDatabase (/Zi or /ZI are set)"
+            )
+            return()
+        endif()
+        message("ArcticDB MSVC build will generate one PDB per translation unit")
+
+        if(ARCTICDB_USE_PCH)
+            message(FATAL_ERROR "Cannot generate .pdb per translation unit and use precompiled headers")
+        endif()
+
+        if(CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT _ARCTICDB_PDB_GENERATION_MODE_WARNED)
+            message(AUTHOR_WARNING
+                "Setting ARCTICDB_PDB_GENERATION_MODE to TU will result in single threaded builds with MSBuild even "
+                "if /MP is set"
+            )
+            set(_ARCTICDB_PDB_GENERATION_MODE_WARNED ON PARENT_SCOPE)
+        endif()
+
+        if(CMAKE_CONFIGURATION_TYPES)
+            foreach(config IN LISTS CMAKE_CONFIGURATION_TYPES)
+                if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${config})
+                    message("ArcticDB creating folder ${CMAKE_CURRENT_BINARY_DIR}/${config} to store .pdb files")
+                    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${config}")
+                endif()
+            endforeach()
+        else()
+            if(CMAKE_BUILD_TYPE)
+                if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+                    message("ArcticDB creating folder ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE} to store .pdb files")
+                    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
+                endif()
+            else()
+                message(FATAL_ERROR "CMAKE_BUILD_TYPE not set") 
+            endif()
+        endif()
+
+        foreach(src IN LISTS ARGN)
+            get_filename_component(filename ${src} NAME_WE)
+            string(MD5 src_hash ${src})
+            set(new_pdb_name "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${filename}_${src_hash}.pdb")
+            set_property(SOURCE ${src} APPEND PROPERTY COMPILE_OPTIONS "/Fd${new_pdb_name}")
+        endforeach()
+    endif()
+endfunction()
+
+# CMAKE_C_COMPILE_OBJECT and CMAKE_CXX_COMPILE_OBJECT are a general template for how to invoke the compiler to compile
+# a source file. It overwrites the /Fd flag even when set_pdb_name_per_translation_unit is used, preventing generation
+# of PDB per TU and preventing the use of compiler caches. This function will strip the flag and will set the parent
+# scope of CMAKE_C_COMPILE_OBJECT and CMAKE_CXX_COMPILE_OBJECT. Must be called once per CMakeLists.txt using
+# set_pdb_name_per_translation_unit.
+function(strip_fd_from_compile_object)
+    if(MSVC AND "${ARCTICDB_PDB_GENERATION_MODE}" STREQUAL "TU")
+        string(REPLACE "/Fd<TARGET_COMPILE_PDB>" "" CMAKE_CXX_COMPILE_OBJECT "${CMAKE_CXX_COMPILE_OBJECT}")
+        string(REPLACE "/Fd<TARGET_COMPILE_PDB>" "" CMAKE_C_COMPILE_OBJECT "${CMAKE_C_COMPILE_OBJECT}")
+        set(CMAKE_C_COMPILE_OBJECT "${CMAKE_C_COMPILE_OBJECT}" PARENT_SCOPE)
+        set(CMAKE_CXX_COMPILE_OBJECT "${CMAKE_CXX_COMPILE_OBJECT}" PARENT_SCOPE)
+    endif()
+endfunction()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21) # TARGET_RUNTIME_DLLS
+cmake_minimum_required(VERSION 3.25)
 
 # Make the `project` command handle the version of the project.
 cmake_policy(SET CMP0048 NEW)
@@ -10,18 +10,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
-
-# Use ccache if available and no compiler launcher is already configured (e.g. sccache via presets)
-if(NOT CMAKE_C_COMPILER_LAUNCHER AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
-    find_program(CCACHE_PROGRAM ccache)
-    if(CCACHE_PROGRAM)
-        set(CMAKE_C_COMPILER_LAUNCHER "env;CCACHE_HARDLINK=1;${CCACHE_PROGRAM}")
-        set(CMAKE_CXX_COMPILER_LAUNCHER "env;CCACHE_HARDLINK=1;${CCACHE_PROGRAM}")
-        message(STATUS "Using ccache: ${CCACHE_PROGRAM} (CCACHE_DIR=$ENV{CCACHE_DIR})")
-    endif()
-endif()
-
 project(arcticdb VERSION 0.0.1)
+
+include(${CMAKE_SOURCE_DIR}/CMake/compiler_cache.cmake)
+include(${CMAKE_SOURCE_DIR}/CMake/pdb_generation.cmake)
 
 enable_testing()
 
@@ -40,6 +32,23 @@ option(ARCTICDB_LOG_PERFORMANCE "Whether to log performance timings." OFF)
 option(ARCTICDB_COUNT_ALLOCATION "Override new and delete to count allocations." OFF)
 option(ARCTICDB_KEEP_DEBUG_SYMBOLS "Whether to keep debug symbols in RelWithDebInfo builds." OFF)
 option(ARCTICDB_ENABLE_SEGMENT_PRETTY_PRINT "Enables pretty printing of segments. The printing can affect runtime" OFF)
+set(ARCTICDB_PDB_GENERATION_MODE "TARGET" CACHE STRING
+    "Whether to generate PDB per translation unit or per target. Possible options are TARGET|TU. Windows only option \
+    Generating PDB per TU does not work with PCH it will also force a single-threaded build for MSBuild even if /MP \
+    is set. Generating PDB per target does not work with compiler caches."
+)
+set(ARCTICDB_COMPILER_CACHE "AUTO" CACHE STRING
+    "Compiler cache for ArcticDB to use. Can be AUTO|CCACHE|SCCACHE|CUSTOM|OFF. If CCACHE or SCCACHE are provided will \
+    try to find the executables on the machine. If CUSTOM is provided ARCTICDB_COMPILER_CACHE_PATH must be set to the \
+    path for the custom compiler cache. AUTO will try to find a usable compiler cache (sccache or ccache) and set it \
+    only if CMAKE_C(XX)_COMPILER_LAUNCHER is empty. Prefer using this to setting explicitly \
+    CMAKE_C(XX)_COMPILER_LAUNCHER to get early exits during configure time if incompatible options are detected."
+)
+set(ARCTICDB_COMPILER_CACHE_PATH "" CACHE FILEPATH
+    "Path to compiler cache executable. In order to use it ARCTICDB_COMPILER_CACHE must be set to CUSTOM"
+)
+
+set_arcticdb_compiler_cache()
 
 set(ARCTICDB_SANITIZER_FLAGS)
 if(${ARCTICDB_USING_ADDRESS_SANITIZER})
@@ -193,12 +202,16 @@ if(WIN32)
             AZ_STORAGE_BLOBS_DLL=1
         )
     endif()
-
-    # We always generate the debug info on Windows since those are not in the final .dll.
-    # sccache needs the /Z7 format, but the linker will still produce .pdb files.
+    # Equivalent of setting /Zi. We need this because /Z7 has a limit of 4GB per file which we reached. The main issue
+    # With /Zi is that it does not work with sccache. It's because /Zi will write the debug symbols of all TUs in a
+    # single file, thus the result of the compiler invocation is non-deterministic when /MP is used. For now this is
+    # solved by using /Fd to generate .pdb file per TU which are then linked (see arcticdb/CMakeLists.txt). Downside
+    # is that linking these files requires a lot of RAM. In case the CI starts OOM-ing we should drop this and give
+    # on using sccache.
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT ProgramDatabase)
     # Guide to MSVC compilation warnings https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199?view=msvc-170
     add_compile_options(
-        /DWIN32 /D_WINDOWS /GR /EHsc /bigobj /Z7 /wd4244 /wd4267
+        /DWIN32 /D_WINDOWS /GR /EHsc /bigobj /wd4244 /wd4267
     )
 
     if(${ARCTICDB_USING_CONDA})

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -38,8 +38,7 @@
       "inherits": "common",
       "cacheVariables": {
         "ARCTICDB_USING_CONDA": "ON",
-        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
-        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache"
+        "ARCTICDB_COMPILER_CACHE": "sccache"
       },
       "condition": {
         "type": "allOf",
@@ -66,7 +65,9 @@
       "environment": { "cmakepreset_expected_host_system": "Windows" },
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl",
-        "CMAKE_CXX_COMPILER": "cl"
+        "CMAKE_CXX_COMPILER": "cl",
+        "ARCTICDB_COMPILER_CACHE": "sccache",
+        "ARCTICDB_PDB_GENERATION_MODE": "TU"
       }
     },
     {
@@ -148,8 +149,7 @@
       "inherits": ["common_vcpkg", "macos"],
       "cacheVariables": {
         "CMAKE_OSX_DEPLOYMENT_TARGET": "15.0",
-        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
-        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache"
+        "ARCTICDB_COMPILER_CACHE": "sccache"
       }
     },
     { "name": "windows-cl-release",       "inherits": "windows-cl-debug",       "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }},

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -599,6 +599,8 @@ set(arcticdb_srcs
         version/python_bindings_common.cpp
         storage/s3/ec2_utils.cpp
 )
+strip_fd_from_compile_object()
+set_pdb_name_per_translation_unit(${arcticdb_srcs})
 
 add_library(arcticdb_core_object OBJECT ${arcticdb_srcs})
 
@@ -913,10 +915,13 @@ set(arcticdb_python_srcs
         toolbox/python_bindings.cpp
         version/python_bindings.cpp
         util/python_bindings.cpp
-        python/reader.hpp
-        python/adapt_read_dataframe.hpp)
-
-add_library(arcticdb_python STATIC ${arcticdb_python_srcs})
+)
+set(arcticdb_python_headers
+    python/reader.hpp
+    python/adapt_read_dataframe.hpp
+)
+set_pdb_name_per_translation_unit(${arcticdb_python_srcs})
+add_library(arcticdb_python STATIC ${arcticdb_python_srcs} ${arcticdb_python_headers})
 if(${ARCTICDB_USE_PCH})
     message(STATUS "Using precompiled headers for target arcticdb_python")
     target_precompile_headers(
@@ -954,12 +959,13 @@ endif ()
 
 ## arcticdb_ext python module
 # This configures: linking to Python::Module + pybind, output pre-/suf-fix, -fvisibility=hidden, strip release build
-pybind11_add_module(arcticdb_ext MODULE
+set(arcticdb_pybind_module_src
         python/python_module.cpp
         python/arctic_version.cpp
-        python/arctic_version.hpp
-        )
-
+)
+set(arcticdb_pybind_module_headers python/arctic_version.hpp)
+pybind11_add_module(arcticdb_ext MODULE ${arcticdb_pybind_module_src} ${arcticdb_pybind_module_headers})
+set_pdb_name_per_translation_unit(${arcticdb_pybind_module_src})
 
 if (HIDE_LINKED_SYMBOLS AND NOT WIN32)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
@@ -1132,7 +1138,8 @@ if(${TEST})
             version/test/test_version_store.cpp
             version/test/version_map_model.hpp
             python/python_handlers.cpp
-)
+    )
+    set_pdb_name_per_translation_unit(${unit_test_srcs})
 
     set(EXECUTABLE_PERMS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE) # 755
 
@@ -1234,7 +1241,9 @@ if(${TEST})
             processing/test/benchmark_common.cpp
             processing/test/benchmark_ternary.cpp
             util/test/benchmark_bitset.cpp
-            version/test/benchmark_write.cpp)
+            version/test/benchmark_write.cpp
+    )
+    set_pdb_name_per_translation_unit(${benchmark_srcs})
 
     add_executable(benchmarks ${benchmark_srcs})
 
@@ -1269,7 +1278,7 @@ if(${TEST})
             util/test/rapidcheck_lru_cache.cpp
             version/test/rapidcheck_version_map.cpp
     )
-
+    set_pdb_name_per_translation_unit(${rapidcheck_srcs})
     add_executable(arcticdb_rapidcheck_tests ${rapidcheck_srcs})
 
     install(TARGETS arcticdb_rapidcheck_tests RUNTIME

--- a/cpp/proto/arcticc/pb2/proto/CMakeLists.txt
+++ b/cpp/proto/arcticc/pb2/proto/CMakeLists.txt
@@ -46,4 +46,6 @@ PROTOBUF_GENERATE_CPP(PROTO_SRC PROTO_HEADER
         ${PROTO_ALTERED_FILES}
         )
 
+strip_fd_from_compile_object()
+set_pdb_name_per_translation_unit(${PROTO_SRC})
 ADD_LIBRARY(arcticdb_proto ${PROTO_HEADER} ${PROTO_SRC})


### PR DESCRIPTION
## Main issue

ArcticDB used to use `/Z7` on windows which generates the debug info inside the `.obj` files. `/Z7` has a limit of 4GB.

## Solution

This commit `/Zi` instead of `/Z7`. Which will generate debug symbols in a separate PDB file.

## Generation of PDB

### Default behavior (per target PDB)

By default PDBs are generated per target. When a translation unit is done compiling it'll try taking a lock and append in the PDB. This makes the invocation of `cl.exe` nondeterministic which messes up compiler caches as the output of compilation can potentially always be different.

### Per TU PDB

To make it possible to use compiler cache a new CMake cache variable is added `ARCTICDB_PDB_GENERATION_MODE` it can be either `TARGET` or `TU`, `TARGET` being the default. If it's `TU` it will generate a single PDB per TU. In theory not having to take a lock should make parallel builds faster, however MSBuild batches compilation by grouping on compiler flags. All TUs sharing the same flags are compiled in parallel together. Having different PDB means different flags, so `ARCTICDB_PDB_GENERATION_MODE=TU` forces MSBuild to compile on a single thread. Note this is only MSBuild issues, Ninja does not have this problem and our CI uses Ninja. `ARCTICDB_PDB_GENERATION_MODE=TU` does not work with PCH.

## Setting compiler cache

This PR also introduces the `ARCTICDB_COMPILER_CACHE` cache variable for controlling compiler caches. It allowed values are `AUTO|SCCACHE|CCACHE|OFF|CUSTOM`. With the following semantics:
 * `OFF` does nothing
* `SCCACHE|CCACHE` the executables for the specified compiler cache are sought. If they are not found the script fails. If the same compiler cache was already set but with different executable the executable will be replaced with the new executable
* `CUSTOM` prepends CMAKE_C(XX)_COMPILER_LAUNCHER with the value of `ARCTICDB_COMPILER_CACHE_PATH`. If `ARCTICDB_COMPILER_CACHE_PATH` is not set the script fails. This is a way to set a custom path for the compiler cache.
* `AUTO` tries to find a compiler cache in the order `sccache|ccache`. If nothing is found the script exits (but does not fail). If the executable is found but `CMAKE_C(XX)_COMPILER_LAUNCHER` is not empty the script will not change anything. If a cache executable was found and `CMAKE_C(XX)_COMPILER_LAUNCHER` is empty `CMAKE_C(XX)_COMPILER_LAUNCHER` will be set to the found executable.


## Minimal required CMake version set to 3.25

Allows the use of `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT`
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
