### PR TITLE
Save a constant for last background deletion time, and add Python bindings for the constants for the enterprise apps to use

### DIFF
--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -13,6 +13,7 @@
 #include <arcticdb/entity/data_error.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
 #include <arcticdb/version/version_store_api.hpp>
+#include <arcticdb/version/version_constants.hpp>
 #include <arcticdb/version/python_bindings_common.hpp>
 #include <arcticdb/python/python_utils.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
@@ -147,6 +148,22 @@ void declare_resample_clause(py::module& version) {
 void register_bindings(py::module& version, py::exception<arcticdb::ArcticException>& base_exception) {
 
     py::register_local_exception<StreamDescriptorMismatch>(version, "StreamDescriptorMismatch", base_exception.ptr());
+
+    // Useful for enterprise
+    auto constants = version.def_submodule("constants", "Reserved stream id constants used by ArcticDB");
+    constants.attr("WRITE_VERSION_ID") = py::str(WriteVersionId);
+    constants.attr("TOMBSTONE_VERSION_ID") = py::str(TombstoneVersionId);
+    constants.attr("TOMBSTONE_ALL_VERSION_ID") = py::str(TombstoneAllVersionId);
+    constants.attr("CREATE_SNAPSHOT_ID") = py::str(CreateSnapshotId);
+    constants.attr("DELETE_SNAPSHOT_ID") = py::str(DeleteSnapshotId);
+    constants.attr("LAST_SYNC_ID") = py::str(LastSyncId);
+    constants.attr("LAST_BACKUP_ID") = py::str(LastBackupId);
+    constants.attr("LAST_BACKGROUND_DELETION_ID") = py::str(LastBackgroundDeletionId);
+    constants.attr("FAILED_TARGET_ID") = py::str(FailedTargetId);
+    constants.attr("STORAGE_LOG_ID") = py::str(StorageLogId);
+    constants.attr("FAILED_STORAGE_LOG_ID") = py::str(FailedStorageLogId);
+    constants.attr("RECREATE_SYMBOL_ID") = py::str(RecreateSymbolId);
+    constants.attr("REFRESH_SYMBOL_ID") = py::str(RefreshSymbolId);
 
     entity::apy::register_common_entity_bindings(version, arcticdb::BindingScope::GLOBAL);
 

--- a/cpp/arcticdb/version/version_constants.hpp
+++ b/cpp/arcticdb/version/version_constants.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 namespace arcticdb {
+// When adding a new constant here, also register a Python binding for it in
+// cpp/arcticdb/version/python_bindings.cpp under the `constants` submodule.
 static const char* const WriteVersionId = "__write__";
 static const char* const TombstoneVersionId = "__tombstone__";
 static const char* const TombstoneAllVersionId = "__tombstone_all__";
@@ -16,6 +18,7 @@ static const char* const CreateSnapshotId = "__create_snapshot__";
 static const char* const DeleteSnapshotId = "__delete_snapshot__";
 static const char* const LastSyncId = "__last_sync__";
 static const char* const LastBackupId = "__last_backup__";
+static const char* const LastBackgroundDeletionId = "__last_background_deletion__";
 static const char* const FailedTargetId = "__failed_target__";
 static const char* const StorageLogId = "__storage_log__";
 static const char* const FailedStorageLogId = "__failed_storage_log__";

--- a/python/tests/unit/arcticdb/version_store/test_constants.py
+++ b/python/tests/unit/arcticdb/version_store/test_constants.py
@@ -1,0 +1,32 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import pytest
+
+from arcticdb_ext.version_store import constants
+
+EXPECTED = {
+    "WRITE_VERSION_ID": "__write__",
+    "TOMBSTONE_VERSION_ID": "__tombstone__",
+    "TOMBSTONE_ALL_VERSION_ID": "__tombstone_all__",
+    "CREATE_SNAPSHOT_ID": "__create_snapshot__",
+    "DELETE_SNAPSHOT_ID": "__delete_snapshot__",
+    "LAST_SYNC_ID": "__last_sync__",
+    "LAST_BACKUP_ID": "__last_backup__",
+    "LAST_BACKGROUND_DELETION_ID": "__last_background_deletion__",
+    "FAILED_TARGET_ID": "__failed_target__",
+    "STORAGE_LOG_ID": "__storage_log__",
+    "FAILED_STORAGE_LOG_ID": "__failed_storage_log__",
+    "RECREATE_SYMBOL_ID": "__recreate__",
+    "REFRESH_SYMBOL_ID": "__refresh__",
+}
+
+
+@pytest.mark.parametrize("name,value", list(EXPECTED.items()))
+def test_constant_value(name, value):
+    assert getattr(constants, name) == value


### PR DESCRIPTION
I'm planning to use the new `LastBackgroundDeletionId` in a `KeyType::STORAGE_INFO` to track last background deletion time, so we can set up monitoring and alerting.

I also bound the existing constants to the Python layer, so the Enterprise apps or data fixes can use them rather than duplicating the strings.