### PR TITLE
Submit delete batches in parallel

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1054,6 +1054,7 @@ if(${TEST})
             entity/test/test_key_serialization.cpp
             entity/test/test_metrics.cpp
             entity/test/test_ref_key.cpp
+            entity/test/test_variant_key.cpp
             entity/test/test_tensor.cpp
             log/test/test_log.cpp
             pipeline/test/test_container.hpp

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -383,26 +383,53 @@ class AsyncStore : public Store {
     folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
             const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts
     ) override {
-        return keys.empty() ? std::vector<RemoveKeyResultType>()
-                            : async::submit_io_task(RemoveBatchTask{keys, library_, opts});
+        return remove_keys(std::vector<entity::VariantKey>{keys}, opts);
     }
 
     folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
             std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts
     ) override {
-        return keys.empty() ? std::vector<RemoveKeyResultType>()
-                            : async::submit_io_task(RemoveBatchTask{std::move(keys), library_, opts});
+        if (keys.empty()) {
+            return std::vector<RemoveKeyResultType>{};
+        }
+        const auto batch_size = library_->max_delete_batch_size();
+        if (!batch_size.has_value() || keys.size() <= *batch_size) {
+            return async::submit_io_task(RemoveBatchTask{std::move(keys), library_, opts});
+        }
+        auto chunks = chunk_keys(std::move(keys), *batch_size);
+        auto futs = folly::window(
+                std::move(chunks),
+                [this, opts](std::vector<entity::VariantKey>&& chunk) {
+                    return async::submit_io_task(RemoveBatchTask{std::move(chunk), library_, opts});
+                },
+                async::TaskScheduler::instance()->io_thread_count()
+        );
+        return folly::collect(std::move(futs)).via(&async::io_executor()).thenValue([](auto&&) {
+            return std::vector<RemoveKeyResultType>{};
+        });
     }
 
     std::vector<RemoveKeyResultType> remove_keys_sync(
             const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts
     ) override {
-        return keys.empty() ? std::vector<RemoveKeyResultType>() : RemoveBatchTask{keys, library_, opts}();
+        return remove_keys_sync(std::vector<entity::VariantKey>{keys}, opts);
     }
 
     std::vector<RemoveKeyResultType> remove_keys_sync(std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts)
             override {
-        return keys.empty() ? std::vector<RemoveKeyResultType>() : RemoveBatchTask{std::move(keys), library_, opts}();
+        if (keys.empty()) {
+            return {};
+        }
+        const auto batch_size = library_->max_delete_batch_size();
+        if (!batch_size.has_value() || keys.size() <= *batch_size) {
+            return RemoveBatchTask{std::move(keys), library_, opts}();
+        }
+        std::vector<RemoveKeyResultType> result;
+        for (auto& chunk : chunk_keys(std::move(keys), *batch_size)) {
+            auto sub = RemoveBatchTask{std::move(chunk), library_, opts}();
+            result.insert(result.end(), std::make_move_iterator(sub.begin()), std::make_move_iterator(sub.end()));
+        }
+        return result;
     }
 
     std::vector<folly::Future<VariantKey>> batch_read_compressed(
@@ -513,6 +540,19 @@ class AsyncStore : public Store {
 
   private:
     friend class arcticdb::toolbox::apy::LibraryTool;
+
+    static std::vector<std::vector<entity::VariantKey>> chunk_keys(
+            std::vector<entity::VariantKey>&& keys, size_t batch_size
+    ) {
+        std::vector<std::vector<entity::VariantKey>> chunks;
+        chunks.reserve((keys.size() + batch_size - 1) / batch_size);
+        for (size_t i = 0; i < keys.size(); i += batch_size) {
+            const size_t end = std::min(i + batch_size, keys.size());
+            chunks.emplace_back(std::make_move_iterator(keys.begin() + i), std::make_move_iterator(keys.begin() + end));
+        }
+        return chunks;
+    }
+
     std::shared_ptr<storage::Library> library_;
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_;
     const EncodingVersion encoding_version_;

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -372,25 +372,22 @@ class AsyncStore : public Store {
         return async::submit_io_task(WriteCompressedBatchTask(std::move(kvs), library_));
     }
 
-    folly::Future<RemoveKeyResultType> remove_key(const entity::VariantKey& key, storage::RemoveOpts opts) override {
+    folly::Future<folly::Unit> remove_key(const entity::VariantKey& key, storage::RemoveOpts opts) override {
         return async::submit_io_task(RemoveTask{key, library_, opts});
     }
 
-    RemoveKeyResultType remove_key_sync(const entity::VariantKey& key, storage::RemoveOpts opts) override {
-        return RemoveTask{key, library_, opts}();
+    void remove_key_sync(const entity::VariantKey& key, storage::RemoveOpts opts) override {
+        RemoveTask{key, library_, opts}();
     }
 
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
-            const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts
-    ) override {
+    folly::Future<folly::Unit> remove_keys(const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts)
+            override {
         return remove_keys(std::vector<entity::VariantKey>{keys}, opts);
     }
 
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
-            std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts
-    ) override {
+    folly::Future<folly::Unit> remove_keys(std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts) override {
         if (keys.empty()) {
-            return std::vector<RemoveKeyResultType>{};
+            return folly::Unit{};
         }
         const auto batch_size = library_->max_delete_batch_size();
         if (!batch_size.has_value() || keys.size() <= *batch_size) {
@@ -405,31 +402,26 @@ class AsyncStore : public Store {
                 async::TaskScheduler::instance()->io_thread_count()
         );
         return folly::collect(std::move(futs)).via(&async::io_executor()).thenValue([](auto&&) {
-            return std::vector<RemoveKeyResultType>{};
+            return folly::Unit{};
         });
     }
 
-    std::vector<RemoveKeyResultType> remove_keys_sync(
-            const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts
-    ) override {
-        return remove_keys_sync(std::vector<entity::VariantKey>{keys}, opts);
+    void remove_keys_sync(const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts) override {
+        remove_keys_sync(std::vector<entity::VariantKey>{keys}, opts);
     }
 
-    std::vector<RemoveKeyResultType> remove_keys_sync(std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts)
-            override {
+    void remove_keys_sync(std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts) override {
         if (keys.empty()) {
-            return {};
+            return;
         }
         const auto batch_size = library_->max_delete_batch_size();
         if (!batch_size.has_value() || keys.size() <= *batch_size) {
-            return RemoveBatchTask{std::move(keys), library_, opts}();
+            RemoveBatchTask{std::move(keys), library_, opts}();
+            return;
         }
-        std::vector<RemoveKeyResultType> result;
         for (auto& chunk : chunk_keys(std::move(keys), *batch_size)) {
-            auto sub = RemoveBatchTask{std::move(chunk), library_, opts}();
-            result.insert(result.end(), std::make_move_iterator(sub.begin()), std::make_move_iterator(sub.end()));
+            RemoveBatchTask{std::move(chunk), library_, opts}();
         }
-        return result;
     }
 
     std::vector<folly::Future<VariantKey>> batch_read_compressed(

--- a/cpp/arcticdb/async/tasks.hpp
+++ b/cpp/arcticdb/async/tasks.hpp
@@ -665,10 +665,7 @@ struct RemoveTask : BaseTask {
 
     ARCTICDB_MOVE_ONLY_DEFAULT(RemoveTask)
 
-    stream::StreamSink::RemoveKeyResultType operator()() {
-        lib_->remove(std::move(key_), opts_);
-        return {};
-    }
+    void operator()() { lib_->remove(std::move(key_), opts_); }
 };
 
 struct RemoveBatchTask : BaseTask {
@@ -685,10 +682,7 @@ struct RemoveBatchTask : BaseTask {
 
     ARCTICDB_MOVE_ONLY_DEFAULT(RemoveBatchTask)
 
-    std::vector<stream::StreamSink::RemoveKeyResultType> operator()() {
-        lib_->remove(std::span(keys_), opts_);
-        return {};
-    }
+    void operator()() { lib_->remove(std::span(keys_), opts_); }
 };
 
 struct VisitObjectSizesTask : BaseTask {

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -24,6 +24,8 @@
 #include <arcticdb/storage/mock/s3_mock_client.hpp>
 #include <arcticdb/storage/s3/detail-inl.hpp>
 #include <arcticdb/storage/mock/storage_mock_client.hpp>
+#include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/key_utils.hpp>
 #include <aws/core/Aws.h>
 
 using namespace arcticdb;
@@ -670,4 +672,146 @@ TEST(Async, CopyCompressedInterStoreKeyExistsCheckFailureWithRetry) {
     auto read_result_2 = targets[2]->read_sync(key);
     ASSERT_EQ(std::get<RefKey>(read_result_2.first), key);
     ASSERT_EQ(read_result_2.second.row_count(), row_count);
+}
+
+namespace remove_batch_test {
+
+class RecordingStorage final : public as::Storage {
+  public:
+    RecordingStorage(const as::LibraryPath& lib, as::OpenMode mode, std::optional<size_t> batch_size) :
+        Storage(lib, mode),
+        batch_size_(batch_size) {}
+
+    std::string name() const final { return "recording_storage"; }
+
+    std::optional<size_t> max_delete_batch_size() const override { return batch_size_; }
+
+    std::vector<size_t> recorded_call_sizes() {
+        std::lock_guard guard(mutex_);
+        return recorded_;
+    }
+
+    void seed_iter_keys(std::vector<entity::VariantKey> keys) {
+        std::lock_guard guard(mutex_);
+        iter_keys_ = std::move(keys);
+    }
+
+  private:
+    void do_write(as::KeySegmentPair&) final { util::raise_rte("unused"); }
+    void do_write_if_none(as::KeySegmentPair&) final { util::raise_rte("unused"); }
+    void do_update(as::KeySegmentPair&, as::UpdateOpts) final { util::raise_rte("unused"); }
+    void do_read(entity::VariantKey&&, const as::ReadVisitor&, as::ReadKeyOpts) final { util::raise_rte("unused"); }
+    as::KeySegmentPair do_read(entity::VariantKey&&, as::ReadKeyOpts) final { util::raise_rte("unused"); }
+
+    void do_remove(entity::VariantKey&&, as::RemoveOpts) final {
+        std::lock_guard guard(mutex_);
+        recorded_.push_back(1);
+    }
+
+    void do_remove(std::span<entity::VariantKey> keys, as::RemoveOpts) final {
+        std::lock_guard guard(mutex_);
+        recorded_.push_back(keys.size());
+    }
+
+    bool do_key_exists(const entity::VariantKey&) final { return false; }
+    bool do_supports_prefix_matching() const final { return false; }
+    as::SupportsAtomicWrites do_supports_atomic_writes() const final { return as::SupportsAtomicWrites::NO; }
+    bool do_fast_delete() final { return false; }
+    bool do_iterate_type_until_match(entity::KeyType, const as::IterateTypePredicate& visitor, const std::string&)
+            final {
+        std::vector<entity::VariantKey> keys;
+        {
+            std::lock_guard guard(mutex_);
+            keys = iter_keys_;
+        }
+        for (auto& key : keys) {
+            if (visitor(entity::VariantKey{key})) {
+                return true;
+            }
+        }
+        return false;
+    }
+    std::string do_key_path(const entity::VariantKey&) const final { return {}; }
+
+    std::optional<size_t> batch_size_;
+    std::mutex mutex_;
+    std::vector<size_t> recorded_;
+    std::vector<entity::VariantKey> iter_keys_;
+};
+
+inline std::shared_ptr<aa::AsyncStore<>> build_async_store(std::shared_ptr<RecordingStorage> storage) {
+    auto storages = std::make_shared<as::Storages>(as::Storages::StorageVector{storage}, as::OpenMode::DELETE);
+    auto library = std::make_shared<as::Library>(as::LibraryPath{"a", "b"}, std::move(storages));
+    return std::make_shared<aa::AsyncStore<>>(std::move(library), proto::encoding::VariantCodec{}, EncodingVersion::V1);
+}
+
+inline std::vector<entity::VariantKey> make_keys(size_t n) {
+    std::vector<entity::VariantKey> keys;
+    keys.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        keys.emplace_back(arcticdb::atom_key_builder().build(fmt::format("k_{}", i), entity::KeyType::TABLE_DATA));
+    }
+    return keys;
+}
+
+} // namespace remove_batch_test
+
+TEST(AsyncStoreRemoveKeys, AsyncSplitsIntoChunksRespectingBatchSize) {
+    using namespace remove_batch_test;
+    auto storage = std::make_shared<RecordingStorage>(as::LibraryPath{"a", "b"}, as::OpenMode::DELETE, 3);
+    auto store = build_async_store(storage);
+
+    store->remove_keys(make_keys(10), as::RemoveOpts{}).get();
+
+    auto sizes = storage->recorded_call_sizes();
+    std::sort(sizes.begin(), sizes.end());
+    ASSERT_EQ(sizes, std::vector<size_t>({1, 3, 3, 3}));
+}
+
+TEST(AsyncStoreRemoveKeys, SyncSplitsIntoChunksRespectingBatchSize) {
+    using namespace remove_batch_test;
+    auto storage = std::make_shared<RecordingStorage>(as::LibraryPath{"a", "b"}, as::OpenMode::DELETE, 3);
+    auto store = build_async_store(storage);
+
+    store->remove_keys_sync(make_keys(10), as::RemoveOpts{});
+
+    auto sizes = storage->recorded_call_sizes();
+    ASSERT_EQ(sizes, std::vector<size_t>({3, 3, 3, 1}));
+}
+
+TEST(AsyncStoreRemoveKeys, NulloptBatchSizeSendsSingleCall) {
+    using namespace remove_batch_test;
+    auto storage = std::make_shared<RecordingStorage>(as::LibraryPath{"a", "b"}, as::OpenMode::DELETE, std::nullopt);
+    auto store = build_async_store(storage);
+
+    store->remove_keys(make_keys(100), as::RemoveOpts{}).get();
+
+    auto sizes = storage->recorded_call_sizes();
+    ASSERT_EQ(sizes, std::vector<size_t>({100}));
+}
+
+TEST(AsyncStoreRemoveKeys, EmptyKeysIsNoOp) {
+    using namespace remove_batch_test;
+    auto storage = std::make_shared<RecordingStorage>(as::LibraryPath{"a", "b"}, as::OpenMode::DELETE, 3);
+    auto store = build_async_store(storage);
+
+    auto result = store->remove_keys(std::vector<entity::VariantKey>{}, as::RemoveOpts{}).get();
+
+    ASSERT_TRUE(result.empty());
+    ASSERT_TRUE(storage->recorded_call_sizes().empty());
+}
+
+TEST(KeyUtilsDeleteBatching, FlushesPendingBufferAtThreshold) {
+    using namespace remove_batch_test;
+    ScopedConfig scoped("Storage.DeletePendingBufferSize", 3);
+
+    auto storage = std::make_shared<RecordingStorage>(as::LibraryPath{"a", "b"}, as::OpenMode::DELETE, std::nullopt);
+    storage->seed_iter_keys(make_keys(11));
+    auto store = build_async_store(storage);
+
+    arcticdb::delete_keys_of_type_if(
+            store, [](const entity::VariantKey&) { return true; }, entity::KeyType::TABLE_DATA
+    );
+
+    ASSERT_EQ(storage->recorded_call_sizes(), std::vector<size_t>({3, 3, 3, 2}));
 }

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -795,9 +795,8 @@ TEST(AsyncStoreRemoveKeys, EmptyKeysIsNoOp) {
     auto storage = std::make_shared<RecordingStorage>(as::LibraryPath{"a", "b"}, as::OpenMode::DELETE, 3);
     auto store = build_async_store(storage);
 
-    auto result = store->remove_keys(std::vector<entity::VariantKey>{}, as::RemoveOpts{}).get();
+    store->remove_keys(std::vector<entity::VariantKey>{}, as::RemoveOpts{}).get();
 
-    ASSERT_TRUE(result.empty());
     ASSERT_TRUE(storage->recorded_call_sizes().empty());
 }
 

--- a/cpp/arcticdb/entity/test/test_variant_key.cpp
+++ b/cpp/arcticdb/entity/test/test_variant_key.cpp
@@ -29,12 +29,12 @@ AtomKey make_atom(KeyType kt, int64_t id) {
 
 TEST(VariantKey, KeyTypesEmpty) {
     std::vector<VariantKey> keys;
-    ASSERT_TRUE(key_types(keys).empty());
+    ASSERT_TRUE(unique_key_types(keys).empty());
 }
 
 TEST(VariantKey, KeyTypesSingleType) {
     std::vector<VariantKey> keys{make_atom(KeyType::TABLE_DATA, 1), make_atom(KeyType::TABLE_DATA, 2)};
-    auto result = key_types(keys);
+    auto result = unique_key_types(keys);
     ASSERT_EQ(result.size(), 1u);
     ASSERT_EQ(result.at(0), KeyType::TABLE_DATA);
 }
@@ -47,7 +47,7 @@ TEST(VariantKey, KeyTypesMultipleTypesDeduped) {
             make_atom(KeyType::VERSION, 4),
             make_atom(KeyType::TABLE_INDEX, 5),
     };
-    auto result = key_types(keys);
+    auto result = unique_key_types(keys);
     ASSERT_EQ(result.size(), 3u);
     // Results are returned in KeyType enum order.
     ASSERT_EQ(result.at(0), KeyType::TABLE_DATA);
@@ -60,7 +60,7 @@ TEST(VariantKey, KeyTypesAtomAndRefMix) {
             make_atom(KeyType::TABLE_DATA, 1),
             RefKey{"sym", KeyType::VERSION_REF},
     };
-    auto result = key_types(keys);
+    auto result = unique_key_types(keys);
     ASSERT_EQ(result.size(), 2u);
     ASSERT_EQ(result.at(0), KeyType::TABLE_DATA);
     ASSERT_EQ(result.at(1), KeyType::VERSION_REF);

--- a/cpp/arcticdb/entity/test/test_variant_key.cpp
+++ b/cpp/arcticdb/entity/test/test_variant_key.cpp
@@ -1,0 +1,67 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/entity/atom_key.hpp>
+#include <arcticdb/entity/ref_key.hpp>
+#include <arcticdb/entity/variant_key.hpp>
+
+using namespace arcticdb;
+using namespace arcticdb::entity;
+
+namespace {
+AtomKey make_atom(KeyType kt, int64_t id) {
+    return atom_key_builder()
+            .version_id(0)
+            .creation_ts(0)
+            .content_hash(0)
+            .start_index(NumericId{0})
+            .end_index(NumericId{0})
+            .build(NumericId{id}, kt);
+}
+} // namespace
+
+TEST(VariantKey, KeyTypesEmpty) {
+    std::vector<VariantKey> keys;
+    ASSERT_TRUE(key_types(keys).empty());
+}
+
+TEST(VariantKey, KeyTypesSingleType) {
+    std::vector<VariantKey> keys{make_atom(KeyType::TABLE_DATA, 1), make_atom(KeyType::TABLE_DATA, 2)};
+    auto result = key_types(keys);
+    ASSERT_EQ(result.size(), 1u);
+    ASSERT_EQ(result.at(0), KeyType::TABLE_DATA);
+}
+
+TEST(VariantKey, KeyTypesMultipleTypesDeduped) {
+    std::vector<VariantKey> keys{
+            make_atom(KeyType::TABLE_DATA, 1),
+            make_atom(KeyType::TABLE_INDEX, 2),
+            make_atom(KeyType::TABLE_DATA, 3),
+            make_atom(KeyType::VERSION, 4),
+            make_atom(KeyType::TABLE_INDEX, 5),
+    };
+    auto result = key_types(keys);
+    ASSERT_EQ(result.size(), 3u);
+    // Results are returned in KeyType enum order.
+    ASSERT_EQ(result.at(0), KeyType::TABLE_DATA);
+    ASSERT_EQ(result.at(1), KeyType::TABLE_INDEX);
+    ASSERT_EQ(result.at(2), KeyType::VERSION);
+}
+
+TEST(VariantKey, KeyTypesAtomAndRefMix) {
+    std::vector<VariantKey> keys{
+            make_atom(KeyType::TABLE_DATA, 1),
+            RefKey{"sym", KeyType::VERSION_REF},
+    };
+    auto result = key_types(keys);
+    ASSERT_EQ(result.size(), 2u);
+    ASSERT_EQ(result.at(0), KeyType::TABLE_DATA);
+    ASSERT_EQ(result.at(1), KeyType::VERSION_REF);
+}

--- a/cpp/arcticdb/entity/variant_key.hpp
+++ b/cpp/arcticdb/entity/variant_key.hpp
@@ -10,7 +10,9 @@
 
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/entity/ref_key.hpp>
+#include <array>
 #include <variant>
+#include <vector>
 #include <ranges>
 
 namespace arcticdb::entity {
@@ -46,6 +48,22 @@ inline std::string_view variant_key_view(const VariantKey& vk) {
 
 inline KeyType variant_key_type(const VariantKey& vk) {
     return std::visit([](const auto& key) { return key.type(); }, vk);
+}
+
+template<std::ranges::range R>
+requires std::same_as<std::remove_cvref_t<std::ranges::range_value_t<R>>, VariantKey>
+std::vector<KeyType> key_types(R&& keys) {
+    std::array<bool, static_cast<size_t>(KeyType::UNDEFINED)> present{};
+    for (const auto& k : keys) {
+        present.at(static_cast<size_t>(variant_key_type(k))) = true;
+    }
+    std::vector<KeyType> result;
+    for (size_t i = 0; i < present.size(); ++i) {
+        if (present.at(i)) {
+            result.push_back(static_cast<KeyType>(i));
+        }
+    }
+    return result;
 }
 
 inline const StreamId& variant_key_id(const VariantKey& vk) {

--- a/cpp/arcticdb/entity/variant_key.hpp
+++ b/cpp/arcticdb/entity/variant_key.hpp
@@ -52,7 +52,7 @@ inline KeyType variant_key_type(const VariantKey& vk) {
 
 template<std::ranges::range R>
 requires std::same_as<std::remove_cvref_t<std::ranges::range_value_t<R>>, VariantKey>
-std::vector<KeyType> key_types(R&& keys) {
+std::vector<KeyType> unique_key_types(R&& keys) {
     std::array<bool, static_cast<size_t>(KeyType::UNDEFINED)> present{};
     for (const auto& k : keys) {
         present.at(static_cast<size_t>(variant_key_type(k))) = true;

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -641,9 +641,7 @@ std::vector<SliceAndKey> flatten_and_fix_rows(
     return output;
 }
 
-folly::Future<StreamSink::RemoveKeyResultType> remove_slice_and_keys(
-        std::vector<SliceAndKey>&& slices, StreamSink& sink
-) {
+folly::Future<folly::Unit> remove_slice_and_keys(std::vector<SliceAndKey>&& slices, StreamSink& sink) {
     std::vector<VariantKey> keys;
     std::transform(
             std::make_move_iterator(std::begin(slices)),
@@ -654,7 +652,7 @@ folly::Future<StreamSink::RemoveKeyResultType> remove_slice_and_keys(
     return sink.remove_keys(std::move(keys)).thenValue([](auto&&) { return folly::makeFuture(); });
 }
 
-folly::Future<StreamSink::RemoveKeyResultType> remove_slice_and_keys_batches(
+folly::Future<folly::Unit> remove_slice_and_keys_batches(
         std::vector<std::vector<SliceAndKey>>&& slices_batches, StreamSink& sink
 ) {
     return folly::collect(folly::window(

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -102,7 +102,7 @@ template<typename T>
 requires std::is_same_v<T, SliceAndKey> || std::is_same_v<T, std::vector<SliceAndKey>>
 folly::SemiFuture<std::vector<T>> rollback_on_quota_exceeded(
         std::vector<folly::Try<T>>&& try_slices,
-        folly::Function<folly::Future<StreamSink::RemoveKeyResultType>(std::vector<T>&&)>&& remove_future
+        folly::Function<folly::Future<folly::Unit>(std::vector<T>&&)>&& remove_future
 ) {
     std::vector<T> succeeded;
     std::optional<folly::exception_wrapper> exception;
@@ -145,8 +145,6 @@ folly::SemiFuture<std::vector<std::vector<SliceAndKey>>> rollback_batches_on_quo
         const std::shared_ptr<stream::StreamSink>& sink
 );
 
-folly::Future<StreamSink::RemoveKeyResultType> remove_slice_and_keys(
-        std::vector<SliceAndKey>&& slices, StreamSink& sink
-);
+folly::Future<folly::Unit> remove_slice_and_keys(std::vector<SliceAndKey>&& slices, StreamSink& sink);
 
 } // namespace arcticdb::pipelines

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -21,8 +21,6 @@
 #include <arcticdb/storage/mock/azure_mock_client.hpp>
 #include <arcticdb/storage/storage_exceptions.hpp>
 
-#include <folly/gen/Base.h>
-
 #undef GetMessage
 
 namespace arcticdb::storage {
@@ -202,15 +200,12 @@ KeySegmentPair do_read_impl(
     return KeySegmentPair{};
 }
 
-namespace fg = folly::gen;
-
 template<class KeyBucketizer>
 void do_remove_impl(
         std::span<VariantKey> variant_keys, const std::string& root_folder, AzureClientWrapper& azure_client,
         KeyBucketizer&& bucketizer, unsigned int request_timeout
 ) {
     ARCTICDB_SUBSAMPLE(AzureStorageDeleteBatch, 0)
-    auto fmt_db = [](auto&& k) { return variant_key_type(k); };
 
     util::check(
             variant_keys.size() <= BATCH_SUBREQUEST_LIMIT,
@@ -220,21 +215,18 @@ void do_remove_impl(
             BATCH_SUBREQUEST_LIMIT
     );
 
-    (fg::from(variant_keys) | fg::move | fg::groupBy(fmt_db))
-            .foreach ([&root_folder, &azure_client, &request_timeout, b = std::move(bucketizer)](auto&& group) {
-                auto key_type_dir = key_type_folder(root_folder, group.key());
-                std::vector<std::string> to_delete;
-                to_delete.reserve(group.size());
-                for (auto k : folly::enumerate(group.values())) {
-                    to_delete.emplace_back(object_path(b.bucketize(key_type_dir, *k), *k));
-                }
-                try {
-                    azure_client.delete_blobs(to_delete, request_timeout);
-                } catch (const Azure::Core::RequestFailedException& e) {
-                    std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
-                    raise_azure_exception(e, failed_objects);
-                }
-            });
+    std::vector<std::string> to_delete;
+    to_delete.reserve(variant_keys.size());
+    for (const auto& k : variant_keys) {
+        auto key_type_dir = key_type_folder(root_folder, variant_key_type(k));
+        to_delete.emplace_back(object_path(bucketizer.bucketize(key_type_dir, k), k));
+    }
+    try {
+        azure_client.delete_blobs(to_delete, request_timeout);
+    } catch (const Azure::Core::RequestFailedException& e) {
+        std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
+        raise_azure_exception(e, failed_objects);
+    }
 }
 
 std::string prefix_handler(

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -211,41 +211,30 @@ void do_remove_impl(
 ) {
     ARCTICDB_SUBSAMPLE(AzureStorageDeleteBatch, 0)
     auto fmt_db = [](auto&& k) { return variant_key_type(k); };
-    std::vector<std::string> to_delete;
-    static const size_t delete_object_limit = std::min(
-            BATCH_SUBREQUEST_LIMIT,
-            static_cast<size_t>(ConfigsMap::instance()->get_int("AzureStorage.DeleteBatchSize", BATCH_SUBREQUEST_LIMIT))
+
+    util::check(
+            variant_keys.size() <= BATCH_SUBREQUEST_LIMIT,
+            "Azure do_remove_impl called with {} keys, which exceeds BATCH_SUBREQUEST_LIMIT={}. "
+            "AsyncStore is responsible for chunking inputs to max_delete_batch_size().",
+            variant_keys.size(),
+            BATCH_SUBREQUEST_LIMIT
     );
 
-    auto submit_batch = [&azure_client, &request_timeout](auto& to_delete) {
-        try {
-            azure_client.delete_blobs(to_delete, request_timeout);
-        } catch (const Azure::Core::RequestFailedException& e) {
-            std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
-            raise_azure_exception(e, failed_objects);
-        }
-        to_delete.clear();
-    };
-
     (fg::from(variant_keys) | fg::move | fg::groupBy(fmt_db))
-            .foreach ([&root_folder,
-                       b = std::move(bucketizer),
-                       delete_object_limit = delete_object_limit,
-                       &to_delete,
-                       &submit_batch](auto&& group
-                      ) { // bypass incorrect 'set but no used" error for delete_object_limit
+            .foreach ([&root_folder, &azure_client, &request_timeout, b = std::move(bucketizer)](auto&& group) {
                 auto key_type_dir = key_type_folder(root_folder, group.key());
+                std::vector<std::string> to_delete;
+                to_delete.reserve(group.size());
                 for (auto k : folly::enumerate(group.values())) {
-                    auto blob_name = object_path(b.bucketize(key_type_dir, *k), *k);
-                    to_delete.emplace_back(std::move(blob_name));
-                    if (to_delete.size() == delete_object_limit) {
-                        submit_batch(to_delete);
-                    }
+                    to_delete.emplace_back(object_path(b.bucketize(key_type_dir, *k), *k));
+                }
+                try {
+                    azure_client.delete_blobs(to_delete, request_timeout);
+                } catch (const Azure::Core::RequestFailedException& e) {
+                    std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
+                    raise_azure_exception(e, failed_objects);
                 }
             });
-    if (!to_delete.empty()) {
-        submit_batch(to_delete);
-    }
 }
 
 std::string prefix_handler(
@@ -357,6 +346,13 @@ void AzureStorage::do_remove(VariantKey&& variant_key, RemoveOpts) {
 
 void AzureStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts) {
     detail::do_remove_impl(std::move(variant_keys), root_folder_, *azure_client_, FlatBucketizer{}, request_timeout_);
+}
+
+std::optional<size_t> AzureStorage::max_delete_batch_size() const {
+    return std::min(
+            BATCH_SUBREQUEST_LIMIT,
+            static_cast<size_t>(ConfigsMap::instance()->get_int("AzureStorage.DeleteBatchSize", BATCH_SUBREQUEST_LIMIT))
+    );
 }
 
 bool AzureStorage::do_iterate_type_until_match(

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -25,6 +25,8 @@ class AzureStorage final : public Storage {
 
     std::string name() const final;
 
+    std::optional<size_t> max_delete_batch_size() const final override;
+
   protected:
     void do_write(KeySegmentPair& key_seg) final;
 

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -171,6 +171,8 @@ class Library {
 
     bool supports_atomic_writes() const { return storages_->supports_atomic_writes(); }
 
+    [[nodiscard]] std::optional<size_t> max_delete_batch_size() const { return storages_->max_delete_batch_size(); }
+
     [[nodiscard]] const LibraryPath& library_path() const { return library_path_; }
 
     [[nodiscard]] OpenMode open_mode() const { return storages_->open_mode(); }

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -9,7 +9,6 @@
 #include <arcticdb/storage/mongo/mongo_storage.hpp>
 
 #include <arcticdb/util/configs_map.hpp>
-#include <folly/gen/Base.h>
 
 #include <arcticdb/storage/mongo/mongo_client.hpp>
 #include <arcticdb/storage/mock/mongo_mock_client.hpp>
@@ -146,35 +145,31 @@ bool MongoStorage::do_fast_delete() {
 }
 
 void MongoStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts) {
-    namespace fg = folly::gen;
-    auto fmt_db = [](auto&& k) { return variant_key_type(k); };
     ARCTICDB_SAMPLE(MongoStorageRemove, 0)
     std::vector<VariantKey> keys_not_found;
 
-    (fg::from(variant_keys) | fg::move | fg::groupBy(fmt_db)).foreach ([&](auto&& group) {
-        for (auto& k : group.values()) {
-            auto collection = collection_name(variant_key_type(k));
-            try {
-                auto result = client_->remove_keyvalue(db_, collection, k);
-                storage::check<ErrorCode::E_MONGO_BULK_OP_NO_REPLY>(
-                        result.delete_count.has_value(), "Mongo did not acknowledge deletion for key {}", k
-                );
-                util::warn(
-                        result.delete_count.value() == 1,
-                        "Expected to delete a single document with key {} deleted {} documents",
-                        k,
-                        result.delete_count.value()
-                );
-                if (result.delete_count.value() == 0 && !opts.ignores_missing_key_) {
-                    keys_not_found.push_back(k);
-                }
-            } catch (const mongocxx::operation_exception& ex) {
-                // mongo delete does not throw exception if key not found, it returns 0 as delete count
-                std::string object_name = std::string(variant_key_view(k));
-                raise_mongo_exception(ex, object_name);
+    for (auto& k : variant_keys) {
+        auto collection = collection_name(variant_key_type(k));
+        try {
+            auto result = client_->remove_keyvalue(db_, collection, k);
+            storage::check<ErrorCode::E_MONGO_BULK_OP_NO_REPLY>(
+                    result.delete_count.has_value(), "Mongo did not acknowledge deletion for key {}", k
+            );
+            util::warn(
+                    result.delete_count.value() == 1,
+                    "Expected to delete a single document with key {} deleted {} documents",
+                    k,
+                    result.delete_count.value()
+            );
+            if (result.delete_count.value() == 0 && !opts.ignores_missing_key_) {
+                keys_not_found.push_back(k);
             }
+        } catch (const mongocxx::operation_exception& ex) {
+            // mongo delete does not throw exception if key not found, it returns 0 as delete count
+            std::string object_name = std::string(variant_key_view(k));
+            raise_mongo_exception(ex, object_name);
         }
-    });
+    }
     if (!keys_not_found.empty()) {
         throw KeyNotFoundException(std::move(keys_not_found));
     }

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -318,7 +318,7 @@ void do_remove_impl(
 
     std::vector<std::optional<query_stats::RAIIAddTime>> stat_timers;
     if (query_stats::QueryStats::instance()->is_enabled()) {
-        auto distinct_key_types = key_types(ks);
+        auto distinct_key_types = unique_key_types(ks);
         stat_timers.reserve(distinct_key_types.size());
         for (auto kt : distinct_key_types) {
             stat_timers.emplace_back(query_stats::add_task_count_and_time(query_stats::TaskType::S3_DeleteObjects, kt));

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -299,62 +299,53 @@ void do_remove_impl(
 ) {
     ARCTICDB_SUBSAMPLE(S3StorageDeleteBatch, 0)
     auto fmt_db = [](auto&& k) { return variant_key_type(k); };
-    std::vector<std::string> to_delete;
     boost::container::small_vector<FailedDelete, 1> failed_deletes;
-    static const size_t delete_object_limit = std::min(
-            DELETE_OBJECTS_LIMIT,
-            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", 1000))
-    );
 
-    to_delete.reserve(std::min(ks.size(), delete_object_limit));
+    util::check(
+            ks.size() <= DELETE_OBJECTS_LIMIT,
+            "S3 do_remove_impl called with {} keys, which exceeds DELETE_OBJECTS_LIMIT={}. "
+            "AsyncStore is responsible for chunking inputs to max_delete_batch_size().",
+            ks.size(),
+            DELETE_OBJECTS_LIMIT
+    );
 
     (fg::from(ks) | fg::move | fg::groupBy(fmt_db))
             .foreach ([&s3_client,
                        &root_folder,
                        &bucket_name,
-                       &to_delete,
                        b = std::forward<KeyBucketizer>(bucketizer),
                        &failed_deletes](auto&& group) {
                 auto key_type_dir = key_type_folder(root_folder, group.key());
+                std::vector<std::string> to_delete;
+                to_delete.reserve(group.size());
                 for (auto k : folly::enumerate(group.values())) {
-                    auto s3_object_name = object_path(b.bucketize(key_type_dir, *k), *k);
-                    to_delete.emplace_back(std::move(s3_object_name));
-
-                    if (to_delete.size() == delete_object_limit || k.index + 1 == group.size()) {
-                        auto query_stat_operation_time = query_stats::add_task_count_and_time(
-                                query_stats::TaskType::S3_DeleteObjects, group.key()
+                    to_delete.emplace_back(object_path(b.bucketize(key_type_dir, *k), *k));
+                }
+                auto query_stat_operation_time =
+                        query_stats::add_task_count_and_time(query_stats::TaskType::S3_DeleteObjects, group.key());
+                auto delete_object_result = s3_client.delete_objects(to_delete, bucket_name);
+                if (delete_object_result.is_success()) {
+                    ARCTICDB_RUNTIME_DEBUG(
+                            log::storage(), "Deleted {} objects of type {}", to_delete.size(), group.key()
+                    );
+                    for (auto& bad_key : delete_object_result.get_output().failed_deletes) {
+                        auto bad_key_name = bad_key.s3_object_name.substr(key_type_dir.size(), std::string::npos);
+                        failed_deletes.emplace_back(
+                                variant_key_from_bytes(
+                                        reinterpret_cast<const uint8_t*>(bad_key_name.data()),
+                                        bad_key_name.size(),
+                                        group.key()
+                                ),
+                                std::move(bad_key.error_message)
                         );
-                        auto delete_object_result = s3_client.delete_objects(to_delete, bucket_name);
-                        if (delete_object_result.is_success()) {
-                            ARCTICDB_RUNTIME_DEBUG(
-                                    log::storage(),
-                                    "Deleted {} objects, one of which with key '{}'",
-                                    to_delete.size(),
-                                    variant_key_view(*k)
-                            );
-                            for (auto& bad_key : delete_object_result.get_output().failed_deletes) {
-                                auto bad_key_name =
-                                        bad_key.s3_object_name.substr(key_type_dir.size(), std::string::npos);
-                                failed_deletes.emplace_back(
-                                        variant_key_from_bytes(
-                                                reinterpret_cast<const uint8_t*>(bad_key_name.data()),
-                                                bad_key_name.size(),
-                                                group.key()
-                                        ),
-                                        std::move(bad_key.error_message)
-                                );
-                            }
-                        } else {
-                            auto& error = delete_object_result.get_error();
-                            std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
-                            raise_s3_exception(error, failed_objects);
-                        }
-                        to_delete.clear();
                     }
+                } else {
+                    auto& error = delete_object_result.get_error();
+                    std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
+                    raise_s3_exception(error, failed_objects);
                 }
             });
 
-    util::check(to_delete.empty(), "Have {} segment that have not been removed", to_delete.size());
     raise_if_failed_deletes(failed_deletes);
 }
 

--- a/cpp/arcticdb/storage/s3/detail-inl.hpp
+++ b/cpp/arcticdb/storage/s3/detail-inl.hpp
@@ -32,6 +32,8 @@
 
 #include <boost/interprocess/streams/bufferstream.hpp>
 
+#include <optional>
+
 #undef GetMessage
 
 namespace arcticdb::storage {
@@ -40,7 +42,6 @@ using namespace object_store_utils;
 
 namespace s3 {
 
-namespace fg = folly::gen;
 namespace detail {
 
 static const size_t DELETE_OBJECTS_LIMIT = 1000;
@@ -267,12 +268,12 @@ void do_read_impl(
 }
 
 struct FailedDelete {
-    VariantKey failed_key;
+    std::string failed_key_name;
     std::string error_message;
 
-    FailedDelete(VariantKey&& failed_key, std::string&& error_message) :
-        failed_key(failed_key),
-        error_message(error_message) {}
+    FailedDelete(std::string failed_key_name, std::string error_message) :
+        failed_key_name(std::move(failed_key_name)),
+        error_message(std::move(error_message)) {}
 };
 
 inline void raise_if_failed_deletes(const boost::container::small_vector<FailedDelete, 1>& failed_deletes) {
@@ -281,7 +282,7 @@ inline void raise_if_failed_deletes(const boost::container::small_vector<FailedD
         for (auto i = 0u; i < failed_deletes.size(); ++i) {
             auto& failed = failed_deletes[i];
             failed_deletes_message << fmt::format(
-                    "'{}' failed with '{}'", to_serialized_key(failed.failed_key), failed.error_message
+                    "'{}' failed with '{}'", failed.failed_key_name, failed.error_message
             );
             if (i != failed_deletes.size()) {
                 failed_deletes_message << ", ";
@@ -298,7 +299,6 @@ void do_remove_impl(
         S3ClientInterface& s3_client, KeyBucketizer&& bucketizer
 ) {
     ARCTICDB_SUBSAMPLE(S3StorageDeleteBatch, 0)
-    auto fmt_db = [](auto&& k) { return variant_key_type(k); };
     boost::container::small_vector<FailedDelete, 1> failed_deletes;
 
     util::check(
@@ -309,42 +309,33 @@ void do_remove_impl(
             DELETE_OBJECTS_LIMIT
     );
 
-    (fg::from(ks) | fg::move | fg::groupBy(fmt_db))
-            .foreach ([&s3_client,
-                       &root_folder,
-                       &bucket_name,
-                       b = std::forward<KeyBucketizer>(bucketizer),
-                       &failed_deletes](auto&& group) {
-                auto key_type_dir = key_type_folder(root_folder, group.key());
-                std::vector<std::string> to_delete;
-                to_delete.reserve(group.size());
-                for (auto k : folly::enumerate(group.values())) {
-                    to_delete.emplace_back(object_path(b.bucketize(key_type_dir, *k), *k));
-                }
-                auto query_stat_operation_time =
-                        query_stats::add_task_count_and_time(query_stats::TaskType::S3_DeleteObjects, group.key());
-                auto delete_object_result = s3_client.delete_objects(to_delete, bucket_name);
-                if (delete_object_result.is_success()) {
-                    ARCTICDB_RUNTIME_DEBUG(
-                            log::storage(), "Deleted {} objects of type {}", to_delete.size(), group.key()
-                    );
-                    for (auto& bad_key : delete_object_result.get_output().failed_deletes) {
-                        auto bad_key_name = bad_key.s3_object_name.substr(key_type_dir.size(), std::string::npos);
-                        failed_deletes.emplace_back(
-                                variant_key_from_bytes(
-                                        reinterpret_cast<const uint8_t*>(bad_key_name.data()),
-                                        bad_key_name.size(),
-                                        group.key()
-                                ),
-                                std::move(bad_key.error_message)
-                        );
-                    }
-                } else {
-                    auto& error = delete_object_result.get_error();
-                    std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
-                    raise_s3_exception(error, failed_objects);
-                }
-            });
+    std::vector<std::string> to_delete;
+    to_delete.reserve(ks.size());
+    for (const auto& k : ks) {
+        auto key_type_dir = key_type_folder(root_folder, variant_key_type(k));
+        to_delete.emplace_back(object_path(bucketizer.bucketize(key_type_dir, k), k));
+    }
+
+    std::vector<std::optional<query_stats::RAIIAddTime>> stat_timers;
+    if (query_stats::QueryStats::instance()->is_enabled()) {
+        auto distinct_key_types = key_types(ks);
+        stat_timers.reserve(distinct_key_types.size());
+        for (auto kt : distinct_key_types) {
+            stat_timers.emplace_back(query_stats::add_task_count_and_time(query_stats::TaskType::S3_DeleteObjects, kt));
+        }
+    }
+
+    auto delete_object_result = s3_client.delete_objects(to_delete, bucket_name);
+    if (delete_object_result.is_success()) {
+        ARCTICDB_RUNTIME_DEBUG(log::storage(), "Deleted {} objects", to_delete.size());
+        for (auto& bad_key : delete_object_result.get_output().failed_deletes) {
+            failed_deletes.emplace_back(std::move(bad_key.s3_object_name), std::move(bad_key.error_message));
+        }
+    } else {
+        auto& error = delete_object_result.get_error();
+        std::string failed_objects = fmt::format("{}", fmt::join(to_delete, ", "));
+        raise_s3_exception(error, failed_objects);
+    }
 
     raise_if_failed_deletes(failed_deletes);
 }
@@ -385,16 +376,7 @@ void do_remove_no_batching_impl(
         } else if (const auto& error = delete_object_result.get_error(); !is_not_found_error(error.GetErrorType())) {
             auto key_type_dir = key_type_folder(root_folder, variant_key_type(k));
             auto s3_object_name = object_path(bucketizer.bucketize(key_type_dir, k), k);
-            auto bad_key_name = s3_object_name.substr(key_type_dir.size(), std::string::npos);
-            auto error_message = error.GetMessage();
-            failed_deletes.push_back(FailedDelete{
-                    variant_key_from_bytes(
-                            reinterpret_cast<const uint8_t*>(bad_key_name.data()),
-                            bad_key_name.size(),
-                            variant_key_type(k)
-                    ),
-                    std::move(error_message)
-            });
+            failed_deletes.emplace_back(std::move(s3_object_name), error.GetMessage());
         } else {
             ARCTICDB_RUNTIME_DEBUG(
                     log::storage(), "Acceptable error when deleting object with key '{}'", variant_key_view(k)

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -221,7 +221,9 @@ void NfsBackedStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts)
 std::optional<size_t> NfsBackedStorage::max_delete_batch_size() const {
     return std::min(
             s3::detail::DELETE_OBJECTS_LIMIT,
-            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", s3::detail::DELETE_OBJECTS_LIMIT))
+            static_cast<size_t>(
+                    ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", s3::detail::DELETE_OBJECTS_LIMIT)
+            )
     );
 }
 

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -221,7 +221,7 @@ void NfsBackedStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts)
 std::optional<size_t> NfsBackedStorage::max_delete_batch_size() const {
     return std::min(
             s3::detail::DELETE_OBJECTS_LIMIT,
-            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", 1000))
+            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", s3::detail::DELETE_OBJECTS_LIMIT))
     );
 }
 

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -218,6 +218,13 @@ void NfsBackedStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts)
     s3::detail::do_remove_impl(std::span(enc), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
 }
 
+std::optional<size_t> NfsBackedStorage::max_delete_batch_size() const {
+    return std::min(
+            s3::detail::DELETE_OBJECTS_LIMIT,
+            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", 1000))
+    );
+}
+
 bool NfsBackedStorage::do_iterate_type_until_match(
         KeyType key_type, const IterateTypePredicate& visitor, const std::string& prefix
 ) {

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -25,6 +25,8 @@ class NfsBackedStorage final : public Storage {
 
     bool supports_object_size_calculation() const final override;
 
+    std::optional<size_t> max_delete_batch_size() const final override;
+
   private:
     void do_write(KeySegmentPair& key_seg) final;
 

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -108,7 +108,7 @@ void S3Storage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts) {
 std::optional<size_t> S3Storage::max_delete_batch_size() const {
     return std::min(
             detail::DELETE_OBJECTS_LIMIT,
-            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", 1000))
+            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", detail::DELETE_OBJECTS_LIMIT))
     );
 }
 

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -105,6 +105,13 @@ void S3Storage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts) {
     detail::do_remove_impl(variant_keys, root_folder_, bucket_name_, client(), FlatBucketizer{});
 }
 
+std::optional<size_t> S3Storage::max_delete_batch_size() const {
+    return std::min(
+            detail::DELETE_OBJECTS_LIMIT,
+            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", 1000))
+    );
+}
+
 void S3Storage::do_remove(VariantKey&& variant_key, RemoveOpts) {
     detail::do_remove_impl(std::move(variant_key), root_folder_, bucket_name_, client(), FlatBucketizer{});
 }

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -108,7 +108,9 @@ void S3Storage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts) {
 std::optional<size_t> S3Storage::max_delete_batch_size() const {
     return std::min(
             detail::DELETE_OBJECTS_LIMIT,
-            static_cast<size_t>(ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", detail::DELETE_OBJECTS_LIMIT))
+            static_cast<size_t>(
+                    ConfigsMap::instance()->get_int("S3Storage.DeleteBatchSize", detail::DELETE_OBJECTS_LIMIT)
+            )
     );
 }
 

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -40,6 +40,8 @@ class S3Storage : public Storage, AsyncStorage {
 
     bool supports_object_size_calculation() const final;
 
+    std::optional<size_t> max_delete_batch_size() const override;
+
     // These are only public for testing purposes
     S3ClientInterface& client() { return *s3_client_; }
     bool directory_bucket() const { return directory_bucket_; }
@@ -102,6 +104,8 @@ class S3Storage : public Storage, AsyncStorage {
 class GCPXMLStorage : public S3Storage {
   public:
     GCPXMLStorage(const LibraryPath& lib, OpenMode mode, const GCPXMLSettings& conf);
+
+    std::optional<size_t> max_delete_batch_size() const override { return std::nullopt; }
 
   protected:
     void do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts) override;

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -15,6 +15,7 @@
 #include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/stream/index.hpp>
 
+#include <optional>
 #include <span>
 
 namespace arcticdb::storage {
@@ -125,6 +126,10 @@ class Storage {
     }
 
     bool fast_delete() { return do_fast_delete(); }
+
+    // Maximum number of keys this storage will accept in a single do_remove(span) call
+    // std::nullopt means no limit (e.g. LMDB, memory)
+    [[nodiscard]] virtual std::optional<size_t> max_delete_batch_size() const { return std::nullopt; }
 
     virtual void cleanup() {}
 

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -203,6 +203,8 @@ class Storages {
 
     void remove(std::span<VariantKey> variant_keys, storage::RemoveOpts opts) { primary().remove(variant_keys, opts); }
 
+    [[nodiscard]] std::optional<size_t> max_delete_batch_size() const { return primary().max_delete_batch_size(); }
+
     [[nodiscard]] OpenMode open_mode() const { return mode_; }
 
     void move_storage(KeyType key_type, timestamp horizon, size_t storage_index = 0) {

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -281,7 +281,7 @@ class InMemoryStore : public Store {
         }
     }
 
-    RemoveKeyResultType remove_key_sync(const entity::VariantKey& key, storage::RemoveOpts opts) override {
+    void remove_key_sync(const entity::VariantKey& key, storage::RemoveOpts opts) override {
         StorageFailureSimulator::instance()->go(FailureType::DELETE);
         std::lock_guard lock{mutex_};
         size_t removed = util::variant_match(
@@ -293,11 +293,11 @@ class InMemoryStore : public Store {
         if (removed == 0 && !opts.ignores_missing_key_) {
             throw storage::KeyNotFoundException(VariantKey(key));
         }
-        return {};
     }
 
-    folly::Future<RemoveKeyResultType> remove_key(const VariantKey& key, storage::RemoveOpts opts) override {
-        return folly::makeFuture(remove_key_sync(key, opts));
+    folly::Future<folly::Unit> remove_key(const VariantKey& key, storage::RemoveOpts opts) override {
+        remove_key_sync(key, opts);
+        return folly::Unit{};
     }
 
     timestamp current_timestamp() override { return PilotedClock::nanos_since_epoch(); }
@@ -401,47 +401,31 @@ class InMemoryStore : public Store {
         return output;
     }
 
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
-            const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts
-    ) override {
-        std::vector<RemoveKeyResultType> output;
-        for (const auto& key : keys) {
-            output.emplace_back(remove_key_sync(key, opts));
-        }
-
-        return output;
-    }
-
-    folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
-            std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts
-    ) override {
-        std::vector<RemoveKeyResultType> output;
-        for (const auto& key : keys) {
-            output.emplace_back(remove_key_sync(key, opts));
-        }
-
-        return output;
-    }
-
-    std::vector<RemoveKeyResultType> remove_keys_sync(
-            const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts
-    ) override {
-        std::vector<RemoveKeyResultType> output;
-        for (const auto& key : keys) {
-            output.emplace_back(remove_key_sync(key, opts));
-        }
-
-        return output;
-    }
-
-    std::vector<RemoveKeyResultType> remove_keys_sync(std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts)
+    folly::Future<folly::Unit> remove_keys(const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts)
             override {
-        std::vector<RemoveKeyResultType> output;
         for (const auto& key : keys) {
-            output.emplace_back(remove_key_sync(key, opts));
+            remove_key_sync(key, opts);
         }
+        return folly::Unit{};
+    }
 
-        return output;
+    folly::Future<folly::Unit> remove_keys(std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts) override {
+        for (const auto& key : keys) {
+            remove_key_sync(key, opts);
+        }
+        return folly::Unit{};
+    }
+
+    void remove_keys_sync(const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts) override {
+        for (const auto& key : keys) {
+            remove_key_sync(key, opts);
+        }
+    }
+
+    void remove_keys_sync(std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts) override {
+        for (const auto& key : keys) {
+            remove_key_sync(key, opts);
+        }
     }
 
     size_t num_atom_keys() const { return seg_by_atom_key_.size(); }

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -46,13 +46,6 @@ struct PartialKey {
 };
 
 struct StreamSink {
-    /**
-     The remove_key{,s,sync} methods used to return the key to indicate success/not. However, most implementations
-     moved() the key internally to avoid expensive string copying, so no key can actually be returned.
-     In the future, may return a bool.
-    */
-    using RemoveKeyResultType = folly::Unit;
-
     virtual ~StreamSink() = default;
 
     [[nodiscard]] virtual folly::Future<entity::VariantKey> write(
@@ -121,27 +114,25 @@ struct StreamSink {
     [[nodiscard]] virtual folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair> kvs
     ) = 0;
 
-    [[nodiscard]] virtual folly::Future<RemoveKeyResultType> remove_key(
+    [[nodiscard]] virtual folly::Future<folly::Unit> remove_key(
             const entity::VariantKey& key, storage::RemoveOpts opts = storage::RemoveOpts{}
     ) = 0;
 
-    virtual RemoveKeyResultType remove_key_sync(
-            const entity::VariantKey& key, storage::RemoveOpts opts = storage::RemoveOpts{}
-    ) = 0;
+    virtual void remove_key_sync(const entity::VariantKey& key, storage::RemoveOpts opts = storage::RemoveOpts{}) = 0;
 
-    [[nodiscard]] virtual folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
+    [[nodiscard]] virtual folly::Future<folly::Unit> remove_keys(
             const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts = storage::RemoveOpts{}
     ) = 0;
 
-    [[nodiscard]] virtual folly::Future<std::vector<RemoveKeyResultType>> remove_keys(
+    [[nodiscard]] virtual folly::Future<folly::Unit> remove_keys(
             std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts = storage::RemoveOpts{}
     ) = 0;
 
-    virtual std::vector<RemoveKeyResultType> remove_keys_sync(
+    virtual void remove_keys_sync(
             const std::vector<entity::VariantKey>& keys, storage::RemoveOpts opts = storage::RemoveOpts{}
     ) = 0;
 
-    virtual std::vector<RemoveKeyResultType> remove_keys_sync(
+    virtual void remove_keys_sync(
             std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts = storage::RemoveOpts{}
     ) = 0;
 

--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -42,6 +42,8 @@ inline void delete_keys_of_type_if(
                         keys = {};
                         keys.reserve(flush_threshold);
                         const auto batch_size = batch.size();
+                        // Async remove_keys spreads the batch out across the IO threadpool, remove_keys_sync would
+                        // delete the keys in serial. We block on the result here to bound memory.
                         store->remove_keys(std::move(batch)).get();
                         total_flushed += batch_size;
                         log::storage().debug(

--- a/cpp/arcticdb/util/key_utils.hpp
+++ b/cpp/arcticdb/util/key_utils.hpp
@@ -21,25 +21,51 @@ inline void delete_keys_of_type_if(
         const std::shared_ptr<Store>& store, Predicate&& predicate, KeyType key_type,
         const std::string& prefix = std::string(), bool continue_on_error = false
 ) {
-    static const size_t delete_object_limit = ConfigsMap::instance()->get_int("Storage.DeleteBatchSize", 1000);
-    std::vector<VariantKey> keys{};
+    const size_t flush_threshold = ConfigsMap::instance()->get_int("Storage.DeletePendingBufferSize", 100'000);
+    std::vector<VariantKey> keys;
+    keys.reserve(flush_threshold);
+    size_t total_flushed = 0;
     try {
         store->iterate_type(
                 key_type,
-                [predicate = std::forward<Predicate>(predicate), store = store, &keys](VariantKey&& key) {
-                    if (predicate(key))
-                        keys.emplace_back(std::move(key));
-
-                    if (keys.size() == delete_object_limit) {
-                        store->remove_keys(keys).get();
-                        keys.clear();
+                [predicate = std::forward<Predicate>(predicate),
+                 &keys,
+                 &total_flushed,
+                 store,
+                 key_type,
+                 flush_threshold](VariantKey&& key) {
+                    if (!predicate(key))
+                        return;
+                    keys.emplace_back(std::move(key));
+                    if (keys.size() >= flush_threshold) {
+                        auto batch = std::move(keys);
+                        keys = {};
+                        keys.reserve(flush_threshold);
+                        const auto batch_size = batch.size();
+                        store->remove_keys(std::move(batch)).get();
+                        total_flushed += batch_size;
+                        log::storage().debug(
+                                "delete_keys_of_type_if: flushed {} keys of type {} (cumulative {})",
+                                batch_size,
+                                key_type,
+                                total_flushed
+                        );
                     }
                 },
                 prefix
         );
 
-        if (!keys.empty())
-            store->remove_keys(keys).get();
+        if (!keys.empty()) {
+            const auto batch_size = keys.size();
+            store->remove_keys(std::move(keys)).get();
+            total_flushed += batch_size;
+            log::storage().debug(
+                    "delete_keys_of_type_if: final flush of {} keys of type {} (cumulative {})",
+                    batch_size,
+                    key_type,
+                    total_flushed
+            );
+        }
     } catch (const std::exception& ex) {
         if (continue_on_error)
             log::storage().warn("Caught exception {} trying to delete key, continuing", ex.what());

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -764,9 +764,7 @@ VariantKey write_symbols(
     return store->write_sync(KeyType::SYMBOL_LIST, 0, stream_id, NumericIndex{0}, NumericIndex{0}, std::move(segment));
 }
 
-std::vector<Store::RemoveKeyResultType> delete_keys(
-        const std::shared_ptr<Store>& store, std::vector<AtomKey>&& remove, const AtomKey& exclude
-) {
+void delete_keys(const std::shared_ptr<Store>& store, std::vector<AtomKey>&& remove, const AtomKey& exclude) {
     auto to_remove = std::move(remove);
     std::vector<VariantKey> variant_keys;
     variant_keys.reserve(to_remove.size());
@@ -777,7 +775,7 @@ std::vector<Store::RemoveKeyResultType> delete_keys(
             variant_keys.emplace_back(atom_key);
     }
 
-    return store->remove_keys_sync(variant_keys);
+    store->remove_keys_sync(variant_keys);
 }
 
 bool has_recent_compaction(

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -215,9 +215,7 @@ class SymbolList {
     [[nodiscard]] bool needs_compaction(const LoadResult& load_result) const;
 };
 
-std::vector<Store::RemoveKeyResultType> delete_keys(
-        const std::shared_ptr<Store>& store, std::vector<AtomKey>&& remove, const AtomKey& exclude
-);
+void delete_keys(const std::shared_ptr<Store>& store, std::vector<AtomKey>&& remove, const AtomKey& exclude);
 
 struct WriteSymbolTask : async::BaseTask {
     const std::shared_ptr<Store> store_;

--- a/cpp/arcticdb/version/version_map.hpp
+++ b/cpp/arcticdb/version/version_map.hpp
@@ -709,7 +709,7 @@ class VersionMapImpl {
             );
             store->remove_key_sync(*entry.head_);
         }
-        std::vector<folly::Future<Store::RemoveKeyResultType>> key_futs;
+        std::vector<folly::Future<folly::Unit>> key_futs;
         for (const auto& key : entry.keys_) {
             if (key.type() == KeyType::VERSION)
                 key_futs.emplace_back(store->remove_key(key.to_atom_key(entry.stream_id_)));

--- a/python/tests/integration/arcticdb/version_store/test_bulk_delete.py
+++ b/python/tests/integration/arcticdb/version_store/test_bulk_delete.py
@@ -1,0 +1,63 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from arcticdb_ext.storage import KeyType
+from arcticdb.util.test import config_context, query_stats_operation_count
+import arcticdb.toolbox.query_stats as qs
+
+
+def _write_versions(lib, symbol, num_versions):
+    for i in range(num_versions):
+        df = pd.DataFrame({"x": np.arange(i, i + 5, dtype=np.int64)})
+        lib.write(symbol, df)
+
+
+@pytest.mark.storage
+def test_bulk_delete_batching(object_and_mem_and_lmdb_version_store, sym):
+    lib = object_and_mem_and_lmdb_version_store
+    num_versions = 12
+    batch_size = 5
+
+    with (
+        config_context("S3Storage.DeleteBatchSize", batch_size),
+        config_context("AzureStorage.DeleteBatchSize", batch_size),
+    ):
+        _write_versions(lib, sym, num_versions)
+
+        lib_tool = lib.library_tool()
+        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, sym)) == num_versions
+        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, sym)) == num_versions
+
+        lib.delete(sym)
+
+        assert lib.has_symbol(sym) is False
+        assert lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, sym) == []
+        assert lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, sym) == []
+
+
+def test_bulk_delete_issues_one_storage_op_per_batch(s3_version_store_v1, sym, clear_query_stats):
+    lib = s3_version_store_v1
+    num_versions = 12
+    batch_size = 5
+    expected_batches_per_key_type = 3
+
+    with config_context("S3Storage.DeleteBatchSize", batch_size):
+        _write_versions(lib, sym, num_versions)
+
+        qs.enable()
+        qs.reset_stats()
+        lib.delete(sym)
+        stats = qs.get_query_stats()
+
+    assert query_stats_operation_count(stats, "S3_DeleteObjects", "TABLE_INDEX") == expected_batches_per_key_type
+    assert query_stats_operation_count(stats, "S3_DeleteObjects", "TABLE_DATA") == expected_batches_per_key_type
+    assert query_stats_operation_count(stats, "S3_DeleteObjects", "COLUMN_STATS") == expected_batches_per_key_type

--- a/python/tests/integration/arcticdb/version_store/test_bulk_delete.py
+++ b/python/tests/integration/arcticdb/version_store/test_bulk_delete.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 from arcticdb_ext.storage import KeyType
-from arcticdb.util.test import config_context, query_stats_operation_count
+from arcticdb.util.test import config_context, config_context_multi, query_stats_operation_count
 import arcticdb.toolbox.query_stats as qs
 
 
@@ -22,15 +22,12 @@ def _write_versions(lib, symbol, num_versions):
 
 
 @pytest.mark.storage
-def test_bulk_delete_batching(object_and_mem_and_lmdb_version_store, sym):
+def test_delete_removes_all_keys_when_chunked(object_and_mem_and_lmdb_version_store, sym):
     lib = object_and_mem_and_lmdb_version_store
     num_versions = 12
     batch_size = 5
 
-    with (
-        config_context("S3Storage.DeleteBatchSize", batch_size),
-        config_context("AzureStorage.DeleteBatchSize", batch_size),
-    ):
+    with config_context_multi({"S3Storage.DeleteBatchSize": batch_size, "AzureStorage.DeleteBatchSize": batch_size}):
         _write_versions(lib, sym, num_versions)
 
         lib_tool = lib.library_tool()

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -80,7 +80,7 @@ def test_remove_incomplete(arctic_library_v1, batch, batch_size, lib_name):
             arctic_library_v1._dev_tools.remove_incompletes(["sym"])
         return  # remove_incompletes not implemented on Mongo 8784267430
 
-    with config_context_multi({"Storage.DeleteBatchSize": batch_size, "S3Storage.DeleteBatchSize": 2 * batch_size}):
+    with config_context_multi({"S3Storage.DeleteBatchSize": batch_size, "AzureStorage.DeleteBatchSize": batch_size}):
         lib_tool = lib.library_tool()
         assert lib_tool.find_keys(KeyType.APPEND_DATA) == []
         assert lib.list_symbols_with_incomplete_data() == []
@@ -134,7 +134,7 @@ def test_remove_incompletes(arctic_library_v1, batch_size):
             arctic_library_v1._dev_tools.remove_incompletes(["sym"])
         return  # remove_incompletes not implemented on Mongo 8784267430
 
-    with config_context_multi({"Storage.DeleteBatchSize": batch_size, "S3Storage.DeleteBatchSize": 2 * batch_size}):
+    with config_context_multi({"S3Storage.DeleteBatchSize": batch_size, "AzureStorage.DeleteBatchSize": batch_size}):
         lib = arctic_library_v1
         lib_tool = lib._dev_tools.library_tool()
         assert lib_tool.find_keys(KeyType.APPEND_DATA) == []


### PR DESCRIPTION
Discovered while working on delayed deletes. I created a library on PURE with 1000 symbols, with ~200 versions each and 10 snapshots.

Then running delayed deletes had these results:

| Side                                    | Elapsed (s) | Peak RSS (MiB) |
| --------------------------------------- | ----------: | -------------: |
| arcticdb HEAD (47bba8011, parallel batches) | 349.9648 |          780.3 |
| arcticdb 2d1e60edf (pre-batching)           | 399.6425 |          792.9 |
| arcticc                                     | 333.3081 |          421.3 |

Notably running delayed deletes in "dry run" mode (which skips the physical deletion) showed no performance difference between arcticc and ArcticDB, for example on a small example:

| Side     | Mode    | Elapsed (s) | Peak RSS (MiB) |
| -------- | ------- | ----------: | -------------: |
| arcticdb | dry-run |      6.4449 |          388.2 |
| arcticdb | real    |     19.2177 |          427.9 |
| arcticc  | dry-run |      8.6100 |          329.0 |
| arcticc  | real    |     11.2915 |          330.4 |

arcticc submitted `RemoveBatchTask` in chunks of 1000 https://mangit.maninvestments.com/projects/DATA/repos/arcticc/browse/arcticcxx_impl/async/async_store.hpp#238 but https://github.com/man-group/ArcticDB/pull/70 changed it to this implementation.

If we delete 10k keys, the old implementation in arcticc would submit 10 tasks to delete 1000 keys in parallel, whereas ArcticDB currently submits 10 HTTP requests to delete 1000 keys in serial.

This explains most of the performance difference between arcticc delayed deletes and enterprise delayed deletes.

To stop storage specific deletion batch size limits leaking out of the storage layer, this PR has each storage declare its maximum deletion batch size, which is then used by the `AsyncStore` when it calculates the batches.